### PR TITLE
[android_alarm_manager] Example uses a firebase plugin, and reinitializes plugins.

### DIFF
--- a/packages/android_alarm_manager/CHANGELOG.md
+++ b/packages/android_alarm_manager/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.0.3] - 12/4/2017
+
+* Adds use of a Firebase plugin to the example. The example also now
+  demonstrates overriding the Application's onCreate method so that the
+  AlarmService can initialize plugin connections.
+
 ## [0.0.2] - 12/3/2017.
 
 * Add FLT prefix to iOS types.

--- a/packages/android_alarm_manager/README.md
+++ b/packages/android_alarm_manager/README.md
@@ -49,6 +49,36 @@ See the [example's](https://github.com/flutter/plugins/tree/master/packages/andr
 [MainActivity](https://github.com/flutter/plugins/blob/master/packages/android_alarm_manager/example/android/app/src/main/java/io/flutter/androidalarmmanagerexample/MainActivity.java)
 to see an example.
 
+If alarm callbacks will need access to other Flutter plugins, including the
+alarm manager plugin itself, it is necessary to teach the background service how
+to initialize plugins. This is done by giving the `AlarmService` a callback to call
+in the application's `onCreate` method. See the example's
+[Application overrides](https://github.com/flutter/plugins/blob/master/packages/android_alarm_manager/example/android/app/src/main/java/io/flutter/androidalarmmanagerexample/Application.java).
+In particular, its `Application` class is as follows:
+
+```java
+public class Application extends FlutterApplication implements PluginRegistrantCallback {
+  @Override
+  public void onCreate() {
+    super.onCreate();
+    AlarmService.setPluginRegistrant(this);
+  }
+
+  @Override
+  public void registerWith(PluginRegistry registry) {
+    GeneratedPluginRegistrant.registerWith(registry);
+  }
+}
+```
+
+Which must be reflected in the application's `AndroidManifest.xml`. E.g.:
+
+```xml
+    <application
+        android:name=".Application"
+        ...
+```
+
 For help getting started with Flutter, view our online
 [documentation](http://flutter.io/).
 

--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/androidalarmmanager/AlarmService.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/androidalarmmanager/AlarmService.java
@@ -15,12 +15,14 @@ import android.os.IBinder;
 import android.util.Log;
 import io.flutter.app.FlutterActivity;
 import io.flutter.app.FlutterApplication;
+import io.flutter.plugin.common.PluginRegistry.PluginRegistrantCallback;
 import io.flutter.view.FlutterMain;
 import io.flutter.view.FlutterNativeView;
 
 public class AlarmService extends Service {
   public static final String TAG = "AlarmService";
   private static FlutterNativeView sSharedFlutterView;
+  private static PluginRegistrantCallback sPluginRegistrantCallback;
 
   private FlutterNativeView mFlutterView;
   private String appBundlePath;
@@ -75,6 +77,10 @@ public class AlarmService extends Service {
     return true;
   }
 
+  public static void setPluginRegistrant(PluginRegistrantCallback callback) {
+    sPluginRegistrantCallback = callback;
+  }
+
   private void ensureFlutterView() {
     if (mFlutterView != null) {
       return;
@@ -88,8 +94,12 @@ public class AlarmService extends Service {
     // mFlutterView and sSharedFlutterView are both null. That likely means that
     // no FlutterView has ever been created in this process before. So, we'll
     // make one, and assign it to both mFlutterView and sSharedFlutterView.
-    mFlutterView = new FlutterNativeView(this);
+    mFlutterView = new FlutterNativeView(getApplicationContext());
     sSharedFlutterView = mFlutterView;
+
+    // If there was no FlutterNativeView before now, then we also must
+    // initialize the PluginRegistry.
+    sPluginRegistrantCallback.registerWith(mFlutterView.getPluginRegistry());
     return;
   }
 

--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/androidalarmmanager/AndroidAlarmManagerPlugin.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/androidalarmmanager/AndroidAlarmManagerPlugin.java
@@ -4,7 +4,6 @@
 
 package io.flutter.androidalarmmanager;
 
-import android.app.Activity;
 import android.content.Context;
 import io.flutter.plugin.common.JSONMethodCodec;
 import io.flutter.plugin.common.MethodCall;
@@ -26,15 +25,15 @@ public class AndroidAlarmManagerPlugin implements MethodCallHandler, ViewDestroy
             registrar.messenger(),
             "plugins.flutter.io/android_alarm_manager",
             JSONMethodCodec.INSTANCE);
-    AndroidAlarmManagerPlugin plugin = new AndroidAlarmManagerPlugin(registrar.activity());
+    AndroidAlarmManagerPlugin plugin = new AndroidAlarmManagerPlugin(registrar.context());
     channel.setMethodCallHandler(plugin);
     registrar.addViewDestroyListener(plugin);
   }
 
   private Context mContext;
 
-  private AndroidAlarmManagerPlugin(Activity activity) {
-    this.mContext = activity;
+  private AndroidAlarmManagerPlugin(Context context) {
+    this.mContext = context;
   }
 
   @Override

--- a/packages/android_alarm_manager/example/android/app/build.gradle
+++ b/packages/android_alarm_manager/example/android/app/build.gradle
@@ -50,3 +50,5 @@ dependencies {
     androidTestCompile 'com.android.support.test:runner:0.5'
     androidTestCompile 'com.android.support.test:rules:0.5'
 }
+
+apply plugin: 'com.google.gms.google-services'

--- a/packages/android_alarm_manager/example/android/app/google-services.json
+++ b/packages/android_alarm_manager/example/android/app/google-services.json
@@ -1,0 +1,48 @@
+{
+  "project_info": {
+    "project_number": "1067712222741",
+    "project_id": "flutter-alarmmanager-example"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:1067712222741:android:b3f895545fce0ad2",
+        "android_client_info": {
+          "package_name": "io.flutter.androidalarmmanagerexample"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "1067712222741-k2jv050djreb4i551vd6q621css54tia.apps.googleusercontent.com",
+          "client_type": 3
+        },
+        {
+          "client_id": "1067712222741-qfv81bdrucm5hpnjqp8157jj1bvjjlqn.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "io.flutter.androidalarmmanagerexample",
+            "certificate_hash": "0f729308cc7f95a84196351d1aa788e1f9b62e9e"
+          }
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyCkXpml3lzlhOzX-ZhOWX95TdKQFZqMkHE"
+        }
+      ],
+      "services": {
+        "analytics_service": {
+          "status": 1
+        },
+        "appinvite_service": {
+          "status": 1,
+          "other_platform_oauth_client": []
+        },
+        "ads_service": {
+          "status": 1
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/packages/android_alarm_manager/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/android_alarm_manager/example/android/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name=".Application"
         android:label="android_alarm_manager_example"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/packages/android_alarm_manager/example/android/app/src/main/java/io/flutter/androidalarmmanagerexample/Application.java
+++ b/packages/android_alarm_manager/example/android/app/src/main/java/io/flutter/androidalarmmanagerexample/Application.java
@@ -1,0 +1,20 @@
+package io.flutter.androidalarmmanagerexample;
+
+import io.flutter.androidalarmmanager.AlarmService;
+import io.flutter.app.FlutterApplication;
+import io.flutter.plugin.common.PluginRegistry;
+import io.flutter.plugin.common.PluginRegistry.PluginRegistrantCallback;
+import io.flutter.plugins.GeneratedPluginRegistrant;
+
+public class Application extends FlutterApplication implements PluginRegistrantCallback {
+  @Override
+  public void onCreate() {
+    super.onCreate();
+    AlarmService.setPluginRegistrant(this);
+  }
+
+  @Override
+  public void registerWith(PluginRegistry registry) {
+    GeneratedPluginRegistrant.registerWith(registry);
+  }
+}

--- a/packages/android_alarm_manager/example/android/build.gradle
+++ b/packages/android_alarm_manager/example/android/build.gradle
@@ -8,6 +8,8 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.3'
+        // Add the google services classpath
+        classpath 'com.google.gms:google-services:3.1.0'
     }
 }
 

--- a/packages/android_alarm_manager/example/lib/main.dart
+++ b/packages/android_alarm_manager/example/lib/main.dart
@@ -5,37 +5,73 @@
 import 'dart:async';
 import 'dart:isolate';
 
-import 'package:flutter/widgets.dart';
 import 'package:android_alarm_manager/android_alarm_manager.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/widgets.dart';
+
+final FirebaseAuth firebaseAuth = FirebaseAuth.instance;
+FirebaseUser firebaseUser;
+
+Future<Null> ensureFirebaseUser() async {
+  if (firebaseUser == null) {
+    firebaseUser = await firebaseAuth.currentUser();
+    if (firebaseUser == null) {
+      firebaseUser = await firebaseAuth.signInAnonymously();
+    }
+  }
+}
+
+class HelloMessage {
+  final DateTime _now;
+  final String _msg;
+  final int _isolate;
+  final FirebaseUser _user;
+  final String _token;
+
+  HelloMessage(this._now, this._msg, this._isolate, this._user, this._token);
+
+  @override
+  String toString() {
+    return "[$_now] $_msg "
+        "isolate=$_isolate "
+        "user='$_user' "
+        "token=$_token";
+  }
+}
+
+void printHelloMessage(String msg) {
+  ensureFirebaseUser().then((_) {
+    firebaseUser.getIdToken().then((String idToken) {
+      print(new HelloMessage(
+        new DateTime.now(),
+        msg,
+        Isolate.current.hashCode,
+        firebaseUser,
+        idToken,
+      ));
+    });
+  });
+}
 
 void printHello() {
-  final DateTime now = new DateTime.now();
-  final int isolateId = Isolate.current.hashCode;
-  print("[$now] Hello, world! isolate=$isolateId function='$printHello'");
+  printHelloMessage("Hello, world!");
 }
 
 void printGoodbye() {
-  final DateTime now = new DateTime.now();
-  final int isolateId = Isolate.current.hashCode;
-  print("[$now] Goodbye, world! isolate=$isolateId function='$printGoodbye'");
+  printHelloMessage("Goodbye, world!");
 }
 
 bool oneShotFired = false;
 
 void printOneShot() {
-  oneShotFired = true;
-  final DateTime now = new DateTime.now();
-  final int isolateId = Isolate.current.hashCode;
-  print("[$now] Hello, once! isolate=$isolateId function='$printOneShot'");
+  printHelloMessage("Hello, once!");
 }
 
 Future<Null> main() async {
   final int helloAlarmID = 0;
   final int goodbyeAlarmID = 1;
   final int oneShotID = 2;
-  final DateTime now = new DateTime.now();
-  final int isolateId = Isolate.current.hashCode;
-  print("[$now] Hello, main()! isolate=$isolateId function='$main'");
+  printHelloMessage("Hello, main()!");
   runApp(const Center(
       child: const Text('Hello, world!', textDirection: TextDirection.ltr)));
   await AndroidAlarmManager.periodic(

--- a/packages/android_alarm_manager/example/pubspec.yaml
+++ b/packages/android_alarm_manager/example/pubspec.yaml
@@ -4,52 +4,15 @@ description: Demonstrates how to use the android_alarm_manager plugin.
 dependencies:
   flutter:
     sdk: flutter
-
 dev_dependencies:
   flutter_test:
     sdk: flutter
-
   android_alarm_manager:
     path: ../
+  firebase_auth:
+    path: ../../firebase_auth
+  google_sign_in:
+    path: ../../google_sign_in
 
-# For information on the generic Dart part of this file, see the
-# following page: https://www.dartlang.org/tools/pub/pubspec
-
-# The following section is specific to Flutter.
 flutter:
-
-  # The following line ensures that the Material Icons font is
-  # included with your application, so that you can use the icons in
-  # the Icons class.
   uses-material-design: true
-
-  # To add assets to your application, add an assets section, like this:
-  # assets:
-  #  - images/a_dot_burr.jpeg
-  #  - images/a_dot_ham.jpeg
-
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.io/assets-and-images/#resolution-aware.
-
-  # For details regarding adding assets from package dependencies, see
-  # https://flutter.io/assets-and-images/#from-packages
-  
-  # To add custom fonts to your application, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts from package dependencies, 
-  # see https://flutter.io/custom-fonts/#from-packages


### PR DESCRIPTION
This change enables the AlarmService to establish plugin connections when it is started in the absence of a main activity. However, for this to work properly, plugins may not assume that there is a current Activity. In particular plugins should not retain a reference to the Activity gleaned from the `Registrar` passed to `registerWith`. Instead, plugins should query the registrar whenever an Activity is needed, and should use registrar.context() when a Context is needed instead of using the Activity as a Context.

In subsequent PR's I will update the plugin API documentation, and try to update first-party plugins as much as I am able.

Until the above changes are made, most plugins won't work correctly when initialized by a background service.