### PR TITLE
Updates to google_sign_in:

### DIFF
--- a/packages/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.3.0
+
+* Add a new `GoogleIdentity` interface, implemented by `GoogleSignInAccount`.
+* Move `GoogleUserCircleAvatar` to "widgets" library (exported by
+  base library for backwards compatibility) and make it take an instance
+  of `GoogleIdentity`, thus allowing it to be used by other packages that
+  provide implementations of `GoogleIdentity`.
+
 ## 0.2.1
 
 * Plugin can (once again) be used in apps that extend `FlutterActivity`

--- a/packages/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
+++ b/packages/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
@@ -129,11 +129,17 @@ public class GoogleSignInPlugin implements MethodCallHandler {
     private GoogleApiClient googleApiClient;
     private List<String> requestedScopes;
     private PendingOperation pendingOperation;
+    private volatile GoogleSignInAccount currentAccount;
 
     public Delegate(PluginRegistry.Registrar registrar) {
       activity = registrar.activity();
       activity.getApplication().registerActivityLifecycleCallbacks(handler);
       registrar.addActivityResultListener(handler);
+    }
+
+    /** Returns the most recently signed-in account, or null if there was none. */
+    public GoogleSignInAccount getCurrentAccount() {
+      return currentAccount;
     }
 
     private void checkAndSetPendingOperation(String method, Result result) {
@@ -303,6 +309,7 @@ public class GoogleSignInPlugin implements MethodCallHandler {
     private void onSignInResult(GoogleSignInResult result) {
       if (result.isSuccess()) {
         GoogleSignInAccount account = result.getSignInAccount();
+        currentAccount = account;
         Map<String, Object> response = new HashMap<>();
         response.put("displayName", account.getDisplayName());
         response.put("email", account.getEmail());

--- a/packages/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
+++ b/packages/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
@@ -311,13 +311,16 @@ public class GoogleSignInPlugin implements MethodCallHandler {
         GoogleSignInAccount account = result.getSignInAccount();
         currentAccount = account;
         Map<String, Object> response = new HashMap<>();
-        response.put("displayName", account.getDisplayName());
         response.put("email", account.getEmail());
         response.put("id", account.getId());
-        response.put("idToken", account.getIdToken());
-        Uri photoUrl = account.getPhotoUrl();
-        if (photoUrl != null) {
-          response.put("photoUrl", photoUrl.toString());
+        if (account.getIdToken() != null) {
+          response.put("idToken", account.getIdToken());
+        }
+        if (account.getDisplayName() != null) {
+          response.put("displayName", account.getDisplayName());
+        }
+        if (account.getPhotoUrl() != null) {
+          response.put("photoUrl", account.getPhotoUrl().toString());
         }
         finishWithSuccess(response);
       } else if (result.getStatus().getStatusCode() == CommonStatusCodes.SIGN_IN_REQUIRED

--- a/packages/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
+++ b/packages/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
@@ -10,7 +10,6 @@ import android.app.Application.ActivityLifecycleCallbacks;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentSender.SendIntentException;
-import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.util.Log;
@@ -313,12 +312,8 @@ public class GoogleSignInPlugin implements MethodCallHandler {
         Map<String, Object> response = new HashMap<>();
         response.put("email", account.getEmail());
         response.put("id", account.getId());
-        if (account.getIdToken() != null) {
-          response.put("idToken", account.getIdToken());
-        }
-        if (account.getDisplayName() != null) {
-          response.put("displayName", account.getDisplayName());
-        }
+        response.put("idToken", account.getIdToken());
+        response.put("displayName", account.getDisplayName());
         if (account.getPhotoUrl() != null) {
           response.put("photoUrl", account.getPhotoUrl().toString());
         }

--- a/packages/google_sign_in/example/lib/main.dart
+++ b/packages/google_sign_in/example/lib/main.dart
@@ -112,7 +112,9 @@ class SignInDemoState extends State<SignInDemo> {
         mainAxisAlignment: MainAxisAlignment.spaceAround,
         children: <Widget>[
           new ListTile(
-            leading: new GoogleUserCircleAvatar(_currentUser.photoUrl),
+            leading: new GoogleUserCircleAvatar(
+              identity: _currentUser,
+            ),
             title: new Text(_currentUser.displayName),
             subtitle: new Text(_currentUser.email),
           ),

--- a/packages/google_sign_in/lib/google_sign_in.dart
+++ b/packages/google_sign_in/lib/google_sign_in.dart
@@ -29,13 +29,6 @@ class GoogleSignInAuthentication {
 }
 
 class GoogleSignInAccount implements GoogleIdentity {
-  final String displayName;
-  final String email;
-  final String id;
-  final String photoUrl;
-  final String _idToken;
-  final GoogleSignIn _googleSignIn;
-
   GoogleSignInAccount._(this._googleSignIn, Map<String, dynamic> data)
       : displayName = data['displayName'],
         email = data['email'],
@@ -45,6 +38,21 @@ class GoogleSignInAccount implements GoogleIdentity {
     assert(displayName != null);
     assert(id != null);
   }
+
+  @override
+  final String displayName;
+
+  @override
+  final String email;
+
+  @override
+  final String id;
+
+  @override
+  final String photoUrl;
+
+  final String _idToken;
+  final GoogleSignIn _googleSignIn;
 
   Future<GoogleSignInAuthentication> get authentication async {
     if (_googleSignIn.currentUser != this) {

--- a/packages/google_sign_in/lib/google_sign_in.dart
+++ b/packages/google_sign_in/lib/google_sign_in.dart
@@ -6,8 +6,12 @@ import 'dart:async';
 import 'dart:ui' show hashValues;
 
 import 'package:flutter/services.dart' show MethodChannel;
-import 'package:flutter/material.dart';
 import 'package:meta/meta.dart' show visibleForTesting;
+
+import 'src/common.dart';
+
+export 'src/common.dart';
+export 'widgets.dart';
 
 class GoogleSignInAuthentication {
   final Map<String, String> _data;
@@ -24,7 +28,7 @@ class GoogleSignInAuthentication {
   String toString() => 'GoogleSignInAuthentication:$_data';
 }
 
-class GoogleSignInAccount {
+class GoogleSignInAccount implements GoogleIdentity {
   final String displayName;
   final String email;
   final String id;
@@ -230,55 +234,6 @@ class GoogleSignIn {
   /// Disconnects the current user from the app and revokes previous
   /// authentication.
   Future<GoogleSignInAccount> disconnect() => _addMethodCall('disconnect');
-}
-
-/// Builds a CircleAvatar profile image of the appropriate resolution
-class GoogleUserCircleAvatar extends StatelessWidget {
-  const GoogleUserCircleAvatar(this._primaryProfileImageUrl);
-  final String _primaryProfileImageUrl;
-
-  @override
-  Widget build(BuildContext context) {
-    return new CircleAvatar(
-      child: new LayoutBuilder(builder: _buildClippedImage),
-    );
-  }
-
-  /// Adds sizing information to the URL, inserted as the last
-  /// directory before the image filename. The format is "/sNN-c/",
-  /// where NN is the max width/height of the image, and "c" indicates we
-  /// want the image cropped.
-  String _sizedProfileImageUrl(double size) {
-    if (_primaryProfileImageUrl == null) {
-      return null;
-    }
-    final Uri profileUri = Uri.parse(_primaryProfileImageUrl);
-    final List<String> pathSegments =
-        new List<String>.from(profileUri.pathSegments);
-    pathSegments.remove("s1337"); // placeholder value added by iOS plugin
-    return new Uri(
-      scheme: profileUri.scheme,
-      host: profileUri.host,
-      pathSegments: pathSegments,
-      query: "sz=${size.round()}",
-    )
-        .toString();
-  }
-
-  Widget _buildClippedImage(BuildContext context, BoxConstraints constraints) {
-    assert(constraints.maxWidth == constraints.maxHeight);
-    final String url = _sizedProfileImageUrl(
-      MediaQuery.of(context).devicePixelRatio * constraints.maxWidth,
-    );
-    if (url == null) {
-      return new Container();
-    }
-    return new ClipOval(
-      child: new Image(
-        image: new NetworkImage(url),
-      ),
-    );
-  }
 }
 
 class _MethodCompleter {

--- a/packages/google_sign_in/lib/src/common.dart
+++ b/packages/google_sign_in/lib/src/common.dart
@@ -11,6 +11,7 @@ abstract class GoogleIdentity {
   /// _Important_: Do not use this returned Google ID to communicate the
   /// currently signed in user to your backend server. Instead, send an ID token
   /// which can be securely validated on the server.
+  /// `GoogleSignInAccount.authentication.idToken` provides such an ID token.
   String get id;
 
   /// The email address of the signed in user.
@@ -21,6 +22,7 @@ abstract class GoogleIdentity {
   /// _Important_: Do not use this returned email address to communicate the
   /// currently signed in user to your backend server. Instead, send an ID token
   /// which can be securely validated on the server.
+  /// `GoogleSignInAccount.authentication.idToken` provides such an ID token.
   String get email;
 
   /// The display name of the signed in user.

--- a/packages/google_sign_in/lib/src/common.dart
+++ b/packages/google_sign_in/lib/src/common.dart
@@ -1,0 +1,35 @@
+// Copyright 2017, the Flutter project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Encapsulation of the fields that represent a Google user's identity.
+abstract class GoogleIdentity {
+  /// The unique ID for the Google account.
+  ///
+  /// This is the preferred unique key to use for a user record.
+  ///
+  /// _Important_: Do not use this returned Google ID to communicate the
+  /// currently signed in user to your backend server. Instead, send an ID token
+  /// which can be securely validated on the server.
+  String get id;
+
+  /// The email address of the signed in user.
+  ///
+  /// Applications should not key users by email address since a Google
+  /// account's email address can change. Use [id] as a key instead.
+  ///
+  /// _Important_: Do not use this returned email address to communicate the
+  /// currently signed in user to your backend server. Instead, send an ID token
+  /// which can be securely validated on the server.
+  String get email;
+
+  /// The display name of the signed in user.
+  ///
+  /// Not guaranteed to be present for all users, even when configured.
+  String get displayName;
+
+  /// The photo url of the signed in user if the user has a profile picture.
+  ///
+  /// Not guaranteed to be present for all users, even when configured.
+  String get photoUrl;
+}

--- a/packages/google_sign_in/lib/widgets.dart
+++ b/packages/google_sign_in/lib/widgets.dart
@@ -22,6 +22,7 @@ class GoogleUserCircleAvatar extends StatelessWidget {
   const GoogleUserCircleAvatar({
     @required this.identity,
     this.placeholderPhotoUrl,
+    this.backgroundColor,
   }) : assert(identity != null);
 
   /// A regular expression that matches against the "size directive" path
@@ -31,12 +32,28 @@ class GoogleUserCircleAvatar extends StatelessWidget {
   /// image, and "`c`" indicates we want the image cropped.
   static final RegExp sizeDirective = new RegExp(r'^s[0-9]{1,5}(-c)?$');
 
+  /// The Google user's identity; guaranteed to be non-null.
   final GoogleIdentity identity;
+
+  /// The color with which to fill the circle. Changing the background color
+  /// will cause the avatar to animate to the new color.
+  ///
+  /// If a background color is not specified, the theme's primary color is used.
+  final Color backgroundColor;
+
+  /// The URL of a photo to use if the user's [identity] does not specify a
+  /// `photoUrl`.
+  ///
+  /// If this is `null` and the user's [identity] does not contain a photo URL,
+  /// then this widget will attempt to display the user's first initial as
+  /// determined from the identity's [displayName] field. If that is `null` a
+  /// default (generic) Google profile photo will be displayed.
   final String placeholderPhotoUrl;
 
   @override
   Widget build(BuildContext context) {
     return new CircleAvatar(
+      backgroundColor: backgroundColor,
       child: new LayoutBuilder(builder: _buildClippedImage),
     );
   }
@@ -65,7 +82,7 @@ class GoogleUserCircleAvatar extends StatelessWidget {
     String photoUrl = identity.photoUrl ?? placeholderPhotoUrl;
     if (photoUrl == null && identity.displayName != null) {
       // Display the user's initials rather than a profile photo.
-      return new Text(identity.displayName.substring(0, 1));
+      return new Text(identity.displayName[0]);
     }
 
     // Add a sizing directive to the profile photo URL if we have one.

--- a/packages/google_sign_in/lib/widgets.dart
+++ b/packages/google_sign_in/lib/widgets.dart
@@ -1,0 +1,59 @@
+// Copyright 2017, the Flutter project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+import 'src/common.dart';
+
+/// Builds a CircleAvatar profile image of the appropriate resolution
+class GoogleUserCircleAvatar extends StatelessWidget {
+  /// Creates a new widget based on the specified identity.
+  const GoogleUserCircleAvatar(this._identity) : assert(_identity != null);
+  final GoogleIdentity _identity;
+
+  @override
+  Widget build(BuildContext context) {
+    return new CircleAvatar(
+      child: new LayoutBuilder(builder: _buildClippedImage),
+    );
+  }
+
+  /// Adds sizing information to the URL, inserted as the last path segment
+  /// before the image filename. The format is "`/sNN-c/`", where `NN` is the
+  /// max width/height of the image, and "`c`" indicates we want the image
+  /// cropped.
+  String _sizedProfileImageUrl(double size) {
+    assert(_identity.photoUrl != null);
+    final Uri profileUri = Uri.parse(_identity.photoUrl);
+    final List<String> pathSegments =
+        new List<String>.from(profileUri.pathSegments);
+    pathSegments.remove("s1337"); // placeholder value added by iOS plugin
+    pathSegments.insert(pathSegments.length - 1, "s${size.round()}-c");
+    return new Uri(
+      scheme: profileUri.scheme,
+      host: profileUri.host,
+      pathSegments: pathSegments,
+    )
+        .toString();
+  }
+
+  Widget _buildClippedImage(BuildContext context, BoxConstraints constraints) {
+    assert(constraints.maxWidth == constraints.maxHeight);
+    if (_identity.photoUrl == null) {
+      // TODO(tvolkert): render a placeholder avatar. Typically, this is the
+      //                 first letter in the user's display name.
+      return new Container();
+    } else {
+      return new ClipOval(
+        child: new Image(
+          image: new NetworkImage(
+            _sizedProfileImageUrl(
+              MediaQuery.of(context).devicePixelRatio * constraints.maxWidth,
+            ),
+          ),
+        ),
+      );
+    }
+  }
+}

--- a/packages/google_sign_in/lib/widgets.dart
+++ b/packages/google_sign_in/lib/widgets.dart
@@ -80,9 +80,11 @@ class GoogleUserCircleAvatar extends StatelessWidget {
     assert(constraints.maxWidth == constraints.maxHeight);
 
     String photoUrl = identity.photoUrl ?? placeholderPhotoUrl;
-    if (photoUrl == null && identity.displayName != null) {
+    if (photoUrl == null &&
+        identity.displayName != null &&
+        identity.displayName.startsWith(new RegExp(r'[A-Z][a-z]'))) {
       // Display the user's initials rather than a profile photo.
-      return new Text(identity.displayName[0]);
+      return new Text(identity.displayName[0].toUpperCase());
     }
 
     // Add a sizing directive to the profile photo URL if we have one.

--- a/packages/google_sign_in/lib/widgets.dart
+++ b/packages/google_sign_in/lib/widgets.dart
@@ -39,7 +39,7 @@ class GoogleUserCircleAvatar extends StatelessWidget {
   /// Adds sizing information to the URL, inserted as the last path segment
   /// before the image filename. The format is described in [sizeDirective].
   String _sizedProfileImageUrl(double size) {
-    String photoUrl = identity.photoUrl ?? placeholderPhotoUrl;
+    final String photoUrl = identity.photoUrl ?? placeholderPhotoUrl;
     assert(photoUrl != null);
     final Uri profileUri = Uri.parse(photoUrl);
     final List<String> pathSegments =

--- a/packages/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/pubspec.yaml
@@ -3,7 +3,7 @@ name: google_sign_in
 description: Google Sign-In plugin for Flutter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_sign_in
-version: 0.2.1
+version: 0.3.0
 
 flutter:
   plugin:


### PR DESCRIPTION
* Add a new `GoogleIdentity` interface, implemented by `GoogleSignInAccount`
* Move GoogleUserCircleAvatar to "widgets" library (exported by
  base library for backwards compatibility) and make it take an instance
  of `GoogleIdentity`, thus allowing it to be used by other packages that
  provide implementations of `GoogleIdentity`