### PR TITLE
DocumentReference `getCollection()` method

### DIFF
--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.6
+
+* Support for getCollection
+
 ## 0.0.5
 
 * Support `isNull` filtering in `Query.where`

--- a/packages/cloud_firestore/lib/src/document_reference.dart
+++ b/packages/cloud_firestore/lib/src/document_reference.dart
@@ -36,6 +36,14 @@ class DocumentReference {
     );
   }
 
+  /// Returns the reference of a collection contained inside of this
+  /// document.
+  CollectionReference getCollection(String collectionPath) {
+    return _firestore.collection(
+      <String>[path, collectionPath].join('/'),
+    );
+  }
+
   /// Notifies of documents at this location
   // TODO(jackson): Reduce code duplication with [Query]
   Stream<DocumentSnapshot> get snapshots {

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ name: cloud_firestore
 description: Cloud Firestore plugin for Flutter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_firestore
-version: 0.0.5
+version: 0.0.6
 
 flutter:
   plugin:

--- a/packages/cloud_firestore/test/cloud_firestore_test.dart
+++ b/packages/cloud_firestore/test/cloud_firestore_test.dart
@@ -202,7 +202,8 @@ void main() {
         );
       });
       test('getCollection', () async {
-        final CollectionReference colRef = collectionReference.document('bar').getCollection('baz');
+        final CollectionReference colRef =
+            collectionReference.document('bar').getCollection('baz');
         expect(colRef.path, 'foo/bar/baz');
       });
     });

--- a/packages/cloud_firestore/test/cloud_firestore_test.dart
+++ b/packages/cloud_firestore/test/cloud_firestore_test.dart
@@ -201,6 +201,10 @@ void main() {
           ]),
         );
       });
+      test('getCollection', () async {
+        final CollectionReference colRef = collectionReference.document('bar').getCollection('baz');
+        expect(colRef.path, 'foo/bar/baz');
+      });
     });
   });
 }


### PR DESCRIPTION
Fixes flutter/flutter#13058.

I was going to implement it on the native side, until I saw [this test](https://github.com/GoogleCloudPlatform/google-cloud-java/blob/e57d4a7d75514fcff2c41c541b616813be466494/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITSystemTest.java#L248) which showed me that the same result could be achieved by simply taking the DocumentReference's path and appending the collectionPath.

To-do:
- [x] Write a test