### PR TITLE
use + for patch version for firebase libraries

### DIFF
--- a/packages/firebase_analytics/CHANGELOG.md
+++ b/packages/firebase_analytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.4
+
+* Updated to Firebase SDK to always use latest patch version for 11.0.x builds
+
 ## 0.0.3
 
 * Updated to Firebase SDK Version 11.0.1

--- a/packages/firebase_analytics/android/build.gradle
+++ b/packages/firebase_analytics/android/build.gradle
@@ -30,7 +30,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        compile 'com.google.firebase:firebase-auth:11.0.1'
-        compile 'com.google.firebase:firebase-analytics:11.0.1'
+        compile 'com.google.firebase:firebase-auth:11.0.+'
+        compile 'com.google.firebase:firebase-analytics:11.0.+'
     }
 }

--- a/packages/firebase_analytics/example/android/app/build.gradle
+++ b/packages/firebase_analytics/example/android/app/build.gradle
@@ -41,7 +41,7 @@ flutter {
 }
 
 dependencies {
-    compile 'com.google.firebase:firebase-core:11.0.1'
+    compile 'com.google.firebase:firebase-core:11.0.+'
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/packages/firebase_analytics/pubspec.yaml
+++ b/packages/firebase_analytics/pubspec.yaml
@@ -3,7 +3,7 @@ name: firebase_analytics
 description: Firebase Analytics plugin for Flutter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_analytics
-version: 0.0.3
+version: 0.0.4
 
 flutter:
   plugin:

--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.1
+
+* Updated to Firebase SDK to always use latest patch version for 11.0.x builds
+
+
 ## 0.1.0
 
 * Updated to Firebase SDK Version 11.0.1

--- a/packages/firebase_auth/android/build.gradle
+++ b/packages/firebase_auth/android/build.gradle
@@ -34,7 +34,7 @@ android {
     }
     dependencies {
         compile 'com.google.guava:guava:20.0'
-        compile 'com.google.firebase:firebase-core:11.0.1'
-        compile 'com.google.firebase:firebase-auth:11.0.1'
+        compile 'com.google.firebase:firebase-core:11.0.+'
+        compile 'com.google.firebase:firebase-auth:11.0.+'
     }
 }

--- a/packages/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/pubspec.yaml
@@ -3,7 +3,7 @@ name: firebase_auth
 description: Firebase Auth plugin for Flutter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_auth
-version: 0.1.0
+version: 0.1.1
 
 flutter:
   plugin:

--- a/packages/firebase_database/CHANGELOG.md
+++ b/packages/firebase_database/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.12
+
+* Updated to Firebase SDK to always use latest patch version for 11.0.x builds
+
+
 ## 0.0.11
 
 * Fixes startAt/endAt on iOS when used without a key

--- a/packages/firebase_database/android/build.gradle
+++ b/packages/firebase_database/android/build.gradle
@@ -30,8 +30,8 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        compile 'com.google.firebase:firebase-core:11.0.1'
-        compile 'com.google.firebase:firebase-auth:11.0.1'
-        compile 'com.google.firebase:firebase-database:11.0.1'
+        compile 'com.google.firebase:firebase-core:11.0.+'
+        compile 'com.google.firebase:firebase-auth:11.0.+'
+        compile 'com.google.firebase:firebase-database:11.0.+'
     }
 }

--- a/packages/firebase_database/pubspec.yaml
+++ b/packages/firebase_database/pubspec.yaml
@@ -3,7 +3,7 @@ name: firebase_database
 description: Firebase Database plugin for Flutter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_database
-version: 0.0.11
+version: 0.0.12
 
 flutter:
   plugin:

--- a/packages/firebase_messaging/CHANGELOG.md
+++ b/packages/firebase_messaging/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.5
+
+* Updated to Firebase SDK to always use latest patch version for 11.0.x builds
+
 ## 0.0.4
 
 * Updated to Firebase SDK Version 11.0.1

--- a/packages/firebase_messaging/android/build.gradle
+++ b/packages/firebase_messaging/android/build.gradle
@@ -30,7 +30,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        compile 'com.google.firebase:firebase-core:11.0.1'
-        compile 'com.google.firebase:firebase-messaging:11.0.1'
+        compile 'com.google.firebase:firebase-core:11.0.+'
+        compile 'com.google.firebase:firebase-messaging:11.0.+'
     }
 }

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -3,7 +3,7 @@ name: firebase_messaging
 description: Firebase Cloud Messaging plugin for Flutter applications.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_messaging
-version: 0.0.4
+version: 0.0.5
 
 flutter:
   plugin:

--- a/packages/firebase_storage/CHANGELOG.md
+++ b/packages/firebase_storage/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.5
+
+* Updated to Firebase SDK to always use latest patch version for 11.0.x builds
+
 ## 0.0.4
 
 * Updated to Firebase SDK Version 11.0.1

--- a/packages/firebase_storage/android/build.gradle
+++ b/packages/firebase_storage/android/build.gradle
@@ -36,7 +36,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        compile 'com.google.firebase:firebase-core:11.0.1'
-        compile 'com.google.firebase:firebase-storage:11.0.1'
+        compile 'com.google.firebase:firebase-core:11.0.+'
+        compile 'com.google.firebase:firebase-storage:11.0.+'
     }
 }

--- a/packages/firebase_storage/pubspec.yaml
+++ b/packages/firebase_storage/pubspec.yaml
@@ -3,7 +3,7 @@ name: firebase_storage
 description: Firebase Storage plugin for Flutter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_storage
-version: 0.0.4
+version: 0.0.5
 
 flutter:
   plugin:

--- a/packages/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1
+
+* Updated to Firebase SDK to always use latest patch version for 11.0.x builds
+
 ## 0.3.0
 
 * Add a new `GoogleIdentity` interface, implemented by `GoogleSignInAccount`.

--- a/packages/google_sign_in/android/build.gradle
+++ b/packages/google_sign_in/android/build.gradle
@@ -35,6 +35,6 @@ android {
 }
 
 dependencies {
-    compile 'com.google.android.gms:play-services-auth:11.0.1'
+    compile 'com.google.android.gms:play-services-auth:11.0.+'
     compile 'com.google.guava:guava:20.0'
 }

--- a/packages/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/pubspec.yaml
@@ -3,7 +3,7 @@ name: google_sign_in
 description: Google Sign-In plugin for Flutter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_sign_in
-version: 0.3.0
+version: 0.3.1
 
 flutter:
   plugin:


### PR DESCRIPTION
Updates firebase plugin versions to `11.0.+` and bumps all plugin versions where affected

cc @collinjackson 