### PR TITLE
Removed broken type-comparison

### DIFF
--- a/packages/device_info/CHANGELOG.md
+++ b/packages/device_info/CHANGELOG.md
@@ -1,9 +1,6 @@
-## 0.0.2+2 - Oct 18, 2017
+## 0.0.2 - Oct 20, 2017
 
 * Fixed broke type comparison
-
-## 0.0.2+1 - Oct 6, 2017
-
 * Added "isPhysicaldevice" field, detecting emulators/simulators
 
 ## 0.0.1 - June 28, 2017

--- a/packages/device_info/CHANGELOG.md
+++ b/packages/device_info/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.0.2+1 - Oct 18, 2017
+
+* Fixed broke type comparison
+
+## 0.0.2+1 - Oct 6, 2017
+
+* Added "isPhysicaldevice" field, detecting emulators/simulators
+
 ## 0.0.1 - June 28, 2017
 
 * Implements platform-specific device/OS properties

--- a/packages/device_info/CHANGELOG.md
+++ b/packages/device_info/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.0.2+1 - Oct 18, 2017
+## 0.0.2+2 - Oct 18, 2017
 
 * Fixed broke type comparison
 

--- a/packages/device_info/lib/device_info.dart
+++ b/packages/device_info/lib/device_info.dart
@@ -141,7 +141,7 @@ class AndroidDeviceInfo {
       supportedAbis: json['supportedAbis'],
       tags: json['tags'],
       type: json['type'],
-      isPhysicalDevice: json['isPhysicalDevice'] == 'true',
+      isPhysicalDevice: json['isPhysicalDevice'],
     );
   }
 }

--- a/packages/device_info/pubspec.yaml
+++ b/packages/device_info/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_info
 description: Provides detailed information about the device the Flutter app is running on.
-version: 0.0.1
+version: 0.0.2
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/device_info
 


### PR DESCRIPTION
I remembered why I used the '.toString()' in my last PR: Android passes actual bool-types which should not be directly compared to 'true'... 
The iOs comparison in line 243 still stands since iOS does pass string-representations of bool-values.