### PR TITLE
Fixes function name collision in FirebaseDatabase and CloudFirestore plugins

### DIFF
--- a/packages/firebase_database/CHANGELOG.md
+++ b/packages/firebase_database/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1
+
+* Fix function name collision when using Firebase Database and Cloud Firestore together on iOS.
+
 ## 0.3.0
 
 * **Breaking change**. Upgraded to Gradle 4.1 and Android Studio Gradle plugin

--- a/packages/firebase_database/ios/Classes/FirebaseDatabasePlugin.m
+++ b/packages/firebase_database/ios/Classes/FirebaseDatabasePlugin.m
@@ -37,7 +37,7 @@ FIRDatabaseReference *getReference(FIRDatabase *database, NSDictionary *argument
   return ref;
 }
 
-FIRDatabaseQuery *getQuery(FIRDatabase *database, NSDictionary *arguments) {
+FIRDatabaseQuery *getDatabaseQuery(FIRDatabase *database, NSDictionary *arguments) {
   FIRDatabaseQuery *query = getReference(database, arguments);
   NSDictionary *parameters = arguments[@"parameters"];
   NSString *orderBy = parameters[@"orderBy"];
@@ -275,7 +275,7 @@ id roundDoubles(id value) {
         }];
   } else if ([@"Query#observe" isEqualToString:call.method]) {
     FIRDataEventType eventType = parseEventType(call.arguments[@"eventType"]);
-    __block FIRDatabaseHandle handle = [getQuery(database, call.arguments)
+    __block FIRDatabaseHandle handle = [getDatabaseQuery(database, call.arguments)
         observeEventType:eventType
         andPreviousSiblingKeyWithBlock:^(FIRDataSnapshot *snapshot, NSString *previousSiblingKey) {
           [self.channel invokeMethod:@"Event"
@@ -298,11 +298,11 @@ id roundDoubles(id value) {
     result([NSNumber numberWithUnsignedInteger:handle]);
   } else if ([@"Query#removeObserver" isEqualToString:call.method]) {
     FIRDatabaseHandle handle = [call.arguments[@"handle"] unsignedIntegerValue];
-    [getQuery(database, call.arguments) removeObserverWithHandle:handle];
+    [getDatabaseQuery(database, call.arguments) removeObserverWithHandle:handle];
     result(nil);
   } else if ([@"Query#keepSynced" isEqualToString:call.method]) {
     NSNumber *value = call.arguments[@"value"];
-    [getQuery(database, call.arguments) keepSynced:value.boolValue];
+    [getDatabaseQuery(database, call.arguments) keepSynced:value.boolValue];
     result(nil);
   } else {
     result(FlutterMethodNotImplemented);

--- a/packages/firebase_database/pubspec.yaml
+++ b/packages/firebase_database/pubspec.yaml
@@ -3,7 +3,7 @@ name: firebase_database
 description: Firebase Database plugin for Flutter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_database
-version: 0.3.0
+version: 0.3.1
 
 flutter:
   plugin:


### PR DESCRIPTION
When both cloud_firestore and firebase_database plugins are included in project dependencies I get following build error when trying to run my app in iOS simulator:

```
/MyProject/build/ios/Debug-iphonesimulator/Runner.app/Runner
    duplicate symbol _getQuery in:
        /MyProject/build/ios/Debug-iphonesimulator/cloud_firestore/libcloud_firestore.a(CloudFirestorePlugin.o)
        /MyProject/build/ios/Debug-iphonesimulator/firebase_database/libfirebase_database.a(FirebaseDatabasePlugin.o)
    ld: 1 duplicate symbol for architecture x86_64
```

This PR simply renames the function in firebase_database plugin.
I'd be happy to update this PR if someone with better knowledge of ObjC can suggest a nicer way to fix this.

Fixes flutter/flutter#12501 for iOS.