### PR TITLE
Make SharedPreferences return failures

### DIFF
--- a/packages/shared_preferences/README.md
+++ b/packages/shared_preferences/README.md
@@ -3,8 +3,9 @@
 [![pub package](https://img.shields.io/pub/v/shared_preferences.svg)](https://pub.dartlang.org/packages/shared_preferences)
 
 Wraps NSUserDefaults (on iOS) and SharedPreferences (on Android), providing
-a persistent store for simple data. Data is persisted to disk automatically
-and asynchronously.
+a persistent store for simple data. Data is persisted to disk asynchronously.
+Neither platform can guarantee that writes will be persisted to disk after
+returning and this plugin must not be used for storing critical data.
 
 ## Usage
 To use this plugin, add `shared_preferences` as a [dependency in your pubspec.yaml file](https://flutter.io/platform-plugins/).
@@ -32,7 +33,7 @@ _incrementCounter() async {
   SharedPreferences prefs = await SharedPreferences.getInstance();
   int counter = (prefs.getInt('counter') ?? 0) + 1;
   print('Pressed $counter times.');
-  prefs.setInt('counter', counter);
+  await prefs.setInt('counter', counter);
 }
 ```
 

--- a/packages/shared_preferences/example/lib/main.dart
+++ b/packages/shared_preferences/example/lib/main.dart
@@ -30,12 +30,24 @@ class SharedPreferencesDemo extends StatefulWidget {
 
 class SharedPreferencesDemoState extends State<SharedPreferencesDemo> {
   Future<SharedPreferences> _prefs = SharedPreferences.getInstance();
+  Future<int> _counter;
 
   Future<Null> _incrementCounter() async {
     final SharedPreferences prefs = await _prefs;
     final int counter = (prefs.getInt('counter') ?? 0) + 1;
+
     setState(() {
-      prefs.setInt("counter", counter);
+      _counter = prefs.setInt("counter", counter).then((bool success) {
+        return counter;
+      });
+    });
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _counter = _prefs.then((SharedPreferences prefs) {
+      return (prefs.getInt('counter') ?? 0);
     });
   }
 
@@ -46,18 +58,21 @@ class SharedPreferencesDemoState extends State<SharedPreferencesDemo> {
         title: const Text("SharedPreferences Demo"),
       ),
       body: new Center(
-          child: new FutureBuilder<SharedPreferences>(
-              future: _prefs,
-              builder: (BuildContext context,
-                  AsyncSnapshot<SharedPreferences> snapshot) {
-                if (snapshot.connectionState == ConnectionState.waiting)
-                  return const Text('Loading...');
-                final int counter = snapshot.requireData.getInt('counter') ?? 0;
-                // ignore: prefer_const_constructors
-                return new Text(
-                  'Button tapped $counter time${ counter == 1 ? '' : 's' }.\n\n'
-                      'This should persist across restarts.',
-                );
+          child: new FutureBuilder<int>(
+              future: _counter,
+              builder: (BuildContext context, AsyncSnapshot<int> snapshot) {
+                switch (snapshot.connectionState) {
+                  case ConnectionState.waiting:
+                    return const CircularProgressIndicator();
+                  default:
+                    if (snapshot.hasError)
+                      return new Text('Error: ${snapshot.error}');
+                    else
+                      return new Text(
+                        'Button tapped ${snapshot.data} time${ snapshot.data == 1 ? '' : 's' }.\n\n'
+                            'This should persist across restarts.',
+                      );
+                }
               })),
       floatingActionButton: new FloatingActionButton(
         onPressed: _incrementCounter,

--- a/packages/shared_preferences/ios/Classes/SharedPreferencesPlugin.m
+++ b/packages/shared_preferences/ios/Classes/SharedPreferencesPlugin.m
@@ -21,7 +21,7 @@ static NSString *const CHANNEL_NAME = @"plugins.flutter.io/shared_preferences";
       NSString *key = arguments[@"key"];
       NSNumber *value = arguments[@"value"];
       [[NSUserDefaults standardUserDefaults] setBool:value.boolValue forKey:key];
-      result(nil);
+      result(@YES);
     } else if ([method isEqualToString:@"setInt"]) {
       NSString *key = arguments[@"key"];
       NSNumber *value = arguments[@"value"];
@@ -29,33 +29,35 @@ static NSString *const CHANNEL_NAME = @"plugins.flutter.io/shared_preferences";
       // It is best to store it as is and send it back when needed.
       // Platform channel will handle the conversion.
       [[NSUserDefaults standardUserDefaults] setValue:value forKey:key];
-      result(nil);
+      result(@YES);
     } else if ([method isEqualToString:@"setDouble"]) {
       NSString *key = arguments[@"key"];
       NSNumber *value = arguments[@"value"];
       [[NSUserDefaults standardUserDefaults] setDouble:value.doubleValue forKey:key];
-      result(nil);
+      result(@YES);
     } else if ([method isEqualToString:@"setString"]) {
       NSString *key = arguments[@"key"];
       NSString *value = arguments[@"value"];
       [[NSUserDefaults standardUserDefaults] setValue:value forKey:key];
-      result(nil);
+      result(@YES);
     } else if ([method isEqualToString:@"setStringList"]) {
       NSString *key = arguments[@"key"];
       NSArray *value = arguments[@"value"];
       [[NSUserDefaults standardUserDefaults] setValue:value forKey:key];
-      result(nil);
+      result(@YES);
     } else if ([method isEqualToString:@"commit"]) {
-      result([NSNumber numberWithBool:[[NSUserDefaults standardUserDefaults] synchronize]]);
+      // synchronize is deprecated.
+      // "this method is unnecessary and shouldn't be used."
+      result(@YES);
     } else if ([method isEqualToString:@"remove"]) {
       [[NSUserDefaults standardUserDefaults] removeObjectForKey:arguments[@"key"]];
-      result(nil);
+      result(@YES);
     } else if ([method isEqualToString:@"clear"]) {
       NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
       for (NSString *key in getAllPrefs()) {
         [defaults removeObjectForKey:key];
       }
-      result([NSNumber numberWithBool:[[NSUserDefaults standardUserDefaults] synchronize]]);
+      result(@YES);
     } else {
       result(FlutterMethodNotImplemented);
     }

--- a/packages/shared_preferences/test/shared_preferences_test.dart
+++ b/packages/shared_preferences/test/shared_preferences_test.dart
@@ -62,18 +62,13 @@ void main() {
     });
 
     test('writing', () async {
-      preferences.setString('String', kTestValues2['flutter.String']);
-      preferences.setBool('bool', kTestValues2['flutter.bool']);
-      preferences.setInt('int', kTestValues2['flutter.int']);
-      preferences.setDouble('double', kTestValues2['flutter.double']);
-      preferences.setStringList('List', kTestValues2['flutter.List']);
-      expect(preferences.getString('String'), kTestValues2['flutter.String']);
-      expect(preferences.getBool('bool'), kTestValues2['flutter.bool']);
-      expect(preferences.getInt('int'), kTestValues2['flutter.int']);
-      expect(preferences.getDouble('double'), kTestValues2['flutter.double']);
-      expect(preferences.getStringList('List'), kTestValues2['flutter.List']);
-      expect(log, equals(<MethodCall>[]));
-      await preferences.commit();
+      await Future.wait(<Future<bool>>[
+        preferences.setString('String', kTestValues2['flutter.String']),
+        preferences.setBool('bool', kTestValues2['flutter.bool']),
+        preferences.setInt('int', kTestValues2['flutter.int']),
+        preferences.setDouble('double', kTestValues2['flutter.double']),
+        preferences.setStringList('List', kTestValues2['flutter.List'])
+      ]);
       expect(
         log,
         <Matcher>[
@@ -97,9 +92,16 @@ void main() {
             'key': 'flutter.List',
             'value': kTestValues2['flutter.List']
           }),
-          isMethodCall('commit', arguments: null),
         ],
       );
+      log.clear();
+
+      expect(preferences.getString('String'), kTestValues2['flutter.String']);
+      expect(preferences.getBool('bool'), kTestValues2['flutter.bool']);
+      expect(preferences.getInt('int'), kTestValues2['flutter.int']);
+      expect(preferences.getDouble('double'), kTestValues2['flutter.double']);
+      expect(preferences.getStringList('List'), kTestValues2['flutter.List']);
+      expect(log, equals(<MethodCall>[]));
     });
 
     test('removing', () async {
@@ -109,20 +111,18 @@ void main() {
         ..setBool(key, null)
         ..setInt(key, null)
         ..setDouble(key, null)
-        ..setStringList(key, null)
-        ..remove(key);
-      await preferences.commit();
+        ..setStringList(key, null);
+      await preferences.remove(key);
       expect(
-        log,
-        new List<Matcher>.filled(
-          6,
-          isMethodCall(
-            'remove',
-            arguments: <String, dynamic>{'key': 'flutter.$key'},
-          ),
-          growable: true,
-        )..add(isMethodCall('commit', arguments: null)),
-      );
+          log,
+          new List<Matcher>.filled(
+            6,
+            isMethodCall(
+              'remove',
+              arguments: <String, dynamic>{'key': 'flutter.$key'},
+            ),
+            growable: true,
+          ));
     });
 
     test('clearing', () async {


### PR DESCRIPTION
On Android, SharedPreferences#apply() will silently fail if there is an
issue. Using #commit() ensures we can propogate errors up the future
chain.
Also updated the example to reflect the fact that preference writes are
not instant.
Deprecated commit() as neither platform actually implements it
correctly.