### PR TITLE
Refresh alarm_manager project template. Move Java package

### DIFF
--- a/packages/android_alarm_manager/CHANGELOG.md
+++ b/packages/android_alarm_manager/CHANGELOG.md
@@ -1,20 +1,25 @@
-## [0.0.4] - 12/20/2017
+## 0.0.5
+
+* Simplified and upgraded Android project template to Android SDK 27.
+* Moved Android package to io.flutter.plugins.
+
+## 0.0.4
 
 * **Breaking change**. Upgraded to Gradle 4.1 and Android Studio Gradle plugin
   3.0.1. Older Flutter projects need to upgrade their Gradle setup as well in
   order to use this version of the plugin. Instructions can be found
   [here](https://github.com/flutter/flutter/wiki/Updating-Flutter-projects-to-Gradle-4.1-and-Android-Studio-Gradle-plugin-3.0.1).
 
-## [0.0.3] - 12/4/2017
+## 0.0.3
 
 * Adds use of a Firebase plugin to the example. The example also now
   demonstrates overriding the Application's onCreate method so that the
   AlarmService can initialize plugin connections.
 
-## [0.0.2] - 12/3/2017.
+## 0.0.2
 
 * Add FLT prefix to iOS types.
 
-## [0.0.1] - 10/24/2017.
+## 0.0.1
 
 * Initial release.

--- a/packages/android_alarm_manager/android/build.gradle
+++ b/packages/android_alarm_manager/android/build.gradle
@@ -1,4 +1,4 @@
-group 'io.flutter.androidalarmmanager'
+group 'io.flutter.plugins.androidalarmmanager'
 version '1.0-SNAPSHOT'
 
 buildscript {
@@ -23,7 +23,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 27
-    
+
     defaultConfig {
         minSdkVersion 16
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/packages/android_alarm_manager/android/src/main/AndroidManifest.xml
+++ b/packages/android_alarm_manager/android/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="io.flutter.androidalarmmanager">
+  package="io.flutter.plugins.androidalarmmanager">
 </manifest>

--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AlarmService.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AlarmService.java
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-package io.flutter.androidalarmmanager;
+package io.flutter.plugins.androidalarmmanager;
 
 import android.app.Activity;
 import android.app.AlarmManager;

--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AndroidAlarmManagerPlugin.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AndroidAlarmManagerPlugin.java
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-package io.flutter.androidalarmmanager;
+package io.flutter.plugins.androidalarmmanager;
 
 import android.content.Context;
 import io.flutter.plugin.common.JSONMethodCodec;

--- a/packages/android_alarm_manager/example/android/app/build.gradle
+++ b/packages/android_alarm_manager/example/android/app/build.gradle
@@ -23,7 +23,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        applicationId "io.flutter.androidalarmmanagerexample"
+        applicationId "io.flutter.plugins.androidalarmmanagerexample"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 

--- a/packages/android_alarm_manager/example/android/app/google-services.json
+++ b/packages/android_alarm_manager/example/android/app/google-services.json
@@ -1,33 +1,35 @@
 {
   "project_info": {
-    "project_number": "1067712222741",
-    "project_id": "flutter-alarmmanager-example"
+    "project_number": "469543255310",
+    "firebase_url": "https://flutter-plugins-alarmmanager.firebaseio.com",
+    "project_id": "flutter-plugins-alarmmanager",
+    "storage_bucket": "flutter-plugins-alarmmanager.appspot.com"
   },
   "client": [
     {
       "client_info": {
-        "mobilesdk_app_id": "1:1067712222741:android:b3f895545fce0ad2",
+        "mobilesdk_app_id": "1:469543255310:android:b691665129a4b343",
         "android_client_info": {
           "package_name": "io.flutter.plugins.androidalarmmanagerexample"
         }
       },
       "oauth_client": [
         {
-          "client_id": "1067712222741-k2jv050djreb4i551vd6q621css54tia.apps.googleusercontent.com",
-          "client_type": 3
-        },
-        {
-          "client_id": "1067712222741-qfv81bdrucm5hpnjqp8157jj1bvjjlqn.apps.googleusercontent.com",
+          "client_id": "469543255310-eb57hpmenljlgej9urc8k3iju63a70ig.apps.googleusercontent.com",
           "client_type": 1,
           "android_info": {
             "package_name": "io.flutter.plugins.androidalarmmanagerexample",
-            "certificate_hash": "0f729308cc7f95a84196351d1aa788e1f9b62e9e"
+            "certificate_hash": "f8323ac5fe6e7adc1ddc5612e16b5d04d7f1358b"
           }
+        },
+        {
+          "client_id": "469543255310-39gq6cjl6h84529omissps5v81la963c.apps.googleusercontent.com",
+          "client_type": 3
         }
       ],
       "api_key": [
         {
-          "current_key": "AIzaSyCkXpml3lzlhOzX-ZhOWX95TdKQFZqMkHE"
+          "current_key": "AIzaSyAXOxEfOptvOfvaRhdXeoUe-KmVDYtc72M"
         }
       ],
       "services": {
@@ -35,11 +37,16 @@
           "status": 1
         },
         "appinvite_service": {
-          "status": 1,
-          "other_platform_oauth_client": []
+          "status": 2,
+          "other_platform_oauth_client": [
+            {
+              "client_id": "469543255310-39gq6cjl6h84529omissps5v81la963c.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
         },
         "ads_service": {
-          "status": 1
+          "status": 2
         }
       }
     }

--- a/packages/android_alarm_manager/example/android/app/google-services.json
+++ b/packages/android_alarm_manager/example/android/app/google-services.json
@@ -8,7 +8,7 @@
       "client_info": {
         "mobilesdk_app_id": "1:1067712222741:android:b3f895545fce0ad2",
         "android_client_info": {
-          "package_name": "io.flutter.androidalarmmanagerexample"
+          "package_name": "io.flutter.plugins.androidalarmmanagerexample"
         }
       },
       "oauth_client": [
@@ -20,7 +20,7 @@
           "client_id": "1067712222741-qfv81bdrucm5hpnjqp8157jj1bvjjlqn.apps.googleusercontent.com",
           "client_type": 1,
           "android_info": {
-            "package_name": "io.flutter.androidalarmmanagerexample",
+            "package_name": "io.flutter.plugins.androidalarmmanagerexample",
             "certificate_hash": "0f729308cc7f95a84196351d1aa788e1f9b62e9e"
           }
         }

--- a/packages/android_alarm_manager/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/android_alarm_manager/example/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.flutter.androidalarmmanagerexample">
+    package="io.flutter.plugins.androidalarmmanagerexample">
 
     <uses-permission android:name="android.permission.INTERNET"/>
 
@@ -23,7 +23,7 @@
             </intent-filter>
         </activity>
         <service
-            android:name="io.flutter.androidalarmmanager.AlarmService"
+            android:name="io.flutter.plugins.androidalarmmanager.AlarmService"
             android:exported="false"/>
     </application>
 </manifest>

--- a/packages/android_alarm_manager/example/android/app/src/main/java/io/flutter/plugins/androidalarmmanagerexample/Application.java
+++ b/packages/android_alarm_manager/example/android/app/src/main/java/io/flutter/plugins/androidalarmmanagerexample/Application.java
@@ -1,10 +1,10 @@
-package io.flutter.androidalarmmanagerexample;
+package io.flutter.plugins.androidalarmmanagerexample;
 
-import io.flutter.androidalarmmanager.AlarmService;
 import io.flutter.app.FlutterApplication;
 import io.flutter.plugin.common.PluginRegistry;
 import io.flutter.plugin.common.PluginRegistry.PluginRegistrantCallback;
 import io.flutter.plugins.GeneratedPluginRegistrant;
+import io.flutter.plugins.androidalarmmanager.AlarmService;
 
 public class Application extends FlutterApplication implements PluginRegistrantCallback {
   @Override

--- a/packages/android_alarm_manager/example/android/app/src/main/java/io/flutter/plugins/androidalarmmanagerexample/MainActivity.java
+++ b/packages/android_alarm_manager/example/android/app/src/main/java/io/flutter/plugins/androidalarmmanagerexample/MainActivity.java
@@ -1,10 +1,10 @@
-package io.flutter.androidalarmmanagerexample;
+package io.flutter.plugins.androidalarmmanagerexample;
 
 import android.os.Bundle;
 import android.util.Log;
-import io.flutter.androidalarmmanager.AlarmService;
 import io.flutter.app.FlutterActivity;
 import io.flutter.plugins.GeneratedPluginRegistrant;
+import io.flutter.plugins.androidalarmmanager.AlarmService;
 import io.flutter.view.FlutterNativeView;
 
 public class MainActivity extends FlutterActivity {

--- a/packages/android_alarm_manager/pubspec.yaml
+++ b/packages/android_alarm_manager/pubspec.yaml
@@ -1,7 +1,7 @@
 name: android_alarm_manager
 description: Flutter plugin for accessing the Android AlarmManager service, and
   running Dart code in the background when alarms fire.
-version: 0.0.4
+version: 0.0.5
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/android_alarm_manager
 
@@ -11,7 +11,7 @@ dependencies:
 
 flutter:
   plugin:
-    androidPackage: io.flutter.androidalarmmanager
+    androidPackage: io.flutter.plugins.androidalarmmanager
     pluginClass: AndroidAlarmManagerPlugin
     iosPrefix: FLT
 


### PR DESCRIPTION
* Refreshed Android project template to match the one created by new Flutter plugin projects (on master branch)
* Moved Java classes to `io.flutter.plugins` "sub"-package to match other plugins.

@zanderso We probably need to regenerate the `google-services.json` file to reflect new package names. Can I ask you to either do that or provide me the necessary permissions?