### PR TITLE
Firestore readme fix

### DIFF
--- a/packages/cloud_firestore/README.md
+++ b/packages/cloud_firestore/README.md
@@ -44,12 +44,12 @@ Binding a `CollectionReference` to a `ListView`:
 class BookList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return new StreamBuilder(
+    return new StreamBuilder<QuerySnapshot>(
       stream: Firestore.instance.collection('books').snapshots,
-      builder: (context, snapshot) {
+      builder: (BuildContext context, AsyncSnapshot<QuerySnapshot> snapshot) {
         if (!snapshot.hasData) return new Text('Loading...');
         return new ListView(
-          children: snapshot.data.documents.map((document) {
+          children: snapshot.data.documents.map((DocumentSnapshot document) {
             return new ListTile(
               title: new Text(document['title']),
               subtitle: new Text(document['author']),


### PR DESCRIPTION
Problem:
![screen shot 2018-04-13 at 9 44 21 pm](https://user-images.githubusercontent.com/1326504/38764443-dc1d4980-3f63-11e8-8f5b-50966e89f22b.png)

```
[ +333 ms] I/flutter ( 3394): ══╡ EXCEPTION CAUGHT BY WIDGETS LIBRARY ╞═══════════════════════════════════════════════════════════
[  +23 ms] I/flutter ( 3394): The following assertion was thrown building StreamBuilder<QuerySnapshot>(dirty, state:
[        ] I/flutter ( 3394): _StreamBuilderBaseState<QuerySnapshot, AsyncSnapshot<QuerySnapshot>>#86114):
[        ] I/flutter ( 3394): type 'List<dynamic>' is not a subtype of type 'List<Widget>' where
[        ] I/flutter ( 3394):   List is from dart:core
[        ] I/flutter ( 3394):   List is from dart:core
[        ] I/flutter ( 3394):   Widget is from package:flutter/src/widgets/framework.dart
[   +7 ms] I/flutter ( 3394): 
[        ] I/flutter ( 3394): Either the assertion indicates an error in the framework itself, or we should provide substantially
[        ] I/flutter ( 3394): more information in this error message to help you determine and fix the underlying cause.
[        ] I/flutter ( 3394): In either case, please report this assertion by filing a bug on GitHub:
[        ] I/flutter ( 3394):   https://github.com/flutter/flutter/issues/new
[        ] I/flutter ( 3394): 
[        ] I/flutter ( 3394): When the exception was thrown, this was the stack:
[   +7 ms] I/flutter ( 3394): #0      MountainList.build.<anonymous closure> (file:///Users/branflake2267/training/flutter/demo_firestore/lib/main.dart:59:14)
[   +2 ms] I/flutter ( 3394): #1      StreamBuilder.build (package:flutter/src/widgets/async.dart:410:74)
[        ] I/flutter ( 3394): #2      _StreamBuilderBaseState.build (package:flutter/src/widgets/async.dart:126:48)
[        ] I/flutter ( 3394): #3      StatefulElement.build (package:flutter/src/widgets/framework.dart:3713:27)
[        ] I/flutter ( 3394): #4      ComponentElement.performRebuild (package:flutter/src/widgets/framework.dart:3625:15)
[        ] I/flutter ( 3394): #5      Element.rebuild (package:flutter/src/widgets/framework.dart:3478:5)
[        ] I/flutter ( 3394): #6      BuildOwner.buildScope (package:flutter/src/widgets/framework.dart:2225:33)
[        ] I/flutter ( 3394): #7      _WidgetsFlutterBinding&BindingBase&GestureBinding&ServicesBinding&SchedulerBinding&PaintingBinding&RendererBinding&WidgetsBinding.drawFrame (package:flutter/src/widgets/binding.dart:621:20)
[        ] I/flutter ( 3394): #8      _WidgetsFlutterBinding&BindingBase&GestureBinding&ServicesBinding&SchedulerBinding&PaintingBinding&RendererBinding._handlePersistentFrameCallback (package:flutter/src/rendering/binding.dart:208:5)
[        ] I/flutter ( 3394): #9      _WidgetsFlutterBinding&BindingBase&GestureBinding&ServicesBinding&SchedulerBinding._invokeFrameCallback (package:flutter/src/scheduler/binding.dart:990:15)
[        ] I/flutter ( 3394): #10     _WidgetsFlutterBinding&BindingBase&GestureBinding&ServicesBinding&SchedulerBinding.handleDrawFrame (package:flutter/src/scheduler/binding.dart:930:9)
[        ] I/flutter ( 3394): #11     _WidgetsFlutterBinding&BindingBase&GestureBinding&ServicesBinding&SchedulerBinding._handleDrawFrame (package:flutter/src/scheduler/binding.dart:842:5)
[        ] I/flutter ( 3394): #12     _invoke (dart:ui/hooks.dart:120:13)
[        ] I/flutter ( 3394): #13     _drawFrame (dart:ui/hooks.dart:109:3)
[        ] I/flutter ( 3394): ════════════════════════════════════════════════════════════════════════════════════════════════════
[ +160 ms] I/zygote  ( 3394): Do partial code cache collection, code=29KB, data=22KB
[        ] I/zygote  ( 3394): After code cache collection, code=26KB, data=21KB
[        ] I/zygote  ( 3394): Increasing code cache capacity to 128KB

```

```
class MountainList extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return new StreamBuilder(
      stream: Firestore.instance.collection('mountain').snapshots,
      builder: (BuildContext context, AsyncSnapshot snapshot) {
        if (!snapshot.hasData) return new Text('Loading...');
        return new ListView(
          children: snapshot.data.documents.map((DocumentSnapshot document) {
            return new ListTile(
              title: new Text(document['title']),
              subtitle: new Text(document['type']),
            );
          }).toList(),
        );
      },
    );
  }
}
```

Fix:
AsyncSnapshot<QuerySnapshot> generic type declaration is required because of the dynamic return (on callback).

