### PR TITLE
Fix: Set "click_action" in example data payload

### DIFF
--- a/packages/firebase_messaging/CHANGELOG.md
+++ b/packages/firebase_messaging/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.5+2
+
+* Fixed README example for "click_action"
+
 ## 0.0.5+1
 
 * Aligned author name with rest of repo.

--- a/packages/firebase_messaging/README.md
+++ b/packages/firebase_messaging/README.md
@@ -78,7 +78,7 @@ For testing purposes, the simplest way to send a notification is via the [Fireba
 Alternatively, a notification or data message can be sent from a terminal:
 
 ```shell
-DATA='{"notification": {"click_action": "FLUTTER_NOTIFICATION_CLICK", "body": "this is a body","title": "this is a title"}, "priority": "high", "data": {"id": "1", "status": "done"}, "to": "<FCM TOKEN>"}'
+DATA='{"notification": {"body": "this is a body","title": "this is a title"}, "priority": "high", "data": {"click_action": "FLUTTER_NOTIFICATION_CLICK", "id": "1", "status": "done"}, "to": "<FCM TOKEN>"}'
 curl https://fcm.googleapis.com/fcm/send -H "Content-Type:application/json" -X POST -d "$DATA" -H "Authorization: key=<FCM SERVER KEY>"
 ```
 

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -3,7 +3,7 @@ name: firebase_messaging
 description: Firebase Cloud Messaging plugin for Flutter applications.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_messaging
-version: 0.0.5+1
+version: 0.0.5+2
 
 flutter:
   plugin:


### PR DESCRIPTION
The curl example in the README currently includes `"click_action": "FLUTTER_NOTIFICATION_CLICK"` as part of the `notification` payload, this doesn't open the app when the notification is tapped.

Moved it into the data payload instead for the desired behavior.