### PR TITLE
Add iOS Phone Number Auth

### DIFF
--- a/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.h
+++ b/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.h
@@ -6,5 +6,5 @@
 
 #import "Firebase/Firebase.h"
 
-@interface FLTFirebaseAuthPlugin : NSObject<FlutterPlugin>
+@interface FLTFirebaseAuthPlugin : NSObject<FlutterPlugin, FlutterStreamHandler>
 @end


### PR DESCRIPTION
iOS phone number auth, as mentioned in #329. Looking at this vs. the Android implementation in the existing PR, I think we could benefit from agreeing on some sort of standard API in terms of the names of the methods and parameters we want to expose between native code and Flutter. I tried to piece this together using what I saw in @alibitek's implementation, but I'm not sure if it's 100%, so maybe we could talk about that?