### PR TITLE
Added isNull filtering to Firestore Query

### DIFF
--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.5
+
+* Support `isNull` filtering in `Query.where`
+* Fixed `DocumentChange.oldIndex` and `DocumentChange.newIndex` to be signed
+  integers (iOS)
+
 ## 0.0.4
 
 * Support for where clauses

--- a/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
+++ b/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
@@ -130,8 +130,8 @@ FIRQuery *getQuery(NSDictionary *arguments) {
               @"type" : type,
               @"document" : documentChange.document.data,
               @"path" : documentChange.document.reference.path,
-              @"oldIndex" : [NSNumber numberWithUnsignedInteger:documentChange.oldIndex],
-              @"newIndex" : [NSNumber numberWithUnsignedInteger:documentChange.newIndex],
+              @"oldIndex" : [NSNumber numberWithInt:documentChange.oldIndex],
+              @"newIndex" : [NSNumber numberWithInt:documentChange.newIndex],
             }];
           }
           [self.channel invokeMethod:@"QuerySnapshot"

--- a/packages/cloud_firestore/lib/src/query.dart
+++ b/packages/cloud_firestore/lib/src/query.dart
@@ -93,6 +93,7 @@ class Query {
     dynamic isLessThanOrEqualTo,
     dynamic isGreaterThan,
     dynamic isGreaterThanOrEqualTo,
+    bool isNull,
   }) {
     final ListEquality<dynamic> equality = const ListEquality<dynamic>();
     final List<List<dynamic>> conditions =
@@ -115,6 +116,13 @@ class Query {
     if (isGreaterThan != null) addCondition(field, '>', isGreaterThan);
     if (isGreaterThanOrEqualTo != null)
       addCondition(field, '>=', isGreaterThanOrEqualTo);
+    if (isNull != null) {
+      assert(
+          isNull,
+          'isNull can only be set to true. '
+          'Use isEqualTo to filter on non-null values.');
+      addCondition(field, '==', null);
+    }
 
     return _copyWithParameters(<String, dynamic>{'where': conditions});
   }

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ name: cloud_firestore
 description: Cloud Firestore plugin for Flutter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_firestore
-version: 0.0.4
+version: 0.0.5
 
 flutter:
   plugin:

--- a/packages/cloud_firestore/test/cloud_firestore_test.dart
+++ b/packages/cloud_firestore/test/cloud_firestore_test.dart
@@ -89,6 +89,35 @@ void main() {
           ]),
         );
       });
+      test('where field isNull', () async {
+        final StreamSubscription<QuerySnapshot> subscription =
+            collectionReference
+                .where('profile', isNull: true)
+                .snapshots
+                .listen((QuerySnapshot querySnapshot) {});
+        subscription.cancel();
+        await new Future<Null>.delayed(Duration.ZERO);
+        expect(
+          log,
+          equals(<Matcher>[
+            isMethodCall(
+              'Query#addSnapshotListener',
+              arguments: <String, dynamic>{
+                'path': 'foo',
+                'parameters': <String, dynamic>{
+                  'where': <List<dynamic>>[
+                    <dynamic>['profile', '==', null],
+                  ],
+                }
+              },
+            ),
+            isMethodCall(
+              'Query#removeListener',
+              arguments: <String, dynamic>{'handle': 0},
+            ),
+          ]),
+        );
+      });
       test('orderBy', () async {
         final StreamSubscription<QuerySnapshot> subscription =
             collectionReference


### PR DESCRIPTION
* Added isNull filtering to Firestore Query; 
* Fixed DocumentChange oldIndex and newIndex to be treated as signed integers (iOS)