### PR TITLE
Make iOS null behavior of SharedPreferences not crash

### DIFF
--- a/packages/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.2.5] - 2017-08-29
+
+* Fixed crash when setting null values on iOS
+
 ## [0.2.4+1] - 2017-06-05
 
 * Fixed typo in changelog

--- a/packages/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [0.2.5] - 2017-08-29
 
-* Fixed crashes when setting null values. They now remove the key.
+* Fixed crashes when setting null values. They now cause the key to be removed.
+* Added remove() method
 
 ## [0.2.4+1] - 2017-06-05
 

--- a/packages/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [0.2.5] - 2017-08-29
 
-* Fixed crash when setting null values on iOS
+* Fixed crashes when setting null values. They now remove the key.
 
 ## [0.2.4+1] - 2017-06-05
 

--- a/packages/shared_preferences/android/src/main/java/io/flutter/plugins/sharedpreferences/SharedPreferencesPlugin.java
+++ b/packages/shared_preferences/android/src/main/java/io/flutter/plugins/sharedpreferences/SharedPreferencesPlugin.java
@@ -111,31 +111,56 @@ public class SharedPreferencesPlugin implements MethodCallHandler {
     try {
       switch (call.method) {
         case "setBool":
-          editor.putBoolean(key, (boolean) call.argument("value")).apply();
+          Boolean boolValue = call.argument("value");
+          if (boolValue == null) {
+            editor.remove(key);
+          } else {
+            editor.putBoolean(key, boolValue);
+          }
+          editor.apply();
           result.success(null);
           break;
         case "setDouble":
-          editor.putFloat(key, (float) call.argument("value")).apply();
+          Float floatValue = call.argument("value");
+          if (floatValue == null) {
+            editor.remove(key);
+          } else {
+            editor.putFloat(key, floatValue);
+          }
+          editor.apply();
           result.success(null);
           break;
         case "setInt":
-          Number number = call.argument("value");
-          if (number instanceof BigInteger) {
-            BigInteger integerValue = (BigInteger) number;
+          Number numberValue = call.argument("value");
+          if (numberValue == null) {
+            editor.remove(key);
+          } else if (numberValue instanceof BigInteger) {
+            BigInteger integerValue = (BigInteger) numberValue;
             editor.putString(key, BIG_INTEGER_PREFIX + integerValue.toString(Character.MAX_RADIX));
           } else {
-            editor.putLong(key, number.longValue());
+            editor.putLong(key, numberValue.longValue());
           }
           editor.apply();
           result.success(null);
           break;
         case "setString":
-          editor.putString(key, (String) call.argument("value")).apply();
+          String stringValue = call.argument("value");
+          if (stringValue == null) {
+            editor.remove(key);
+          } else {
+            editor.putString(key, stringValue);
+          }
+          editor.apply();
           result.success(null);
           break;
         case "setStringList":
-          List<String> list = call.argument("value");
-          editor.putString(key, LIST_IDENTIFIER + encodeList(list)).apply();
+          List<String> listValue = call.argument("value");
+          if (listValue == null) {
+            editor.remove(key);
+          } else {
+            editor.putString(key, LIST_IDENTIFIER + encodeList(listValue));
+          }
+          editor.apply();
           result.success(null);
           break;
         case "commit":

--- a/packages/shared_preferences/android/src/main/java/io/flutter/plugins/sharedpreferences/SharedPreferencesPlugin.java
+++ b/packages/shared_preferences/android/src/main/java/io/flutter/plugins/sharedpreferences/SharedPreferencesPlugin.java
@@ -111,56 +111,31 @@ public class SharedPreferencesPlugin implements MethodCallHandler {
     try {
       switch (call.method) {
         case "setBool":
-          Boolean boolValue = call.argument("value");
-          if (boolValue == null) {
-            editor.remove(key);
-          } else {
-            editor.putBoolean(key, boolValue);
-          }
-          editor.apply();
+          editor.putBoolean(key, (boolean) call.argument("value")).apply();
           result.success(null);
           break;
         case "setDouble":
-          Float floatValue = call.argument("value");
-          if (floatValue == null) {
-            editor.remove(key);
-          } else {
-            editor.putFloat(key, floatValue);
-          }
-          editor.apply();
+          editor.putFloat(key, (float) call.argument("value")).apply();
           result.success(null);
           break;
         case "setInt":
-          Number numberValue = call.argument("value");
-          if (numberValue == null) {
-            editor.remove(key);
-          } else if (numberValue instanceof BigInteger) {
-            BigInteger integerValue = (BigInteger) numberValue;
+          Number number = call.argument("value");
+          if (number instanceof BigInteger) {
+            BigInteger integerValue = (BigInteger) number;
             editor.putString(key, BIG_INTEGER_PREFIX + integerValue.toString(Character.MAX_RADIX));
           } else {
-            editor.putLong(key, numberValue.longValue());
+            editor.putLong(key, number.longValue());
           }
           editor.apply();
           result.success(null);
           break;
         case "setString":
-          String stringValue = call.argument("value");
-          if (stringValue == null) {
-            editor.remove(key);
-          } else {
-            editor.putString(key, stringValue);
-          }
-          editor.apply();
+          editor.putString(key, (String) call.argument("value")).apply();
           result.success(null);
           break;
         case "setStringList":
-          List<String> listValue = call.argument("value");
-          if (listValue == null) {
-            editor.remove(key);
-          } else {
-            editor.putString(key, LIST_IDENTIFIER + encodeList(listValue));
-          }
-          editor.apply();
+          List<String> list = call.argument("value");
+          editor.putString(key, LIST_IDENTIFIER + encodeList(list)).apply();
           result.success(null);
           break;
         case "commit":
@@ -168,6 +143,10 @@ public class SharedPreferencesPlugin implements MethodCallHandler {
           break;
         case "getAll":
           result.success(getAllPrefs());
+          break;
+        case "remove":
+          editor.remove(key).apply();
+          result.success(null);
           break;
         case "clear":
           for (String keyToDelete : getAllPrefs().keySet()) {

--- a/packages/shared_preferences/ios/Classes/SharedPreferencesPlugin.m
+++ b/packages/shared_preferences/ios/Classes/SharedPreferencesPlugin.m
@@ -20,10 +20,7 @@ static NSString *const CHANNEL_NAME = @"plugins.flutter.io/shared_preferences";
     } else if ([method isEqualToString:@"setBool"]) {
       NSString *key = arguments[@"key"];
       NSNumber *value = arguments[@"value"];
-      if ([[NSNull null] isEqual:value])
-        [[NSUserDefaults standardUserDefaults] removeObjectForKey:key];
-      else
-        [[NSUserDefaults standardUserDefaults] setBool:value.boolValue forKey:key];
+      [[NSUserDefaults standardUserDefaults] setBool:value.boolValue forKey:key];
       result(nil);
     } else if ([method isEqualToString:@"setInt"]) {
       NSString *key = arguments[@"key"];
@@ -31,37 +28,28 @@ static NSString *const CHANNEL_NAME = @"plugins.flutter.io/shared_preferences";
       // int type in Dart can come to native side in a variety of forms
       // It is best to store it as is and send it back when needed.
       // Platform channel will handle the conversion.
-      if ([[NSNull null] isEqual:value])
-        [[NSUserDefaults standardUserDefaults] removeObjectForKey:key];
-      else
-        [[NSUserDefaults standardUserDefaults] setValue:value forKey:key];
+      [[NSUserDefaults standardUserDefaults] setValue:value forKey:key];
       result(nil);
     } else if ([method isEqualToString:@"setDouble"]) {
       NSString *key = arguments[@"key"];
       NSNumber *value = arguments[@"value"];
-      if ([[NSNull null] isEqual:value])
-        [[NSUserDefaults standardUserDefaults] removeObjectForKey:key];
-      else
-        [[NSUserDefaults standardUserDefaults] setDouble:value.doubleValue forKey:key];
+      [[NSUserDefaults standardUserDefaults] setDouble:value.doubleValue forKey:key];
       result(nil);
     } else if ([method isEqualToString:@"setString"]) {
       NSString *key = arguments[@"key"];
       NSString *value = arguments[@"value"];
-      if ([[NSNull null] isEqual:value])
-        [[NSUserDefaults standardUserDefaults] removeObjectForKey:key];
-      else
-        [[NSUserDefaults standardUserDefaults] setValue:value forKey:key];
+      [[NSUserDefaults standardUserDefaults] setValue:value forKey:key];
       result(nil);
     } else if ([method isEqualToString:@"setStringList"]) {
       NSString *key = arguments[@"key"];
       NSArray *value = arguments[@"value"];
-      if ([[NSNull null] isEqual:value])
-        [[NSUserDefaults standardUserDefaults] removeObjectForKey:key];
-      else
-        [[NSUserDefaults standardUserDefaults] setValue:value forKey:key];
+      [[NSUserDefaults standardUserDefaults] setValue:value forKey:key];
       result(nil);
     } else if ([method isEqualToString:@"commit"]) {
       result([NSNumber numberWithBool:[[NSUserDefaults standardUserDefaults] synchronize]]);
+    } else if ([method isEqualToString:@"remove"]) {
+      [[NSUserDefaults standardUserDefaults] removeObjectForKey:arguments[@"key"]];
+      result(nil);
     } else if ([method isEqualToString:@"clear"]) {
       NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
       for (NSString *key in getAllPrefs()) {

--- a/packages/shared_preferences/ios/Classes/SharedPreferencesPlugin.m
+++ b/packages/shared_preferences/ios/Classes/SharedPreferencesPlugin.m
@@ -20,6 +20,10 @@ static NSString *const CHANNEL_NAME = @"plugins.flutter.io/shared_preferences";
     } else if ([method isEqualToString:@"setBool"]) {
       NSString *key = arguments[@"key"];
       NSNumber *value = arguments[@"value"];
+      if ([[NSNull null] isEqual:value])
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:key];
+      else
+        [[NSUserDefaults standardUserDefaults] setValue:value forKey:key];
       [[NSUserDefaults standardUserDefaults] setBool:value.boolValue forKey:key];
       result(nil);
     } else if ([method isEqualToString:@"setInt"]) {
@@ -28,22 +32,34 @@ static NSString *const CHANNEL_NAME = @"plugins.flutter.io/shared_preferences";
       // int type in Dart can come to native side in a variety of forms
       // It is best to store it as is and send it back when needed.
       // Platform channel will handle the conversion.
-      [[NSUserDefaults standardUserDefaults] setValue:value forKey:key];
+      if ([[NSNull null] isEqual:value])
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:key];
+      else
+        [[NSUserDefaults standardUserDefaults] setValue:value forKey:key];
       result(nil);
     } else if ([method isEqualToString:@"setDouble"]) {
       NSString *key = arguments[@"key"];
       NSNumber *value = arguments[@"value"];
-      [[NSUserDefaults standardUserDefaults] setDouble:value.doubleValue forKey:key];
+      if ([[NSNull null] isEqual:value])
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:key];
+      else
+        [[NSUserDefaults standardUserDefaults] setDouble:value.doubleValue forKey:key];
       result(nil);
     } else if ([method isEqualToString:@"setString"]) {
       NSString *key = arguments[@"key"];
       NSString *value = arguments[@"value"];
-      [[NSUserDefaults standardUserDefaults] setValue:value forKey:key];
+      if ([[NSNull null] isEqual:value])
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:key];
+      else
+        [[NSUserDefaults standardUserDefaults] setValue:value forKey:key];
       result(nil);
     } else if ([method isEqualToString:@"setStringList"]) {
       NSString *key = arguments[@"key"];
       NSArray *value = arguments[@"value"];
-      [[NSUserDefaults standardUserDefaults] setValue:value forKey:key];
+      if ([[NSNull null] isEqual:value])
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:key];
+      else
+        [[NSUserDefaults standardUserDefaults] setValue:value forKey:key];
       result(nil);
     } else if ([method isEqualToString:@"commit"]) {
       result([NSNumber numberWithBool:[[NSUserDefaults standardUserDefaults] synchronize]]);

--- a/packages/shared_preferences/ios/Classes/SharedPreferencesPlugin.m
+++ b/packages/shared_preferences/ios/Classes/SharedPreferencesPlugin.m
@@ -23,8 +23,7 @@ static NSString *const CHANNEL_NAME = @"plugins.flutter.io/shared_preferences";
       if ([[NSNull null] isEqual:value])
         [[NSUserDefaults standardUserDefaults] removeObjectForKey:key];
       else
-        [[NSUserDefaults standardUserDefaults] setValue:value forKey:key];
-      [[NSUserDefaults standardUserDefaults] setBool:value.boolValue forKey:key];
+        [[NSUserDefaults standardUserDefaults] setBool:value.boolValue forKey:key];
       result(nil);
     } else if ([method isEqualToString:@"setInt"]) {
       NSString *key = arguments[@"key"];

--- a/packages/shared_preferences/lib/shared_preferences.dart
+++ b/packages/shared_preferences/lib/shared_preferences.dart
@@ -84,7 +84,8 @@ class SharedPreferences {
   void _setValue(String valueType, String key, Object value) {
     _preferenceCache[key] = value;
     // Set the value in the background.
-    _kChannel.invokeMethod('set$valueType', <String, dynamic>{
+    String method = (value == null) ? 'remove' : 'set$valueType';
+    _kChannel.invokeMethod(method, <String, dynamic>{
       'key': '$_prefix$key',
       'value': value,
     });

--- a/packages/shared_preferences/lib/shared_preferences.dart
+++ b/packages/shared_preferences/lib/shared_preferences.dart
@@ -11,8 +11,10 @@ const MethodChannel _kChannel =
     const MethodChannel('plugins.flutter.io/shared_preferences');
 
 /// Wraps NSUserDefaults (on iOS) and SharedPreferences (on Android), providing
-/// a persistent store for simple data. Data is persisted to disk automatically
-/// and asynchronously. Use commit() to be notified when a save is successful.
+/// a persistent store for simple data.
+///
+/// Data is persisted to disk automatically and asynchronously. Use [commit()]
+/// to be notified when a save is successful.
 class SharedPreferences {
   SharedPreferences._(this._preferenceCache);
 
@@ -45,50 +47,69 @@ class SharedPreferences {
   final Map<String, Object> _preferenceCache;
 
   /// Reads a value from persistent storage, throwing an exception if it's not a
-  /// bool
+  /// bool.
   bool getBool(String key) => _preferenceCache[key];
 
   /// Reads a value from persistent storage, throwing an exception if it's not
-  /// an int
+  /// an int.
   int getInt(String key) => _preferenceCache[key];
 
   /// Reads a value from persistent storage, throwing an exception if it's not a
-  /// double
+  /// double.
   double getDouble(String key) => _preferenceCache[key];
 
   /// Reads a value from persistent storage, throwing an exception if it's not a
-  /// String
+  /// String.
   String getString(String key) => _preferenceCache[key];
 
-  /// Reads a set of string values from persistent storage,
-  /// throwing an exception if it's not a string set.
+  /// Reads a set of string values from persistent storage, throwing an
+  /// exception if it's not a string set.
   List<String> getStringList(String key) => _preferenceCache[key];
 
   /// Saves a boolean [value] to persistent storage in the background.
+  ///
+  /// If [value] is null, this is equivalent to calling [remove()] on the [key].
   void setBool(String key, bool value) => _setValue('Bool', key, value);
 
   /// Saves an integer [value] to persistent storage in the background.
+  ///
+  /// If [value] is null, this is equivalent to calling [remove()] on the [key].
   void setInt(String key, int value) => _setValue('Int', key, value);
 
   /// Saves a double [value] to persistent storage in the background.
+  ///
   /// Android doesn't support storing doubles, so it will be stored as a float.
+  ///
+  /// If [value] is null, this is equivalent to calling [remove()] on the [key].
   void setDouble(String key, double value) => _setValue('Double', key, value);
 
   /// Saves a string [value] to persistent storage in the background.
+  ///
+  /// If [value] is null, this is equivalent to calling [remove()] on the [key].
   void setString(String key, String value) => _setValue('String', key, value);
 
   /// Saves a list of strings [value] to persistent storage in the background.
+  ///
+  /// If [value] is null, this is equivalent to calling [remove()] on the [key].
   void setStringList(String key, List<String> value) =>
       _setValue('StringList', key, value);
 
+  /// Removes an entry from persistent storage.
+  void remove(String key) => _setValue(null, key, null);
+
   void _setValue(String valueType, String key, Object value) {
-    _preferenceCache[key] = value;
     // Set the value in the background.
-    String method = (value == null) ? 'remove' : 'set$valueType';
-    _kChannel.invokeMethod(method, <String, dynamic>{
+    final Map<String, dynamic> params = <String, dynamic>{
       'key': '$_prefix$key',
-      'value': value,
-    });
+    };
+    if (value == null) {
+      _preferenceCache.remove(key);
+      _kChannel.invokeMethod('remove', params);
+    } else {
+      _preferenceCache[key] = value;
+      params['value'] = value;
+      _kChannel.invokeMethod('set$valueType', params);
+    }
   }
 
   /// Completes with true once saved values have been persisted to local

--- a/packages/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shared_preferences
 
-version: 0.2.4+1
+version: 0.2.5
 description: A Flutter plugin for reading and writing simple key-value pairs.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/shared_preferences

--- a/packages/shared_preferences/test/shared_preferences_test.dart
+++ b/packages/shared_preferences/test/shared_preferences_test.dart
@@ -105,6 +105,27 @@ void main() {
           ]));
     });
 
+    test('removing', () async {
+      const String key = 'testKey';
+      sharedPreferences
+        ..setString(key, null)
+        ..setBool(key, null)
+        ..setInt(key, null)
+        ..setDouble(key, null)
+        ..setStringList(key, null)
+        ..remove(key);
+      await sharedPreferences.commit();
+      expect(log, equals(new List<MethodCall>.filled(
+          6,
+          const MethodCall(
+            'remove',
+            const <String, dynamic>{ 'key': 'flutter.$key' },
+          ),
+          growable: true
+        )..add(const MethodCall('commit')),
+      ));
+    });
+
     test('clearing', () async {
       await sharedPreferences.clear();
       expect(sharedPreferences.getString('String'), null);

--- a/packages/shared_preferences/test/shared_preferences_test.dart
+++ b/packages/shared_preferences/test/shared_preferences_test.dart
@@ -115,15 +115,19 @@ void main() {
         ..setStringList(key, null)
         ..remove(key);
       await sharedPreferences.commit();
-      expect(log, equals(new List<MethodCall>.filled(
-          6,
-          const MethodCall(
-            'remove',
-            const <String, dynamic>{ 'key': 'flutter.$key' },
-          ),
-          growable: true
-        )..add(const MethodCall('commit')),
-      ));
+      expect(
+        log,
+        equals(
+          new List<MethodCall>.filled(
+            6,
+            const MethodCall(
+              'remove',
+              const <String, dynamic>{'key': 'flutter.$key'},
+            ),
+            growable: true,
+          )..add(const MethodCall('commit')),
+        ),
+      );
     });
 
     test('clearing', () async {


### PR DESCRIPTION
Do what we do on Android and clear the value instead.

Fixes flutter/flutter#11774