### PR TITLE
Remove pointless UIImagePickerControllerCropRect use from image_picker

### DIFF
--- a/packages/image_picker/ios/Classes/ImagePickerPlugin.m
+++ b/packages/image_picker/ios/Classes/ImagePickerPlugin.m
@@ -100,9 +100,6 @@
   if (image == nil) {
     image = [info objectForKey:UIImagePickerControllerOriginalImage];
   }
-  if (image == nil) {
-    image = [info objectForKey:UIImagePickerControllerCropRect];
-  }
   image = [self normalizedImage:image];
   NSData *data = UIImageJPEGRepresentation(image, 1.0);
   NSString *tmpDirectory = NSTemporaryDirectory();


### PR DESCRIPTION
`info` dictionary stores NSValue(with CGRect inside) for UIImagePickerControllerCropRect key, so there is no sense to save this value in `UIImage` variable :)