### PR TITLE
Firebase Database fixes for startAt and endAt

### DIFF
--- a/packages/firebase_database/CHANGELOG.md
+++ b/packages/firebase_database/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.10
+
+* Added workaround for inconsistent numeric types when using keepSynced on iOS
+* Bug fixes to Query handling
+
 ## 0.0.9
 
 * Updated to Firebase SDK Version 11.0.1

--- a/packages/firebase_database/android/src/main/java/io/flutter/plugins/firebase/database/FirebaseDatabasePlugin.java
+++ b/packages/firebase_database/android/src/main/java/io/flutter/plugins/firebase/database/FirebaseDatabasePlugin.java
@@ -75,8 +75,6 @@ public class FirebaseDatabasePlugin implements MethodCallHandler {
           query = query.startAt((Boolean) startAt, startAtKey);
         } else if (startAt instanceof String) {
           query = query.startAt((String) startAt, startAtKey);
-        } else if (startAt instanceof Integer) {
-          query = query.startAt((int) startAt, startAtKey);
         } else {
           query = query.startAt(((Number) startAt).doubleValue(), startAtKey);
         }
@@ -85,8 +83,6 @@ public class FirebaseDatabasePlugin implements MethodCallHandler {
           query = query.startAt((Boolean) startAt);
         } else if (startAt instanceof String) {
           query = query.startAt((String) startAt);
-        } else if (startAt instanceof Integer) {
-          query = query.startAt((int) startAt);
         } else {
           query = query.startAt(((Number) startAt).doubleValue());
         }

