### PR TITLE
Revert change to uiDelegate setter that caused a Google Sign In crash on iOS.

### DIFF
--- a/packages/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.6
+
+* Fix crash on iOS when signing in caused by nil uiDelegate
+
 ## 0.0.5
 
 * Require the use of `support-v4` library on Android. This is an API change in

--- a/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
+++ b/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
@@ -33,17 +33,6 @@
   [registrar addMethodCallDelegate:instance channel:channel];
 }
 
-- (void)signIn:(GIDSignIn *)signIn presentViewController:(UIViewController *)viewController {
-  [[UIApplication sharedApplication].delegate.window.rootViewController
-      presentViewController:viewController
-                   animated:YES
-                 completion:nil];
-}
-
-- (void)signIn:(GIDSignIn *)signIn dismissViewController:(UIViewController *)viewController {
-  [viewController dismissViewControllerAnimated:YES completion:nil];
-}
-
 - (instancetype)init {
   self = [super init];
   if (self) {
@@ -99,6 +88,19 @@
   return [[GIDSignIn sharedInstance] handleURL:url
                              sourceApplication:sourceApplication
                                     annotation:annotation];
+}
+
+#pragma mark - <GIDSignInUIDelegate> protocol
+
+- (void)signIn:(GIDSignIn *)signIn presentViewController:(UIViewController *)viewController {
+  [[UIApplication sharedApplication].delegate.window.rootViewController
+   presentViewController:viewController
+   animated:YES
+   completion:nil];
+}
+
+- (void)signIn:(GIDSignIn *)signIn dismissViewController:(UIViewController *)viewController {
+  [viewController dismissViewControllerAnimated:YES completion:nil];
 }
 
 #pragma mark - <GIDSignInDelegate> protocol

--- a/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
+++ b/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
@@ -28,7 +28,8 @@
   FlutterMethodChannel *channel =
       [FlutterMethodChannel methodChannelWithName:@"plugins.flutter.io/google_sign_in"
                                   binaryMessenger:[registrar messenger]];
-  UIViewController *viewController = [UIApplication sharedApplication].keyWindow.rootViewController;
+  // TODO(goderbauer): cast is workaround for https://github.com/flutter/flutter/issues/9961
+  UIViewController *viewController = (UIViewController *)registrar.messenger;
   GoogleSignInPlugin *instance = [[GoogleSignInPlugin alloc] initWithViewController:viewController];
   [registrar addApplicationDelegate:instance];
   [registrar addMethodCallDelegate:instance channel:channel];

--- a/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
+++ b/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
@@ -93,10 +93,9 @@
 #pragma mark - <GIDSignInUIDelegate> protocol
 
 - (void)signIn:(GIDSignIn *)signIn presentViewController:(UIViewController *)viewController {
-  [[UIApplication sharedApplication].delegate.window.rootViewController
-   presentViewController:viewController
-   animated:YES
-   completion:nil];
+  UIViewController *rootViewController =
+      [UIApplication sharedApplication].delegate.window.rootViewController;
+  [viewController presentViewController:viewController animated:YES completion:nil];
 }
 
 - (void)signIn:(GIDSignIn *)signIn dismissViewController:(UIViewController *)viewController {

--- a/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
+++ b/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
@@ -33,11 +33,22 @@
   [registrar addMethodCallDelegate:instance channel:channel];
 }
 
+- (void)signIn:(GIDSignIn *)signIn presentViewController:(UIViewController *)viewController
+{
+  [[UIApplication sharedApplication].delegate.window.rootViewController presentViewController:viewController animated:YES completion:nil];
+}
+
+- (void)signIn:(GIDSignIn *)signIn dismissViewController:(UIViewController *)viewController
+{
+  [viewController dismissViewControllerAnimated:YES completion:nil];
+}
+
 - (instancetype)init {
   self = [super init];
   if (self) {
     _accountRequests = [[NSMutableArray alloc] init];
     [GIDSignIn sharedInstance].delegate = self;
+    [GIDSignIn sharedInstance].uiDelegate = self;
 
     // On the iOS simulator, we get "Broken pipe" errors after sign-in for some
     // unknown reason. We can avoid crashing the app by ignoring them.
@@ -54,8 +65,6 @@
     [[GGLContext sharedInstance] configureWithError:&error];
     [GIDSignIn sharedInstance].scopes = call.arguments[@"scopes"];
     [GIDSignIn sharedInstance].hostedDomain = call.arguments[@"hostedDomain"];
-    UIViewController *viewController = [UIApplication sharedApplication].keyWindow.rootViewController;
-    [GIDSignIn sharedInstance].uiDelegate = viewController;
     result(error.flutterError);
   } else if ([call.method isEqualToString:@"signInSilently"]) {
     [_accountRequests insertObject:result atIndex:0];

--- a/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
+++ b/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
@@ -28,19 +28,16 @@
   FlutterMethodChannel *channel =
       [FlutterMethodChannel methodChannelWithName:@"plugins.flutter.io/google_sign_in"
                                   binaryMessenger:[registrar messenger]];
-  // TODO(goderbauer): cast is workaround for https://github.com/flutter/flutter/issues/9961
-  UIViewController *viewController = (UIViewController *)registrar.messenger;
-  GoogleSignInPlugin *instance = [[GoogleSignInPlugin alloc] initWithViewController:viewController];
+  GoogleSignInPlugin *instance = [[GoogleSignInPlugin alloc] init];
   [registrar addApplicationDelegate:instance];
   [registrar addMethodCallDelegate:instance channel:channel];
 }
 
-- (instancetype)initWithViewController:(UIViewController *)viewController {
+- (instancetype)init {
   self = [super init];
   if (self) {
     _accountRequests = [[NSMutableArray alloc] init];
     [GIDSignIn sharedInstance].delegate = self;
-    [GIDSignIn sharedInstance].uiDelegate = (id)viewController;
 
     // On the iOS simulator, we get "Broken pipe" errors after sign-in for some
     // unknown reason. We can avoid crashing the app by ignoring them.
@@ -57,6 +54,8 @@
     [[GGLContext sharedInstance] configureWithError:&error];
     [GIDSignIn sharedInstance].scopes = call.arguments[@"scopes"];
     [GIDSignIn sharedInstance].hostedDomain = call.arguments[@"hostedDomain"];
+    UIViewController *viewController = [UIApplication sharedApplication].keyWindow.rootViewController;
+    [GIDSignIn sharedInstance].uiDelegate = viewController;
     result(error.flutterError);
   } else if ([call.method isEqualToString:@"signInSilently"]) {
     [_accountRequests insertObject:result atIndex:0];

--- a/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
+++ b/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
@@ -33,13 +33,14 @@
   [registrar addMethodCallDelegate:instance channel:channel];
 }
 
-- (void)signIn:(GIDSignIn *)signIn presentViewController:(UIViewController *)viewController
-{
-  [[UIApplication sharedApplication].delegate.window.rootViewController presentViewController:viewController animated:YES completion:nil];
+- (void)signIn:(GIDSignIn *)signIn presentViewController:(UIViewController *)viewController {
+  [[UIApplication sharedApplication].delegate.window.rootViewController
+      presentViewController:viewController
+                   animated:YES
+                 completion:nil];
 }
 
-- (void)signIn:(GIDSignIn *)signIn dismissViewController:(UIViewController *)viewController
-{
+- (void)signIn:(GIDSignIn *)signIn dismissViewController:(UIViewController *)viewController {
   [viewController dismissViewControllerAnimated:YES completion:nil];
 }
 

--- a/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
+++ b/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
@@ -95,7 +95,7 @@
 - (void)signIn:(GIDSignIn *)signIn presentViewController:(UIViewController *)viewController {
   UIViewController *rootViewController =
       [UIApplication sharedApplication].delegate.window.rootViewController;
-  [viewController presentViewController:viewController animated:YES completion:nil];
+  [rootViewController presentViewController:viewController animated:YES completion:nil];
 }
 
 - (void)signIn:(GIDSignIn *)signIn dismissViewController:(UIViewController *)viewController {

--- a/packages/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/pubspec.yaml
@@ -3,7 +3,7 @@ name: google_sign_in
 description: Google Sign-In plugin for Flutter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_sign_in
-version: 0.0.5
+version: 0.0.6
 
 flutter:
   plugin:


### PR DESCRIPTION
Fixes flutter/flutter#9961

This should resolve error message `uiDelegate must either be a |UIViewController| or implement the |signIn:presentViewController:| and |signIn:dismissViewController:| methods from |GIDSignInUIDelegate|.`