### PR TITLE
Manually manage GoogleApiClient

### DIFF
--- a/packages/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.1
+
+* Plugin can (once again) be used in apps that extend `FlutterActivity`
+* `signInSilently` is guaranteed to never throw
+* A failed sign-in (caused by a failing `init` step) will no longer block subsequent sign-in attempts
+
 ## 0.2.0
 
 * Updated dependencies

--- a/packages/google_sign_in/android/build.gradle
+++ b/packages/google_sign_in/android/build.gradle
@@ -35,7 +35,6 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:25.4.0'
     compile 'com.google.android.gms:play-services-auth:11.0.1'
     compile 'com.google.guava:guava:20.0'
 }

--- a/packages/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
+++ b/packages/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
@@ -99,7 +99,6 @@ public class GoogleSignInPlugin
     final GoogleSignInPlugin instance =
         new GoogleSignInPlugin(activity, new BackgroundTaskRunner(1), REQUEST_CODE);
     registrar.addActivityResultListener(instance);
-    registrar.publish(instance);
     channel.setMethodCallHandler(instance);
   }
 
@@ -381,8 +380,8 @@ public class GoogleSignInPlugin
         resolvingError = true;
         result.startResolutionForResult(activity, REQUEST_CODE_RESOLVE_ERROR);
       } catch (SendIntentException e) {
-        // There was an error with the resolution intent. Try again.
-        googleApiClient.connect();
+        resolvingError = false;
+        finishWithError(ERROR_REASON_CONNECTION_FAILED, String.valueOf(result.getErrorCode()));
       }
     } else {
       resolvingError = true;
@@ -495,7 +494,7 @@ public class GoogleSignInPlugin
 
     @Override
     public void onActivitySaveInstanceState(Activity activity, Bundle outState) {
-      outState.putBoolean(STATE_RESOLVING_ERROR, GoogleSignInPlugin.this.resolvingError);
+      outState.putBoolean(STATE_RESOLVING_ERROR, resolvingError);
     }
 
     @Override

--- a/packages/google_sign_in/example/android/app/src/main/java/io/flutter/plugins/googlesigninexample/MainActivity.java
+++ b/packages/google_sign_in/example/android/app/src/main/java/io/flutter/plugins/googlesigninexample/MainActivity.java
@@ -5,10 +5,10 @@
 package io.flutter.plugins.googlesigninexample;
 
 import android.os.Bundle;
-import io.flutter.app.FlutterFragmentActivity;
+import io.flutter.app.FlutterActivity;
 import io.flutter.plugins.GeneratedPluginRegistrant;
 
-public class MainActivity extends FlutterFragmentActivity {
+public class MainActivity extends FlutterActivity {
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);

--- a/packages/google_sign_in/lib/google_sign_in.dart
+++ b/packages/google_sign_in/lib/google_sign_in.dart
@@ -130,19 +130,18 @@ class GoogleSignIn {
   Future<Null> _initialization;
 
   Future<GoogleSignInAccount> _callMethod(String method) async {
-    print('<<< $method');
     if (_initialization == null) {
       _initialization = channel.invokeMethod("init", <String, dynamic>{
         'scopes': scopes ?? <String>[],
         'hostedDomain': hostedDomain,
-      })..catchError((dynamic _) {
-        // Invalidate initialization if it errored out.
-        _initialization = null;
-      });
+      })
+        ..catchError((dynamic _) {
+          // Invalidate initialization if it errored out.
+          _initialization = null;
+        });
     }
     await _initialization;
     final Map<String, dynamic> response = await channel.invokeMethod(method);
-    print('>>> $response');
     return _setCurrentUser(response != null && response.isNotEmpty
         ? new GoogleSignInAccount._(this, response)
         : null);

--- a/packages/google_sign_in/lib/google_sign_in.dart
+++ b/packages/google_sign_in/lib/google_sign_in.dart
@@ -208,6 +208,7 @@ class GoogleSignIn {
   Future<GoogleSignInAccount> signInSilently() {
     return _addMethodCall('signInSilently').catchError((dynamic _) {
       // ignore, we promised to be silent.
+      // TODO(goderbauer): revisit when the native side throws less aggressively.
     });
   }
 

--- a/packages/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/pubspec.yaml
@@ -3,7 +3,7 @@ name: google_sign_in
 description: Google Sign-In plugin for Flutter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_sign_in
-version: 0.2.0
+version: 0.2.1
 
 flutter:
   plugin:

--- a/packages/google_sign_in/test/google_sign_in_test.dart
+++ b/packages/google_sign_in/test/google_sign_in_test.dart
@@ -247,7 +247,8 @@ void main() {
         }
         return responses[methodCall.method];
       });
-      expect(googleSignIn.signIn(), throwsA(const isInstanceOf<PlatformException>()));
+      expect(googleSignIn.signIn(),
+          throwsA(const isInstanceOf<PlatformException>()));
       expect(await googleSignIn.signIn(), isNotNull);
     });
   });

