### PR TITLE
Make iOS sensor events same type as on Android

### DIFF
--- a/packages/sensors/CHANGELOG.md
+++ b/packages/sensors/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1
+
+* Fixed Dart 2 type error with iOS sensor events.
+
 ## 0.3.0
 
 * **Breaking change**. Set SDK constraints to match the Flutter beta release.

--- a/packages/sensors/ios/Classes/SensorsPlugin.m
+++ b/packages/sensors/ios/Classes/SensorsPlugin.m
@@ -51,7 +51,8 @@ static void sendTriplet(Float64 x, Float64 y, Float64 z, FlutterEventSink sink) 
                              CMAcceleration acceleration = accelerometerData.acceleration;
                              // Multiply by gravity, and adjust sign values to
                              // align with Android.
-                             sendTriplet(-acceleration.x * GRAVITY, -acceleration.y * GRAVITY, -acceleration.z * GRAVITY, eventSink);
+                             sendTriplet(-acceleration.x * GRAVITY, -acceleration.y * GRAVITY,
+                                         -acceleration.z * GRAVITY, eventSink);
                            }];
   return nil;
 }
@@ -67,11 +68,12 @@ static void sendTriplet(Float64 x, Float64 y, Float64 z, FlutterEventSink sink) 
 
 - (FlutterError*)onListenWithArguments:(id)arguments eventSink:(FlutterEventSink)eventSink {
   _initMotionManager();
-  [_motionManager startGyroUpdatesToQueue:[[NSOperationQueue alloc] init]
-                              withHandler:^(CMGyroData* gyroData, NSError* error) {
-                                CMRotationRate rotationRate = gyroData.rotationRate;
-                                sendTriplet(rotationRate.x, rotationRate.y, rotationRate.z, eventSink);
-                              }];
+  [_motionManager
+      startGyroUpdatesToQueue:[[NSOperationQueue alloc] init]
+                  withHandler:^(CMGyroData* gyroData, NSError* error) {
+                    CMRotationRate rotationRate = gyroData.rotationRate;
+                    sendTriplet(rotationRate.x, rotationRate.y, rotationRate.z, eventSink);
+                  }];
   return nil;
 }
 

--- a/packages/sensors/ios/Classes/SensorsPlugin.m
+++ b/packages/sensors/ios/Classes/SensorsPlugin.m
@@ -33,6 +33,14 @@ void _initMotionManager() {
   }
 }
 
+static void sendTriplet(Float64 x, Float64 y, Float64 z, FlutterEventSink sink) {
+  NSMutableData* event = [NSMutableData dataWithCapacity:3 * sizeof(Float64)];
+  [event appendBytes:&x length:sizeof(Float64)];
+  [event appendBytes:&y length:sizeof(Float64)];
+  [event appendBytes:&z length:sizeof(Float64)];
+  sink([FlutterStandardTypedData typedDataWithFloat64:event]);
+}
+
 @implementation FLTAccelerometerStreamHandler
 
 - (FlutterError*)onListenWithArguments:(id)arguments eventSink:(FlutterEventSink)eventSink {
@@ -43,11 +51,7 @@ void _initMotionManager() {
                              CMAcceleration acceleration = accelerometerData.acceleration;
                              // Multiply by gravity, and adjust sign values to
                              // align with Android.
-                             NSArray* accelerationValues = @[
-                               @(-acceleration.x * GRAVITY), @(-acceleration.y * GRAVITY),
-                               @(-acceleration.z * GRAVITY)
-                             ];
-                             eventSink(accelerationValues);
+                             sendTriplet(-acceleration.x * GRAVITY, -acceleration.y * GRAVITY, -acceleration.z * GRAVITY, eventSink);
                            }];
   return nil;
 }
@@ -66,9 +70,7 @@ void _initMotionManager() {
   [_motionManager startGyroUpdatesToQueue:[[NSOperationQueue alloc] init]
                               withHandler:^(CMGyroData* gyroData, NSError* error) {
                                 CMRotationRate rotationRate = gyroData.rotationRate;
-                                NSArray* gyroscopeValues =
-                                    @[ @(rotationRate.x), @(rotationRate.y), @(rotationRate.z) ];
-                                eventSink(gyroscopeValues);
+                                sendTriplet(rotationRate.x, rotationRate.y, rotationRate.z, eventSink);
                               }];
   return nil;
 }

--- a/packages/sensors/pubspec.yaml
+++ b/packages/sensors/pubspec.yaml
@@ -1,7 +1,7 @@
 name: sensors
 description: Flutter plugin for accessing the Android and iOS accelerometer and
   gyroscope sensors.
-version: 0.3.0
+version: 0.3.1
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/sensors
 


### PR DESCRIPTION
Android side uses `double[]`, iOS side uses `NSArray` to convey (x,y,z) triplets. On Dart, that deserializes to `Float64List` and `List<dynamic>`, respectively. While the former is a subtype of `List<double>`, the latter is not, so it fails at runtime on iOS.

This PR changes iOS side to use `FlutterStandardTypedData`, to make the triplet events deserialize as `Float64List` on both platforms.

Fixes https://github.com/flutter/flutter/issues/16425