### PR TITLE
Update GMS to 11.+

### DIFF
--- a/packages/firebase_admob/CHANGELOG.md
+++ b/packages/firebase_admob/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.0.2]
+
+* Change GMS dependency to 11.+
+
 ## [0.0.1]
 
 * Initial Release: not ready for production use

--- a/packages/firebase_admob/android/build.gradle
+++ b/packages/firebase_admob/android/build.gradle
@@ -30,7 +30,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        compile 'com.google.firebase:firebase-core:11.0.+'
-        compile 'com.google.firebase:firebase-ads:11.0.+'
+        compile 'com.google.firebase:firebase-core:11.+'
+        compile 'com.google.firebase:firebase-ads:11.+'
     }
 }

--- a/packages/firebase_admob/pubspec.yaml
+++ b/packages/firebase_admob/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_admob
 description: Firebase AdMob plugin for Flutter applications.
-version: 0.0.1
+version: 0.0.2
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_admob
 

--- a/packages/firebase_analytics/CHANGELOG.md
+++ b/packages/firebase_analytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.2
+
+* Change GMS dependency to 11.+
+
 ## 0.1.0+1
 
 * Aligned author name with rest of repo.

--- a/packages/firebase_analytics/CHANGELOG.md
+++ b/packages/firebase_analytics/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.0.2
+## 0.1.1
 
 * Change GMS dependency to 11.+
 

--- a/packages/firebase_analytics/android/build.gradle
+++ b/packages/firebase_analytics/android/build.gradle
@@ -30,7 +30,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        compile 'com.google.firebase:firebase-auth:11.0.+'
-        compile 'com.google.firebase:firebase-analytics:11.0.+'
+        compile 'com.google.firebase:firebase-auth:11.+'
+        compile 'com.google.firebase:firebase-analytics:11.+'
     }
 }

--- a/packages/firebase_analytics/example/android/app/build.gradle
+++ b/packages/firebase_analytics/example/android/app/build.gradle
@@ -41,7 +41,6 @@ flutter {
 }
 
 dependencies {
-    compile 'com.google.firebase:firebase-core:11.0.+'
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/packages/firebase_analytics/pubspec.yaml
+++ b/packages/firebase_analytics/pubspec.yaml
@@ -3,7 +3,7 @@ name: firebase_analytics
 description: Firebase Analytics plugin for Flutter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_analytics
-version: 0.0.2
+version: 0.1.1
 
 flutter:
   plugin:

--- a/packages/firebase_analytics/pubspec.yaml
+++ b/packages/firebase_analytics/pubspec.yaml
@@ -3,7 +3,7 @@ name: firebase_analytics
 description: Firebase Analytics plugin for Flutter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_analytics
-version: 0.1.0+1
+version: 0.0.2
 
 flutter:
   plugin:

--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1
+
+* Change GMS dependency to 11.+
+
 ## 0.3.0
 
 * **Breaking Change**: Method FirebaseUser getToken was renamed to getIdToken.

--- a/packages/firebase_auth/android/build.gradle
+++ b/packages/firebase_auth/android/build.gradle
@@ -34,7 +34,7 @@ android {
     }
     dependencies {
         compile 'com.google.guava:guava:20.0'
-        compile 'com.google.firebase:firebase-core:11.0.+'
-        compile 'com.google.firebase:firebase-auth:11.0.+'
+        compile 'com.google.firebase:firebase-core:11.+'
+        compile 'com.google.firebase:firebase-auth:11.+'
     }
 }

--- a/packages/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/pubspec.yaml
@@ -3,7 +3,7 @@ name: firebase_auth
 description: Firebase Auth plugin for Flutter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_auth
-version: 0.3.0
+version: 0.3.1
 
 flutter:
   plugin:

--- a/packages/firebase_database/CHANGELOG.md
+++ b/packages/firebase_database/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2
+
+* Change GMS dependency to 11.+
+
 ## 0.1.1
 
 * Add RTDB transaction support.

