### PR TITLE
Upgrade examples to work with Gradle 4

### DIFF
--- a/packages/android_intent/example/android/build.gradle
+++ b/packages/android_intent/example/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 

--- a/packages/battery/example/android/build.gradle
+++ b/packages/battery/example/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 

--- a/packages/cloud_firestore/example/android/build.gradle
+++ b/packages/cloud_firestore/example/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
         classpath 'com.google.gms:google-services:3.1.0'
     }
 }

--- a/packages/connectivity/example/android/build.gradle
+++ b/packages/connectivity/example/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 

--- a/packages/firebase_admob/example/android/build.gradle
+++ b/packages/firebase_admob/example/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
         classpath 'com.google.gms:google-services:3.0.0'
     }
 }

--- a/packages/firebase_analytics/example/android/build.gradle
+++ b/packages/firebase_analytics/example/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
         classpath 'com.google.gms:google-services:3.1.0'
     }
 }

--- a/packages/firebase_auth/example/android/build.gradle
+++ b/packages/firebase_auth/example/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
         classpath 'com.google.gms:google-services:3.1.0'
     }
 }

--- a/packages/firebase_database/example/android/build.gradle
+++ b/packages/firebase_database/example/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
         classpath 'com.google.gms:google-services:3.1.0'
     }
 }

--- a/packages/firebase_messaging/example/android/build.gradle
+++ b/packages/firebase_messaging/example/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
         classpath 'com.google.gms:google-services:3.1.0'
     }
 }

--- a/packages/firebase_storage/example/android/build.gradle
+++ b/packages/firebase_storage/example/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
         classpath 'com.google.gms:google-services:3.1.0'
     }
 }

--- a/packages/google_sign_in/example/android/build.gradle
+++ b/packages/google_sign_in/example/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 

--- a/packages/image_picker/example/android/build.gradle
+++ b/packages/image_picker/example/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 

--- a/packages/local_auth/example/android/build.gradle
+++ b/packages/local_auth/example/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 

--- a/packages/package_info/example/android/build.gradle
+++ b/packages/package_info/example/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 

--- a/packages/path_provider/example/android/build.gradle
+++ b/packages/path_provider/example/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 

--- a/packages/quick_actions/example/android/build.gradle
+++ b/packages/quick_actions/example/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 

--- a/packages/sensors/example/android/build.gradle
+++ b/packages/sensors/example/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 

--- a/packages/share/example/android/build.gradle
+++ b/packages/share/example/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 

--- a/packages/shared_preferences/example/android/build.gradle
+++ b/packages/shared_preferences/example/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 

--- a/packages/url_launcher/example/android/build.gradle
+++ b/packages/url_launcher/example/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 


### PR DESCRIPTION
Version 2.3.0 of the Android Gradle plugin uses Gradle API that has been removed in Gradle 4. Version 2.3.3 does not (and has been used by the Flutter project template for a long time).

This change affects example projects only, not the plugins themselves.