### PR TITLE
Add support for Android explicit intents

### DIFF
--- a/packages/android_intent/android/src/main/java/io/flutter/plugins/androidintent/AndroidIntentPlugin.java
+++ b/packages/android_intent/android/src/main/java/io/flutter/plugins/androidintent/AndroidIntentPlugin.java
@@ -128,11 +128,10 @@ public class AndroidIntentPlugin implements MethodCallHandler {
     }
     if (call.argument("package") != null) {
       intent.setPackage((String) call.argument("package"));
-    }
-    // If we cannot resolve an explicit intent fallback to an implicit one
-    if (intent.getPackage() != null
-        && intent.resolveActivity(context.getPackageManager()) == null) {
-      intent.setPackage(null);
+      if (intent.resolveActivity(context.getPackageManager()) == null) {
+        Log.i(TAG, "Cannot resolve explicit intent - ignoring package");
+        intent.setPackage(null);
+      }
     }
 
     Log.i(TAG, "Sending intent " + intent);

--- a/packages/android_intent/android/src/main/java/io/flutter/plugins/androidintent/AndroidIntentPlugin.java
+++ b/packages/android_intent/android/src/main/java/io/flutter/plugins/androidintent/AndroidIntentPlugin.java
@@ -106,10 +106,13 @@ public class AndroidIntentPlugin implements MethodCallHandler {
     return true;
   }
 
+  private Context getActiveContext() {
+    return (mRegistrar.activity() != null) ? mRegistrar.activity() : mRegistrar.context();
+  }
+
   @Override
   public void onMethodCall(MethodCall call, Result result) {
-    Context context =
-        (mRegistrar.activity() != null) ? mRegistrar.activity() : mRegistrar.context();
+    Context context = getActiveContext();
     String action = convertAction((String) call.argument("action"));
 
     // Build intent

--- a/packages/android_intent/example/lib/main.dart
+++ b/packages/android_intent/example/lib/main.dart
@@ -129,7 +129,7 @@ class ExplicitIntentsWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return new Scaffold(
       appBar: new AppBar(
-        title: const Text('Test explict intents'),
+        title: const Text('Test explicit intents'),
       ),
       body: new Center(
         child: new Padding(
@@ -157,7 +157,7 @@ class ExplicitIntentsWidget extends StatelessWidget {
               ),
               new RaisedButton(
                 child: const Text(
-                    'Tap here to test explict intent fallback to implicit.'),
+                    'Tap here to test explicit intent fallback to implicit.'),
                 onPressed: _testExplicitIntentFallback,
               ),
             ],

--- a/packages/android_intent/example/lib/main.dart
+++ b/packages/android_intent/example/lib/main.dart
@@ -20,6 +20,10 @@ class MyApp extends StatelessWidget {
         primarySwatch: Colors.blue,
       ),
       home: new MyHomePage(),
+      routes: <String, WidgetBuilder>{
+        ExplicitIntentsWidget.routeName: (BuildContext context) =>
+            const ExplicitIntentsWidget()
+      },
     );
   }
 }
@@ -38,6 +42,47 @@ class MyHomePage extends StatelessWidget {
     );
     intent.launch();
   }
