### PR TITLE
Fix broken listeners in firebase_admob

### DIFF
--- a/packages/firebase_admob/CHANGELOG.md
+++ b/packages/firebase_admob/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.1
+
+* Fixed Dart 2 type errors.
+
 ## 0.5.0
 
 * **Breaking change**. The BannerAd constructor now requires an AdSize

--- a/packages/firebase_admob/lib/firebase_admob.dart
+++ b/packages/firebase_admob/lib/firebase_admob.dart
@@ -466,7 +466,7 @@ class FirebaseAdMob {
 
   Future<dynamic> _handleMethod(MethodCall call) {
     assert(call.arguments is Map);
-    final Map<String, dynamic> argumentsMap = call.arguments;
+    final Map<dynamic, dynamic> argumentsMap = call.arguments;
     final RewardedVideoAdEvent rewardedEvent =
         _methodToRewardedVideoAdEvent[call.method];
     if (rewardedEvent != null) {

--- a/packages/firebase_admob/pubspec.yaml
+++ b/packages/firebase_admob/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_admob
 description: Firebase AdMob plugin for Flutter applications.
-version: 0.5.0
+version: 0.5.1
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_admob
 


### PR DESCRIPTION
Fix listeners in firebase_admob. 

```
type '_InternalLinkedHashMap<dynamic, dynamic>' is not a subtype of type 'Map<String, dynamic>'
```