### PR TITLE
Replace AnchorType.andhorBottom with AnchorType.bottom

### DIFF
--- a/packages/firebase_admob/README.md
+++ b/packages/firebase_admob/README.md
@@ -45,7 +45,7 @@ Ads must be loaded before they're shown.
 ```
 myBanner
   ..load() // typically this happens well before the ad is shown
-  ..show(anchorOffset: 60.0, anchorType: AnchorType.anchorBottom);
+  ..show(anchorOffset: 60.0, anchorType: AnchorType.bottom);
 // Positions the banner ad 60 pixels from the bottom of the screen
 // InterstitialAds are loaded and shown in the same way
 ```


### PR DESCRIPTION
## Overview
Replace `AnchorType.andhorBottom` with `AnchorType.bottom`.

## Refarence
https://github.com/rkowase/plugins/blob/master/packages/firebase_admob/lib/firebase_admob.dart#L85
```dart
enum AnchorType { bottom, top }
```