### PR TITLE
Add Android Firebase phone number authentication

### DIFF
--- a/packages/firebase_auth/example/lib/main.dart
+++ b/packages/firebase_auth/example/lib/main.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:google_sign_in/google_sign_in.dart';
+import 'package:flutter/services.dart';
 
 final FirebaseAuth _auth = FirebaseAuth.instance;
 final GoogleSignIn _googleSignIn = new GoogleSignIn();
@@ -21,13 +22,17 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return new MaterialApp(
       title: 'Firebase Auth Demo',
-      home: new MyHomePage(title: 'Firebase Auth Demo'),
+      home: const MyHomePage(title: 'Firebase Auth Demo'),
+      routes: <String, WidgetBuilder>{
+        '/signInWithPhoneNumber': (BuildContext context) =>
+            const PhoneNumberSignInPage(title: 'Sign in with phone number')
+      },
     );
   }
 }
 
 class MyHomePage extends StatefulWidget {
-  MyHomePage({Key key, this.title}) : super(key: key);
+  const MyHomePage({Key key, this.title}) : super(key: key);
 
   final String title;
 
@@ -105,14 +110,343 @@ class _MyHomePageState extends State<MyHomePage> {
                   _message = _testSignInWithGoogle();
                 });
               }),
+          new MaterialButton(
+              child: const Text('Test signInWithPhoneNumber'),
+              onPressed: () {
+                Navigator.of(context).pushNamed("/signInWithPhoneNumber");
+              }),
           new FutureBuilder<String>(
               future: _message,
               builder: (_, AsyncSnapshot<String> snapshot) {
-                return new Text(snapshot.data ?? '',
-                    style: const TextStyle(
-                        color: const Color.fromARGB(255, 0, 155, 0)));
+                return new Text(
+                  snapshot.data ?? '',
+                  style: const TextStyle(
+                    color: const Color.fromARGB(255, 0, 155, 0),
+                  ),
+                );
               }),
         ],
