### PR TITLE
Set environment in pubspec.yaml where missing

### DIFF
--- a/packages/android_alarm_manager/pubspec.yaml
+++ b/packages/android_alarm_manager/pubspec.yaml
@@ -14,3 +14,6 @@ flutter:
     androidPackage: io.flutter.androidalarmmanager
     pluginClass: AndroidAlarmManagerPlugin
     iosPrefix: FLT
+
+environment:
+  sdk: ">=1.8.0 <2.0.0"

--- a/packages/camera/pubspec.yaml
+++ b/packages/camera/pubspec.yaml
@@ -13,3 +13,6 @@ flutter:
   plugin:
     androidPackage: io.flutter.plugins.camera
     pluginClass: CameraPlugin
+
+environment:
+  sdk: ">=1.8.0 <2.0.0"

--- a/packages/connectivity/pubspec.yaml
+++ b/packages/connectivity/pubspec.yaml
@@ -14,3 +14,6 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
+
+environment:
+  sdk: ">=1.8.0 <2.0.0"

--- a/packages/device_info/pubspec.yaml
+++ b/packages/device_info/pubspec.yaml
@@ -14,3 +14,6 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
+
+environment:
+  sdk: ">=1.8.0 <2.0.0"

--- a/packages/package_info/pubspec.yaml
+++ b/packages/package_info/pubspec.yaml
@@ -14,3 +14,6 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
+
+environment:
+  sdk: ">=1.8.0 <2.0.0"

--- a/packages/sensors/pubspec.yaml
+++ b/packages/sensors/pubspec.yaml
@@ -14,3 +14,6 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
+
+environment:
+  sdk: ">=1.8.0 <2.0.0"

--- a/packages/share/pubspec.yaml
+++ b/packages/share/pubspec.yaml
@@ -16,4 +16,4 @@ dependencies:
     sdk: flutter
 
 environment:
-    sdk: ">=1.8.0 <2.0.0"
+  sdk: ">=1.8.0 <2.0.0"

--- a/packages/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/pubspec.yaml
@@ -21,4 +21,4 @@ dev_dependencies:
     sdk: flutter
 
 environment:
-    sdk: ">=1.8.0 <2.0.0"
+  sdk: ">=1.8.0 <2.0.0"

--- a/packages/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/pubspec.yaml
@@ -20,4 +20,4 @@ dev_dependencies:
     sdk: flutter
 
 environment:
-    sdk: ">=1.8.0 <2.0.0"
+  sdk: ">=1.8.0 <2.0.0"

--- a/packages/video_player/pubspec.yaml
+++ b/packages/video_player/pubspec.yaml
@@ -17,4 +17,4 @@ dependencies:
     sdk: flutter
 
 environment:
-    sdk: ">=1.8.0 <2.0.0"
+  sdk: ">=1.8.0 <2.0.0"


### PR DESCRIPTION
Specify `environment:` clause in all plugin `pubspec.yaml` files to comply with `pub`lishing requirements.