### PR TITLE
Clarify changelog for google_sign_in

### DIFF
--- a/packages/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.3.1
 
-* Updated to Firebase SDK to always use latest patch version for 11.0.x builds
+* Updated GMS to always use latest patch version for 11.0.x builds
 
 ## 0.3.0
 


### PR DESCRIPTION
Replace Firebase with GMS

I haven't published 0.3.1 yet.