### PR TITLE
Document necessary permissions for ImagePicker plugin to avoid crashes on real devices

### DIFF
--- a/packages/image_picker/README.md
+++ b/packages/image_picker/README.md
@@ -7,8 +7,27 @@ and taking new pictures with the camera.
 
 *Note*: This plugin is still under development, and some APIs might not be available yet. [Feedback welcome](https://github.com/flutter/flutter/issues) and [Pull Requests](https://github.com/flutter/plugins/pulls) are most welcome!
 
-## Usage
-To use this plugin, add `image_picker` as a [dependency in your pubspec.yaml file](https://flutter.io/platform-plugins/).
+## Installation
+
+First, add `image_picker` as a [dependency in your pubspec.yaml file](https://flutter.io/platform-plugins/).
+
+### iOS
+
+Add the following keys to your _Info.plist_ file, located in `<project root>/ios/Runner/Info.plist`:
+
+* `NSPhotoLibraryUsageDescription` - describe why your app needs permission for the photo library. This is called _Privacy - Photo Library Usage Description_ in the visual editor.
+* `NSCameraUsageDescription` - describe why your app needs access to the camera. This is called _Privacy - Camera Usage Description_ in the visual editor.
+
+### Android
+
+Add the following permissions to your Android Manifest, located in `<project root>/android/app/src/main/AndroidManifest.xml:
+
+```xml
+<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+<uses-permission android:name="android.permission.CAMERA"/>
+```
+
+You're good to go!
 
 ### Example
 


### PR DESCRIPTION
Fixes [flutter/issues/12937](https://github.com/flutter/flutter/issues/12937).