### PR TITLE
ImagePicker: Preserve Exif with scaling (only android)

### DIFF
--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /** Location Plugin */
@@ -221,8 +222,8 @@ public class ImagePickerPlugin implements MethodCallHandler, ActivityResultListe
       ExifInterface oldExif = new ExifInterface(filePathOri);
       ExifInterface newExif = new ExifInterface(filePathDest);
 
-      List attributes = Arrays.asList("FNumber", "ExposureTime", "ISOSpeedRatings",
-              "GPSAltitude", "GPSAltitudeRef", "FocalLength", "GPSDateStamp", "WhiteBalance"
+      List<String> attributes = Arrays.asList("FNumber", "ExposureTime", "ISOSpeedRatings",
+              "GPSAltitude", "GPSAltitudeRef", "FocalLength", "GPSDateStamp", "WhiteBalance",
               "GPSProcessingMethod", "GPSTimeStamp", "DateTime", "Flash", "GPSLatitude",
               "GPSLatitudeRef", "GPSLongitude", "GPSLongitudeRef", "Make", "Model", "Orientation"
       );

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -222,10 +222,27 @@ public class ImagePickerPlugin implements MethodCallHandler, ActivityResultListe
       ExifInterface oldExif = new ExifInterface(filePathOri);
       ExifInterface newExif = new ExifInterface(filePathDest);
 
-      List<String> attributes = Arrays.asList("FNumber", "ExposureTime", "ISOSpeedRatings",
-              "GPSAltitude", "GPSAltitudeRef", "FocalLength", "GPSDateStamp", "WhiteBalance",
-              "GPSProcessingMethod", "GPSTimeStamp", "DateTime", "Flash", "GPSLatitude",
-              "GPSLatitudeRef", "GPSLongitude", "GPSLongitudeRef", "Make", "Model", "Orientation"
+      List<String> attributes = 
+        Arrays.asList(
+          "FNumber",
+          "ExposureTime",
+          "ISOSpeedRatings",
+          "GPSAltitude",
+          "GPSAltitudeRef",
+          "FocalLength",
+          "GPSDateStamp",
+          "WhiteBalance",
+          "GPSProcessingMethod",
+          "GPSTimeStamp",
+          "DateTime",
+          "Flash",
+          "GPSLatitude",
+          "GPSLatitudeRef",
+          "GPSLongitude",
+          "GPSLongitudeRef",
+          "Make",
+          "Model",
+          "Orientation"
       );
       for (String attribute : attributes) {
         setIfNotNull(oldExif, newExif, attribute);

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -209,8 +209,7 @@ public class ImagePickerPlugin implements MethodCallHandler, ActivityResultListe
     fileOutput.write(outputStream.toByteArray());
     fileOutput.close();
 
-    if (shouldDownscale)
-      copyExif(image.getPath(), scaledCopyPath);
+    if (shouldDownscale) copyExif(image.getPath(), scaledCopyPath);
 
     return imageFile;
   }
@@ -226,97 +225,72 @@ public class ImagePickerPlugin implements MethodCallHandler, ActivityResultListe
       // From API 11
       if (build >= 11) {
         if (oldexif.getAttribute("FNumber") != null) {
-          newexif.setAttribute("FNumber",
-                  oldexif.getAttribute("FNumber"));
+          newexif.setAttribute("FNumber", oldexif.getAttribute("FNumber"));
         }
         if (oldexif.getAttribute("ExposureTime") != null) {
-          newexif.setAttribute("ExposureTime",
-                  oldexif.getAttribute("ExposureTime"));
+          newexif.setAttribute("ExposureTime", oldexif.getAttribute("ExposureTime"));
         }
         if (oldexif.getAttribute("ISOSpeedRatings") != null) {
-          newexif.setAttribute("ISOSpeedRatings",
-                  oldexif.getAttribute("ISOSpeedRatings"));
+          newexif.setAttribute("ISOSpeedRatings", oldexif.getAttribute("ISOSpeedRatings"));
         }
       }
       // From API 9
       if (build >= 9) {
         if (oldexif.getAttribute("GPSAltitude") != null) {
-          newexif.setAttribute("GPSAltitude",
-                  oldexif.getAttribute("GPSAltitude"));
+          newexif.setAttribute("GPSAltitude", oldexif.getAttribute("GPSAltitude"));
         }
         if (oldexif.getAttribute("GPSAltitudeRef") != null) {
-          newexif.setAttribute("GPSAltitudeRef",
-                  oldexif.getAttribute("GPSAltitudeRef"));
+          newexif.setAttribute("GPSAltitudeRef", oldexif.getAttribute("GPSAltitudeRef"));
         }
       }
       // From API 8
       if (build >= 8) {
         if (oldexif.getAttribute("FocalLength") != null) {
-          newexif.setAttribute("FocalLength",
-                  oldexif.getAttribute("FocalLength"));
+          newexif.setAttribute("FocalLength", oldexif.getAttribute("FocalLength"));
         }
         if (oldexif.getAttribute("GPSDateStamp") != null) {
-          newexif.setAttribute("GPSDateStamp",
-                  oldexif.getAttribute("GPSDateStamp"));
+          newexif.setAttribute("GPSDateStamp", oldexif.getAttribute("GPSDateStamp"));
         }
         if (oldexif.getAttribute("GPSProcessingMethod") != null) {
-          newexif.setAttribute(
-                  "GPSProcessingMethod",
-                  oldexif.getAttribute("GPSProcessingMethod"));
+          newexif.setAttribute("GPSProcessingMethod", oldexif.getAttribute("GPSProcessingMethod"));
         }
         if (oldexif.getAttribute("GPSTimeStamp") != null) {
-          newexif.setAttribute("GPSTimeStamp", ""
-                  + oldexif.getAttribute("GPSTimeStamp"));
+          newexif.setAttribute("GPSTimeStamp", "" + oldexif.getAttribute("GPSTimeStamp"));
         }
       }
       if (oldexif.getAttribute("DateTime") != null) {
-        newexif.setAttribute("DateTime",
-                oldexif.getAttribute("DateTime"));
+        newexif.setAttribute("DateTime", oldexif.getAttribute("DateTime"));
       }
       if (oldexif.getAttribute("Flash") != null) {
-        newexif.setAttribute("Flash",
-                oldexif.getAttribute("Flash"));
+        newexif.setAttribute("Flash", oldexif.getAttribute("Flash"));
       }
       if (oldexif.getAttribute("GPSLatitude") != null) {
-        newexif.setAttribute("GPSLatitude",
-                oldexif.getAttribute("GPSLatitude"));
+        newexif.setAttribute("GPSLatitude", oldexif.getAttribute("GPSLatitude"));
       }
       if (oldexif.getAttribute("GPSLatitudeRef") != null) {
-        newexif.setAttribute("GPSLatitudeRef",
-                oldexif.getAttribute("GPSLatitudeRef"));
+        newexif.setAttribute("GPSLatitudeRef", oldexif.getAttribute("GPSLatitudeRef"));
       }
       if (oldexif.getAttribute("GPSLongitude") != null) {
-        newexif.setAttribute("GPSLongitude",
-                oldexif.getAttribute("GPSLongitude"));
+        newexif.setAttribute("GPSLongitude", oldexif.getAttribute("GPSLongitude"));
       }
       if (oldexif.getAttribute("GPSLatitudeRef") != null) {
-        newexif.setAttribute("GPSLongitudeRef",
-                oldexif.getAttribute("GPSLongitudeRef"));
-      }
-      //Need to update it, with your new height width
-      newexif.setAttribute("ImageLength",
-              "200");
-      newexif.setAttribute("ImageWidth",
-              "200");
-
+        newexif.setAttribute("GPSLongitudeRef", oldexif.getAttribute("GPSLongitudeRef"));
+      }      
       if (oldexif.getAttribute("Make") != null) {
-        newexif.setAttribute("Make",
-                oldexif.getAttribute("Make"));
+        newexif.setAttribute("Make", oldexif.getAttribute("Make"));
       }
       if (oldexif.getAttribute("Model") != null) {
-        newexif.setAttribute("Model",
-                oldexif.getAttribute("Model"));
+        newexif.setAttribute("Model", oldexif.getAttribute("Model"));
       }
       if (oldexif.getAttribute("Orientation") != null) {
-        newexif.setAttribute("Orientation",
-                oldexif.getAttribute("Orientation"));
+        newexif.setAttribute("Orientation", oldexif.getAttribute("Orientation"));
       }
       if (oldexif.getAttribute("WhiteBalance") != null) {
-        newexif.setAttribute("WhiteBalance",
-                oldexif.getAttribute("WhiteBalance"));
+        newexif.setAttribute("WhiteBalance", oldexif.getAttribute("WhiteBalance"));
       }
       newexif.saveAttributes();
 
-    } catch (Exception ex) { }
+    } catch (Exception ex) { 
+    }
   }
 }

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -250,7 +250,7 @@ public class ImagePickerPlugin implements MethodCallHandler, ActivityResultListe
       newExif.saveAttributes();
 
     } catch (Exception ex) {
-      Log.e(TAG, "copying exif " + ex);
+      Log.e(TAG, "Error preserving Exif data on selected image: " + ex);
     }
   }
 

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -223,26 +223,26 @@ public class ImagePickerPlugin implements MethodCallHandler, ActivityResultListe
       ExifInterface newExif = new ExifInterface(filePathDest);
 
       List<String> attributes = 
