### PR TITLE
Remove `-dev.infinity` from environment dart sdk

### DIFF
--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -22,4 +22,4 @@ dev_dependencies:
     sdk: flutter
 
 environment:
-    sdk: ">=1.8.0 <2.0.0-dev.infinity"
+    sdk: ">=1.8.0 <2.0.0"


### PR DESCRIPTION
use `sdk: ">=1.8.0 <2.0.0"` instead of `sdk: ">=1.8.0 <2.0.0-dev.infinity"`
Use similar format like here:
https://github.com/flutter/plugins/blame/master/packages/firebase_database/pubspec.yaml#L25
Currently i'm getting error:
```Package cloud_firestore requires SDK version >=1.8.0 <2.0.0-dev.infinity but the current SDK is 2.0.0-edge.223eeb2ebe112aaaddca206aab55cd54b4e54391.```
When using `cloud_firestore: "any"`
on
```bash
Flutter 0.1.2-pre.11 • channel master • https://github.com/flutter/flutter.git
Framework • revision 8754e4f90f (59 minutes ago) • 2018-02-14 11:48:42 -0800
Engine • revision 7a6d12fabc
Tools • Dart 2.0.0-edge.3c4dccbd46f152be9e1b6ca95c57357e8e48057c
```