### PR TITLE
Image source selection support for ImagePicker plugin

### DIFF
--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -16,7 +16,8 @@ dependencies:
   meta: "^1.0.5"
 
 dev_dependencies:
-  test: 0.12.24+8
+  flutter_test:
+    sdk: flutter
 
 environment:
     sdk: ">=1.8.0 <2.0.0-dev.infinity"

--- a/packages/cloud_firestore/test/cloud_firestore_test.dart
+++ b/packages/cloud_firestore/test/cloud_firestore_test.dart
@@ -4,11 +4,9 @@
 
 import 'dart:async';
 
-import 'package:test/test.dart';
-
-import 'package:flutter/services.dart';
-
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('$Firestore', () {
@@ -48,19 +46,19 @@ void main() {
         await new Future<Null>.delayed(Duration.ZERO);
         expect(
           log,
-          equals(<MethodCall>[
-            new MethodCall(
+          <Matcher>[
+            isMethodCall(
               'Query#addSnapshotListener',
-              <String, dynamic>{
+              arguments: <String, dynamic>{
                 'path': 'foo',
-                'parameters': <String, dynamic>{}
+                'parameters': <String, dynamic>{},
               },
             ),
-            new MethodCall(
+            isMethodCall(
               'Query#removeListener',
-              <String, dynamic>{'handle': 0},
+              arguments: <String, dynamic>{'handle': 0},
             ),
-          ]),
+          ],
         );
       });
     });
@@ -75,18 +73,18 @@ void main() {
         await new Future<Null>.delayed(Duration.ZERO);
         expect(
           log,
-          equals(<MethodCall>[
-            new MethodCall(
+          <Matcher>[
+            isMethodCall(
               'Query#addDocumentListener',
-              <String, dynamic>{
+              arguments: <String, dynamic>{
                 'path': 'foo',
               },
             ),
-            new MethodCall(
+            isMethodCall(
               'Query#removeListener',
-              <String, dynamic>{'handle': 0},
-            )
-          ]),
+              arguments: <String, dynamic>{'handle': 0},
+            ),
+          ],
         );
       });
       test('set', () async {
@@ -95,15 +93,15 @@ void main() {
             .setData(<String, String>{'bazKey': 'quxValue'});
         expect(
           log,
-          equals(<MethodCall>[
-            new MethodCall(
+          <Matcher>[
+            isMethodCall(
               'DocumentReference#setData',
-              <String, dynamic>{
+              arguments: <String, dynamic>{
                 'path': 'foo/bar',
-                'data': <String, String>{'bazKey': 'quxValue'}
+                'data': <String, String>{'bazKey': 'quxValue'},
               },
             ),
-          ]),
+          ],
         );
       });
     });

--- a/packages/firebase_admob/pubspec.yaml
+++ b/packages/firebase_admob/pubspec.yaml
@@ -17,7 +17,8 @@ dependencies:
 
 dev_dependencies:
   mockito: ^2.0.2
-  test: 0.12.24+8
+  flutter_test:
+    sdk: flutter
 
 environment:
   sdk: ">=1.8.0 <2.0.0"

--- a/packages/firebase_admob/test/firebase_admob_test.dart
+++ b/packages/firebase_admob/test/firebase_admob_test.dart
@@ -3,9 +3,10 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'package:flutter/services.dart';
+
 import 'package:firebase_admob/firebase_admob.dart';
-import 'package:test/test.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('FirebaseAdMob', () {
@@ -40,15 +41,13 @@ void main() {
       log.clear();
 
       expect(await admob.initialize(appId: appId), true);
-      expect(
-          log,
-          equals(<MethodCall>[
-            new MethodCall('initialize', <String, dynamic>{
-              'appId': appId,
-              'trackingId': null,
-              'analyticsEnabled': false,
-            }),
-          ]));
+      expect(log, <Matcher>[
+        isMethodCall('initialize', arguments: <String, dynamic>{
+          'appId': appId,
+          'trackingId': null,
+          'analyticsEnabled': false,
+        }),
+      ]);
     });
 
     test('banner', () async {
@@ -63,21 +62,19 @@ void main() {
       expect(await banner.show(), true);
       expect(await banner.dispose(), true);
 
-      expect(
-          log,
-          equals(<MethodCall>[
-            new MethodCall('loadBannerAd', <String, dynamic>{
-              'id': id,
-              'unitId': bannerAdUnitId,
-              'targetingInfo': null,
-            }),
-            new MethodCall('showAd', <String, dynamic>{
-              'id': id,
-            }),
-            new MethodCall('disposeAd', <String, dynamic>{
-              'id': id,
-            }),
-          ]));
+      expect(log, <Matcher>[
+        isMethodCall('loadBannerAd', arguments: <String, dynamic>{
+          'id': id,
+          'unitId': bannerAdUnitId,
+          'targetingInfo': null,
+        }),
+        isMethodCall('showAd', arguments: <String, dynamic>{
+          'id': id,
+        }),
+        isMethodCall('disposeAd', arguments: <String, dynamic>{
+          'id': id,
+        }),
+      ]);
     });
 
     test('interstitial', () async {
@@ -92,21 +89,19 @@ void main() {
       expect(await interstitial.show(), true);
       expect(await interstitial.dispose(), true);
 
-      expect(
-          log,
-          equals(<MethodCall>[
-            new MethodCall('loadInterstitialAd', <String, dynamic>{
-              'id': id,
-              'unitId': interstitialAdUnitId,
-              'targetingInfo': null,
-            }),
-            new MethodCall('showAd', <String, dynamic>{
-              'id': id,
-            }),
-            new MethodCall('disposeAd', <String, dynamic>{
-              'id': id,
-            }),
-          ]));
+      expect(log, <Matcher>[
+        isMethodCall('loadInterstitialAd', arguments: <String, dynamic>{
+          'id': id,
+          'unitId': interstitialAdUnitId,
+          'targetingInfo': null,
+        }),
+        isMethodCall('showAd', arguments: <String, dynamic>{
+          'id': id,
+        }),
+        isMethodCall('disposeAd', arguments: <String, dynamic>{
+          'id': id,
+        }),
+      ]);
     });
   });
 }

--- a/packages/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/pubspec.yaml
@@ -16,7 +16,8 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  test: 0.12.24+8
-
+  flutter_test:
+    sdk: flutter
+    
 environment:
     sdk: ">=1.8.0 <2.0.0"

--- a/packages/firebase_auth/test/firebase_auth_test.dart
+++ b/packages/firebase_auth/test/firebase_auth_test.dart
@@ -4,11 +4,9 @@
 
 import 'dart:async';
 
-import 'package:test/test.dart';
-
-import 'package:flutter/services.dart';
-
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 const String kMockProviderId = 'firebase';
 const String kMockUid = '12345';
@@ -62,9 +60,9 @@ void main() {
       verifyUser(user);
       expect(
         log,
-        equals(<MethodCall>[
-          const MethodCall('currentUser'),
-        ]),
+        <Matcher>[
+          isMethodCall('currentUser', arguments: null),
+        ],
       );
     });
 
@@ -75,12 +73,17 @@ void main() {
       expect(await user.getIdToken(refresh: true), equals(kMockIdToken));
       expect(
         log,
-        equals(<MethodCall>[
-          const MethodCall('signInAnonymously'),
-          const MethodCall(
-              'getIdToken', const <String, bool>{'refresh': false}),
-          const MethodCall('getIdToken', const <String, bool>{'refresh': true}),
-        ]),
+        <Matcher>[
+          isMethodCall('signInAnonymously', arguments: null),
+          isMethodCall(
+            'getIdToken',
+            arguments: <String, bool>{'refresh': false},
+          ),
+          isMethodCall(
+            'getIdToken',
+            arguments: <String, bool>{'refresh': true},
+          ),
+        ],
       );
     });
 
