### PR TITLE
Fix few Dart 2 issues in the Flutter plugins.

### DIFF
--- a/packages/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.3
+
+* Fixed Dart 2 issues.
+
 ## 0.3.2
 
 * Added an getter that can retrieve values of any type

--- a/packages/shared_preferences/lib/shared_preferences.dart
+++ b/packages/shared_preferences/lib/shared_preferences.dart
@@ -22,7 +22,7 @@ class SharedPreferences {
   static SharedPreferences _instance;
   static Future<SharedPreferences> getInstance() async {
     if (_instance == null) {
-      final Map<String, Object> fromSystem =
+      final Map<Object, Object> fromSystem =
           await _kChannel.invokeMethod('getAll');
       assert(fromSystem != null);
       // Strip the flutter. prefix from the returned preferences.
@@ -67,7 +67,14 @@ class SharedPreferences {
 
   /// Reads a set of string values from persistent storage, throwing an
   /// exception if it's not a string set.
-  List<String> getStringList(String key) => _preferenceCache[key];
+  List<String> getStringList(String key) {
+    List<Object> list = _preferenceCache[key];
+    if (list != null && list is! List<String>) {
+      list = list.cast<String>().toList();
+      _preferenceCache[key] = list;
+    }
+    return list;
+  }
 
   /// Saves a boolean [value] to persistent storage in the background.
   ///

--- a/packages/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/pubspec.yaml
@@ -1,7 +1,7 @@
 name: shared_preferences
 description: Flutter plugin for reading and writing simple key-value pairs.
   Wraps NSUserDefaults on iOS and SharedPreferences on Android.
-version: 0.3.2
+version: 0.3.3
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/shared_preferences
 

--- a/packages/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.2
+
+* Fixed Dart 2 issue: `launch` now returns `Future<void>` instead of
+  `Future<Null>`.
+
 ## 2.0.1
 
 * Simplified and upgraded Android project template to Android SDK 27.

--- a/packages/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/lib/url_launcher.dart
@@ -30,7 +30,7 @@ const MethodChannel _channel =
 ///
 /// Note that if any of the above are set to true but the URL is not a web URL,
 /// this will throw a [PlatformException].
-Future<Null> launch(
+Future<void> launch(
   String urlString, {
   bool forceSafariVC,
   bool forceWebView,

--- a/packages/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/pubspec.yaml
@@ -1,7 +1,7 @@
 name: url_launcher
 description: Flutter plugin for launching a URL on Android and iOS. Supports
   web, phone, SMS, and email schemes.
-version: 2.0.1
+version: 2.0.2
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher
 


### PR DESCRIPTION
* Channels don't preserve type arguments, so we need
to either use containers with dynamic element types
or explicitly cast containers;
* In url_launcher: invokeMethod returns Future<dynamic>
rather than Future<Null>. Use Future<void> instead of
Future<Null>.

Fixes https://github.com/flutter/flutter/issues/14921