### PR TITLE
Fix FirebaseSortedList onChange handling

### DIFF
--- a/packages/firebase_database/CHANGELOG.md
+++ b/packages/firebase_database/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.14
+
+* Fix FirebaseSortedList to show data changes.
+
 ## 0.0.13
 
 * Fixed lingering value/child listeners.

--- a/packages/firebase_database/CHANGELOG.md
+++ b/packages/firebase_database/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.13
+
+* Fix FirebaseSortedList to show data changes.
+
 ## 0.0.12
 
 * Updated to Firebase SDK to always use latest patch version for 11.0.x builds

--- a/packages/firebase_database/lib/ui/firebase_sorted_list.dart
+++ b/packages/firebase_database/lib/ui/firebase_sorted_list.dart
@@ -94,7 +94,7 @@ class FirebaseSortedList extends ListBase<DataSnapshot>
       return snapshot.key == event.snapshot.key;
     });
     final int index = _snapshots.indexOf(snapshot);
-    this[index] = event.snapshot;
+    _snapshots[index] = event.snapshot;
     onChildChanged(index, event.snapshot);
   }
 

--- a/packages/firebase_database/pubspec.yaml
+++ b/packages/firebase_database/pubspec.yaml
@@ -3,7 +3,7 @@ name: firebase_database
 description: Firebase Database plugin for Flutter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_database
-version: 0.0.12
+version: 0.0.13
 
 flutter:
   plugin:

--- a/packages/firebase_database/pubspec.yaml
+++ b/packages/firebase_database/pubspec.yaml
@@ -3,7 +3,7 @@ name: firebase_database
 description: Firebase Database plugin for Flutter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_database
-version: 0.0.13
+version: 0.0.14
 
 flutter:
   plugin:


### PR DESCRIPTION
_snapshots was not being updated when a change was made.
This resulted in list items displaying stale values. This
change matches what is used in FirebaseList which does
correctly handle onChange.