### PR TITLE
Image picker plugin: use the native Android gallery / file chooser

### DIFF
--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.0
+
+* **Breaking change**. The `source` parameter for the `pickImage` is now required. Also, the `ImageSource.any` option doesn't exist anymore.
+* Use the native Android image gallery for picking images instead of a custom UI. 
+
 ## 0.3.0
 
 * **Breaking change**. Set SDK constraints to match the Flutter beta release.

--- a/packages/image_picker/LICENSE
+++ b/packages/image_picker/LICENSE
@@ -25,16 +25,205 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 --------------------------------------------------------------------------------
-Copyright 2011 - 2013 Paul Burke
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-   http://www.apache.org/licenses/LICENSE-2.0
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2011 - 2013 Paul Burke
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/image_picker/LICENSE
+++ b/packages/image_picker/LICENSE
@@ -24,3 +24,17 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--------------------------------------------------------------------------------
+Copyright 2011 - 2013 Paul Burke
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/image_picker/README.md
+++ b/packages/image_picker/README.md
@@ -38,7 +38,7 @@ class _MyHomePageState extends State<MyHomePage> {
   File imageFile;
 
   getImage() async {
-    var _fileName = await ImagePicker.pickImage(ImageSource.camera);
+    var _fileName = await ImagePicker.pickImage(source: ImageSource.camera);
     setState(() {
       imageFile = _fileName;
     });

--- a/packages/image_picker/README.md
+++ b/packages/image_picker/README.md
@@ -38,7 +38,7 @@ class _MyHomePageState extends State<MyHomePage> {
   File imageFile;
 
   getImage() async {
-    var _fileName = await ImagePicker.pickImage();
+    var _fileName = await ImagePicker.pickImage(ImageSource.camera);
     setState(() {
       imageFile = _fileName;
     });

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ExifDataCopier.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ExifDataCopier.java
@@ -1,0 +1,52 @@
+package io.flutter.plugins.imagepicker;
+
+import android.media.ExifInterface;
+import android.util.Log;
+
+import java.util.Arrays;
+import java.util.List;
+
+class ExifDataCopier {
+    void copyExif(String filePathOri, String filePathDest) {
+        try {
+            ExifInterface oldExif = new ExifInterface(filePathOri);
+            ExifInterface newExif = new ExifInterface(filePathDest);
+
+            List<String> attributes =
+                    Arrays.asList(
+                            "FNumber",
+                            "ExposureTime",
+                            "ISOSpeedRatings",
+                            "GPSAltitude",
+                            "GPSAltitudeRef",
+                            "FocalLength",
+                            "GPSDateStamp",
+                            "WhiteBalance",
+                            "GPSProcessingMethod",
+                            "GPSTimeStamp",
+                            "DateTime",
+                            "Flash",
+                            "GPSLatitude",
+                            "GPSLatitudeRef",
+                            "GPSLongitude",
+                            "GPSLongitudeRef",
+                            "Make",
+                            "Model",
+                            "Orientation");
+            for (String attribute : attributes) {
+                setIfNotNull(oldExif, newExif, attribute);
+            }
+
+            newExif.saveAttributes();
+
+        } catch (Exception ex) {
+            Log.e("ExifDataCopier", "Error preserving Exif data on selected image: " + ex);
+        }
+    }
+
+    private static void setIfNotNull(ExifInterface oldExif, ExifInterface newExif, String property) {
+        if (oldExif.getAttribute(property) != null) {
+            newExif.setAttribute(property, oldExif.getAttribute(property));
+        }
+    }
+}

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ExifDataCopier.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ExifDataCopier.java
@@ -1,3 +1,7 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package io.flutter.plugins.imagepicker;
 
 import android.media.ExifInterface;

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ExifDataCopier.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ExifDataCopier.java
@@ -2,51 +2,50 @@ package io.flutter.plugins.imagepicker;
 
 import android.media.ExifInterface;
 import android.util.Log;
-
 import java.util.Arrays;
 import java.util.List;
 
 class ExifDataCopier {
-    void copyExif(String filePathOri, String filePathDest) {
-        try {
-            ExifInterface oldExif = new ExifInterface(filePathOri);
-            ExifInterface newExif = new ExifInterface(filePathDest);
+  void copyExif(String filePathOri, String filePathDest) {
+    try {
+      ExifInterface oldExif = new ExifInterface(filePathOri);
+      ExifInterface newExif = new ExifInterface(filePathDest);
 
-            List<String> attributes =
-                    Arrays.asList(
-                            "FNumber",
-                            "ExposureTime",
-                            "ISOSpeedRatings",
-                            "GPSAltitude",
-                            "GPSAltitudeRef",
-                            "FocalLength",
-                            "GPSDateStamp",
-                            "WhiteBalance",
-                            "GPSProcessingMethod",
-                            "GPSTimeStamp",
-                            "DateTime",
-                            "Flash",
-                            "GPSLatitude",
-                            "GPSLatitudeRef",
-                            "GPSLongitude",
-                            "GPSLongitudeRef",
-                            "Make",
-                            "Model",
-                            "Orientation");
-            for (String attribute : attributes) {
-                setIfNotNull(oldExif, newExif, attribute);
-            }
+      List<String> attributes =
+          Arrays.asList(
+              "FNumber",
+              "ExposureTime",
+              "ISOSpeedRatings",
+              "GPSAltitude",
+              "GPSAltitudeRef",
+              "FocalLength",
+              "GPSDateStamp",
+              "WhiteBalance",
+              "GPSProcessingMethod",
+              "GPSTimeStamp",
+              "DateTime",
+              "Flash",
+              "GPSLatitude",
+              "GPSLatitudeRef",
+              "GPSLongitude",
+              "GPSLongitudeRef",
+              "Make",
+              "Model",
+              "Orientation");
+      for (String attribute : attributes) {
+        setIfNotNull(oldExif, newExif, attribute);
+      }
 
-            newExif.saveAttributes();
+      newExif.saveAttributes();
 
-        } catch (Exception ex) {
-            Log.e("ExifDataCopier", "Error preserving Exif data on selected image: " + ex);
-        }
+    } catch (Exception ex) {
+      Log.e("ExifDataCopier", "Error preserving Exif data on selected image: " + ex);
     }
+  }
 
-    private static void setIfNotNull(ExifInterface oldExif, ExifInterface newExif, String property) {
-        if (oldExif.getAttribute(property) != null) {
-            newExif.setAttribute(property, oldExif.getAttribute(property));
-        }
+  private static void setIfNotNull(ExifInterface oldExif, ExifInterface newExif, String property) {
+    if (oldExif.getAttribute(property) != null) {
+      newExif.setAttribute(property, oldExif.getAttribute(property));
     }
+  }
 }

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
@@ -9,14 +9,7 @@ import android.os.Build;
 import android.os.Environment;
 import android.provider.DocumentsContract;
 import android.provider.MediaStore;
-import android.support.annotation.NonNull;
 import android.text.TextUtils;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.nio.channels.FileChannel;
 
 /*
  * Copyright (C) 2007-2008 OpenIntents.org
@@ -100,25 +93,6 @@ class FileUtils {
         }
 
         return null;
-    }
-
-    public static void copyFile(@NonNull String pathFrom, @NonNull String pathTo) throws IOException {
-        if (pathFrom.equalsIgnoreCase(pathTo)) {
-            return;
-        }
-
-        FileChannel outputChannel = null;
-        FileChannel inputChannel = null;
-
-        try {
-            inputChannel = new FileInputStream(new File(pathFrom)).getChannel();
-            outputChannel = new FileOutputStream(new File(pathTo)).getChannel();
-            inputChannel.transferTo(0, inputChannel.size(), outputChannel);
-            inputChannel.close();
-        } finally {
-            if (inputChannel != null) inputChannel.close();
-            if (outputChannel != null) outputChannel.close();
-        }
     }
 
     private static String getDataColumn(Context context, Uri uri, String selection,

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
@@ -30,108 +30,103 @@ import android.text.TextUtils;
  * https://raw.githubusercontent.com/iPaulPro/aFileChooser/master/aFileChooser/src/com/ipaulpro/afilechooser/utils/FileUtils.java
  */
 class FileUtils {
-    private FileUtils() {
-    }
+  private FileUtils() {}
 
-    @SuppressLint("NewApi")
-    static String getPathFromUri(final Context context, final Uri uri) {
-        final boolean isKitKat = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
+  @SuppressLint("NewApi")
+  static String getPathFromUri(final Context context, final Uri uri) {
+    final boolean isKitKat = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
 
-        if (isKitKat && DocumentsContract.isDocumentUri(context, uri)) {
-            if (isExternalStorageDocument(uri)) {
-                final String docId = DocumentsContract.getDocumentId(uri);
-                final String[] split = docId.split(":");
-                final String type = split[0];
+    if (isKitKat && DocumentsContract.isDocumentUri(context, uri)) {
+      if (isExternalStorageDocument(uri)) {
+        final String docId = DocumentsContract.getDocumentId(uri);
+        final String[] split = docId.split(":");
+        final String type = split[0];
 
-                if ("primary".equalsIgnoreCase(type)) {
-                    return Environment.getExternalStorageDirectory() + "/" + split[1];
-                }
-            } else if (isDownloadsDocument(uri)) {
-                final String id = DocumentsContract.getDocumentId(uri);
+        if ("primary".equalsIgnoreCase(type)) {
+          return Environment.getExternalStorageDirectory() + "/" + split[1];
+        }
+      } else if (isDownloadsDocument(uri)) {
+        final String id = DocumentsContract.getDocumentId(uri);
 
-                if (!TextUtils.isEmpty(id)) {
-                    try {
-                        final Uri contentUri = ContentUris.withAppendedId(
-                                Uri.parse("content://downloads/public_downloads"), Long.valueOf(id));
-                        return getDataColumn(context, contentUri, null, null);
-                    } catch (NumberFormatException e) {
-                        return null;
-                    }
-                }
-
-            } else if (isMediaDocument(uri)) {
-                final String docId = DocumentsContract.getDocumentId(uri);
-                final String[] split = docId.split(":");
-                final String type = split[0];
-
-                Uri contentUri = null;
-                if ("image".equals(type)) {
-                    contentUri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
-                } else if ("video".equals(type)) {
-                    contentUri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI;
-                } else if ("audio".equals(type)) {
-                    contentUri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI;
-                }
-
-                final String selection = "_id=?";
-                final String[] selectionArgs = new String[]{
-                        split[1]
-                };
-
-                return getDataColumn(context, contentUri, selection, selectionArgs);
-            }
-        } else if ("content".equalsIgnoreCase(uri.getScheme())) {
-
-            // Return the remote address
-            if (isGooglePhotosUri(uri)) {
-                return uri.getLastPathSegment();
-            }
-
-            return getDataColumn(context, uri, null, null);
-        } else if ("file".equalsIgnoreCase(uri.getScheme())) {
-            return uri.getPath();
+        if (!TextUtils.isEmpty(id)) {
+          try {
+            final Uri contentUri =
+                ContentUris.withAppendedId(
+                    Uri.parse("content://downloads/public_downloads"), Long.valueOf(id));
+            return getDataColumn(context, contentUri, null, null);
+          } catch (NumberFormatException e) {
+            return null;
+          }
         }
 
-        return null;
-    }
+      } else if (isMediaDocument(uri)) {
+        final String docId = DocumentsContract.getDocumentId(uri);
+        final String[] split = docId.split(":");
+        final String type = split[0];
 
-    private static String getDataColumn(Context context, Uri uri, String selection,
-                                        String[] selectionArgs) {
-        Cursor cursor = null;
-
-        final String column = "_data";
-        final String[] projection = {
-                column
-        };
-
-        try {
-            cursor = context.getContentResolver().query(uri, projection, selection, selectionArgs,
-                    null);
-            if (cursor != null && cursor.moveToFirst()) {
-                final int column_index = cursor.getColumnIndexOrThrow(column);
-                return cursor.getString(column_index);
-            }
-        } finally {
-            if (cursor != null) {
-                cursor.close();
-            }
+        Uri contentUri = null;
+        if ("image".equals(type)) {
+          contentUri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
+        } else if ("video".equals(type)) {
+          contentUri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI;
+        } else if ("audio".equals(type)) {
+          contentUri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI;
         }
-        return null;
+
+        final String selection = "_id=?";
+        final String[] selectionArgs = new String[] {split[1]};
+
+        return getDataColumn(context, contentUri, selection, selectionArgs);
+      }
+    } else if ("content".equalsIgnoreCase(uri.getScheme())) {
+
+      // Return the remote address
+      if (isGooglePhotosUri(uri)) {
+        return uri.getLastPathSegment();
+      }
+
+      return getDataColumn(context, uri, null, null);
+    } else if ("file".equalsIgnoreCase(uri.getScheme())) {
+      return uri.getPath();
     }
 
-    private static boolean isExternalStorageDocument(Uri uri) {
-        return "com.android.externalstorage.documents".equals(uri.getAuthority());
-    }
+    return null;
+  }
 
-    private static boolean isDownloadsDocument(Uri uri) {
-        return "com.android.providers.downloads.documents".equals(uri.getAuthority());
-    }
+  private static String getDataColumn(
+      Context context, Uri uri, String selection, String[] selectionArgs) {
+    Cursor cursor = null;
 
-    private static boolean isMediaDocument(Uri uri) {
-        return "com.android.providers.media.documents".equals(uri.getAuthority());
-    }
+    final String column = "_data";
+    final String[] projection = {column};
 
-    private static boolean isGooglePhotosUri(Uri uri) {
-        return "com.google.android.apps.photos.content".equals(uri.getAuthority());
+    try {
+      cursor = context.getContentResolver().query(uri, projection, selection, selectionArgs, null);
+      if (cursor != null && cursor.moveToFirst()) {
+        final int column_index = cursor.getColumnIndexOrThrow(column);
+        return cursor.getString(column_index);
+      }
+    } finally {
+      if (cursor != null) {
+        cursor.close();
+      }
     }
+    return null;
+  }
+
+  private static boolean isExternalStorageDocument(Uri uri) {
+    return "com.android.externalstorage.documents".equals(uri.getAuthority());
+  }
+
+  private static boolean isDownloadsDocument(Uri uri) {
+    return "com.android.providers.downloads.documents".equals(uri.getAuthority());
+  }
+
+  private static boolean isMediaDocument(Uri uri) {
+    return "com.android.providers.media.documents".equals(uri.getAuthority());
+  }
+
+  private static boolean isGooglePhotosUri(Uri uri) {
+    return "com.google.android.apps.photos.content".equals(uri.getAuthority());
+  }
 }

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
@@ -1,18 +1,5 @@
-package io.flutter.plugins.imagepicker;
-
-import android.annotation.SuppressLint;
-import android.content.ContentUris;
-import android.content.Context;
-import android.database.Cursor;
-import android.net.Uri;
-import android.os.Build;
-import android.os.Environment;
-import android.provider.DocumentsContract;
-import android.provider.MediaStore;
-import android.text.TextUtils;
-
 /*
- * Copyright (C) 2007-2008 OpenIntents.org
+ * Copyright 2011 - 2013 Paul Burke
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,9 +13,27 @@ import android.text.TextUtils;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * A modified version of
+ * This file was modified by the Flutter authors from the following original file:
  * https://raw.githubusercontent.com/iPaulPro/aFileChooser/master/aFileChooser/src/com/ipaulpro/afilechooser/utils/FileUtils.java
  */
+
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.plugins.imagepicker;
+
+import android.annotation.SuppressLint;
+import android.content.ContentUris;
+import android.content.Context;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Environment;
+import android.provider.DocumentsContract;
+import android.provider.MediaStore;
+import android.text.TextUtils;
+
 class FileUtils {
   private FileUtils() {}
 

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 - 2013 Paul Burke
+ * Copyright (C) 2007-2008 OpenIntents.org
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,14 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * This file was modified by the Flutter authors from the following original file:
- * https://raw.githubusercontent.com/iPaulPro/aFileChooser/master/aFileChooser/src/com/ipaulpro/afilechooser/utils/FileUtils.java
  */
-
-// Copyright 2017 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
 
 package io.flutter.plugins.imagepicker;
 

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
@@ -12,6 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * This file was modified by the Flutter authors from the following original file:
+ * https://raw.githubusercontent.com/iPaulPro/aFileChooser/master/aFileChooser/src/com/ipaulpro/afilechooser/utils/FileUtils.java
  */
 
 package io.flutter.plugins.imagepicker;

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
@@ -1,0 +1,163 @@
+package io.flutter.plugins.imagepicker;
+
+import android.annotation.SuppressLint;
+import android.content.ContentUris;
+import android.content.Context;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Environment;
+import android.provider.DocumentsContract;
+import android.provider.MediaStore;
+import android.support.annotation.NonNull;
+import android.text.TextUtils;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+
+/*
+ * Copyright (C) 2007-2008 OpenIntents.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * A modified version of
+ * https://raw.githubusercontent.com/iPaulPro/aFileChooser/master/aFileChooser/src/com/ipaulpro/afilechooser/utils/FileUtils.java
+ */
+class FileUtils {
+    private FileUtils() {
+    }
+
+    @SuppressLint("NewApi")
+    static String getPathFromUri(final Context context, final Uri uri) {
+        final boolean isKitKat = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
+
+        if (isKitKat && DocumentsContract.isDocumentUri(context, uri)) {
+            if (isExternalStorageDocument(uri)) {
+                final String docId = DocumentsContract.getDocumentId(uri);
+                final String[] split = docId.split(":");
+                final String type = split[0];
+
+                if ("primary".equalsIgnoreCase(type)) {
+                    return Environment.getExternalStorageDirectory() + "/" + split[1];
+                }
+            } else if (isDownloadsDocument(uri)) {
+                final String id = DocumentsContract.getDocumentId(uri);
+
+                if (!TextUtils.isEmpty(id)) {
+                    try {
+                        final Uri contentUri = ContentUris.withAppendedId(
+                                Uri.parse("content://downloads/public_downloads"), Long.valueOf(id));
+                        return getDataColumn(context, contentUri, null, null);
+                    } catch (NumberFormatException e) {
+                        return null;
+                    }
+                }
+
+            } else if (isMediaDocument(uri)) {
+                final String docId = DocumentsContract.getDocumentId(uri);
+                final String[] split = docId.split(":");
+                final String type = split[0];
+
+                Uri contentUri = null;
+                if ("image".equals(type)) {
+                    contentUri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
+                } else if ("video".equals(type)) {
+                    contentUri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI;
+                } else if ("audio".equals(type)) {
+                    contentUri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI;
+                }
+
+                final String selection = "_id=?";
+                final String[] selectionArgs = new String[]{
+                        split[1]
+                };
+
+                return getDataColumn(context, contentUri, selection, selectionArgs);
+            }
+        } else if ("content".equalsIgnoreCase(uri.getScheme())) {
+
+            // Return the remote address
+            if (isGooglePhotosUri(uri)) {
+                return uri.getLastPathSegment();
+            }
+
+            return getDataColumn(context, uri, null, null);
+        } else if ("file".equalsIgnoreCase(uri.getScheme())) {
+            return uri.getPath();
+        }
+
+        return null;
+    }
+
+    public static void copyFile(@NonNull String pathFrom, @NonNull String pathTo) throws IOException {
+        if (pathFrom.equalsIgnoreCase(pathTo)) {
+            return;
+        }
+
+        FileChannel outputChannel = null;
+        FileChannel inputChannel = null;
+
+        try {
+            inputChannel = new FileInputStream(new File(pathFrom)).getChannel();
+            outputChannel = new FileOutputStream(new File(pathTo)).getChannel();
+            inputChannel.transferTo(0, inputChannel.size(), outputChannel);
+            inputChannel.close();
+        } finally {
+            if (inputChannel != null) inputChannel.close();
+            if (outputChannel != null) outputChannel.close();
+        }
+    }
+
+    private static String getDataColumn(Context context, Uri uri, String selection,
+                                        String[] selectionArgs) {
+        Cursor cursor = null;
+
+        final String column = "_data";
+        final String[] projection = {
+                column
+        };
+
+        try {
+            cursor = context.getContentResolver().query(uri, projection, selection, selectionArgs,
+                    null);
+            if (cursor != null && cursor.moveToFirst()) {
+                final int column_index = cursor.getColumnIndexOrThrow(column);
+                return cursor.getString(column_index);
+            }
+        } finally {
+            if (cursor != null) {
+                cursor.close();
+            }
+        }
+        return null;
+    }
+
+    private static boolean isExternalStorageDocument(Uri uri) {
+        return "com.android.externalstorage.documents".equals(uri.getAuthority());
+    }
+
+    private static boolean isDownloadsDocument(Uri uri) {
+        return "com.android.providers.downloads.documents".equals(uri.getAuthority());
+    }
+
+    private static boolean isMediaDocument(Uri uri) {
+        return "com.android.providers.media.documents".equals(uri.getAuthority());
+    }
+
+    private static boolean isGooglePhotosUri(Uri uri) {
+        return "com.google.android.apps.photos.content".equals(uri.getAuthority());
+    }
+}

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 import java.util.List;
 
 public class ImagePickerPlugin
-        implements MethodChannel.MethodCallHandler,
+    implements MethodChannel.MethodCallHandler,
         PluginRegistry.ActivityResultListener,
         PluginRegistry.RequestPermissionsResultListener {
   private static final String CHANNEL = "plugins.flutter.io/image_picker";
@@ -48,7 +48,7 @@ public class ImagePickerPlugin
   public static void registerWith(PluginRegistry.Registrar registrar) {
     final MethodChannel channel = new MethodChannel(registrar.messenger(), CHANNEL);
     final ImagePickerPlugin instance =
-            new ImagePickerPlugin(registrar, new ImageResizer(), new ExifDataCopier());
+        new ImagePickerPlugin(registrar, new ImageResizer(), new ExifDataCopier());
 
     registrar.addActivityResultListener(instance);
     registrar.addRequestPermissionsResultListener(instance);
@@ -57,9 +57,9 @@ public class ImagePickerPlugin
   }
 
   private ImagePickerPlugin(
-          PluginRegistry.Registrar registrar,
-          ImageResizer imageResizer,
-          ExifDataCopier exifDataCopier) {
+      PluginRegistry.Registrar registrar,
+      ImageResizer imageResizer,
+      ExifDataCopier exifDataCopier) {
     this.registrar = registrar;
     this.imageResizer = imageResizer;
     this.exifDataCopier = exifDataCopier;
@@ -91,19 +91,19 @@ public class ImagePickerPlugin
         case SOURCE_CAMERA:
           if (ContextCompat.checkSelfPermission(activity, Manifest.permission.CAMERA)
                   != PackageManager.PERMISSION_GRANTED
-                  || ContextCompat.checkSelfPermission(
-                  activity, Manifest.permission.READ_EXTERNAL_STORAGE)
+              || ContextCompat.checkSelfPermission(
+                      activity, Manifest.permission.READ_EXTERNAL_STORAGE)
                   != PackageManager.PERMISSION_GRANTED) {
             ActivityCompat.requestPermissions(
-                    activity,
-                    new String[] {
-                            Manifest.permission.CAMERA, Manifest.permission.READ_EXTERNAL_STORAGE
-                    },
-                    REQUEST_CAMERA_PERMISSIONS);
+                activity,
+                new String[] {
+                  Manifest.permission.CAMERA, Manifest.permission.READ_EXTERNAL_STORAGE
+                },
+                REQUEST_CAMERA_PERMISSIONS);
             break;
           }
           activity.startActivityForResult(
-                  cameraModule.getCameraIntent(activity), REQUEST_CODE_CAMERA);
+              cameraModule.getCameraIntent(activity), REQUEST_CODE_CAMERA);
           break;
         default:
           throw new IllegalArgumentException("Invalid image source: " + imageSource);
@@ -131,14 +131,14 @@ public class ImagePickerPlugin
     if (requestCode == REQUEST_CODE_CAMERA) {
       if (resultCode == Activity.RESULT_OK) {
         cameraModule.getImage(
-                registrar.context(),
-                data,
-                new OnImageReadyListener() {
-                  @Override
-                  public void onImageReady(List<Image> images) {
-                    handleResult(images.get(0).getPath());
-                  }
-                });
+            registrar.context(),
+            data,
+            new OnImageReadyListener() {
+              @Override
+              public void onImageReady(List<Image> images) {
+                handleResult(images.get(0).getPath());
+              }
+            });
         return true;
       } else if (resultCode != Activity.RESULT_CANCELED) {
         pendingResult.error("PICK_ERROR", "Error taking photo", null);
@@ -153,8 +153,8 @@ public class ImagePickerPlugin
 
   private void pickImageFromGallery(Activity activity) {
     boolean hasPermission =
-            ActivityCompat.checkSelfPermission(activity, Manifest.permission.READ_EXTERNAL_STORAGE)
-                    == PackageManager.PERMISSION_GRANTED;
+        ActivityCompat.checkSelfPermission(activity, Manifest.permission.READ_EXTERNAL_STORAGE)
+            == PackageManager.PERMISSION_GRANTED;
 
     if (hasPermission) {
       Intent pickImageIntent = new Intent(Intent.ACTION_GET_CONTENT);
@@ -168,31 +168,31 @@ public class ImagePickerPlugin
 
   private void requestReadExternalStoragePermission() {
     ActivityCompat.requestPermissions(
-            registrar.activity(),
-            new String[] {Manifest.permission.READ_EXTERNAL_STORAGE},
-            REQUEST_EXTERNAL_STORAGE_PERMISSIONS);
+        registrar.activity(),
+        new String[] {Manifest.permission.READ_EXTERNAL_STORAGE},
+        REQUEST_EXTERNAL_STORAGE_PERMISSIONS);
   }
 
   @Override
   public boolean onRequestPermissionsResult(
-          int requestCode, String[] permissions, int[] grantResults) {
+      int requestCode, String[] permissions, int[] grantResults) {
     if (requestCode == REQUEST_EXTERNAL_STORAGE_PERMISSIONS
-            && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+        && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
       pickImageFromGallery(registrar.activity());
     } else if (requestCode == REQUEST_CAMERA_PERMISSIONS) {
       if (grantResults.length == 2
-              && grantResults[0] == PackageManager.PERMISSION_GRANTED
-              && grantResults[1] == PackageManager.PERMISSION_GRANTED) {
+          && grantResults[0] == PackageManager.PERMISSION_GRANTED
+          && grantResults[1] == PackageManager.PERMISSION_GRANTED) {
         Activity activity = registrar.activity();
         if (activity == null) {
           pendingResult.error(
-                  "no_activity", "image_picker plugin requires a foreground activity.", null);
+              "no_activity", "image_picker plugin requires a foreground activity.", null);
         }
         activity.startActivityForResult(
-                cameraModule.getCameraIntent(activity), REQUEST_CODE_CAMERA);
+            cameraModule.getCameraIntent(activity), REQUEST_CODE_CAMERA);
       } else {
         pendingResult.error(
-                "no_permissions", "image_picker plugin requires camera permissions", null);
+            "no_permissions", "image_picker plugin requires camera permissions", null);
         pendingResult = null;
         methodCall = null;
       }

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -9,24 +9,23 @@ import android.app.Activity;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.support.v4.app.ActivityCompat;
-
 import com.esafirm.imagepicker.features.camera.DefaultCameraModule;
 import com.esafirm.imagepicker.features.camera.OnImageReadyListener;
 import com.esafirm.imagepicker.model.Image;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.List;
-
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry;
 import io.flutter.plugin.common.PluginRegistry.ActivityResultListener;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
 
-public class ImagePickerPlugin implements MethodCallHandler,
-        ActivityResultListener, PluginRegistry.RequestPermissionsResultListener {
+public class ImagePickerPlugin
+    implements MethodCallHandler,
+        ActivityResultListener,
+        PluginRegistry.RequestPermissionsResultListener {
   private static final String CHANNEL = "plugins.flutter.io/image_picker";
 
   private static final int REQUEST_CODE_PICK = 2342;
@@ -49,11 +48,8 @@ public class ImagePickerPlugin implements MethodCallHandler,
 
   public static void registerWith(PluginRegistry.Registrar registrar) {
     final MethodChannel channel = new MethodChannel(registrar.messenger(), CHANNEL);
-    final ImagePickerPlugin instance = new ImagePickerPlugin(
-            registrar,
-            new ImageResizer(),
-            new ExifDataCopier()
-    );
+    final ImagePickerPlugin instance =
+        new ImagePickerPlugin(registrar, new ImageResizer(), new ExifDataCopier());
 
     registrar.addActivityResultListener(instance);
     registrar.addRequestPermissionsResultListener(instance);
@@ -62,10 +58,9 @@ public class ImagePickerPlugin implements MethodCallHandler,
   }
 
   private ImagePickerPlugin(
-          PluginRegistry.Registrar registrar,
-          ImageResizer imageResizer,
-          ExifDataCopier exifDataCopier
-  ) {
+      PluginRegistry.Registrar registrar,
+      ImageResizer imageResizer,
+      ExifDataCopier exifDataCopier) {
     this.registrar = registrar;
     this.imageResizer = imageResizer;
     this.exifDataCopier = exifDataCopier;
@@ -145,10 +140,9 @@ public class ImagePickerPlugin implements MethodCallHandler,
   }
 
   private void pickImageFromGallery(Activity activity) {
-    boolean hasPermission = ActivityCompat.checkSelfPermission(
-            activity,
-            Manifest.permission.READ_EXTERNAL_STORAGE
-    ) == PackageManager.PERMISSION_GRANTED;
+    boolean hasPermission =
+        ActivityCompat.checkSelfPermission(activity, Manifest.permission.READ_EXTERNAL_STORAGE)
+            == PackageManager.PERMISSION_GRANTED;
 
     if (hasPermission) {
       Intent pickImageIntent = new Intent(Intent.ACTION_GET_CONTENT);
@@ -162,16 +156,16 @@ public class ImagePickerPlugin implements MethodCallHandler,
 
   private void requestReadExternalStoragePermission() {
     ActivityCompat.requestPermissions(
-            registrar.activity(),
-            new String[]{Manifest.permission.READ_EXTERNAL_STORAGE},
-            PERMISSION_REQUEST_CODE_EXTERNAL_STORAGE
-    );
+        registrar.activity(),
+        new String[] {Manifest.permission.READ_EXTERNAL_STORAGE},
+        PERMISSION_REQUEST_CODE_EXTERNAL_STORAGE);
   }
 
   @Override
-  public boolean onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+  public boolean onRequestPermissionsResult(
+      int requestCode, String[] permissions, int[] grantResults) {
     if (requestCode == PERMISSION_REQUEST_CODE_EXTERNAL_STORAGE
-            && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+        && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
       pickImageFromGallery(registrar.activity());
     }
 

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -31,7 +31,7 @@ import java.util.List;
 /** Location Plugin */
 public class ImagePickerPlugin implements MethodCallHandler, ActivityResultListener {
   private static String TAG = "ImagePicker";
-  private static final String CHANNEL = "image_picker";
+  private static final String CHANNEL = "plugins.flutter.io/image_picker";
 
   public static final int REQUEST_CODE_PICK = 2342;
   public static final int REQUEST_CODE_CAMERA = 2343;

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -103,6 +103,8 @@ public class ImagePickerPlugin
             break;
           }
           activity.startActivityForResult(
+                  // TODO: Refactor to use the native camera. After that, remove the
+                  // com.esafirm.imagepicker depency.
               cameraModule.getCameraIntent(activity), REQUEST_CODE_CAMERA);
           break;
         default:

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -103,8 +103,8 @@ public class ImagePickerPlugin
             break;
           }
           activity.startActivityForResult(
-                  // TODO: Refactor to use the native camera. After that, remove the
-                  // com.esafirm.imagepicker depency.
+              // TODO: Refactor to use the native camera. After that, remove the
+              // com.esafirm.imagepicker depency.
               cameraModule.getCameraIntent(activity), REQUEST_CODE_CAMERA);
           break;
         default:

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImageResizer.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImageResizer.java
@@ -2,66 +2,65 @@ package io.flutter.plugins.imagepicker;
 
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
-
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
 class ImageResizer {
-    File resizedImage(String path, Double maxWidth, Double maxHeight) throws IOException {
-        Bitmap bmp = BitmapFactory.decodeFile(path);
-        double originalWidth = bmp.getWidth() * 1.0;
-        double originalHeight = bmp.getHeight() * 1.0;
+  File resizedImage(String path, Double maxWidth, Double maxHeight) throws IOException {
+    Bitmap bmp = BitmapFactory.decodeFile(path);
+    double originalWidth = bmp.getWidth() * 1.0;
+    double originalHeight = bmp.getHeight() * 1.0;
 
-        boolean hasMaxWidth = maxWidth != null;
-        boolean hasMaxHeight = maxHeight != null;
+    boolean hasMaxWidth = maxWidth != null;
+    boolean hasMaxHeight = maxHeight != null;
 
-        Double width = hasMaxWidth ? Math.min(originalWidth, maxWidth) : originalWidth;
-        Double height = hasMaxHeight ? Math.min(originalHeight, maxHeight) : originalHeight;
+    Double width = hasMaxWidth ? Math.min(originalWidth, maxWidth) : originalWidth;
+    Double height = hasMaxHeight ? Math.min(originalHeight, maxHeight) : originalHeight;
 
-        boolean shouldDownscaleWidth = hasMaxWidth && maxWidth < originalWidth;
-        boolean shouldDownscaleHeight = hasMaxHeight && maxHeight < originalHeight;
-        boolean shouldDownscale = shouldDownscaleWidth || shouldDownscaleHeight;
+    boolean shouldDownscaleWidth = hasMaxWidth && maxWidth < originalWidth;
+    boolean shouldDownscaleHeight = hasMaxHeight && maxHeight < originalHeight;
+    boolean shouldDownscale = shouldDownscaleWidth || shouldDownscaleHeight;
 
-        if (shouldDownscale) {
-            double downscaledWidth = (height / originalHeight) * originalWidth;
-            double downscaledHeight = (width / originalWidth) * originalHeight;
+    if (shouldDownscale) {
+      double downscaledWidth = (height / originalHeight) * originalWidth;
+      double downscaledHeight = (width / originalWidth) * originalHeight;
 
-            if (width < height) {
-                if (!hasMaxWidth) {
-                    width = downscaledWidth;
-                } else {
-                    height = downscaledHeight;
-                }
-            } else if (height < width) {
-                if (!hasMaxHeight) {
-                    height = downscaledHeight;
-                } else {
-                    width = downscaledWidth;
-                }
-            } else {
-                if (originalWidth < originalHeight) {
-                    width = downscaledWidth;
-                } else if (originalHeight < originalWidth) {
-                    height = downscaledHeight;
-                }
-            }
+      if (width < height) {
+        if (!hasMaxWidth) {
+          width = downscaledWidth;
+        } else {
+          height = downscaledHeight;
         }
-
-        Bitmap scaledBmp = Bitmap.createScaledBitmap(bmp, width.intValue(), height.intValue(), false);
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        scaledBmp.compress(Bitmap.CompressFormat.JPEG, 100, outputStream);
-
-        String[] pathParts = path.split("/");
-        String imageName = pathParts[pathParts.length - 1];
-        String scaledCopyPath = path.replace(imageName, "scaled_" + imageName);
-
-        File imageFile = new File(scaledCopyPath);
-        FileOutputStream fileOutput = new FileOutputStream(imageFile);
-        fileOutput.write(outputStream.toByteArray());
-        fileOutput.close();
-
-        return imageFile;
+      } else if (height < width) {
+        if (!hasMaxHeight) {
+          height = downscaledHeight;
+        } else {
+          width = downscaledWidth;
+        }
+      } else {
+        if (originalWidth < originalHeight) {
+          width = downscaledWidth;
+        } else if (originalHeight < originalWidth) {
+          height = downscaledHeight;
+        }
+      }
     }
+
+    Bitmap scaledBmp = Bitmap.createScaledBitmap(bmp, width.intValue(), height.intValue(), false);
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    scaledBmp.compress(Bitmap.CompressFormat.JPEG, 100, outputStream);
+
+    String[] pathParts = path.split("/");
+    String imageName = pathParts[pathParts.length - 1];
+    String scaledCopyPath = path.replace(imageName, "scaled_" + imageName);
+
+    File imageFile = new File(scaledCopyPath);
+    FileOutputStream fileOutput = new FileOutputStream(imageFile);
+    fileOutput.write(outputStream.toByteArray());
+    fileOutput.close();
+
+    return imageFile;
+  }
 }

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImageResizer.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImageResizer.java
@@ -1,3 +1,7 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package io.flutter.plugins.imagepicker;
 
 import android.graphics.Bitmap;

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImageResizer.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImageResizer.java
@@ -53,15 +53,15 @@ class ImageResizer {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         scaledBmp.compress(Bitmap.CompressFormat.JPEG, 100, outputStream);
 
-        throw new RuntimeException(path);
-        /*
-        String scaledCopyPath = path; //path.replace(image.getName(), "scaled_" + image.getName())
-        File imageFile = new File(scaledCopyPath);
+        String[] pathParts = path.split("/");
+        String imageName = pathParts[pathParts.length - 1];
+        String scaledCopyPath = path.replace(imageName, "scaled_" + imageName);
 
+        File imageFile = new File(scaledCopyPath);
         FileOutputStream fileOutput = new FileOutputStream(imageFile);
         fileOutput.write(outputStream.toByteArray());
         fileOutput.close();
 
-        return imageFile;*/
+        return imageFile;
     }
 }

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImageResizer.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImageResizer.java
@@ -3,16 +3,14 @@ package io.flutter.plugins.imagepicker;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 
-import com.esafirm.imagepicker.model.Image;
-
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
 class ImageResizer {
-    File resizedImage(Image image, Double maxWidth, Double maxHeight) throws IOException {
-        Bitmap bmp = BitmapFactory.decodeFile(image.getPath());
+    File resizedImage(String path, Double maxWidth, Double maxHeight) throws IOException {
+        Bitmap bmp = BitmapFactory.decodeFile(path);
         double originalWidth = bmp.getWidth() * 1.0;
         double originalHeight = bmp.getHeight() * 1.0;
 
@@ -55,13 +53,15 @@ class ImageResizer {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         scaledBmp.compress(Bitmap.CompressFormat.JPEG, 100, outputStream);
 
-        String scaledCopyPath = image.getPath().replace(image.getName(), "scaled_" + image.getName());
+        throw new RuntimeException(path);
+        /*
+        String scaledCopyPath = path; //path.replace(image.getName(), "scaled_" + image.getName())
         File imageFile = new File(scaledCopyPath);
 
         FileOutputStream fileOutput = new FileOutputStream(imageFile);
         fileOutput.write(outputStream.toByteArray());
         fileOutput.close();
 
-        return imageFile;
+        return imageFile;*/
     }
 }

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImageResizer.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImageResizer.java
@@ -1,0 +1,67 @@
+package io.flutter.plugins.imagepicker;
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+
+import com.esafirm.imagepicker.model.Image;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+class ImageResizer {
+    File resizedImage(Image image, Double maxWidth, Double maxHeight) throws IOException {
+        Bitmap bmp = BitmapFactory.decodeFile(image.getPath());
+        double originalWidth = bmp.getWidth() * 1.0;
+        double originalHeight = bmp.getHeight() * 1.0;
+
+        boolean hasMaxWidth = maxWidth != null;
+        boolean hasMaxHeight = maxHeight != null;
+
+        Double width = hasMaxWidth ? Math.min(originalWidth, maxWidth) : originalWidth;
+        Double height = hasMaxHeight ? Math.min(originalHeight, maxHeight) : originalHeight;
+
+        boolean shouldDownscaleWidth = hasMaxWidth && maxWidth < originalWidth;
+        boolean shouldDownscaleHeight = hasMaxHeight && maxHeight < originalHeight;
+        boolean shouldDownscale = shouldDownscaleWidth || shouldDownscaleHeight;
+
+        if (shouldDownscale) {
+            double downscaledWidth = (height / originalHeight) * originalWidth;
+            double downscaledHeight = (width / originalWidth) * originalHeight;
+
+            if (width < height) {
+                if (!hasMaxWidth) {
+                    width = downscaledWidth;
+                } else {
+                    height = downscaledHeight;
+                }
+            } else if (height < width) {
+                if (!hasMaxHeight) {
+                    height = downscaledHeight;
+                } else {
+                    width = downscaledWidth;
+                }
+            } else {
+                if (originalWidth < originalHeight) {
+                    width = downscaledWidth;
+                } else if (originalHeight < originalWidth) {
+                    height = downscaledHeight;
+                }
+            }
+        }
+
+        Bitmap scaledBmp = Bitmap.createScaledBitmap(bmp, width.intValue(), height.intValue(), false);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        scaledBmp.compress(Bitmap.CompressFormat.JPEG, 100, outputStream);
+
+        String scaledCopyPath = image.getPath().replace(image.getName(), "scaled_" + image.getName());
+        File imageFile = new File(scaledCopyPath);
+
+        FileOutputStream fileOutput = new FileOutputStream(imageFile);
+        fileOutput.write(outputStream.toByteArray());
+        fileOutput.close();
+
+        return imageFile;
+    }
+}

--- a/packages/image_picker/example/lib/main.dart
+++ b/packages/image_picker/example/lib/main.dart
@@ -34,6 +34,12 @@ class MyHomePage extends StatefulWidget {
 class _MyHomePageState extends State<MyHomePage> {
   Future<File> _imageFile;
 
+  void _onImageButtonPressed(ImageSource source) {
+    setState(() {
+      _imageFile = ImagePicker.pickImage(source: source);
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return new Scaffold(
@@ -41,23 +47,34 @@ class _MyHomePageState extends State<MyHomePage> {
         title: const Text('Image Picker Example'),
       ),
       body: new Center(
-          child: new FutureBuilder<File>(
-              future: _imageFile,
-              builder: (BuildContext context, AsyncSnapshot<File> snapshot) {
-                if (snapshot.connectionState == ConnectionState.done) {
-                  return new Image.file(snapshot.data);
-                } else {
-                  return const Text('You have not yet picked an image.');
-                }
-              })),
-      floatingActionButton: new FloatingActionButton(
-        onPressed: () {
-          setState(() {
-            _imageFile = ImagePicker.pickImage();
-          });
-        },
-        tooltip: 'Pick Image',
-        child: new Icon(Icons.add_a_photo),
+        child: new FutureBuilder<File>(
+          future: _imageFile,
+          builder: (BuildContext context, AsyncSnapshot<File> snapshot) {
+            if (snapshot.connectionState == ConnectionState.done) {
+              return new Image.file(snapshot.data);
+            } else {
+              return const Text('You have not yet picked an image.');
+            }
+          },
+        ),
+      ),
+      floatingActionButton: new Column(
+        mainAxisAlignment: MainAxisAlignment.end,
+        children: <Widget>[
+          new FloatingActionButton(
+            onPressed: () => _onImageButtonPressed(ImageSource.gallery),
+            tooltip: 'Pick Image from gallery',
+            child: new Icon(Icons.photo_library),
+          ),
+          new Padding(
+            padding: const EdgeInsets.only(top: 16.0),
+            child: new FloatingActionButton(
+              onPressed: () => _onImageButtonPressed(ImageSource.camera),
+              tooltip: 'Take a Photo',
+              child: new Icon(Icons.camera_alt),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/packages/image_picker/example/lib/main.dart
+++ b/packages/image_picker/example/lib/main.dart
@@ -50,8 +50,11 @@ class _MyHomePageState extends State<MyHomePage> {
         child: new FutureBuilder<File>(
           future: _imageFile,
           builder: (BuildContext context, AsyncSnapshot<File> snapshot) {
-            if (snapshot.connectionState == ConnectionState.done) {
+            if (snapshot.connectionState == ConnectionState.done &&
+                snapshot.error == null) {
               return new Image.file(snapshot.data);
+            } else if (snapshot.error != null) {
+              return const Text('error picking image.');
             } else {
               return const Text('You have not yet picked an image.');
             }

--- a/packages/image_picker/ios/Classes/ImagePickerPlugin.m
+++ b/packages/image_picker/ios/Classes/ImagePickerPlugin.m
@@ -22,7 +22,7 @@ static const int SOURCE_GALLERY = 2;
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
   FlutterMethodChannel *channel =
-      [FlutterMethodChannel methodChannelWithName:@"image_picker"
+      [FlutterMethodChannel methodChannelWithName:@"plugins.flutter.io/image_picker"
                                   binaryMessenger:[registrar messenger]];
   UIViewController *viewController =
       [UIApplication sharedApplication].delegate.window.rootViewController;

--- a/packages/image_picker/ios/Classes/ImagePickerPlugin.m
+++ b/packages/image_picker/ios/Classes/ImagePickerPlugin.m
@@ -9,9 +9,8 @@
 @interface FLTImagePickerPlugin ()<UINavigationControllerDelegate, UIImagePickerControllerDelegate>
 @end
 
-static const int SOURCE_ASK_USER = 0;
-static const int SOURCE_CAMERA = 1;
-static const int SOURCE_GALLERY = 2;
+static const int SOURCE_CAMERA = 0;
+static const int SOURCE_GALLERY = 1;
 
 @implementation FLTImagePickerPlugin {
   FlutterResult _result;
@@ -58,9 +57,6 @@ static const int SOURCE_GALLERY = 2;
     int imageSource = [[_arguments objectForKey:@"source"] intValue];
 
     switch (imageSource) {
-      case SOURCE_ASK_USER:
-        [self showImageSourceSelector];
-        break;
       case SOURCE_CAMERA:
         [self showCamera];
         break;
@@ -76,31 +72,6 @@ static const int SOURCE_GALLERY = 2;
   } else {
     result(FlutterMethodNotImplemented);
   }
-}
-
-- (void)showImageSourceSelector {
-  UIAlertControllerStyle style = UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad
-                                     ? UIAlertControllerStyleAlert
-                                     : UIAlertControllerStyleActionSheet;
-
-  UIAlertController *alert =
-      [UIAlertController alertControllerWithTitle:nil message:nil preferredStyle:style];
-  UIAlertAction *camera = [UIAlertAction actionWithTitle:@"Take Photo"
-                                                   style:UIAlertActionStyleDefault
-                                                 handler:^(UIAlertAction *action) {
-                                                   [self showCamera];
-                                                 }];
-  UIAlertAction *library = [UIAlertAction actionWithTitle:@"Choose Photo"
-                                                    style:UIAlertActionStyleDefault
-                                                  handler:^(UIAlertAction *action) {
-                                                    [self showPhotoLibrary];
-                                                  }];
-  UIAlertAction *cancel =
-      [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil];
-  [alert addAction:camera];
-  [alert addAction:library];
-  [alert addAction:cancel];
-  [_viewController presentViewController:alert animated:YES completion:nil];
 }
 
 - (void)showCamera {

--- a/packages/image_picker/lib/image_picker.dart
+++ b/packages/image_picker/lib/image_picker.dart
@@ -23,10 +23,8 @@ class ImagePicker {
 
   /// Returns a [File] object pointing to the image that was picked.
   ///
-  /// On both Android & iOS, the user can choose to either:
-  ///
-  /// * pick an image from the gallery
-  /// * take a photo using the device camera.
+  /// The [source] argument controls where the image comes from. This can
+  /// be either [ImageSource.camera] or [ImageSource.gallery].
   ///
   /// If specified, the image will be at most [maxWidth] wide and
   /// [maxHeight] tall. Otherwise the image will be returned at it's

--- a/packages/image_picker/lib/image_picker.dart
+++ b/packages/image_picker/lib/image_picker.dart
@@ -13,7 +13,7 @@ enum ImageSource {
   /// Opens up the device camera, letting the user to take a new picture.
   camera,
 
-  /// Opens the users photo gallery.
+  /// Opens the user's photo gallery.
   gallery,
 }
 

--- a/packages/image_picker/lib/image_picker.dart
+++ b/packages/image_picker/lib/image_picker.dart
@@ -30,7 +30,7 @@ enum ImageSource {
 }
 
 class ImagePicker {
-  static const MethodChannel _channel = const MethodChannel('image_picker');
+  static const MethodChannel _channel = const MethodChannel('plugins.flutter.io/image_picker');
 
   /// Returns a [File] object pointing to the image that was picked.
   ///

--- a/packages/image_picker/lib/image_picker.dart
+++ b/packages/image_picker/lib/image_picker.dart
@@ -18,7 +18,8 @@ enum ImageSource {
 }
 
 class ImagePicker {
-  static const MethodChannel _channel = const MethodChannel('plugins.flutter.io/image_picker');
+  static const MethodChannel _channel =
+      const MethodChannel('plugins.flutter.io/image_picker');
 
   /// Returns a [File] object pointing to the image that was picked.
   ///

--- a/packages/image_picker/lib/image_picker.dart
+++ b/packages/image_picker/lib/image_picker.dart
@@ -6,26 +6,14 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/services.dart';
+import 'package:meta/meta.dart';
 
 /// Specifies the source where the picked image should come from.
 enum ImageSource {
-  /// Let the user choose an image from a source they prefer.
-  ///
-  /// On Android, opens a new screen with a grid of images (from the users
-  /// gallery) and a camera icon on the top right corner. The user can
-  /// either pick an image from the image grid, or tap the camera icon
-  /// to take a picture using the device camera.
-  ///
-  /// On iOS, the user is presented with an alert box with options to
-  /// either take a photo using the device camera or pick an image from
-  /// the photo library.
-  askUser,
-
-  /// Opens up the device camera on both Android and iOS.
+  /// Opens up the device camera, letting the user to take a new picture.
   camera,
 
-  /// On Android, presents a grid of images from the users gallery. On iOS,
-  /// opens the users photo library.
+  /// Opens the users photo gallery.
   gallery,
 }
 
@@ -39,14 +27,11 @@ class ImagePicker {
   /// * pick an image from the gallery
   /// * take a photo using the device camera.
   ///
-  /// Use the [source] argument for controlling where the image comes from.
-  /// By default, the user can choose the image from either camera or gallery.
-  ///
   /// If specified, the image will be at most [maxWidth] wide and
   /// [maxHeight] tall. Otherwise the image will be returned at it's
   /// original width and height.
   static Future<File> pickImage({
-    ImageSource source = ImageSource.askUser,
+    @required ImageSource source,
     double maxWidth,
     double maxHeight,
   }) async {

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for selecting images from the Android and iOS image
   library, and taking new pictures with the camera.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.3.0
+version: 0.4.0
 
 flutter:
   plugin:

--- a/packages/image_picker/test/image_picker_test.dart
+++ b/packages/image_picker/test/image_picker_test.dart
@@ -8,7 +8,8 @@ import 'package:image_picker/image_picker.dart';
 
 void main() {
   group('$ImagePicker', () {
-    const MethodChannel channel = const MethodChannel('plugins.flutter.io/image_picker');
+    const MethodChannel channel =
+        const MethodChannel('plugins.flutter.io/image_picker');
 
     final List<MethodCall> log = <MethodCall>[];
 

--- a/packages/image_picker/test/image_picker_test.dart
+++ b/packages/image_picker/test/image_picker_test.dart
@@ -8,7 +8,7 @@ import 'package:image_picker/image_picker.dart';
 
 void main() {
   group('$ImagePicker', () {
-    const MethodChannel channel = const MethodChannel('image_picker');
+    const MethodChannel channel = const MethodChannel('plugins.flutter.io/image_picker');
 
     final List<MethodCall> log = <MethodCall>[];
 
@@ -22,23 +22,7 @@ void main() {
     });
 
     group('#pickImage', () {
-      test('ImageSource.askUser is the default image source', () async {
-        await ImagePicker.pickImage();
-
-        expect(
-          log,
-          <Matcher>[
-            isMethodCall('pickImage', arguments: <String, dynamic>{
-              'source': 0,
-              'maxWidth': null,
-              'maxHeight': null,
-            }),
-          ],
-        );
-      });
-
       test('passes the image source argument correctly', () async {
-        await ImagePicker.pickImage(source: ImageSource.askUser);
         await ImagePicker.pickImage(source: ImageSource.camera);
         await ImagePicker.pickImage(source: ImageSource.gallery);
 
@@ -55,20 +39,22 @@ void main() {
               'maxWidth': null,
               'maxHeight': null,
             }),
-            isMethodCall('pickImage', arguments: <String, dynamic>{
-              'source': 2,
-              'maxWidth': null,
-              'maxHeight': null,
-            }),
           ],
         );
       });
 
       test('passes the width and height arguments correctly', () async {
-        await ImagePicker.pickImage();
-        await ImagePicker.pickImage(maxWidth: 10.0);
-        await ImagePicker.pickImage(maxHeight: 10.0);
+        await ImagePicker.pickImage(source: ImageSource.camera);
         await ImagePicker.pickImage(
+          source: ImageSource.camera,
+          maxWidth: 10.0,
+        );
+        await ImagePicker.pickImage(
+          source: ImageSource.camera,
+          maxHeight: 10.0,
+        );
+        await ImagePicker.pickImage(
+          source: ImageSource.camera,
           maxWidth: 10.0,
           maxHeight: 20.0,
         );
@@ -101,8 +87,15 @@ void main() {
       });
 
       test('does not accept a negative width or height argument', () {
-        expect(ImagePicker.pickImage(maxWidth: -1.0), throwsArgumentError);
-        expect(ImagePicker.pickImage(maxHeight: -1.0), throwsArgumentError);
+        expect(
+          ImagePicker.pickImage(source: ImageSource.camera, maxWidth: -1.0),
+          throwsArgumentError,
+        );
+
+        expect(
+          ImagePicker.pickImage(source: ImageSource.camera, maxHeight: -1.0),
+          throwsArgumentError,
+        );
       });
     });
   });


### PR DESCRIPTION
Changes: 
* Uses the native Android gallery UI for picking images, instead of a custom one
* removes the image source selection dialog on iOS
* **Breaking API change:** now the `source` named parameter for the `pickImage` method is annotated with `@required`.

Issues fixed:
* Fixes flutter/flutter#13706
* Fixes flutter/flutter#11577, except for step 4. Which could be a separate ticket.
* Fixes flutter/flutter#13060, which is an old leftover issue that was actually merged a while ago, but verified working here

Currently, the image picker plugin uses a custom gallery UI from [this library](https://github.com/esafirm/android-image-picker), instead of the native one. I'll guess that the original reason for that is that picking images by using the native gallery can be quite wonky.

While this worked fine on my emulator and Motorola Z, there might be a risk that this breaks picking images from gallery for some devices.

Here's what I mean by "native Android gallery":

![imgpick](https://user-images.githubusercontent.com/13744304/37431554-3d3a87e8-27de-11e8-8747-4d20a0070cee.gif)

I also refactored the image resizing and Exif data copying logic to separate classes to make the code cleaner.

Here's what's currently missing to land this, feel free to give further feedback:

- [x] figure out the license headers: needs input from @Hixie 
- [x] inform the flutter-dev mailing list about the breaking API change: https://groups.google.com/forum/#!topic/flutter-dev/YE5tM2Y0BP8