### PR TITLE
Fix crash on iOS when loading a video from assets without a package

### DIFF
--- a/packages/video_player/ios/Classes/VideoPlayerPlugin.m
+++ b/packages/video_player/ios/Classes/VideoPlayerPlugin.m
@@ -298,7 +298,7 @@ static void* playbackLikelyToKeepUpContext = &playbackLikelyToKeepUpContext;
     if (dataSource) {
       NSString* assetPath;
       NSString* package = argsMap[@"package"];
-      if (package) {
+      if (![package isEqual:[NSNull null]]) {
         assetPath = [_registrar lookupKeyForAsset:dataSource fromPackage:package];
       } else {
         assetPath = [_registrar lookupKeyForAsset:dataSource];


### PR DESCRIPTION
The video_player plugin crashes on iOS whenever it attempts to load an asset image. This only happens when the image has no package. The problem seems to be that `package` in Obj-C is deserialized as a `NSNull` instance instead of `nil`. 
