### PR TITLE
Image source selection support for ImagePicker plugin

### DIFF
--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3
+
+* Added optional source argument to pickImage for controlling where the image comes from.
+
 ## 0.1.2
 
 * Added optional maxWidth and maxHeight arguments to pickImage.

--- a/packages/image_picker/ios/Classes/ImagePickerPlugin.m
+++ b/packages/image_picker/ios/Classes/ImagePickerPlugin.m
@@ -9,6 +9,10 @@
 @interface ImagePickerPlugin ()<UINavigationControllerDelegate, UIImagePickerControllerDelegate>
 @end
 
+static const int SOURCE_ASK_USER = 0;
+static const int SOURCE_CAMERA = 1;
+static const int SOURCE_GALLERY = 2;
+
 @implementation ImagePickerPlugin {
   FlutterResult _result;
   NSDictionary *_arguments;
@@ -42,37 +46,60 @@
                                 details:nil]);
     _result = nil;
   }
+
   if ([@"pickImage" isEqualToString:call.method]) {
     _imagePickerController.modalPresentationStyle = UIModalPresentationCurrentContext;
     _imagePickerController.delegate = self;
+
     _result = result;
     _arguments = call.arguments;
 
-    UIAlertControllerStyle style = UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad
-                                       ? UIAlertControllerStyleAlert
-                                       : UIAlertControllerStyleActionSheet;
+    int imageSource = [[_arguments objectForKey:@"source"] intValue];
 
-    UIAlertController *alert =
-        [UIAlertController alertControllerWithTitle:nil message:nil preferredStyle:style];
-    UIAlertAction *camera = [UIAlertAction actionWithTitle:@"Take Photo"
-                                                     style:UIAlertActionStyleDefault
-                                                   handler:^(UIAlertAction *action) {
-                                                     [self showCamera];
-                                                   }];
-    UIAlertAction *library = [UIAlertAction actionWithTitle:@"Choose Photo"
-                                                      style:UIAlertActionStyleDefault
-                                                    handler:^(UIAlertAction *action) {
-                                                      [self showPhotoLibrary];
-                                                    }];
-    UIAlertAction *cancel =
-        [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil];
-    [alert addAction:camera];
-    [alert addAction:library];
-    [alert addAction:cancel];
-    [_viewController presentViewController:alert animated:YES completion:nil];
+    switch (imageSource) {
+      case SOURCE_ASK_USER:
+        [self showImageSourceSelector];
+        break;
+      case SOURCE_CAMERA:
+        [self showCamera];
+        break;
+      case SOURCE_GALLERY:
+        [self showPhotoLibrary];
+        break;
+      default:
+        result([FlutterError errorWithCode:@"invalid_source"
+                                   message:@"Invalid image source."
+                                   details:nil]);
+        break;
+    }
   } else {
     result(FlutterMethodNotImplemented);
   }
