### PR TITLE
Fix Dart 2 run time errors: Use dynamic types

### DIFF
--- a/packages/camera/lib/camera.dart
+++ b/packages/camera/lib/camera.dart
@@ -41,8 +41,7 @@ Future<List<CameraDescription>> availableCameras() async {
   try {
     final List<dynamic> cameras = await _channel.invokeMethod('list');
     return cameras
-        .cast<Map<String, dynamic>>()
-        .map((Map<String, dynamic> camera) {
+        .map((dynamic camera) {
       return new CameraDescription(
         name: camera['name'],
         lensDirection: _parseCameraLensDirection(camera['lensFacing']),
@@ -162,7 +161,7 @@ class CameraController extends ValueNotifier<CameraValue> {
   final ResolutionPreset resolutionPreset;
   int _textureId;
   bool _disposed = false;
-  StreamSubscription<Map<String, dynamic>> _eventSubscription;
+  StreamSubscription<dynamic> _eventSubscription;
   Completer<Null> _creatingCompleter;
 
   CameraController(this.description, this.resolutionPreset)
@@ -177,7 +176,7 @@ class CameraController extends ValueNotifier<CameraValue> {
     }
     try {
       _creatingCompleter = new Completer<Null>();
-      final Map<String, dynamic> reply = await _channel.invokeMethod(
+      final dynamic reply = await _channel.invokeMethod(
         'create',
         <String, dynamic>{
           'cameraName': description.name,

--- a/packages/camera/lib/camera.dart
+++ b/packages/camera/lib/camera.dart
@@ -40,8 +40,7 @@ CameraLensDirection _parseCameraLensDirection(String string) {
 Future<List<CameraDescription>> availableCameras() async {
   try {
     final List<dynamic> cameras = await _channel.invokeMethod('list');
-    return cameras
-        .map((dynamic camera) {
+    return cameras.map((dynamic camera) {
       return new CameraDescription(
         name: camera['name'],
         lensDirection: _parseCameraLensDirection(camera['lensFacing']),
@@ -204,7 +203,7 @@ class CameraController extends ValueNotifier<CameraValue> {
   }
 
   void _listener(dynamic event) {
-    final Map<String, dynamic> map = event;
+    final dynamic map = event;
     if (_disposed) {
       return;
     }


### PR DESCRIPTION
Dart 2 throws error when Map<String, dynamic> types are used. Using dynamic types fixes the issue for now.