### PR TITLE
Return exception code as Android does to be consistent. 

### DIFF
--- a/packages/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
+++ b/packages/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
@@ -57,7 +57,6 @@ public class GoogleSignInPlugin
 
   private static final String ERROR_REASON_EXCEPTION = "exception";
   private static final String ERROR_REASON_STATUS = "status";
-  private static final String ERROR_REASON_CANCELED = "canceled";
   private static final String ERROR_REASON_OPERATION_IN_PROGRESS = "operation_in_progress";
   private static final String ERROR_REASON_CONNECTION_FAILED = "connection_failed";
 
@@ -398,7 +397,8 @@ public class GoogleSignInPlugin
     }
 
     if (resultCode != Activity.RESULT_OK) {
-      finishWithError(ERROR_REASON_CANCELED, String.valueOf(resultCode));
+      // User cancelled so we return a null auth object.
+      finishWithSuccess(null);
       return true;
     }
 

--- a/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
+++ b/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
@@ -16,7 +16,7 @@ static NSString *const kClientIdKey = @"CLIENT_ID";
 
 @implementation NSError (FlutterError)
 - (FlutterError *)flutterError {
-  return [FlutterError errorWithCode:[NSString stringWithFormat:@"%ld", (long)self.code]
+  return [FlutterError errorWithCode:@"exception"
                              message:self.domain
                              details:self.localizedDescription];
 }
@@ -120,8 +120,9 @@ static NSString *const kClientIdKey = @"CLIENT_ID";
     didSignInForUser:(GIDGoogleUser *)user
            withError:(NSError *)error {
   if (error != nil) {
-    if (error.code == -4) {
-      // Occurs when silent sign-in is not possible, return an empty user in this case
+    if (error.code == -4 || error.code == -5) {
+      // Occurs when silent sign-in is not possible or user has cancelled sign in,
+      // return an empty user in this case
       [self respondWithAccount:nil error:nil];
     } else {
       [self respondWithAccount:nil error:error];


### PR DESCRIPTION
Do not return error if user cancels signin on iOS.