### PR TITLE
Configure Flutter CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 container:
-  image: cirrusci/flutter:0.1.1
+  image: cirrusci/flutter:latest
 
 task:
   upgrade_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,20 @@
+container:
+  image: cirrusci/flutter:0.0.24
+
+task:
+  pub_cache:
+    folder: ~/.pub-cache
+  activate_script: pub global activate flutter_plugin_tools
+  matrix:
+    - name: test+format
+      install_script:
+        - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+        - sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-5.0 main"
+        - sudo apt-get update
+        - sudo apt-get install -y --allow-unauthenticated clang-format-5.0
+      format_script: ./script/plugin_tools.sh format --travis --clang-format=clang-format-5.0
+      test_script: ./script/plugin_tools.sh test
+    - name: analyze
+      script: ./script/plugin_tools.sh analyze
+    - name: build-apks
+      script: ./script/plugin_tools.sh build-examples --apk

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 container:
-  image: cirrusci/flutter:0.0.24
+  image: cirrusci/flutter:0.1.0
 
 task:
   pub_cache:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,9 +1,12 @@
 container:
-  image: cirrusci/flutter:0.1.0
+  image: cirrusci/flutter:0.1.1
 
 task:
   pub_cache:
     folder: ~/.pub-cache
+  upgrade_script:
+    - flutter channel master
+    - flutter upgrade
   activate_script: pub global activate flutter_plugin_tools
   matrix:
     - name: test+format

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,8 +2,6 @@ container:
   image: cirrusci/flutter:0.1.1
 
 task:
-  pub_cache:
-    folder: ~/.pub-cache
   upgrade_script:
     - flutter channel master
     - flutter upgrade

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,9 +2,6 @@ container:
   image: cirrusci/flutter:latest
 
 task:
-  upgrade_script:
-    - flutter channel master
-    - flutter upgrade
   activate_script: pub global activate flutter_plugin_tools
   matrix:
     - name: test+format


### PR DESCRIPTION
Cirrus CI recently added Flutter support by providing [Docker images with Flutter pre-installed](https://hub.docker.com/r/cirrusci/flutter/). It allows to avoid boilerplate of setting up an environment which makes it possible to start tests execution in a few hundred milliseconds from the moment a change is pushed to GitHub.

For this repository particularly I've seen CI times from 12 to 15 minutes for the longest part of the build (building apks). It's 2 to 3 times faster comparing to the current CI setup. 

Unfortunately `flutter_plugin_tools` can't run things in parallel and take advantage of up to 8 cores that Cirrus CI can provide.

Here is [a build for that particular change](https://cirrus-ci.com/build/5640120652791808):

![image](https://user-images.githubusercontent.com/989066/36113668-903d851c-0ffb-11e8-8811-4da945154ac6.png)

I was testing Flutter support on this repository and decided to share the results. Feel free to close the PR if not interested in a better CI. Didn't want to waste my work 😅

In case you will merge the PR. Don't forget to [install Cirrus CI application from Github Marketplace](https://github.com/apps/cirrus-ci) as described in [Quick Start guide](https://cirrus-ci.org/guide/quick-start/). 