+      ),
+    );
+  }
+}
+
+class PhoneNumberSignInPage extends StatefulWidget {
+  const PhoneNumberSignInPage({Key key, this.title}) : super(key: key);
+
+  final String title;
+
+  @override
+  _PhoneNumberSignInPageState createState() =>
+      new _PhoneNumberSignInPageState();
+}
+
+class _PhoneNumberSignInPageState extends State<PhoneNumberSignInPage> {
+  final GlobalKey<ScaffoldState> _scaffoldKey = new GlobalKey<ScaffoldState>();
+  final GlobalKey<FormState> _phoneNumberFormKey = new GlobalKey<FormState>();
+  final GlobalKey<FormState> _verificationCodeFormKey =
+      new GlobalKey<FormState>();
+  bool _autoValidatePhoneNumberForm = false;
+  bool _autoValidateVerificationCodeForm = false;
+
+  Future<String> _message = new Future<String>.value('');
+  String _phoneNumber;
+  String _verificationCode;
+
+  StreamSubscription<PhoneSignInEvent> _phoneSignInEventSubscription;
+
+  @override
+  void initState() {
+    super.initState();
+    _phoneSignInEventSubscription =
+        _auth.onPhoneSignInEvents.listen((PhoneSignInEvent phoneSignInEvent) {
+      switch (phoneSignInEvent) {
+        case PhoneSignInEvent.CODE_SENT:
+          print("[UI] Code sent event - Display view to let the user enter it");
+          break;
+
+        case PhoneSignInEvent.CODE_AUTO_RETRIEVAL_TIMEOUT:
+          print("[UI] Code auto retrieval timeout event");
+          break;
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    if (_phoneSignInEventSubscription != null) {
+      _phoneSignInEventSubscription.cancel();
+    }
+  }
+
+  Future<String> _testSignInWithPhoneNumber(String phoneNumber) async {
+    try {
+      final FirebaseUser user =
+          await _auth.signInWithPhoneNumber(phoneNumber: phoneNumber);
+
+      assert(!user.isEmailVerified);
+      assert(!user.isAnonymous);
+      assert(await user.getIdToken() != null);
+
+      final FirebaseUser currentUser = await _auth.currentUser();
+      assert(user.uid == currentUser.uid);
+
+      return 'signInWithPhoneNumber succeeded: $user';
+    } on PlatformException catch (e) {
+      return _handlePhoneSignInError(e);
+    }
+  }
+
+  Future<String> _testVerifyPhoneNumber(String code) async {
+    try {
+      final FirebaseUser user = await _auth.verifyPhoneNumber(code: code);
+
+      assert(!user.isEmailVerified);
+      assert(!user.isAnonymous);
+      assert(await user.getIdToken() != null);
+
+      final FirebaseUser currentUser = await _auth.currentUser();
+      assert(user.uid == currentUser.uid);
+
+      return 'verifyPhoneNumber succeeded: $user';
+    } on PlatformException catch (e) {
+      return _handlePhoneSignInError(e);
+    }
+  }
+
+  Future<String> _testResendVerificationCode(String phoneNumber) async {
+    try {
+      final FirebaseUser user =
+          await _auth.resendVerificationCode(phoneNumber: phoneNumber);
+
+      assert(!user.isEmailVerified);
+      assert(!user.isAnonymous);
+      assert(await user.getIdToken() != null);
+
+      final FirebaseUser currentUser = await _auth.currentUser();
+      assert(user.uid == currentUser.uid);
+
+      return 'resendVerificationCode succeeded: $user';
+    } on PlatformException catch (e) {
+      return _handlePhoneSignInError(e);
+    }
+  }
+
+  Future<String> _handlePhoneSignInError(PlatformException e) {
+    final PhoneSignInError phoneSignInError =
+        stringToPhoneSignInErrorEnum(e.code);
+
+    switch (phoneSignInError) {
+      case PhoneSignInError.NO_FOREGROUND_ACTIVITY:
+        print("[handlePhoneSignInError] No foreground activity\n${e.message}");
+        break;
+
+      case PhoneSignInError.INVALID_REQUEST:
+        print("[handlePhoneSignInError] Invalid request\n${e.message}");
+        break;
+
+      case PhoneSignInError.SMS_QUOTA_EXCEEDED:
+        print("[handlePhoneSignInError] SMS quota exceeded\n${e.message}");
+        break;
+
+      case PhoneSignInError.UNAUTHORIZED:
+        print("[handlePhoneSignInError] Unauthorized\n${e.message}");
+        break;
+
+      case PhoneSignInError.API_NOT_AVAILABLE:
+        print("[handlePhoneSignInError] API not available\n${e.message}");
+        break;
+    }
+
+    return new Future<String>.value(e.message);
+  }
+
+  void _closeKeyBoard() {
+    SystemChannels.textInput.invokeMethod('TextInput.hide');
+  }
+
+  void _showInSnackBar(String value) {
+    _scaffoldKey.currentState
+        .showSnackBar(new SnackBar(content: new Text(value)));
+  }
+
+  String _validatePhoneNumber(String phoneNumber) {
+    final RegExp phoneExp = new RegExp(r'^[\d -+(),.*#]+$');
+    if (!phoneExp.hasMatch(phoneNumber))
+      return 'Please enter a valid phone number.';
+    return null;
+  }
+
+  String _validateVerificationCode(String verificationCode) {
+    final RegExp phoneExp = new RegExp(r'^\d{6}$');
+    if (!phoneExp.hasMatch(verificationCode))
+      return 'Please enter a valid verification code.';
+    return null;
+  }
+
+  void _handlePhoneNumberSubmitted() {
+    final FormState form = _phoneNumberFormKey.currentState;
+    if (!form.validate()) {
+      _autoValidatePhoneNumberForm = true;
+      _showInSnackBar('Invalid phone number!');
+    } else {
+      form.save();
+      _closeKeyBoard();
+      _showInSnackBar('Phone number: $_phoneNumber');
+    }
+  }
+
+  void _handlePhoneNumberSaved(String phoneNumber) {
+    _phoneNumber = phoneNumber;
+    setState(() {
+      _message = _testSignInWithPhoneNumber(_phoneNumber);
+    });
+  }
+
+  void _handleVerificationCodeSubmitted() {
+    final FormState form = _verificationCodeFormKey.currentState;
+    if (!form.validate()) {
+      _autoValidateVerificationCodeForm = true;
+      _showInSnackBar('Invalid verification code!');
+    } else {
+      form.save();
+      _closeKeyBoard();
+      _showInSnackBar('Verification code: $_verificationCode');
+    }
+  }
+
+  void _handleVerificationCodeSaved(String verificationCode) {
+    _verificationCode = verificationCode;
+    setState(() {
+      _message = _testVerifyPhoneNumber(_verificationCode);
+    });
+  }
+
+  void _handleResendVerificationCode() {
+    if (_phoneNumber == null || _phoneNumber == '') {
+      _showInSnackBar('Please signInWithPhoneNumber first!');
+      return;
+    }
+
+    setState(() {
+      _message = _testResendVerificationCode(_phoneNumber);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return new Scaffold(
+      key: _scaffoldKey,
+      resizeToAvoidBottomPadding: false,
+      appBar: new AppBar(
+        title: new Text(widget.title),
+      ),
+      body: new SafeArea(
+        top: false,
+        bottom: false,
+        child: new Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            new Center(
+              child: new Text("Step 1",
+                  style: Theme.of(context).textTheme.headline),
+            ),
+            new Container(
+              height: 150.0,
+              child: new Form(
+                key: _phoneNumberFormKey,
+                autovalidate: _autoValidatePhoneNumberForm,
+                child: new ListView(
+                  padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                  children: <Widget>[
+                    new TextFormField(
+                      initialValue: _phoneNumber ?? '',
+                      decoration: const InputDecoration(
+                        icon: const Icon(Icons.phone),
+                        hintText:
+                            'Phone number with country calling code prefix',
+                        labelText: 'Phone Number *',
+                      ),
+                      keyboardType: TextInputType.phone,
+                      onSaved: _handlePhoneNumberSaved,
+                      validator: _validatePhoneNumber,
+                    ),
+                    new Container(
+                      padding: const EdgeInsets.all(20.0),
+                      alignment: Alignment.center,
+                      child: new Column(
+                        children: <Widget>[
+                          new RaisedButton(
+                            child: const Text('Test signInWithPhoneNumber'),
+                            onPressed: _handlePhoneNumberSubmitted,
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            new Center(
+                child: new Text(
+              "Step 2",
+              style: Theme.of(context).textTheme.headline,
+            )),
+            new Expanded(
+              child: new Form(
+                key: _verificationCodeFormKey,
+                autovalidate: _autoValidateVerificationCodeForm,
+                child: new ListView(
+                  padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                  children: <Widget>[
+                    new TextFormField(
+                      initialValue: _verificationCode ?? '',
+                      keyboardType: TextInputType.number,
+                      decoration: const InputDecoration(
+                        labelText: 'Verification code',
+                      ),
+                      maxLines: 1,
+                      onSaved: _handleVerificationCodeSaved,
+                      validator: _validateVerificationCode,
+                    ),
+                    new Container(
+                      height: 150.0,
+                      padding: const EdgeInsets.only(top: 5.0),
+                      alignment: Alignment.center,
+                      child: new Column(
+                        children: <Widget>[
+                          new RaisedButton(
+                            child: const Text('Test verifyPhoneNumber'),
+                            onPressed: _handleVerificationCodeSubmitted,
+                          ),
+                          const SizedBox(height: 10.0),
+                          new RaisedButton(
+                            child: const Text('Test resendVerificationCode'),
+                            onPressed: _handleResendVerificationCode,
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            new Expanded(
+              child: new FutureBuilder<String>(
+                future: _message,
+                builder: (_, AsyncSnapshot<String> snapshot) {
+                  return new Text(
+                    snapshot.data ?? '',
+                    style: const TextStyle(
+                      color: const Color.fromARGB(255, 0, 155, 0),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/packages/firebase_auth/test/firebase_auth_test.dart
+++ b/packages/firebase_auth/test/firebase_auth_test.dart
@@ -17,6 +17,8 @@ const String kMockPassword = 'passw0rd';
 const String kMockIdToken = '12345';
 const String kMockAccessToken = '67890';
 const String kMockCustomToken = '12345';
+const String kMockPhoneNumber = '1-123-456-7890';
+const String kMockVerificationCode = '123456';
 
 void main() {
   group('$FirebaseAuth', () {
@@ -327,6 +329,50 @@ void main() {
         <Matcher>[
           isMethodCall('signInWithCustomToken', arguments: <String, String>{
             'token': kMockCustomToken,
+          })
+        ],
+      );
+    });
+
+    test('signInWithPhoneNumber', () async {
+      final FirebaseUser user =
+          await auth.signInWithPhoneNumber(phoneNumber: kMockPhoneNumber);
+      verifyUser(user);
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('signInWithPhoneNumber', arguments: <String, dynamic>{
+            'phoneNumber': kMockPhoneNumber,
+            'timeout': 60
+          })
+        ],
+      );
+    });
+
+    test('verifyPhoneNumber', () async {
+      final FirebaseUser user =
+          await auth.verifyPhoneNumber(code: kMockVerificationCode);
+      verifyUser(user);
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('verifyPhoneNumber', arguments: <String, String>{
+            'code': kMockVerificationCode,
+          })
+        ],
+      );
+    });
+
+    test('resendVerificationCode', () async {
+      final FirebaseUser user =
+          await auth.resendVerificationCode(phoneNumber: kMockPhoneNumber);
+      verifyUser(user);
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('resendVerificationCode', arguments: <String, dynamic>{
+            'phoneNumber': kMockPhoneNumber,
+            'timeout': 60
           })
         ],
       );


### PR DESCRIPTION
Half fix issue https://github.com/flutter/flutter/issues/10404 by adding support for Firebase phone number authentication on the Android platform in the [firebase_auth plugin](https://github.com/flutter/plugins/tree/master/packages/firebase_auth).

For usage example and testing purposes I've implemented a widget - [PhoneNumberSignInPage](https://github.com/alibitek/plugins/blob/b5df6939b0303f9473e58149eb289ace9dbdf7b1/packages/firebase_auth/example/lib/main.dart#L131) in the example application where the user can enter the phone number and verification code (see screenshot bellow).

This showcases how to use the [Dart API for Firebase phone number authentication](https://github.com/alibitek/plugins/blob/b5df6939b0303f9473e58149eb289ace9dbdf7b1/packages/firebase_auth/lib/firebase_auth.dart#L263-L390), which consists of the following three methods on the FirebaseAuth class: 

1. [signInWithPhoneNumber: Signs in a user by sending a verification code to the user's [phoneNumber]](https://github.com/alibitek/plugins/blob/b5df6939b0303f9473e58149eb289ace9dbdf7b1/packages/firebase_auth/lib/firebase_auth.dart#L263:L356)
2. [verifyPhoneNumber: Verify the authenticity of the phone number using the provided [code]](https://github.com/alibitek/plugins/blob/b5df6939b0303f9473e58149eb289ace9dbdf7b1/packages/firebase_auth/lib/firebase_auth.dart#L358:L372)
3. [resendVerificationCode: Resend the verification code for the provided [phoneNumber]](https://github.com/alibitek/plugins/blob/b5df6939b0303f9473e58149eb289ace9dbdf7b1/packages/firebase_auth/lib/firebase_auth.dart#L374:L390)

The implementation is based on the documentation available at:
- [Authenticate with Firebase on Android using a Phone Number](https://firebase.google.com/docs/auth/android/phone-auth)
- [PhoneAuthActivity.java](https://github.com/firebase/quickstart-android/blob/master/auth/app/src/main/java/com/google/firebase/quickstart/auth/PhoneAuthActivity.java)
- [com.google.firebase.auth.PhoneAuthProvider](https://firebase.google.com/docs/reference/android/com/google/firebase/auth/PhoneAuthProvider)

For a description of the usage I've provided documentation to the [`signInWithPhoneNumber` method](https://github.com/alibitek/plugins/blob/b5df6939b0303f9473e58149eb289ace9dbdf7b1/packages/firebase_auth/lib/firebase_auth.dart#L263:L340).

To test you need to generate your own `firebase_auth/example/android/app/google-services.json` file from the Settings page of the project created in the [Firebase Console](https://firebase.google.com/docs/auth/android/phone-auth#before-you-begin).

Feel free to provide any feedback regarding the design and implementation.

Possible improvements:
- Store the Result object as a data member in the FirebaseAuthPlugin class and use it in PhoneVerificationStateChangedCallbacks instead of PhoneSignInStreamHandler?
- Throw custom exceptions with error codes indicating cause of exception?

<a href="https://user-images.githubusercontent.com/528448/34523503-77df7bf8-f0a0-11e7-94e7-83d75a59d2b7.jpg" target="_blank"><img src="https://user-images.githubusercontent.com/528448/34523503-77df7bf8-f0a0-11e7-94e7-83d75a59d2b7.jpg" align="center" height="1000" width="600" ></a>

  
  