--- a/packages/google_sign_in/test/google_sign_in_test.dart
+++ b/packages/google_sign_in/test/google_sign_in_test.dart
@@ -8,7 +8,7 @@ import 'package:google_sign_in/google_sign_in.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('$GoogleSignIn', () {
+  group('GoogleSignIn', () {
     const MethodChannel channel = const MethodChannel(
       'plugins.flutter.io/google_sign_in',
     );
@@ -140,8 +140,7 @@ void main() {
 
     test('can sign in after previously failed attempt', () async {
       responses['signInSilently'] = <String, dynamic>{'error': 'Not a user'};
-      expect(googleSignIn.signInSilently(),
-          throwsA(const isInstanceOf<AssertionError>()));
+      expect(await googleSignIn.signInSilently(), isNull);
       expect(await googleSignIn.signIn(), isNotNull);
       expect(
           log,
@@ -227,6 +226,29 @@ void main() {
             const MethodCall('signIn'),
             const MethodCall('disconnect'),
           ]));
+    });
+
+    test('signInSilently does not throw on error', () async {
+      channel.setMockMethodCallHandler((MethodCall methodCall) {
+        throw "I am an error";
+      });
+      expect(await googleSignIn.signInSilently(), isNull); // should not throw
+    });
+
+    test('can sign in after init failed before', () async {
+      int initCount = 0;
+      channel.setMockMethodCallHandler((MethodCall methodCall) {
+        print(methodCall.method);
+        if (methodCall.method == 'init') {
+          initCount++;
+          if (initCount == 1) {
+            throw "First init fails";
+          }
+        }
+        return responses[methodCall.method];
+      });
+      expect(googleSignIn.signIn(), throwsA(const isInstanceOf<PlatformException>()));
+      expect(await googleSignIn.signIn(), isNotNull);
     });
   });
 }

--- a/packages/google_sign_in/test/google_sign_in_test.dart
+++ b/packages/google_sign_in/test/google_sign_in_test.dart
@@ -238,7 +238,6 @@ void main() {
     test('can sign in after init failed before', () async {
       int initCount = 0;
       channel.setMockMethodCallHandler((MethodCall methodCall) {
-        print(methodCall.method);
         if (methodCall.method == 'init') {
           initCount++;
           if (initCount == 1) {


### PR DESCRIPTION
This allows users to use the sign-in plugin in a regular `FlutterActivity` (instead of just a `FlutterFragmentActivity`)

Fixes https://github.com/flutter/flutter/issues/10688.
Fixes https://github.com/flutter/flutter/issues/10690.

In addition to that, this also includes tiny fixes for problems I discovered along the way:
* `signInSilently` will now never throw (after all, an exception is not really silent).
* If the `init` step fails, we'll now attempt to retry init when a new sign-in is triggered. (Previously, if init failed for any reason, you had to restart the app to try signing-in again).