### PR TITLE
Add request mask to the example People API url

### DIFF
--- a/packages/google_sign_in/example/lib/main.dart
+++ b/packages/google_sign_in/example/lib/main.dart
@@ -51,7 +51,7 @@ class SignInDemoState extends State<SignInDemo> {
     });
     http.Response response = await http.get(
         'https://people.googleapis.com/v1/people/me/connections' +
-            '?requestMask.includeField=person.names%2Cperson.email_addresses',
+            '?requestMask.includeField=person.names',
         headers: await _currentUser.authHeaders,
     );
     if (response.statusCode != 200) {

--- a/packages/google_sign_in/example/lib/main.dart
+++ b/packages/google_sign_in/example/lib/main.dart
@@ -50,7 +50,8 @@ class SignInDemoState extends State<SignInDemo> {
       _contactText = "Loading contact info...";
     });
     http.Response response = await http.get(
-        'https://people.googleapis.com/v1/people/me/connections',
+        'https://people.googleapis.com/v1/people/me/connections' +
+            '?requestMask.includeField=person.names%2Cperson.email_addresses',
         headers: await _currentUser.authHeaders,
     );
     if (response.statusCode != 200) {


### PR DESCRIPTION
Without this parameter the server responds with a 400 error informing
about the malformed request and displaying the error on the page.

The error message in the json response is:
"Request mask can not be empty. Valid paths are: [person.adresses,
person.age_ranges....