### PR TITLE
Add android_alarm_manager package to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ These are the available plugins in this repository.
 
 | Plugin | Pub |
 |--------|-----|
+| [android_alarm_manager](./packages/android_alarm_manager/) | [![pub package](https://img.shields.io/pub/v/android_alarm_manager.svg)](https://pub.dartlang.org/packages/android_alarm_manager) |
 | [android_intent](./packages/android_intent/) | [![pub package](https://img.shields.io/pub/v/android_intent.svg)](https://pub.dartlang.org/packages/android_intent) |
 | [battery](./packages/battery/) | [![pub package](https://img.shields.io/pub/v/battery.svg)](https://pub.dartlang.org/packages/battery) |
 | [connectivity](./packages/connectivity/) | [![pub package](https://img.shields.io/pub/v/connectivity.svg)](https://pub.dartlang.org/packages/connectivity) |


### PR DESCRIPTION
Travis build fails due to: https://github.com/flutter/flutter/issues/13813 , fixed in https://github.com/flutter/flutter/pull/13814