+}
+
+- (void)showImageSourceSelector {
+  UIAlertControllerStyle style = UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad
+                                     ? UIAlertControllerStyleAlert
+                                     : UIAlertControllerStyleActionSheet;
+
+  UIAlertController *alert =
+      [UIAlertController alertControllerWithTitle:nil message:nil preferredStyle:style];
+  UIAlertAction *camera = [UIAlertAction actionWithTitle:@"Take Photo"
+                                                   style:UIAlertActionStyleDefault
+                                                 handler:^(UIAlertAction *action) {
+                                                   [self showCamera];
+                                                 }];
+  UIAlertAction *library = [UIAlertAction actionWithTitle:@"Choose Photo"
+                                                    style:UIAlertActionStyleDefault
+                                                  handler:^(UIAlertAction *action) {
+                                                    [self showPhotoLibrary];
+                                                  }];
+  UIAlertAction *cancel =
+      [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil];
+  [alert addAction:camera];
+  [alert addAction:library];
+  [alert addAction:cancel];
+  [_viewController presentViewController:alert animated:YES completion:nil];
 }
 
 - (void)showCamera {

--- a/packages/image_picker/lib/image_picker.dart
+++ b/packages/image_picker/lib/image_picker.dart
@@ -7,6 +7,28 @@ import 'dart:io';
 
 import 'package:flutter/services.dart';
 
+/// Specifies the source where the picked image should come from.
+enum ImageSource {
+  /// Let the user choose an image from a source they prefer.
+  ///
+  /// On Android, opens a new screen with a grid of images (from the users
+  /// gallery) and a camera icon on the top right corner. The user can
+  /// either pick an image from the image grid, or tap the camera icon
+  /// to take a picture using the device camera.
+  ///
+  /// On iOS, the user is presented with an alert box with options to
+  /// either take a photo using the device camera or pick an image from
+  /// the photo library.
+  askUser,
+
+  /// Opens up the device camera on both Android and iOS.
+  camera,
+
+  /// On Android, presents a grid of images from the users gallery. On iOS,
+  /// opens the users photo library.
+  gallery,
+}
+
 class ImagePicker {
   static const MethodChannel _channel = const MethodChannel('image_picker');
 
@@ -17,10 +39,19 @@ class ImagePicker {
   /// * pick an image from the gallery
   /// * take a photo using the device camera.
   ///
+  /// Use the [source] argument for controlling where the image comes from.
+  /// By default, the user can choose the image from either camera or gallery.
+  ///
   /// If specified, the image will be at most [maxWidth] wide and
   /// [maxHeight] tall. Otherwise the image will be returned at it's
   /// original width and height.
-  static Future<File> pickImage({double maxWidth, double maxHeight}) async {
+  static Future<File> pickImage({
+    ImageSource source = ImageSource.askUser,
+    double maxWidth,
+    double maxHeight,
+  }) async {
+    assert(source != null);
+
     if (maxWidth != null && maxWidth < 0) {
       throw new ArgumentError.value(maxWidth, 'maxWidth can\'t be negative');
     }
@@ -31,7 +62,8 @@ class ImagePicker {
 
     final String path = await _channel.invokeMethod(
       'pickImage',
-      <String, double>{
+      <String, dynamic>{
+        'source': source.index,
         'maxWidth': maxWidth,
         'maxHeight': maxHeight,
       },

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -3,7 +3,7 @@ name: image_picker
 description: Flutter plugin that shows an image picker and uses the camera.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.1.2
+version: 0.1.3
 
 flutter:
   plugin:

--- a/packages/image_picker/test/image_picker_test.dart
+++ b/packages/image_picker/test/image_picker_test.dart
@@ -22,6 +22,48 @@ void main() {
     });
 
     group('#pickImage', () {
+      test('ImageSource.askUser is the default image source', () async {
+        await ImagePicker.pickImage();
+
+        expect(
+          log,
+          <Matcher>[
+            isMethodCall('pickImage', arguments: <String, dynamic>{
+              'source': 0,
+              'maxWidth': null,
+              'maxHeight': null,
+            }),
+          ],
+        );
+      });
+
+      test('passes the image source argument correctly', () async {
+        await ImagePicker.pickImage(source: ImageSource.askUser);
+        await ImagePicker.pickImage(source: ImageSource.camera);
+        await ImagePicker.pickImage(source: ImageSource.gallery);
+
+        expect(
+          log,
+          <Matcher>[
+            isMethodCall('pickImage', arguments: <String, dynamic>{
+              'source': 0,
+              'maxWidth': null,
+              'maxHeight': null,
+            }),
+            isMethodCall('pickImage', arguments: <String, dynamic>{
+              'source': 1,
+              'maxWidth': null,
+              'maxHeight': null,
+            }),
+            isMethodCall('pickImage', arguments: <String, dynamic>{
+              'source': 2,
+              'maxWidth': null,
+              'maxHeight': null,
+            }),
+          ],
+        );
+      });
+
       test('passes the width and height arguments correctly', () async {
         await ImagePicker.pickImage();
         await ImagePicker.pickImage(maxWidth: 10.0);
@@ -34,19 +76,23 @@ void main() {
         expect(
           log,
           <Matcher>[
-            isMethodCall('pickImage', arguments: <String, double>{
+            isMethodCall('pickImage', arguments: <String, dynamic>{
+              'source': 0,
               'maxWidth': null,
               'maxHeight': null,
             }),
-            isMethodCall('pickImage', arguments: <String, double>{
+            isMethodCall('pickImage', arguments: <String, dynamic>{
+              'source': 0,
               'maxWidth': 10.0,
               'maxHeight': null,
             }),
-            isMethodCall('pickImage', arguments: <String, double>{
+            isMethodCall('pickImage', arguments: <String, dynamic>{
+              'source': 0,
               'maxWidth': null,
               'maxHeight': 10.0,
             }),
-            isMethodCall('pickImage', arguments: <String, double>{
+            isMethodCall('pickImage', arguments: <String, dynamic>{
+              'source': 0,
               'maxWidth': 10.0,
               'maxHeight': 20.0,
             }),


### PR DESCRIPTION
**(I started over because of the googlebot CLA confusion and ugly change history.)**

This PR makes it possible to control whether the image comes from _gallery_ or _camera_. The old behavior is preserved as the default option, which lets the user decide.

Here are the available options:

```dart
enum ImageSource {
  /// Let the user choose an image from a source they prefer.
  /// (the old default behavior)
  askUser,

  /// Opens up the device camera on both Android and iOS.
  camera,

  /// On Android, presents a grid of images from the users gallery. On iOS,
  /// opens the users photo library.
  gallery,
}
```

Here's how someone might pick an image from the device camera now:

```dart
Future<File> imageFile = ImagePicker.pickImage(source: ImageSource.camera);
```