### PR TITLE
Fix GIF image

### DIFF
--- a/packages/video_player/README.md
+++ b/packages/video_player/README.md
@@ -4,7 +4,7 @@
 
 A Flutter plugin for iOS and Android for playing back video on a Widget surface.
 
-![The example app running in iOS](doc/demo_ipod.gif)
+![The example app running in iOS](https://github.com/flutter/plugins/blob/master/packages/video_player/doc/demo_ipod.gif?raw=true)
 
 *Note*: This plugin is still under development, and some APIs might not be available yet.
 [Feedback welcome](https://github.com/flutter/flutter/issues) and


### PR DESCRIPTION
Demo GIF image doesn't work on pub site because link is relative rather than absolute. Need to resubmit the readme for the video package.