### PR TITLE
Add method for external storage

### DIFF
--- a/packages/path-provider/CHANGELOG.md
+++ b/packages/path-provider/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.2.1] - 2017-05-16
+
+* Add function to determine external storage directory.
+
 ## [0.2.0] - 2017-05-10
 
 * Upgrade to new plugin registration. (https://groups.google.com/forum/#!topic/flutter-dev/zba1Ynf2OKM)

--- a/packages/path-provider/android/src/main/java/io/flutter/plugins/path_provider/PathProviderPlugin.java
+++ b/packages/path-provider/android/src/main/java/io/flutter/plugins/path_provider/PathProviderPlugin.java
@@ -5,6 +5,7 @@
 package io.flutter.plugins.path_provider;
 
 import android.app.Activity;
+import android.os.Environment;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
@@ -35,6 +36,9 @@ public class PathProviderPlugin implements MethodCallHandler {
       case "getApplicationDocumentsDirectory":
         result.success(getPathProviderApplicationDocumentsDirectory());
         break;
+      case "getStorageDirectory":
+        result.success(getPathProviderStorageDirectory());
+        break;
       default:
         result.notImplemented();
     }
@@ -46,5 +50,9 @@ public class PathProviderPlugin implements MethodCallHandler {
 
   private String getPathProviderApplicationDocumentsDirectory() {
     return PathUtils.getDataDirectory(activity);
+  }
+
+  private String getPathProviderStorageDirectory() {
+    return Environment.getExternalStorageDirectory().getAbsolutePath();
   }
 }

--- a/packages/path-provider/example/lib/main.dart
+++ b/packages/path-provider/example/lib/main.dart
@@ -36,6 +36,7 @@ class MyHomePage extends StatefulWidget {
 class _MyHomePageState extends State<MyHomePage> {
   Future<Directory> _tempDirectory;
   Future<Directory> _appDocumentsDirectory;
+  Future<Directory> _externalDocumentsDirectory;
 
   void _requestTempDirectory() {
     setState(() {
@@ -62,6 +63,12 @@ class _MyHomePageState extends State<MyHomePage> {
   void _requestAppDocumentsDirectory() {
     setState(() {
       _appDocumentsDirectory = getApplicationDocumentsDirectory();
+    });
+  }
+
+  void _requestExternalStorageDirectory() {
+    setState(() {
+      _externalDocumentsDirectory = getExternalStorageDirectory();
     });
   }
 
@@ -104,6 +111,25 @@ class _MyHomePageState extends State<MyHomePage> {
             new Expanded(
               child: new FutureBuilder<Directory>(
                   future: _appDocumentsDirectory, builder: _buildDirectory),
+            ),
+            new Column(
+              children : <Widget>[
+                new Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: new RaisedButton(
+                    child: new Text('${Platform.isIOS ?
+                                    "External directories are unavailable " +
+                                    "on iOS":
+                                    "Get External Storage Directory" }'),
+                    onPressed: Platform.isIOS ? null :
+                      _requestExternalStorageDirectory,
+                  ),
+                ),
+              ]
+            ),
+            new Expanded(
+              child: new FutureBuilder<Directory>(
+               future: _externalDocumentsDirectory, builder: _buildDirectory),
             ),
           ],
         ),

--- a/packages/path-provider/lib/path_provider.dart
+++ b/packages/path-provider/lib/path_provider.dart
@@ -40,3 +40,20 @@ const _channel = const MethodChannel('plugins.flutter.io/path_provider');
       return null;
     return new Directory(path);
   }
+
+  /// Path to a directory where the application may access top level storage.
+  /// The current operating system should be determined before issuing this
+  /// function call, as this functionality is only available on Android.
+  ///
+  /// On iOS, this function throws an UnsupportedError as it is not possible
+  /// to access outside the app's sandbox.
+  ///
+  /// On Android this returns getExternalStorageDirectory.
+  Future<Directory> getExternalStorageDirectory() async {
+    if (Platform.isIOS)
+      throw new UnsupportedError("Functionality not available on iOS");
+    final String path = await _channel.invokeMethod('getStorageDirectory');
+    if (path == null)
+      return null;
+    return new Directory(path);
+  }

--- a/packages/path-provider/pubspec.yaml
+++ b/packages/path-provider/pubspec.yaml
@@ -1,6 +1,6 @@
 name: path_provider
 
-version: 0.2.0
+version: 0.2.1
 description: A Flutter plugin for getting commonly used locations on the filesystem.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/path_provider


### PR DESCRIPTION
Android supports accessing the "external" storage medium. Support
finding this path in flutter with a method call in path_provider

I am interested in writing a flutter app that will access some files a user may have put on their device manually (android). This necessitates looking up the path for the external storage. Though I could do the same thing in my own package, I figured it would be more useful to have this functionality in the path provider package so it can be more broadly used. Sadly this functionality is restricted to android only, as iOS does not let you escape the app sandbox. If there is some other mechanism you would prefer me to go through instead of just creating a pull request, please let me know.