### PR TITLE
Fixed deprecation warnings

### DIFF
--- a/packages/cloud_firestore/test/cloud_firestore_test.dart
+++ b/packages/cloud_firestore/test/cloud_firestore_test.dart
@@ -193,7 +193,7 @@ void main() {
         expect(document.reference.path, equals('foo/0'));
         expect(document.data, equals(kMockDocumentSnapshotData));
         // Flush the async removeListener call
-        await new Future<Null>.delayed(Duration.ZERO);
+        await new Future<Null>.delayed(Duration.zero);
         expect(log, <Matcher>[
           isMethodCall(
             'Query#addSnapshotListener',
@@ -218,7 +218,7 @@ void main() {
                 .snapshots
                 .listen((QuerySnapshot querySnapshot) {});
         subscription.cancel();
-        await new Future<Null>.delayed(Duration.ZERO);
+        await new Future<Null>.delayed(Duration.zero);
         expect(
           log,
           equals(<Matcher>[
@@ -248,7 +248,7 @@ void main() {
                 .snapshots
                 .listen((QuerySnapshot querySnapshot) {});
         subscription.cancel();
-        await new Future<Null>.delayed(Duration.ZERO);
+        await new Future<Null>.delayed(Duration.zero);
         expect(
           log,
           equals(<Matcher>[
@@ -278,7 +278,7 @@ void main() {
                 .snapshots
                 .listen((QuerySnapshot querySnapshot) {});
         subscription.cancel();
-        await new Future<Null>.delayed(Duration.ZERO);
+        await new Future<Null>.delayed(Duration.zero);
         expect(
           log,
           equals(<Matcher>[
@@ -311,7 +311,7 @@ void main() {
         expect(snapshot.reference.path, equals('path/to/foo'));
         expect(snapshot.data, equals(kMockDocumentSnapshotData));
         // Flush the async removeListener call
-        await new Future<Null>.delayed(Duration.ZERO);
+        await new Future<Null>.delayed(Duration.zero);
         expect(
           log,
           <Matcher>[

--- a/packages/google_sign_in/example/lib/main.dart
+++ b/packages/google_sign_in/example/lib/main.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert' show JSON;
+import 'dart:convert' show json;
 
 import "package:http/http.dart" as http;
 import 'package:flutter/material.dart';
@@ -65,7 +65,7 @@ class SignInDemoState extends State<SignInDemo> {
       print('People API ${response.statusCode} response: ${response.body}');
       return;
     }
-    final Map<String, dynamic> data = JSON.decode(response.body);
+    final Map<String, dynamic> data = json.decode(response.body);
     final String namedContact = _pickFirstNamedContact(data);
     setState(() {
       if (namedContact != null) {


### PR DESCRIPTION
After running `analyze`.

Saw it because #419 was failing `analyze` task.