### PR TITLE
Renamed 'getCollection()' to 'collection()' for DocumentReference

### DIFF
--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.0
+
+* **Breaking change**. Renamed 'getCollection()' to 'collection().'
+
 ## 0.5.1
 
 * Expose the Firebase app corresponding to a Firestore

--- a/packages/cloud_firestore/lib/src/document_reference.dart
+++ b/packages/cloud_firestore/lib/src/document_reference.dart
@@ -87,7 +87,7 @@ class DocumentReference {
 
   /// Returns the reference of a collection contained inside of this
   /// document.
-  CollectionReference getCollection(String collectionPath) {
+  CollectionReference collection(String collectionPath) {
     return firestore.collection(
       <String>[path, collectionPath].join('/'),
     );

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_firestore
-version: 0.5.1
+version: 0.6.0
 
 flutter:
   plugin:

--- a/packages/cloud_firestore/test/cloud_firestore_test.dart
+++ b/packages/cloud_firestore/test/cloud_firestore_test.dart
@@ -475,9 +475,9 @@ void main() {
           expect(e.code, equals('UNKNOWN_PATH'));
         }
       });
-      test('getCollection', () async {
+      test('collection', () async {
         final CollectionReference colRef =
-            collectionReference.document('bar').getCollection('baz');
+            collectionReference.document('bar').collection('baz');
         expect(colRef.path, 'foo/bar/baz');
       });
     });


### PR DESCRIPTION
fixes flutter/flutter#14982