### PR TITLE
Fix error when returning empty list of supported ABIs

### DIFF
--- a/packages/device_info/CHANGELOG.md
+++ b/packages/device_info/CHANGELOG.md
@@ -1,11 +1,15 @@
+## 0.0.4 - November 11, 2017
+
+* Fixed Java/Dart communication error with empty lists
+
 ## 0.0.3 - October 24, 2017
 
 * Add support for utsname
 
 ## 0.0.2 - October 20, 2017
 
-* Fixed broke type comparison
-* Added "isPhysicaldevice" field, detecting emulators/simulators
+* Fixed broken type comparison
+* Added "isPhysicalDevice" field, detecting emulators/simulators
 
 ## 0.0.1 - June 28, 2017
 

--- a/packages/device_info/android/src/main/java/io/flutter/plugins/deviceinfo/DeviceInfoPlugin.java
+++ b/packages/device_info/android/src/main/java/io/flutter/plugins/deviceinfo/DeviceInfoPlugin.java
@@ -53,9 +53,9 @@ public class DeviceInfoPlugin implements MethodCallHandler {
         build.put("supported64BitAbis", Arrays.asList(Build.SUPPORTED_64_BIT_ABIS));
         build.put("supportedAbis", Arrays.asList(Build.SUPPORTED_ABIS));
       } else {
-        build.put("supported32BitAbis", EMPTY_STRING_LIST);
-        build.put("supported64BitAbis", EMPTY_STRING_LIST);
-        build.put("supportedAbis", EMPTY_STRING_LIST);
+        build.put("supported32BitAbis", Arrays.asList(EMPTY_STRING_LIST));
+        build.put("supported64BitAbis", Arrays.asList(EMPTY_STRING_LIST));
+        build.put("supportedAbis", Arrays.asList(EMPTY_STRING_LIST));
       }
       build.put("tags", Build.TAGS);
       build.put("type", Build.TYPE);

--- a/packages/device_info/pubspec.yaml
+++ b/packages/device_info/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_info
 description: Provides detailed information about the device the Flutter app is running on.
-version: 0.0.3
+version: 0.0.4
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/device_info
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/12862