### PR TITLE
Minor fixes in iOS sign-in plugin

### DIFF
--- a/packages/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.0.5
+
+* Require the use of `support-v4` library on Android. This is an API change in
+  that plugin users will need their activity class to be an instance of
+  `android.support.v4.app.FragmentActivity`. Flutter framework provides such
+  an activity out of the box: `io.flutter.app.FlutterFragmentActivity`
+* Ignore "Broken pipe" errors affecting iOS simulator
+* Update to non-deprecated `application:openURL:options:` on iOS
+
 ## 0.0.4
 
 * Prevent race conditions when GoogleSignIn methods are called concurrently (#94)

--- a/packages/google_sign_in/example/ios/Runner/AppDelegate.m
+++ b/packages/google_sign_in/example/ios/Runner/AppDelegate.m
@@ -14,14 +14,4 @@
   return [super application:application didFinishLaunchingWithOptions:launchOptions];
 }
 
-// Regression test for https://github.com/flutter/flutter/issues/10106
-- (BOOL)application:(UIApplication *)application
-              openURL:(NSURL *)url
-    sourceApplication:(NSString *)sourceApplication
-           annotation:(id)annotation {
-  return [super application:application
-                    openURL:url
-          sourceApplication:sourceApplication
-                 annotation:annotation];
-}
 @end

--- a/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
+++ b/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
@@ -28,8 +28,7 @@
   FlutterMethodChannel *channel =
       [FlutterMethodChannel methodChannelWithName:@"plugins.flutter.io/google_sign_in"
                                   binaryMessenger:[registrar messenger]];
-  // TODO(goderbauer): cast is workaround for https://github.com/flutter/flutter/issues/9961.
-  UIViewController *viewController = (UIViewController *)registrar.messenger;
+  UIViewController *viewController = [UIApplication sharedApplication].keyWindow.rootViewController;
   GoogleSignInPlugin *instance = [[GoogleSignInPlugin alloc] initWithViewController:viewController];
   [registrar addApplicationDelegate:instance];
   [registrar addMethodCallDelegate:instance channel:channel];
@@ -41,9 +40,15 @@
     _accountRequests = [[NSMutableArray alloc] init];
     [GIDSignIn sharedInstance].delegate = self;
     [GIDSignIn sharedInstance].uiDelegate = (id)viewController;
+
+    // On the iOS simulator, we get "Broken pipe" errors after sign-in for some
+    // unknown reason. We can avoid crashing the app by ignoring them.
+    signal(SIGPIPE, SIG_IGN);
   }
   return self;
 }
+
+#pragma mark - <FlutterPlugin> protocol
 
 - (void)handleMethodCall:(FlutterMethodCall *)call result:(FlutterResult)result {
   if ([call.method isEqualToString:@"init"]) {
@@ -78,14 +83,15 @@
   }
 }
 
-- (BOOL)application:(UIApplication *)application
-              openURL:(NSURL *)url
-    sourceApplication:(NSString *)sourceApplication
-           annotation:(id)annotation {
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary *)options {
+  NSString *sourceApplication = options[UIApplicationOpenURLOptionsSourceApplicationKey];
+  id annotation = options[UIApplicationOpenURLOptionsAnnotationKey];
   return [[GIDSignIn sharedInstance] handleURL:url
                              sourceApplication:sourceApplication
                                     annotation:annotation];
 }
+
+#pragma mark - <GIDSignInDelegate> protocol
 
 - (void)signIn:(GIDSignIn *)signIn
     didSignInForUser:(GIDGoogleUser *)user
@@ -118,6 +124,8 @@
                 withError:(NSError *)error {
   [self respondWithAccount:@{} error:nil];
 }
+
+#pragma mark - private methods
 
 - (void)respondWithAccount:(id)account error:(NSError *)error {
   NSArray<FlutterResult> *requests = _accountRequests;

--- a/packages/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/pubspec.yaml
@@ -3,7 +3,7 @@ name: google_sign_in
 description: Google Sign-In plugin for Flutter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_sign_in
-version: 0.0.4
+version: 0.0.5
 
 flutter:
   plugin:


### PR DESCRIPTION
* Ignore "Broken pipe" errors affecting simulator
* Apply suggested workaround in https://github.com/flutter/flutter/issues/9961
* Update to non-deprecated `application:openURL:options:`