### PR TITLE
Self-manage Andorid SDK on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,20 +48,6 @@ matrix:
     - os: linux
       env:
         - SHARD=Build-example-APKs
-      language: android
-      licenses:
-        - 'android-sdk-preview-license-.+'
-        - 'android-sdk-license-.+'
-        - 'google-gdk-license-.+'
-      android:
-        components:
-          - tools
-          - platform-tools
-          - build-tools-25.0.3
-          - android-25
-          - extra-android-m2repository
-          - extra-google-m2repository
-          - extra-google-android-support
       jdk: oraclejdk8
       sudo: false
       addons:
@@ -70,15 +56,30 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test # if we don't specify this, the libstdc++6 we get is the wrong version
           packages:
+            - lib32stdc++6 # https://github.com/flutter/flutter/issues/6207
             - libstdc++6
             - fonts-droid
       before_script:
+        - wget https://dl.google.com/android/repository/sdk-tools-linux-3859397.zip
+        - mkdir android-sdk
+        - unzip -qq sdk-tools-linux-3859397.zip -d android-sdk
+        - export ANDROID_HOME=`pwd`/android-sdk
+        - export PATH=`pwd`/android-sdk/tools/bin:$PATH
+        - mkdir -p /home/travis/.android # silence sdkmanager warning
+        - echo 'count=0' > /home/travis/.android/repositories.cfg # silence sdkmanager warning
+        - echo y | sdkmanager "tools"
+        - echo y | sdkmanager "platform-tools"
+        - echo y | sdkmanager "build-tools;25.0.3"
+        - echo y | sdkmanager "platforms;android-25"
+        - echo y | sdkmanager "extras;android;m2repository"
+        - echo y | sdkmanager "extras;google;m2repository"
+        - echo y | sdkmanager "patcher;v4"
+        - sdkmanager --list
         - wget http://services.gradle.org/distributions/gradle-3.5-bin.zip
         - unzip -qq gradle-3.5-bin.zip
         - export GRADLE_HOME=$PWD/gradle-3.5
         - export PATH=$GRADLE_HOME/bin:$PATH
         - gradle -v
-        - android list targets
         - git clone https://github.com/flutter/flutter.git --depth 1
         - export PATH=`pwd`/flutter/bin:`pwd`/flutter/bin/cache/dart-sdk/bin:$PATH
         - flutter doctor


### PR DESCRIPTION
Travis uses the deprecated `android` CLI to install the Android SDK. Unfortunately, at this point that outdated tool is unable to install the latest version of the "Google Repository" Android SDK component. Switching to managing the Android SDK by hand on Travis. That way, we can use `sdkmanager` (one of the replacements for `android`) and download the latest versions of the Android SDK components.

This change is required to update the plugin dependencies to the latest versions (https://github.com/flutter/plugins/pull/141), which require the latest "Google Repository" version.