### PR TITLE
Firestore updates

### DIFF
--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.0.4
 
-* Support for queries
+* Support for where clauses
+* Support for deletion
 
 ## 0.0.3
 

--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.4
+
+* Support for queries
+
 ## 0.0.3
 
 * Renamed package to cloud_firestore

--- a/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/CloudFirestorePlugin.java
+++ b/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/CloudFirestorePlugin.java
@@ -57,11 +57,11 @@ public class CloudFirestorePlugin implements MethodCallHandler {
   }
 
   private Query getQuery(Map<String, Object> arguments) {
-    Query query =  getCollectionReference(arguments);
+    Query query = getCollectionReference(arguments);
     @SuppressWarnings("unchecked")
     Map<String, Object> parameters = (Map<String, Object>) arguments.get("parameters");
     if (parameters == null) return query;
-    for (Map.Entry<String, Object> entry: parameters.entrySet()) {
+    for (Map.Entry<String, Object> entry : parameters.entrySet()) {
       String key = entry.getKey();
       Object value = entry.getValue();
       if (key.startsWith("where==:")) {
@@ -82,9 +82,8 @@ public class CloudFirestorePlugin implements MethodCallHandler {
       } else if (key.startsWith("orderBy:")) {
         String field = key.replace("orderBy:", "");
         Boolean descending = (Boolean) value;
-        Query.Direction direction = descending
-          ? Query.Direction.DESCENDING
-          : Query.Direction.ASCENDING;
+        Query.Direction direction =
+            descending ? Query.Direction.DESCENDING : Query.Direction.ASCENDING;
         query = query.orderBy(field, direction);
       }
     }

--- a/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/CloudFirestorePlugin.java
+++ b/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/CloudFirestorePlugin.java
@@ -173,6 +173,14 @@ public class CloudFirestorePlugin implements MethodCallHandler {
           result.success(null);
           break;
         }
+      case "DocumentReference#delete":
+        {
+          Map<String, Object> arguments = call.arguments();
+          DocumentReference documentReference = getDocumentReference(arguments);
+          documentReference.delete();
+          result.success(null);
+          break;
+        }
       default:
         {
           result.notImplemented();

--- a/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
+++ b/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
@@ -21,37 +21,32 @@
 FIRQuery *getQuery(NSDictionary *arguments) {
   FIRQuery *query = [[FIRFirestore firestore] collectionWithPath:arguments[@"path"]];
   NSDictionary *parameters = arguments[@"parameters"];
-  for (id key in parameters) {
-    NSString *keyString = key;
-    if ([keyString hasPrefix:@"where==:"]) {
-      NSString *field = [keyString stringByReplacingOccurrencesOfString:@"where==:"
-                                                             withString:@""];
-      query = [query queryWhereField:field isEqualTo:parameters[key]];
-    } else if ([keyString hasPrefix:@"where<:"]) {
-      NSString *field = [keyString stringByReplacingOccurrencesOfString:@"where<:"
-                                                             withString:@""];
-      query = [query queryWhereField:field isLessThan:parameters[key]];
-    } else if ([keyString hasPrefix:@"where<=:"]) {
-      NSString *field = [keyString stringByReplacingOccurrencesOfString:@"where<=:"
-                                                             withString:@""];
-      query = [query queryWhereField:field isLessThanOrEqualTo:parameters[key]];
-    } else if ([keyString hasPrefix:@"where>:"]) {
-      NSString *field = [keyString stringByReplacingOccurrencesOfString:@"where>:"
-                                                             withString:@""];
-      query = [query queryWhereField:field isGreaterThan:parameters[key]];
-    } else if ([keyString hasPrefix:@"where>=:"]) {
-      NSString *field = [keyString stringByReplacingOccurrencesOfString:@"where>=:"
-                                                             withString:@""];
-      query = [query queryWhereField:field isGreaterThanOrEqualTo:parameters[key]];
-    } else if ([keyString hasPrefix:@"orderBy:"]) {
-      NSString *field = [keyString stringByReplacingOccurrencesOfString:@"orderBy:"
-                                                             withString:@""];
-      NSNumber *val = parameters[key];
-      BOOL desc = [val boolValue];
-      query = [query queryOrderedByField:field descending:desc];
+  NSArray *whereConditions = parameters[@"where"];
+  for (id item in whereConditions) {
+    NSArray *condition = item;
+    NSString *fieldName = condition[0];
+    NSString *op = condition[1];
+    id value = condition[2];
+    if ([op isEqualToString:@"=="]) {
+      query = [query queryWhereField:fieldName isEqualTo:value];
+    } else if ([op isEqualToString:@"<"]) {
+      query = [query queryWhereField:fieldName isLessThan:value];
+    } else if ([op isEqualToString:@"<="]) {
+      query = [query queryWhereField:fieldName isLessThanOrEqualTo:value];
+    } else if ([op isEqualToString:@">"]) {
+      query = [query queryWhereField:fieldName isGreaterThan:value];
+    } else if ([op isEqualToString:@">="]) {
+      query = [query queryWhereField:fieldName isGreaterThanOrEqualTo:value];
     } else {
-      // Not implemented.
+      // Unsupported operator
     }
+  }
+  id orderBy = parameters[@"orderBy"];
+  if (orderBy) {
+    NSArray *orderByParameters = orderBy;
+    NSString *fieldName = orderByParameters[0];
+    NSNumber *descending = orderByParameters[1];
+    query = [query queryOrderedByField:fieldName descending:[descending boolValue]];
   }
   return query;
 }

--- a/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
+++ b/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
@@ -52,7 +52,6 @@ FIRQuery *getQuery(NSDictionary *arguments) {
     } else {
       // Not implemented.
     }
-
   }
   return query;
 }

--- a/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
+++ b/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
@@ -20,7 +20,40 @@
 
 FIRQuery *getQuery(NSDictionary *arguments) {
   FIRQuery *query = [[FIRFirestore firestore] collectionWithPath:arguments[@"path"]];
-  // TODO(jackson): Implement query parameters
+  NSDictionary *parameters = arguments[@"parameters"];
+  for (id key in parameters) {
+    NSString *keyString = key;
+    if ([keyString hasPrefix:@"where==:"]) {
+      NSString *field = [keyString stringByReplacingOccurrencesOfString:@"where==:"
+                                                             withString:@""];
+      query = [query queryWhereField:field isEqualTo:parameters[key]];
+    } else if ([keyString hasPrefix:@"where<:"]) {
+      NSString *field = [keyString stringByReplacingOccurrencesOfString:@"where<:"
+                                                             withString:@""];
+      query = [query queryWhereField:field isLessThan:parameters[key]];
+    } else if ([keyString hasPrefix:@"where<=:"]) {
+      NSString *field = [keyString stringByReplacingOccurrencesOfString:@"where<=:"
+                                                             withString:@""];
+      query = [query queryWhereField:field isLessThanOrEqualTo:parameters[key]];
+    } else if ([keyString hasPrefix:@"where>:"]) {
+      NSString *field = [keyString stringByReplacingOccurrencesOfString:@"where>:"
+                                                             withString:@""];
+      query = [query queryWhereField:field isGreaterThan:parameters[key]];
+    } else if ([keyString hasPrefix:@"where>=:"]) {
+      NSString *field = [keyString stringByReplacingOccurrencesOfString:@"where>=:"
+                                                             withString:@""];
+      query = [query queryWhereField:field isGreaterThanOrEqualTo:parameters[key]];
+    } else if ([keyString hasPrefix:@"orderBy:"]) {
+      NSString *field = [keyString stringByReplacingOccurrencesOfString:@"orderBy:"
+                                                             withString:@""];
+      NSNumber *val = parameters[key];
+      BOOL desc = [val boolValue];
+      query = [query queryOrderedByField:field descending:desc];
+    } else {
+      // Not implemented.
+    }
+
+  }
   return query;
 }
 

--- a/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
+++ b/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
@@ -95,7 +95,15 @@ FIRQuery *getQuery(NSDictionary *arguments) {
     [reference deleteDocumentWithCompletion:defaultCompletionBlock];
   } else if ([@"Query#addSnapshotListener" isEqualToString:call.method]) {
     __block NSNumber *handle = [NSNumber numberWithInt:_nextListenerHandle++];
-    id<FIRListenerRegistration> listener = [getQuery(call.arguments)
+    FIRQuery *query;
+    @try {
+      query = getQuery(call.arguments);
+    } @catch (NSException *exception) {
+      result([FlutterError errorWithCode:@"invalid_query"
+                                 message:[exception name]
+                                 details:[exception reason]]);
+    }
+    id<FIRListenerRegistration> listener = [query
         addSnapshotListener:^(FIRQuerySnapshot *_Nullable snapshot, NSError *_Nullable error) {
           if (error) result(error.flutterError);
           NSMutableArray *paths = [NSMutableArray array];

--- a/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
+++ b/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
@@ -62,6 +62,10 @@ FIRQuery *getQuery(NSDictionary *arguments) {
     NSString *path = call.arguments[@"path"];
     FIRDocumentReference *reference = [[FIRFirestore firestore] documentWithPath:path];
     [reference setData:call.arguments[@"data"] completion:defaultCompletionBlock];
+  } else if ([@"DocumentReference#delete" isEqualToString:call.method]) {
+    NSString *path = call.arguments[@"path"];
+    FIRDocumentReference *reference = [[FIRFirestore firestore] documentWithPath:path];
+    [reference deleteDocumentWithCompletion:defaultCompletionBlock];
   } else if ([@"Query#addSnapshotListener" isEqualToString:call.method]) {
     __block NSNumber *handle = [NSNumber numberWithInt:_nextListenerHandle++];
     id<FIRListenerRegistration> listener = [getQuery(call.arguments)

--- a/packages/cloud_firestore/lib/cloud_firestore.dart
+++ b/packages/cloud_firestore/lib/cloud_firestore.dart
@@ -8,6 +8,7 @@ import 'dart:async';
 
 import 'package:flutter/services.dart';
 import 'package:meta/meta.dart';
+import 'package:collection/collection.dart';
 
 import 'src/utils/push_id_generator.dart';
 

--- a/packages/cloud_firestore/lib/src/document_reference.dart
+++ b/packages/cloud_firestore/lib/src/document_reference.dart
@@ -29,6 +29,13 @@ class DocumentReference {
     );
   }
 
+  Future<Null> delete() {
+    return Firestore.channel.invokeMethod(
+      'DocumentReference#delete',
+      <String, dynamic>{'path': path},
+    );
+  }
+
   /// Notifies of documents at this location
   // TODO(jackson): Reduce code duplication with [Query]
   Stream<DocumentSnapshot> get snapshots {

--- a/packages/cloud_firestore/lib/src/query.dart
+++ b/packages/cloud_firestore/lib/src/query.dart
@@ -25,6 +25,16 @@ class Query {
   /// (relative to the root of the database).
   String get path => _pathComponents.join('/');
 
+  Query _copyWithParameters(Map<String, dynamic> parameters) {
+    return new Query._(
+      firestore: _firestore,
+      pathComponents: _pathComponents,
+      parameters: new Map<String, dynamic>.unmodifiable(
+        new Map<String, dynamic>.from(_parameters)..addAll(parameters),
+      ),
+    );
+  }
+
   Map<String, dynamic> buildArguments() {
     return new Map<String, dynamic>.from(_parameters)
       ..addAll(<String, dynamic>{
@@ -68,4 +78,24 @@ class Query {
   /// Obtains a CollectionReference corresponding to this query's location.
   CollectionReference reference() =>
       new CollectionReference._(_firestore, _pathComponents);
+
+  /// Creates and returns a new [Query] with additional filter on specified
+  /// [field].
+  ///
+  /// Only documents satisfying provided condition are included in the result
+  /// set. [operator] can be one of `==`, `<`, `<=`, `>`, `>=`.
+  Query where(String field, String operator, dynamic value) {
+    assert(const <String>['>', '<', '==', '>=', '<='].contains(operator));
+    final String key = 'where$operator:$field';
+    assert(!_parameters.containsKey(key));
+    return _copyWithParameters(<String, dynamic>{key: value});
+  }
+
+  /// Creates and returns a new [Query] that's additionally sorted by the specified
+  /// [field].
+  Query orderBy(String field, {bool descending: false}) {
+    final String key = "orderBy:$field";
+    assert(!_parameters.containsKey(key));
+    return _copyWithParameters(<String, dynamic>{key: descending});
+  }
 }

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ name: cloud_firestore
 description: Cloud Firestore plugin for Flutter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_firestore
-version: 0.0.3
+version: 0.0.4
 
 flutter:
   plugin:

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: "^1.0.5"
+  collection: "^1.14.3"
 
 dev_dependencies:
   test: 0.12.24+8

--- a/packages/cloud_firestore/test/cloud_firestore_test.dart
+++ b/packages/cloud_firestore/test/cloud_firestore_test.dart
@@ -53,7 +53,9 @@ void main() {
               'Query#addSnapshotListener',
               <String, dynamic>{
                 'path': 'foo',
-                'parameters': <String, dynamic>{}
+                'parameters': <String, dynamic>{
+                  'where': <List<dynamic>>[],
+                }
               },
             ),
             new MethodCall(
@@ -79,7 +81,9 @@ void main() {
               <String, dynamic>{
                 'path': 'foo',
                 'parameters': <String, dynamic>{
-                  'where<:createdAt': 100,
+                  'where': <List<dynamic>>[
+                    <dynamic>['createdAt', '<', 100],
+                  ],
                 }
               },
             ),
@@ -106,7 +110,8 @@ void main() {
               <String, dynamic>{
                 'path': 'foo',
                 'parameters': <String, dynamic>{
-                  'orderBy:createdAt': false,
+                  'where': <List<dynamic>>[],
+                  'orderBy': <dynamic>['createdAt', false],
                 }
               },
             ),

--- a/packages/cloud_firestore/test/cloud_firestore_test.dart
+++ b/packages/cloud_firestore/test/cloud_firestore_test.dart
@@ -66,7 +66,7 @@ void main() {
       test('where', () async {
         final StreamSubscription<QuerySnapshot> subscription =
             collectionReference
-                .where('createdAt', '<', 100)
+                .where('createdAt', isLessThan: 100)
                 .snapshots
                 .listen((QuerySnapshot querySnapshot) {});
         subscription.cancel();

--- a/packages/cloud_firestore/test/cloud_firestore_test.dart
+++ b/packages/cloud_firestore/test/cloud_firestore_test.dart
@@ -106,6 +106,18 @@ void main() {
           ]),
         );
       });
+      test('delete', () async {
+        await collectionReference.document('bar').delete();
+        expect(
+          log,
+          equals(<MethodCall>[
+            new MethodCall(
+              'DocumentReference#delete',
+              <String, dynamic>{'path': 'foo/bar'},
+            ),
+          ]),
+        );
+      });
     });
   });
 }

--- a/packages/cloud_firestore/test/cloud_firestore_test.dart
+++ b/packages/cloud_firestore/test/cloud_firestore_test.dart
@@ -63,6 +63,60 @@ void main() {
           ]),
         );
       });
+      test('where', () async {
+        final StreamSubscription<QuerySnapshot> subscription =
+            collectionReference
+                .where('createdAt', '<', 100)
+                .snapshots
+                .listen((QuerySnapshot querySnapshot) {});
+        subscription.cancel();
+        await new Future<Null>.delayed(Duration.ZERO);
+        expect(
+          log,
+          equals(<MethodCall>[
+            new MethodCall(
+              'Query#addSnapshotListener',
+              <String, dynamic>{
+                'path': 'foo',
+                'parameters': <String, dynamic>{
+                  'where<:createdAt': 100,
+                }
+              },
+            ),
+            new MethodCall(
+              'Query#removeListener',
+              <String, dynamic>{'handle': 0},
+            ),
+          ]),
+        );
+      });
+      test('orderBy', () async {
+        final StreamSubscription<QuerySnapshot> subscription =
+            collectionReference
+                .orderBy('createdAt')
+                .snapshots
+                .listen((QuerySnapshot querySnapshot) {});
+        subscription.cancel();
+        await new Future<Null>.delayed(Duration.ZERO);
+        expect(
+          log,
+          equals(<MethodCall>[
+            new MethodCall(
+              'Query#addSnapshotListener',
+              <String, dynamic>{
+                'path': 'foo',
+                'parameters': <String, dynamic>{
+                  'orderBy:createdAt': false,
+                }
+              },
+            ),
+            new MethodCall(
+              'Query#removeListener',
+              <String, dynamic>{'handle': 0},
+            ),
+          ]),
+        );
+      });
     });
 
     group('DocumentReference', () {


### PR DESCRIPTION
Adds:

- `DocumentReference.delete()`
- `Query.where`
- `Query.orderBy`

Tested in iOS and Android (si|e)mulators.

For the `Query` methods I had to do some string manipulation to fit everything in existing `parameters` Map, but I'd be happy to refactor if needed.

Fixes flutter/flutter#12802 flutter/flutter#12509 flutter/flutter#12396.