### PR TITLE
Bump firebase_core dependency to ^0.2.2

### DIFF
--- a/packages/firebase_database/example/pubspec.yaml
+++ b/packages/firebase_database/example/pubspec.yaml
@@ -6,7 +6,7 @@ dependencies:
     sdk: flutter
   firebase_database:
     path: ../
-  firebase_core: ^0.1.0
+  firebase_core: ^0.2.2
 
 flutter:
   uses-material-design: true

--- a/packages/firebase_database/pubspec.yaml
+++ b/packages/firebase_database/pubspec.yaml
@@ -14,6 +14,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
+  firebase_core: ^0.2.2
 
 dev_dependencies:
   mockito: ^2.0.2

--- a/packages/firebase_database/pubspec.yaml
+++ b/packages/firebase_database/pubspec.yaml
@@ -14,7 +14,6 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  firebase_core: ^0.1.0
 
 dev_dependencies:
   mockito: ^2.0.2


### PR DESCRIPTION
@mravn-google This is needed so that the recent Cocoapods fixes to `firebase_core` can be applied when using `firebase_database`.

See https://github.com/flutter/plugins/pull/483.
