### PR TITLE
Remove yourcompany.com from iOS product bundle IDs

### DIFF
--- a/packages/camera/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/camera/example/ios/Runner.xcodeproj/project.pbxproj
@@ -445,7 +445,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.yourcompany.cameraExample;
+				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.cameraExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -468,7 +468,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.yourcompany.cameraExample;
+				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.cameraExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/packages/device_info/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/device_info/example/ios/Runner.xcodeproj/project.pbxproj
@@ -437,7 +437,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.yourcompany.deviceInfoExample;
+				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.deviceInfoExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -459,7 +459,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.yourcompany.deviceInfoExample;
+				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.deviceInfoExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/packages/image_picker/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/image_picker/example/ios/Runner.xcodeproj/project.pbxproj
@@ -439,7 +439,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.yourcompany.imagePickerExample;
+				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.imagePickerExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -462,7 +462,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.yourcompany.imagePickerExample;
+				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.imagePickerExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/packages/shared_preferences/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/shared_preferences/example/ios/Runner.xcodeproj/project.pbxproj
@@ -437,7 +437,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.yourcompany.sharedPreferencesExample;
+				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.sharedPreferencesExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -459,7 +459,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.yourcompany.sharedPreferencesExample;
+				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.sharedPreferencesExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;


### PR DESCRIPTION
This PR is one of several (extracted from #386) intended to remove all remaining uses of yourcompany.com from the plugin repo.