### PR TITLE
Add transaction support.

### DIFF
--- a/packages/firebase_database/CHANGELOG.md
+++ b/packages/firebase_database/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1
+
+* Add RTDB transaction support.
+
 ## 0.1.0+1
 
 * Aligned author name with rest of repo.

--- a/packages/firebase_database/android/src/main/java/io/flutter/plugins/firebase/database/FirebaseDatabasePlugin.java
+++ b/packages/firebase_database/android/src/main/java/io/flutter/plugins/firebase/database/FirebaseDatabasePlugin.java
@@ -321,9 +321,9 @@ public class FirebaseDatabasePlugin implements MethodCallHandler {
                   // Tasks are used to allow native execution of doTransaction to wait while Snapshot is
                   // processed by logic on the dart side.
                   final TaskCompletionSource<Map<String, Object>> updateMutableDataTCS =
-                          new TaskCompletionSource<>();
-                  final Task<Map<String, Object>> updateMutableDataTCSTask = updateMutableDataTCS.getTask();
-
+                      new TaskCompletionSource<>();
+                  final Task<Map<String, Object>> updateMutableDataTCSTask =
+                      updateMutableDataTCS.getTask();
 
                   // Add transaction task to array for later retrieval.
                   transactionTasks.append(getTransactionKey(arguments), updateMutableDataTCS);
@@ -341,8 +341,11 @@ public class FirebaseDatabasePlugin implements MethodCallHandler {
 
                   try {
                     // Wait for updated snapshot from the dart side.
-                    Map<String, Object> updatedSnapshotMap = Tasks.await(updateMutableDataTCSTask,
-                            getTransactionTimeout(arguments), TimeUnit.NANOSECONDS);
+                    Map<String, Object> updatedSnapshotMap =
+                        Tasks.await(
+                            updateMutableDataTCSTask,
+                            getTransactionTimeout(arguments),
+                            TimeUnit.NANOSECONDS);
                     // Set value of MutableData to value returned from the dart side.
                     mutableData.setValue(updatedSnapshotMap.get("updatedDataSnapshot"));
                   } catch (ExecutionException | InterruptedException | TimeoutException e) {

--- a/packages/firebase_database/example/lib/main.dart
+++ b/packages/firebase_database/example/lib/main.dart
@@ -78,6 +78,10 @@ class _MyHomePageState extends State<MyHomePage> {
         .set(<String, String>{_kTestKey: '$_kTestValue $_counter'});
   }
 
+  void _updateInTransaction() {
+    _messagesRef.runTransaction(new DemoTransactionHandler());
+  }
+
   @override
   Widget build(BuildContext context) {
     return new Scaffold(
@@ -94,6 +98,12 @@ class _MyHomePageState extends State<MyHomePage> {
                     'This includes all devices, ever.',
               ),
             ),
+          ),
+          new RaisedButton(
+            child: const Text('UPDATE IN TRANSACTION'),
+            onPressed: () {
+              _updateInTransaction();
+            },
           ),
           new ListTile(
             leading: new Checkbox(
@@ -131,5 +141,36 @@ class _MyHomePageState extends State<MyHomePage> {
         child: new Icon(Icons.add),
       ),
     );
+  }
+}
+
+class DemoTransactionHandler extends TransactionHandler {
+  @override
+  Future<DataSnapshot> doTransaction(DataSnapshot dataSnapshot) {
+    if (dataSnapshot != null && dataSnapshot.value != null) {
+      // Update snapshot here.
+      print('snapshot received by doTransaction: ${dataSnapshot.value}');
+      final Map<String, dynamic> snapshots = dataSnapshot.value;
+      snapshots.forEach((String key, Map<String, String> value) {
+        if (value['Hello'].endsWith(' updated')) {
+          value['Hello'] = value['Hello'].replaceAll(' updated', '');
+        } else {
+          value['Hello'] = value['Hello'] + ' updated';
+        }
+      });
+      print('snapshot after doTransaction: ${dataSnapshot.value}');
+    }
+    return new Future<DataSnapshot>(() => dataSnapshot);
+  }
+
+  @override
+  void onComplete(
+      DatabaseError error, bool committed, DataSnapshot dataSnapshot) {
+    // Implement onComplete
+    print('transaction complete:');
+    print('error : $error');
+    print('committed: $committed');
+    print('snapshot value: ${dataSnapshot.key}');
+    print('snapshot value: ${dataSnapshot.value}');
   }
 }

--- a/packages/firebase_database/example/lib/main.dart
+++ b/packages/firebase_database/example/lib/main.dart
@@ -68,13 +68,13 @@ class _MyHomePageState extends State<MyHomePage> {
   Future<Null> _increment() async {
     await FirebaseAuth.instance.signInAnonymously();
     // Increment counter in transaction.
-    await _counterRef.runTransaction(new TransactionHandler((DataSnapshot dataSnapshot) {
+    await _counterRef
+        .runTransaction(new TransactionHandler((DataSnapshot dataSnapshot) {
       dataSnapshot.value = dataSnapshot.value + 1;
       return new Future<DataSnapshot>(() => dataSnapshot);
     }, (DatabaseError error, bool committed, DataSnapshot dataSnapshot) {
-      _messagesRef
-          .push()
-          .set(<String, String>{_kTestKey: '$_kTestValue ${dataSnapshot.value}'});
+      _messagesRef.push().set(
+          <String, String>{_kTestKey: '$_kTestValue ${dataSnapshot.value}'});
     }));
   }
 

--- a/packages/firebase_database/example/lib/main.dart
+++ b/packages/firebase_database/example/lib/main.dart
@@ -69,12 +69,12 @@ class _MyHomePageState extends State<MyHomePage> {
     await FirebaseAuth.instance.signInAnonymously();
     // Increment counter in transaction.
     final TransactionResult transactionResult =
-        await _counterRef.runTransaction((MutableData mutableData) {
-      mutableData.value = mutableData.value + 1;
-      return new Future<MutableData>(() => mutableData);
+        await _counterRef.runTransaction((MutableData mutableData) async {
+      mutableData.value = (mutableData.value ?? 0) + 1;
+      return mutableData;
     });
 
-    if (transactionResult.committed && transactionResult.error == null) {
+    if (transactionResult.committed) {
       _messagesRef.push().set(<String, String>{
         _kTestKey: '$_kTestValue ${transactionResult.dataSnapshot.value}'
       });

--- a/packages/firebase_database/ios/Classes/FirebaseDatabasePlugin.h
+++ b/packages/firebase_database/ios/Classes/FirebaseDatabasePlugin.h
@@ -5,4 +5,7 @@
 #import <Flutter/Flutter.h>
 
 @interface FirebaseDatabasePlugin : NSObject<FlutterPlugin>
+
+@property(nonatomic) NSMutableDictionary *updatedSnapshots;
+
 @end

--- a/packages/firebase_database/ios/Classes/FirebaseDatabasePlugin.h
+++ b/packages/firebase_database/ios/Classes/FirebaseDatabasePlugin.h
@@ -5,4 +5,6 @@
 #import <Flutter/Flutter.h>
 
 @interface FirebaseDatabasePlugin : NSObject<FlutterPlugin>
+@property NSMutableDictionary *semas;
+@property NSMutableDictionary *updatedSnapshots;
 @end

--- a/packages/firebase_database/ios/Classes/FirebaseDatabasePlugin.h
+++ b/packages/firebase_database/ios/Classes/FirebaseDatabasePlugin.h
@@ -5,6 +5,4 @@
 #import <Flutter/Flutter.h>
 
 @interface FirebaseDatabasePlugin : NSObject<FlutterPlugin>
-@property NSMutableDictionary *semas;
-@property NSMutableDictionary *updatedSnapshots;
 @end

--- a/packages/firebase_database/ios/Classes/FirebaseDatabasePlugin.m
+++ b/packages/firebase_database/ios/Classes/FirebaseDatabasePlugin.m
@@ -25,6 +25,11 @@ FIRDatabaseReference *getReference(NSDictionary *arguments) {
   return ref;
 }
 
+NSString *getTransactionKey(NSDictionary *arguments) {
+  NSString *transactionKey = arguments[@"transactionKey"];
+  return transactionKey;
+}
+
 FIRDatabaseQuery *getQuery(NSDictionary *arguments) {
   FIRDatabaseQuery *query = getReference(arguments);
   NSDictionary *parameters = arguments[@"parameters"];
@@ -136,6 +141,8 @@ id roundDoubles(id value) {
     if (![FIRApp defaultApp]) {
       [FIRApp configure];
     }
+    self.semas = [NSMutableDictionary new];
+    self.updatedSnapshots = [NSMutableDictionary new];
   }
   return self;
 }
@@ -190,6 +197,52 @@ id roundDoubles(id value) {
   } else if ([@"DatabaseReference#setPriority" isEqualToString:call.method]) {
     [getReference(call.arguments) setPriority:call.arguments[@"priority"]
                           withCompletionBlock:defaultCompletionBlock];
+  } else if ([@"DatabaseReference#runTransaction" isEqualToString:call.method]) {
+    [getReference(call.arguments)
+        runTransactionBlock:^FIRTransactionResult *_Nonnull(FIRMutableData *_Nonnull currentData) {
+
+          if (!currentData.value) {
+            return [FIRTransactionResult successWithValue:currentData];
+          }
+
+          // Create semaphore to allow native side to wait while snapshot
+          // updates occurr on the dart side.
+          dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+
+          // Add semaphore to dictionary so it can be retrieved later.
+          [[self semas] setObject:sema forKey:getTransactionKey(call.arguments)];
+
+          // Send snapshot to dart side for updates.
+          result(@{@"key" : currentData.key ?: [NSNull null], @"value" : currentData.value});
+
+          // Wait while dart side updates the snapshot.
+          dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+
+          // Set FIRMutableData value to value returned from the dart side.
+          currentData.value = [self.updatedSnapshots
+              objectForKey:getTransactionKey(call.arguments)][@"updatedDataSnapshot"];
+
+          return [FIRTransactionResult successWithValue:currentData];
+        }
+        andCompletionBlock:^(NSError *_Nullable error, BOOL committed,
+                             FIRDataSnapshot *_Nullable snapshot) {
+          // Invoke transaction complete on the dart side.
+          [self.channel
+              invokeMethod:@"TransactionComplete"
+                 arguments:@{
+                   @"transactionKey" : getTransactionKey(call.arguments),
+                   @"error" : error ? error.flutterError : [NSNull null],
+                   @"committed" : [NSNumber numberWithBool:committed],
+                   @"snapshot" :
+                       @{@"key" : snapshot.key ?: [NSNull null], @"value" : snapshot.value}
+                 }];
+        }];
+  } else if ([@"DatabaseReference#finishDoTransaction" isEqualToString:call.method]) {
+    // Return the updated snapshot from the dart side to the native side. The
+    // runTransactionBlock method completes after this method is called.
+    [[self updatedSnapshots] setObject:call.arguments forKey:getTransactionKey(call.arguments)];
+    dispatch_semaphore_t sema = [[self semas] objectForKey:getTransactionKey(call.arguments)];
+    dispatch_semaphore_signal(sema);
   } else if ([@"Query#observe" isEqualToString:call.method]) {
     FIRDataEventType eventType = parseEventType(call.arguments[@"eventType"]);
     __block FIRDatabaseHandle handle = [getQuery(call.arguments)

--- a/packages/firebase_database/ios/Classes/FirebaseDatabasePlugin.m
+++ b/packages/firebase_database/ios/Classes/FirebaseDatabasePlugin.m
@@ -6,6 +6,11 @@
 
 #import <Firebase/Firebase.h>
 
+@interface FirebaseDatabasePlugin ()
+@property NSMutableDictionary *transactionSemaphores;
+@property NSMutableDictionary *updatedSnapshots;
+@end
+
 @interface NSError (FlutterError)
 @property(readonly, nonatomic) FlutterError *flutterError;
 @end
@@ -28,6 +33,11 @@ FIRDatabaseReference *getReference(NSDictionary *arguments) {
 NSString *getTransactionKey(NSDictionary *arguments) {
   NSString *transactionKey = arguments[@"transactionKey"];
   return transactionKey;
+}
+
+NSInteger getTransactionTimeout(NSDictionary *arguments) {
+  NSString *transactionTimeout = arguments[@"transactionTimeout"];
+  return [transactionTimeout integerValue];
 }
 
 FIRDatabaseQuery *getQuery(NSDictionary *arguments) {
@@ -141,7 +151,7 @@ id roundDoubles(id value) {
     if (![FIRApp defaultApp]) {
       [FIRApp configure];
     }
-    self.semas = [NSMutableDictionary new];
+    self.transactionSemaphores = [NSMutableDictionary new];
     self.updatedSnapshots = [NSMutableDictionary new];
   }
   return self;
@@ -200,49 +210,61 @@ id roundDoubles(id value) {
   } else if ([@"DatabaseReference#runTransaction" isEqualToString:call.method]) {
     [getReference(call.arguments)
         runTransactionBlock:^FIRTransactionResult *_Nonnull(FIRMutableData *_Nonnull currentData) {
-
+          // Handle null value case.
           if (!currentData.value) {
             return [FIRTransactionResult successWithValue:currentData];
           }
 
           // Create semaphore to allow native side to wait while snapshot
-          // updates occurr on the dart side.
-          dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+          // updates occur on the dart side.
+          dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
           // Add semaphore to dictionary so it can be retrieved later.
-          [[self semas] setObject:sema forKey:getTransactionKey(call.arguments)];
+          [[self transactionSemaphores] setObject:semaphore forKey:getTransactionKey(call.arguments)];
 
-          // Send snapshot to dart side for updates.
-          result(@{@"key" : currentData.key ?: [NSNull null], @"value" : currentData.value});
+
+          [self.channel invokeMethod:@"DoTransaction" arguments:@{
+                                                                  @"transactionKey": getTransactionKey(call.arguments),
+                                                                  @"snapshot": @{
+                                                                      @"key" : currentData.key ?: [NSNull null],
+                                                                      @"value" : currentData.value
+                                                                      }
+                                                                  }];
 
           // Wait while dart side updates the snapshot.
-          dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+          long result = dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, getTransactionTimeout(call.arguments)));
 
-          // Set FIRMutableData value to value returned from the dart side.
-          currentData.value = [self.updatedSnapshots
-              objectForKey:getTransactionKey(call.arguments)][@"updatedDataSnapshot"];
+          if (result == 0) {
+            // Set FIRMutableData value to value returned from the dart side.
+            currentData.value = [self.updatedSnapshots
+                                 objectForKey:getTransactionKey(call.arguments)][@"updatedDataSnapshot"];
+          } else {
+            NSLog(@"Transaction timed out.");
+            return [FIRTransactionResult abort];
+          }
+
+          // Remove semaphore from dictionary.
+          [[self transactionSemaphores] removeObjectForKey:getTransactionKey(call.arguments)];
 
           return [FIRTransactionResult successWithValue:currentData];
         }
         andCompletionBlock:^(NSError *_Nullable error, BOOL committed,
                              FIRDataSnapshot *_Nullable snapshot) {
-          // Invoke transaction complete on the dart side.
-          [self.channel
-              invokeMethod:@"TransactionComplete"
-                 arguments:@{
+          // Invoke transaction completion on the dart side.
+          result(@{
                    @"transactionKey" : getTransactionKey(call.arguments),
                    @"error" : error ? error.flutterError : [NSNull null],
                    @"committed" : [NSNumber numberWithBool:committed],
                    @"snapshot" :
-                       @{@"key" : snapshot.key ?: [NSNull null], @"value" : snapshot.value}
-                 }];
+                     @{@"key" : snapshot.key ?: [NSNull null], @"value" : snapshot.value}
+                   });
         }];
   } else if ([@"DatabaseReference#finishDoTransaction" isEqualToString:call.method]) {
     // Return the updated snapshot from the dart side to the native side. The
     // runTransactionBlock method completes after this method is called.
     [[self updatedSnapshots] setObject:call.arguments forKey:getTransactionKey(call.arguments)];
-    dispatch_semaphore_t sema = [[self semas] objectForKey:getTransactionKey(call.arguments)];
-    dispatch_semaphore_signal(sema);
+    dispatch_semaphore_t semaphore = [[self transactionSemaphores] objectForKey:getTransactionKey(call.arguments)];
+    dispatch_semaphore_signal(semaphore);
   } else if ([@"Query#observe" isEqualToString:call.method]) {
     FIRDataEventType eventType = parseEventType(call.arguments[@"eventType"]);
     __block FIRDatabaseHandle handle = [getQuery(call.arguments)

--- a/packages/firebase_database/lib/src/database_reference.dart
+++ b/packages/firebase_database/lib/src/database_reference.dart
@@ -130,12 +130,8 @@ class DatabaseReference extends Query {
   /// this Firebase Database location.
   Future<TransactionResult> runTransaction(
       TransactionHandler transactionHandler,
-      [Duration transactionTimeout]) async {
-    if (transactionTimeout == null) {
-      transactionTimeout = new Duration(seconds: 5);
-    }
-
-    assert(transactionTimeout.inMilliseconds > 0,
+      {Duration timeout: const Duration(seconds: 5)}) async {
+    assert(timeout.inMilliseconds > 0,
         'Transaction timeout must be more than 0 milliseconds.');
 
     final Completer<TransactionResult> completer =
@@ -151,7 +147,7 @@ class DatabaseReference extends Query {
         .invokeMethod('DatabaseReference#runTransaction', <String, dynamic>{
       'path': path,
       'transactionKey': transactionKey,
-      'transactionTimeout': transactionTimeout.inMilliseconds
+      'transactionTimeout': timeout.inMilliseconds
     }).then((Map<String, dynamic> result) {
       final DatabaseError databaseError =
           result['error'] != null ? new DatabaseError._(result['error']) : null;

--- a/packages/firebase_database/lib/src/database_reference.dart
+++ b/packages/firebase_database/lib/src/database_reference.dart
@@ -144,13 +144,14 @@ class DatabaseReference extends Query {
   Future<Null> runTransaction(TransactionHandler transactionHandler,
       [int transactionTimeout = _transactionTimeout]) async {
     if (transactionTimeout < 0) {
-      throw new ArgumentError('Transaction timeout ($transactionTimeout) cannot be less than zero.');
+      throw new ArgumentError(
+          'Transaction timeout ($transactionTimeout) cannot be less than zero.');
     }
     final int transactionKey = _getNextTransactionKey();
     FirebaseDatabase._transactions[transactionKey] = transactionHandler;
 
     final Map<String, dynamic> completion = await _database._channel
-        .invokeMethod('DatabaseReference#runTransaction', <String, dynamic> {
+        .invokeMethod('DatabaseReference#runTransaction', <String, dynamic>{
       'path': path,
       'transactionKey': transactionKey,
       'transactionTimeout': transactionTimeout
@@ -178,8 +179,8 @@ class ServerValue {
 }
 
 typedef Future<DataSnapshot> DoTransaction(DataSnapshot dataSnapshot);
-typedef void OnComplete(DatabaseError error, bool committed,
-    DataSnapshot dataSnapshot);
+typedef void OnComplete(
+    DatabaseError error, bool committed, DataSnapshot dataSnapshot);
 
 /// TransactionHandler requires the implementation of functions to handle a
 /// Firebase Database transaction.

--- a/packages/firebase_database/lib/src/event.dart
+++ b/packages/firebase_database/lib/src/event.dart
@@ -34,3 +34,17 @@ class DataSnapshot {
   /// Returns the contents of this data snapshot as native types.
   dynamic get value => _data['value'];
 }
+
+/// A DatabaseError contains code, message and details of a Firebase Database
+/// Error that results from a transaction operation at a Firebase Database
+/// location.
+class DatabaseError {
+  Map<String, dynamic> _data;
+  DatabaseError._(this._data);
+
+  int get code => _data['code'];
+
+  String get message => _data['message'];
+
+  String get details => _data['details'];
+}

--- a/packages/firebase_database/lib/src/event.dart
+++ b/packages/firebase_database/lib/src/event.dart
@@ -37,14 +37,14 @@ class DataSnapshot {
 
 class MutableData {
   final Map<String, dynamic> _data;
-  MutableData._(this._data);
+  @visibleForTesting
+  MutableData.private(this._data);
 
-  /// The key of the location that generated this DataSnapshot.
+  /// The key of the location that generated this MutableData.
   String get key => _data['key'];
 
-  /// Returns the contents of this data snapshot as native types.
+  /// Returns the mutable contents of this MutableData as native types.
   dynamic get value => _data['value'];
-
   set value(dynamic newValue) => _data['value'] = newValue;
 }
 

--- a/packages/firebase_database/lib/src/event.dart
+++ b/packages/firebase_database/lib/src/event.dart
@@ -25,7 +25,7 @@ class Event {
 /// A DataSnapshot contains data from a Firebase Database location.
 /// Any time you read Firebase data, you receive the data as a DataSnapshot.
 class DataSnapshot {
-  Map<String, dynamic> _data;
+  final Map<String, dynamic> _data;
   DataSnapshot._(this._data);
 
   /// The key of the location that generated this DataSnapshot.
@@ -33,8 +33,18 @@ class DataSnapshot {
 
   /// Returns the contents of this data snapshot as native types.
   dynamic get value => _data['value'];
+}
 
-  /// Sets the contents of this data snapshot.
+class MutableData {
+  final Map<String, dynamic> _data;
+  MutableData._(this._data);
+
+  /// The key of the location that generated this DataSnapshot.
+  String get key => _data['key'];
+
+  /// Returns the contents of this data snapshot as native types.
+  dynamic get value => _data['value'];
+
   set value(dynamic newValue) => _data['value'] = newValue;
 }
 

--- a/packages/firebase_database/lib/src/event.dart
+++ b/packages/firebase_database/lib/src/event.dart
@@ -33,9 +33,9 @@ class DataSnapshot {
 
   /// Returns the contents of this data snapshot as native types.
   dynamic get value => _data['value'];
-  /// Sets the contents of this data snapshot.
-          set value(dynamic newValue) => _data['value'] = newValue;
 
+  /// Sets the contents of this data snapshot.
+  set value(dynamic newValue) => _data['value'] = newValue;
 }
 
 /// A DatabaseError contains code, message and details of a Firebase Database

--- a/packages/firebase_database/lib/src/event.dart
+++ b/packages/firebase_database/lib/src/event.dart
@@ -33,6 +33,9 @@ class DataSnapshot {
 
   /// Returns the contents of this data snapshot as native types.
   dynamic get value => _data['value'];
+  /// Sets the contents of this data snapshot.
+          set value(dynamic newValue) => _data['value'] = newValue;
+
 }
 
 /// A DatabaseError contains code, message and details of a Firebase Database
@@ -42,9 +45,12 @@ class DatabaseError {
   Map<String, dynamic> _data;
   DatabaseError._(this._data);
 
+  /// One of the defined status codes, depending on the error.
   int get code => _data['code'];
 
+  /// A human-readable description of the error.
   String get message => _data['message'];
 
+  /// Human-readable details on the error and additional information.
   String get details => _data['details'];
 }

--- a/packages/firebase_database/lib/src/firebase_database.dart
+++ b/packages/firebase_database/lib/src/firebase_database.dart
@@ -15,11 +15,25 @@ class FirebaseDatabase {
   static final Map<int, StreamController<Event>> _observers =
       <int, StreamController<Event>>{};
 
+  static final Map<int, TransactionHandler> _transactions =
+      <int, TransactionHandler>{};
+
   FirebaseDatabase._() {
     _channel.setMethodCallHandler((MethodCall call) {
       if (call.method == 'Event') {
         final Event event = new Event._(call.arguments);
         _observers[call.arguments['handle']].add(event);
+      } else if (call.method == 'TransactionComplete') {
+        final DatabaseError databaseError = call.arguments['error'] != null
+            ? new DatabaseError._(call.arguments['error'])
+            : null;
+        final bool committed = call.arguments['committed'];
+        final DataSnapshot dataSnapshot = call.arguments['snapshot'] != null
+            ? new DataSnapshot._(call.arguments['snapshot'])
+            : null;
+        _transactions[call.arguments['transactionKey']]
+            .onComplete(databaseError, committed, dataSnapshot);
+        _transactions.remove(_transactions[call.arguments['transactionKey']]);
       }
     });
   }
@@ -28,6 +42,8 @@ class FirebaseDatabase {
 
   /// Gets the instance of FirebaseDatabase for the default Firebase app.
   static FirebaseDatabase get instance => _instance;
+
+  static Map<int, TransactionHandler> get transactions => _transactions;
 
   /// Gets a DatabaseReference for the root of your Firebase Database.
   DatabaseReference reference() => new DatabaseReference._(this, <String>[]);

--- a/packages/firebase_database/lib/src/firebase_database.dart
+++ b/packages/firebase_database/lib/src/firebase_database.dart
@@ -19,20 +19,20 @@ class FirebaseDatabase {
       <int, TransactionHandler>{};
 
   FirebaseDatabase._() {
-    _channel.setMethodCallHandler((MethodCall call) {
+    _channel.setMethodCallHandler((MethodCall call) async {
       if (call.method == 'Event') {
         final Event event = new Event._(call.arguments);
         _observers[call.arguments['handle']].add(event);
       } else if (call.method == 'DoTransaction') {
         final MutableData mutableData =
-            new MutableData._(call.arguments['snapshot']);
-        return _transactions[call.arguments['transactionKey']](mutableData)
-            .then<Map<String, dynamic>>((MutableData updated) {
-          return <String, dynamic>{'value': updated.value};
-        });
+            new MutableData.private(call.arguments['snapshot']);
+        final MutableData updated =
+            await _transactions[call.arguments['transactionKey']](mutableData);
+        return <String, dynamic>{'value': updated.value};
       } else {
         throw new MissingPluginException(
-            '${call.method} method not implemented on the Dart side.');
+          '${call.method} method not implemented on the Dart side.',
+        );
       }
     });
   }

--- a/packages/firebase_database/lib/src/firebase_database.dart
+++ b/packages/firebase_database/lib/src/firebase_database.dart
@@ -24,15 +24,15 @@ class FirebaseDatabase {
         final Event event = new Event._(call.arguments);
         _observers[call.arguments['handle']].add(event);
       } else if (call.method == 'DoTransaction') {
-        _transactions[call.arguments['transactionKey']]
-            .doTransaction(new DataSnapshot._(call.arguments['snapshot']))
-            .then((DataSnapshot dataSnapshot) {
-          _channel.invokeMethod(
-              'DatabaseReference#finishDoTransaction', <String, dynamic>{
-            'updatedDataSnapshot': dataSnapshot.value,
-            'transactionKey': call.arguments['transactionKey']
-          });
+        final MutableData mutableData =
+            new MutableData._(call.arguments['snapshot']);
+        return _transactions[call.arguments['transactionKey']](mutableData)
+            .then<Map<String, dynamic>>((MutableData updated) {
+          return <String, dynamic>{'value': updated.value};
         });
+      } else {
+        throw new MissingPluginException(
+            '${call.method} method not implemented on the Dart side.');
       }
     });
   }

--- a/packages/firebase_database/lib/src/firebase_database.dart
+++ b/packages/firebase_database/lib/src/firebase_database.dart
@@ -27,7 +27,8 @@ class FirebaseDatabase {
         _transactions[call.arguments['transactionKey']]
             .doTransaction(new DataSnapshot._(call.arguments['snapshot']))
             .then((DataSnapshot dataSnapshot) {
-          _channel.invokeMethod('DatabaseReference#finishDoTransaction', <String, dynamic>{
+          _channel.invokeMethod(
+              'DatabaseReference#finishDoTransaction', <String, dynamic>{
             'updatedDataSnapshot': dataSnapshot.value,
             'transactionKey': call.arguments['transactionKey']
           });

--- a/packages/firebase_database/pubspec.yaml
+++ b/packages/firebase_database/pubspec.yaml
@@ -3,7 +3,7 @@ name: firebase_database
 description: Firebase Database plugin for Flutter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_database
-version: 0.1.0+1
+version: 0.1.1
 
 flutter:
   plugin:

--- a/packages/firebase_database/test/firebase_database_test.dart
+++ b/packages/firebase_database/test/firebase_database_test.dart
@@ -156,12 +156,17 @@ void main() {
         expect(
             log,
             equals(<MethodCall>[
-              new MethodCall('DatabaseReference#runTransaction',
-                  <String, dynamic>{'path': 'foo', 'transactionKey': 0,
-                    'transactionTimeout': 5000000000}),
+              new MethodCall(
+                  'DatabaseReference#runTransaction', <String, dynamic>{
+                'path': 'foo',
+                'transactionKey': 0,
+                'transactionTimeout': 5000000000
+              }),
             ]));
         expect(
-            database.reference().child('foo')
+            database
+                .reference()
+                .child('foo')
                 .runTransaction(new MockTransactionHandler._(), -1),
             throwsA(const isInstanceOf<ArgumentError>()));
       });
@@ -319,7 +324,8 @@ class MockTransactionHandler extends TransactionHandler {
       return new Future<DataSnapshot>(() => dataSnapshot);
     };
 
-    onComplete = (DatabaseError databaseError, bool committed, DataSnapshot dataSnapshot) {
+    onComplete = (DatabaseError databaseError, bool committed,
+        DataSnapshot dataSnapshot) {
       print('Transaction Complete');
     };
   }

--- a/packages/firebase_database/test/firebase_database_test.dart
+++ b/packages/firebase_database/test/firebase_database_test.dart
@@ -152,7 +152,9 @@ void main() {
         await database
             .reference()
             .child('foo')
-            .runTransaction(new MockTransactionHandler._());
+            .runTransaction((MutableData mutableData) {
+          return new Future<MutableData>(() => mutableData);
+        });
         expect(
             log,
             equals(<MethodCall>[
@@ -160,17 +162,14 @@ void main() {
                   'DatabaseReference#runTransaction', <String, dynamic>{
                 'path': 'foo',
                 'transactionKey': 0,
-                'transactionTimeout': 5000000000
+                'transactionTimeout': 5000
               }),
             ]));
         expect(
-            database
-                .reference()
-                .child('foo')
-                .runTransaction(new MockTransactionHandler._(), -1),
-            throwsA(const isInstanceOf<ArgumentError>()));
+            database.reference().child('foo').runTransaction(
+                (MutableData mutableData) {}, const Duration(milliseconds: 0)),
+            throwsA(const isInstanceOf<AssertionError>()));
       });
-      // TODO(arthurthompson): Write tests for DoTransaction.
     });
 
     group('$Query', () {
@@ -314,19 +313,5 @@ class AsyncQueue<T> {
     } else {
       return _completers[index] = new Completer<T>();
     }
-  }
-}
-
-class MockTransactionHandler extends TransactionHandler {
-  MockTransactionHandler._() : super(null, null) {
-    doTransaction = (DataSnapshot dataSnapshot) {
-      // Leave snapshot unchanged.
-      return new Future<DataSnapshot>(() => dataSnapshot);
-    };
-
-    onComplete = (DatabaseError databaseError, bool committed,
-        DataSnapshot dataSnapshot) {
-      print('Transaction Complete');
-    };
   }
 }


### PR DESCRIPTION
Add Firebase Realtime Database transaction support.

- Dart side initiates the transaction on the native side via
method channel.
- Native side returns snapshot to be updated then blocks for
update from dart side.
- Dart side updates snapshot and passes it back to the native
side.
- The native side releases the block and the transaction continues
on the native side.