### PR TITLE
Update GoogleSignInPlugin to require the use of support-v4

### DIFF
--- a/packages/google_sign_in/android/build.gradle
+++ b/packages/google_sign_in/android/build.gradle
@@ -14,6 +14,9 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 }
 
@@ -32,6 +35,7 @@ android {
 }
 
 dependencies {
-  compile 'com.google.android.gms:play-services-auth:10.2.1'
-  compile 'com.google.guava:guava:20.0'
+    compile "com.android.support:support-v4:25.0.0"
+    compile 'com.google.android.gms:play-services-auth:10.2.1'
+    compile 'com.google.guava:guava:20.0'
 }

--- a/packages/google_sign_in/example/android/app/src/main/java/io/flutter/plugins/googlesigninexample/MainActivity.java
+++ b/packages/google_sign_in/example/android/app/src/main/java/io/flutter/plugins/googlesigninexample/MainActivity.java
@@ -5,10 +5,10 @@
 package io.flutter.plugins.googlesigninexample;
 
 import android.os.Bundle;
-import io.flutter.app.FlutterActivity;
+import io.flutter.app.FlutterFragmentActivity;
 import io.flutter.plugins.GeneratedPluginRegistrant;
 
-public class MainActivity extends FlutterActivity {
+public class MainActivity extends FlutterFragmentActivity {
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);


### PR DESCRIPTION
Since auto-managed activities in the GMS Auth API require the
use of `android.support.v4.app.FragmentActivity`, this change
updates the plugin to require their use as well. This shouldn't
be a burden on app authors anymore, since the Flutter engine
now provides `FlutterFragmentActivity`