### PR TITLE
Support for firebase_core interoperating with native code that configures Firebase apps.

### DIFF
--- a/packages/firebase_core/CHANGELOG.md
+++ b/packages/firebase_core/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.0
+
+* **Breaking change**. Options API is now async to interoperate with native code that configures Firebase apps.
+* Provide a getter for the default app
+* Fix setting of GCM sender ID on iOS
+
 ## 0.1.2
 
 * Fix projectID on iOS

--- a/packages/firebase_core/android/src/main/java/io/flutter/plugins/firebase/core/FirebaseCorePlugin.java
+++ b/packages/firebase_core/android/src/main/java/io/flutter/plugins/firebase/core/FirebaseCorePlugin.java
@@ -85,6 +85,7 @@ public class FirebaseCorePlugin implements MethodCallHandler {
             FirebaseApp app = FirebaseApp.getInstance(name);
             result.success(asMap(app));
           } catch (IllegalStateException ex) {
+            // App doesn't exist, so successfully return null.
             result.success(null);
           }
           break;

--- a/packages/firebase_core/android/src/main/java/io/flutter/plugins/firebase/core/FirebaseCorePlugin.java
+++ b/packages/firebase_core/android/src/main/java/io/flutter/plugins/firebase/core/FirebaseCorePlugin.java
@@ -32,7 +32,7 @@ public class FirebaseCorePlugin implements MethodCallHandler {
     this.context = context;
   }
 
