### PR TITLE
Support for specifying a database URL in firebase_database

### DIFF
--- a/packages/firebase_database/CHANGELOG.md
+++ b/packages/firebase_database/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.2
+
+* Support to specify a database by URL if required
+
 ## 0.3.1
 
 * Fix function name collision when using Firebase Database and Cloud Firestore together on iOS.

--- a/packages/firebase_database/CHANGELOG.md
+++ b/packages/firebase_database/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.3.3
 
-* Support to specify a database by URL if required
+* Support to specify a database by URL if required 
 
 ## 0.3.2
 

--- a/packages/firebase_database/android/src/main/java/io/flutter/plugins/firebase/database/FirebaseDatabasePlugin.java
+++ b/packages/firebase_database/android/src/main/java/io/flutter/plugins/firebase/database/FirebaseDatabasePlugin.java
@@ -220,7 +220,7 @@ public class FirebaseDatabasePlugin implements MethodCallHandler {
     String appName = (String) arguments.get("app");
     String databaseURL = (String) arguments.get("databaseURL");
     if (appName != null && databaseURL != null) {
-      database = FirebaseApp.getInstance(FirebaseApp.getInstance(appName), databaseURL);
+      database = FirebaseDatabase.getInstance(FirebaseApp.getInstance(appName), databaseURL);
     } else if (appName != null) {
       database = FirebaseDatabase.getInstance(FirebaseApp.getInstance(appName));
     } else if (databaseURL != null) {

--- a/packages/firebase_database/android/src/main/java/io/flutter/plugins/firebase/database/FirebaseDatabasePlugin.java
+++ b/packages/firebase_database/android/src/main/java/io/flutter/plugins/firebase/database/FirebaseDatabasePlugin.java
@@ -218,8 +218,13 @@ public class FirebaseDatabasePlugin implements MethodCallHandler {
     final Map<String, Object> arguments = call.arguments();
     FirebaseDatabase database;
     String appName = (String) arguments.get("app");
-    if (appName != null) {
+    String databaseURL = (String) arguments.get("databaseURL");
+    if (appName != null && databaseURL != null) {
+      database = FirebaseApp.getInstance(FirebaseApp.getInstance(appName), databaseURL);
+    } else if (appName != null) {
       database = FirebaseDatabase.getInstance(FirebaseApp.getInstance(appName));
+    } else if (databaseURL != null) {
+      database = FirebaseDatabase.getInstance(databaseURL);
     } else {
       database = FirebaseDatabase.getInstance();
     }

--- a/packages/firebase_database/ios/Classes/FirebaseDatabasePlugin.m
+++ b/packages/firebase_database/ios/Classes/FirebaseDatabasePlugin.m
@@ -158,11 +158,11 @@ id roundDoubles(id value) {
   NSString *appName = call.arguments[@"app"];
   NSString *databaseURL = call.arguments[@"databaseURL"];
   if (![appName isEqual:[NSNull null]] && ![databaseURL isEqual:[NSNull null]]) {
-    database = [FIRDatabase databaseForApp:[FIRApp appNamed:appName] URL: databaseURL];
+    database = [FIRDatabase databaseForApp:[FIRApp appNamed:appName] URL:databaseURL];
   } else if (![appName isEqual:[NSNull null]]) {
     database = [FIRDatabase databaseForApp:[FIRApp appNamed:appName]];
   } else if (![databaseURL isEqual:[NSNull null]]) {
-    database = [FIRDatabase databaseWithURL: databaseURL];
+    database = [FIRDatabase databaseWithURL:databaseURL];
   } else {
     database = [FIRDatabase database];
   }

--- a/packages/firebase_database/ios/Classes/FirebaseDatabasePlugin.m
+++ b/packages/firebase_database/ios/Classes/FirebaseDatabasePlugin.m
@@ -156,8 +156,13 @@ id roundDoubles(id value) {
 - (void)handleMethodCall:(FlutterMethodCall *)call result:(FlutterResult)result {
   FIRDatabase *database;
   NSString *appName = call.arguments[@"app"];
-  if (![appName isEqual:[NSNull null]]) {
+  NSString *databaseURL = call.arguments[@"databaseURL"];
+  if (![appName isEqual:[NSNull null]] && ![databaseURL isEqual:[NSNull null]]) {
+    database = [FIRDatabase databaseForApp:[FIRApp appNamed:appName] URL: databaseURL];
+  } else if (![appName isEqual:[NSNull null]]) {
     database = [FIRDatabase databaseForApp:[FIRApp appNamed:appName]];
+  } else if (![databaseURL isEqual:[NSNull null]]) {
+    database = [FIRDatabase databaseWithURL: databaseURL];
   } else {
     database = [FIRDatabase database];
   }

--- a/packages/firebase_database/lib/src/database_reference.dart
+++ b/packages/firebase_database/lib/src/database_reference.dart
@@ -75,6 +75,7 @@ class DatabaseReference extends Query {
       'DatabaseReference#set',
       <String, dynamic>{
         'app': _database.app?.name,
+        'databaseURL': _database.databaseURL,
         'path': path,
         'value': value,
         'priority': priority,
@@ -88,6 +89,7 @@ class DatabaseReference extends Query {
       'DatabaseReference#update',
       <String, dynamic>{
         'app': _database.app?.name,
+        'databaseURL': _database.databaseURL,
         'path': path,
         'value': value,
       },
@@ -123,6 +125,7 @@ class DatabaseReference extends Query {
       'DatabaseReference#setPriority',
       <String, dynamic>{
         'app': _database.app?.name,
+        'databaseURL': _database.databaseURL,
         'path': path,
         'priority': priority,
       },
@@ -159,6 +162,7 @@ class DatabaseReference extends Query {
     _database._channel
         .invokeMethod('DatabaseReference#runTransaction', <String, dynamic>{
       'app': _database.app?.name,
+      'databaseURL': _database.databaseURL,
       'path': path,
       'transactionKey': transactionKey,
       'transactionTimeout': timeout.inMilliseconds

--- a/packages/firebase_database/lib/src/firebase_database.dart
+++ b/packages/firebase_database/lib/src/firebase_database.dart
@@ -23,7 +23,7 @@ class FirebaseDatabase {
   /// Gets an instance of [FirebaseDatabase].
   ///
   /// If [app] is specified, its options should include a [databaseURL].
-  FirebaseDatabase({this.app}) {
+  FirebaseDatabase({this.app, this.databaseURL}) {
     assert(app == null || app.options.databaseURL != null);
     if (_initialized) return;
     _channel.setMethodCallHandler((MethodCall call) async {
@@ -59,6 +59,11 @@ class FirebaseDatabase {
   /// If null, the default [FirebaseApp] is used.
   final FirebaseApp app;
 
+  /// The URL to which this [FirebaseDatabase] belongs
+  ///
+  /// If null, the URL of the specified [FirebaseApp] is used
+  final String databaseURL;
+
   /// Gets the instance of FirebaseDatabase for the default Firebase app.
   static FirebaseDatabase get instance => _instance;
 
@@ -87,6 +92,7 @@ class FirebaseDatabase {
     return _channel.invokeMethod(
         'FirebaseDatabase#setPersistenceEnabled', <String, dynamic>{
       'app': app?.name,
+      'databaseURL': databaseURL,
       'enabled': enabled,
     });
   }
@@ -112,6 +118,7 @@ class FirebaseDatabase {
     return _channel.invokeMethod(
         'FirebaseDatabase#setPersistenceCacheSizeBytes', <String, dynamic>{
       'app': app?.name,
+      'databaseURL': databaseURL,
       'cacheSize': cacheSize,
     });
   }
@@ -121,7 +128,10 @@ class FirebaseDatabase {
   Future<Null> goOnline() {
     return _channel.invokeMethod(
       'FirebaseDatabase#goOnline',
-      <String, dynamic>{'app': app?.name},
+      <String, dynamic>{
+        'app': app?.name,
+        'databaseURL': databaseURL,
+      },
     );
   }
 
@@ -130,7 +140,10 @@ class FirebaseDatabase {
   Future<Null> goOffline() {
     return _channel.invokeMethod(
       'FirebaseDatabase#goOffline',
-      <String, dynamic>{'app': app?.name},
+      <String, dynamic>{
+        'app': app?.name,
+        'databaseURL': databaseURL,
+      },
     );
   }
 
@@ -147,7 +160,10 @@ class FirebaseDatabase {
   Future<Null> purgeOutstandingWrites() {
     return _channel.invokeMethod(
       'FirebaseDatabase#purgeOutstandingWrites',
-      <String, dynamic>{'app': app?.name},
+      <String, dynamic>{
+        'app': app?.name,
+        'databaseURL': databaseURL,
+      },
     );
   }
 }

--- a/packages/firebase_database/lib/src/query.dart
+++ b/packages/firebase_database/lib/src/query.dart
@@ -51,6 +51,7 @@ class Query {
           'Query#observe',
           <String, dynamic>{
             'app': _database.app?.name,
+            'databaseURL': _database.databaseURL,
             'path': path,
             'parameters': _parameters,
             'eventType': eventType.toString(),
@@ -66,6 +67,7 @@ class Query {
             'Query#removeObserver',
             <String, dynamic>{
               'app': _database.app?.name,
+              'databaseURL': _database.databaseURL,
               'path': path,
               'parameters': _parameters,
               'handle': handle,
@@ -196,6 +198,7 @@ class Query {
       'Query#keepSynced',
       <String, dynamic>{
         'app': _database.app?.name,
+        'databaseURL': _database.databaseURL,
         'path': path,
         'parameters': _parameters,
         'value': value

--- a/packages/firebase_database/pubspec.yaml
+++ b/packages/firebase_database/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Database, a cloud-hosted NoSQL database
   with realtime data syncing across Android and iOS clients, and offline access.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_database
-version: 0.3.2
+version: 0.3.3
 
 flutter:
   plugin:

--- a/packages/firebase_database/test/firebase_database_test.dart
+++ b/packages/firebase_database/test/firebase_database_test.dart
@@ -27,7 +27,7 @@ void main() {
     );
     final String databaseURL = 'https://fake-database-url2.firebaseio.com';
     final FirebaseDatabase database =
-      new FirebaseDatabase(app: app, databaseURL: databaseURL);
+        new FirebaseDatabase(app: app, databaseURL: databaseURL);
 
     setUp(() async {
       channel.setMockMethodCallHandler((MethodCall methodCall) async {

--- a/packages/firebase_database/test/firebase_database_test.dart
+++ b/packages/firebase_database/test/firebase_database_test.dart
@@ -25,7 +25,9 @@ void main() {
         databaseURL: 'https://fake-database-url.firebaseio.com',
       ),
     );
-    final FirebaseDatabase database = new FirebaseDatabase(app: app);
+    final String databaseURL = 'https://fake-database-url2.firebaseio.com';
+    final FirebaseDatabase database = new FirebaseDatabase(app: app,
+        databaseURL: databaseURL);
 
     setUp(() async {
       channel.setMockMethodCallHandler((MethodCall methodCall) async {
@@ -93,6 +95,7 @@ void main() {
             'FirebaseDatabase#setPersistenceEnabled',
             arguments: <String, dynamic>{
               'app': app.name,
+              'databaseURL': databaseURL,
               'enabled': false,
             },
           ),
@@ -100,6 +103,7 @@ void main() {
             'FirebaseDatabase#setPersistenceEnabled',
             arguments: <String, dynamic>{
               'app': app.name,
+              'databaseURL': databaseURL,
               'enabled': true,
             },
           ),
@@ -116,6 +120,7 @@ void main() {
             'FirebaseDatabase#setPersistenceCacheSizeBytes',
             arguments: <String, dynamic>{
               'app': app.name,
+              'databaseURL': databaseURL,
               'cacheSize': 42,
             },
           ),
@@ -132,6 +137,7 @@ void main() {
             'FirebaseDatabase#goOnline',
             arguments: <String, dynamic>{
               'app': app.name,
+              'databaseURL': databaseURL,
             },
           ),
         ],
@@ -147,6 +153,7 @@ void main() {
             'FirebaseDatabase#goOffline',
             arguments: <String, dynamic>{
               'app': app.name,
+              'databaseURL': databaseURL,
             },
           ),
         ],
@@ -162,6 +169,7 @@ void main() {
             'FirebaseDatabase#purgeOutstandingWrites',
             arguments: <String, dynamic>{
               'app': app.name,
+              'databaseURL': databaseURL,
             },
           ),
         ],
@@ -181,6 +189,7 @@ void main() {
               'DatabaseReference#set',
               arguments: <String, dynamic>{
                 'app': app.name,
+                'databaseURL': databaseURL,
                 'path': 'foo',
                 'value': value,
                 'priority': null,
@@ -190,6 +199,7 @@ void main() {
               'DatabaseReference#set',
               arguments: <String, dynamic>{
                 'app': app.name,
+                'databaseURL': databaseURL,
                 'path': 'bar',
                 'value': value,
                 'priority': priority,
@@ -208,6 +218,7 @@ void main() {
               'DatabaseReference#update',
               arguments: <String, dynamic>{
                 'app': app.name,
+                'databaseURL': databaseURL,
                 'path': 'foo',
                 'value': value,
               },
@@ -226,6 +237,7 @@ void main() {
               'DatabaseReference#setPriority',
               arguments: <String, dynamic>{
                 'app': app.name,
+                'databaseURL': databaseURL,
                 'path': 'foo',
                 'priority': priority,
               },
@@ -252,6 +264,7 @@ void main() {
               'DatabaseReference#runTransaction',
               arguments: <String, dynamic>{
                 'app': app.name,
+                'databaseURL': databaseURL,
                 'path': 'foo',
                 'transactionKey': 0,
                 'transactionTimeout': 5000,
@@ -285,6 +298,7 @@ void main() {
               'Query#keepSynced',
               arguments: <String, dynamic>{
                 'app': app.name,
+                'databaseURL': databaseURL,
                 'path': path,
                 'parameters': <String, dynamic>{},
                 'value': true,
@@ -320,6 +334,7 @@ void main() {
               'Query#keepSynced',
               arguments: <String, dynamic>{
                 'app': app.name,
+                'databaseURL': databaseURL,
                 'path': path,
                 'parameters': expectedParameters,
                 'value': false
@@ -417,6 +432,7 @@ void main() {
               'Query#observe',
               arguments: <String, dynamic>{
                 'app': app.name,
+                'databaseURL': databaseURL,
                 'path': path,
                 'parameters': <String, dynamic>{},
                 'eventType': '_EventType.value',
@@ -426,6 +442,7 @@ void main() {
               'Query#removeObserver',
               arguments: <String, dynamic>{
                 'app': app.name,
+                'databaseURL': databaseURL,
                 'path': path,
                 'parameters': <String, dynamic>{},
                 'handle': 87,

--- a/packages/firebase_database/test/firebase_database_test.dart
+++ b/packages/firebase_database/test/firebase_database_test.dart
@@ -26,8 +26,8 @@ void main() {
       ),
     );
     final String databaseURL = 'https://fake-database-url2.firebaseio.com';
-    final FirebaseDatabase database = new FirebaseDatabase(app: app,
-        databaseURL: databaseURL);
+    final FirebaseDatabase database =
+      new FirebaseDatabase(app: app, databaseURL: databaseURL);
 
     setUp(() async {
       channel.setMockMethodCallHandler((MethodCall methodCall) async {


### PR DESCRIPTION
Previous implementation required that we specify a FirebaseApp if we wanted to specify a database URL to use.  However, it is possible to only specify the database URL which doesn't require you to configure a FirebaseApp.  

With this pull request, to specify a different database is just, `new FirebaseDatabase(databaseURL: 'https://examplefirebaseapp-db2.firebaseio.com/');`