### PR TITLE
Updating firebase and playservices version to 11.4.+

### DIFF
--- a/packages/firebase_admob/android/build.gradle
+++ b/packages/firebase_admob/android/build.gradle
@@ -30,7 +30,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        compile 'com.google.firebase:firebase-core:11.0.+'
-        compile 'com.google.firebase:firebase-ads:11.0.+'
+        compile 'com.google.firebase:firebase-core:11.4.+'
+        compile 'com.google.firebase:firebase-ads:11.4.+'
     }
 }

--- a/packages/firebase_analytics/android/build.gradle
+++ b/packages/firebase_analytics/android/build.gradle
@@ -30,7 +30,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        compile 'com.google.firebase:firebase-auth:11.0.+'
-        compile 'com.google.firebase:firebase-analytics:11.0.+'
+        compile 'com.google.firebase:firebase-auth:11.4.+'
+        compile 'com.google.firebase:firebase-analytics:11.4.+'
     }
 }

--- a/packages/firebase_analytics/example/android/app/build.gradle
+++ b/packages/firebase_analytics/example/android/app/build.gradle
@@ -41,7 +41,7 @@ flutter {
 }
 
 dependencies {
-    compile 'com.google.firebase:firebase-core:11.0.+'
+    compile 'com.google.firebase:firebase-core:11.4.+'
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/packages/firebase_auth/android/build.gradle
+++ b/packages/firebase_auth/android/build.gradle
@@ -34,7 +34,7 @@ android {
     }
     dependencies {
         compile 'com.google.guava:guava:20.0'
-        compile 'com.google.firebase:firebase-core:11.0.+'
-        compile 'com.google.firebase:firebase-auth:11.0.+'
+        compile 'com.google.firebase:firebase-core:11.4.+'
+        compile 'com.google.firebase:firebase-auth:11.4.+'
     }
 }

--- a/packages/firebase_database/android/build.gradle
+++ b/packages/firebase_database/android/build.gradle
@@ -30,8 +30,8 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        compile 'com.google.firebase:firebase-core:11.0.+'
-        compile 'com.google.firebase:firebase-auth:11.0.+'
-        compile 'com.google.firebase:firebase-database:11.0.+'
+        compile 'com.google.firebase:firebase-core:11.4.+'
+        compile 'com.google.firebase:firebase-auth:11.4.+'
+        compile 'com.google.firebase:firebase-database:11.4.+'
     }
 }

--- a/packages/firebase_messaging/android/build.gradle
+++ b/packages/firebase_messaging/android/build.gradle
@@ -30,7 +30,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        compile 'com.google.firebase:firebase-core:11.0.+'
-        compile 'com.google.firebase:firebase-messaging:11.0.+'
+        compile 'com.google.firebase:firebase-core:11.4.+'
+        compile 'com.google.firebase:firebase-messaging:11.4.+'
     }
 }

--- a/packages/firebase_storage/android/build.gradle
+++ b/packages/firebase_storage/android/build.gradle
@@ -38,7 +38,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        compile 'com.google.firebase:firebase-core:11.0.+'
-        compile 'com.google.firebase:firebase-storage:11.0.+'
+        compile 'com.google.firebase:firebase-core:11.4.+'
+        compile 'com.google.firebase:firebase-storage:11.4.+'
     }
 }

--- a/packages/google_sign_in/android/build.gradle
+++ b/packages/google_sign_in/android/build.gradle
@@ -35,6 +35,6 @@ android {
 }
 
 dependencies {
-    compile 'com.google.android.gms:play-services-auth:11.0.+'
+    compile 'com.google.android.gms:play-services-auth:11.4.+'
     compile 'com.google.guava:guava:20.0'
 }


### PR DESCRIPTION
The Firestore plugin is causing a version conflict of Firebase and Google Play Android library dependencies using `11.0.+`  while Firestore is depending on `11.4.+`. 