### PR TITLE
Updated to 0.5.0

### DIFF
--- a/packages/firebase_admob/CHANGELOG.md
+++ b/packages/firebase_admob/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.5.0
+
+* **Breaking change**. The BannerAd constructor now requires an AdSize
+  parameter. BannerAds can be created with AdSize.smartBanner, or one of
+  the other predefined AdSize values. Previously BannerAds were always
+  defined with the smartBanner size.
+
 ## 0.4.0
 
 * **Breaking change**. Set SDK constraints to match the Flutter beta release.

--- a/packages/firebase_admob/pubspec.yaml
+++ b/packages/firebase_admob/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_admob
 description: Firebase AdMob plugin for Flutter applications.
-version: 0.4.0
+version: 0.5.0
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_admob
 


### PR DESCRIPTION
This version of the plugin includes https://github.com/flutter/plugins/pull/402 which ads support for specifying the size of a `BannerAd`
