### PR TITLE
Add some better error checking to the Google sign-in example.

### DIFF
--- a/packages/google_sign_in/README.md
+++ b/packages/google_sign_in/README.md
@@ -71,12 +71,9 @@ GoogleSignIn _googleSignIn = new GoogleSignIn(
 You can now use the `GoogleSignIn` class to authenticate in your Dart code, e.g. 
 
 ```
-Future<Null> _handleSignIn() async {
-  try {
-    await _googleSignIn.signIn();
-  } catch (error) {
-    print(error);
-  }
+Future<GoogleSignInAccount> _handleGoogleSignIn() async {
+  await _googleSignIn.signIn();
+  return _googleSignIn.currentUser;
 }
 ```
 


### PR DESCRIPTION
Use the future catch error function to catch the error. I think this fits better than catching and silently printing the error. The future then, catch error behavior semantics are nice. 