-        Arrays.asList(
-          "FNumber",
-          "ExposureTime",
-          "ISOSpeedRatings",
-          "GPSAltitude",
-          "GPSAltitudeRef",
-          "FocalLength",
-          "GPSDateStamp",
-          "WhiteBalance",
-          "GPSProcessingMethod",
-          "GPSTimeStamp",
-          "DateTime",
-          "Flash",
-          "GPSLatitude",
-          "GPSLatitudeRef",
-          "GPSLongitude",
-          "GPSLongitudeRef",
-          "Make",
-          "Model",
-          "Orientation");
+          Arrays.asList(
+              "FNumber",
+              "ExposureTime",
+              "ISOSpeedRatings",
+              "GPSAltitude",
+              "GPSAltitudeRef",
+              "FocalLength",
+              "GPSDateStamp",
+              "WhiteBalance",
+              "GPSProcessingMethod",
+              "GPSTimeStamp",
+              "DateTime",
+              "Flash",
+              "GPSLatitude",
+              "GPSLatitudeRef",
+              "GPSLongitude",
+              "GPSLongitudeRef",
+              "Make",
+              "Model",
+              "Orientation");
       for (String attribute : attributes) {
         setIfNotNull(oldExif, newExif, attribute);
       }

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -221,7 +221,6 @@ public class ImagePickerPlugin implements MethodCallHandler, ActivityResultListe
 
       int build = Build.VERSION.SDK_INT;
 
