### PR TITLE
Added password reset function to Firebase Auth object

### DIFF
--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.4
+
+* Added support for sendPasswordResetEmail
+
 ## 0.4.3
 
 * Moved to the io.flutter.plugins organization.

--- a/packages/firebase_auth/android/src/main/java/io/flutter/plugins/firebaseauth/FirebaseAuthPlugin.java
+++ b/packages/firebase_auth/android/src/main/java/io/flutter/plugins/firebaseauth/FirebaseAuthPlugin.java
@@ -58,6 +58,9 @@ public class FirebaseAuthPlugin implements MethodCallHandler {
       case "createUserWithEmailAndPassword":
         handleCreateUserWithEmailAndPassword(call, result);
         break;
+      case "sendPasswordResetEmail":
+        handleSendPasswordResetEmail(call, result);
+        break;
       case "signInWithEmailAndPassword":
         handleSignInWithEmailAndPassword(call, result);
         break;
@@ -138,6 +141,16 @@ public class FirebaseAuthPlugin implements MethodCallHandler {
     firebaseAuth
         .createUserWithEmailAndPassword(email, password)
         .addOnCompleteListener(new SignInCompleteListener(result));
+  }
+
+  private void handleSendPasswordResetEmail(MethodCall call, final Result result) {
+    @SuppressWarnings("unchecked")
+    Map<String, String> arguments = (Map<String, String>) call.arguments;
+    String email = arguments.get("email");
+
+    firebaseAuth
+        .sendPasswordResetEmail(email)
+        .addOnCompleteListener(new TaskVoidCompleteListener(result));
   }
 
   private void handleSignInWithEmailAndPassword(MethodCall call, final Result result) {
@@ -301,6 +314,24 @@ public class FirebaseAuthPlugin implements MethodCallHandler {
         FirebaseUser user = task.getResult().getUser();
         ImmutableMap<String, Object> userMap = mapFromUser(user);
         result.success(userMap);
+      }
+    }
+  }
+
+  private class TaskVoidCompleteListener implements OnCompleteListener<Void> {
+    private final Result result;
+
+    TaskVoidCompleteListener(Result result) {
+      this.result = result;
+    }
+
+    @Override
+    public void onComplete(@NonNull Task<Void> task) {
+      if (!task.isSuccessful()) {
+        Exception e = task.getException();
+        result.error(ERROR_REASON_EXCEPTION, e.getMessage(), null);
+      } else {
+        result.success(null);
       }
     }
   }

--- a/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
+++ b/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
@@ -93,6 +93,12 @@ int nextHandle = 0;
                              completion:^(FIRUser *user, NSError *error) {
                                [self sendResult:result forUser:user error:error];
                              }];
+  } else if ([@"sendPasswordResetEmail" isEqualToString:call.method]) {
+    NSString *email = call.arguments[@"email"];
+    [[FIRAuth auth] sendPasswordResetWithEmail:email
+                                    completion:^(NSError *error) {
+                                      [self sendResult:result forUser:nil error:error];
+                                    }];
   } else if ([@"signInWithEmailAndPassword" isEqualToString:call.method]) {
     NSString *email = call.arguments[@"email"];
     NSString *password = call.arguments[@"password"];

--- a/packages/firebase_auth/lib/firebase_auth.dart
+++ b/packages/firebase_auth/lib/firebase_auth.dart
@@ -156,6 +156,18 @@ class FirebaseAuth {
     return currentUser;
   }
 
+  Future<Null> sendPasswordResetEmail({
+    @required String email,
+  }) async {
+    assert(email != null);
+    return await channel.invokeMethod(
+      'sendPasswordResetEmail',
+      <String, String>{
+        'email': email,
+      },
+    );
+  }
+
   Future<FirebaseUser> signInWithEmailAndPassword({
     @required String email,
     @required String password,

--- a/packages/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Firebase Auth, enabling Android and iOS
   and Twitter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_auth
-version: 0.4.3
+version: 0.4.4
 
 flutter:
   plugin:

--- a/packages/firebase_auth/test/firebase_auth_test.dart
+++ b/packages/firebase_auth/test/firebase_auth_test.dart
@@ -36,6 +36,7 @@ void main() {
           case "startListeningAuthState":
             return mockHandleId++;
             break;
+          case "sendPasswordResetEmail":
           case "updateProfile":
             return null;
             break;
@@ -202,6 +203,23 @@ void main() {
             arguments: <String, String>{
               'email': kMockEmail,
               'password': kMockPassword,
+            },
+          ),
+        ],
+      );
+    });
+
+    test('sendPasswordResetEmail', () async {
+      await auth.sendPasswordResetEmail(
+        email: kMockEmail,
+      );
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall(
+            'sendPasswordResetEmail',
+            arguments: <String, String>{
+              'email': kMockEmail,
             },
           ),
         ],


### PR DESCRIPTION
Small addition to include the Firebase Auth password reset feature, both Android and iOS supported. Basic usage is:

```
await FirebaseAuth.instance.sendPasswordResetEmail(
  email: emailAddress,
);
```

This follows the same pattern as other methods in the relevant source files. Throws a platform exception on error (invalid email, no user exists, etc).