### PR TITLE
Fix travis by suppressing sdkmanager's output from log

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,13 +67,14 @@ matrix:
         - export PATH=`pwd`/android-sdk/tools/bin:$PATH
         - mkdir -p /home/travis/.android # silence sdkmanager warning
         - echo 'count=0' > /home/travis/.android/repositories.cfg # silence sdkmanager warning
-        - echo y | sdkmanager "tools"
-        - echo y | sdkmanager "platform-tools"
-        - echo y | sdkmanager "build-tools;25.0.3"
-        - echo y | sdkmanager "platforms;android-25"
-        - echo y | sdkmanager "extras;android;m2repository"
-        - echo y | sdkmanager "extras;google;m2repository"
-        - echo y | sdkmanager "patcher;v4"
+        # suppressing output of sdkmanager to keep log under 4MB (travis limit)
+        - echo y | sdkmanager "tools" >/dev/null
+        - echo y | sdkmanager "platform-tools" >/dev/null
+        - echo y | sdkmanager "build-tools;25.0.3" >/dev/null
+        - echo y | sdkmanager "platforms;android-25" >/dev/null
+        - echo y | sdkmanager "extras;android;m2repository" >/dev/null
+        - echo y | sdkmanager "extras;google;m2repository" >/dev/null
+        - echo y | sdkmanager "patcher;v4" >/dev/null
         - sdkmanager --list
         - wget http://services.gradle.org/distributions/gradle-3.5-bin.zip
         - unzip -qq gradle-3.5-bin.zip

--- a/packages/local_auth/pubspec.yaml
+++ b/packages/local_auth/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.0.5
-  intl: '>=0.14.0 <0.15.0'
+  intl: ^0.15.1
 
 environment:
   sdk: ">=1.8.0 <2.0.0"


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/12241.

Recently (last ~10 days), `sdkmanager` started to print a status bar to the console, which is increasing the size of the log above 4MB. 4MB is the limit at which travis kills a job. This PR suppresses `sdkmanager`'s stdout (which is rather uninteresting) from the logs to fix that issue.

Also bumps `intl` version for `package:local_auth`to resolve a version conflict.