@@ -92,12 +95,15 @@ void main() {
       verifyUser(user);
       expect(
         log,
-        equals(<MethodCall>[
-          new MethodCall('createUserWithEmailAndPassword', <String, String>{
-            'email': kMockEmail,
-            'password': kMockPassword,
-          })
-        ]),
+        <Matcher>[
+          isMethodCall(
+            'createUserWithEmailAndPassword',
+            arguments: <String, String>{
+              'email': kMockEmail,
+              'password': kMockPassword,
+            },
+          ),
+        ],
       );
     });
 
@@ -109,12 +115,15 @@ void main() {
       verifyUser(user);
       expect(
         log,
-        equals(<MethodCall>[
-          new MethodCall('linkWithEmailAndPassword', <String, String>{
-            'email': kMockEmail,
-            'password': kMockPassword,
-          })
-        ]),
+        <Matcher>[
+          isMethodCall(
+            'linkWithEmailAndPassword',
+            arguments: <String, String>{
+              'email': kMockEmail,
+              'password': kMockPassword,
+            },
+          ),
+        ],
       );
     });
 
@@ -126,12 +135,15 @@ void main() {
       verifyUser(user);
       expect(
         log,
-        equals(<MethodCall>[
-          new MethodCall('signInWithGoogle', <String, String>{
-            'idToken': kMockIdToken,
-            'accessToken': kMockAccessToken,
-          })
-        ]),
+        <Matcher>[
+          isMethodCall(
+            'signInWithGoogle',
+            arguments: <String, String>{
+              'idToken': kMockIdToken,
+              'accessToken': kMockAccessToken,
+            },
+          ),
+        ],
       );
     });
 
@@ -143,12 +155,15 @@ void main() {
       verifyUser(user);
       expect(
         log,
-        equals(<MethodCall>[
-          new MethodCall('linkWithGoogleCredential', <String, String>{
-            'idToken': kMockIdToken,
-            'accessToken': kMockAccessToken,
-          })
-        ]),
+        <Matcher>[
+          isMethodCall(
+            'linkWithGoogleCredential',
+            arguments: <String, String>{
+              'idToken': kMockIdToken,
+              'accessToken': kMockAccessToken,
+            },
+          ),
+        ],
       );
     });
 
@@ -159,11 +174,14 @@ void main() {
       verifyUser(user);
       expect(
         log,
-        equals(<MethodCall>[
-          new MethodCall('signInWithFacebook', <String, String>{
-            'accessToken': kMockAccessToken,
-          })
-        ]),
+        <Matcher>[
+          isMethodCall(
+            'signInWithFacebook',
+            arguments: <String, String>{
+              'accessToken': kMockAccessToken,
+            },
+          ),
+        ],
       );
     });
 
@@ -175,12 +193,15 @@ void main() {
       verifyUser(user);
       expect(
         log,
-        equals(<MethodCall>[
-          new MethodCall('linkWithEmailAndPassword', <String, String>{
-            'email': kMockEmail,
-            'password': kMockPassword,
-          })
-        ]),
+        <Matcher>[
+          isMethodCall(
+            'linkWithEmailAndPassword',
+            arguments: <String, String>{
+              'email': kMockEmail,
+              'password': kMockPassword,
+            },
+          ),
+        ],
       );
     });
 
@@ -190,11 +211,11 @@ void main() {
       verifyUser(user);
       expect(
         log,
-        equals(<MethodCall>[
-          new MethodCall('signInWithCustomToken', <String, String>{
+        <Matcher>[
+          isMethodCall('signInWithCustomToken', arguments: <String, String>{
             'token': kMockCustomToken,
           })
-        ]),
+        ],
       );
     });
 
@@ -205,8 +226,10 @@ void main() {
         await BinaryMessages.handlePlatformMessage(
           FirebaseAuth.channel.name,
           FirebaseAuth.channel.codec.encodeMethodCall(
-            new MethodCall('onAuthStateChanged',
-                <String, dynamic>{'id': 42, 'user': user}),
+            new MethodCall(
+              'onAuthStateChanged',
+              <String, dynamic>{'id': 42, 'user': user},
+            ),
           ),
           (_) {},
         );
@@ -234,15 +257,15 @@ void main() {
 
       expect(
         log,
-        equals(<MethodCall>[
-          const MethodCall('startListeningAuthState'),
-          new MethodCall(
+        <Matcher>[
+          isMethodCall('startListeningAuthState', arguments: null),
+          isMethodCall(
             'stopListeningAuthState',
-            <String, dynamic>{
+            arguments: <String, dynamic>{
               'id': 42,
             },
           ),
-        ]),
+        ],
       );
     });
   });

--- a/packages/firebase_database/pubspec.yaml
+++ b/packages/firebase_database/pubspec.yaml
@@ -16,7 +16,8 @@ dependencies:
   meta: "^1.0.5"
 
 dev_dependencies:
-  test: 0.12.24+8
+  flutter_test:
+    sdk: flutter
 
 environment:
     sdk: ">=1.8.0 <2.0.0"

--- a/packages/firebase_database/test/firebase_database_test.dart
+++ b/packages/firebase_database/test/firebase_database_test.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 
 import 'package:firebase_database/firebase_database.dart';
 import 'package:flutter/services.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('$FirebaseDatabase', () {
@@ -35,13 +35,17 @@ void main() {
               await BinaryMessages.handlePlatformMessage(
                 channel.name,
                 channel.codec.encodeMethodCall(
-                    new MethodCall('DoTransaction', <String, dynamic>{
-                  'transactionKey': transactionKey,
-                  'snapshot': <String, dynamic>{
-                    'key': mutableData.key,
-                    'value': mutableData.value,
-                  },
-                })),
+                  new MethodCall(
+                    'DoTransaction',
+                    <String, dynamic>{
+                      'transactionKey': transactionKey,
+                      'snapshot': <String, dynamic>{
+                        'key': mutableData.key,
+                        'value': mutableData.value,
+                      },
+                    },
+                  ),
+                ),
                 (_) {
                   updatedValue = channel.codec.decodeEnvelope(_)['value'];
                 },
@@ -75,10 +79,16 @@ void main() {
       expect(await database.setPersistenceEnabled(true), true);
       expect(
         log,
-        equals(<MethodCall>[
-          const MethodCall('FirebaseDatabase#setPersistenceEnabled', false),
-          const MethodCall('FirebaseDatabase#setPersistenceEnabled', true),
-        ]),
+        <Matcher>[
+          isMethodCall(
+            'FirebaseDatabase#setPersistenceEnabled',
+            arguments: false,
+          ),
+          isMethodCall(
+            'FirebaseDatabase#setPersistenceEnabled',
+            arguments: true,
+          ),
+        ],
       );
     });
 
@@ -86,9 +96,12 @@ void main() {
       expect(await database.setPersistenceCacheSizeBytes(42), true);
       expect(
         log,
-        equals(<MethodCall>[
-          const MethodCall('FirebaseDatabase#setPersistenceCacheSizeBytes', 42),
-        ]),
+        <Matcher>[
+          isMethodCall(
+            'FirebaseDatabase#setPersistenceCacheSizeBytes',
+            arguments: 42,
+          ),
+        ],
       );
     });
 
