### PR TITLE
Remove yourcompany.com from cloud_firestore

### DIFF
--- a/packages/cloud_firestore/example/android/app/google-services.json
+++ b/packages/cloud_firestore/example/android/app/google-services.json
@@ -1,86 +1,27 @@
 {
   "project_info": {
-    "project_number": "297855924061",
-    "firebase_url": "https://flutterfire-cd2f7.firebaseio.com",
-    "project_id": "flutterfire-cd2f7",
-    "storage_bucket": "flutterfire-cd2f7.appspot.com"
+    "project_number": "159623150305",
+    "firebase_url": "https://flutter-firebase-plugins.firebaseio.com",
+    "project_id": "flutter-firebase-plugins",
+    "storage_bucket": "flutter-firebase-plugins.appspot.com"
   },
   "client": [
     {
       "client_info": {
-        "mobilesdk_app_id": "1:297855924061:android:669871c998cc21bd",
+        "mobilesdk_app_id": "1:159623150305:android:236f9daea101f77e",
         "android_client_info": {
-          "package_name": "com.yourcompany.firebaseauth.example"
+          "package_name": "io.flutter.plugins.firebase.firestoreexample"
         }
       },
       "oauth_client": [
         {
-          "client_id": "297855924061-r1u58cnh4p6l1ghpkteil46erlkfll62.apps.googleusercontent.com",
-          "client_type": 1,
-          "android_info": {
-            "package_name": "com.yourcompany.firebaseauth.example",
-            "certificate_hash": "c3adef7e7773e40e777d5c236dbba7461cbea5f0"
-          }
-        },
-        {
-          "client_id": "297855924061-col4in4uubarifm60nbq8id01ec3ss4c.apps.googleusercontent.com",
-          "client_type": 1,
-          "android_info": {
-            "package_name": "com.yourcompany.firebaseauth.example",
-            "certificate_hash": "8a4e194f5bfc3fb1075e7daae8dcddd526fde207"
-          }
-        },
-        {
-          "client_id": "297855924061-f68m5v860ms5faiotn5mv9f50cmpacdq.apps.googleusercontent.com",
+          "client_id": "159623150305-q05bbbtsutr02abhips3suj7hujfk4bg.apps.googleusercontent.com",
           "client_type": 3
         }
       ],
       "api_key": [
         {
-          "current_key": "AIzaSyD_shO5mfO9lhy2TVWhfo1VUmARKlG4suk"
-        }
-      ],
-      "services": {
-        "analytics_service": {
-          "status": 1
-        },
-        "appinvite_service": {
-          "status": 2,
-          "other_platform_oauth_client": [
-            {
-              "client_id": "297855924061-f68m5v860ms5faiotn5mv9f50cmpacdq.apps.googleusercontent.com",
-              "client_type": 3
-            },
-            {
-              "client_id": "297855924061-1skfqv2sc9avlclefi3q2l229t98dpda.apps.googleusercontent.com",
-              "client_type": 2,
-              "ios_info": {
-                "bundle_id": "com.yourcompany.firestoreExample"
-              }
-            }
-          ]
-        },
-        "ads_service": {
-          "status": 2
-        }
-      }
-    },
-    {
-      "client_info": {
-        "mobilesdk_app_id": "1:297855924061:android:92efa9a0df6f077f",
-        "android_client_info": {
-          "package_name": "io.flutter.plugins.firebase_storage_example"
-        }
-      },
-      "oauth_client": [
-        {
-          "client_id": "297855924061-f68m5v860ms5faiotn5mv9f50cmpacdq.apps.googleusercontent.com",
-          "client_type": 3
-        }
-      ],
-      "api_key": [
-        {
-          "current_key": "AIzaSyD_shO5mfO9lhy2TVWhfo1VUmARKlG4suk"
+          "current_key": "AIzaSyChk3KEG7QYrs4kQPLP1tjJNxBTbfCAdgg"
         }
       ],
       "services": {
@@ -90,108 +31,6 @@
         "appinvite_service": {
           "status": 1,
           "other_platform_oauth_client": []
-        },
-        "ads_service": {
-          "status": 2
-        }
-      }
-    },
-    {
-      "client_info": {
-        "mobilesdk_app_id": "1:297855924061:android:db912bec12847bd9",
-        "android_client_info": {
-          "package_name": "io.flutter.plugins.firebase_database_example"
-        }
-      },
-      "oauth_client": [
-        {
-          "client_id": "297855924061-fbg7lp8bvtbibn2edns7d5fc3k0fhsa3.apps.googleusercontent.com",
-          "client_type": 1,
-          "android_info": {
-            "package_name": "io.flutter.plugins.firebase_database_example",
-            "certificate_hash": "c3adef7e7773e40e777d5c236dbba7461cbea5f0"
-          }
-        },
-        {
-          "client_id": "297855924061-f68m5v860ms5faiotn5mv9f50cmpacdq.apps.googleusercontent.com",
-          "client_type": 3
-        }
-      ],
-      "api_key": [
-        {
-          "current_key": "AIzaSyD_shO5mfO9lhy2TVWhfo1VUmARKlG4suk"
-        }
-      ],
-      "services": {
-        "analytics_service": {
-          "status": 1
-        },
-        "appinvite_service": {
-          "status": 2,
-          "other_platform_oauth_client": [
-            {
-              "client_id": "297855924061-f68m5v860ms5faiotn5mv9f50cmpacdq.apps.googleusercontent.com",
-              "client_type": 3
-            },
-            {
-              "client_id": "297855924061-1skfqv2sc9avlclefi3q2l229t98dpda.apps.googleusercontent.com",
-              "client_type": 2,
-              "ios_info": {
-                "bundle_id": "com.yourcompany.firestoreExample"
-              }
-            }
-          ]
-        },
-        "ads_service": {
-          "status": 2
-        }
-      }
-    },
-    {
-      "client_info": {
-        "mobilesdk_app_id": "1:297855924061:android:236f9daea101f77e",
-        "android_client_info": {
-          "package_name": "io.flutter.plugins.firebase.firestoreexample"
-        }
-      },
-      "oauth_client": [
-        {
-          "client_id": "297855924061-n8i063j2dib6goh5or4lrctg6sccpevi.apps.googleusercontent.com",
-          "client_type": 1,
-          "android_info": {
-            "package_name": "io.flutter.plugins.firebase.firestoreexample",
-            "certificate_hash": "a8fc78a37cd4f0471580936de67a2cb2ae4657c7"
-          }
-        },
-        {
-          "client_id": "297855924061-f68m5v860ms5faiotn5mv9f50cmpacdq.apps.googleusercontent.com",
-          "client_type": 3
-        }
-      ],
-      "api_key": [
-        {
-          "current_key": "AIzaSyD_shO5mfO9lhy2TVWhfo1VUmARKlG4suk"
-        }
-      ],
-      "services": {
-        "analytics_service": {
-          "status": 1
-        },
-        "appinvite_service": {
-          "status": 2,
-          "other_platform_oauth_client": [
-            {
-              "client_id": "297855924061-f68m5v860ms5faiotn5mv9f50cmpacdq.apps.googleusercontent.com",
-              "client_type": 3
-            },
-            {
-              "client_id": "297855924061-1skfqv2sc9avlclefi3q2l229t98dpda.apps.googleusercontent.com",
-              "client_type": 2,
-              "ios_info": {
-                "bundle_id": "com.yourcompany.firestoreExample"
-              }
-            }
-          ]
         },
         "ads_service": {
           "status": 2

--- a/packages/cloud_firestore/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/cloud_firestore/example/ios/Runner.xcodeproj/project.pbxproj
@@ -7,8 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		2D5378261FAA1A9400D5DBA9 /* flutter_assets in Resources */ = {isa = PBXBuildFile; fileRef = 2D5378251FAA1A9400D5DBA9 /* flutter_assets */; };
+		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		3B80C3941E831B6300D905FE /* App.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B80C3931E831B6300D905FE /* App.framework */; };
 		3B80C3951E831B6300D905FE /* App.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3B80C3931E831B6300D905FE /* App.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5C6F5A711EC3CCCC008D64B5 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C6F5A701EC3CCCC008D64B5 /* GeneratedPluginRegistrant.m */; };
@@ -41,8 +41,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		2D5378251FAA1A9400D5DBA9 /* flutter_assets */ = {isa = PBXFileReference; lastKnownFileType = folder; name = flutter_assets; path = Flutter/flutter_assets; sourceTree = SOURCE_ROOT; };
+		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		3B80C3931E831B6300D905FE /* App.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = App.framework; path = Flutter/App.framework; sourceTree = "<group>"; };
 		5C6F5A6F1EC3CCCC008D64B5 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		5C6F5A701EC3CCCC008D64B5 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
@@ -186,7 +186,6 @@
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
 						CreatedOnToolsVersion = 7.3.1;
-						DevelopmentTeam = 3GRKCVVJ22;
 					};
 				};
 			};
@@ -248,11 +247,11 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-Runner/Pods-Runner-resources.sh",
-				"$PODS_CONFIGURATION_BUILD_DIR/gRPC/gRPCCertificates.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/gRPC/gRPCCertificates.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/gRPCCertificates.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -266,7 +265,7 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
-				"${PODS_ROOT}/../../../../../../flutter/bin/cache/artifacts/engine/ios/Flutter.framework",
+				"${PODS_ROOT}/.symlinks/flutter/ios/Flutter.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
@@ -440,7 +439,6 @@
 			buildSettings = {
 				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = 3GRKCVVJ22;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -452,7 +450,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.yourcompany.firestoreExample;
+				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.firestoreExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -463,7 +461,6 @@
 			buildSettings = {
 				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = 3GRKCVVJ22;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -475,7 +472,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.yourcompany.firestoreExample;
+				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.firestoreExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/packages/cloud_firestore/example/ios/Runner/GoogleService-Info.plist
+++ b/packages/cloud_firestore/example/ios/Runner/GoogleService-Info.plist
@@ -7,21 +7,21 @@
 	<key>AD_UNIT_ID_FOR_INTERSTITIAL_TEST</key>
 	<string>ca-app-pub-3940256099942544/4411468910</string>
 	<key>CLIENT_ID</key>
-	<string>297855924061-1skfqv2sc9avlclefi3q2l229t98dpda.apps.googleusercontent.com</string>
+	<string>159623150305-1iiqqggbff817a8bpnalo64nuc3qobid.apps.googleusercontent.com</string>
 	<key>REVERSED_CLIENT_ID</key>
-	<string>com.googleusercontent.apps.297855924061-1skfqv2sc9avlclefi3q2l229t98dpda</string>
+	<string>com.googleusercontent.apps.159623150305-1iiqqggbff817a8bpnalo64nuc3qobid</string>
 	<key>API_KEY</key>
-	<string>AIzaSyBq6mcufFXfyqr79uELCiqM_O_1-G72PVU</string>
+	<string>AIzaSyDyzecVw1zXTpBKwfFHxpl7QyYBhimNhUk</string>
 	<key>GCM_SENDER_ID</key>
-	<string>297855924061</string>
+	<string>159623150305</string>
 	<key>PLIST_VERSION</key>
 	<string>1</string>
 	<key>BUNDLE_ID</key>
-	<string>com.yourcompany.firestoreExample</string>
+	<string>io.flutter.plugins.firestoreExample</string>
 	<key>PROJECT_ID</key>
-	<string>flutterfire-cd2f7</string>
+	<string>flutter-firebase-plugins</string>
 	<key>STORAGE_BUCKET</key>
-	<string>flutterfire-cd2f7.appspot.com</string>
+	<string>flutter-firebase-plugins.appspot.com</string>
 	<key>IS_ADS_ENABLED</key>
 	<true></true>
 	<key>IS_ANALYTICS_ENABLED</key>
@@ -33,8 +33,8 @@
 	<key>IS_SIGNIN_ENABLED</key>
 	<true></true>
 	<key>GOOGLE_APP_ID</key>
-	<string>1:297855924061:ios:5f2bcc6ba8cecddd</string>
+	<string>1:159623150305:ios:7e8aafdf0bd8d289</string>
 	<key>DATABASE_URL</key>
-	<string>https://flutterfire-cd2f7.firebaseio.com</string>
+	<string>https://flutter-firebase-plugins.firebaseio.com</string>
 </dict>
 </plist>

--- a/packages/cloud_firestore/example/ios/Runner/Info.plist
+++ b/packages/cloud_firestore/example/ios/Runner/Info.plist
@@ -18,18 +18,6 @@
 	<string>1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
-	<key>CFBundleURLTypes</key>
-	<array>
-		<dict>
-			<key>CFBundleTypeRole</key>
-			<string>Editor</string>
-			<key>CFBundleURLSchemes</key>
-			<array>
-				<string>com.googleusercontent.apps.297855924061-1skfqv2sc9avlclefi3q2l229t98dpda</string>
-				<string>com.yourcompany.firestoreExample</string>
-			</array>
-		</dict>
-	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/packages/cloud_firestore/example/lib/main.dart
+++ b/packages/cloud_firestore/example/lib/main.dart
@@ -11,19 +11,23 @@ void main() {
   runApp(new MaterialApp(title: 'Firestore Example', home: new MyHomePage()));
 }
 
-class BookList extends StatelessWidget {
+class MessageList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return new StreamBuilder<QuerySnapshot>(
-      stream: Firestore.instance.collection('books').snapshots,
+      stream: Firestore.instance.collection('messages').snapshots,
       builder: (BuildContext context, AsyncSnapshot<QuerySnapshot> snapshot) {
         if (!snapshot.hasData) return const Text('Loading...');
-        return new ListView(
-          children: snapshot.data.documents.map((DocumentSnapshot document) {
+        final int messageCount = snapshot.data.documents.length;
+        return new ListView.builder(
+          itemCount: messageCount,
+          itemBuilder: (_, int index) {
+            final DocumentSnapshot document = snapshot.data.documents[index];
             return new ListTile(
               title: new Text(document['message'] ?? '<No message retrieved>'),
+              subtitle: new Text('Message ${index + 1} of $messageCount'),
             );
-          }).toList(),
+          },
         );
       },
     );
@@ -34,10 +38,7 @@ class MyHomePage extends StatelessWidget {
   CollectionReference get messages => Firestore.instance.collection('messages');
 
   Future<Null> _addMessage() async {
-    Firestore.instance
-        .collection('books')
-        .document()
-        .setData(<String, String>{'message': 'Hello world!'});
+    messages.document().setData(<String, String>{'message': 'Hello world!'});
   }
 
   @override
@@ -46,7 +47,7 @@ class MyHomePage extends StatelessWidget {
       appBar: new AppBar(
         title: const Text('Firestore Example'),
       ),
-      body: new BookList(),
+      body: new MessageList(),
       floatingActionButton: new FloatingActionButton(
         onPressed: _addMessage,
         tooltip: 'Increment',

--- a/packages/cloud_firestore/lib/cloud_firestore.dart
+++ b/packages/cloud_firestore/lib/cloud_firestore.dart
@@ -23,4 +23,5 @@ part 'src/firestore.dart';
 part 'src/query.dart';
 part 'src/query_snapshot.dart';
 part 'src/set_options.dart';
+part 'src/snapshot_metadata.dart';
 part 'src/write_batch.dart';


### PR DESCRIPTION
This PR is one of several (extracted from https://github.com/flutter/plugins/pull/386) intended to remove all remaining uses of `yourcompany.com` from the plugin repo.

Since `yourcompany.com` was previously part of app IDs, the Google services json/plist files and their their source Firebase projects need updating. I do not have access to the original Firebase project used, and so created a new one. (@collinjackson feel free to push back on this, e.g. by sending me updated Google services files generated from the original project.)

For `cloud_firestore` in particular, a few other corrections were made in #386, and replicated here:
- example changed from books to messages
- missing library part declared in main library file
- Apple developer ID removed from iOS 