-  private Map appAsMap(FirebaseApp app) {
+  private Map asMap(FirebaseApp app) {
     Map<String, Object> appMap = new HashMap<>();
     appMap.put("name", app.getName());
     FirebaseOptions options = app.getOptions();
@@ -73,7 +73,7 @@ public class FirebaseCorePlugin implements MethodCallHandler {
         {
           List<Map<String, Object>> apps = new ArrayList<>();
           for (FirebaseApp app : FirebaseApp.getApps(context)) {
-            apps.add(appAsMap(app));
+            apps.add(asMap(app));
           }
           result.success(apps);
           break;
@@ -83,7 +83,7 @@ public class FirebaseCorePlugin implements MethodCallHandler {
           String name = (String) call.arguments();
           try {
             FirebaseApp app = FirebaseApp.getInstance(name);
-            result.success(appAsMap(app));
+            result.success(asMap(app));
           } catch (IllegalStateException ex) {
             result.success(null);
           }

--- a/packages/firebase_core/android/src/main/java/io/flutter/plugins/firebase/core/FirebaseCorePlugin.java
+++ b/packages/firebase_core/android/src/main/java/io/flutter/plugins/firebase/core/FirebaseCorePlugin.java
@@ -32,6 +32,21 @@ public class FirebaseCorePlugin implements MethodCallHandler {
     this.context = context;
   }
 
+  private Map appAsMap(FirebaseApp app) {
+    Map<String, Object> appMap = new HashMap<>();
+    appMap.put("name", app.getName());
+    FirebaseOptions options = app.getOptions();
+    Map<String, String> optionsMap = new HashMap<>();
+    optionsMap.put("googleAppID", options.getApplicationId());
+    optionsMap.put("GCMSenderID", options.getGcmSenderId());
+    optionsMap.put("APIKey", options.getApiKey());
+    optionsMap.put("databaseURL", options.getDatabaseUrl());
+    optionsMap.put("storageBucket", options.getStorageBucket());
+    optionsMap.put("projectID", options.getProjectId());
+    appMap.put("options", optionsMap);
+    return appMap;
+  }
+
   @Override
   public void onMethodCall(MethodCall call, final Result result) {
     switch (call.method) {
@@ -50,32 +65,28 @@ public class FirebaseCorePlugin implements MethodCallHandler {
                   .setProjectId(optionsMap.get("projectId"))
                   .setStorageBucket(optionsMap.get("storageBucket"))
                   .build();
-          if (name != null) {
-            FirebaseApp.initializeApp(context, options, name);
-          } else {
-            FirebaseApp.initializeApp(context, options);
-          }
+          FirebaseApp.initializeApp(context, options, name);
           result.success(null);
           break;
         }
       case "FirebaseApp#allApps":
         {
           List<Map<String, Object>> apps = new ArrayList<>();
-          Map<String, Object> appMap = new HashMap<>();
           for (FirebaseApp app : FirebaseApp.getApps(context)) {
-            appMap.put("name", app.getName());
-            FirebaseOptions options = app.getOptions();
-            Map<String, String> optionsMap = new HashMap<>();
-            optionsMap.put("googleAppID", options.getApplicationId());
-            optionsMap.put("GCMSenderID", options.getGcmSenderId());
-            optionsMap.put("APIKey", options.getApiKey());
-            optionsMap.put("databaseURL", options.getDatabaseUrl());
-            optionsMap.put("storageBucket", options.getStorageBucket());
-            optionsMap.put("projectID", options.getProjectId());
-            appMap.put("options", optionsMap);
-            apps.add(appMap);
+            apps.add(appAsMap(app));
           }
           result.success(apps);
+          break;
+        }
+      case "FirebaseApp#appNamed":
+        {
+          String name = (String) call.arguments();
+          try {
+            FirebaseApp app = FirebaseApp.getInstance(name);
+            result.success(appAsMap(app));
+          } catch (IllegalStateException ex) {
+            result.success(null);
+          }
           break;
         }
       default:

--- a/packages/firebase_core/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/firebase_core/example/ios/Runner.xcodeproj/project.pbxproj
@@ -9,8 +9,8 @@
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		2AE3C69805AB6FB8C037C7BA /* libPods-Runner.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 39D23D0C629B8A857DE66538 /* libPods-Runner.a */; };
-		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		2D5378261FAA1A9400D5DBA9 /* flutter_assets in Resources */ = {isa = PBXBuildFile; fileRef = 2D5378251FAA1A9400D5DBA9 /* flutter_assets */; };
+		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		3B80C3941E831B6300D905FE /* App.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B80C3931E831B6300D905FE /* App.framework */; };
 		3B80C3951E831B6300D905FE /* App.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3B80C3931E831B6300D905FE /* App.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9705A1C61CF904A100538489 /* Flutter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9740EEBA1CF902C7004384FC /* Flutter.framework */; };
@@ -42,9 +42,9 @@
 /* Begin PBXFileReference section */
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
+		2D5378251FAA1A9400D5DBA9 /* flutter_assets */ = {isa = PBXFileReference; lastKnownFileType = folder; name = flutter_assets; path = Flutter/flutter_assets; sourceTree = SOURCE_ROOT; };
 		39D23D0C629B8A857DE66538 /* libPods-Runner.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Runner.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
-		2D5378251FAA1A9400D5DBA9 /* flutter_assets */ = {isa = PBXFileReference; lastKnownFileType = folder; name = flutter_assets; path = Flutter/flutter_assets; sourceTree = SOURCE_ROOT; };
 		3B80C3931E831B6300D905FE /* App.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = App.framework; path = Flutter/App.framework; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		7AFFD8ED1D35381100E5BB4D /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -276,7 +276,7 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
-				"${PODS_ROOT}/../../../../../../flutter/bin/cache/artifacts/engine/ios/Flutter.framework",
+				"${PODS_ROOT}/.symlinks/flutter/ios/Flutter.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (

--- a/packages/firebase_core/example/lib/main.dart
+++ b/packages/firebase_core/example/lib/main.dart
@@ -26,6 +26,12 @@ class MyApp extends StatelessWidget {
     print('Currently configured apps: $apps');
   }
 
+  Future<Null> _options() async {
+    final FirebaseApp app = await FirebaseApp.appNamed(name);
+    final FirebaseOptions options = await app?.options;
+    print('Configured options for app $name: $options');
+  }
+
   @override
   Widget build(BuildContext context) {
     return new MaterialApp(
@@ -43,6 +49,8 @@ class MyApp extends StatelessWidget {
                   onPressed: _configure, child: const Text('initialize')),
               new RaisedButton(
                   onPressed: _allApps, child: const Text('allApps')),
+              new RaisedButton(
+                  onPressed: _options, child: const Text('options')),
             ],
           ),
         ),

--- a/packages/firebase_core/example/lib/main.dart
+++ b/packages/firebase_core/example/lib/main.dart
@@ -29,7 +29,7 @@ class MyApp extends StatelessWidget {
   Future<Null> _options() async {
     final FirebaseApp app = await FirebaseApp.appNamed(name);
     final FirebaseOptions options = await app?.options;
-    print('Configured options for app $name: $options');
+    print('Current options for app $name: $options');
   }
 
   @override

--- a/packages/firebase_core/ios/Classes/FirebaseCorePlugin.h
+++ b/packages/firebase_core/ios/Classes/FirebaseCorePlugin.h
@@ -1,4 +1,8 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #import <Flutter/Flutter.h>
 
-@interface FLTFirebaseCorePlugin : NSObject<FlutterPlugin>
+@interface FLTFirebaseCorePlugin : NSObject <FlutterPlugin>
 @end

--- a/packages/firebase_core/ios/Classes/FirebaseCorePlugin.h
+++ b/packages/firebase_core/ios/Classes/FirebaseCorePlugin.h
@@ -4,5 +4,5 @@
 
 #import <Flutter/Flutter.h>
 
-@interface FLTFirebaseCorePlugin : NSObject <FlutterPlugin>
+@interface FLTFirebaseCorePlugin : NSObject<FlutterPlugin>
 @end

--- a/packages/firebase_core/ios/Classes/FirebaseCorePlugin.m
+++ b/packages/firebase_core/ios/Classes/FirebaseCorePlugin.m
@@ -1,3 +1,7 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #import "FirebaseCorePlugin.h"
 
 #import <Firebase/Firebase.h>
@@ -7,7 +11,7 @@
 @end
 
 @implementation FIROptions (FLTFirebaseCorePlugin)
-- (NSDictionary *)dictionary {
+- (NSDictionary *)flutterDictionary {
   return @{
     @"googleAppID" : self.googleAppID ?: [NSNull null],
     @"bundleID" : self.bundleID ?: [NSNull null],
@@ -20,6 +24,15 @@
     @"databaseUrl" : self.databaseURL ?: [NSNull null],
     @"storageBucket" : self.storageBucket ?: [NSNull null],
     @"deepLinkURLScheme" : self.deepLinkURLScheme ?: [NSNull null],
+  };
+}
+@end
+
+@implementation FIRApp (FLTFirebaseCorePlugin)
+- (NSDictionary *)flutterDictionary {
+  return @{
+    @"name" : self.name,
+    @"options" : self.options.flutterDictionary,
   };
 }
 @end
@@ -58,20 +71,20 @@
       options.storageBucket = optionsDictionary[@"storageBucket"];
     if (![optionsDictionary[@"deepLinkURLScheme"] isEqual:[NSNull null]])
       options.deepLinkURLScheme = optionsDictionary[@"deepLinkURLScheme"];
-    if (![name isEqual:[NSNull null]]) {
-      [FIRApp configureWithName:name options:options];
-    } else {
-      [FIRApp configureWithOptions:options];
-    }
+    [FIRApp configureWithName:name options:options];
     result(nil);
   } else if ([@"FirebaseApp#allApps" isEqualToString:call.method]) {
     NSDictionary<NSString *, FIRApp *> *allApps = [FIRApp allApps];
     NSMutableArray *appsList = [NSMutableArray array];
     for (NSString *name in allApps) {
       FIRApp *app = allApps[name];
-      [appsList addObject:@{@"name" : app.name, @"options" : app.options.dictionary}];
+      [appsList addObject:app.flutterDictionary];
     }
     result(appsList.count > 0 ? appsList : nil);
+  } else if ([@"FirebaseApp#appNamed" isEqualToString:call.method]) {
+    NSString *name = call.arguments;
+    FIRApp *app = [FIRApp appNamed:name];
+    result(app.flutterDictionary);
   } else {
     result(FlutterMethodNotImplemented);
   }

--- a/packages/firebase_core/lib/firebase_core.dart
+++ b/packages/firebase_core/lib/firebase_core.dart
@@ -5,6 +5,7 @@
 library firebase_core;
 
 import 'dart:async';
+import 'dart:io' show Platform;
 import 'dart:ui' show hashValues;
 
 import 'package:flutter/services.dart';

--- a/packages/firebase_core/lib/src/firebase_app.dart
+++ b/packages/firebase_core/lib/src/firebase_app.dart
@@ -64,7 +64,7 @@ class FirebaseApp {
     final FirebaseApp existingApp = await FirebaseApp.appNamed(name);
     if (existingApp != null) {
       assert(await existingApp.options == options);
-      return;
+      return existingApp;
     }
     await channel.invokeMethod(
       'FirebaseApp#configure',

--- a/packages/firebase_core/lib/src/firebase_app.dart
+++ b/packages/firebase_core/lib/src/firebase_app.dart
@@ -8,7 +8,7 @@ class FirebaseApp {
   @visibleForTesting
   const FirebaseApp({@required this.name}) : assert(name != null);
 
-  /// Gets the name of this app.
+  /// The name of this app.
   final String name;
 
   static final String defaultAppName =
@@ -19,7 +19,7 @@ class FirebaseApp {
     'plugins.flutter.io/firebase_core',
   );
 
-  /// Gets a copy of the options for this app. These are non-modifiable.
+  /// A copy of the options for this app. These are non-modifiable.
   ///
   /// This getter is asynchronous because apps can also be configured by native
   /// code.
@@ -68,7 +68,7 @@ class FirebaseApp {
     }
     await channel.invokeMethod(
       'FirebaseApp#configure',
-      <String, dynamic>{'name': name, 'options': options?.asMap},
+      <String, dynamic>{'name': name, 'options': options.asMap},
     );
     return new FirebaseApp(name: name);
   }

--- a/packages/firebase_core/lib/src/firebase_app.dart
+++ b/packages/firebase_core/lib/src/firebase_app.dart
@@ -6,44 +6,71 @@ part of firebase_core;
 
 class FirebaseApp {
   @visibleForTesting
-  const FirebaseApp({this.name, @required this.options});
+  const FirebaseApp({@required this.name}) : assert(name != null);
 
   /// Gets the name of this app.
-  ///
-  /// If null, the default name is used.
   final String name;
 
-  /// Gets a copy of the options for this app. These are non-modifiable.
-  final FirebaseOptions options;
+  static final String defaultAppName =
+      Platform.isIOS ? '__FIRAPP_DEFAULT' : '[DEFAULT]';
 
   @visibleForTesting
   static const MethodChannel channel = const MethodChannel(
     'plugins.flutter.io/firebase_core',
   );
 
-  static Map<String, FirebaseApp> _namedApps = <String, FirebaseApp>{};
+  /// Gets a copy of the options for this app. These are non-modifiable.
+  ///
+  /// This method is asynchronous because apps can also be configured by native
+  /// code.
+  Future<FirebaseOptions> get options async {
+    final Map<dynamic, dynamic> app = await channel.invokeMethod(
+      'FirebaseApp#appNamed',
+      name,
+    );
+    assert(app != null);
+    return new FirebaseOptions.from(app['options']);
+  }
 
   /// Returns a previously created FirebaseApp instance with the given name,
   /// or null if no such app exists.
-  factory FirebaseApp.named(String name) => _namedApps[name];
+  static Future<FirebaseApp> appNamed(String name) async {
+    final Map<dynamic, dynamic> app = await channel.invokeMethod(
+      'FirebaseApp#appNamed',
+      name,
+    );
+    return app == null ? null : new FirebaseApp(name: app['name']);
+  }
 
-  /// Configures an app with the given name.
+  /// Returns the default (first initialized) instance of the FirebaseApp.
+  static final FirebaseApp instance = new FirebaseApp(name: defaultAppName);
+
+  /// Configures an app with the given [name] and [options].
   ///
-  /// If an app with that name has already been configured, asserts that the
-  /// [options] haven't changed.
-  static Future<FirebaseApp> configure(
-      {String name, @required FirebaseOptions options}) {
-    final FirebaseApp existingApp = _namedApps[name];
-    if (existingApp != null) {
-      assert(existingApp.options == options);
-      return new Future<FirebaseApp>.sync(() => existingApp);
-    }
+  /// Configuring the default app is not currently supported. Plugins that
+  /// can interact with the default app should configure it automatically at
+  /// plugin registration time.
+  ///
+  /// Changing the options of a configured app is not supported. Reconfiguring
+  /// an existing app will assert that the options haven't changed.
+  static Future<FirebaseApp> configure({
+    @required String name,
+    @required FirebaseOptions options,
+  }) async {
+    assert(name != null);
+    assert(name != defaultAppName);
+    assert(options != null);
     assert(options.googleAppID != null);
-    _namedApps[name] = new FirebaseApp(name: name, options: options);
-    return channel.invokeMethod('FirebaseApp#configure', <String, dynamic>{
-      'name': name,
-      'options': options.asMap,
-    }).then((dynamic _) => _namedApps[name]);
+    final FirebaseApp existingApp = await FirebaseApp.appNamed(name);
+    if (existingApp != null) {
+      assert(await existingApp.options == options);
+      return;
+    }
+    await channel.invokeMethod(
+      'FirebaseApp#configure',
+      <String, dynamic>{'name': name, 'options': options?.asMap},
+    );
+    return new FirebaseApp(name: name);
   }
 
   /// Returns a list of all extant FirebaseApp instances, or null if there are
@@ -52,24 +79,23 @@ class FirebaseApp {
     final List<dynamic> result = await channel.invokeMethod(
       'FirebaseApp#allApps',
     );
-    return result?.map<FirebaseApp>((dynamic app) {
-      return new FirebaseApp(
-        name: app['name'],
-        options: new FirebaseOptions.from(app['options']),
-      );
-    })?.toList();
+    return result
+        ?.map<FirebaseApp>(
+          (dynamic app) => new FirebaseApp(name: app['name']),
+        )
+        ?.toList();
   }
 
   @override
   bool operator ==(dynamic other) {
     if (identical(this, other)) return true;
     if (other is! FirebaseApp) return false;
-    return other.name == name && other.options == options;
+    return other.name == name;
   }
 
   @override
-  int get hashCode => hashValues(name, options);
+  int get hashCode => name.hashCode;
 
   @override
-  String toString() => '$FirebaseApp($name, $options)';
+  String toString() => '$FirebaseApp($name)';
 }

--- a/packages/firebase_core/lib/src/firebase_app.dart
+++ b/packages/firebase_core/lib/src/firebase_app.dart
@@ -21,7 +21,7 @@ class FirebaseApp {
 
   /// Gets a copy of the options for this app. These are non-modifiable.
   ///
-  /// This method is asynchronous because apps can also be configured by native
+  /// This getter is asynchronous because apps can also be configured by native
   /// code.
   Future<FirebaseOptions> get options async {
     final Map<dynamic, dynamic> app = await channel.invokeMethod(

--- a/packages/firebase_core/lib/src/firebase_options.dart
+++ b/packages/firebase_core/lib/src/firebase_options.dart
@@ -101,7 +101,7 @@ class FirebaseOptions {
       'bundleID': bundleID,
       'clientID': clientID,
       'trackingID': trackingID,
-      'gcmSenderID': gcmSenderID,
+      'GCMSenderID': gcmSenderID,
       'projectID': projectID,
       'androidClientID': androidClientID,
       'googleAppID': googleAppID,

--- a/packages/firebase_core/pubspec.yaml
+++ b/packages/firebase_core/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Core, enabling connecting to multiple
   Firebase apps.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_core
-version: 0.1.2
+version: 0.2.0
 
 flutter:
   plugin:

--- a/packages/firebase_core/test/firebase_core_test.dart
+++ b/packages/firebase_core/test/firebase_core_test.dart
@@ -12,6 +12,19 @@ void main() {
     const FirebaseApp testApp = const FirebaseApp(
       name: 'testApp',
     );
+    const FirebaseOptions testOptions = const FirebaseOptions(
+      apiKey: 'testAPIKey',
+      bundleID: 'testBundleID',
+      clientID: 'testClientID',
+      trackingID: 'testTrackingID',
+      gcmSenderID: 'testGCMSenderID',
+      projectID: 'testProjectID',
+      androidClientID: 'testAndroidClientID',
+      googleAppID: 'testGoogleAppID',
+      databaseURL: 'testDatabaseURL',
+      deepLinkURLScheme: 'testDeepLinkURLScheme',
+      storageBucket: 'testStorageBucket',
+    );
 
     setUp(() async {
       FirebaseApp.channel
@@ -19,17 +32,15 @@ void main() {
         log.add(methodCall);
         switch (methodCall.method) {
           case 'FirebaseApp#appNamed':
-            if (methodCall.arguments != testApp.name) return null;
+            if (methodCall.arguments != 'testApp') return null;
             return <String, dynamic>{
-              'name': testApp.name,
-              'options': <String, dynamic>{
-                'googleAppID': '12345',
-              },
+              'name': 'testApp',
+              'options': testOptions.asMap,
             };
           case 'FirebaseApp#allApps':
             return <Map<String, dynamic>>[
               <String, dynamic>{
-                'name': testApp.name,
+                'name': 'testApp',
               },
             ];
           default:
@@ -40,32 +51,36 @@ void main() {
     });
 
     test('configure', () async {
-      final String name = 'configuredApp';
-      const FirebaseOptions options = const FirebaseOptions(
-        apiKey: 'testAPIKey',
-        bundleID: 'testBundleID',
-        clientID: 'testClientID',
-        trackingID: 'testTrackingID',
-        gcmSenderID: 'testGCMSenderID',
-        projectID: 'testProjectID',
-        androidClientID: 'testAndroidClientID',
-        googleAppID: 'testGoogleAppID',
-        databaseURL: 'testDatabaseURL',
-        deepLinkURLScheme: 'testDeepLinkURLScheme',
-        storageBucket: 'testStorageBucket',
+      final FirebaseApp reconfiguredApp = await FirebaseApp.configure(
+        name: 'testApp',
+        options: testOptions,
       );
-      await FirebaseApp.configure(
-        name: name,
-        options: options,
+      expect(reconfiguredApp, equals(testApp));
+      final FirebaseApp newApp = await FirebaseApp.configure(
+        name: 'newApp',
+        options: testOptions,
       );
+      expect(newApp.name, equals('newApp'));
       expect(
         log,
         <Matcher>[
           isMethodCall(
+            'FirebaseApp#appNamed',
+            arguments: 'testApp',
+          ),
+          isMethodCall(
+            'FirebaseApp#appNamed',
+            arguments: 'testApp',
+          ),
+          isMethodCall(
+            'FirebaseApp#appNamed',
+            arguments: 'newApp',
+          ),
+          isMethodCall(
             'FirebaseApp#configure',
             arguments: <String, dynamic>{
-              'name': name,
-              'options': options.asMap,
+              'name': 'newApp',
+              'options': testOptions.asMap,
             },
           ),
         ],
@@ -73,21 +88,25 @@ void main() {
     });
 
     test('appNamed', () async {
-      final FirebaseApp existingApp = await FirebaseApp.appNamed(testApp.name);
-      expect(existingApp.name, equals(testApp.name));
-      expect((await existingApp.options).googleAppID, equals('12345'));
-      final FirebaseApp missingApp = await FirebaseApp.appNamed('missing');
+      final FirebaseApp existingApp = await FirebaseApp.appNamed('testApp');
+      expect(existingApp.name, equals('testApp'));
+      expect((await existingApp.options), equals(testOptions));
+      final FirebaseApp missingApp = await FirebaseApp.appNamed('missingApp');
       expect(missingApp, isNull);
       expect(
         log,
         <Matcher>[
           isMethodCall(
             'FirebaseApp#appNamed',
-            arguments: testApp.name,
+            arguments: 'testApp',
           ),
           isMethodCall(
             'FirebaseApp#appNamed',
-            arguments: 'missing',
+            arguments: 'testApp',
+          ),
+          isMethodCall(
+            'FirebaseApp#appNamed',
+            arguments: 'missingApp',
           ),
         ],
       );

--- a/packages/firebase_core/test/firebase_core_test.dart
+++ b/packages/firebase_core/test/firebase_core_test.dart
@@ -33,9 +33,9 @@ void main() {
         switch (methodCall.method) {
           case 'FirebaseApp#appNamed':
             if (methodCall.arguments != 'testApp') return null;
-            return <String, dynamic>{
+            return <dynamic, dynamic>{
               'name': 'testApp',
-              'options': <String, dynamic>{
+              'options': <dynamic, dynamic>{
                 'APIKey': 'testAPIKey',
                 'bundleID': 'testBundleID',
                 'clientID': 'testClientID',
@@ -50,8 +50,8 @@ void main() {
               },
             };
           case 'FirebaseApp#allApps':
-            return <Map<String, dynamic>>[
-              <String, dynamic>{
+            return <Map<dynamic, dynamic>>[
+              <dynamic, dynamic>{
                 'name': 'testApp',
               },
             ];

--- a/packages/firebase_core/test/firebase_core_test.dart
+++ b/packages/firebase_core/test/firebase_core_test.dart
@@ -35,7 +35,19 @@ void main() {
             if (methodCall.arguments != 'testApp') return null;
             return <String, dynamic>{
               'name': 'testApp',
-              'options': testOptions.asMap,
+              'options': <String, dynamic>{
+                'APIKey': 'testAPIKey',
+                'bundleID': 'testBundleID',
+                'clientID': 'testClientID',
+                'trackingID': 'testTrackingID',
+                'GCMSenderID': 'testGCMSenderID',
+                'projectID': 'testProjectID',
+                'androidClientID': 'testAndroidClientID',
+                'googleAppID': 'testGoogleAppID',
+                'databaseURL': 'testDatabaseURL',
+                'deepLinkURLScheme': 'testDeepLinkURLScheme',
+                'storageBucket': 'testStorageBucket',
+              },
             };
           case 'FirebaseApp#allApps':
             return <Map<String, dynamic>>[


### PR DESCRIPTION
Required for #476 

In practice, I doubt anyone would need read the options of an app, it's far more common to set it via `configure()` than read it. So making this API `async` doesn't affect the developer much.

An alternative is that we could make the `options` getter synchronous but throw an exception for the default app unless the developer puts an `await FirebaseApp.configure()` in their code first.