### PR TITLE
Fixed code example to use 'FirebaseAnalyticsObserver'

### DIFF
--- a/packages/firebase_analytics/README.md
+++ b/packages/firebase_analytics/README.md
@@ -23,7 +23,7 @@ FirebaseAnalytics analytics = new FirebaseAnalytics();
 MaterialApp(
   home: new MyAppHome(),
   navigatorObservers: [
-    new FirebaseAnalyticsPageRouteObserver(analytics: analytics),
+    new FirebaseAnalyticsObserver(analytics: analytics),
   ],
 );
 ```


### PR DESCRIPTION
... instead of 'FirebaseAnalyticsPageRouteObserver'