### PR TITLE
Change requestAgent to "flutter-alpha"

### DIFF
--- a/packages/firebase_admob/lib/firebase_admob.dart
+++ b/packages/firebase_admob/lib/firebase_admob.dart
@@ -156,8 +156,11 @@ class BannerAd extends MobileAd {
     @required String unitId,
     MobileAdTargetingInfo targetingInfo,
     MobileAdListener listener,
-  })
-      : super(unitId: unitId, targetingInfo: targetingInfo, listener: listener);
+  }) : super(
+    unitId: unitId,
+    targetingInfo: targetingInfo ?? const MobileAdTargetingInfo(),
+    listener: listener
+  );
 
   @override
   Future<bool> load() => _doLoad("loadBannerAd");
@@ -172,8 +175,11 @@ class InterstitialAd extends MobileAd {
     String unitId,
     MobileAdTargetingInfo targetingInfo,
     MobileAdListener listener,
-  })
-      : super(unitId: unitId, targetingInfo: targetingInfo, listener: listener);
+  }) : super(
+    unitId: unitId,
+    targetingInfo: targetingInfo ?? const MobileAdTargetInfo(),
+    listener: listener
+  );
 
   @override
   Future<bool> load() => _doLoad("loadInterstitialAd");

--- a/packages/firebase_admob/lib/firebase_admob.dart
+++ b/packages/firebase_admob/lib/firebase_admob.dart
@@ -90,14 +90,16 @@ abstract class MobileAd {
   static final Map<int, MobileAd> _allAds = <int, MobileAd>{};
 
   /// Default constructor, used by subclasses.
-  MobileAd({@required this.unitId, this.targetingInfo, this.listener}) {
+  MobileAd({@required this.unitId, MobileAdTargetingInfo targetingInfo, this.listener}) {
     assert(unitId != null && unitId.isNotEmpty);
     assert(_allAds[id] == null);
+    _targetingInfo = targetingInfo ?? const MobileAdTargetingInfo();
     _allAds[id] = this;
   }
 
   /// Optional targeting info per the native AdMob API.
-  final MobileAdTargetingInfo targetingInfo;
+  MobileAdTargetingInfo get targetingInfo => _targetingInfo;
+  final MobileAdTargetingInfo _targetingInfo;
 
   /// Identifies the source of ads for your application.
   ///
@@ -156,11 +158,7 @@ class BannerAd extends MobileAd {
     @required String unitId,
     MobileAdTargetingInfo targetingInfo,
     MobileAdListener listener,
-  }) : super(
-    unitId: unitId,
-    targetingInfo: targetingInfo ?? const MobileAdTargetingInfo(),
-    listener: listener
-  );
+  }) : super(unitId: unitId, targetingInfo: targetingInfo, listener: listener);
 
   @override
   Future<bool> load() => _doLoad("loadBannerAd");
@@ -175,11 +173,7 @@ class InterstitialAd extends MobileAd {
     String unitId,
     MobileAdTargetingInfo targetingInfo,
     MobileAdListener listener,
-  }) : super(
-    unitId: unitId,
-    targetingInfo: targetingInfo ?? const MobileAdTargetInfo(),
-    listener: listener
-  );
+  }) : super(unitId: unitId, targetingInfo: targetingInfo, listener: listener);
 
   @override
   Future<bool> load() => _doLoad("loadInterstitialAd");

--- a/packages/firebase_admob/lib/firebase_admob.dart
+++ b/packages/firebase_admob/lib/firebase_admob.dart
@@ -90,9 +90,11 @@ abstract class MobileAd {
   static final Map<int, MobileAd> _allAds = <int, MobileAd>{};
 
   /// Default constructor, used by subclasses.
-  MobileAd({@required this.unitId, MobileAdTargetingInfo targetingInfo, this.listener})
-    : _targetingInfo = targetingInfo ?? const MobileAdTargetingInfo()
-  {
+  MobileAd(
+      {@required this.unitId,
+      MobileAdTargetingInfo targetingInfo,
+      this.listener})
+      : _targetingInfo = targetingInfo ?? const MobileAdTargetingInfo() {
     assert(unitId != null && unitId.isNotEmpty);
     assert(_allAds[id] == null);
     _allAds[id] = this;
@@ -159,7 +161,8 @@ class BannerAd extends MobileAd {
     @required String unitId,
     MobileAdTargetingInfo targetingInfo,
     MobileAdListener listener,
-  }) : super(unitId: unitId, targetingInfo: targetingInfo, listener: listener);
+  })
+      : super(unitId: unitId, targetingInfo: targetingInfo, listener: listener);
 
   @override
   Future<bool> load() => _doLoad("loadBannerAd");
