### PR TITLE
Fix url_launcher for iOS <10

### DIFF
--- a/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
+++ b/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
@@ -92,18 +92,30 @@
 - (void)launchURL:(NSString *)urlString result:(FlutterResult)result {
   NSURL *url = [NSURL URLWithString:urlString];
   UIApplication *application = [UIApplication sharedApplication];
-  [application openURL:url
-      options:@{}
-      completionHandler:^(BOOL success) {
-        if (success) {
-          result(nil);
-        } else {
-          result([FlutterError
-              errorWithCode:@"Error"
-                    message:[NSString stringWithFormat:@"Error while launching %@", url]
-                    details:nil]);
-        }
-      }];
+  if ([application respondsToSelector:@selector(openURL:options:completionHandler:)]) {
+    [application openURL:url
+        options:@{}
+        completionHandler:^(BOOL success) {
+          if (success) {
+            result(nil);
+          } else {
+            result([FlutterError
+                errorWithCode:@"Error"
+                      message:[NSString stringWithFormat:@"Error while launching %@", url]
+                      details:nil]);
+          }
+        }];
+  } else {
+    BOOL success = [application openURL:url];
+    if (success) {
+      result(nil);
+    } else {
+      result([FlutterError
+          errorWithCode:@"Error"
+                message:[NSString stringWithFormat:@"Error while launching %@", url]
+                details:nil]);
+    }
+  }
 }
 
 - (void)launchURLInVC:(NSString *)urlString result:(FlutterResult)result {


### PR DESCRIPTION
For older phones pre iOS 10 you get the following exception 
'unrecognized selector sent to instance'

This kills the App completely. I fixed this with this patch.

To replicate, just attempt to open a url on any old device / simulator.

Cheers,
Rob