### PR TITLE
Updates to Google Sign-In:

### DIFF
--- a/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
+++ b/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
@@ -52,7 +52,8 @@
 - (void)handleMethodCall:(FlutterMethodCall *)call result:(FlutterResult)result {
   if ([call.method isEqualToString:@"init"]) {
     NSError *error;
-    if (call.arguments[@"clientId"]) {
+    NSString *clientId = call.arguments[@"clientId"];
+    if (clientId && ![clientId isEqual:[NSNull null]]) {
       [GIDSignIn sharedInstance].clientID = call.arguments[@"clientId"];
     } else {
       [[GGLContext sharedInstance] configureWithError:&error];

--- a/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
+++ b/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
@@ -52,7 +52,11 @@
 - (void)handleMethodCall:(FlutterMethodCall *)call result:(FlutterResult)result {
   if ([call.method isEqualToString:@"init"]) {
     NSError *error;
-    [[GGLContext sharedInstance] configureWithError:&error];
+    if (call.arguments[@"clientId"]) {
+      [GIDSignIn sharedInstance].clientID = call.arguments[@"clientId"];
+    } else {
+      [[GGLContext sharedInstance] configureWithError:&error];
+    }
     [GIDSignIn sharedInstance].scopes = call.arguments[@"scopes"];
     [GIDSignIn sharedInstance].hostedDomain = call.arguments[@"hostedDomain"];
     result(error.flutterError);

--- a/packages/google_sign_in/lib/google_sign_in.dart
+++ b/packages/google_sign_in/lib/google_sign_in.dart
@@ -3,12 +3,17 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:ui' show hashValues;
 
 import 'package:flutter/services.dart' show MethodChannel;
 import 'package:flutter/material.dart';
 
+const MethodChannel _kChannel =
+    const MethodChannel('plugins.flutter.io/google_sign_in');
+
 class GoogleSignInAuthentication {
   final Map<String, String> _data;
+
   GoogleSignInAuthentication._(this._data);
 
   /// An OpenID Connect ID token that identifies the user.
@@ -44,8 +49,7 @@ class GoogleSignInAccount {
       throw new StateError('User is no longer signed in.');
     }
 
-    final Map<String, String> response =
-        await _googleSignIn._channel.invokeMethod(
+    final Map<String, String> response = await _kChannel.invokeMethod(
       'getTokens',
       <String, dynamic>{'email': email},
     );
@@ -66,6 +70,21 @@ class GoogleSignInAccount {
   }
 
   @override
+  bool operator ==(dynamic other) {
+    if (identical(this, other)) return true;
+    if (other is! GoogleSignInAccount) return false;
+    final GoogleSignInAccount otherAccount = other;
+    return displayName == otherAccount.displayName &&
+        email == otherAccount.email &&
+        id == otherAccount.id &&
+        photoUrl == otherAccount.photoUrl &&
+        _idToken == otherAccount._idToken;
+  }
+
+  @override
+  int get hashCode => hashValues(displayName, email, id, photoUrl, _idToken);
+
+  @override
   String toString() {
     final Map<String, dynamic> data = <String, dynamic>{
       'displayName': displayName,
@@ -79,13 +98,19 @@ class GoogleSignInAccount {
 
 /// GoogleSignIn allows you to authenticate Google users.
 class GoogleSignIn {
-  final MethodChannel _channel;
-
   /// The list of [scopes] are OAuth scope codes requested when signing in.
   final List<String> scopes;
 
   /// Domain to restrict sign-in to.
   final String hostedDomain;
+
+  /// The ID that was assigned to your app when it was registered with Google.
+  ///
+  /// This value can be found in the
+  /// [Google API console](console.developers.google.com).
+  ///
+  /// This field is optional, as it will be automatically deduced if it's unset.
+  final String clientId;
 
   /// Initializes global sign-in configuration settings.
   ///
@@ -96,35 +121,43 @@ class GoogleSignIn {
   /// The [hostedDomain] argument specifies a hosted domain restriction. By
   /// setting this, sign in will be restricted to accounts of the user in the
   /// specified domain. By default, the list of accounts will not be restricted.
-  GoogleSignIn({this.scopes, this.hostedDomain})
-      : _channel = const MethodChannel('plugins.flutter.io/google_sign_in');
+  ///
+  /// The [clientId] argument specifies the ID that was assigned to your app
+  /// when it was registered with Google. It is optional; if unspecified, it
+  /// will be deduced based on your project's metadata (e.g.
+  /// `GoogleServices-Info.plist` on iOS).
+  GoogleSignIn({this.scopes, this.hostedDomain, this.clientId});
 
-  StreamController<GoogleSignInAccount> _streamController =
+  StreamController<GoogleSignInAccount> _currentUserController =
       new StreamController<GoogleSignInAccount>.broadcast();
 
-  /// Subscribe to this stream to be notified when the current user changes
+  /// Subscribe to this stream to be notified when the current user changes.
   Stream<GoogleSignInAccount> get onCurrentUserChanged =>
-      _streamController.stream;
+      _currentUserController.stream;
 
-  // Future that completes when we've finished calling init on the native side
+  // Future that completes when we've finished calling `init` on the native side
   Future<Null> _initialization;
 
   Future<GoogleSignInAccount> _callMethod(String method) async {
     if (_initialization == null) {
-      _initialization = _channel.invokeMethod(
-        "init",
-        <String, dynamic>{
-          'scopes': scopes ?? <String>[],
-          'hostedDomain': hostedDomain,
-        },
-      );
+      _initialization = _kChannel.invokeMethod("init", <String, dynamic>{
+        'scopes': scopes ?? <String>[],
+        'hostedDomain': hostedDomain,
+        'clientId': clientId,
+      });
     }
     await _initialization;
-    final Map<String, dynamic> response = await _channel.invokeMethod(method);
-    _currentUser = (response != null && response.isNotEmpty)
+    final Map<String, dynamic> response = await _kChannel.invokeMethod(method);
+    return _setCurrentUser(response != null && response.isNotEmpty
         ? new GoogleSignInAccount._(this, response)
-        : null;
-    _streamController.add(_currentUser);
+        : null);
+  }
+
+  GoogleSignInAccount _setCurrentUser(GoogleSignInAccount currentUser) {
+    if (currentUser != _currentUser) {
+      _currentUser = currentUser;
+      _currentUserController.add(_currentUser);
+    }
     return _currentUser;
   }
 

--- a/packages/google_sign_in/lib/google_sign_in.dart
+++ b/packages/google_sign_in/lib/google_sign_in.dart
@@ -7,9 +7,7 @@ import 'dart:ui' show hashValues;
 
 import 'package:flutter/services.dart' show MethodChannel;
 import 'package:flutter/material.dart';
-
-const MethodChannel _kChannel =
-    const MethodChannel('plugins.flutter.io/google_sign_in');
+import 'package:meta/meta.dart' show visibleForTesting;
 
 class GoogleSignInAuthentication {
   final Map<String, String> _data;
@@ -49,7 +47,8 @@ class GoogleSignInAccount {
       throw new StateError('User is no longer signed in.');
     }
 
-    final Map<String, String> response = await _kChannel.invokeMethod(
+    final Map<String, String> response =
+        await GoogleSignIn.channel.invokeMethod(
       'getTokens',
       <String, dynamic>{'email': email},
     );
@@ -98,6 +97,11 @@ class GoogleSignInAccount {
 
 /// GoogleSignIn allows you to authenticate Google users.
 class GoogleSignIn {
+  /// The [MethodChannel] over which this class communicates.
+  @visibleForTesting
+  static const MethodChannel channel =
+      const MethodChannel('plugins.flutter.io/google_sign_in');
+
   /// The list of [scopes] are OAuth scope codes requested when signing in.
   final List<String> scopes;
 
@@ -140,14 +144,14 @@ class GoogleSignIn {
 
   Future<GoogleSignInAccount> _callMethod(String method) async {
     if (_initialization == null) {
-      _initialization = _kChannel.invokeMethod("init", <String, dynamic>{
+      _initialization = channel.invokeMethod("init", <String, dynamic>{
         'scopes': scopes ?? <String>[],
         'hostedDomain': hostedDomain,
         'clientId': clientId,
       });
     }
     await _initialization;
-    final Map<String, dynamic> response = await _kChannel.invokeMethod(method);
+    final Map<String, dynamic> response = await channel.invokeMethod(method);
     return _setCurrentUser(response != null && response.isNotEmpty
         ? new GoogleSignInAccount._(this, response)
         : null);

--- a/packages/google_sign_in/test/google_sign_in_test.dart
+++ b/packages/google_sign_in/test/google_sign_in_test.dart
@@ -48,8 +48,11 @@ void main() {
       expect(
           log,
           equals(<MethodCall>[
-            new MethodCall('init',
-                <String, dynamic>{'scopes': <String>[], 'hostedDomain': null}),
+            new MethodCall('init', <String, dynamic>{
+              'scopes': <String>[],
+              'hostedDomain': null,
+              'clientId': null,
+            }),
             const MethodCall('signInSilently'),
           ]));
     });
@@ -60,8 +63,11 @@ void main() {
       expect(
           log,
           equals(<MethodCall>[
-            new MethodCall('init',
-                <String, dynamic>{'scopes': <String>[], 'hostedDomain': null}),
+            new MethodCall('init', <String, dynamic>{
+              'scopes': <String>[],
+              'hostedDomain': null,
+              'clientId': null,
+            }),
             const MethodCall('signIn'),
           ]));
     });
@@ -72,8 +78,11 @@ void main() {
       expect(
           log,
           equals(<MethodCall>[
-            new MethodCall('init',
-                <String, dynamic>{'scopes': <String>[], 'hostedDomain': null}),
+            new MethodCall('init', <String, dynamic>{
+              'scopes': <String>[],
+              'hostedDomain': null,
+              'clientId': null,
+            }),
             const MethodCall('signOut'),
           ]));
     });
@@ -84,8 +93,11 @@ void main() {
       expect(
           log,
           equals(<MethodCall>[
-            new MethodCall('init',
-                <String, dynamic>{'scopes': <String>[], 'hostedDomain': null}),
+            new MethodCall('init', <String, dynamic>{
+              'scopes': <String>[],
+              'hostedDomain': null,
+              'clientId': null,
+            }),
             const MethodCall('disconnect'),
           ]));
     });
@@ -97,8 +109,11 @@ void main() {
       expect(
           log,
           equals(<MethodCall>[
-            new MethodCall('init',
-                <String, dynamic>{'scopes': <String>[], 'hostedDomain': null}),
+            new MethodCall('init', <String, dynamic>{
+              'scopes': <String>[],
+              'hostedDomain': null,
+              'clientId': null,
+            }),
             const MethodCall('disconnect'),
           ]));
     });
@@ -120,8 +135,11 @@ void main() {
       expect(
           log,
           equals(<MethodCall>[
-            new MethodCall('init',
-                <String, dynamic>{'scopes': <String>[], 'hostedDomain': null}),
+            new MethodCall('init', <String, dynamic>{
+              'scopes': <String>[],
+              'hostedDomain': null,
+              'clientId': null,
+            }),
             const MethodCall('signInSilently'),
           ]));
     });
@@ -134,8 +152,11 @@ void main() {
       expect(
           log,
           equals(<MethodCall>[
-            new MethodCall('init',
-                <String, dynamic>{'scopes': <String>[], 'hostedDomain': null}),
+            new MethodCall('init', <String, dynamic>{
+              'scopes': <String>[],
+              'hostedDomain': null,
+              'clientId': null,
+            }),
             const MethodCall('signInSilently'),
             const MethodCall('signIn'),
           ]));
@@ -152,8 +173,11 @@ void main() {
       expect(
           log,
           equals(<MethodCall>[
-            new MethodCall('init',
-                <String, dynamic>{'scopes': <String>[], 'hostedDomain': null}),
+            new MethodCall('init', <String, dynamic>{
+              'scopes': <String>[],
+              'hostedDomain': null,
+              'clientId': null,
+            }),
             const MethodCall('signInSilently'),
           ]));
       expect(users.first, users.last, reason: 'Must return the same user');
@@ -179,8 +203,11 @@ void main() {
       expect(
           log,
           equals(<MethodCall>[
-            new MethodCall('init',
-                <String, dynamic>{'scopes': <String>[], 'hostedDomain': null}),
+            new MethodCall('init', <String, dynamic>{
+              'scopes': <String>[],
+              'hostedDomain': null,
+              'clientId': null,
+            }),
             const MethodCall('signOut'),
             const MethodCall('signOut'),
             const MethodCall('disconnect'),
@@ -200,8 +227,11 @@ void main() {
       expect(
           log,
           equals(<MethodCall>[
-            new MethodCall('init',
-                <String, dynamic>{'scopes': <String>[], 'hostedDomain': null}),
+            new MethodCall('init', <String, dynamic>{
+              'scopes': <String>[],
+              'hostedDomain': null,
+              'clientId': null,
+            }),
             const MethodCall('signInSilently'),
             const MethodCall('signOut'),
             const MethodCall('signIn'),


### PR DESCRIPTION
* Allow `clientId` to be specified in Dart, which will take
  precedence over the config-based discovery.
* Only fire "current user changed" stream events when the current
  user really did change.