### PR TITLE
Update dependencies of plugins

### DIFF
--- a/packages/firebase_analytics/CHANGELOG.md
+++ b/packages/firebase_analytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.3
+
+* Updated to Firebase SDK Version 11.0.1
+
 ## 0.0.2
 
 * Bumped buildToolsVersion to 25.0.3

--- a/packages/firebase_analytics/android/build.gradle
+++ b/packages/firebase_analytics/android/build.gradle
@@ -30,7 +30,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        compile 'com.google.firebase:firebase-auth:10.2.1'
-        compile 'com.google.firebase:firebase-analytics:10.2.1'
+        compile 'com.google.firebase:firebase-auth:11.0.1'
+        compile 'com.google.firebase:firebase-analytics:11.0.1'
     }
 }

--- a/packages/firebase_analytics/example/android/app/build.gradle
+++ b/packages/firebase_analytics/example/android/app/build.gradle
@@ -24,6 +24,7 @@ android {
 
     defaultConfig {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        applicationId "io.flutter.firebaseanalyticsexample"
     }
 
     buildTypes {
@@ -40,7 +41,7 @@ flutter {
 }
 
 dependencies {
-    compile 'com.google.firebase:firebase-core:10.0.1'
+    compile 'com.google.firebase:firebase-core:11.0.1'
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/packages/firebase_analytics/example/android/build.gradle
+++ b/packages/firebase_analytics/example/android/build.gradle
@@ -4,8 +4,8 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
-        classpath 'com.google.gms:google-services:3.0.0'
+        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.google.gms:google-services:3.1.0'
     }
 }
 

--- a/packages/firebase_analytics/pubspec.yaml
+++ b/packages/firebase_analytics/pubspec.yaml
@@ -3,7 +3,7 @@ name: firebase_analytics
 description: Firebase Analytics plugin for Flutter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_analytics
-version: 0.0.2
+version: 0.0.3
 
 flutter:
   plugin:

--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 0.1.0
+
+* Updated to Firebase SDK Version 11.0.1
+* **Breaking Change**: You need to add a maven section with the "https://maven.google.com" endpoint to the repository section of your `android/build.gradle`. For example:
+```gradle
+allprojects {
+    repositories {
+        jcenter()
+        maven {                              // NEW
+            url "https://maven.google.com"   // NEW
+        }                                    // NEW
+    }
+}
+```
+
 ## 0.0.4
 
 * Add method getToken() to FirebaseUser

--- a/packages/firebase_auth/README.md
+++ b/packages/firebase_auth/README.md
@@ -25,7 +25,7 @@ dependencies {
   // Example existing classpath
   classpath 'com.android.tools.build:gradle:2.2.3'
   // Add the google services classpath
-  classpath 'com.google.gms:google-services:3.0.0'
+  classpath 'com.google.gms:google-services:3.1.0'
 }
 ```
 
@@ -35,15 +35,15 @@ dependencies {
 apply plugin: 'com.google.gms.google-services'
 ```
 
-*Note:* If this section is not completed you will get an error like this: 
+*Note:* If this section is not completed you will get an error like this:
 ```
-java.lang.IllegalStateException: 
-Default FirebaseApp is not initialized in this process [package name]. 
+java.lang.IllegalStateException:
+Default FirebaseApp is not initialized in this process [package name].
 Make sure to call FirebaseApp.initializeApp(Context) first.
 ```
 
-*Note:* When you are debugging on android, use a device or AVD with Google Play services. 
-Otherwise you will not be able to authenticate. 
+*Note:* When you are debugging on android, use a device or AVD with Google Play services.
+Otherwise you will not be able to authenticate.
 
 ### Use the plugin
 
@@ -57,7 +57,7 @@ Initialize `FirebaseAuth`:
 final FirebaseAuth _auth = FirebaseAuth.instance;
 ```
 
-You can now use the Firebase `_auth` to authenticate in your Dart code, e.g. 
+You can now use the Firebase `_auth` to authenticate in your Dart code, e.g.
 ```
 Future<Null> _handleSignIn() async {
   try {
@@ -76,7 +76,7 @@ Future<Null> _handleSignIn() async {
 
 ## Example
 
-See the [example application](https://github.com/flutter/plugins/tree/master/packages/firebase_auth/example) source 
+See the [example application](https://github.com/flutter/plugins/tree/master/packages/firebase_auth/example) source
 for a complete sample app using the Firebase authentication.
 
 ## Issues and feedback

--- a/packages/firebase_auth/android/build.gradle
+++ b/packages/firebase_auth/android/build.gradle
@@ -14,6 +14,9 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 }
 
@@ -31,7 +34,7 @@ android {
     }
     dependencies {
         compile 'com.google.guava:guava:20.0'
-        compile 'com.google.firebase:firebase-core:10.2.1'
-        compile 'com.google.firebase:firebase-auth:10.2.1'
+        compile 'com.google.firebase:firebase-core:11.0.1'
+        compile 'com.google.firebase:firebase-auth:11.0.1'
     }
 }

--- a/packages/firebase_auth/example/android/app/build.gradle
+++ b/packages/firebase_auth/example/android/app/build.gradle
@@ -41,7 +41,7 @@ flutter {
 }
 
 dependencies {
-    androidTestCompile 'com.android.support:support-annotations:24.0.0'
+    androidTestCompile 'com.android.support:support-annotations:25.0.0'
     androidTestCompile 'com.android.support.test:runner:0.5'
     androidTestCompile 'com.android.support.test:rules:0.5'
 }

--- a/packages/firebase_auth/example/android/build.gradle
+++ b/packages/firebase_auth/example/android/build.gradle
@@ -5,13 +5,16 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
-        classpath 'com.google.gms:google-services:3.0.0'
+        classpath 'com.google.gms:google-services:3.1.0'
     }
 }
 
 allprojects {
     repositories {
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 }
 

--- a/packages/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/pubspec.yaml
@@ -3,7 +3,7 @@ name: firebase_auth
 description: Firebase Auth plugin for Flutter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_auth
-version: 0.0.4
+version: 0.1.0
 
 flutter:
   plugin:

--- a/packages/firebase_database/CHANGELOG.md
+++ b/packages/firebase_database/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.9
+
+* Updated to Firebase SDK Version 11.0.1
+
 ## 0.0.8
 
 * Added missing offline persistence and query functionality on Android

--- a/packages/firebase_database/android/build.gradle
+++ b/packages/firebase_database/android/build.gradle
@@ -30,8 +30,8 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        compile 'com.google.firebase:firebase-core:10.2.1'
-        compile 'com.google.firebase:firebase-auth:10.2.1'
-        compile 'com.google.firebase:firebase-database:10.2.1'
+        compile 'com.google.firebase:firebase-core:11.0.1'
+        compile 'com.google.firebase:firebase-auth:11.0.1'
+        compile 'com.google.firebase:firebase-database:11.0.1'
     }
 }

--- a/packages/firebase_database/example/android/build.gradle
+++ b/packages/firebase_database/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
-        classpath 'com.google.gms:google-services:3.0.0'
+        classpath 'com.google.gms:google-services:3.1.0'
     }
 }
 

