### PR TITLE
Simplify podspecs for Cocoapods 1.5.0

### DIFF
--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.1
+
+* Simplified podspec for Cocoapods 1.5.0, avoiding link issues in app archives.
+
 ## 0.6.0
 
 * **Breaking change**. Renamed 'getCollection()' to 'collection().'

--- a/packages/cloud_firestore/ios/cloud_firestore.podspec
+++ b/packages/cloud_firestore/ios/cloud_firestore.podspec
@@ -20,9 +20,5 @@ Firestore plugin for Flutter.
   s.dependency 'Firebase/Core'
   s.dependency 'Firebase/Auth'
   s.dependency 'Firebase/Firestore'
-  s.pod_target_xcconfig = {
-   'FRAMEWORK_SEARCH_PATHS' => '$(inherited) $(PODS_ROOT)/**',
-   'OTHER_LDFLAGS' => '$(inherited) -undefined dynamic_lookup'
-  }
+  s.static_framework = true
 end
-

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_firestore
-version: 0.6.0
+version: 0.6.1
 
 flutter:
   plugin:

--- a/packages/firebase_admob/CHANGELOG.md
+++ b/packages/firebase_admob/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.2
+
+* Simplified podspec for Cocoapods 1.5.0, avoiding link issues in app archives.
+
 ## 0.5.1
 
 * Fixed Dart 2 type errors.

--- a/packages/firebase_admob/ios/firebase_admob.podspec
+++ b/packages/firebase_admob/ios/firebase_admob.podspec
@@ -20,8 +20,5 @@ Firebase Admob plugin for Flutter.
 
   s.ios.deployment_target = '8.0'
 
-  s.pod_target_xcconfig = {
-   'FRAMEWORK_SEARCH_PATHS' => '$(inherited) $(PODS_ROOT)/**',
-   'OTHER_LDFLAGS' => '$(inherited) -undefined dynamic_lookup'
-  }
+  s.static_framework = true
 end

--- a/packages/firebase_admob/pubspec.yaml
+++ b/packages/firebase_admob/pubspec.yaml
@@ -1,8 +1,8 @@
 name: firebase_admob
 description: Firebase AdMob plugin for Flutter applications.
-version: 0.5.1
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_admob
+version: 0.5.2
 
 flutter:
   plugin:

--- a/packages/firebase_analytics/CHANGELOG.md
+++ b/packages/firebase_analytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1
+
+* Simplified podspec for Cocoapods 1.5.0, avoiding link issues in app archives.
+
 ## 0.3.0
 
 * **Breaking change**. Set SDK constraints to match the Flutter beta release.

--- a/packages/firebase_analytics/ios/firebase_analytics.podspec
+++ b/packages/firebase_analytics/ios/firebase_analytics.podspec
@@ -17,8 +17,5 @@ Firebase Analytics plugin for Flutter.
   s.ios.deployment_target = '6.0'
   s.dependency 'Flutter'
   s.dependency 'Firebase/Core'
-  s.pod_target_xcconfig = {
-   'FRAMEWORK_SEARCH_PATHS' => '$(inherited) $(PODS_ROOT)/GoogleSignIn',
-   'OTHER_LDFLAGS' => '$(inherited) -undefined dynamic_lookup'
-  }
+  s.static_framework = true
 end

--- a/packages/firebase_analytics/pubspec.yaml
+++ b/packages/firebase_analytics/pubspec.yaml
@@ -3,8 +3,7 @@ description: Flutter plugin for Google Analytics for Firebase, an app measuremen
   solution that provides insight on app usage and user engagement on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_analytics
-
-version: 0.3.0
+version: 0.3.1
 
 flutter:
   plugin:

--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.4
+
+* Simplified podspec for Cocoapods 1.5.0, avoiding link issues in app archives.
+
 ## 0.5.3
 
 * Secure fetchProvidersForEmail (no providers)

--- a/packages/firebase_auth/ios/firebase_auth.podspec
+++ b/packages/firebase_auth/ios/firebase_auth.podspec
@@ -18,8 +18,5 @@ Firebase Auth plugin for Flutter.
   s.dependency 'Flutter'
   s.dependency 'Firebase/Auth'
   s.dependency 'Firebase/Core'
-  s.pod_target_xcconfig = {
-   'FRAMEWORK_SEARCH_PATHS' => '$(inherited) $(PODS_ROOT)/**',
-   'OTHER_LDFLAGS' => '$(inherited) -undefined dynamic_lookup'
-  }
+  s.static_framework = true
 end

--- a/packages/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Firebase Auth, enabling Android and iOS
   and Twitter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_auth
-version: 0.5.3
+version: 0.5.4
 
 flutter:
   plugin:

--- a/packages/firebase_core/CHANGELOG.md
+++ b/packages/firebase_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.2
+
+* Simplified podspec for Cocoapods 1.5.0, avoiding link issues in app archives.
+
 ## 0.2.1
 
 * Fix setting project ID on Android.

--- a/packages/firebase_core/ios/firebase_core.podspec
+++ b/packages/firebase_core/ios/firebase_core.podspec
@@ -17,9 +17,5 @@ A new flutter plugin project.
   s.dependency 'Flutter'
   s.dependency 'Firebase/Core'
   s.ios.deployment_target = '8.0'
-  s.pod_target_xcconfig = {
-   'FRAMEWORK_SEARCH_PATHS' => '$(inherited) $(PODS_ROOT)/**',
-   'OTHER_LDFLAGS' => '$(inherited) -undefined dynamic_lookup'
-  }
+  s.static_framework = true
 end
