### PR TITLE
add runtime permission requests for external storage and camera

### DIFF
--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -171,6 +171,7 @@ public class ImagePickerPlugin
         activity.startActivityForResult(
             cameraModule.getCameraIntent(activity), REQUEST_CODE_CAMERA);
       } else {
+        pendingResult.error("no_permissions", "image_picker plugin requires camera permissions", null);
         pendingResult = null;
         methodCall = null;
       }

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -33,7 +33,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-/** Location Plugin */
+/** ImagePicker Plugin */
 public class ImagePickerPlugin
     implements MethodCallHandler, ActivityResultListener, RequestPermissionsResultListener {
   private static String TAG = "ImagePicker";

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -171,7 +171,8 @@ public class ImagePickerPlugin
         activity.startActivityForResult(
             cameraModule.getCameraIntent(activity), REQUEST_CODE_CAMERA);
       } else {
-        pendingResult.error("no_permissions", "image_picker plugin requires camera permissions", null);
+        pendingResult.error(
+            "no_permissions", "image_picker plugin requires camera permissions", null);
         pendingResult = null;
         methodCall = null;
       }

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -11,9 +11,9 @@ import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.media.ExifInterface;
-import android.util.Log;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
+import android.util.Log;
 import com.esafirm.imagepicker.features.ImagePicker;
 import com.esafirm.imagepicker.features.camera.DefaultCameraModule;
 import com.esafirm.imagepicker.features.camera.OnImageReadyListener;
@@ -40,7 +40,7 @@ public class ImagePickerPlugin implements MethodCallHandler, ActivityResultListe
   public static final int REQUEST_CODE_PICK = 2342;
   public static final int REQUEST_CODE_CAMERA = 2343;
   public static final int REQUEST_PERMISSIONS = 2345;
-      
+
   private static final int SOURCE_ASK_USER = 0;
   private static final int SOURCE_CAMERA = 1;
   private static final int SOURCE_GALLERY = 2;
@@ -91,10 +91,17 @@ public class ImagePickerPlugin implements MethodCallHandler, ActivityResultListe
           ImagePicker.create(activity).single().showCamera(false).start(REQUEST_CODE_PICK);
           break;
         case SOURCE_CAMERA:
-          if (ContextCompat.checkSelfPermission(activity, Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED ||
-            ContextCompat.checkSelfPermission(activity, Manifest.permission.READ_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
-            ActivityCompat.requestPermissions(activity,
-                new String[]{Manifest.permission.CAMERA, Manifest.permission.READ_EXTERNAL_STORAGE}, REQUEST_PERMISSIONS);
+          if (ContextCompat.checkSelfPermission(activity, Manifest.permission.CAMERA)
+                  != PackageManager.PERMISSION_GRANTED
+              || ContextCompat.checkSelfPermission(
+                      activity, Manifest.permission.READ_EXTERNAL_STORAGE)
+                  != PackageManager.PERMISSION_GRANTED) {
+            ActivityCompat.requestPermissions(
+                activity,
+                new String[] {
+                  Manifest.permission.CAMERA, Manifest.permission.READ_EXTERNAL_STORAGE
+                },
+                REQUEST_PERMISSIONS);
             pendingResult = null;
             methodCall = null;
             break;

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -4,12 +4,16 @@
 
 package io.flutter.plugins.imagepicker;
 
+import android.Manifest;
 import android.app.Activity;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.media.ExifInterface;
 import android.util.Log;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
 import com.esafirm.imagepicker.features.ImagePicker;
 import com.esafirm.imagepicker.features.camera.DefaultCameraModule;
 import com.esafirm.imagepicker.features.camera.OnImageReadyListener;
@@ -35,7 +39,8 @@ public class ImagePickerPlugin implements MethodCallHandler, ActivityResultListe
 
   public static final int REQUEST_CODE_PICK = 2342;
   public static final int REQUEST_CODE_CAMERA = 2343;
-
+  public static final int REQUEST_PERMISSIONS = 2345;
+      
   private static final int SOURCE_ASK_USER = 0;
   private static final int SOURCE_CAMERA = 1;
   private static final int SOURCE_GALLERY = 2;
@@ -86,6 +91,14 @@ public class ImagePickerPlugin implements MethodCallHandler, ActivityResultListe
           ImagePicker.create(activity).single().showCamera(false).start(REQUEST_CODE_PICK);
           break;
         case SOURCE_CAMERA:
+          if (ContextCompat.checkSelfPermission(activity, Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED ||
+            ContextCompat.checkSelfPermission(activity, Manifest.permission.READ_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
+            ActivityCompat.requestPermissions(activity,
+                new String[]{Manifest.permission.CAMERA, Manifest.permission.READ_EXTERNAL_STORAGE}, REQUEST_PERMISSIONS);
+            pendingResult = null;
+            methodCall = null;
+            break;
+          }
           activity.startActivityForResult(
               cameraModule.getCameraIntent(activity), REQUEST_CODE_CAMERA);
           break;

--- a/packages/image_picker/example/lib/main.dart
+++ b/packages/image_picker/example/lib/main.dart
@@ -44,11 +44,12 @@ class _MyHomePageState extends State<MyHomePage> {
           child: new FutureBuilder<File>(
               future: _imageFile,
               builder: (BuildContext context, AsyncSnapshot<File> snapshot) {
-                if (snapshot.connectionState == ConnectionState.done && snapshot.error == null) {
+                if (snapshot.connectionState == ConnectionState.done &&
+                    snapshot.error == null) {
                   return new Image.file(snapshot.data);
                 } else if (snapshot.error != null) {
                   return const Text('error picking image.');
-                } else  {
+                } else {
                   return const Text('You have not yet picked an image.');
                 }
               })),

--- a/packages/image_picker/example/lib/main.dart
+++ b/packages/image_picker/example/lib/main.dart
@@ -44,9 +44,11 @@ class _MyHomePageState extends State<MyHomePage> {
           child: new FutureBuilder<File>(
               future: _imageFile,
               builder: (BuildContext context, AsyncSnapshot<File> snapshot) {
-                if (snapshot.connectionState == ConnectionState.done) {
+                if (snapshot.connectionState == ConnectionState.done && snapshot.error == null) {
                   return new Image.file(snapshot.data);
-                } else {
+                } else if (snapshot.error != null) {
+                  return const Text('error picking image.');
+                } else  {
                   return const Text('You have not yet picked an image.');
                 }
               })),


### PR DESCRIPTION
Adds runtime permission requests for image_picker when image source is set to camera on Android.

partially fixes https://github.com/flutter/flutter/issues/13921