@@ -96,9 +109,9 @@ void main() {
       await database.goOnline();
       expect(
         log,
-        equals(<MethodCall>[
-          const MethodCall('FirebaseDatabase#goOnline'),
-        ]),
+        <Matcher>[
+          isMethodCall('FirebaseDatabase#goOnline', arguments: null),
+        ],
       );
     });
 
@@ -106,9 +119,9 @@ void main() {
       await database.goOffline();
       expect(
         log,
-        equals(<MethodCall>[
-          const MethodCall('FirebaseDatabase#goOffline'),
-        ]),
+        <Matcher>[
+          isMethodCall('FirebaseDatabase#goOffline', arguments: null),
+        ],
       );
     });
 
@@ -116,9 +129,12 @@ void main() {
       await database.purgeOutstandingWrites();
       expect(
         log,
-        equals(<MethodCall>[
-          const MethodCall('FirebaseDatabase#purgeOutstandingWrites'),
-        ]),
+        <Matcher>[
+          isMethodCall(
+            'FirebaseDatabase#purgeOutstandingWrites',
+            arguments: null,
+          ),
+        ],
       );
     });
 
@@ -130,24 +146,24 @@ void main() {
         await database.reference().child('bar').set(value, priority: priority);
         expect(
           log,
-          equals(<MethodCall>[
-            new MethodCall(
+          <Matcher>[
+            isMethodCall(
               'DatabaseReference#set',
-              <String, dynamic>{
+              arguments: <String, dynamic>{
                 'path': 'foo',
                 'value': value,
-                'priority': null
+                'priority': null,
               },
             ),
-            new MethodCall(
+            isMethodCall(
               'DatabaseReference#set',
-              <String, dynamic>{
+              arguments: <String, dynamic>{
                 'path': 'bar',
                 'value': value,
-                'priority': priority
+                'priority': priority,
               },
             ),
-          ]),
+          ],
         );
       });
       test('update', () async {
@@ -155,12 +171,12 @@ void main() {
         await database.reference().child("foo").update(value);
         expect(
           log,
-          equals(<MethodCall>[
-            new MethodCall(
+          <Matcher>[
+            isMethodCall(
               'DatabaseReference#update',
-              <String, dynamic>{'path': 'foo', 'value': value},
+              arguments: <String, dynamic>{'path': 'foo', 'value': value},
             ),
-          ]),
+          ],
         );
       });
 
@@ -169,12 +185,12 @@ void main() {
         await database.reference().child('foo').setPriority(priority);
         expect(
           log,
-          equals(<MethodCall>[
-            new MethodCall(
+          <Matcher>[
+            isMethodCall(
               'DatabaseReference#setPriority',
-              <String, dynamic>{'path': 'foo', 'priority': priority},
+              arguments: <String, dynamic>{'path': 'foo', 'priority': priority},
             ),
-          ]),
+          ],
         );
       });
 
@@ -191,14 +207,16 @@ void main() {
         });
         expect(
           log,
-          equals(<MethodCall>[
-            new MethodCall(
-                'DatabaseReference#runTransaction', <String, dynamic>{
-              'path': 'foo',
-              'transactionKey': 0,
-              'transactionTimeout': 5000
-            }),
-          ]),
+          <Matcher>[
+            isMethodCall(
+              'DatabaseReference#runTransaction',
+              arguments: <String, dynamic>{
+                'path': 'foo',
+                'transactionKey': 0,
+                'transactionTimeout': 5000,
+              },
+            ),
+          ],
         );
         expect(transactionResult.committed, equals(true));
         expect(transactionResult.dataSnapshot.value,
@@ -221,16 +239,16 @@ void main() {
         await query.keepSynced(true);
         expect(
           log,
-          equals(<MethodCall>[
-            new MethodCall(
+          <Matcher>[
+            isMethodCall(
               'Query#keepSynced',
-              <String, dynamic>{
+              arguments: <String, dynamic>{
                 'path': path,
                 'parameters': <String, dynamic>{},
-                'value': true
+                'value': true,
               },
             ),
-          ]),
+          ],
         );
       });
       test('keepSynced, complex query', () async {
@@ -255,16 +273,16 @@ void main() {
         };
         expect(
           log,
-          equals(<MethodCall>[
-            new MethodCall(
+          <Matcher>[
+            isMethodCall(
               'Query#keepSynced',
-              <String, dynamic>{
+              arguments: <String, dynamic>{
                 'path': path,
                 'parameters': expectedParameters,
                 'value': false
               },
             ),
-          ]),
+          ],
         );
       });
       test('observing value events', () async {
@@ -309,24 +327,24 @@ void main() {
 
         expect(
           log,
-          equals(<MethodCall>[
-            new MethodCall(
+          <Matcher>[
+            isMethodCall(
               'Query#observe',
-              <String, dynamic>{
+              arguments: <String, dynamic>{
                 'path': path,
                 'parameters': <String, dynamic>{},
-                'eventType': '_EventType.value'
+                'eventType': '_EventType.value',
               },
             ),
-            new MethodCall(
+            isMethodCall(
               'Query#removeObserver',
-              <String, dynamic>{
+              arguments: <String, dynamic>{
                 'path': path,
                 'parameters': <String, dynamic>{},
                 'handle': 87,
               },
             ),
-          ]),
+          ],
         );
       });
     });
@@ -344,8 +362,7 @@ class AsyncQueue<T> {
   }
 
   Future<T> remove() {
-    final Future<T> result = _completer(_nextToRemove++).future;
-    return result;
+    return _completer(_nextToRemove++).future;
   }
 
   Completer<T> _completer(int index) {

--- a/packages/firebase_storage/pubspec.yaml
+++ b/packages/firebase_storage/pubspec.yaml
@@ -15,7 +15,8 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  test: 0.12.24+8
+  flutter_test:
+    sdk: flutter
 
 environment:
     sdk: ">=1.8.0 <2.0.0"

--- a/packages/firebase_storage/test/firebase_storage_test.dart
+++ b/packages/firebase_storage/test/firebase_storage_test.dart
@@ -7,7 +7,7 @@ import 'dart:typed_data';
 
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter/services.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('StorageReference', () {
@@ -36,14 +36,15 @@ void main() {
       test('invokes correct method', () async {
         await ref.getData(10);
 
-        expect(
-            log,
-            equals(<MethodCall>[
-              new MethodCall('StorageReference#getData', <String, dynamic>{
-                'maxSize': 10,
-                'path': 'avatars/large/image.jpg',
-              }),
-            ]));
+        expect(log, <Matcher>[
+          isMethodCall(
+            'StorageReference#getData',
+            arguments: <String, dynamic>{
+              'maxSize': 10,
+              'path': 'avatars/large/image.jpg',
+            },
+          ),
+        ]);
       });
 
       test('returns correct result', () async {

--- a/packages/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/pubspec.yaml
@@ -16,8 +16,8 @@ dependencies:
   meta: ^1.0.4
 
 dev_dependencies:
-  mockito: ^2.0.2
-  test: 0.12.24+8
+  flutter_test:
+    sdk: flutter
 
 environment:
     sdk: ">=1.8.0 <2.0.0"

--- a/packages/google_sign_in/test/google_sign_in_test.dart
+++ b/packages/google_sign_in/test/google_sign_in_test.dart
@@ -3,10 +3,11 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+
 import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:google_sign_in/testing.dart';
-import 'package:test/test.dart';
 
 void main() {
   group('GoogleSignIn', () {
@@ -47,56 +48,57 @@ void main() {
       await googleSignIn.signInSilently();
       expect(googleSignIn.currentUser, isNotNull);
       expect(
-          log,
-          equals(<MethodCall>[
-            new MethodCall('init', <String, dynamic>{
-              'scopes': <String>[],
-              'hostedDomain': null,
-            }),
-            const MethodCall('signInSilently'),
-          ]));
+        log,
+        <Matcher>[
+          isMethodCall('init', arguments: <String, dynamic>{
+            'scopes': <String>[],
+            'hostedDomain': null,
+          }),
+          isMethodCall('signInSilently', arguments: null),
+        ],
+      );
     });
 
     test('signIn', () async {
       await googleSignIn.signIn();
       expect(googleSignIn.currentUser, isNotNull);
       expect(
-          log,
-          equals(<MethodCall>[
-            new MethodCall('init', <String, dynamic>{
-              'scopes': <String>[],
-              'hostedDomain': null,
-            }),
-            const MethodCall('signIn'),
-          ]));
+        log,
+        <Matcher>[
+          isMethodCall('init', arguments: <String, dynamic>{
+            'scopes': <String>[],
+            'hostedDomain': null,
+          }),
+          isMethodCall('signIn', arguments: null),
+        ],
+      );
     });
 
     test('signOut', () async {
       await googleSignIn.signOut();
       expect(googleSignIn.currentUser, isNull);
-      expect(
-          log,
-          equals(<MethodCall>[
-            new MethodCall('init', <String, dynamic>{
-              'scopes': <String>[],
-              'hostedDomain': null,
-            }),
-            const MethodCall('signOut'),
-          ]));
+      expect(log, <Matcher>[
+        isMethodCall('init', arguments: <String, dynamic>{
+          'scopes': <String>[],
+          'hostedDomain': null,
+        }),
+        isMethodCall('signOut', arguments: null),
+      ]);
     });
 
     test('disconnect; null response', () async {
       await googleSignIn.disconnect();
       expect(googleSignIn.currentUser, isNull);
       expect(
-          log,
-          equals(<MethodCall>[
-            new MethodCall('init', <String, dynamic>{
-              'scopes': <String>[],
-              'hostedDomain': null,
-            }),
-            const MethodCall('disconnect'),
-          ]));
+        log,
+        <Matcher>[
+          isMethodCall('init', arguments: <String, dynamic>{
+            'scopes': <String>[],
+            'hostedDomain': null,
+          }),
+          isMethodCall('disconnect', arguments: null),
+        ],
+      );
     });
 
     test('disconnect; empty response as on iOS', () async {
@@ -104,14 +106,15 @@ void main() {
       await googleSignIn.disconnect();
       expect(googleSignIn.currentUser, isNull);
       expect(
-          log,
-          equals(<MethodCall>[
-            new MethodCall('init', <String, dynamic>{
-              'scopes': <String>[],
-              'hostedDomain': null,
-            }),
-            const MethodCall('disconnect'),
-          ]));
+        log,
+        <Matcher>[
+          isMethodCall('init', arguments: <String, dynamic>{
+            'scopes': <String>[],
+            'hostedDomain': null,
+          }),
+          isMethodCall('disconnect', arguments: null),
+        ],
+      );
     });
 
     test('concurrent calls of the same method trigger sign in once', () async {
@@ -129,14 +132,15 @@ void main() {
         googleSignIn.currentUser
       ]);
       expect(
-          log,
-          equals(<MethodCall>[
-            new MethodCall('init', <String, dynamic>{
-              'scopes': <String>[],
-              'hostedDomain': null,
-            }),
-            const MethodCall('signInSilently'),
-          ]));
+        log,
+        <Matcher>[
+          isMethodCall('init', arguments: <String, dynamic>{
+            'scopes': <String>[],
+            'hostedDomain': null,
+          }),
+          isMethodCall('signInSilently', arguments: null),
+        ],
+      );
     });
 
     test('can sign in after previously failed attempt', () async {
@@ -144,15 +148,16 @@ void main() {
       expect(await googleSignIn.signInSilently(), isNull);
       expect(await googleSignIn.signIn(), isNotNull);
       expect(
-          log,
-          equals(<MethodCall>[
-            new MethodCall('init', <String, dynamic>{
-              'scopes': <String>[],
-              'hostedDomain': null,
-            }),
-            const MethodCall('signInSilently'),
-            const MethodCall('signIn'),
-          ]));
+        log,
+        <Matcher>[
+          isMethodCall('init', arguments: <String, dynamic>{
+            'scopes': <String>[],
+            'hostedDomain': null,
+          }),
+          isMethodCall('signInSilently', arguments: null),
+          isMethodCall('signIn', arguments: null),
+        ],
+      );
     });
 
     test('concurrent calls of different signIn methods', () async {
@@ -164,14 +169,15 @@ void main() {
       expect(futures.first, isNot(futures.last));
       final List<GoogleSignInAccount> users = await Future.wait(futures);
       expect(
-          log,
-          equals(<MethodCall>[
-            new MethodCall('init', <String, dynamic>{
-              'scopes': <String>[],
-              'hostedDomain': null,
-            }),
-            const MethodCall('signInSilently'),
-          ]));
+        log,
+        <Matcher>[
+          isMethodCall('init', arguments: <String, dynamic>{
+            'scopes': <String>[],
+            'hostedDomain': null,
+          }),
+          isMethodCall('signInSilently', arguments: null),
+        ],
+      );
       expect(users.first, users.last, reason: 'Must return the same user');
       expect(googleSignIn.currentUser, users.last);
     });
@@ -193,17 +199,18 @@ void main() {
       ];
       await Future.wait(futures);
       expect(
-          log,
-          equals(<MethodCall>[
-            new MethodCall('init', <String, dynamic>{
-              'scopes': <String>[],
-              'hostedDomain': null,
-            }),
-            const MethodCall('signOut'),
-            const MethodCall('signOut'),
-            const MethodCall('disconnect'),
-            const MethodCall('disconnect'),
-          ]));
+        log,
+        <Matcher>[
+          isMethodCall('init', arguments: <String, dynamic>{
+            'scopes': <String>[],
+            'hostedDomain': null,
+          }),
+          isMethodCall('signOut', arguments: null),
+          isMethodCall('signOut', arguments: null),
+          isMethodCall('disconnect', arguments: null),
+          isMethodCall('disconnect', arguments: null),
+        ],
+      );
     });
 
     test('queue of many concurrent calls', () async {
@@ -216,17 +223,18 @@ void main() {
       ];
       await Future.wait(futures);
       expect(
-          log,
-          equals(<MethodCall>[
-            new MethodCall('init', <String, dynamic>{
-              'scopes': <String>[],
-              'hostedDomain': null,
-            }),
-            const MethodCall('signInSilently'),
-            const MethodCall('signOut'),
-            const MethodCall('signIn'),
-            const MethodCall('disconnect'),
-          ]));
+        log,
+        <Matcher>[
+          isMethodCall('init', arguments: <String, dynamic>{
+            'scopes': <String>[],
+            'hostedDomain': null,
+          }),
+          isMethodCall('signInSilently', arguments: null),
+          isMethodCall('signOut', arguments: null),
+          isMethodCall('signIn', arguments: null),
+          isMethodCall('disconnect', arguments: null),
+        ],
+      );
     });
 
     test('signInSilently does not throw on error', () async {

--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3
+
+* Added optional source argument to pickImage for controlling where the image comes from.
+
 ## 0.1.2
 
 * Added optional maxWidth and maxHeight arguments to pickImage.

--- a/packages/image_picker/ios/Classes/ImagePickerPlugin.m
+++ b/packages/image_picker/ios/Classes/ImagePickerPlugin.m
@@ -9,6 +9,10 @@
 @interface ImagePickerPlugin ()<UINavigationControllerDelegate, UIImagePickerControllerDelegate>
 @end
 
+static const int SOURCE_ASK_USER = 0;
+static const int SOURCE_CAMERA = 1;
+static const int SOURCE_GALLERY = 2;
+
 @implementation ImagePickerPlugin {
   FlutterResult _result;
   NSDictionary *_arguments;
@@ -42,37 +46,60 @@
                                 details:nil]);
     _result = nil;
   }
+
   if ([@"pickImage" isEqualToString:call.method]) {
     _imagePickerController.modalPresentationStyle = UIModalPresentationCurrentContext;
     _imagePickerController.delegate = self;
+
     _result = result;
     _arguments = call.arguments;
 
-    UIAlertControllerStyle style = UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad
-                                       ? UIAlertControllerStyleAlert
-                                       : UIAlertControllerStyleActionSheet;
+    int imageSource = [[_arguments objectForKey:@"source"] intValue];
 
-    UIAlertController *alert =
-        [UIAlertController alertControllerWithTitle:nil message:nil preferredStyle:style];
-    UIAlertAction *camera = [UIAlertAction actionWithTitle:@"Take Photo"
-                                                     style:UIAlertActionStyleDefault
-                                                   handler:^(UIAlertAction *action) {
-                                                     [self showCamera];
-                                                   }];
-    UIAlertAction *library = [UIAlertAction actionWithTitle:@"Choose Photo"
-                                                      style:UIAlertActionStyleDefault
-                                                    handler:^(UIAlertAction *action) {
-                                                      [self showPhotoLibrary];
-                                                    }];
-    UIAlertAction *cancel =
-        [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil];
-    [alert addAction:camera];
-    [alert addAction:library];
-    [alert addAction:cancel];
-    [_viewController presentViewController:alert animated:YES completion:nil];
+    switch (imageSource) {
+      case SOURCE_ASK_USER:
+        [self showImageSourceSelector];
+        break;
+      case SOURCE_CAMERA:
+        [self showCamera];
+        break;
+      case SOURCE_GALLERY:
+        [self showPhotoLibrary];
+        break;
+      default:
+        result([FlutterError errorWithCode:@"invalid_source"
+                                   message:@"Invalid image source."
+                                   details:nil]);
+        break;
+    }
   } else {
     result(FlutterMethodNotImplemented);
   }
+}
+
+- (void)showImageSourceSelector {
+  UIAlertControllerStyle style = UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad
+                                     ? UIAlertControllerStyleAlert
+                                     : UIAlertControllerStyleActionSheet;
+
+  UIAlertController *alert =
+      [UIAlertController alertControllerWithTitle:nil message:nil preferredStyle:style];
+  UIAlertAction *camera = [UIAlertAction actionWithTitle:@"Take Photo"
+                                                   style:UIAlertActionStyleDefault
+                                                 handler:^(UIAlertAction *action) {
+                                                   [self showCamera];
+                                                 }];
+  UIAlertAction *library = [UIAlertAction actionWithTitle:@"Choose Photo"
+                                                    style:UIAlertActionStyleDefault
+                                                  handler:^(UIAlertAction *action) {
+                                                    [self showPhotoLibrary];
+                                                  }];
+  UIAlertAction *cancel =
+      [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil];
+  [alert addAction:camera];
+  [alert addAction:library];
+  [alert addAction:cancel];
+  [_viewController presentViewController:alert animated:YES completion:nil];
 }
 
 - (void)showCamera {

--- a/packages/image_picker/lib/image_picker.dart
+++ b/packages/image_picker/lib/image_picker.dart
@@ -7,9 +7,25 @@ import 'dart:io';
 
 import 'package:flutter/services.dart';
 
+/// Specifies the source where the picked image should come from.
 enum ImageSource {
+  /// Let the user choose an image from a source they prefer.
+  ///
+  /// On Android, opens a new screen with a grid of images (from the users
+  /// gallery) and a camera icon on the top right corner. The user can
+  /// either pick an image from the image grid, or tap the camera icon
+  /// to take a picture using the device camera.
+  ///
+  /// On iOS, the user is presented with an alert box with options to
+  /// either take a photo using the device camera or pick an image from
+  /// the photo library.
   askUser,
+
+  /// Opens up the device camera on both Android and iOS.
   camera,
+
+  /// On Android, presents a grid of images from the users gallery. On iOS,
+  /// opens the users photo library.
   gallery,
 }
 
@@ -22,6 +38,9 @@ class ImagePicker {
   ///
   /// * pick an image from the gallery
   /// * take a photo using the device camera.
+  ///
+  /// Use the [source] argument for controlling where the image comes from.
+  /// By default, the user can choose the image from either camera or gallery.
   ///
   /// If specified, the image will be at most [maxWidth] wide and
   /// [maxHeight] tall. Otherwise the image will be returned at it's

--- a/packages/image_picker/lib/image_picker.dart
+++ b/packages/image_picker/lib/image_picker.dart
@@ -7,6 +7,12 @@ import 'dart:io';
 
 import 'package:flutter/services.dart';
 
+enum ImageSource {
+  askUser,
+  camera,
+  gallery,
+}
+
 class ImagePicker {
   static const MethodChannel _channel = const MethodChannel('image_picker');
 
@@ -20,7 +26,13 @@ class ImagePicker {
   /// If specified, the image will be at most [maxWidth] wide and
   /// [maxHeight] tall. Otherwise the image will be returned at it's
   /// original width and height.
-  static Future<File> pickImage({double maxWidth, double maxHeight}) async {
+  static Future<File> pickImage({
+    ImageSource source = ImageSource.askUser,
+    double maxWidth,
+    double maxHeight,
+  }) async {
+    assert(source != null);
+
     if (maxWidth != null && maxWidth < 0) {
       throw new ArgumentError.value(maxWidth, 'maxWidth can\'t be negative');
     }
@@ -31,7 +43,8 @@ class ImagePicker {
 
     final String path = await _channel.invokeMethod(
       'pickImage',
-      <String, double>{
+      <String, dynamic>{
+        'source': source.index,
         'maxWidth': maxWidth,
         'maxHeight': maxHeight,
       },

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -3,7 +3,7 @@ name: image_picker
 description: Flutter plugin that shows an image picker and uses the camera.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.1.2
+version: 0.1.3
 
 flutter:
   plugin:

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -15,7 +15,8 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  test: 0.12.21
+  flutter_test:
+    sdk: flutter
 
 environment:
     sdk: ">=1.8.0 <2.0.0"

--- a/packages/image_picker/test/image_picker_test.dart
+++ b/packages/image_picker/test/image_picker_test.dart
@@ -1,6 +1,10 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:image_picker/image_picker.dart';
-import 'package:test/test.dart';
 
 void main() {
   group('$ImagePicker', () {
@@ -29,26 +33,24 @@ void main() {
 
         expect(
           log,
-          equals(
-            <MethodCall>[
-              const MethodCall('pickImage', const <String, double>{
-                'maxWidth': null,
-                'maxHeight': null,
-              }),
-              const MethodCall('pickImage', const <String, double>{
-                'maxWidth': 10.0,
-                'maxHeight': null,
-              }),
-              const MethodCall('pickImage', const <String, double>{
-                'maxWidth': null,
-                'maxHeight': 10.0,
-              }),
-              const MethodCall('pickImage', const <String, double>{
-                'maxWidth': 10.0,
-                'maxHeight': 20.0,
-              }),
-            ],
-          ),
+          <Matcher>[
+            isMethodCall('pickImage', arguments: <String, double>{
+              'maxWidth': null,
+              'maxHeight': null,
+            }),
+            isMethodCall('pickImage', arguments: <String, double>{
+              'maxWidth': 10.0,
+              'maxHeight': null,
+            }),
+            isMethodCall('pickImage', arguments: <String, double>{
+              'maxWidth': null,
+              'maxHeight': 10.0,
+            }),
+            isMethodCall('pickImage', arguments: <String, double>{
+              'maxWidth': 10.0,
+              'maxHeight': 20.0,
+            }),
+          ],
         );
       });
 

--- a/packages/image_picker/test/image_picker_test.dart
+++ b/packages/image_picker/test/image_picker_test.dart
@@ -26,15 +26,13 @@ void main() {
 
         expect(
           log,
-          equals(
-            <MethodCall>[
-              const MethodCall('pickImage', const <String, dynamic>{
-                'source': 0,
-                'maxWidth': null,
-                'maxHeight': null,
-              }),
-            ],
-          ),
+          <Matcher>[
+            isMethodCall('pickImage', arguments: <String, dynamic>{
+              'source': 0,
+              'maxWidth': null,
+              'maxHeight': null,
+            }),
+          ],
         );
       });
 
@@ -45,25 +43,23 @@ void main() {
 
         expect(
           log,
-          equals(
-            <MethodCall>[
-              const MethodCall('pickImage', const <String, dynamic>{
-                'source': 0,
-                'maxWidth': null,
-                'maxHeight': null,
-              }),
-              const MethodCall('pickImage', const <String, dynamic>{
-                'source': 1,
-                'maxWidth': null,
-                'maxHeight': null,
-              }),
-              const MethodCall('pickImage', const <String, dynamic>{
-                'source': 2,
-                'maxWidth': null,
-                'maxHeight': null,
-              }),
-            ],
-          ),
+          <Matcher>[
+            isMethodCall('pickImage', arguments: <String, dynamic>{
+              'source': 0,
+              'maxWidth': null,
+              'maxHeight': null,
+            }),
+            isMethodCall('pickImage', arguments: <String, dynamic>{
+              'source': 1,
+              'maxWidth': null,
+              'maxHeight': null,
+            }),
+            isMethodCall('pickImage', arguments: <String, dynamic>{
+              'source': 2,
+              'maxWidth': null,
+              'maxHeight': null,
+            }),
+          ],
         );
       });
 
@@ -79,19 +75,23 @@ void main() {
         expect(
           log,
           <Matcher>[
-            isMethodCall('pickImage', arguments: <String, double>{
+            isMethodCall('pickImage', arguments: <String, dynamic>{
+              'source': 0,
               'maxWidth': null,
               'maxHeight': null,
             }),
-            isMethodCall('pickImage', arguments: <String, double>{
+            isMethodCall('pickImage', arguments: <String, dynamic>{
+              'source': 0,
               'maxWidth': 10.0,
               'maxHeight': null,
             }),
-            isMethodCall('pickImage', arguments: <String, double>{
+            isMethodCall('pickImage', arguments: <String, dynamic>{
+              'source': 0,
               'maxWidth': null,
               'maxHeight': 10.0,
             }),
-            isMethodCall('pickImage', arguments: <String, double>{
+            isMethodCall('pickImage', arguments: <String, dynamic>{
+              'source': 0,
               'maxWidth': 10.0,
               'maxHeight': 20.0,
             }),

--- a/packages/image_picker/test/image_picker_test.dart
+++ b/packages/image_picker/test/image_picker_test.dart
@@ -9,7 +9,6 @@ import 'package:image_picker/image_picker.dart';
 void main() {
   group('$ImagePicker', () {
     const MethodChannel channel = const MethodChannel('image_picker');
-
     final List<MethodCall> log = <MethodCall>[];
 
     setUp(() {
@@ -22,6 +21,52 @@ void main() {
     });
 
     group('#pickImage', () {
+      test('ImageSource.any is the default image source', () async {
+        await ImagePicker.pickImage();
+
+        expect(
+          log,
+          equals(
+            <MethodCall>[
+              const MethodCall('pickImage', const <String, dynamic>{
+                'source': 0,
+                'maxWidth': null,
+                'maxHeight': null,
+              }),
+            ],
+          ),
+        );
+      });
+
+      test('passes the image source argument correctly', () async {
+        await ImagePicker.pickImage(source: ImageSource.askUser);
+        await ImagePicker.pickImage(source: ImageSource.camera);
+        await ImagePicker.pickImage(source: ImageSource.gallery);
+
+        expect(
+          log,
+          equals(
+            <MethodCall>[
+              const MethodCall('pickImage', const <String, dynamic>{
+                'source': 0,
+                'maxWidth': null,
+                'maxHeight': null,
+              }),
+              const MethodCall('pickImage', const <String, dynamic>{
+                'source': 1,
+                'maxWidth': null,
+                'maxHeight': null,
+              }),
+              const MethodCall('pickImage', const <String, dynamic>{
+                'source': 2,
+                'maxWidth': null,
+                'maxHeight': null,
+              }),
+            ],
+          ),
+        );
+      });
+
       test('passes the width and height arguments correctly', () async {
         await ImagePicker.pickImage();
         await ImagePicker.pickImage(maxWidth: 10.0);

--- a/packages/image_picker/test/image_picker_test.dart
+++ b/packages/image_picker/test/image_picker_test.dart
@@ -21,7 +21,7 @@ void main() {
     });
 
     group('#pickImage', () {
-      test('ImageSource.any is the default image source', () async {
+      test('ImageSource.askUser is the default image source', () async {
         await ImagePicker.pickImage();
 
         expect(

--- a/packages/path_provider/pubspec.yaml
+++ b/packages/path_provider/pubspec.yaml
@@ -15,7 +15,8 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  test: 0.12.24+8
+  flutter_test:
+    sdk: flutter
 
 environment:
     sdk: ">=1.8.0 <2.0.0"

--- a/packages/path_provider/test/path_provider_test.dart
+++ b/packages/path_provider/test/path_provider_test.dart
@@ -5,8 +5,8 @@
 import 'dart:io';
 
 import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:path_provider/path_provider.dart';
-import 'package:test/test.dart';
 
 void main() {
   const MethodChannel channel =
@@ -27,7 +27,9 @@ void main() {
     response = null;
     final Directory directory = await getTemporaryDirectory();
     expect(
-        log, equals(<MethodCall>[const MethodCall('getTemporaryDirectory')]));
+      log,
+      <Matcher>[isMethodCall('getTemporaryDirectory', arguments: null)],
+    );
     expect(directory, isNull);
   });
 
@@ -36,8 +38,9 @@ void main() {
     final Directory directory = await getApplicationDocumentsDirectory();
     expect(
       log,
-      equals(
-          <MethodCall>[const MethodCall('getApplicationDocumentsDirectory')]),
+      <Matcher>[
+        isMethodCall('getApplicationDocumentsDirectory', arguments: null)
+      ],
     );
     expect(directory, isNull);
   });

--- a/packages/shared_preferences/android/src/main/java/io/flutter/plugins/sharedpreferences/SharedPreferencesPlugin.java
+++ b/packages/shared_preferences/android/src/main/java/io/flutter/plugins/sharedpreferences/SharedPreferencesPlugin.java
@@ -115,7 +115,8 @@ public class SharedPreferencesPlugin implements MethodCallHandler {
           result.success(null);
           break;
         case "setDouble":
-          editor.putFloat(key, (float) call.argument("value")).apply();
+          float floatValue = ((Number) call.argument("value")).floatValue();
+          editor.putFloat(key, floatValue).apply();
           result.success(null);
           break;
         case "setInt":

--- a/packages/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/pubspec.yaml
@@ -16,8 +16,8 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  mockito: ^2.0.2
-  test: 0.12.24+8
+  flutter_test:
+    sdk: flutter
 
 environment:
     sdk: ">=1.8.0 <2.0.0"

--- a/packages/shared_preferences/test/shared_preferences_test.dart
+++ b/packages/shared_preferences/test/shared_preferences_test.dart
@@ -2,11 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:mockito/mockito.dart';
-import 'package:test/test.dart';
-
 import 'package:flutter/services.dart';
-
+import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
@@ -32,7 +29,7 @@ void main() {
     };
 
     final List<MethodCall> log = <MethodCall>[];
-    SharedPreferences sharedPreferences;
+    SharedPreferences preferences;
 
     setUp(() async {
       channel.setMockMethodCallHandler((MethodCall methodCall) async {
@@ -42,102 +39,95 @@ void main() {
         }
         return null;
       });
-      sharedPreferences = await SharedPreferences.getInstance();
+      preferences = await SharedPreferences.getInstance();
       log.clear();
     });
 
     tearDown(() {
-      sharedPreferences.clear();
+      preferences.clear();
     });
 
     test('reading', () async {
-      expect(
-          sharedPreferences.getString('String'), kTestValues['flutter.String']);
-      expect(sharedPreferences.getBool('bool'), kTestValues['flutter.bool']);
-      expect(sharedPreferences.getInt('int'), kTestValues['flutter.int']);
-      expect(
-          sharedPreferences.getDouble('double'), kTestValues['flutter.double']);
-      expect(
-          sharedPreferences.getStringList('List'), kTestValues['flutter.List']);
-      expect(log, equals(<MethodCall>[]));
+      expect(preferences.getString('String'), kTestValues['flutter.String']);
+      expect(preferences.getBool('bool'), kTestValues['flutter.bool']);
+      expect(preferences.getInt('int'), kTestValues['flutter.int']);
+      expect(preferences.getDouble('double'), kTestValues['flutter.double']);
+      expect(preferences.getStringList('List'), kTestValues['flutter.List']);
+      expect(log, <Matcher>[]);
     });
 
     test('writing', () async {
-      sharedPreferences.setString('String', kTestValues2['flutter.String']);
-      sharedPreferences.setBool('bool', kTestValues2['flutter.bool']);
-      sharedPreferences.setInt('int', kTestValues2['flutter.int']);
-      sharedPreferences.setDouble('double', kTestValues2['flutter.double']);
-      sharedPreferences.setStringList('List', kTestValues2['flutter.List']);
-      expect(sharedPreferences.getString('String'),
-          kTestValues2['flutter.String']);
-      expect(sharedPreferences.getBool('bool'), kTestValues2['flutter.bool']);
-      expect(sharedPreferences.getInt('int'), kTestValues2['flutter.int']);
-      expect(sharedPreferences.getDouble('double'),
-          kTestValues2['flutter.double']);
-      expect(sharedPreferences.getStringList('List'),
-          kTestValues2['flutter.List']);
+      preferences.setString('String', kTestValues2['flutter.String']);
+      preferences.setBool('bool', kTestValues2['flutter.bool']);
+      preferences.setInt('int', kTestValues2['flutter.int']);
+      preferences.setDouble('double', kTestValues2['flutter.double']);
+      preferences.setStringList('List', kTestValues2['flutter.List']);
+      expect(preferences.getString('String'), kTestValues2['flutter.String']);
+      expect(preferences.getBool('bool'), kTestValues2['flutter.bool']);
+      expect(preferences.getInt('int'), kTestValues2['flutter.int']);
+      expect(preferences.getDouble('double'), kTestValues2['flutter.double']);
+      expect(preferences.getStringList('List'), kTestValues2['flutter.List']);
       expect(log, equals(<MethodCall>[]));
-      await sharedPreferences.commit();
+      await preferences.commit();
       expect(
-          log,
-          equals(<MethodCall>[
-            new MethodCall('setString', <String, dynamic>{
-              'key': 'flutter.String',
-              'value': kTestValues2['flutter.String']
-            }),
-            new MethodCall('setBool', <String, dynamic>{
-              'key': 'flutter.bool',
-              'value': kTestValues2['flutter.bool']
-            }),
-            new MethodCall('setInt', <String, dynamic>{
-              'key': 'flutter.int',
-              'value': kTestValues2['flutter.int']
-            }),
-            new MethodCall('setDouble', <String, dynamic>{
-              'key': 'flutter.double',
-              'value': kTestValues2['flutter.double']
-            }),
-            new MethodCall('setStringList', <String, dynamic>{
-              'key': 'flutter.List',
-              'value': kTestValues2['flutter.List']
-            }),
-            const MethodCall('commit'),
-          ]));
+        log,
+        <Matcher>[
+          isMethodCall('setString', arguments: <String, dynamic>{
+            'key': 'flutter.String',
+            'value': kTestValues2['flutter.String']
+          }),
+          isMethodCall('setBool', arguments: <String, dynamic>{
+            'key': 'flutter.bool',
+            'value': kTestValues2['flutter.bool']
+          }),
+          isMethodCall('setInt', arguments: <String, dynamic>{
+            'key': 'flutter.int',
+            'value': kTestValues2['flutter.int']
+          }),
+          isMethodCall('setDouble', arguments: <String, dynamic>{
+            'key': 'flutter.double',
+            'value': kTestValues2['flutter.double']
+          }),
+          isMethodCall('setStringList', arguments: <String, dynamic>{
+            'key': 'flutter.List',
+            'value': kTestValues2['flutter.List']
+          }),
+          isMethodCall('commit', arguments: null),
+        ],
+      );
     });
 
     test('removing', () async {
       const String key = 'testKey';
-      sharedPreferences
+      preferences
         ..setString(key, null)
         ..setBool(key, null)
         ..setInt(key, null)
         ..setDouble(key, null)
         ..setStringList(key, null)
         ..remove(key);
-      await sharedPreferences.commit();
+      await preferences.commit();
       expect(
         log,
-        equals(
-          new List<MethodCall>.filled(
-            6,
-            const MethodCall(
-              'remove',
-              const <String, dynamic>{'key': 'flutter.$key'},
-            ),
-            growable: true,
-          )..add(const MethodCall('commit')),
-        ),
+        new List<Matcher>.filled(
+          6,
+          isMethodCall(
+            'remove',
+            arguments: <String, dynamic>{'key': 'flutter.$key'},
+          ),
+          growable: true,
+        )..add(isMethodCall('commit', arguments: null)),
       );
     });
 
     test('clearing', () async {
-      await sharedPreferences.clear();
-      expect(sharedPreferences.getString('String'), null);
-      expect(sharedPreferences.getBool('bool'), null);
-      expect(sharedPreferences.getInt('int'), null);
-      expect(sharedPreferences.getDouble('double'), null);
-      expect(sharedPreferences.getStringList('List'), null);
-      expect(log, equals(<MethodCall>[const MethodCall('clear')]));
+      await preferences.clear();
+      expect(preferences.getString('String'), null);
+      expect(preferences.getBool('bool'), null);
+      expect(preferences.getInt('int'), null);
+      expect(preferences.getDouble('double'), null);
+      expect(preferences.getStringList('List'), null);
+      expect(log, <Matcher>[isMethodCall('clear', arguments: null)]);
     });
 
     test('mocking', () async {
@@ -147,5 +137,3 @@ void main() {
     });
   });
 }
-
-class MockPlatformChannel extends Mock implements MethodChannel {}

--- a/packages/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/pubspec.yaml
@@ -15,7 +15,8 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  test: 0.12.24+8
+  flutter_test:
+    sdk: flutter
 
 environment:
     sdk: ">=1.8.0 <2.0.0"

--- a/packages/url_launcher/test/url_launcher_test.dart
+++ b/packages/url_launcher/test/url_launcher_test.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/services.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 void main() {
@@ -18,21 +18,19 @@ void main() {
     log.clear();
   });
 
-  test('canLaunch test', () async {
+  test('canLaunch', () async {
     await canLaunch('http://example.com/');
     expect(
       log,
-      equals(
-          <MethodCall>[const MethodCall('canLaunch', 'http://example.com/')]),
+      <Matcher>[isMethodCall('canLaunch', arguments: 'http://example.com/')],
     );
-    log.clear();
   });
 
-  test('launch test', () async {
+  test('launch', () async {
     await launch('http://example.com/');
     expect(
-        log,
-        equals(
-            <MethodCall>[const MethodCall('launch', 'http://example.com/')]));
+      log,
+      <Matcher>[isMethodCall('launch', arguments: 'http://example.com/')],
+    );
   });
 }


### PR DESCRIPTION
This PR makes it possible to control whether the image comes from _gallery_ or _camera_. The old behavior is preserved as the default option, which lets the user decide.

Here are the available options:

```dart
enum ImageSource {
  /// Let the user choose an image from a source they prefer.
  /// (the old default behavior)
  askUser,

  /// Opens up the device camera on both Android and iOS.
  camera,

  /// On Android, presents a grid of images from the users gallery. On iOS,
  /// opens the users photo library.
  gallery,
}
```

Here's how someone might pick an image from the device camera now:

```dart
Future<File> imageFile = ImagePicker.pickImage(source: ImageSource.camera);
```