### PR TITLE
Fix FirebaseApp projectID on iOS

### DIFF
--- a/packages/firebase_core/CHANGELOG.md
+++ b/packages/firebase_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2
+
+* Fix projectID on iOS
+
 ## 0.1.1
 
 * Fix behavior of constructor for named Firebase apps.

--- a/packages/firebase_core/ios/Classes/FirebaseCorePlugin.m
+++ b/packages/firebase_core/ios/Classes/FirebaseCorePlugin.m
@@ -49,7 +49,7 @@
     if (![optionsDictionary[@"trackingID"] isEqual:[NSNull null]])
       options.trackingID = optionsDictionary[@"trackingID"];
     if (![optionsDictionary[@"projectID"] isEqual:[NSNull null]])
-      options.androidClientID = optionsDictionary[@"projectID"];
+      options.projectID = optionsDictionary[@"projectID"];
     if (![optionsDictionary[@"androidClientID"] isEqual:[NSNull null]])
       options.androidClientID = optionsDictionary[@"androidClientID"];
     if (![optionsDictionary[@"databaseURL"] isEqual:[NSNull null]])

--- a/packages/firebase_core/pubspec.yaml
+++ b/packages/firebase_core/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Core, enabling connecting to multiple
   Firebase apps.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_core
-version: 0.1.1
+version: 0.1.2
 
 flutter:
   plugin:


### PR DESCRIPTION
This fix is required for Firestore multiple app support.