### PR TITLE
Add missing `break`

### DIFF
--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1
+
+* Fix bug on Android where removeListener is sometimes called without a handle
+
 ## 0.2.0
 
 * **Breaking change**. Upgraded to Gradle 4.1 and Android Studio Gradle plugin

--- a/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
+++ b/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
@@ -208,6 +208,7 @@ public class CloudFirestorePlugin implements MethodCallHandler {
           listenerRegistrations.put(
               handle, getDocumentReference(arguments).addSnapshotListener(observer));
           result.success(handle);
+          break;
         }
       case "Query#removeListener":
         {

--- a/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
+++ b/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
@@ -213,7 +213,6 @@ public class CloudFirestorePlugin implements MethodCallHandler {
       case "Query#removeListener":
         {
           Map<String, Object> arguments = call.arguments();
-          // TODO(arthurthompson): find out why removeListener is sometimes called without handle.
           int handle = (Integer) arguments.get("handle");
           listenerRegistrations.get(handle).remove();
           listenerRegistrations.remove(handle);

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ name: cloud_firestore
 description: Cloud Firestore plugin for Flutter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_firestore
-version: 0.2.0
+version: 0.2.1
 
 flutter:
   plugin:


### PR DESCRIPTION
Fixes flutter/flutter#12714
Without the break statement, `Query#addDocumentListener` was falling through to `Query#removeListener`.