@@ -174,7 +177,8 @@ class InterstitialAd extends MobileAd {
     String unitId,
     MobileAdTargetingInfo targetingInfo,
     MobileAdListener listener,
-  }) : super(unitId: unitId, targetingInfo: targetingInfo, listener: listener);
+  })
+      : super(unitId: unitId, targetingInfo: targetingInfo, listener: listener);
 
   @override
   Future<bool> load() => _doLoad("loadInterstitialAd");

--- a/packages/firebase_admob/lib/firebase_admob.dart
+++ b/packages/firebase_admob/lib/firebase_admob.dart
@@ -46,7 +46,6 @@ class MobileAdTargetingInfo {
     this.designedForFamilies,
     this.childDirected,
     this.testDevices,
-    this.requestAgent,
   });
 
   final List<String> keywords;
@@ -56,10 +55,11 @@ class MobileAdTargetingInfo {
   final bool designedForFamilies;
   final bool childDirected;
   final List<String> testDevices;
-  final String requestAgent;
 
   Map<String, dynamic> toJson() {
-    final Map<String, dynamic> json = <String, dynamic>{};
+    final Map<String, dynamic> json = <String, dynamic>{
+      'requestAgent': 'flutter-alpha',
+    };
 
     if (keywords != null && keywords.isNotEmpty) {
       assert(keywords.every((String s) => s != null && s.isNotEmpty));
@@ -76,8 +76,6 @@ class MobileAdTargetingInfo {
       assert(testDevices.every((String s) => s != null && s.isNotEmpty));
       json['testDevices'] = testDevices;
     }
-    if (requestAgent != null && requestAgent.isNotEmpty)
-      json['requestAgent'] = requestAgent;
 
     return json;
   }

--- a/packages/firebase_admob/lib/firebase_admob.dart
+++ b/packages/firebase_admob/lib/firebase_admob.dart
@@ -90,10 +90,11 @@ abstract class MobileAd {
   static final Map<int, MobileAd> _allAds = <int, MobileAd>{};
 
   /// Default constructor, used by subclasses.
-  MobileAd({@required this.unitId, MobileAdTargetingInfo targetingInfo, this.listener}) {
+  MobileAd({@required this.unitId, MobileAdTargetingInfo targetingInfo, this.listener})
+    : _targetingInfo = targetingInfo ?? const MobileAdTargetingInfo();
+  {
     assert(unitId != null && unitId.isNotEmpty);
     assert(_allAds[id] == null);
-    _targetingInfo = targetingInfo ?? const MobileAdTargetingInfo();
     _allAds[id] = this;
   }
 

--- a/packages/firebase_admob/lib/firebase_admob.dart
+++ b/packages/firebase_admob/lib/firebase_admob.dart
@@ -91,7 +91,7 @@ abstract class MobileAd {
 
   /// Default constructor, used by subclasses.
   MobileAd({@required this.unitId, MobileAdTargetingInfo targetingInfo, this.listener})
-    : _targetingInfo = targetingInfo ?? const MobileAdTargetingInfo();
+    : _targetingInfo = targetingInfo ?? const MobileAdTargetingInfo()
   {
     assert(unitId != null && unitId.isNotEmpty);
     assert(_allAds[id] == null);

--- a/packages/firebase_admob/test/firebase_admob_test.dart
+++ b/packages/firebase_admob/test/firebase_admob_test.dart
@@ -58,7 +58,6 @@ void main() {
       );
       final int id = banner.id;
 
-      expect(banner.targetingInfo?.requestAgent, 'flutter-alpha');
       expect(await banner.load(), true);
       expect(await banner.show(), true);
       expect(await banner.dispose(), true);
@@ -67,7 +66,7 @@ void main() {
         isMethodCall('loadBannerAd', arguments: <String, dynamic>{
           'id': id,
           'unitId': bannerAdUnitId,
-          'targetingInfo': null,
+          'targetingInfo': <String, String>{'requestAgent:', 'flutter-alpha'},
         }),
         isMethodCall('showAd', arguments: <String, dynamic>{
           'id': id,
@@ -95,7 +94,7 @@ void main() {
         isMethodCall('loadInterstitialAd', arguments: <String, dynamic>{
           'id': id,
           'unitId': interstitialAdUnitId,
-          'targetingInfo': null,
+          'targetingInfo': <String, String>{'requestAgent:', 'flutter-alpha'},
         }),
         isMethodCall('showAd', arguments: <String, dynamic>{
           'id': id,

--- a/packages/firebase_admob/test/firebase_admob_test.dart
+++ b/packages/firebase_admob/test/firebase_admob_test.dart
@@ -58,6 +58,7 @@ void main() {
       );
       final int id = banner.id;
 
+      expect(banner.targetingInfo?.requestAgent, 'flutter-alpha');
       expect(await banner.load(), true);
       expect(await banner.show(), true);
       expect(await banner.dispose(), true);
@@ -85,6 +86,7 @@ void main() {
       );
       final int id = interstitial.id;
 
+      expect(interstitial.targetingInfo?.requestAgent, 'flutter-alpha');
       expect(await interstitial.load(), true);
       expect(await interstitial.show(), true);
       expect(await interstitial.dispose(), true);

--- a/packages/firebase_admob/test/firebase_admob_test.dart
+++ b/packages/firebase_admob/test/firebase_admob_test.dart
@@ -85,7 +85,6 @@ void main() {
       );
       final int id = interstitial.id;
 
-      expect(interstitial.targetingInfo?.requestAgent, 'flutter-alpha');
       expect(await interstitial.load(), true);
       expect(await interstitial.show(), true);
       expect(await interstitial.dispose(), true);

--- a/packages/firebase_admob/test/firebase_admob_test.dart
+++ b/packages/firebase_admob/test/firebase_admob_test.dart
@@ -66,7 +66,7 @@ void main() {
         isMethodCall('loadBannerAd', arguments: <String, dynamic>{
           'id': id,
           'unitId': bannerAdUnitId,
-          'targetingInfo': <String, String>{'requestAgent:', 'flutter-alpha'},
+          'targetingInfo': <String, String>{'requestAgent':, 'flutter-alpha'},
         }),
         isMethodCall('showAd', arguments: <String, dynamic>{
           'id': id,
@@ -94,7 +94,7 @@ void main() {
         isMethodCall('loadInterstitialAd', arguments: <String, dynamic>{
           'id': id,
           'unitId': interstitialAdUnitId,
-          'targetingInfo': <String, String>{'requestAgent:', 'flutter-alpha'},
+          'targetingInfo': <String, String>{'requestAgent':, 'flutter-alpha'},
         }),
         isMethodCall('showAd', arguments: <String, dynamic>{
           'id': id,

--- a/packages/firebase_admob/test/firebase_admob_test.dart
+++ b/packages/firebase_admob/test/firebase_admob_test.dart
@@ -66,7 +66,7 @@ void main() {
         isMethodCall('loadBannerAd', arguments: <String, dynamic>{
           'id': id,
           'unitId': bannerAdUnitId,
-          'targetingInfo': <String, String>{'requestAgent':, 'flutter-alpha'},
+          'targetingInfo': <String, String>{'requestAgent': 'flutter-alpha'},
         }),
         isMethodCall('showAd', arguments: <String, dynamic>{
           'id': id,
@@ -94,7 +94,7 @@ void main() {
         isMethodCall('loadInterstitialAd', arguments: <String, dynamic>{
           'id': id,
           'unitId': interstitialAdUnitId,
-          'targetingInfo': <String, String>{'requestAgent':, 'flutter-alpha'},
+          'targetingInfo': <String, String>{'requestAgent': 'flutter-alpha'},
         }),
         isMethodCall('showAd', arguments: <String, dynamic>{
           'id': id,


### PR DESCRIPTION
The AdMob team advised us to not make the `requestAgent` a public part of the `MobileAdTargetingInfo` class but to set it to "flutter-version".