--- a/packages/firebase_database/android/src/main/java/io/flutter/plugins/firebase/database/FirebaseDatabasePlugin.java
+++ b/packages/firebase_database/android/src/main/java/io/flutter/plugins/firebase/database/FirebaseDatabasePlugin.java
@@ -69,28 +69,52 @@ public class FirebaseDatabasePlugin implements MethodCallHandler {
     }
     if (parameters.containsKey("startAt")) {
       Object startAt = parameters.get("startAt");
-      String startAtKey = (String) parameters.get("startAtKey");
-      if (startAt instanceof Boolean) {
-        query = query.startAt((Boolean) startAt, startAtKey);
-      } else if (startAt instanceof String) {
-        query = query.startAt((String) startAt, startAtKey);
-      } else if (startAt instanceof Double) {
-        query = query.endAt((Double) startAt);
-      } else if (startAt instanceof Integer) {
-        query = query.startAt((int) startAt);
+      if (parameters.containsKey("startAtKey")) {
+        String startAtKey = (String) parameters.get("startAtKey");
+        if (startAt instanceof Boolean) {
+          query = query.startAt((Boolean) startAt, startAtKey);
+        } else if (startAt instanceof String) {
+          query = query.startAt((String) startAt, startAtKey);
+        } else if (startAt instanceof Integer) {
+          query = query.startAt((int) startAt, startAtKey);
+        } else {
+          query = query.startAt(((Number) startAt).doubleValue(), startAtKey);
+        }
+      } else {
+        if (startAt instanceof Boolean) {
+          query = query.startAt((Boolean) startAt);
+        } else if (startAt instanceof String) {
+          query = query.startAt((String) startAt);
+        } else if (startAt instanceof Integer) {
+          query = query.startAt((int) startAt);
+        } else {
+          query = query.startAt(((Number) startAt).doubleValue());
+        }
       }
     }
     if (parameters.containsKey("endAt")) {
       Object endAt = parameters.get("endAt");
-      String endAtKey = (String) parameters.get("endAtKey");
-      if (endAt instanceof Boolean) {
-        query = query.endAt((Boolean) endAt, endAtKey);
-      } else if (endAt instanceof String) {
-        query = query.endAt((String) endAt, endAtKey);
-      } else if (endAt instanceof Double) {
-        query = query.endAt((Double) endAt);
-      } else if (endAt instanceof Integer) {
-        query = query.endAt((int) endAt);
+      if (parameters.containsKey("endAtKey")) {
+        String endAtKey = (String) parameters.get("endAtKey");
+        if (endAt instanceof Boolean) {
+          query = query.endAt((Boolean) endAt, endAtKey);
+        } else if (endAt instanceof String) {
+          query = query.endAt((String) endAt, endAtKey);
+        } else if (endAt instanceof Integer) {
+          query = query.endAt((int) endAt, endAtKey);
+        } else {
+          query = query.endAt(((Number) endAt).doubleValue(), endAtKey);
+        }
+      } else {
+        if (endAt instanceof Boolean) {
+          query = query.endAt((Boolean) endAt);
+        } else if (endAt instanceof String) {
+          query = query.endAt((String) endAt);
+        } else if (endAt instanceof Integer) {
+          query = query.endAt((int) endAt);
+        } else {
+          query = query.endAt(((Number) endAt).doubleValue());
+        }
       }
     }
     if (parameters.containsKey("equalTo")) {
@@ -99,10 +123,10 @@ public class FirebaseDatabasePlugin implements MethodCallHandler {
         query = query.equalTo((Boolean) equalTo);
       } else if (equalTo instanceof String) {
         query = query.equalTo((String) equalTo);
-      } else if (equalTo instanceof Double) {
-        query = query.equalTo((Double) equalTo);
       } else if (equalTo instanceof Integer) {
         query = query.equalTo((int) equalTo);
+      } else {
+        query = query.equalTo(((Number) equalTo).doubleValue());
       }
     }
     if (parameters.containsKey("limitToFirst")) {

--- a/packages/firebase_database/android/src/main/java/io/flutter/plugins/firebase/database/FirebaseDatabasePlugin.java
+++ b/packages/firebase_database/android/src/main/java/io/flutter/plugins/firebase/database/FirebaseDatabasePlugin.java
@@ -96,8 +96,6 @@ public class FirebaseDatabasePlugin implements MethodCallHandler {
           query = query.endAt((Boolean) endAt, endAtKey);
         } else if (endAt instanceof String) {
           query = query.endAt((String) endAt, endAtKey);
-        } else if (endAt instanceof Integer) {
-          query = query.endAt((int) endAt, endAtKey);
         } else {
           query = query.endAt(((Number) endAt).doubleValue(), endAtKey);
         }
@@ -106,8 +104,6 @@ public class FirebaseDatabasePlugin implements MethodCallHandler {
           query = query.endAt((Boolean) endAt);
         } else if (endAt instanceof String) {
           query = query.endAt((String) endAt);
-        } else if (endAt instanceof Integer) {
-          query = query.endAt((int) endAt);
         } else {
           query = query.endAt(((Number) endAt).doubleValue());
         }
@@ -119,8 +115,6 @@ public class FirebaseDatabasePlugin implements MethodCallHandler {
         query = query.equalTo((Boolean) equalTo);
       } else if (equalTo instanceof String) {
         query = query.equalTo((String) equalTo);
-      } else if (equalTo instanceof Integer) {
-        query = query.equalTo((int) equalTo);
       } else {
         query = query.equalTo(((Number) equalTo).doubleValue());
       }

--- a/packages/firebase_database/example/android/build.gradle
+++ b/packages/firebase_database/example/android/build.gradle
@@ -1,6 +1,9 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 
     dependencies {

--- a/packages/firebase_database/ios/Classes/FirebaseDatabasePlugin.m
+++ b/packages/firebase_database/ios/Classes/FirebaseDatabasePlugin.m
@@ -51,7 +51,7 @@ FIRDatabaseQuery *getQuery(NSDictionary *arguments) {
   if (endAt) {
     id endAtKey = parameters[@"endAtKey"];
     if (endAtKey) {
-      query = [query queryEndingAtValue:endAt childKey:parameters[@"endAtKey"]];
+      query = [query queryEndingAtValue:endAt childKey:endAtKey];
     } else {
       query = [query queryEndingAtValue:endAt];
     }

--- a/packages/firebase_database/ios/Classes/FirebaseDatabasePlugin.m
+++ b/packages/firebase_database/ios/Classes/FirebaseDatabasePlugin.m
@@ -40,11 +40,21 @@ FIRDatabaseQuery *getQuery(NSDictionary *arguments) {
   }
   id startAt = parameters[@"startAt"];
   if (startAt) {
-    query = [query queryStartingAtValue:startAt childKey:parameters[@"startAtKey"]];
+    id startAtKey = parameters[@"startAtKey"];
+    if (startAtKey) {
+      query = [query queryStartingAtValue:startAt childKey:startAtKey];
+    } else {
+      query = [query queryStartingAtValue:startAt];
+    }
   }
   id endAt = parameters[@"endAt"];
   if (endAt) {
-    query = [query queryEndingAtValue:endAt childKey:parameters[@"endAtKey"]];
+    id endAtKey = parameters[@"endAtKey"];
+    if (endAtKey) {
+      query = [query queryEndingAtValue:endAt childKey:parameters[@"endAtKey"]];
+    } else {
+      query = [query queryEndingAtValue:endAt];
+    }
   }
   id equalTo = parameters[@"equalTo"];
   if (equalTo) {

--- a/packages/firebase_database/pubspec.yaml
+++ b/packages/firebase_database/pubspec.yaml
@@ -3,7 +3,7 @@ name: firebase_database
 description: Firebase Database plugin for Flutter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_database
-version: 0.0.9
+version: 0.0.10
 
 flutter:
   plugin:


### PR DESCRIPTION
This prevents exceptions when startAt/endAt is used without a key on iOS, and also allows values that don't fit in a Java int on Android.

Fixes flutter/flutter#10899
Fixes flutter/flutter#10900