### PR TITLE
Add AdMob and Firestore to README and FlutterFire.md

### DIFF
--- a/FlutterFire.md
+++ b/FlutterFire.md
@@ -14,12 +14,17 @@ The plugins are still under development, and some APIs might not be available ye
 
 | Plugin | Firebase feature | Source code |
 |---|---|---|
+| [firebase_admob][admob_pub] | [Firebase AdMob][admob_product] | [`packages/firebase_admob`][admob_code] |
 | [firebase_analytics][analytics_pub] | [Firebase Analytics][analytics_product] | [`packages/firebase_analytics`][analytics_code] |
 | [firebase_auth][auth_pub] | [Firebase Authentication][auth_product] | [`packages/firebase_auth`][auth_code] |
 | [firebase_database][database_pub] | [Firebase Realtime Database][database_product] | [`packages/firebase_database`][database_code] |
 | [cloud_firestore][firestore_pub] | [Cloud Firestore][firestore_product] | [`packages/cloud_firestore`][firestore_code] |
 | [firebase_messaging][messaging_pub] | [Firebase Cloud Messaging][messaging_product] | [`packages/firebase_messaging`][messaging_code] |
 | [firebase_storage][storage_pub] | [Firebase Cloud Storage][storage_product] | [`packages/firebase_storage`][storage_code] |
+
+[admob_pub]: https://pub.dartlang.org/packages/firebase_admob
+[admob_product]: https://firebase.google.com/docs/admob/
+[admob_code]: https://github.com/flutter/plugins/tree/master/packages/firebase_admob
 
 [analytics_pub]: https://pub.dartlang.org/packages/firebase_analytics
 [analytics_product]: https://firebase.google.com/products/analytics/

--- a/README.md
+++ b/README.md
@@ -54,8 +54,10 @@ These are the available plugins in this repository.
 | [url_launcher](./packages/url_launcher/) | [![pub package](https://img.shields.io/pub/v/url_launcher.svg)](https://pub.dartlang.org/packages/url_launcher) |
 | | |
 | **FlutterFire Plugins** |  |
+| [firebase_admob](./packages/firebase_admob/) | [![pub package](https://img.shields.io/pub/v/firebase_admob.svg)](https://pub.dartlang.org/packages/firebase_admob) |
 | [firebase_analytics](./packages/firebase_analytics/) | [![pub package](https://img.shields.io/pub/v/firebase_analytics.svg)](https://pub.dartlang.org/packages/firebase_analytics) |
 | [firebase_auth](./packages/firebase_auth/) | [![pub package](https://img.shields.io/pub/v/firebase_auth.svg)](https://pub.dartlang.org/packages/firebase_auth) |
+| [cloud_firestore](./packages/cloud_firestore/) | [![pub package](https://img.shields.io/pub/v/cloud_firestore.svg)](https://pub.dartlang.org/packages/cloud_firestore)
 | [firebase_database](./packages/firebase_database/) | [![pub package](https://img.shields.io/pub/v/firebase_database.svg)](https://pub.dartlang.org/packages/firebase_database) |
 | [firebase_messaging](./packages/firebase_messaging/) | [![pub package](https://img.shields.io/pub/v/firebase_messaging.svg)](https://pub.dartlang.org/packages/firebase_messaging) |
 | [firebase_storage](./packages/firebase_storage/) | [![pub package](https://img.shields.io/pub/v/firebase_storage.svg)](https://pub.dartlang.org/packages/firebase_storage) |


### PR DESCRIPTION
Does what it says on the tin — these two packages were missing from `README.md`, and AdMob was missing from `FlutterFire.md`