### PR TITLE
Firestore: Allow null document snapshot data when document does not exist

### DIFF
--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.12
+
+* Fix handling of `null` document snapshots (document not exists).
+* Add `DocumentSnapshot.exists`.
+
 ## 0.2.11
 * Fix Dart 2 type errors.
 

--- a/packages/cloud_firestore/lib/src/document_snapshot.dart
+++ b/packages/cloud_firestore/lib/src/document_snapshot.dart
@@ -26,9 +26,13 @@ class DocumentSnapshot {
 
   /// Returns the ID of the snapshot's document
   String get documentID => _path.split('/').last;
+
+  /// Returns `true` if the document exists.
+  bool get exists => data != null;
 }
 
 Map<String, dynamic> _asStringKeyedMap(Map<dynamic, dynamic> map) {
+  if (map == null) return null;
   if (map is Map<String, dynamic>) {
     return map;
   } else {

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_firestore
-version: 0.2.11
+version: 0.2.12
 
 flutter:
   plugin:

--- a/packages/cloud_firestore/test/cloud_firestore_test.dart
+++ b/packages/cloud_firestore/test/cloud_firestore_test.dart
@@ -84,6 +84,8 @@ void main() {
                 'path': 'foo/bar',
                 'data': <String, dynamic>{'key1': 'val1'}
               };
+            } else if (methodCall.arguments['path'] == 'foo/notExists') {
+              return <String, dynamic>{'path': 'foo/notExists', 'data': null};
             }
             throw new PlatformException(code: 'UNKNOWN_PATH');
           case 'Firestore#runTransaction':
@@ -407,6 +409,12 @@ void main() {
         expect(snapshot.reference.path, equals('foo/bar'));
         expect(snapshot.data.containsKey('key1'), equals(true));
         expect(snapshot.data['key1'], equals('val1'));
+        expect(snapshot.exists, isTrue);
+
+        final DocumentSnapshot snapshot2 =
+            await collectionReference.document('notExists').get();
+        expect(snapshot2.data, isNull);
+        expect(snapshot2.exists, isFalse);
 
         try {
           await collectionReference.document('baz').get();


### PR DESCRIPTION
Fixes following exception when getting document snapshot when the document does not exist yet:

```
NoSuchMethodError: The method 'forEach' was called on null.
  Receiver: null
  Tried calling: forEach(Closure: (dynamic, dynamic) => dynamic)
  dart:collection                                            new LinkedHashMap.from
  package:cloud_firestore/src/document_snapshot.dart 36:16   _asStringKeyedMap
  package:cloud_firestore/src/document_reference.dart 58:7   DocumentReference.get
```

I also added `DocumentSnapshot.exists` to match implementations in other languages (Java/Node.js/ObjC).