--- a/packages/firebase_database/android/build.gradle
+++ b/packages/firebase_database/android/build.gradle
@@ -30,8 +30,8 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        compile 'com.google.firebase:firebase-core:11.0.+'
-        compile 'com.google.firebase:firebase-auth:11.0.+'
-        compile 'com.google.firebase:firebase-database:11.0.+'
+        compile 'com.google.firebase:firebase-core:11.+'
+        compile 'com.google.firebase:firebase-auth:11.+'
+        compile 'com.google.firebase:firebase-database:11.+'
     }
 }

--- a/packages/firebase_database/pubspec.yaml
+++ b/packages/firebase_database/pubspec.yaml
@@ -3,7 +3,7 @@ name: firebase_database
 description: Firebase Database plugin for Flutter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_database
-version: 0.1.1
+version: 0.1.2
 
 flutter:
   plugin:

--- a/packages/firebase_messaging/CHANGELOG.md
+++ b/packages/firebase_messaging/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.6
+
+* Change GMS dependency to 11.+
+
 ## 0.0.5+2
 
 * Fixed README example for "click_action"

--- a/packages/firebase_messaging/android/build.gradle
+++ b/packages/firebase_messaging/android/build.gradle
@@ -30,7 +30,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        compile 'com.google.firebase:firebase-core:11.0.+'
-        compile 'com.google.firebase:firebase-messaging:11.0.+'
+        compile 'com.google.firebase:firebase-core:11.+'
+        compile 'com.google.firebase:firebase-messaging:11.+'
     }
 }

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -3,7 +3,7 @@ name: firebase_messaging
 description: Firebase Cloud Messaging plugin for Flutter applications.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_messaging
-version: 0.0.5+2
+version: 0.0.6
 
 flutter:
   plugin:

--- a/packages/firebase_storage/CHANGELOG.md
+++ b/packages/firebase_storage/CHANGELOG.md
@@ -1,5 +1,4 @@
-
-## 0.1.0
+## 0.0.7
 
 * Change GMS dependency to 11.+
 

--- a/packages/firebase_storage/CHANGELOG.md
+++ b/packages/firebase_storage/CHANGELOG.md
@@ -1,3 +1,8 @@
+
+## 0.1.0
+
+* Change GMS dependency to 11.+
+
 ## 0.0.6
 
 * Added StorageReference getData function to download files into memory.

--- a/packages/firebase_storage/android/build.gradle
+++ b/packages/firebase_storage/android/build.gradle
@@ -38,7 +38,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        compile 'com.google.firebase:firebase-core:11.0.+'
-        compile 'com.google.firebase:firebase-storage:11.0.+'
+        compile 'com.google.firebase:firebase-core:11.+'
+        compile 'com.google.firebase:firebase-storage:11.+'
     }
 }

--- a/packages/firebase_storage/pubspec.yaml
+++ b/packages/firebase_storage/pubspec.yaml
@@ -3,7 +3,7 @@ name: firebase_storage
 description: Firebase Storage plugin for Flutter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_storage
-version: 0.0.6
+version: 0.0.7
 
 flutter:
   plugin:

--- a/packages/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+
+* Change GMS dependency to 11.+
+
 ## 1.0.0
 
 * Make GoogleUserCircleAvatar fade profile image over the top of placeholder

--- a/packages/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.0
+## 1.0.1
 
 * Change GMS dependency to 11.+
 

--- a/packages/google_sign_in/android/build.gradle
+++ b/packages/google_sign_in/android/build.gradle
@@ -35,6 +35,6 @@ android {
 }
 
 dependencies {
-    compile 'com.google.android.gms:play-services-auth:11.0.+'
+    compile 'com.google.android.gms:play-services-auth:11.+'
     compile 'com.google.guava:guava:20.0'
 }

--- a/packages/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/pubspec.yaml
@@ -3,7 +3,7 @@ name: google_sign_in
 description: Google Sign-In plugin for Flutter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_sign_in
-version: 1.0.0
+version: 1.0.1
 
 flutter:
   plugin:


### PR DESCRIPTION
This should allow us to be compatible with new functionality like [Firestore](https://cloud.google.com/firestore/docs/) without having to rev every plugin when a new API is introduced.

Fixes flutter/flutter#12399