### PR TITLE
Add ability to scale images with ImagePicker plugin

### DIFF
--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2
+
+* Added optional maxWidth and maxHeight arguments to pickImage.
+
 ## 0.1.1
 
 * Updated Gradle repositories declaration to avoid the need for manual configuration

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -13,21 +13,20 @@ import com.esafirm.imagepicker.features.ImagePicker;
 import com.esafirm.imagepicker.features.camera.DefaultCameraModule;
 import com.esafirm.imagepicker.features.camera.OnImageReadyListener;
 import com.esafirm.imagepicker.model.Image;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry;
 import io.flutter.plugin.common.PluginRegistry.ActivityResultListener;
-
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 
 /** Location Plugin */
 public class ImagePickerPlugin implements MethodCallHandler, ActivityResultListener {

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -8,26 +8,22 @@ import android.app.Activity;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
-import android.util.Log;
-
 import com.esafirm.imagepicker.features.ImagePicker;
 import com.esafirm.imagepicker.features.camera.DefaultCameraModule;
 import com.esafirm.imagepicker.features.camera.OnImageReadyListener;
 import com.esafirm.imagepicker.model.Image;
-
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry;
 import io.flutter.plugin.common.PluginRegistry.ActivityResultListener;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /** Location Plugin */
 public class ImagePickerPlugin implements MethodCallHandler, ActivityResultListener {
@@ -136,8 +132,8 @@ public class ImagePickerPlugin implements MethodCallHandler, ActivityResultListe
     boolean hasMaxWidth = maxWidth != null;
     boolean hasMaxHeight = maxHeight != null;
 
-    Double width = hasMaxWidth? Math.min(originalWidth, maxWidth) : originalWidth;
-    Double height = hasMaxHeight? Math.min(originalHeight, maxHeight) : originalHeight;
+    Double width = hasMaxWidth ? Math.min(originalWidth, maxWidth) : originalWidth;
+    Double height = hasMaxHeight ? Math.min(originalHeight, maxHeight) : originalHeight;
 
     boolean shouldDownscaleWidth = hasMaxWidth && maxWidth < originalWidth;
     boolean shouldDownscaleHeight = hasMaxHeight && maxHeight < originalHeight;

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -106,15 +106,15 @@ public class ImagePickerPlugin implements MethodCallHandler, ActivityResultListe
 
   private void handleResult(Image image) {
     if (pendingResult != null) {
-      Double requestedWidth = methodCall.argument("width");
-      Double requestedHeight = methodCall.argument("height");
-      boolean shouldScale = requestedWidth != null || requestedHeight != null;
+      Double maxWidth = methodCall.argument("maxWidth");
+      Double maxHeight = methodCall.argument("maxHeight");
+      boolean shouldScale = maxWidth != null || maxHeight != null;
 
       if (!shouldScale) {
         pendingResult.success(image.getPath());
       } else {
         try {
-          File imageFile = scaleImage(image, requestedWidth, requestedHeight);
+          File imageFile = scaleImage(image, maxWidth, maxHeight);
           pendingResult.success(imageFile.getPath());
         } catch (IOException e) {
           throw new RuntimeException(e);
@@ -128,13 +128,13 @@ public class ImagePickerPlugin implements MethodCallHandler, ActivityResultListe
     }
   }
 
-  private File scaleImage(Image image, Double requestedWidth, Double requestedHeight) throws IOException {
+  private File scaleImage(Image image, Double maxWidth, Double maxHeight) throws IOException {
     Bitmap bmp = BitmapFactory.decodeFile(image.getPath());
     int originalWidth = bmp.getWidth();
     int originalHeight = bmp.getHeight();
 
-    int finalWidth = requestedWidth != null? requestedWidth.intValue() : originalWidth;
-    int finalHeight = requestedHeight != null? requestedHeight.intValue() : originalHeight;
+    int finalWidth = maxWidth != null? Math.min(maxWidth.intValue(), originalWidth) : originalWidth;
+    int finalHeight = maxHeight != null? Math.min(maxHeight.intValue(), originalHeight) : originalHeight;
 
     Bitmap scaledBmp = Bitmap.createScaledBitmap(bmp, finalWidth, finalHeight, false);
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();

--- a/packages/image_picker/example/lib/main.dart
+++ b/packages/image_picker/example/lib/main.dart
@@ -53,7 +53,7 @@ class _MyHomePageState extends State<MyHomePage> {
       floatingActionButton: new FloatingActionButton(
         onPressed: () {
           setState(() {
-            _imageFile = ImagePicker.pickImage();
+            _imageFile = ImagePicker.pickImage(maxWidth: 300.0, maxHeight: 300.0);
           });
         },
         tooltip: 'Pick Image',

--- a/packages/image_picker/example/lib/main.dart
+++ b/packages/image_picker/example/lib/main.dart
@@ -53,7 +53,7 @@ class _MyHomePageState extends State<MyHomePage> {
       floatingActionButton: new FloatingActionButton(
         onPressed: () {
           setState(() {
-            _imageFile = ImagePicker.pickImage(maxWidth: 300.0, maxHeight: 300.0);
+            _imageFile = ImagePicker.pickImage();
           });
         },
         tooltip: 'Pick Image',

--- a/packages/image_picker/ios/Classes/ImagePickerPlugin.m
+++ b/packages/image_picker/ios/Classes/ImagePickerPlugin.m
@@ -144,24 +144,26 @@
   return normalizedImage;
 }
 
-- (UIImage *)scaledImage:(UIImage *)image maxWidth:(NSNumber*)maxWidth maxHeight:(NSNumber*)maxHeight {
+- (UIImage *)scaledImage:(UIImage *)image
+                maxWidth:(NSNumber *)maxWidth
+               maxHeight:(NSNumber *)maxHeight {
   double originalWidth = image.size.width;
   double originalHeight = image.size.height;
-    
+
   bool hasMaxWidth = maxWidth != (id)[NSNull null];
   bool hasMaxHeight = maxHeight != (id)[NSNull null];
 
-  double width = hasMaxWidth? MIN([maxWidth doubleValue], originalWidth) : originalWidth;
-  double height = hasMaxHeight? MIN([maxHeight doubleValue], originalHeight) : originalHeight;
-    
+  double width = hasMaxWidth ? MIN([maxWidth doubleValue], originalWidth) : originalWidth;
+  double height = hasMaxHeight ? MIN([maxHeight doubleValue], originalHeight) : originalHeight;
+
   bool shouldDownscaleWidth = hasMaxWidth && [maxWidth doubleValue] < originalWidth;
   bool shouldDownscaleHeight = hasMaxHeight && [maxHeight doubleValue] < originalHeight;
   bool shouldDownscale = shouldDownscaleWidth || shouldDownscaleHeight;
-    
+
   if (shouldDownscale) {
     double downscaledWidth = (height / originalHeight) * originalWidth;
     double downscaledHeight = (width / originalWidth) * originalHeight;
-        
+
     if (width < height) {
       if (!hasMaxWidth) {
         width = downscaledWidth;

--- a/packages/image_picker/ios/Classes/ImagePickerPlugin.m
+++ b/packages/image_picker/ios/Classes/ImagePickerPlugin.m
@@ -104,11 +104,11 @@
   }
   image = [self normalizedImage:image];
 
-  NSNumber *width = [_arguments objectForKey:@"width"];
-  NSNumber *height = [_arguments objectForKey:@"height"];
+  NSNumber *maxWidth = [_arguments objectForKey:@"maxWidth"];
+  NSNumber *maxHeight = [_arguments objectForKey:@"maxHeight"];
 
-  if (width != (id)[NSNull null] || height != (id)[NSNull null]) {
-    image = [self scaledImage:image width:width height:height];
+  if (maxWidth != (id)[NSNull null] || maxHeight != (id)[NSNull null]) {
+    image = [self scaledImage:image maxWidth:maxWidth maxHeight:maxHeight];
   }
 
   NSData *data = UIImageJPEGRepresentation(image, 1.0);
@@ -144,12 +144,12 @@
   return normalizedImage;
 }
 
-- (UIImage *)scaledImage:(UIImage *)image width:(NSNumber*)width height:(NSNumber*)height {
+- (UIImage *)scaledImage:(UIImage *)image maxWidth:(NSNumber*)maxWidth maxHeight:(NSNumber*)maxHeight {
   double originalWidth = image.size.width;
   double originalHeight = image.size.height;
 
-  double finalWidth = width != (id)[NSNull null]? [width doubleValue] : originalWidth;
-  double finalHeight = height != (id)[NSNull null]? [height doubleValue] : originalHeight;
+  double finalWidth = maxWidth != (id)[NSNull null]? MIN([maxWidth doubleValue], originalWidth) : originalWidth;
+  double finalHeight = maxHeight != (id)[NSNull null]? MIN([maxHeight doubleValue], originalHeight) : originalHeight;
 
   UIGraphicsBeginImageContextWithOptions(CGSizeMake(finalWidth, finalHeight), NO, 1.0);
   [image drawInRect:CGRectMake(0, 0, finalWidth, finalHeight)];

--- a/packages/image_picker/ios/Classes/ImagePickerPlugin.m
+++ b/packages/image_picker/ios/Classes/ImagePickerPlugin.m
@@ -147,12 +147,44 @@
 - (UIImage *)scaledImage:(UIImage *)image maxWidth:(NSNumber*)maxWidth maxHeight:(NSNumber*)maxHeight {
   double originalWidth = image.size.width;
   double originalHeight = image.size.height;
+    
+  bool hasMaxWidth = maxWidth != (id)[NSNull null];
+  bool hasMaxHeight = maxHeight != (id)[NSNull null];
 
-  double finalWidth = maxWidth != (id)[NSNull null]? MIN([maxWidth doubleValue], originalWidth) : originalWidth;
-  double finalHeight = maxHeight != (id)[NSNull null]? MIN([maxHeight doubleValue], originalHeight) : originalHeight;
+  double width = hasMaxWidth? MIN([maxWidth doubleValue], originalWidth) : originalWidth;
+  double height = hasMaxHeight? MIN([maxHeight doubleValue], originalHeight) : originalHeight;
+    
+  bool shouldDownscaleWidth = hasMaxWidth && [maxWidth doubleValue] < originalWidth;
+  bool shouldDownscaleHeight = hasMaxHeight && [maxHeight doubleValue] < originalHeight;
+  bool shouldDownscale = shouldDownscaleWidth || shouldDownscaleHeight;
+    
+  if (shouldDownscale) {
+    double downscaledWidth = (height / originalHeight) * originalWidth;
+    double downscaledHeight = (width / originalWidth) * originalHeight;
+        
+    if (width < height) {
+      if (!hasMaxWidth) {
+        width = downscaledWidth;
+      } else {
+        height = downscaledHeight;
+      }
+    } else if (height < width) {
+      if (!hasMaxHeight) {
+        height = downscaledHeight;
+      } else {
+        width = downscaledWidth;
+      }
+    } else {
+      if (originalWidth < originalHeight) {
+        width = downscaledWidth;
+      } else if (originalHeight < originalWidth) {
+        height = downscaledHeight;
+      }
+    }
+  }
 
-  UIGraphicsBeginImageContextWithOptions(CGSizeMake(finalWidth, finalHeight), NO, 1.0);
-  [image drawInRect:CGRectMake(0, 0, finalWidth, finalHeight)];
+  UIGraphicsBeginImageContextWithOptions(CGSizeMake(width, height), NO, 1.0);
+  [image drawInRect:CGRectMake(0, 0, width, height)];
 
   UIImage *scaledImage = UIGraphicsGetImageFromCurrentImageContext();
   UIGraphicsEndImageContext();

--- a/packages/image_picker/lib/image_picker.dart
+++ b/packages/image_picker/lib/image_picker.dart
@@ -17,22 +17,23 @@ class ImagePicker {
   /// * pick an image from the gallery
   /// * take a photo using the device camera.
   ///
-  /// If specified, image will be resized to [desiredWidth] and [desiredHeight].
-  static Future<File> pickImage(
-      {double desiredWidth, double desiredHeight}) async {
-    if (desiredWidth != null && desiredWidth < 0) {
-      throw new ArgumentError.value(desiredWidth, 'width can\'t be negative');
+  /// If specified, the image will be at most [maxWidth] wide and
+  /// [maxHeight] tall. Otherwise the image will be returned at it's
+  /// original width and height.
+  static Future<File> pickImage({double maxWidth, double maxHeight}) async {
+    if (maxWidth != null && maxWidth < 0) {
+      throw new ArgumentError.value(maxWidth, 'maxWidth can\'t be negative');
     }
 
-    if (desiredHeight != null && desiredHeight < 0) {
-      throw new ArgumentError.value(desiredHeight, 'height can\'t be negative');
+    if (maxHeight != null && maxHeight < 0) {
+      throw new ArgumentError.value(maxHeight, 'maxHeight can\'t be negative');
     }
 
     final String path = await _channel.invokeMethod(
       'pickImage',
       <String, double>{
-        'width': desiredWidth,
-        'height': desiredHeight,
+        'maxWidth': maxWidth,
+        'maxHeight': maxHeight,
       },
     );
 

--- a/packages/image_picker/lib/image_picker.dart
+++ b/packages/image_picker/lib/image_picker.dart
@@ -10,7 +10,14 @@ import 'package:flutter/services.dart';
 class ImagePicker {
   static const MethodChannel _channel = const MethodChannel('image_picker');
 
-  // Returns the URL of the picked image
+  /// Returns a [File] object pointing to the image that was picked.
+  ///
+  /// On both Android & iOS, the user can choose to either:
+  ///
+  /// * pick an image from the gallery
+  /// * take a photo using the device camera.
+  ///
+  /// If specified, image will be resized to [desiredWidth] and [desiredHeight].
   static Future<File> pickImage({double desiredWidth, double desiredHeight}) async {
     final String path = await _channel.invokeMethod('pickImage',
       <String, double> {

--- a/packages/image_picker/lib/image_picker.dart
+++ b/packages/image_picker/lib/image_picker.dart
@@ -18,13 +18,24 @@ class ImagePicker {
   /// * take a photo using the device camera.
   ///
   /// If specified, image will be resized to [desiredWidth] and [desiredHeight].
-  static Future<File> pickImage({double desiredWidth, double desiredHeight}) async {
-    final String path = await _channel.invokeMethod('pickImage',
-      <String, double> {
+  static Future<File> pickImage(
+      {double desiredWidth, double desiredHeight}) async {
+    if (desiredWidth != null && desiredWidth < 0) {
+      throw new ArgumentError.value(desiredWidth, 'width can\'t be negative');
+    }
+
+    if (desiredHeight != null && desiredHeight < 0) {
+      throw new ArgumentError.value(desiredHeight, 'height can\'t be negative');
+    }
+
+    final String path = await _channel.invokeMethod(
+      'pickImage',
+      <String, double>{
         'width': desiredWidth,
         'height': desiredHeight,
       },
     );
+
     return new File(path);
   }
 }

--- a/packages/image_picker/lib/image_picker.dart
+++ b/packages/image_picker/lib/image_picker.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 import 'dart:io';
+import 'dart:ui';
 
 import 'package:flutter/services.dart';
 
@@ -11,8 +12,13 @@ class ImagePicker {
   static const MethodChannel _channel = const MethodChannel('image_picker');
 
   // Returns the URL of the picked image
-  static Future<File> pickImage() async {
-    final String path = await _channel.invokeMethod('pickImage');
+  static Future<File> pickImage({double desiredWidth, double desiredHeight}) async {
+    final String path = await _channel.invokeMethod('pickImage',
+      <String, double> {
+        'width': desiredWidth,
+        'height': desiredHeight,
+      },
+    );
     return new File(path);
   }
 }

--- a/packages/image_picker/lib/image_picker.dart
+++ b/packages/image_picker/lib/image_picker.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 import 'dart:io';
-import 'dart:ui';
 
 import 'package:flutter/services.dart';
 

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -14,5 +14,8 @@ dependencies:
   flutter:
     sdk: flutter
 
+dev_dependencies:
+  test: 0.12.21
+
 environment:
     sdk: ">=1.8.0 <2.0.0"

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -3,7 +3,7 @@ name: image_picker
 description: Flutter plugin that shows an image picker and uses the camera.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.1.1
+version: 0.1.2
 
 flutter:
   plugin:

--- a/packages/image_picker/test/image_picker_test.dart
+++ b/packages/image_picker/test/image_picker_test.dart
@@ -20,11 +20,11 @@ void main() {
     group('#pickImage', () {
       test('passes the width and height arguments correctly', () async {
         await ImagePicker.pickImage();
-        await ImagePicker.pickImage(desiredWidth: 10.0);
-        await ImagePicker.pickImage(desiredHeight: 10.0);
+        await ImagePicker.pickImage(maxWidth: 10.0);
+        await ImagePicker.pickImage(maxHeight: 10.0);
         await ImagePicker.pickImage(
-          desiredWidth: 10.0,
-          desiredHeight: 20.0,
+          maxWidth: 10.0,
+          maxHeight: 20.0,
         );
 
         expect(
@@ -32,20 +32,20 @@ void main() {
           equals(
             <MethodCall>[
               const MethodCall('pickImage', const <String, double>{
-                'width': null,
-                'height': null,
+                'maxWidth': null,
+                'maxHeight': null,
               }),
               const MethodCall('pickImage', const <String, double>{
-                'width': 10.0,
-                'height': null,
+                'maxWidth': 10.0,
+                'maxHeight': null,
               }),
               const MethodCall('pickImage', const <String, double>{
-                'width': null,
-                'height': 10.0,
+                'maxWidth': null,
+                'maxHeight': 10.0,
               }),
               const MethodCall('pickImage', const <String, double>{
-                'width': 10.0,
-                'height': 20.0,
+                'maxWidth': 10.0,
+                'maxHeight': 20.0,
               }),
             ],
           ),
@@ -53,8 +53,8 @@ void main() {
       });
 
       test('does not accept a negative width or height argument', () {
-        expect(ImagePicker.pickImage(desiredWidth: -1.0), throwsArgumentError);
-        expect(ImagePicker.pickImage(desiredHeight: -1.0), throwsArgumentError);
+        expect(ImagePicker.pickImage(maxWidth: -1.0), throwsArgumentError);
+        expect(ImagePicker.pickImage(maxHeight: -1.0), throwsArgumentError);
       });
     });
   });

--- a/packages/image_picker/test/image_picker_test.dart
+++ b/packages/image_picker/test/image_picker_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/services.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('$ImagePicker', () {
+    const MethodChannel channel = const MethodChannel('image_picker');
+
+    final List<MethodCall> log = <MethodCall>[];
+
+    setUp(() {
+      channel.setMockMethodCallHandler((MethodCall methodCall) async {
+        log.add(methodCall);
+        return '';
+      });
+
+      log.clear();
+    });
+
+    group('#pickImage', () {
+      test('passes the width and height arguments correctly', () async {
+        await ImagePicker.pickImage();
+        await ImagePicker.pickImage(desiredWidth: 10.0);
+        await ImagePicker.pickImage(desiredHeight: 10.0);
+        await ImagePicker.pickImage(
+          desiredWidth: 10.0,
+          desiredHeight: 20.0,
+        );
+
+        expect(
+          log,
+          equals(
+            <MethodCall>[
+              const MethodCall('pickImage', const <String, double>{
+                'width': null,
+                'height': null,
+              }),
+              const MethodCall('pickImage', const <String, double>{
+                'width': 10.0,
+                'height': null,
+              }),
+              const MethodCall('pickImage', const <String, double>{
+                'width': null,
+                'height': 10.0,
+              }),
+              const MethodCall('pickImage', const <String, double>{
+                'width': 10.0,
+                'height': 20.0,
+              }),
+            ],
+          ),
+        );
+      });
+
+      test('does not accept a negative width or height argument', () {
+        expect(ImagePicker.pickImage(desiredWidth: -1.0), throwsArgumentError);
+        expect(ImagePicker.pickImage(desiredHeight: -1.0), throwsArgumentError);
+      });
+    });
+  });
+}


### PR DESCRIPTION
[flutter/flutter/#10149](https://github.com/flutter/flutter/issues/10149)

This makes it possible to specificy a `maxWidth` and `maxHeight` for the `pickImage` method, like so:

```dart
Future<File> imageFile = ImagePicker.pickImage(maxWidth: 400.0, maxHeight: 700.0);
```

The picked image will then be scaled accordingly, while **preserving aspect ratio**.

Let me know if there's something that could be improved on. [This is me doing Objective C](https://cdn-images-1.medium.com/max/455/1*snTXFElFuQLSFDnvZKJ6IA.png), so I'm pretty sure it's not the most idiomatic code possible.