### PR TITLE
Batch support for Firestore

### DIFF
--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.2
+
+* Support for batched writes.
+
 ## 0.3.1
 
 * Add GeoPoint class

--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.3.2
 
 * Support for batched writes.
+* Fix example app
 
 ## 0.3.1
 

--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## 0.3.2
 
 * Support for batched writes.
-* Fix example app
 
 ## 0.3.1
 

--- a/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
+++ b/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
@@ -13,7 +13,6 @@ import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.android.gms.tasks.Tasks;
-import com.google.firebase.firestore.WriteBatch;
 import com.google.firebase.firestore.CollectionReference;
 import com.google.firebase.firestore.DocumentChange;
 import com.google.firebase.firestore.DocumentReference;

--- a/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
+++ b/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
@@ -376,7 +376,7 @@ public class CloudFirestorePlugin implements MethodCallHandler {
           }.execute();
           break;
         }
-      case "Batch#create":
+      case "WriteBatch#create":
         {
           int handle = nextBatchHandle++;
           WriteBatch batch = FirebaseFirestore.getInstance().batch();
@@ -384,7 +384,7 @@ public class CloudFirestorePlugin implements MethodCallHandler {
           result.success(handle);
           break;
         }
-      case "Batch#set":
+      case "WriteBatch#setData":
         {
           Map<String, Object> arguments = call.arguments();
           int handle = (Integer) arguments.get("handle");
@@ -400,7 +400,7 @@ public class CloudFirestorePlugin implements MethodCallHandler {
           result.success(null);
           break;
         }
-      case "Batch#update":
+      case "WriteBatch#updateData":
         {
           Map<String, Object> arguments = call.arguments();
           int handle = (Integer) arguments.get("handle");
@@ -412,7 +412,7 @@ public class CloudFirestorePlugin implements MethodCallHandler {
           result.success(null);
           break;
         }
-      case "Batch#delete":
+      case "WriteBatch#delete":
         {
           Map<String, Object> arguments = call.arguments();
           int handle = (Integer) arguments.get("handle");
@@ -422,7 +422,7 @@ public class CloudFirestorePlugin implements MethodCallHandler {
           result.success(null);
           break;
         }
-      case "Batch#commit":
+      case "WriteBatch#commit":
         {
           Map<String, Object> arguments = call.arguments();
           int handle = (Integer) arguments.get("handle");

--- a/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
+++ b/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
@@ -50,7 +50,7 @@ public class CloudFirestorePlugin implements MethodCallHandler {
   private final MethodChannel channel;
 
   // Handles are ints used as indexes into the sparse array of active observers
-  private int nextHandle = 0;
+  private int nextListenerHandle = 0;
   private int nextBatchHandle = 0;
   private final SparseArray<EventObserver> observers = new SparseArray<>();
   private final SparseArray<DocumentObserver> documentObservers = new SparseArray<>();
@@ -428,13 +428,14 @@ public class CloudFirestorePlugin implements MethodCallHandler {
           int handle = (Integer) arguments.get("handle");
           WriteBatch batch = batches.get(handle);
           Task<Void> task = batch.commit();
+          batches.delete(handle);
           addDefaultListeners("commit", task, result);
           break;
         }
       case "Query#addSnapshotListener":
         {
           Map<String, Object> arguments = call.arguments();
-          int handle = nextHandle++;
+          int handle = nextListenerHandle++;
           EventObserver observer = new EventObserver(handle);
           observers.put(handle, observer);
           listenerRegistrations.put(handle, getQuery(arguments).addSnapshotListener(observer));
@@ -444,7 +445,7 @@ public class CloudFirestorePlugin implements MethodCallHandler {
       case "Query#addDocumentListener":
         {
           Map<String, Object> arguments = call.arguments();
-          int handle = nextHandle++;
+          int handle = nextListenerHandle++;
           DocumentObserver observer = new DocumentObserver(handle);
           documentObservers.put(handle, observer);
           listenerRegistrations.put(

--- a/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
+++ b/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
@@ -13,6 +13,7 @@ import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.android.gms.tasks.Tasks;
+import com.google.firebase.firestore.WriteBatch;
 import com.google.firebase.firestore.CollectionReference;
 import com.google.firebase.firestore.DocumentChange;
 import com.google.firebase.firestore.DocumentReference;
@@ -50,11 +51,13 @@ public class CloudFirestorePlugin implements MethodCallHandler {
 
   // Handles are ints used as indexes into the sparse array of active observers
   private int nextHandle = 0;
+  private int nextBatchHandle = 0;
   private final SparseArray<EventObserver> observers = new SparseArray<>();
   private final SparseArray<DocumentObserver> documentObservers = new SparseArray<>();
   private final SparseArray<ListenerRegistration> listenerRegistrations = new SparseArray<>();
   private final SparseArray<Transaction> transactions = new SparseArray<>();
   private final SparseArray<TaskCompletionSource> completionTasks = new SparseArray<>();
+  private final SparseArray<WriteBatch> batches = new SparseArray<>();
 
   public static void registerWith(PluginRegistry.Registrar registrar) {
     final MethodChannel channel =
@@ -371,6 +374,61 @@ public class CloudFirestorePlugin implements MethodCallHandler {
               return null;
             }
           }.execute();
+          break;
+        }
+      case "Batch#create":
+        {
+          int handle = nextBatchHandle++;
+          WriteBatch batch = FirebaseFirestore.getInstance().batch();
+          batches.put(handle, batch);
+          result.success(handle);
+          break;
+        }
+      case "Batch#set":
+        {
+          Map<String, Object> arguments = call.arguments();
+          int handle = (Integer) arguments.get("handle");
+          DocumentReference reference = getDocumentReference(arguments);
+          @SuppressWarnings("unchecked")
+          Map<String, Object> options = (Map<String, Object>) arguments.get("options");
+          WriteBatch batch = batches.get(handle);
+          if (options != null && (Boolean) options.get("merge")){
+            batch.set(reference, arguments.get("data"), SetOptions.merge());
+          } else {
+            batch.set(reference, arguments.get("data"));
+          }
+          result.success(null);
+          break;
+        }
+      case "Batch#update":
+        {
+          Map<String, Object> arguments = call.arguments();
+          int handle = (Integer) arguments.get("handle");
+          DocumentReference reference = getDocumentReference(arguments);
+          @SuppressWarnings("unchecked")
+          Map<String, Object> data = (Map<String, Object>) arguments.get("data");
+          WriteBatch batch = batches.get(handle);
+          batch.update(reference, data);
+          result.success(null);
+          break;
+        }
+      case "Batch#delete":
+        {
+          Map<String, Object> arguments = call.arguments();
+          int handle = (Integer) arguments.get("handle");
+          DocumentReference reference = getDocumentReference(arguments);
+          WriteBatch batch = batches.get(handle);
+          batch.delete(reference);
+          result.success(null);
+          break;
+        }
+      case "Batch#commit":
+        {
+          Map<String, Object> arguments = call.arguments();
+          int handle = (Integer) arguments.get("handle");
+          WriteBatch batch = batches.get(handle);
+          Task<Void> task = batch.commit();
+          addDefaultListeners("commit", task, result);
           break;
         }
       case "Query#addSnapshotListener":

--- a/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
+++ b/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
@@ -27,6 +27,7 @@ import com.google.firebase.firestore.Query;
 import com.google.firebase.firestore.QuerySnapshot;
 import com.google.firebase.firestore.SetOptions;
 import com.google.firebase.firestore.Transaction;
+import com.google.firebase.firestore.WriteBatch;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
@@ -392,7 +393,7 @@ public class CloudFirestorePlugin implements MethodCallHandler {
           @SuppressWarnings("unchecked")
           Map<String, Object> options = (Map<String, Object>) arguments.get("options");
           WriteBatch batch = batches.get(handle);
-          if (options != null && (Boolean) options.get("merge")){
+          if (options != null && (Boolean) options.get("merge")) {
             batch.set(reference, arguments.get("data"), SetOptions.merge());
           } else {
             batch.set(reference, arguments.get("data"));

--- a/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
+++ b/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
@@ -242,62 +242,6 @@ public class CloudFirestorePlugin implements MethodCallHandler {
   @Override
   public void onMethodCall(MethodCall call, final Result result) {
     switch (call.method) {
-      case "WriteBatch#create":
-        {
-          int handle = nextBatchHandle++;
-          WriteBatch batch = FirebaseFirestore.getInstance().batch();
-          batches.put(handle, batch);
-          result.success(handle);
-          break;
-        }
-      case "WriteBatch#setData":
-        {
-          Map<String, Object> arguments = call.arguments();
-          int handle = (Integer) arguments.get("handle");
-          DocumentReference reference = getDocumentReference(arguments);
-          @SuppressWarnings("unchecked")
-          Map<String, Object> options = (Map<String, Object>) arguments.get("options");
-          WriteBatch batch = batches.get(handle);
-          if (options != null && (Boolean) options.get("merge")) {
-            batch.set(reference, arguments.get("data"), SetOptions.merge());
-          } else {
-            batch.set(reference, arguments.get("data"));
-          }
-          result.success(null);
-          break;
-        }
-      case "WriteBatch#updateData":
-        {
-          Map<String, Object> arguments = call.arguments();
-          int handle = (Integer) arguments.get("handle");
-          DocumentReference reference = getDocumentReference(arguments);
-          @SuppressWarnings("unchecked")
-          Map<String, Object> data = (Map<String, Object>) arguments.get("data");
-          WriteBatch batch = batches.get(handle);
-          batch.update(reference, data);
-          result.success(null);
-          break;
-        }
-      case "WriteBatch#delete":
-        {
-          Map<String, Object> arguments = call.arguments();
-          int handle = (Integer) arguments.get("handle");
-          DocumentReference reference = getDocumentReference(arguments);
-          WriteBatch batch = batches.get(handle);
-          batch.delete(reference);
-          result.success(null);
-          break;
-        }
-      case "WriteBatch#commit":
-        {
-          Map<String, Object> arguments = call.arguments();
-          int handle = (Integer) arguments.get("handle");
-          WriteBatch batch = batches.get(handle);
-          Task<Void> task = batch.commit();
-          batches.delete(handle);
-          addDefaultListeners("commit", task, result);
-          break;
-        }
       case "Firestore#runTransaction":
         {
           final TaskCompletionSource<Map<String, Object>> transactionTCS =

--- a/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
+++ b/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
@@ -56,9 +56,9 @@ public class CloudFirestorePlugin implements MethodCallHandler {
   private final SparseArray<EventObserver> observers = new SparseArray<>();
   private final SparseArray<DocumentObserver> documentObservers = new SparseArray<>();
   private final SparseArray<ListenerRegistration> listenerRegistrations = new SparseArray<>();
+  private final SparseArray<WriteBatch> batches = new SparseArray<>();
   private final SparseArray<Transaction> transactions = new SparseArray<>();
   private final SparseArray<TaskCompletionSource> completionTasks = new SparseArray<>();
-  private final SparseArray<WriteBatch> batches = new SparseArray<>();
 
   public static void registerWith(PluginRegistry.Registrar registrar) {
     final MethodChannel channel =

--- a/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
+++ b/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
@@ -422,10 +422,8 @@ const UInt8 DOCUMENT_REFERENCE = 130;
     FIRDocumentReference *reference = [[FIRFirestore firestore] documentWithPath:path];
     FIRWriteBatch batch = [_batches objectForKey:handle];
     if (![options isEqual:[NSNull null]] &&
-        [options[@"merge"] isEqual:[NSNumber numberWithBool:YES]]){
-      [batch setData:call.arguments[@"data"]
-         forDocument:reference
-             options:[FIRSetOptions merge]];
+        [options[@"merge"] isEqual:[NSNumber numberWithBool:YES]]) {
+      [batch setData:call.arguments[@"data"] forDocument:reference options:[FIRSetOptions merge]];
     } else {
       [batch setData:call.arguments[@"data"] forDocument:reference];
     }

--- a/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
+++ b/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
@@ -410,12 +410,12 @@ const UInt8 DOCUMENT_REFERENCE = 130;
     [[_listeners objectForKey:handle] remove];
     [_listeners removeObjectForKey:handle];
     result(nil);
-  } else if ([@"Batch#create" isEqualToString:call.method]) {
+  } else if ([@"WriteBatch#create" isEqualToString:call.method]) {
     __block NSNumber *handle = [NSNumber numberWithInt:_nextBatchHandle++];
     FIRWriteBatch *batch = [[FIRFirestore firestore] batch];
     _batches[handle] = batch;
     result(handle);
-  } else if ([@"Batch#set" isEqualToString:call.method]) {
+  } else if ([@"WriteBatch#setData" isEqualToString:call.method]) {
     NSNumber *handle = call.arguments[@"handle"];
     NSString *path = call.arguments[@"path"];
     NSDictionary *options = call.arguments[@"options"];
@@ -430,21 +430,21 @@ const UInt8 DOCUMENT_REFERENCE = 130;
       [batch setData:call.arguments[@"data"] forDocument:reference];
     }
     result(nil);
-  } else if ([@"Batch#update" isEqualToString:call.method]) {
+  } else if ([@"WriteBatch#updateData" isEqualToString:call.method]) {
     NSNumber *handle = call.arguments[@"handle"];
     NSString *path = call.arguments[@"path"];
     FIRDocumentReference *reference = [[FIRFirestore firestore] documentWithPath:path];
     FIRWriteBatch batch = [_batches objectForKey:handle];
     [batch updateData:call.arguments[@"data"] forDocument:reference];
     result(nil);
-  } else if ([@"Batch#delete" isEqualToString:call.method]) {
+  } else if ([@"WriteBatch#delete" isEqualToString:call.method]) {
     NSNumber *handle = call.arguments[@"handle"];
     NSString *path = call.arguments[@"path"];
     FIRDocumentReference *reference = [[FIRFirestore firestore] documentWithPath:path];
     FIRWriteBatch batch = [_batches objectForKey:handle];
     [batch deleteDocument:reference];
     result(nil);
-  } else if ([@"Batch#commit" isEqualToString:call.method]) {
+  } else if ([@"WriteBatch#commit" isEqualToString:call.method]) {
     // TODO:
     NSNumber *handle = call.arguments[@"handle"];
     FIRWriteBatch batch = [_batches objectForKey:handle];

--- a/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
+++ b/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
@@ -445,10 +445,10 @@ const UInt8 DOCUMENT_REFERENCE = 130;
     [batch deleteDocument:reference];
     result(nil);
   } else if ([@"WriteBatch#commit" isEqualToString:call.method]) {
-    // TODO:
     NSNumber *handle = call.arguments[@"handle"];
     FIRWriteBatch batch = [_batches objectForKey:handle];
     [batch commitWithCompletion:defaultCompletionBlock];
+    [_batches removeObjectForKey:handle];
   } else {
     result(FlutterMethodNotImplemented);
   }

--- a/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
+++ b/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
@@ -203,6 +203,8 @@ const UInt8 DOCUMENT_REFERENCE = 130;
   int _nextListenerHandle;
   NSMutableDictionary *transactions;
   NSMutableDictionary *transactionResults;
+  NSMutableDictionary<NSNumber *, FIRWriteBatch *> *_batches;
+  int _nextBatchHandle;
 }
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
@@ -224,7 +226,7 @@ const UInt8 DOCUMENT_REFERENCE = 130;
       [FIRApp configure];
     }
     _listeners = [NSMutableDictionary<NSNumber *, id<FIRListenerRegistration>> dictionary];
-    _batches = [NSMutableDictionary<NSNumber *, id<FIRWriteBatch>> dictionary];
+    _batches = [NSMutableDictionary<NSNumber *, FIRWriteBatch *> dictionary];
     _nextListenerHandle = 0;
     _nextBatchHandle = 0;
     transactions = [NSMutableDictionary<NSNumber *, FIRTransaction *> dictionary];
@@ -420,7 +422,7 @@ const UInt8 DOCUMENT_REFERENCE = 130;
     NSString *path = call.arguments[@"path"];
     NSDictionary *options = call.arguments[@"options"];
     FIRDocumentReference *reference = [[FIRFirestore firestore] documentWithPath:path];
-    FIRWriteBatch batch = [_batches objectForKey:handle];
+    FIRWriteBatch *batch = [_batches objectForKey:handle];
     if (![options isEqual:[NSNull null]] &&
         [options[@"merge"] isEqual:[NSNumber numberWithBool:YES]]) {
       [batch setData:call.arguments[@"data"] forDocument:reference options:[FIRSetOptions merge]];
@@ -432,19 +434,19 @@ const UInt8 DOCUMENT_REFERENCE = 130;
     NSNumber *handle = call.arguments[@"handle"];
     NSString *path = call.arguments[@"path"];
     FIRDocumentReference *reference = [[FIRFirestore firestore] documentWithPath:path];
-    FIRWriteBatch batch = [_batches objectForKey:handle];
+    FIRWriteBatch *batch = [_batches objectForKey:handle];
     [batch updateData:call.arguments[@"data"] forDocument:reference];
     result(nil);
   } else if ([@"WriteBatch#delete" isEqualToString:call.method]) {
     NSNumber *handle = call.arguments[@"handle"];
     NSString *path = call.arguments[@"path"];
     FIRDocumentReference *reference = [[FIRFirestore firestore] documentWithPath:path];
-    FIRWriteBatch batch = [_batches objectForKey:handle];
+    FIRWriteBatch *batch = [_batches objectForKey:handle];
     [batch deleteDocument:reference];
     result(nil);
   } else if ([@"WriteBatch#commit" isEqualToString:call.method]) {
     NSNumber *handle = call.arguments[@"handle"];
-    FIRWriteBatch batch = [_batches objectForKey:handle];
+    FIRWriteBatch *batch = [_batches objectForKey:handle];
     [batch commitWithCompletion:defaultCompletionBlock];
     [_batches removeObjectForKey:handle];
   } else {

--- a/packages/cloud_firestore/lib/cloud_firestore.dart
+++ b/packages/cloud_firestore/lib/cloud_firestore.dart
@@ -15,7 +15,6 @@ import 'package:collection/collection.dart';
 
 import 'src/utils/push_id_generator.dart';
 
-part 'src/batch.dart';
 part 'src/collection_reference.dart';
 part 'src/document_change.dart';
 part 'src/document_snapshot.dart';
@@ -24,3 +23,4 @@ part 'src/firestore.dart';
 part 'src/query.dart';
 part 'src/query_snapshot.dart';
 part 'src/set_options.dart';
+part 'src/write_batch.dart';

--- a/packages/cloud_firestore/lib/cloud_firestore.dart
+++ b/packages/cloud_firestore/lib/cloud_firestore.dart
@@ -15,6 +15,7 @@ import 'package:collection/collection.dart';
 
 import 'src/utils/push_id_generator.dart';
 
+part 'src/batch.dart';
 part 'src/collection_reference.dart';
 part 'src/document_change.dart';
 part 'src/document_snapshot.dart';

--- a/packages/cloud_firestore/lib/src/batch.dart
+++ b/packages/cloud_firestore/lib/src/batch.dart
@@ -1,0 +1,73 @@
+// Copyright 2017, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+part of cloud_firestore;
+
+// TODO: Find out what happens to batches post-commit.
+// Use Java source and iOS source
+// See if I need to dispose or block.
+
+class Batch {
+  Batch():
+    _handle = Firestore.channel.invokeMethod(
+      'Batch#create',
+    );
+
+  Future<int> _handle;
+
+  final List<Future<Null>> _actions = <Future<Null>>[];
+
+  Future<Null> commit() async {
+    await Future.wait(_actions);
+    return await Firestore.channel.invokeMethod(
+      'Batch#commit',
+      <String, dynamic>{'handle': await _handle}
+    );
+  }
+
+  void delete(DocumentReference reference){
+    _handle.then((int handle){
+      _actions.add(
+        Firestore.channel.invokeMethod(
+          'Batch#delete',
+          <String, dynamic>{
+            'handle': handle,
+            'path': reference.path
+          },
+        ),
+      );
+    });
+  }
+
+  void set(DocumentReference reference, Map<String, dynamic> data, [SetOptions options]){
+    _handle.then((int handle){
+      _actions.add(
+        Firestore.channel.invokeMethod(
+          'Batch#set',
+          <String, dynamic>{
+            'handle': handle,
+            'path': reference.path,
+            'data': data,
+            'options': options?._data,
+          },
+        ),
+      );
+    });
+  }
+
+  void update(DocumentReference reference, Map<String, dynamic> data){
+    _handle.then((int handle){
+      _actions.add(
+        Firestore.channel.invokeMethod(
+          'Batch#update',
+          <String, dynamic>{
+            'handle': handle,
+            'path': reference.path,
+            'data': data,
+          },
+        ),
+      );
+    });
+  }
+}

--- a/packages/cloud_firestore/lib/src/firestore.dart
+++ b/packages/cloud_firestore/lib/src/firestore.dart
@@ -63,6 +63,13 @@ class Firestore {
     return new DocumentReference._(this, path.split('/'));
   }
 
+  /// Creates a write batch, used for performing multiple writes as a single
+  /// atomic operation.
+  ///
+  /// Unlike transactions, write batches are persisted offline and therefore are
+  /// preferable when you don’t need to condition your writes on read data.
+  WriteBatch batch() => new WriteBatch._();
+
   /// Executes the given TransactionHandler and then attempts to commit the
   /// changes applied within an atomic transaction.
   ///

--- a/packages/cloud_firestore/lib/src/write_batch.dart
+++ b/packages/cloud_firestore/lib/src/write_batch.dart
@@ -11,7 +11,7 @@ part of cloud_firestore;
 /// Once committed, no further operations can be performed on the [WriteBatch],
 /// nor can it be committed again.
 class WriteBatch {
-  WriteBatch()
+  WriteBatch._()
       : _handle = Firestore.channel.invokeMethod(
           'WriteBatch#create',
         );
@@ -22,8 +22,9 @@ class WriteBatch {
   /// Indicator to whether or not this [WriteBatch] has been committed.
   bool _committed = false;
 
-  /// Processes all operations in this [WriteBatch] and prevents any future
-  /// operations from being added.
+  /// Commits all of the writes in this write batch as a single atomic unit.
+  ///
+  /// Calling this method prevents any future operations from being added.
   Future<Null> commit() async {
     if (!_committed) {
       _committed = true;
@@ -35,14 +36,14 @@ class WriteBatch {
     }
   }
 
-  /// Adds a delete operation for the given [DocumentReference].
-  void delete(DocumentReference reference) {
+  /// Deletes the document referred to by [document].
+  void delete(DocumentReference document) {
     if (!_committed) {
       _handle.then((int handle) {
         _actions.add(
           Firestore.channel.invokeMethod(
             'WriteBatch#delete',
-            <String, dynamic>{'handle': handle, 'path': reference.path},
+            <String, dynamic>{'handle': handle, 'path': document.path},
           ),
         );
       });
@@ -52,10 +53,13 @@ class WriteBatch {
     }
   }
 
-  /// Adds a write operation for the given [DocumentReference]. If the document
-  /// does not yet exist, it will be created. If you pass [SetOptions], the
-  /// provided data will be merged into an existing document.
-  void setData(DocumentReference reference, Map<String, dynamic> data,
+  /// Writes to the document referred to by [document].
+  ///
+  /// If the document does not yet exist, it will be created.
+  ///
+  /// If you pass [SetOptions], the provided data will be merged into an
+  /// existing document.
+  void setData(DocumentReference document, Map<String, dynamic> data,
       [SetOptions options]) {
     if (!_committed) {
       _handle.then((int handle) {
@@ -64,7 +68,7 @@ class WriteBatch {
             'WriteBatch#setData',
             <String, dynamic>{
               'handle': handle,
-              'path': reference.path,
+              'path': document.path,
               'data': data,
               'options': options?._data,
             },
@@ -77,10 +81,10 @@ class WriteBatch {
     }
   }
 
-  /// Adds an update operation for the given [DocumentReference].
+  /// Updates fields in the document referred to by [document].
   ///
-  /// If the document doesn't exist yet, the operation will fail.
-  void updateData(DocumentReference reference, Map<String, dynamic> data) {
+  /// If the document does not exist, the operation will fail.
+  void updateData(DocumentReference document, Map<String, dynamic> data) {
     if (!_committed) {
       _handle.then((int handle) {
         _actions.add(
@@ -88,7 +92,7 @@ class WriteBatch {
             'WriteBatch#updateData',
             <String, dynamic>{
               'handle': handle,
-              'path': reference.path,
+              'path': document.path,
               'data': data,
             },
           ),

--- a/packages/cloud_firestore/lib/src/write_batch.dart
+++ b/packages/cloud_firestore/lib/src/write_batch.dart
@@ -16,8 +16,8 @@ class WriteBatch {
           'WriteBatch#create',
         );
 
-  Future<int> _handle;
-  final List<Future<Null>> _actions = <Future<Null>>[];
+  Future<dynamic> _handle;
+  final List<Future<dynamic>> _actions = <Future<dynamic>>[];
 
   /// Indicator to whether or not this [WriteBatch] has been committed.
   bool _committed = false;
@@ -28,7 +28,7 @@ class WriteBatch {
   Future<Null> commit() async {
     if (!_committed) {
       _committed = true;
-      await Future.wait(_actions);
+      await Future.wait<dynamic>(_actions);
       return await Firestore.channel.invokeMethod(
           'WriteBatch#commit', <String, dynamic>{'handle': await _handle});
     } else {
@@ -39,7 +39,7 @@ class WriteBatch {
   /// Deletes the document referred to by [document].
   void delete(DocumentReference document) {
     if (!_committed) {
-      _handle.then((int handle) {
+      _handle.then((dynamic handle) {
         _actions.add(
           Firestore.channel.invokeMethod(
             'WriteBatch#delete',
@@ -62,7 +62,7 @@ class WriteBatch {
   void setData(DocumentReference document, Map<String, dynamic> data,
       [SetOptions options]) {
     if (!_committed) {
-      _handle.then((int handle) {
+      _handle.then((dynamic handle) {
         _actions.add(
           Firestore.channel.invokeMethod(
             'WriteBatch#setData',
@@ -86,7 +86,7 @@ class WriteBatch {
   /// If the document does not exist, the operation will fail.
   void updateData(DocumentReference document, Map<String, dynamic> data) {
     if (!_committed) {
-      _handle.then((int handle) {
+      _handle.then((dynamic handle) {
         _actions.add(
           Firestore.channel.invokeMethod(
             'WriteBatch#updateData',

--- a/packages/cloud_firestore/lib/src/write_batch.dart
+++ b/packages/cloud_firestore/lib/src/write_batch.dart
@@ -8,23 +8,22 @@ part of cloud_firestore;
 // Use Java source and iOS source
 // See if I need to dispose or block.
 
-class Batch {
-  Batch():
+class WriteBatch {
+  WriteBatch():
     _handle = Firestore.channel.invokeMethod(
       'Batch#create',
     );
 
   Future<int> _handle;
-
   final List<Future<Null>> _actions = <Future<Null>>[];
 
   Future<Null> commit() async {
-    await Future.wait(_actions);
-    return await Firestore.channel.invokeMethod(
-      'Batch#commit',
-      <String, dynamic>{'handle': await _handle}
-    );
-  }
+      await Future.wait(_actions);
+      return await Firestore.channel.invokeMethod(
+        'Batch#commit',
+        <String, dynamic>{'handle': await _handle}
+      );
+    }
 
   void delete(DocumentReference reference){
     _handle.then((int handle){

--- a/packages/cloud_firestore/lib/src/write_batch.dart
+++ b/packages/cloud_firestore/lib/src/write_batch.dart
@@ -13,7 +13,7 @@ part of cloud_firestore;
 class WriteBatch {
   WriteBatch():
     _handle = Firestore.channel.invokeMethod(
-      'Batch#create',
+      'WriteBatch#create',
     );
 
   Future<int> _handle;
@@ -29,7 +29,7 @@ class WriteBatch {
       committed = true;
       await Future.wait(_actions);
       return await Firestore.channel.invokeMethod(
-        'Batch#commit',
+        'WriteBatch#commit',
         <String, dynamic>{'handle': await _handle}
       );
     } else {
@@ -43,7 +43,7 @@ class WriteBatch {
       _handle.then((int handle){
         _actions.add(
           Firestore.channel.invokeMethod(
-            'Batch#delete',
+            'WriteBatch#delete',
             <String, dynamic>{
               'handle': handle,
               'path': reference.path
@@ -59,12 +59,12 @@ class WriteBatch {
   /// Adds a write operation for the given [DocumentReference]. If the document
   /// does not yet exist, it will be created. If you pass [SetOptions], the
   /// provided data will be merged into an existing document.
-  void set(DocumentReference reference, Map<String, dynamic> data, [SetOptions options]){
+  void setData(DocumentReference reference, Map<String, dynamic> data, [SetOptions options]){
     if (!committed){
       _handle.then((int handle){
         _actions.add(
           Firestore.channel.invokeMethod(
-            'Batch#set',
+            'WriteBatch#setData',
             <String, dynamic>{
               'handle': handle,
               'path': reference.path,
@@ -82,12 +82,12 @@ class WriteBatch {
   /// Adds an update operation for the given [DocumentReference].
   /// 
   /// If the document doesn't exist yet, the operation will fail.
-  void update(DocumentReference reference, Map<String, dynamic> data){
+  void updateData(DocumentReference reference, Map<String, dynamic> data){
     if (!committed){
       _handle.then((int handle){
         _actions.add(
           Firestore.channel.invokeMethod(
-            'Batch#update',
+            'WriteBatch#updateData',
             <String, dynamic>{
               'handle': handle,
               'path': reference.path,

--- a/packages/cloud_firestore/lib/src/write_batch.dart
+++ b/packages/cloud_firestore/lib/src/write_batch.dart
@@ -1,4 +1,4 @@
-// Copyright 2017, the Chromium project authors.  Please see the AUTHORS file
+// Copyright 2018, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/packages/cloud_firestore/lib/src/write_batch.dart
+++ b/packages/cloud_firestore/lib/src/write_batch.dart
@@ -4,6 +4,12 @@
 
 part of cloud_firestore;
 
+/// A [WriteBatch] is a series of write operations to be performed as one unit.
+/// 
+/// Operations done on a [WriteBatch] do not take effect until you [commit].
+/// 
+/// Once committed, no further operations can be performed on the [WriteBatch],
+/// nor can it be committed again.
 class WriteBatch {
   WriteBatch():
     _handle = Firestore.channel.invokeMethod(
@@ -11,9 +17,13 @@ class WriteBatch {
     );
 
   Future<int> _handle;
-  bool committed = false;
   final List<Future<Null>> _actions = <Future<Null>>[];
+  
+  /// Indicator to whether or not this [WriteBatch] has been committed.
+  bool committed = false;
 
+  /// Processes all operations in this [WriteBatch] and prevents any future
+  /// operations from being added.
   Future<Null> commit() async {
     if (!committed){
       committed = true;
@@ -27,6 +37,7 @@ class WriteBatch {
     }
   }
 
+  /// Adds a delete operation for the given [DocumentReference].
   void delete(DocumentReference reference){
     if (!committed){
       _handle.then((int handle){
@@ -45,6 +56,9 @@ class WriteBatch {
     }
   }
 
+  /// Adds a write operation for the given [DocumentReference]. If the document
+  /// does not yet exist, it will be created. If you pass [SetOptions], the
+  /// provided data will be merged into an existing document.
   void set(DocumentReference reference, Map<String, dynamic> data, [SetOptions options]){
     if (!committed){
       _handle.then((int handle){
@@ -65,6 +79,9 @@ class WriteBatch {
     }
   }
 
+  /// Adds an update operation for the given [DocumentReference].
+  /// 
+  /// If the document doesn't exist yet, the operation will fail.
   void update(DocumentReference reference, Map<String, dynamic> data){
     if (!committed){
       _handle.then((int handle){

--- a/packages/cloud_firestore/lib/src/write_batch.dart
+++ b/packages/cloud_firestore/lib/src/write_batch.dart
@@ -20,13 +20,13 @@ class WriteBatch {
   final List<Future<Null>> _actions = <Future<Null>>[];
   
   /// Indicator to whether or not this [WriteBatch] has been committed.
-  bool committed = false;
+  bool _committed = false;
 
   /// Processes all operations in this [WriteBatch] and prevents any future
   /// operations from being added.
   Future<Null> commit() async {
-    if (!committed){
-      committed = true;
+    if (!_committed){
+      _committed = true;
       await Future.wait(_actions);
       return await Firestore.channel.invokeMethod(
         'WriteBatch#commit',
@@ -39,7 +39,7 @@ class WriteBatch {
 
   /// Adds a delete operation for the given [DocumentReference].
   void delete(DocumentReference reference){
-    if (!committed){
+    if (!_committed){
       _handle.then((int handle){
         _actions.add(
           Firestore.channel.invokeMethod(
@@ -60,7 +60,7 @@ class WriteBatch {
   /// does not yet exist, it will be created. If you pass [SetOptions], the
   /// provided data will be merged into an existing document.
   void setData(DocumentReference reference, Map<String, dynamic> data, [SetOptions options]){
-    if (!committed){
+    if (!_committed){
       _handle.then((int handle){
         _actions.add(
           Firestore.channel.invokeMethod(
@@ -83,7 +83,7 @@ class WriteBatch {
   /// 
   /// If the document doesn't exist yet, the operation will fail.
   void updateData(DocumentReference reference, Map<String, dynamic> data){
-    if (!committed){
+    if (!_committed){
       _handle.then((int handle){
         _actions.add(
           Firestore.channel.invokeMethod(

--- a/packages/cloud_firestore/lib/src/write_batch.dart
+++ b/packages/cloud_firestore/lib/src/write_batch.dart
@@ -5,63 +5,60 @@
 part of cloud_firestore;
 
 /// A [WriteBatch] is a series of write operations to be performed as one unit.
-/// 
+///
 /// Operations done on a [WriteBatch] do not take effect until you [commit].
-/// 
+///
 /// Once committed, no further operations can be performed on the [WriteBatch],
 /// nor can it be committed again.
 class WriteBatch {
-  WriteBatch():
-    _handle = Firestore.channel.invokeMethod(
-      'WriteBatch#create',
-    );
+  WriteBatch()
+      : _handle = Firestore.channel.invokeMethod(
+          'WriteBatch#create',
+        );
 
   Future<int> _handle;
   final List<Future<Null>> _actions = <Future<Null>>[];
-  
+
   /// Indicator to whether or not this [WriteBatch] has been committed.
   bool _committed = false;
 
   /// Processes all operations in this [WriteBatch] and prevents any future
   /// operations from being added.
   Future<Null> commit() async {
-    if (!_committed){
+    if (!_committed) {
       _committed = true;
       await Future.wait(_actions);
       return await Firestore.channel.invokeMethod(
-        'WriteBatch#commit',
-        <String, dynamic>{'handle': await _handle}
-      );
+          'WriteBatch#commit', <String, dynamic>{'handle': await _handle});
     } else {
       throw new StateError("This batch has already been committed.");
     }
   }
 
   /// Adds a delete operation for the given [DocumentReference].
-  void delete(DocumentReference reference){
-    if (!_committed){
-      _handle.then((int handle){
+  void delete(DocumentReference reference) {
+    if (!_committed) {
+      _handle.then((int handle) {
         _actions.add(
           Firestore.channel.invokeMethod(
             'WriteBatch#delete',
-            <String, dynamic>{
-              'handle': handle,
-              'path': reference.path
-            },
+            <String, dynamic>{'handle': handle, 'path': reference.path},
           ),
         );
       });
     } else {
-      throw new StateError("This batch has been committed and can no longer be changed.");
+      throw new StateError(
+          "This batch has been committed and can no longer be changed.");
     }
   }
 
   /// Adds a write operation for the given [DocumentReference]. If the document
   /// does not yet exist, it will be created. If you pass [SetOptions], the
   /// provided data will be merged into an existing document.
-  void setData(DocumentReference reference, Map<String, dynamic> data, [SetOptions options]){
-    if (!_committed){
-      _handle.then((int handle){
+  void setData(DocumentReference reference, Map<String, dynamic> data,
+      [SetOptions options]) {
+    if (!_committed) {
+      _handle.then((int handle) {
         _actions.add(
           Firestore.channel.invokeMethod(
             'WriteBatch#setData',
@@ -75,16 +72,17 @@ class WriteBatch {
         );
       });
     } else {
-      throw new StateError("This batch has been committed and can no longer be changed.");
+      throw new StateError(
+          "This batch has been committed and can no longer be changed.");
     }
   }
 
   /// Adds an update operation for the given [DocumentReference].
-  /// 
+  ///
   /// If the document doesn't exist yet, the operation will fail.
-  void updateData(DocumentReference reference, Map<String, dynamic> data){
-    if (!_committed){
-      _handle.then((int handle){
+  void updateData(DocumentReference reference, Map<String, dynamic> data) {
+    if (!_committed) {
+      _handle.then((int handle) {
         _actions.add(
           Firestore.channel.invokeMethod(
             'WriteBatch#updateData',
@@ -97,7 +95,8 @@ class WriteBatch {
         );
       });
     } else {
-      throw new StateError("This batch has been committed and can no longer be changed.");
+      throw new StateError(
+          "This batch has been committed and can no longer be changed.");
     }
   }
 }

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_firestore
-version: 0.3.1
+version: 0.3.2
 
 flutter:
   plugin:

--- a/packages/cloud_firestore/test/cloud_firestore_test.dart
+++ b/packages/cloud_firestore/test/cloud_firestore_test.dart
@@ -431,7 +431,6 @@ void main() {
         expect(colRef.path, 'foo/bar/baz');
       });
     });
-<<<<<<< HEAD
 
     group('Query', () {
       test('getDocuments', () async {
@@ -476,8 +475,7 @@ void main() {
           firestore.document('foo/bar'),
         ];
         _checkEncodeDecode<dynamic>(codec, message);
-=======
-    group('WriteBatch', (){
+    group('WriteBatch', () {
       test('set', () async {
         final WriteBatch batch = new WriteBatch();
         batch.setData(
@@ -520,15 +518,12 @@ void main() {
           log,
           <Matcher>[
             isMethodCall('WriteBatch#create', arguments: null),
-            isMethodCall(
-              'WriteBatch#setData',
-              arguments: <String, dynamic>{
-                'handle': 1,
-                'path': 'foo/bar',
-                'data': <String, String>{'bazKey': 'quxValue'},
-                'options': <String, bool>{'merge': true},
-              }
-            ),
+            isMethodCall('WriteBatch#setData', arguments: <String, dynamic>{
+              'handle': 1,
+              'path': 'foo/bar',
+              'data': <String, String>{'bazKey': 'quxValue'},
+              'options': <String, bool>{'merge': true},
+            }),
             isMethodCall(
               'WriteBatch#commit',
               arguments: <String, dynamic>{
@@ -589,7 +584,6 @@ void main() {
             ),
           ],
         );
->>>>>>> Add some tests
       });
     });
   });

--- a/packages/cloud_firestore/test/cloud_firestore_test.dart
+++ b/packages/cloud_firestore/test/cloud_firestore_test.dart
@@ -477,7 +477,7 @@ void main() {
         _checkEncodeDecode<dynamic>(codec, message);
     group('WriteBatch', () {
       test('set', () async {
-        final WriteBatch batch = new WriteBatch();
+        final WriteBatch batch = firestore.batch();
         batch.setData(
           collectionReference.document('bar'),
           <String, String>{'bazKey': 'quxValue'},
@@ -506,7 +506,7 @@ void main() {
         );
       });
       test('merge set', () async {
-        final WriteBatch batch = new WriteBatch();
+        final WriteBatch batch = firestore.batch();
         batch.setData(
           collectionReference.document('bar'),
           <String, String>{'bazKey': 'quxValue'},
@@ -534,7 +534,7 @@ void main() {
         );
       });
       test('update', () async {
-        final WriteBatch batch = new WriteBatch();
+        final WriteBatch batch = firestore.batch();
         batch.updateData(
           collectionReference.document('bar'),
           <String, String>{'bazKey': 'quxValue'},
@@ -562,7 +562,7 @@ void main() {
         );
       });
       test('delete', () async {
-        final WriteBatch batch = new WriteBatch();
+        final WriteBatch batch = firestore.batch();
         batch.delete(collectionReference.document('bar'));
         await batch.commit();
         expect(

--- a/packages/cloud_firestore/test/cloud_firestore_test.dart
+++ b/packages/cloud_firestore/test/cloud_firestore_test.dart
@@ -475,6 +475,9 @@ void main() {
           firestore.document('foo/bar'),
         ];
         _checkEncodeDecode<dynamic>(codec, message);
+      });
+    });
+
     group('WriteBatch', () {
       test('set', () async {
         final WriteBatch batch = firestore.batch();

--- a/packages/cloud_firestore/test/cloud_firestore_test.dart
+++ b/packages/cloud_firestore/test/cloud_firestore_test.dart
@@ -102,6 +102,8 @@ void main() {
             return null;
           case 'Transaction#delete':
             return null;
+          case 'WriteBatch#create':
+            return 1;
           default:
             return null;
         }
@@ -429,6 +431,7 @@ void main() {
         expect(colRef.path, 'foo/bar/baz');
       });
     });
+<<<<<<< HEAD
 
     group('Query', () {
       test('getDocuments', () async {
@@ -473,6 +476,120 @@ void main() {
           firestore.document('foo/bar'),
         ];
         _checkEncodeDecode<dynamic>(codec, message);
+=======
+    group('WriteBatch', (){
+      test('set', () async {
+        final WriteBatch batch = new WriteBatch();
+        batch.setData(
+          collectionReference.document('bar'),
+          <String, String>{'bazKey': 'quxValue'},
+        );
+        await batch.commit();
+        expect(
+          log,
+          <Matcher>[
+            isMethodCall('WriteBatch#create', arguments: null),
+            isMethodCall(
+              'WriteBatch#setData',
+              arguments: <String, dynamic>{
+                'handle': 1,
+                'path': 'foo/bar',
+                'data': <String, String>{'bazKey': 'quxValue'},
+                'options': null,
+              },
+            ),
+            isMethodCall(
+              'WriteBatch#commit',
+              arguments: <String, dynamic>{
+                'handle': 1,
+              },
+            ),
+          ],
+        );
+      });
+      test('merge set', () async {
+        final WriteBatch batch = new WriteBatch();
+        batch.setData(
+          collectionReference.document('bar'),
+          <String, String>{'bazKey': 'quxValue'},
+          SetOptions.merge,
+        );
+        await batch.commit();
+        expect(SetOptions.merge, isNotNull);
+        expect(
+          log,
+          <Matcher>[
+            isMethodCall('WriteBatch#create', arguments: null),
+            isMethodCall(
+              'WriteBatch#setData',
+              arguments: <String, dynamic>{
+                'handle': 1,
+                'path': 'foo/bar',
+                'data': <String, String>{'bazKey': 'quxValue'},
+                'options': <String, bool>{'merge': true},
+              }
+            ),
+            isMethodCall(
+              'WriteBatch#commit',
+              arguments: <String, dynamic>{
+                'handle': 1,
+              },
+            ),
+          ],
+        );
+      });
+      test('update', () async {
+        final WriteBatch batch = new WriteBatch();
+        batch.updateData(
+          collectionReference.document('bar'),
+          <String, String>{'bazKey': 'quxValue'},
+        );
+        await batch.commit();
+        expect(
+          log,
+          <Matcher>[
+            isMethodCall('WriteBatch#create', arguments: null),
+            isMethodCall(
+              'WriteBatch#updateData',
+              arguments: <String, dynamic>{
+                'handle': 1,
+                'path': 'foo/bar',
+                'data': <String, String>{'bazKey': 'quxValue'},
+              },
+            ),
+            isMethodCall(
+              'WriteBatch#commit',
+              arguments: <String, dynamic>{
+                'handle': 1,
+              },
+            ),
+          ],
+        );
+      });
+      test('delete', () async {
+        final WriteBatch batch = new WriteBatch();
+        batch.delete(collectionReference.document('bar'));
+        await batch.commit();
+        expect(
+          log,
+          <Matcher>[
+            isMethodCall('WriteBatch#create', arguments: null),
+            isMethodCall(
+              'WriteBatch#delete',
+              arguments: <String, dynamic>{
+                'handle': 1,
+                'path': 'foo/bar',
+              },
+            ),
+            isMethodCall(
+              'WriteBatch#commit',
+              arguments: <String, dynamic>{
+                'handle': 1,
+              },
+            ),
+          ],
+        );
+>>>>>>> Add some tests
       });
     });
   });


### PR DESCRIPTION
Fixes flutter/flutter#14026

I've done some initial testing on Android, including a sync call to an operation followed by an async call.

iOS support is here but needs to be tested.