### PR TITLE
GoogleSignIn updates

### DIFF
--- a/packages/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0
+
+* Update to use `GoogleSignIn` CocoaPod
+
 ## 0.0.6
 
 * Fix crash on iOS when signing in caused by nil uiDelegate

--- a/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
+++ b/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 #import "GoogleSignInPlugin.h"
-#import <Google/SignIn.h>
+#import <GoogleSignIn/GoogleSignIn.h>
 
 @interface NSError (FlutterError)
 @property(readonly, nonatomic) FlutterError *flutterError;
@@ -51,16 +51,12 @@
 
 - (void)handleMethodCall:(FlutterMethodCall *)call result:(FlutterResult)result {
   if ([call.method isEqualToString:@"init"]) {
-    NSError *error;
-    NSString *clientId = call.arguments[@"clientId"];
-    if (clientId && ![clientId isEqual:[NSNull null]]) {
-      [GIDSignIn sharedInstance].clientID = call.arguments[@"clientId"];
-    } else {
-      [[GGLContext sharedInstance] configureWithError:&error];
-    }
+    NSString *path = [[NSBundle mainBundle] pathForResource:@"GoogleService-Info" ofType:@"plist"];
+    NSMutableDictionary *plist = [[NSMutableDictionary alloc] initWithContentsOfFile:path];
+    [GIDSignIn sharedInstance].clientID = plist[@"CLIENT_ID"];
     [GIDSignIn sharedInstance].scopes = call.arguments[@"scopes"];
     [GIDSignIn sharedInstance].hostedDomain = call.arguments[@"hostedDomain"];
-    result(error.flutterError);
+    result(nil);
   } else if ([call.method isEqualToString:@"signInSilently"]) {
     [_accountRequests insertObject:result atIndex:0];
     [[GIDSignIn sharedInstance] signInSilently];

--- a/packages/google_sign_in/ios/google_sign_in.podspec
+++ b/packages/google_sign_in/ios/google_sign_in.podspec
@@ -15,5 +15,5 @@ Enables Google Sign-In in Flutter apps.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'Google/SignIn', '~> 3.0'
+  s.dependency 'GoogleSignIn', '~> 4.0'
 end

--- a/packages/google_sign_in/lib/google_sign_in.dart
+++ b/packages/google_sign_in/lib/google_sign_in.dart
@@ -108,14 +108,6 @@ class GoogleSignIn {
   /// Domain to restrict sign-in to.
   final String hostedDomain;
 
-  /// The ID that was assigned to your app when it was registered with Google.
-  ///
-  /// This value can be found in the
-  /// [Google API console](console.developers.google.com).
-  ///
-  /// This field is optional, as it will be automatically deduced if it's unset.
-  final String clientId;
-
   /// Initializes global sign-in configuration settings.
   ///
   /// The list of [scopes] are OAuth scope codes to request when signing in.
@@ -125,12 +117,7 @@ class GoogleSignIn {
   /// The [hostedDomain] argument specifies a hosted domain restriction. By
   /// setting this, sign in will be restricted to accounts of the user in the
   /// specified domain. By default, the list of accounts will not be restricted.
-  ///
-  /// The [clientId] argument specifies the ID that was assigned to your app
-  /// when it was registered with Google. It is optional; if unspecified, it
-  /// will be deduced based on your project's metadata (e.g.
-  /// `GoogleServices-Info.plist` on iOS).
-  GoogleSignIn({this.scopes, this.hostedDomain, this.clientId});
+  GoogleSignIn({this.scopes, this.hostedDomain});
 
   StreamController<GoogleSignInAccount> _currentUserController =
       new StreamController<GoogleSignInAccount>.broadcast();
@@ -147,7 +134,6 @@ class GoogleSignIn {
       _initialization = channel.invokeMethod("init", <String, dynamic>{
         'scopes': scopes ?? <String>[],
         'hostedDomain': hostedDomain,
-        'clientId': clientId,
       });
     }
     await _initialization;

--- a/packages/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/pubspec.yaml
@@ -3,7 +3,7 @@ name: google_sign_in
 description: Google Sign-In plugin for Flutter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_sign_in
-version: 0.0.6
+version: 0.1.0
 
 flutter:
   plugin:

--- a/packages/google_sign_in/test/google_sign_in_test.dart
+++ b/packages/google_sign_in/test/google_sign_in_test.dart
@@ -51,7 +51,6 @@ void main() {
             new MethodCall('init', <String, dynamic>{
               'scopes': <String>[],
               'hostedDomain': null,
-              'clientId': null,
             }),
             const MethodCall('signInSilently'),
           ]));
@@ -66,7 +65,6 @@ void main() {
             new MethodCall('init', <String, dynamic>{
               'scopes': <String>[],
               'hostedDomain': null,
-              'clientId': null,
             }),
             const MethodCall('signIn'),
           ]));
@@ -81,7 +79,6 @@ void main() {
             new MethodCall('init', <String, dynamic>{
               'scopes': <String>[],
               'hostedDomain': null,
-              'clientId': null,
             }),
             const MethodCall('signOut'),
           ]));
@@ -96,7 +93,6 @@ void main() {
             new MethodCall('init', <String, dynamic>{
               'scopes': <String>[],
               'hostedDomain': null,
-              'clientId': null,
             }),
             const MethodCall('disconnect'),
           ]));
@@ -112,7 +108,6 @@ void main() {
             new MethodCall('init', <String, dynamic>{
               'scopes': <String>[],
               'hostedDomain': null,
-              'clientId': null,
             }),
             const MethodCall('disconnect'),
           ]));
@@ -138,7 +133,6 @@ void main() {
             new MethodCall('init', <String, dynamic>{
               'scopes': <String>[],
               'hostedDomain': null,
-              'clientId': null,
             }),
             const MethodCall('signInSilently'),
           ]));
@@ -155,7 +149,6 @@ void main() {
             new MethodCall('init', <String, dynamic>{
               'scopes': <String>[],
               'hostedDomain': null,
-              'clientId': null,
             }),
             const MethodCall('signInSilently'),
             const MethodCall('signIn'),
@@ -176,7 +169,6 @@ void main() {
             new MethodCall('init', <String, dynamic>{
               'scopes': <String>[],
               'hostedDomain': null,
-              'clientId': null,
             }),
             const MethodCall('signInSilently'),
           ]));
@@ -206,7 +198,6 @@ void main() {
             new MethodCall('init', <String, dynamic>{
               'scopes': <String>[],
               'hostedDomain': null,
-              'clientId': null,
             }),
             const MethodCall('signOut'),
             const MethodCall('signOut'),
@@ -230,7 +221,6 @@ void main() {
             new MethodCall('init', <String, dynamic>{
               'scopes': <String>[],
               'hostedDomain': null,
-              'clientId': null,
             }),
             const MethodCall('signInSilently'),
             const MethodCall('signOut'),


### PR DESCRIPTION
    * Switch to use GoogleSignIn CocoaPod instead of Google
    * Read client ID manually from `GoogleService-Info.plist`,
      and don't support passing the client ID from Dart anymore.
    
    https://github.com/flutter/flutter/issues/10819