### PR TITLE
Update pubspecs to use material font package

### DIFF
--- a/packages/android_intent/example/pubspec.yaml
+++ b/packages/android_intent/example/pubspec.yaml
@@ -6,6 +6,7 @@ dependencies:
     sdk: flutter
   android_intent:
     path: ../
+  material_icons_font: ^0.1.1
 
 # The following section is specific to Flutter.
 flutter:

--- a/packages/battery/example/pubspec.yaml
+++ b/packages/battery/example/pubspec.yaml
@@ -6,6 +6,7 @@ dependencies:
     sdk: flutter
   battery:
     path: ../
+  material_icons_font: ^0.1.1
 
 flutter:
   uses-material-design: true

--- a/packages/connectivity/example/pubspec.yaml
+++ b/packages/connectivity/example/pubspec.yaml
@@ -6,6 +6,7 @@ dependencies:
     sdk: flutter
   connectivity:
     path: ../
+  material_icons_font: ^0.1.1
 
 flutter:
   uses-material-design: true

--- a/packages/device_info/example/pubspec.yaml
+++ b/packages/device_info/example/pubspec.yaml
@@ -6,6 +6,7 @@ dependencies:
     sdk: flutter
   device_info:
     path: ../
+  material_icons_font: ^0.1.1
 
 flutter:
   uses-material-design: true

--- a/packages/firebase_admob/example/pubspec.yaml
+++ b/packages/firebase_admob/example/pubspec.yaml
@@ -6,6 +6,7 @@ dependencies:
     sdk: flutter
   firebase_admob:
     path: ../
+  material_icons_font: ^0.1.1
 
 flutter:
   uses-material-design: true

--- a/packages/firebase_analytics/example/pubspec.yaml
+++ b/packages/firebase_analytics/example/pubspec.yaml
@@ -6,6 +6,7 @@ dependencies:
     sdk: flutter
   firebase_analytics:
     path: ../
+  material_icons_font: ^0.1.1
 
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec

--- a/packages/firebase_auth/example/pubspec.yaml
+++ b/packages/firebase_auth/example/pubspec.yaml
@@ -8,6 +8,7 @@ dependencies:
     path: ../
   google_sign_in:
     path: ../../google_sign_in
+  material_icons_font: ^0.1.1
 
 flutter:
   uses-material-design: true

--- a/packages/firebase_database/example/pubspec.yaml
+++ b/packages/firebase_database/example/pubspec.yaml
@@ -8,6 +8,7 @@ dependencies:
     path: ../../firebase_auth
   firebase_database:
     path: ../
+  material_icons_font: ^0.1.1
 
 flutter:
   uses-material-design: true

--- a/packages/firebase_firestore/example/pubspec.yaml
+++ b/packages/firebase_firestore/example/pubspec.yaml
@@ -6,6 +6,7 @@ dependencies:
     sdk: flutter
   firebase_firestore:
     path: ../
+  material_icons_font: ^0.1.1
 
 flutter:
   uses-material-design: true

--- a/packages/firebase_messaging/example/pubspec.yaml
+++ b/packages/firebase_messaging/example/pubspec.yaml
@@ -6,6 +6,7 @@ dependencies:
     sdk: flutter
   firebase_messaging:
     path: ../
+  material_icons_font: ^0.1.1
 
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec

--- a/packages/firebase_storage/example/pubspec.yaml
+++ b/packages/firebase_storage/example/pubspec.yaml
@@ -7,6 +7,7 @@ dependencies:
   firebase_storage:
     path: ../
   http: ^0.11.3
+  material_icons_font: ^0.1.1
 
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec

--- a/packages/google_sign_in/example/pubspec.yaml
+++ b/packages/google_sign_in/example/pubspec.yaml
@@ -7,6 +7,7 @@ dependencies:
   google_sign_in:
     path: ../
   http: ^0.11.3
+  material_icons_font: ^0.1.1
 
 flutter:
   uses-material-design: true

--- a/packages/image_picker/example/pubspec.yaml
+++ b/packages/image_picker/example/pubspec.yaml
@@ -6,6 +6,7 @@ dependencies:
     sdk: flutter
   image_picker:
     path: ../
+  material_icons_font: ^0.1.1
 
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec

--- a/packages/local_auth/example/pubspec.yaml
+++ b/packages/local_auth/example/pubspec.yaml
@@ -6,6 +6,7 @@ dependencies:
     sdk: flutter
   local_auth:
     path: ../
+  material_icons_font: ^0.1.1
 
 flutter:
   uses-material-design: true

--- a/packages/package_info/example/pubspec.yaml
+++ b/packages/package_info/example/pubspec.yaml
@@ -6,6 +6,7 @@ dependencies:
     sdk: flutter
   package_info:
     path: ../
+  material_icons_font: ^0.1.1
 
 flutter:
   uses-material-design: true

--- a/packages/path_provider/example/pubspec.yaml
+++ b/packages/path_provider/example/pubspec.yaml
@@ -6,6 +6,7 @@ dependencies:
     sdk: flutter
   path_provider:
     path: ../
+  material_icons_font: ^0.1.1
 
 flutter:
   uses-material-design: true

--- a/packages/quick_actions/example/pubspec.yaml
+++ b/packages/quick_actions/example/pubspec.yaml
@@ -6,6 +6,7 @@ dependencies:
     sdk: flutter
   quick_actions:
     path: ../
+  material_icons_font: ^0.1.1
 
 flutter:
   uses-material-design: true

--- a/packages/sensors/example/pubspec.yaml
+++ b/packages/sensors/example/pubspec.yaml
@@ -6,7 +6,7 @@ dependencies:
     sdk: flutter
   sensors:
     path: ../
+  material_icons_font: ^0.1.1
 
 flutter:
-
   uses-material-design: true

--- a/packages/share/example/pubspec.yaml
+++ b/packages/share/example/pubspec.yaml
@@ -6,6 +6,7 @@ dependencies:
     sdk: flutter
   share:
     path: ../
+  material_icons_font: ^0.1.1
 
 flutter:
   uses-material-design: true

--- a/packages/shared_preferences/example/pubspec.yaml
+++ b/packages/shared_preferences/example/pubspec.yaml
@@ -6,6 +6,7 @@ dependencies:
     sdk: flutter
   shared_preferences:
     path: ../
+  material_icons_font: ^0.1.1
 
 flutter:
   uses-material-design: true

--- a/packages/url_launcher/example/pubspec.yaml
+++ b/packages/url_launcher/example/pubspec.yaml
@@ -6,6 +6,7 @@ dependencies:
     sdk: flutter
   url_launcher:
     path: ../
+  material_icons_font: ^0.1.1
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
Submit after https://github.com/flutter/flutter/pull/12730

Keep both material_icons_font and uses-material-design in case the plugin is used by users with old flutter tools versions