### PR TITLE
Always use the latest Flutter available

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,6 +2,9 @@ container:
   image: cirrusci/flutter:latest
 
 task:
+  upgrade_script:
+    - flutter channel master
+    - flutter upgrade
   activate_script: pub global activate flutter_plugin_tools
   matrix:
     - name: test+format


### PR DESCRIPTION
Right now `cirrusci/flutter:latest` tag points to the latest released version of Flutter. For example, `0.2.0` right now. To make sure we always test agains the latest Flutter available I've added a script to always run `flutter upgrade`.

Another possibility will be to incorporate [Cirrus CI's Container Builder](https://medium.com/cirruslabs/introducing-container-builder-for-cirrus-ci-80b9234f007) into https://github.com/flutter/flutter so successful master builds will publish a Docker container.

to: @Hixie @yjbanov 