### PR TITLE
Pin package:test to 0.12.21

### DIFF
--- a/packages/battery/pubspec.yaml
+++ b/packages/battery/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   meta: "^1.0.5"
 
 dev_dependencies:
-   test: "^0.12.20+13"
+   test: 0.12.21
    mockito: "^2.0.2"
    async: "^1.13.2"
 

--- a/packages/firebase_analytics/pubspec.yaml
+++ b/packages/firebase_analytics/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
 
 dev_dependencies:
   mockito: ^2.0.2
-  test: ^0.12.20
+  test: 0.12.21
 
 environment:
     sdk: ">=1.8.0 <2.0.0"

--- a/packages/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
 
 dev_dependencies:
   mockito: ^2.0.2
-  test: ^0.12.20
+  test: 0.12.21
 
 environment:
     sdk: ">=1.8.0 <2.0.0"

--- a/packages/firebase_database/pubspec.yaml
+++ b/packages/firebase_database/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
 
 dev_dependencies:
   mockito: ^2.0.2
-  test: ^0.12.20
+  test: 0.12.21
 
 environment:
     sdk: ">=1.8.0 <2.0.0"

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
 
 dev_dependencies:
   mockito: ^2.0.2
-  test: ^0.12.20
+  test: 0.12.21
 
 environment:
   sdk: ">=1.8.0 <2.0.0"

--- a/packages/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
 
 dev_dependencies:
   mockito: ^2.0.2
-  test: ^0.12.20
+  test: 0.12.21
 
 environment:
     sdk: ">=1.8.0 <2.0.0"

--- a/packages/path_provider/pubspec.yaml
+++ b/packages/path_provider/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  test:
+  test: 0.12.21
 
 environment:
     sdk: ">=1.8.0 <2.0.0"

--- a/packages/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
 
 dev_dependencies:
   mockito: ^2.0.2
-  test: ^0.12.20
+  test: 0.12.21
 
 environment:
     sdk: ">=1.8.0 <2.0.0"

--- a/packages/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  test:
+  test: 0.12.21
 
 environment:
     sdk: ">=1.8.0 <2.0.0"


### PR DESCRIPTION
This fixes recent test failures that only occur on 0.12.22.
We can look into these separately, but in the meantime this
fixes the build.