### PR TITLE
Podfile should not use_frameworks with Google signin static lib

### DIFF
--- a/packages/android_alarm_manager/example/ios/Podfile
+++ b/packages/android_alarm_manager/example/ios/Podfile
@@ -1,0 +1,50 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '9.0'
+
+def parse_KV_file(file,seperator='=')
+  file_abs_path = File.expand_path(file)
+  if !File.exists? file_abs_path
+    return [];
+  end
+  pods_ary = []
+  File.foreach(file_abs_path) { |line|
+      plugin = line.split(pattern=seperator)
+      if plugin.length == 2
+        podname = plugin[0].strip()
+        path = plugin[1].strip()
+        podpath = File.expand_path("#{path}", file_abs_path)
+        pods_ary.push({:name => podname,:path=>podpath});
+      else
+        puts "Invalid plugin specification: #{line}"
+      end
+  }
+  return pods_ary
+end
+
+target 'Runner' do
+  # use_frameworks!
+  # Flutter Pods
+  generated_xcode_build_settings = parse_KV_file("./Flutter/Generated.xcconfig")
+  if generated_xcode_build_settings.empty?
+    puts "Generated.xcconfig must exist. If you're running pod install manually, make sure flutter build or flutter run is executed once first."
+  end
+  generated_xcode_build_settings.map{ |p|
+    if p[:name]=='FLUTTER_FRAMEWORK_DIR'
+      pod 'Flutter', :path => p[:path]
+    end
+  }
+
+  # Plugin Pods
+  plugin_pods = parse_KV_file("../.flutter-plugins")
+  plugin_pods.map{ |p|
+    pod p[:name], :path => File.expand_path("ios",p[:path])
+  }
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |config|
+      config.build_settings['ENABLE_BITCODE'] = 'NO'
+    end
+  end
+end

--- a/packages/android_alarm_manager/example/pubspec.yaml
+++ b/packages/android_alarm_manager/example/pubspec.yaml
@@ -4,15 +4,15 @@ description: Demonstrates how to use the android_alarm_manager plugin.
 dependencies:
   flutter:
     sdk: flutter
-dev_dependencies:
-  flutter_test:
-    sdk: flutter
   android_alarm_manager:
     path: ../
   firebase_auth:
     path: ../../firebase_auth
   google_sign_in:
     path: ../../google_sign_in
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
Check in `Podfile` with `use_frameworks!` commented out to allow `ipa` build of example project that depends on static library via `google_sign_in` plugin.

Also made example project dependencies real dependencies (rather than dev dependencies).