### PR TITLE
Added pub and separated FlutterFire plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,20 +16,22 @@ These plugins are also available on
 ## Plugins
 These are the available plugins in this repository. 
 
-| Plugin |
-|--------|
-| [battery](./packages/battery/) |
-| [firebase_analytics](./packages/firebase_analytics/) |
-| [firebase_auth](./packages/firebase_auth/) |
-| [firebase_database](./packages/firebase_database/) |
-| [firebase_messaging](./packages/firebase_messaging/) |
-| [firebase_storage](./packages/firebase_storage/) |
-| [google_sign_in](./packages/google_sign_in/) |
-| [image_picker](./packages/image_picker/) |
-| [path_provider](./packages/path_provider/) |
-| [share](./packages/share/) |
-| [shared_preferences](./packages/shared_preferences/) |
-| [url_launcher](./packages/url_launcher/) |
+| Plugin | Pub |
+|--------|-----|
+| [battery](./packages/battery/) | [![pub package](https://img.shields.io/pub/v/battery.svg)](https://pub.dartlang.org/packages/battery) |
+| [google_sign_in](./packages/google_sign_in/) | [![pub package](https://img.shields.io/pub/v/google_sign_in.svg)](https://pub.dartlang.org/packages/google_sign_in) |
+| [image_picker](./packages/image_picker/) | [![pub package](https://img.shields.io/pub/v/image_picker.svg)](https://pub.dartlang.org/packages/image_picker) |
+| [path_provider](./packages/path_provider/) | [![pub package](https://img.shields.io/pub/v/path_provider.svg)](https://pub.dartlang.org/packages/path_provider) |
+| [share](./packages/share/) | [![pub package](https://img.shields.io/pub/v/share.svg)](https://pub.dartlang.org/packages/share) |
+| [shared_preferences](./packages/shared_preferences/) | [![pub package](https://img.shields.io/pub/v/shared_preferences.svg)](https://pub.dartlang.org/packages/shared_preferences) |
+| [url_launcher](./packages/url_launcher/) | [![pub package](https://img.shields.io/pub/v/url_launcher.svg)](https://pub.dartlang.org/packages/url_launcher) |
+|  |  | 
+| **FlutterFire Plugins** |  | 
+| [firebase_analytics](./packages/firebase_analytics/) | [![pub package](https://img.shields.io/pub/v/firebase_analytics.svg)](https://pub.dartlang.org/packages/firebase_analytics) |
+| [firebase_auth](./packages/firebase_auth/) | [![pub package](https://img.shields.io/pub/v/firebase_auth.svg)](https://pub.dartlang.org/packages/firebase_auth) |
+| [firebase_database](./packages/firebase_database/) | [![pub package](https://img.shields.io/pub/v/firebase_database.svg)](https://pub.dartlang.org/packages/firebase_database) |
+| [firebase_messaging](./packages/firebase_messaging/) | [![pub package](https://img.shields.io/pub/v/firebase_messaging.svg)](https://pub.dartlang.org/packages/firebase_messaging) |
+| [firebase_storage](./packages/firebase_storage/) | [![pub package](https://img.shields.io/pub/v/firebase_storage.svg)](https://pub.dartlang.org/packages/firebase_storage) |
 
 ## Issues
 


### PR DESCRIPTION
Another iteration. One of these can be closed. 

This is using the table with a division to separate the FlutterFire plugins.

![screen shot 2017-06-01 at 8 12 02 am](https://cloud.githubusercontent.com/assets/1326504/26686525/0a50d5f8-46a2-11e7-841c-14560ddcb492.png)