### PR TITLE
Added getAll for debugging purposes

### DIFF
--- a/packages/shared_preferences/lib/shared_preferences.dart
+++ b/packages/shared_preferences/lib/shared_preferences.dart
@@ -45,6 +45,9 @@ class SharedPreferences {
   /// in sync since the setter method might fail for any reason.
   final Map<String, Object> _preferenceCache;
 
+  /// returns the entire set for debugging purposes.
+  Map<String,Object> getAll() => _preferenceCache;
+
   /// Reads a value of any type from persistent storage.
   dynamic get(String key) => _preferenceCache[key];
 


### PR DESCRIPTION
As far as I know in the shared_preferences plugin. There is no way to debug what key/value pairs are set in the storage. I added a simple method that returns the entire Map so it's easier to debug.

Maybe i'm just wrong and overlooking something on how to debug it. If that's the case please do tell and i'll remove the Pull request.