### PR TITLE
GoogleSignIn Plugin fixes

### DIFF
--- a/packages/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
+++ b/packages/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
@@ -231,7 +231,6 @@ public class GoogleSignInPlugin implements MethodCallHandler {
      * user with the specified email address.
      */
     public void getTokens(Result result, final String email) {
-      checkAndSetPendingOperation(METHOD_GET_TOKENS, result);
       if (email == null) {
         result.error(ERROR_REASON_EXCEPTION, "Email is null", null);
         return;

--- a/packages/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
+++ b/packages/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
@@ -231,6 +231,8 @@ public class GoogleSignInPlugin implements MethodCallHandler {
      * user with the specified email address.
      */
     public void getTokens(final Result result, final String email) {
+      // TODO(issue/11107): Add back the checkAndSetPendingOperation once getTokens is properly
+      // gated from Dart code. Change result.success/error calls below to use finishWith()
       if (email == null) {
         result.error(ERROR_REASON_EXCEPTION, "Email is null", null);
         return;

--- a/packages/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
+++ b/packages/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
@@ -230,7 +230,7 @@ public class GoogleSignInPlugin implements MethodCallHandler {
      * Gets an OAuth access token with the scopes that were specified during initialization for the
      * user with the specified email address.
      */
-    public void getTokens(Result result, final String email) {
+    public void getTokens(final Result result, final String email) {
       if (email == null) {
         result.error(ERROR_REASON_EXCEPTION, "Email is null", null);
         return;
@@ -253,18 +253,18 @@ public class GoogleSignInPlugin implements MethodCallHandler {
             public void run(Future<String> tokenFuture) {
               try {
                 String token = tokenFuture.get();
-                HashMap<String, String> result = new HashMap<>();
-                result.put("accessToken", token);
+                HashMap<String, String> tokenResult = new HashMap<>();
+                tokenResult.put("accessToken", token);
                 // TODO(jackson): If we had a way to get the current user at this
                 // point, we could use that to obtain an up-to-date idToken here
                 // instead of the value we cached during sign in. At least, that's
                 // how it works on iOS.
-                finishWithSuccess(result);
+                result.success(tokenResult);
               } catch (ExecutionException e) {
                 Log.e(TAG, "Exception getting access token", e);
-                finishWithError(ERROR_REASON_EXCEPTION, e.getCause().getMessage());
+                result.error(ERROR_REASON_EXCEPTION, e.getCause().getMessage(), null);
               } catch (InterruptedException e) {
-                finishWithError(ERROR_REASON_EXCEPTION, e.getMessage());
+                result.error(ERROR_REASON_EXCEPTION, e.getMessage(), null);
                 Thread.currentThread().interrupt();
               }
             }

--- a/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
+++ b/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
@@ -68,11 +68,13 @@ static NSString *const kClientIdKey = @"CLIENT_ID";
                                  details:nil]);
     }
   } else if ([call.method isEqualToString:@"signInSilently"]) {
-    [self setAccountRequest:result];
-    [[GIDSignIn sharedInstance] signInSilently];
+    if ([self setAccountRequest:result]) {
+      [[GIDSignIn sharedInstance] signInSilently];
+    }
   } else if ([call.method isEqualToString:@"signIn"]) {
-    [self setAccountRequest:result];
-    [[GIDSignIn sharedInstance] signIn];
+    if ([self setAccountRequest:result]) {
+      [[GIDSignIn sharedInstance] signIn];
+    }
   } else if ([call.method isEqualToString:@"getTokens"]) {
     GIDGoogleUser *currentUser = [GIDSignIn sharedInstance].currentUser;
     GIDAuthentication *auth = currentUser.authentication;
@@ -86,20 +88,23 @@ static NSString *const kClientIdKey = @"CLIENT_ID";
     [[GIDSignIn sharedInstance] signOut];
     result(nil);
   } else if ([call.method isEqualToString:@"disconnect"]) {
-    [self setAccountRequest:result];
-    [[GIDSignIn sharedInstance] disconnect];
+    if ([self setAccountRequest:result]) {
+      [[GIDSignIn sharedInstance] disconnect];
+    }
   } else {
     result(FlutterMethodNotImplemented);
   }
 }
 
-- (void)setAccountRequest:(FlutterResult)request {
+- (BOOL)setAccountRequest:(FlutterResult)request {
   if (_accountRequest != nil) {
     request([FlutterError errorWithCode:@"concurrent-requests"
                                 message:@"Concurrent requests to account signin"
                                 details:nil]);
+    return NO;
   }
   _accountRequest = request;
+  return YES;
 }
 
 - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary *)options {

--- a/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
+++ b/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
@@ -26,7 +26,7 @@ static NSString *const kClientIdKey = @"CLIENT_ID";
 @end
 
 @implementation GoogleSignInPlugin {
-  NSMutableArray<FlutterResult> *_accountRequests;
+  FlutterResult _accountRequest;
 }
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
@@ -41,7 +41,6 @@ static NSString *const kClientIdKey = @"CLIENT_ID";
 - (instancetype)init {
   self = [super init];
   if (self) {
-    _accountRequests = [[NSMutableArray alloc] init];
     [GIDSignIn sharedInstance].delegate = self;
     [GIDSignIn sharedInstance].uiDelegate = self;
 
@@ -69,10 +68,10 @@ static NSString *const kClientIdKey = @"CLIENT_ID";
                                  details:nil]);
     }
   } else if ([call.method isEqualToString:@"signInSilently"]) {
-    [_accountRequests insertObject:result atIndex:0];
+    [self setAccountRequest:result];
     [[GIDSignIn sharedInstance] signInSilently];
   } else if ([call.method isEqualToString:@"signIn"]) {
-    [_accountRequests insertObject:result atIndex:0];
+    [self setAccountRequest:result];
     [[GIDSignIn sharedInstance] signIn];
   } else if ([call.method isEqualToString:@"getTokens"]) {
     GIDGoogleUser *currentUser = [GIDSignIn sharedInstance].currentUser;
@@ -87,11 +86,20 @@ static NSString *const kClientIdKey = @"CLIENT_ID";
     [[GIDSignIn sharedInstance] signOut];
     result(nil);
   } else if ([call.method isEqualToString:@"disconnect"]) {
-    [_accountRequests insertObject:result atIndex:0];
+    [self setAccountRequest:result];
     [[GIDSignIn sharedInstance] disconnect];
   } else {
     result(FlutterMethodNotImplemented);
   }
+}
+
+- (void)setAccountRequest:(FlutterResult)request {
+  if (_accountRequest != nil) {
+    request([FlutterError errorWithCode:@"concurrent-requests"
+                                message:@"Concurrent requests to account signin"
+                                details:nil]);
+  }
+  _accountRequest = request;
 }
 
 - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary *)options {
@@ -153,11 +161,9 @@ static NSString *const kClientIdKey = @"CLIENT_ID";
 #pragma mark - private methods
 
 - (void)respondWithAccount:(id)account error:(NSError *)error {
-  NSArray<FlutterResult> *requests = _accountRequests;
-  _accountRequests = [[NSMutableArray alloc] init];
-  for (FlutterResult accountRequest in requests) {
-    accountRequest(error != nil ? error.flutterError : account);
-  }
+  FlutterResult result = _accountRequest;
+  _accountRequest = nil;
+  result(error != nil ? error.flutterError : account);
 }
 
 @end


### PR DESCRIPTION
- Do not check serial execution for getTokens(). I looked into whether we should be caching tokens and it seems both iOS and Android do this caching already. The tokens have a lifetime of 1-hr by default. Calling getTokens(), even concurrently, should not be a problem.

- Assert serial execution of signIn/signOut methods on iOS just like we are doing on Android.