### PR TITLE
Fix iOS queries when startAt or endAt does not specify key value

### DIFF
--- a/packages/firebase_database/CHANGELOG.md
+++ b/packages/firebase_database/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.11
+
+* Fixes startAt/endAt on iOS when used without a key
+
 ## 0.0.10
 
 * Added workaround for inconsistent numeric types when using keepSynced on iOS

--- a/packages/firebase_database/lib/src/query.dart
+++ b/packages/firebase_database/lib/src/query.dart
@@ -94,9 +94,9 @@ class Query {
   Query startAt(dynamic value, { String key }) {
     assert(!_parameters.containsKey('startAt'));
     assert(value is String || value is bool || value is double || value is int);
-    return _copyWithParameters(
-      <String, dynamic>{ 'startAt': value, 'startAtKey': key },
-    );
+    final Map<String, dynamic> parameters = <String, dynamic>{ 'startAt': value };
+    if (key != null) parameters['startAtKey'] = key;
+    return _copyWithParameters(parameters);
   }
 
   /// Create a query constrained to only return child nodes with a value less
@@ -106,9 +106,9 @@ class Query {
   Query endAt(dynamic value, { String key }) {
     assert(!_parameters.containsKey('endAt'));
     assert(value is String || value is bool || value is double || value is int);
-    return _copyWithParameters(
-      <String, dynamic>{ 'endAt': value, 'endAtKey': key },
-    );
+    final Map<String, dynamic> parameters = <String, dynamic>{ 'endAt': value };
+    if (key != null) parameters['endAtKey'] = key;
+    return _copyWithParameters(parameters);
   }
 
   /// Create a query constrained to only return child nodes with the given

--- a/packages/firebase_database/pubspec.yaml
+++ b/packages/firebase_database/pubspec.yaml
@@ -3,7 +3,7 @@ name: firebase_database
 description: Firebase Database plugin for Flutter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_database
-version: 0.0.10
+version: 0.0.11
 
 flutter:
   plugin:

--- a/packages/firebase_database/test/firebase_database_test.dart
+++ b/packages/firebase_database/test/firebase_database_test.dart
@@ -122,49 +122,63 @@ void main() {
         final int priority = 42;
         await database.reference().child('foo').setPriority(priority);
         expect(
-            log,
-            equals(<MethodCall>[
-              new MethodCall(
-                'DatabaseReference#setPriority',
-                <String, dynamic>{'path': 'foo', 'priority': priority},
-              ),
-            ]));
+          log,
+          equals(<MethodCall>[
+            new MethodCall(
+              'DatabaseReference#setPriority',
+              <String, dynamic>{'path': 'foo', 'priority': priority},
+            ),
+          ]),
+        );
       });
     });
 
     group('$Query', () {
       // TODO(jackson): Write more tests for queries
       test('observing', () async {
-        final Query query =
-            database.reference().child('foo').orderByChild('bar');
+        final int startAt = 42;
+        final String path = 'foo';
+        final String childKey = 'bar';
+        final bool endAt = true;
+        final String endAtKey = 'baz';
+        final Query query = database
+            .reference()
+            .child(path)
+            .orderByChild(childKey)
+            .startAt(startAt)
+            .endAt(endAt, key: endAtKey);
         final StreamSubscription<Event> subscription =
             query.onValue.listen((_) {});
         await query.keepSynced(true);
         subscription.cancel();
         final Map<String, dynamic> expectedParameters = <String, dynamic>{
           'orderBy': 'child',
-          'orderByChildKey': 'bar',
+          'orderByChildKey': childKey,
+          'startAt': startAt,
+          'endAt': endAt,
+          'endAtKey': endAtKey,
         };
         expect(
-            log,
-            equals(<MethodCall>[
-              new MethodCall(
-                'Query#observe',
-                <String, dynamic>{
-                  'path': 'foo',
-                  'parameters': expectedParameters,
-                  'eventType': '_EventType.value'
-                },
-              ),
-              new MethodCall(
-                'Query#keepSynced',
-                <String, dynamic>{
-                  'path': 'foo',
-                  'parameters': expectedParameters,
-                  'value': true
-                },
-              ),
-            ]));
+          log,
+          equals(<MethodCall>[
+            new MethodCall(
+              'Query#observe',
+              <String, dynamic>{
+                'path': path,
+                'parameters': expectedParameters,
+                'eventType': '_EventType.value'
+              },
+            ),
+            new MethodCall(
+              'Query#keepSynced',
+              <String, dynamic>{
+                'path': path,
+                'parameters': expectedParameters,
+                'value': true
+              },
+            ),
+          ]),
+        );
       });
     });
   });


### PR DESCRIPTION
This was occurring because `[NSNull null]` and `nil` are not the same on iOS, whereas on Android we can pass null to Firebase without an exception. I'd rather fix the Dart side where we can have a unit test for it, and avoid calling the key versions of methods unless a key string is specified.

Fixes flutter/flutter#10899