### PR TITLE
stop() gets called from go to settings dialog

### DIFF
--- a/packages/local_auth/android/src/main/java/io/flutter/plugins/localauth/AuthenticationHelper.java
+++ b/packages/local_auth/android/src/main/java/io/flutter/plugins/localauth/AuthenticationHelper.java
@@ -124,7 +124,9 @@ class AuthenticationHelper extends FingerprintManagerCompat.AuthenticationCallba
   }
 
   private void pause() {
-    cancellationSignal.cancel();
+    if (cancellationSignal != null) {
+      cancellationSignal.cancel();
+    }
     if (fingerprintDialog != null && fingerprintDialog.isShowing()) {
       fingerprintDialog.dismiss();
     }


### PR DESCRIPTION
Let's make pause() completely harmless if we have not initialized since this flow gets called from multiple places (even without calling start).