-
       // From API 11
       if (build >= 11) {
         if (oldexif.getAttribute("FNumber") != null) {

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -8,6 +8,8 @@ import android.app.Activity;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.media.ExifInterface;
+import android.os.Build;
 import com.esafirm.imagepicker.features.ImagePicker;
 import com.esafirm.imagepicker.features.camera.DefaultCameraModule;
 import com.esafirm.imagepicker.features.camera.OnImageReadyListener;
@@ -207,6 +209,114 @@ public class ImagePickerPlugin implements MethodCallHandler, ActivityResultListe
     fileOutput.write(outputStream.toByteArray());
     fileOutput.close();
 
+    if (shouldDownscale)
+      copyExif(image.getPath(), scaledCopyPath);
+
     return imageFile;
+  }
+
+  private void copyExif(String filePathOri, String filePathDest) {
+    try {
+      ExifInterface oldexif = new ExifInterface(filePathOri);
+      ExifInterface newexif = new ExifInterface(filePathDest);
+
+      int build = Build.VERSION.SDK_INT;
+
+
+      // From API 11
+      if (build >= 11) {
+        if (oldexif.getAttribute("FNumber") != null) {
+          newexif.setAttribute("FNumber",
+                  oldexif.getAttribute("FNumber"));
+        }
+        if (oldexif.getAttribute("ExposureTime") != null) {
+          newexif.setAttribute("ExposureTime",
+                  oldexif.getAttribute("ExposureTime"));
+        }
+        if (oldexif.getAttribute("ISOSpeedRatings") != null) {
+          newexif.setAttribute("ISOSpeedRatings",
+                  oldexif.getAttribute("ISOSpeedRatings"));
+        }
+      }
+      // From API 9
+      if (build >= 9) {
+        if (oldexif.getAttribute("GPSAltitude") != null) {
+          newexif.setAttribute("GPSAltitude",
+                  oldexif.getAttribute("GPSAltitude"));
+        }
+        if (oldexif.getAttribute("GPSAltitudeRef") != null) {
+          newexif.setAttribute("GPSAltitudeRef",
+                  oldexif.getAttribute("GPSAltitudeRef"));
+        }
+      }
+      // From API 8
+      if (build >= 8) {
+        if (oldexif.getAttribute("FocalLength") != null) {
+          newexif.setAttribute("FocalLength",
+                  oldexif.getAttribute("FocalLength"));
+        }
+        if (oldexif.getAttribute("GPSDateStamp") != null) {
+          newexif.setAttribute("GPSDateStamp",
+                  oldexif.getAttribute("GPSDateStamp"));
+        }
+        if (oldexif.getAttribute("GPSProcessingMethod") != null) {
+          newexif.setAttribute(
+                  "GPSProcessingMethod",
+                  oldexif.getAttribute("GPSProcessingMethod"));
+        }
+        if (oldexif.getAttribute("GPSTimeStamp") != null) {
+          newexif.setAttribute("GPSTimeStamp", ""
+                  + oldexif.getAttribute("GPSTimeStamp"));
+        }
+      }
+      if (oldexif.getAttribute("DateTime") != null) {
+        newexif.setAttribute("DateTime",
+                oldexif.getAttribute("DateTime"));
+      }
+      if (oldexif.getAttribute("Flash") != null) {
+        newexif.setAttribute("Flash",
+                oldexif.getAttribute("Flash"));
+      }
+      if (oldexif.getAttribute("GPSLatitude") != null) {
+        newexif.setAttribute("GPSLatitude",
+                oldexif.getAttribute("GPSLatitude"));
+      }
+      if (oldexif.getAttribute("GPSLatitudeRef") != null) {
+        newexif.setAttribute("GPSLatitudeRef",
+                oldexif.getAttribute("GPSLatitudeRef"));
+      }
+      if (oldexif.getAttribute("GPSLongitude") != null) {
+        newexif.setAttribute("GPSLongitude",
+                oldexif.getAttribute("GPSLongitude"));
+      }
+      if (oldexif.getAttribute("GPSLatitudeRef") != null) {
+        newexif.setAttribute("GPSLongitudeRef",
+                oldexif.getAttribute("GPSLongitudeRef"));
+      }
+      //Need to update it, with your new height width
+      newexif.setAttribute("ImageLength",
+              "200");
+      newexif.setAttribute("ImageWidth",
+              "200");
+
+      if (oldexif.getAttribute("Make") != null) {
+        newexif.setAttribute("Make",
+                oldexif.getAttribute("Make"));
+      }
+      if (oldexif.getAttribute("Model") != null) {
+        newexif.setAttribute("Model",
+                oldexif.getAttribute("Model"));
+      }
+      if (oldexif.getAttribute("Orientation") != null) {
+        newexif.setAttribute("Orientation",
+                oldexif.getAttribute("Orientation"));
+      }
+      if (oldexif.getAttribute("WhiteBalance") != null) {
+        newexif.setAttribute("WhiteBalance",
+                oldexif.getAttribute("WhiteBalance"));
+      }
+      newexif.saveAttributes();
+
+    } catch (Exception ex) { }
   }
 }

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -242,8 +242,7 @@ public class ImagePickerPlugin implements MethodCallHandler, ActivityResultListe
           "GPSLongitudeRef",
           "Make",
           "Model",
