### PR TITLE
Remove pointless array count check in iOS implementation of path_provider plugin

### DIFF
--- a/packages/path_provider/ios/Classes/PathProviderPlugin.m
+++ b/packages/path_provider/ios/Classes/PathProviderPlugin.m
@@ -6,7 +6,6 @@
 
 NSString* GetDirectoryOfType(NSSearchPathDirectory dir) {
   NSArray* paths = NSSearchPathForDirectoriesInDomains(dir, NSUserDomainMask, YES);
-  if (paths.count == 0) return nil;
   return paths.firstObject;
 }
 

--- a/packages/path_provider/lib/path_provider.dart
+++ b/packages/path_provider/lib/path_provider.dart
@@ -17,7 +17,7 @@ const MethodChannel _channel =
 /// (and cleaning up) files or directories within this directory. This
 /// directory is scoped to the calling application.
 ///
-/// On iOS, this uses the `NSTemporaryDirectory` API.
+/// On iOS, this uses the `NSCachesDirectory` API.
 ///
 /// On Android, this uses the `getCacheDir` API on the context.
 Future<Directory> getTemporaryDirectory() async {


### PR DESCRIPTION
No need to check array count here, because `-[NSArray firstObject]` returns nil if there are no elements in array.