### PR TITLE
Fix iOS signin code to make it consistent with Android side

### DIFF
--- a/packages/google_sign_in/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/google_sign_in/example/ios/Runner.xcodeproj/project.pbxproj
@@ -297,7 +297,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/packages/google_sign_in/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/google_sign_in/example/ios/Runner.xcodeproj/project.pbxproj
@@ -297,7 +297,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
+++ b/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
@@ -16,7 +16,7 @@ static NSString *const kClientIdKey = @"CLIENT_ID";
 
 @implementation NSError (FlutterError)
 - (FlutterError *)flutterError {
-  return [FlutterError errorWithCode:[NSString stringWithFormat:@"%ld", (long)self.code]
+  return [FlutterError errorWithCode:@"exception"
                              message:self.domain
                              details:self.localizedDescription];
 }
@@ -120,8 +120,10 @@ static NSString *const kClientIdKey = @"CLIENT_ID";
     didSignInForUser:(GIDGoogleUser *)user
            withError:(NSError *)error {
   if (error != nil) {
-    if (error.code == -4) {
-      // Occurs when silent sign-in is not possible, return an empty user in this case
+    if (error.code == kGIDSignInErrorCodeHasNoAuthInKeychain ||
+        error.code == kGIDSignInErrorCodeCanceled) {
+      // Occurs when silent sign-in is not possible or user has cancelled sign in,
+      // return an empty user in this case
       [self respondWithAccount:nil error:nil];
     } else {
       [self respondWithAccount:nil error:error];


### PR DESCRIPTION
- iOS should not return exception code. Android returns "exception" as code.
- Return null success when user cancels signin