### PR TITLE
Make video plugin ready for republication

### DIFF
--- a/packages/video_player/CHANGELOG.md
+++ b/packages/video_player/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.2.1
 
 * Fixed some signatures to account for strong mode runtime errors.
+* Fixed spelling mistake in toString output.
 
 ## 0.2.0
 

--- a/packages/video_player/lib/video_player.dart
+++ b/packages/video_player/lib/video_player.dart
@@ -162,22 +162,26 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
 
     void eventListener(dynamic event) {
       final Map<dynamic, dynamic> map = event;
-      if (map['event'] == 'initialized') {
-        value = value.copyWith(
-          duration: new Duration(milliseconds: map['duration']),
-          size: new Size(map['width'].toDouble(), map['height'].toDouble()),
-        );
-        _applyLooping();
-        _applyVolume();
-        _applyPlayPause();
-      } else if (map['event'] == 'completed') {
-        value = value.copyWith(isPlaying: false);
-        timer?.cancel();
-      } else if (map['event'] == 'bufferingUpdate') {
-        final List<dynamic> values = map['values'];
-        value = value.copyWith(
-          buffered: values.map<DurationRange>(toDurationRange).toList(),
-        );
+      switch (map['event']) {
+        case 'initialized':
+          value = value.copyWith(
+            duration: new Duration(milliseconds: map['duration']),
+            size: new Size(map['width'].toDouble(), map['height'].toDouble()),
+          );
+          _applyLooping();
+          _applyVolume();
+          _applyPlayPause();
+          break;
+        case 'completed':
+          value = value.copyWith(isPlaying: false);
+          timer?.cancel();
+          break;
+        case 'bufferingUpdate':
+          final List<dynamic> values = map['values'];
+          value = value.copyWith(
+            buffered: values.map<DurationRange>(toDurationRange).toList(),
+          );
+          break;
       }
     }
 

--- a/packages/video_player/lib/video_player.dart
+++ b/packages/video_player/lib/video_player.dart
@@ -11,7 +11,7 @@ import 'package:meta/meta.dart';
 final MethodChannel _channel = const MethodChannel('flutter.io/videoPlayer')
   // This will clear all open videos on the platform when a full restart is
   // performed.
-  ..invokeMethod("init");
+  ..invokeMethod('init');
 
 class DurationRange {
   DurationRange(this.start, this.end);
@@ -113,7 +113,7 @@ class VideoPlayerValue {
         'size: $size, '
         'position: $position, '
         'buffered: [${buffered.join(', ')}], '
-        'isplaying: $isPlaying, '
+        'isPlaying: $isPlaying, '
         'isLooping: $isLooping, '
         'volume: $volume, '
         'errorDescription: $errorDescription)';
@@ -149,34 +149,34 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
       'create',
       <String, dynamic>{'dataSource': uri},
     );
-    _textureId = response["textureId"];
+    _textureId = response['textureId'];
     _creatingCompleter.complete(null);
 
-    DurationRange toDurationRange(List<dynamic> values) {
+    DurationRange toDurationRange(dynamic value) {
+      final List<dynamic> pair = value;
       return new DurationRange(
-        new Duration(milliseconds: values[0]),
-        new Duration(milliseconds: values[1]),
+        new Duration(milliseconds: pair[0]),
+        new Duration(milliseconds: pair[1]),
       );
     }
 
     void eventListener(dynamic event) {
       final Map<dynamic, dynamic> map = event;
-      if (map["event"] == "initialized") {
+      if (map['event'] == 'initialized') {
         value = value.copyWith(
-          duration: new Duration(milliseconds: map["duration"]),
-          size: new Size(map["width"].toDouble(), map["height"].toDouble()),
+          duration: new Duration(milliseconds: map['duration']),
+          size: new Size(map['width'].toDouble(), map['height'].toDouble()),
         );
         _applyLooping();
         _applyVolume();
         _applyPlayPause();
-      } else if (map["event"] == "completed") {
+      } else if (map['event'] == 'completed') {
         value = value.copyWith(isPlaying: false);
         timer?.cancel();
-      } else if (map["event"] == "bufferingUpdate") {
-        final List<List<dynamic>> bufferedValues =
-            map["values"].cast<List<List<dynamic>>>();
+      } else if (map['event'] == 'bufferingUpdate') {
+        final List<dynamic> values = map['values'];
         value = value.copyWith(
-          buffered: bufferedValues.map<DurationRange>(toDurationRange).toList(),
+          buffered: values.map<DurationRange>(toDurationRange).toList(),
         );
       }
     }
@@ -193,7 +193,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   }
 
   EventChannel _eventChannelFor(int textureId) {
-    return new EventChannel("flutter.io/videoPlayer/videoEvents$textureId");
+    return new EventChannel('flutter.io/videoPlayer/videoEvents$textureId');
   }
 
   @override

--- a/packages/video_player/pubspec.yaml
+++ b/packages/video_player/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player
 description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
-version: 0.2.0
+version: 0.2.1
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player
 
 flutter:


### PR DESCRIPTION
Removed use of `List.cast` to avoid an awkward Dart SDK constraint.
Bit of code cleanup.
Bump version for republication.