### PR TITLE
Fix the package ID of firestore

### DIFF
--- a/packages/firebase_firestore/android/build.gradle
+++ b/packages/firebase_firestore/android/build.gradle
@@ -1,4 +1,4 @@
-group 'io.flutter.plugins.firebase.database'
+group 'io.flutter.plugins.firebase.firestore'
 version '1.0-SNAPSHOT'
 
 buildscript {

--- a/packages/firebase_firestore/android/settings.gradle
+++ b/packages/firebase_firestore/android/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'firebase_database'
+rootProject.name = 'firebase_firestore'

--- a/packages/firebase_firestore/android/src/main/AndroidManifest.xml
+++ b/packages/firebase_firestore/android/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="io.flutter.plugins.firebase.database"
+  package="io.flutter.plugins.firebase.firestore"
   android:versionCode="1"
   android:versionName="0.0.1">
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/12501

Currently an app that declares a dependency on both firebase_database and firebase_firestore will fail during compilation with:
```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:transformClassesWithDexForRelease'.
> com.android.build.api.transform.TransformException: com.android.ide.common.process.ProcessException: java.util.concurrent.ExecutionException: com.android.dex.DexException: Multiple dex files define Lio/flutter/plugins/firebase/database/BuildConfig;
```

The reason for this is a wrong package ID in the android manifest of firestore.