### PR TITLE
Remove 'always_specify_types' from analysis options

### DIFF
--- a/.analysis_options
+++ b/.analysis_options
@@ -61,7 +61,6 @@ linter:
     - always_declare_return_types
     - always_put_control_body_on_new_line
     - always_require_non_null_named_parameters
-    - always_specify_types
     - annotate_overrides
     # - avoid_annotating_with_dynamic # not yet tested
     - avoid_as


### PR DESCRIPTION
If we use Dart conventions in plugin example code we don't require explicit type annotations.

Perhaps this option should be removed from flutter/.analysis_options_repo too.