### PR TITLE
Cancel the Firebase stream subscriptions.

### DIFF
--- a/packages/firebase_database/CHANGELOG.md
+++ b/packages/firebase_database/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3
+
+* Fix memory leak in FirebaseAnimatedList
+
 ## 0.1.2
 
 * Change GMS dependency to 11.+

--- a/packages/firebase_database/lib/ui/firebase_animated_list.dart
+++ b/packages/firebase_database/lib/ui/firebase_animated_list.dart
@@ -162,6 +162,14 @@ class FirebaseAnimatedListState extends State<FirebaseAnimatedList> {
     super.didChangeDependencies();
   }
 
+  @override
+  void dispose() {
+    // Cancel the Firebase stream subscriptions
+    _model.clear();
+
+    super.dispose();
+  }
+
   void _onChildAdded(int index, DataSnapshot snapshot) {
     if (!_loaded) {
       return; // AnimatedList is not created yet

--- a/packages/firebase_database/lib/ui/firebase_list.dart
+++ b/packages/firebase_database/lib/ui/firebase_list.dart
@@ -70,6 +70,13 @@ class FirebaseList extends ListBase<DataSnapshot>
     throw new UnsupportedError("List cannot be modified.");
   }
 
+  @override
+  void clear() {
+    cancelSubscriptions();
+
+    // Do not call super.clear(), it will set the length, it's unsupported.
+  }
+
   int _indexForKey(String key) {
     assert(key != null);
     // TODO(jackson): We could binary search since the list is already sorted.

--- a/packages/firebase_database/lib/ui/utils/stream_subscriber_mixin.dart
+++ b/packages/firebase_database/lib/ui/utils/stream_subscriber_mixin.dart
@@ -17,7 +17,7 @@ abstract class StreamSubscriberMixin<T> {
   }
 
   /// Cancels all streams that were previously added with listen().
-  void dispose() {
+  void cancelSubscriptions() {
     _subscriptions
         .forEach((StreamSubscription<T> subscription) => subscription.cancel());
   }

--- a/packages/firebase_database/pubspec.yaml
+++ b/packages/firebase_database/pubspec.yaml
@@ -3,7 +3,7 @@ name: firebase_database
 description: Firebase Database plugin for Flutter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_database
-version: 0.1.2
+version: 0.1.3
 
 flutter:
   plugin:


### PR DESCRIPTION
setState is getting called after the the firebase list is disposed, which is inducing a memory leak. To fix this, list.clear() is used to clear the subscriptions to the firebase streams in the list. 