-          "Orientation"
-      );
+          "Orientation");
       for (String attribute : attributes) {
         setIfNotNull(oldExif, newExif, attribute);
       }

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -222,7 +222,7 @@ public class ImagePickerPlugin implements MethodCallHandler, ActivityResultListe
       ExifInterface oldExif = new ExifInterface(filePathOri);
       ExifInterface newExif = new ExifInterface(filePathDest);
 
-      List<String> attributes = 
+      List<String> attributes =
           Arrays.asList(
               "FNumber",
               "ExposureTime",

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -9,7 +9,7 @@ import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.media.ExifInterface;
-import android.os.Build;
+import android.util.Log;
 import com.esafirm.imagepicker.features.ImagePicker;
 import com.esafirm.imagepicker.features.camera.DefaultCameraModule;
 import com.esafirm.imagepicker.features.camera.OnImageReadyListener;
@@ -29,7 +29,7 @@ import java.util.List;
 
 /** Location Plugin */
 public class ImagePickerPlugin implements MethodCallHandler, ActivityResultListener {
-  private static String TAG = "flutter";
+  private static String TAG = "ImagePicker";
   private static final String CHANNEL = "image_picker";
 
   public static final int REQUEST_CODE_PICK = 2342;
@@ -209,87 +209,37 @@ public class ImagePickerPlugin implements MethodCallHandler, ActivityResultListe
     fileOutput.write(outputStream.toByteArray());
     fileOutput.close();
 
-    if (shouldDownscale) copyExif(image.getPath(), scaledCopyPath);
+    if (shouldDownscale) {
+      copyExif(image.getPath(), scaledCopyPath);
+    }
 
     return imageFile;
   }
 
   private void copyExif(String filePathOri, String filePathDest) {
     try {
-      ExifInterface oldexif = new ExifInterface(filePathOri);
-      ExifInterface newexif = new ExifInterface(filePathDest);
+      ExifInterface oldExif = new ExifInterface(filePathOri);
+      ExifInterface newExif = new ExifInterface(filePathDest);
 
-      int build = Build.VERSION.SDK_INT;
+      List attributes = Arrays.asList("FNumber", "ExposureTime", "ISOSpeedRatings",
+              "GPSAltitude", "GPSAltitudeRef", "FocalLength", "GPSDateStamp", "WhiteBalance"
+              "GPSProcessingMethod", "GPSTimeStamp", "DateTime", "Flash", "GPSLatitude",
+              "GPSLatitudeRef", "GPSLongitude", "GPSLongitudeRef", "Make", "Model", "Orientation"
+      );
+      for (String attribute : attributes) {
+        setIfNotNull(oldExif, newExif, attribute);
+      }
 
-      // From API 11
-      if (build >= 11) {
-        if (oldexif.getAttribute("FNumber") != null) {
-          newexif.setAttribute("FNumber", oldexif.getAttribute("FNumber"));
-        }
-        if (oldexif.getAttribute("ExposureTime") != null) {
-          newexif.setAttribute("ExposureTime", oldexif.getAttribute("ExposureTime"));
-        }
-        if (oldexif.getAttribute("ISOSpeedRatings") != null) {
-          newexif.setAttribute("ISOSpeedRatings", oldexif.getAttribute("ISOSpeedRatings"));
-        }
-      }
-      // From API 9
-      if (build >= 9) {
-        if (oldexif.getAttribute("GPSAltitude") != null) {
-          newexif.setAttribute("GPSAltitude", oldexif.getAttribute("GPSAltitude"));
-        }
-        if (oldexif.getAttribute("GPSAltitudeRef") != null) {
-          newexif.setAttribute("GPSAltitudeRef", oldexif.getAttribute("GPSAltitudeRef"));
-        }
-      }
-      // From API 8
-      if (build >= 8) {
-        if (oldexif.getAttribute("FocalLength") != null) {
-          newexif.setAttribute("FocalLength", oldexif.getAttribute("FocalLength"));
-        }
-        if (oldexif.getAttribute("GPSDateStamp") != null) {
-          newexif.setAttribute("GPSDateStamp", oldexif.getAttribute("GPSDateStamp"));
-        }
-        if (oldexif.getAttribute("GPSProcessingMethod") != null) {
-          newexif.setAttribute("GPSProcessingMethod", oldexif.getAttribute("GPSProcessingMethod"));
-        }
-        if (oldexif.getAttribute("GPSTimeStamp") != null) {
-          newexif.setAttribute("GPSTimeStamp", "" + oldexif.getAttribute("GPSTimeStamp"));
-        }
-      }
-      if (oldexif.getAttribute("DateTime") != null) {
-        newexif.setAttribute("DateTime", oldexif.getAttribute("DateTime"));
-      }
-      if (oldexif.getAttribute("Flash") != null) {
-        newexif.setAttribute("Flash", oldexif.getAttribute("Flash"));
-      }
-      if (oldexif.getAttribute("GPSLatitude") != null) {
-        newexif.setAttribute("GPSLatitude", oldexif.getAttribute("GPSLatitude"));
-      }
-      if (oldexif.getAttribute("GPSLatitudeRef") != null) {
-        newexif.setAttribute("GPSLatitudeRef", oldexif.getAttribute("GPSLatitudeRef"));
-      }
-      if (oldexif.getAttribute("GPSLongitude") != null) {
-        newexif.setAttribute("GPSLongitude", oldexif.getAttribute("GPSLongitude"));
-      }
-      if (oldexif.getAttribute("GPSLongitudeRef") != null) {
-        newexif.setAttribute("GPSLongitudeRef", oldexif.getAttribute("GPSLongitudeRef"));
-      }
-      if (oldexif.getAttribute("Make") != null) {
-        newexif.setAttribute("Make", oldexif.getAttribute("Make"));
-      }
-      if (oldexif.getAttribute("Model") != null) {
-        newexif.setAttribute("Model", oldexif.getAttribute("Model"));
-      }
-      if (oldexif.getAttribute("Orientation") != null) {
-        newexif.setAttribute("Orientation", oldexif.getAttribute("Orientation"));
-      }
-      if (oldexif.getAttribute("WhiteBalance") != null) {
-        newexif.setAttribute("WhiteBalance", oldexif.getAttribute("WhiteBalance"));
-      }
-      newexif.saveAttributes();
+      newExif.saveAttributes();
 
     } catch (Exception ex) {
+      Log.e(TAG, "copying exif " + ex);
+    }
+  }
+
+  private void setIfNotNull(ExifInterface oldExif, ExifInterface newExif, String property) {
+    if (oldExif.getAttribute(property) != null) {
+      newExif.setAttribute(property, oldExif.getAttribute(property));
     }
   }
 }

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -273,9 +273,9 @@ public class ImagePickerPlugin implements MethodCallHandler, ActivityResultListe
       if (oldexif.getAttribute("GPSLongitude") != null) {
         newexif.setAttribute("GPSLongitude", oldexif.getAttribute("GPSLongitude"));
       }
-      if (oldexif.getAttribute("GPSLatitudeRef") != null) {
+      if (oldexif.getAttribute("GPSLongitudeRef") != null) {
         newexif.setAttribute("GPSLongitudeRef", oldexif.getAttribute("GPSLongitudeRef"));
-      }      
+      }
       if (oldexif.getAttribute("Make") != null) {
         newexif.setAttribute("Make", oldexif.getAttribute("Make"));
       }
@@ -290,7 +290,7 @@ public class ImagePickerPlugin implements MethodCallHandler, ActivityResultListe
       }
       newexif.saveAttributes();
 
-    } catch (Exception ex) { 
+    } catch (Exception ex) {
     }
   }
 }


### PR DESCRIPTION
If the image is scaled, the exif params will copied after the resize.
Sorry but it's only for android

