### PR TITLE
Use safe area layout to place ad in iOS 11

### DIFF
--- a/packages/firebase_admob/ios/Classes/MobileAd.m
+++ b/packages/firebase_admob/ios/Classes/MobileAd.m
@@ -218,11 +218,21 @@ GADBannerView *_banner;
   }
   if (_status != LOADED) return;
 
+  _banner.translatesAutoresizingMaskIntoConstraints = NO;
   UIView *screen = [FLTMobileAd rootViewController].view;
-  CGFloat x = screen.frame.size.width / 2 - _banner.frame.size.width / 2;
-  CGFloat y = screen.frame.size.height - _banner.frame.size.height;
-  _banner.frame = (CGRect){{x, y}, _banner.frame.size};
   [screen addSubview:_banner];
+
+  if (@available(ios 11.0, *)) {
+    UILayoutGuide *guide = [FLTMobileAd rootViewController].view.safeAreaLayoutGuide;
+    [NSLayoutConstraint activateConstraints:@[
+      [_banner.centerXAnchor constraintEqualToAnchor:guide.centerXAnchor],
+      [_banner.bottomAnchor constraintEqualToAnchor:guide.bottomAnchor]
+    ]];
+  } else {
+    CGFloat x = screen.frame.size.width / 2 - _banner.frame.size.width / 2;
+    CGFloat y = screen.frame.size.height - _banner.frame.size.height;
+    _banner.frame = (CGRect){{x, y}, _banner.frame.size};
+  }
 }
 
 - (void)adViewDidReceiveAd:(GADBannerView *)adView {


### PR DESCRIPTION
This fixes ad placement for the iPhone X.  iOS code was updated per the [AdMob guidelines announced on October 24](https://support.google.com/admob/answer/7553599?ctx=ui&hl=en)