### PR TITLE
shared_preferences: Expand and suppress unchecked warnings

### DIFF
--- a/packages/shared_preferences/android/build.gradle
+++ b/packages/shared_preferences/android/build.gradle
@@ -15,6 +15,12 @@ allprojects {
     repositories {
         jcenter()
     }
+
+    gradle.projectsEvaluated {
+        tasks.withType(JavaCompile) {
+            options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
+        }
+    }
 }
 
 apply plugin: 'com.android.library'

--- a/packages/shared_preferences/android/src/main/java/io/flutter/plugins/shared_preferences/SharedPreferencesPlugin.java
+++ b/packages/shared_preferences/android/src/main/java/io/flutter/plugins/shared_preferences/SharedPreferencesPlugin.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Set;
 
 /** SharedPreferencesPlugin */
+@SuppressWarnings("unchecked")
 public class SharedPreferencesPlugin implements MethodCallHandler {
   private static final String SHARED_PREFERENCES_NAME = "FlutterSharedPreferences";
   private static final String CHANNEL_NAME = "plugins.flutter.io/shared_preferences";


### PR DESCRIPTION
When I added this plugin as a dependency, I started getting `Xlint:unchecked` compiler warnings. This stops them.

Due to the position in the flutter architecture (between dart/java) I'm not sure if there's a better approach than just suppressing the warnings at the top.