+
+  void _openExplicitIntentsView(BuildContext context) {
+    Navigator.of(context).pushNamed(ExplicitIntentsWidget.routeName);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    Widget body;
+    if (const LocalPlatform().isAndroid) {
+      body = new Padding(
+        padding: const EdgeInsets.symmetric(vertical: 15.0),
+        child: new Column(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          children: <Widget>[
+            new RaisedButton(
+              child: const Text(
+                  'Tap here to set an alarm\non weekdays at 9:30pm.'),
+              onPressed: _createAlarm,
+            ),
+            new RaisedButton(
+                child: const Text('Tap here to test explicit intents.'),
+                onPressed: () => _openExplicitIntentsView(context)),
+          ],
+        ),
+      );
+    } else {
+      body = const Text('This plugin only works with Android');
+    }
+    return new Scaffold(
+      appBar: new AppBar(
+        title: const Text('Plugin example app'),
+      ),
+      body: new Center(child: body),
+    );
+  }
+}
+
+class ExplicitIntentsWidget extends StatelessWidget {
+  static const String routeName = "/explicitIntents";
+
+  const ExplicitIntentsWidget();
 
   void _openGoogleMapsStreetView() {
     final AndroidIntent intent = new AndroidIntent(
@@ -72,20 +117,26 @@ class MyHomePage extends StatelessWidget {
     intent.launch();
   }
 
+  void _testExplicitIntentFallback() {
+    final AndroidIntent intent = new AndroidIntent(
+        action: 'action_view',
+        data: Uri.encodeFull('https://flutter.io'),
+        package: 'com.android.chrome.implicit.fallback');
+    intent.launch();
+  }
+
   @override
   Widget build(BuildContext context) {
-    Widget body;
-    if (const LocalPlatform().isAndroid) {
-      body = new Padding(
+    return new Scaffold(
+      appBar: new AppBar(
+        title: const Text('Test explict intents'),
+      ),
+      body: new Center(
+        child: new Padding(
           padding: const EdgeInsets.symmetric(vertical: 15.0),
           child: new Column(
             mainAxisAlignment: MainAxisAlignment.spaceEvenly,
             children: <Widget>[
-              new RaisedButton(
-                child: const Text(
-                    'Tap here to set an alarm\non weekdays at 9:30pm.'),
-                onPressed: _createAlarm,
-              ),
               new RaisedButton(
                 child: const Text(
                     'Tap here to display panorama\nimagery in Google Street View.'),
@@ -104,16 +155,15 @@ class MyHomePage extends StatelessWidget {
                 child: const Text('Tap here to open link in Google Chrome.'),
                 onPressed: _openLinkInGoogleChrome,
               ),
+              new RaisedButton(
+                child: const Text(
+                    'Tap here to test explict intent fallback to implicit.'),
+                onPressed: _testExplicitIntentFallback,
+              ),
             ],
-          ));
-    } else {
-      body = const Text('This plugin only works with Android');
-    }
-    return new Scaffold(
-      appBar: new AppBar(
-        title: const Text('Plugin example app'),
+          ),
+        ),
       ),
-      body: new Center(child: body),
     );
   }
 }

--- a/packages/android_intent/example/lib/main.dart
+++ b/packages/android_intent/example/lib/main.dart
@@ -39,14 +39,73 @@ class MyHomePage extends StatelessWidget {
     intent.launch();
   }
 
+  void _openGoogleMapsStreetView() {
+    final AndroidIntent intent = new AndroidIntent(
+        action: 'action_view',
+        data: Uri.encodeFull('google.streetview:cbll=46.414382,10.013988'),
+        package: 'com.google.android.apps.maps');
+    intent.launch();
+  }
+
+  void _displayMapInGoogleMaps({int zoomLevel: 12}) {
+    final AndroidIntent intent = new AndroidIntent(
+        action: 'action_view',
+        data: Uri.encodeFull('geo:37.7749,-122.4194?z=$zoomLevel'),
+        package: 'com.google.android.apps.maps');
+    intent.launch();
+  }
+
+  void _launchTurnByTurnNavigationInGoogleMaps() {
+    final AndroidIntent intent = new AndroidIntent(
+        action: 'action_view',
+        data: Uri.encodeFull(
+            'google.navigation:q=Taronga+Zoo,+Sydney+Australia&avoid=tf'),
+        package: 'com.google.android.apps.maps');
+    intent.launch();
+  }
+
+  void _openLinkInGoogleChrome() {
+    final AndroidIntent intent = new AndroidIntent(
+        action: 'action_view',
+        data: Uri.encodeFull('https://flutter.io'),
+        package: 'com.android.chrome');
+    intent.launch();
+  }
+
   @override
   Widget build(BuildContext context) {
     Widget body;
     if (const LocalPlatform().isAndroid) {
-      body = new InkWell(
-        child: const Text('Tap here to set an alarm\non weekdays at 9:30pm.'),
-        onTap: _createAlarm,
-      );
+      body = new Padding(
+          padding: const EdgeInsets.symmetric(vertical: 15.0),
+          child: new Column(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: <Widget>[
+              new RaisedButton(
+                child: const Text(
+                    'Tap here to set an alarm\non weekdays at 9:30pm.'),
+                onPressed: _createAlarm,
+              ),
+              new RaisedButton(
+                child: const Text(
+                    'Tap here to display panorama\nimagery in Google Street View.'),
+                onPressed: _openGoogleMapsStreetView,
+              ),
+              new RaisedButton(
+                child: const Text('Tap here to display\na map in Google Maps.'),
+                onPressed: _displayMapInGoogleMaps,
+              ),
+              new RaisedButton(
+                child: const Text(
+                    'Tap here to launch turn-by-turn\nnavigation in Google Maps.'),
+                onPressed: _launchTurnByTurnNavigationInGoogleMaps,
+              ),
+              new RaisedButton(
+                child: const Text('Tap here to open link in Google Chrome.'),
+                onPressed: _openLinkInGoogleChrome,
+              ),
+            ],
+          ));
     } else {
       body = const Text('This plugin only works with Android');
     }

--- a/packages/android_intent/lib/android_intent.dart
+++ b/packages/android_intent/lib/android_intent.dart
@@ -16,6 +16,7 @@ class AndroidIntent {
   final String category;
   final String data;
   final Map<String, dynamic> arguments;
+  final String package;
   final MethodChannel _channel;
   final Platform _platform;
 
@@ -31,6 +32,7 @@ class AndroidIntent {
       this.category,
       this.data,
       this.arguments,
+      this.package,
       Platform platform})
       : assert(action != null),
         _channel = const MethodChannel(kChannelName),
@@ -51,6 +53,9 @@ class AndroidIntent {
     }
     if (arguments != null) {
       args['arguments'] = arguments;
+    }
+    if (package != null) {
+      args['package'] = package;
     }
     await _channel.invokeMethod('launch', args);
   }

--- a/packages/android_intent/lib/android_intent.dart
+++ b/packages/android_intent/lib/android_intent.dart
@@ -27,13 +27,14 @@ class AndroidIntent {
   /// intent.
   /// [arguments] is the map that will be converted into an extras bundle and
   /// passed to the intent.
-  const AndroidIntent(
-      {@required this.action,
-      this.category,
-      this.data,
-      this.arguments,
-      this.package,
-      Platform platform})
+  const AndroidIntent({
+    @required this.action,
+    this.category,
+    this.data,
+    this.arguments,
+    this.package,
+    Platform platform,
+  })
       : assert(action != null),
         _channel = const MethodChannel(kChannelName),
         _platform = platform ?? const LocalPlatform();


### PR DESCRIPTION
Allows to specify an explicit package name when sending an intent.
If there is no package installed in the system with that name or the package cannot handle the intent,  it'll fallback to an implicit intent by removing the specified package from the intent.