--- a/packages/firebase_messaging/CHANGELOG.md
+++ b/packages/firebase_messaging/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.4
+
+* Updated to Firebase SDK Version 11.0.1
+
 ## 0.0.3
 
 * Updated README.md

--- a/packages/firebase_messaging/android/build.gradle
+++ b/packages/firebase_messaging/android/build.gradle
@@ -30,7 +30,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        compile 'com.google.firebase:firebase-core:10.2.1'
-        compile 'com.google.firebase:firebase-messaging:10.2.4'
+        compile 'com.google.firebase:firebase-core:11.0.1'
+        compile 'com.google.firebase:firebase-messaging:11.0.1'
     }
 }

--- a/packages/firebase_messaging/example/android/app/build.gradle
+++ b/packages/firebase_messaging/example/android/app/build.gradle
@@ -41,7 +41,7 @@ flutter {
 }
 
 dependencies {
-    androidTestCompile 'com.android.support:support-annotations:24.0.0'
+    androidTestCompile 'com.android.support:support-annotations:25.0.0'
     androidTestCompile 'com.android.support.test:runner:0.5'
     androidTestCompile 'com.android.support.test:rules:0.5'
 }

--- a/packages/firebase_messaging/example/android/build.gradle
+++ b/packages/firebase_messaging/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
-        classpath 'com.google.gms:google-services:3.0.0'
+        classpath 'com.google.gms:google-services:3.1.0'
     }
 }
 

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -3,7 +3,7 @@ name: firebase_messaging
 description: Firebase Cloud Messaging plugin for Flutter applications.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_messaging
-version: 0.0.3
+version: 0.0.4
 
 flutter:
   plugin:

--- a/packages/firebase_storage/CHANGELOG.md
+++ b/packages/firebase_storage/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.4
+
+* Updated to Firebase SDK Version 11.0.1
+
 ## 0.0.3
 
 * Suppress unchecked warnings

--- a/packages/firebase_storage/android/build.gradle
+++ b/packages/firebase_storage/android/build.gradle
@@ -36,7 +36,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        compile 'com.google.firebase:firebase-core:10.2.1'
-        compile 'com.google.firebase:firebase-storage:10.2.1'
+        compile 'com.google.firebase:firebase-core:11.0.1'
+        compile 'com.google.firebase:firebase-storage:11.0.1'
     }
 }

