### PR TITLE
Adjust content view to place admob below

### DIFF
--- a/packages/firebase_admob/android/src/main/java/io/flutter/plugins/firebaseadmob/FirebaseAdMobPlugin.java
+++ b/packages/firebase_admob/android/src/main/java/io/flutter/plugins/firebaseadmob/FirebaseAdMobPlugin.java
@@ -14,6 +14,7 @@ import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
+import io.flutter.view.FlutterView;
 import java.util.Map;
 
 public class FirebaseAdMobPlugin implements MethodCallHandler {
@@ -21,6 +22,7 @@ public class FirebaseAdMobPlugin implements MethodCallHandler {
 
   private final Activity activity;
   private final MethodChannel channel;
+  private final FlutterView view;
 
   private LinearLayout banner;
   InterstitialAd interstitial;
@@ -28,11 +30,13 @@ public class FirebaseAdMobPlugin implements MethodCallHandler {
   public static void registerWith(Registrar registrar) {
     final MethodChannel channel =
         new MethodChannel(registrar.messenger(), "plugins.flutter.io/firebase_admob");
-    channel.setMethodCallHandler(new FirebaseAdMobPlugin(registrar.activity(), channel));
+    channel.setMethodCallHandler(
+        new FirebaseAdMobPlugin(registrar.activity(), registrar.view(), channel));
   }
 
-  private FirebaseAdMobPlugin(Activity activity, MethodChannel channel) {
+  private FirebaseAdMobPlugin(Activity activity, FlutterView view, MethodChannel channel) {
     this.activity = activity;
+    this.view = view;
     this.channel = channel;
     FirebaseApp.initializeApp(activity);
   }
@@ -104,7 +108,7 @@ public class FirebaseAdMobPlugin implements MethodCallHandler {
 
     switch (call.method) {
       case "loadBannerAd":
-        callLoadAd(MobileAd.createBanner(id, activity, channel), call, result);
+        callLoadAd(MobileAd.createBanner(id, activity, view, channel), call, result);
         break;
       case "loadInterstitialAd":
         callLoadAd(MobileAd.createInterstitial(id, activity, channel), call, result);


### PR DESCRIPTION
Use ~~RelativeLayout~~ FrameLayout.LayoutParams.bottomMargin on Android to move existing content view above AdMob views. This still may not work well if someone tries to place 2 AdMobs banners (do not think that's a requirement).

This is needed in order not to overlap with a flutter view. Currently it uses addContentView which would place AdMob view over flutter view and cover and hide some of the flutter content on bottom.

~~I am personally not big fan of this solution. It introduces a blink because of removal of the view, I will try to see if I can provide better solution. In the meantime~~ any feedback is welcome.