-

--- a/packages/firebase_core/pubspec.yaml
+++ b/packages/firebase_core/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Core, enabling connecting to multiple
   Firebase apps.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_core
-version: 0.2.1
+version: 0.2.2
 
 flutter:
   plugin:

--- a/packages/firebase_database/CHANGELOG.md
+++ b/packages/firebase_database/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.3
+
+* Simplified podspec for Cocoapods 1.5.0, avoiding link issues in app archives.
+
 ## 0.4.2
 
 * Updated `firebase_core` dependency.

--- a/packages/firebase_database/ios/firebase_database.podspec
+++ b/packages/firebase_database/ios/firebase_database.podspec
@@ -17,9 +17,5 @@ Firebase Database plugin for Flutter.
   s.ios.deployment_target = '6.0'
   s.dependency 'Flutter'
   s.dependency 'Firebase/Database'
-  s.pod_target_xcconfig = {
-   'FRAMEWORK_SEARCH_PATHS' => '$(inherited) $(PODS_ROOT)/**',
-   'OTHER_LDFLAGS' => '$(inherited) -undefined dynamic_lookup'
-  }
+  s.static_framework = true
 end
-

--- a/packages/firebase_database/pubspec.yaml
+++ b/packages/firebase_database/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Database, a cloud-hosted NoSQL database
   with realtime data syncing across Android and iOS clients, and offline access.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_database
-version: 0.4.2
+version: 0.4.3
 
 flutter:
   plugin:

--- a/packages/firebase_messaging/CHANGELOG.md
+++ b/packages/firebase_messaging/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.2
+
+* Simplified podspec for Cocoapods 1.5.0, avoiding link issues in app archives.
+
 ## 0.2.1
 
 * Fixed Dart 2 type errors.

--- a/packages/firebase_messaging/ios/firebase_messaging.podspec
+++ b/packages/firebase_messaging/ios/firebase_messaging.podspec
@@ -17,11 +17,6 @@ Firebase Cloud Messaging plugin for Flutter.
   s.dependency 'Flutter'
   s.dependency 'Firebase/Core'
   s.dependency 'Firebase/Messaging'
-  s.pod_target_xcconfig = {
-   'FRAMEWORK_SEARCH_PATHS' => '$(inherited) $(PODS_ROOT)/**',
-   'OTHER_LDFLAGS' => '$(inherited) -undefined dynamic_lookup'
-  }
-  
+  s.static_framework = true
   s.ios.deployment_target = '8.0'
 end
-

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Cloud Messaging, a cross-platform
   messaging solution that lets you reliably deliver messages on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_messaging
-version: 0.2.1
+version: 0.2.2
 
 flutter:
   plugin:

--- a/packages/firebase_storage/CHANGELOG.md
+++ b/packages/firebase_storage/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.2
+
+* Simplified podspec for Cocoapods 1.5.0, avoiding link issues in app archives.
+
 ## 0.2.1
 
 * Added support for getDownloadUrl.

--- a/packages/firebase_storage/ios/firebase_storage.podspec
+++ b/packages/firebase_storage/ios/firebase_storage.podspec
@@ -17,9 +17,5 @@ Firebase Storage plugin for Flutter.
   s.ios.deployment_target = '6.0'
   s.dependency 'Flutter'
   s.dependency 'Firebase/Storage'
-  s.pod_target_xcconfig = {
-   'FRAMEWORK_SEARCH_PATHS' => '$(inherited) $(PODS_ROOT)/**',
-   'OTHER_LDFLAGS' => '$(inherited) -undefined dynamic_lookup'
-  }
+  s.static_framework = true
 end
-

--- a/packages/firebase_storage/pubspec.yaml
+++ b/packages/firebase_storage/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Cloud Storage, a powerful, simple, and
   cost-effective object storage service for Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_storage
-version: 0.2.1
+version: 0.2.2
 
 flutter:
   plugin:

--- a/packages/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.1
+
+* Simplified podspec for Cocoapods 1.5.0, avoiding link issues in app archives.
+
 ## 3.0.0
 
 * **Breaking change**. Set SDK constraints to match the Flutter beta release.

--- a/packages/google_sign_in/ios/google_sign_in.podspec
+++ b/packages/google_sign_in/ios/google_sign_in.podspec
@@ -16,9 +16,5 @@ Enables Google Sign-In in Flutter apps.
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.dependency 'GoogleSignIn', '~> 4.0'
-  s.pod_target_xcconfig = {
-   'FRAMEWORK_SEARCH_PATHS' => '$(inherited) $(PODS_ROOT)/**',
-   'OTHER_LDFLAGS' => '$(inherited) -undefined dynamic_lookup'
-  }
+  s.static_framework = true
 end
-

--- a/packages/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_sign_in
-version: 3.0.0
+version: 3.0.1
 
 flutter:
   plugin:


### PR DESCRIPTION
Partial fix of https://github.com/flutter/flutter/issues/15031

Cocoapods 1.4.0 is barely able to build Swift-based Flutter projects that depends on static frameworks. The workarounds required result in errors after archival and submission to the app store.

Cocoapods 1.5.0 appears able to handle this situation without workarounds of any kind (removed partially by this PR, partially by a [companion PR](https://github.com/flutter/flutter/pull/16443) in the `flutter/flutter` repo). It does require `s.static_framework = true` to be added to the `.podspec` file of each plugin that uses static libs like `GoogleSignIn`.