--- a/packages/firebase_storage/example/android/build.gradle
+++ b/packages/firebase_storage/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'
-        classpath 'com.google.gms:google-services:3.0.0'
+        classpath 'com.google.gms:google-services:3.1.0'
     }
 }
 

--- a/packages/firebase_storage/pubspec.yaml
+++ b/packages/firebase_storage/pubspec.yaml
@@ -3,7 +3,7 @@ name: firebase_storage
 description: Firebase Storage plugin for Flutter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_storage
-version: 0.0.3
+version: 0.0.4
 
 flutter:
   plugin:

--- a/packages/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/CHANGELOG.md
@@ -1,6 +1,22 @@
+## 0.2.0
+
+* Updated dependencies
+* **Breaking Change**: You need to add a maven section with the "https://maven.google.com" endpoint to the repository section of your `android/build.gradle`. For example:
+```gradle
+allprojects {
+    repositories {
+        jcenter()
+        maven {                              // NEW
+            url "https://maven.google.com"   // NEW
+        }                                    // NEW
+    }
+}
+```
+
 ## 0.1.0
 
 * Update to use `GoogleSignIn` CocoaPod
+
 
 ## 0.0.6
 

--- a/packages/google_sign_in/android/build.gradle
+++ b/packages/google_sign_in/android/build.gradle
@@ -35,7 +35,7 @@ android {
 }
 
 dependencies {
-    compile "com.android.support:support-v4:25.0.0"
-    compile 'com.google.android.gms:play-services-auth:10.2.1'
+    compile 'com.android.support:support-v4:25.4.0'
+    compile 'com.google.android.gms:play-services-auth:11.0.1'
     compile 'com.google.guava:guava:20.0'
 }

--- a/packages/google_sign_in/example/android/build.gradle
+++ b/packages/google_sign_in/example/android/build.gradle
@@ -11,6 +11,9 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 }
 

--- a/packages/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/pubspec.yaml
@@ -3,7 +3,7 @@ name: google_sign_in
 description: Google Sign-In plugin for Flutter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_sign_in
-version: 0.1.0
+version: 0.2.0
 
 flutter:
   plugin:

--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 0.1.0
+
+* Updated dependencies
+* **Breaking Change**: You need to add a maven section with the "https://maven.google.com" endpoint to the repository section of your `android/build.gradle`. For example:
+```gradle
+allprojects {
+    repositories {
+        jcenter()
+        maven {                              // NEW
+            url "https://maven.google.com"   // NEW
+        }                                    // NEW
+    }
+}
+```
+
 ## 0.0.3
 
 * Fix for crash on iPad when showing the Camera/Gallery selection dialog

--- a/packages/image_picker/android/build.gradle
+++ b/packages/image_picker/android/build.gradle
@@ -14,7 +14,12 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
-        maven { url "https://jitpack.io" }
+        maven {
+            url "https://jitpack.io"
+        }
+        maven {
+            url "https://maven.google.com"
+        }
     }
 }
 
@@ -34,7 +39,7 @@ android {
 
 dependencies {
     compile 'com.github.bumptech.glide:glide:3.7.0'
-    compile 'com.github.esafirm.android-image-picker:imagepicker:1.3.4@aar'
-    compile 'com.android.support:appcompat-v7:25.0.1'
-    compile 'com.android.support:recyclerview-v7:25.0.1'
+    compile 'com.github.esafirm.android-image-picker:imagepicker:1.5.0@aar'
+    compile 'com.android.support:appcompat-v7:25.4.0'
+    compile 'com.android.support:recyclerview-v7:25.4.0'
 }

--- a/packages/image_picker/example/android/build.gradle
+++ b/packages/image_picker/example/android/build.gradle
@@ -11,7 +11,12 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
-        maven { url "https://jitpack.io" }
+        maven {
+            url "https://jitpack.io"
+        }
+        maven {
+            url "https://maven.google.com"
+        }
     }
 }
 

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -3,7 +3,7 @@ name: image_picker
 description: Flutter plugin that shows an image picker.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.0.3
+version: 0.1.0
 
 flutter:
   plugin:


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/10749.

Some of these changes are breaking changes as noted in the CHANGELOGs. I am preparing an email [1] that will be send out to flutter-users before publishing the updated plugins to pub. No action is required for new flutter apps (after https://github.com/flutter/flutter/pull/10842 is merged). This is only a breaking change because of https://github.com/flutter/flutter/issues/9881.

Plugin users will also have to make sure that they update their "Google Repository" version to 54 (or newer) in the Android SDK manager.

[1] https://docs.google.com/document/d/1B9RZ-PpdFKdgUvLxu1mvBxwG3ytDVJo0GFxCZVMyu0E/edit