### PR TITLE
Add isSignedIn to GoogleSignIn; allow clients to customize error handling

### DIFF
--- a/packages/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
+++ b/packages/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
@@ -390,7 +390,7 @@ public class GoogleSignInPlugin implements MethodCallHandler {
         finishWithSuccess(response);
       }else {
         // Forward all errors and let Dart side decide how to handle.
-        int errorCode = errorCodeForStatus(result.getStatus().getStatusCode());
+        String errorCode = errorCodeForStatus(result.getStatus().getStatusCode());
         finishWithError(errorCode, result.getStatus().toString());
       }
     }

--- a/packages/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
+++ b/packages/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
@@ -16,6 +16,7 @@ import android.support.annotation.NonNull;
 import android.util.Log;
 import com.google.android.gms.auth.GoogleAuthUtil;
 import com.google.android.gms.auth.api.Auth;
+import com.google.android.gms.auth.api.signin.GoogleSignIn;
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount;
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions;
 import com.google.android.gms.auth.api.signin.GoogleSignInResult;
@@ -54,6 +55,7 @@ public class GoogleSignInPlugin implements MethodCallHandler {
   private static final String METHOD_GET_TOKENS = "getTokens";
   private static final String METHOD_SIGN_OUT = "signOut";
   private static final String METHOD_DISCONNECT = "disconnect";
+  private static final String METHOD_IS_SIGNED_IN = "isSignedIn";
 
   private final IDelegate delegate;
 
@@ -97,6 +99,10 @@ public class GoogleSignInPlugin implements MethodCallHandler {
         delegate.disconnect(result);
         break;
 
+      case METHOD_IS_SIGNED_IN:
+        delegate.isSignedIn(result);
+        break;
+
       default:
         result.notImplemented();
     }
@@ -137,6 +143,9 @@ public class GoogleSignInPlugin implements MethodCallHandler {
 
     /** Signs the user out, and revokes their credentials. */
     public void disconnect(Result result);
+
+    /** Checks if there is a signed in user. */
+    public void isSignedIn(Result result);
   }
 
   /**
@@ -356,6 +365,17 @@ public class GoogleSignInPlugin implements MethodCallHandler {
               });
     }
 
+    /**
+     * Checks if there is a signed in user.
+     */
+    @Override
+    public void isSignedIn(final Result result) {
+      Map<String, Object> response = new HashMap<>();
+      boolean value = GoogleSignIn.getLastSignedInAccount(registrar.context()) != null;
+      response.put("isSignedIn", value);
+      result.success(response);
+    }
+
     private void onSignInResult(GoogleSignInResult result) {
       if (result.isSuccess()) {
         GoogleSignInAccount account = result.getSignInAccount();
@@ -369,12 +389,8 @@ public class GoogleSignInPlugin implements MethodCallHandler {
           response.put("photoUrl", account.getPhotoUrl().toString());
         }
         finishWithSuccess(response);
-      } else if (result.getStatus().getStatusCode() == CommonStatusCodes.SIGN_IN_REQUIRED
-          || result.getStatus().getStatusCode() == GoogleSignInStatusCodes.SIGN_IN_CANCELLED) {
-        // This isn't an error from the caller's (Dart's) perspective; this just
-        // means that the user didn't sign in.
-        finishWithSuccess(null);
       } else {
+        // Forward all errors and let Dart side decide how to handle.
         finishWithError(ERROR_REASON_STATUS, result.getStatus().toString());
       }
     }

--- a/packages/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
+++ b/packages/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
@@ -20,10 +20,8 @@ import com.google.android.gms.auth.api.signin.GoogleSignIn;
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount;
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions;
 import com.google.android.gms.auth.api.signin.GoogleSignInResult;
-import com.google.android.gms.auth.api.signin.GoogleSignInStatusCodes;
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
-import com.google.android.gms.common.api.CommonStatusCodes;
 import com.google.android.gms.common.api.GoogleApiClient;
 import com.google.android.gms.common.api.OptionalPendingResult;
 import com.google.android.gms.common.api.ResultCallback;
@@ -365,9 +363,7 @@ public class GoogleSignInPlugin implements MethodCallHandler {
               });
     }
 
-    /**
-     * Checks if there is a signed in user.
-     */
+    /** Checks if there is a signed in user. */
     @Override
     public void isSignedIn(final Result result) {
       Map<String, Object> response = new HashMap<>();

--- a/packages/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
+++ b/packages/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
@@ -388,7 +388,7 @@ public class GoogleSignInPlugin implements MethodCallHandler {
           response.put("photoUrl", account.getPhotoUrl().toString());
         }
         finishWithSuccess(response);
-      }else {
+      } else {
         // Forward all errors and let Dart side decide how to handle.
         String errorCode = errorCodeForStatus(result.getStatus().getStatusCode());
         finishWithError(errorCode, result.getStatus().toString());

--- a/packages/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
+++ b/packages/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
@@ -366,10 +366,8 @@ public class GoogleSignInPlugin implements MethodCallHandler {
     /** Checks if there is a signed in user. */
     @Override
     public void isSignedIn(final Result result) {
-      Map<String, Object> response = new HashMap<>();
       boolean value = GoogleSignIn.getLastSignedInAccount(registrar.context()) != null;
-      response.put("isSignedIn", value);
-      result.success(response);
+      result.success(value);
     }
 
     private void onSignInResult(GoogleSignInResult result) {

--- a/packages/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
+++ b/packages/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
@@ -167,6 +167,7 @@ public class GoogleSignInPlugin implements MethodCallHandler {
     // These error codes must match with ones declared on iOS and Dart sides.
     private static final String ERROR_REASON_SIGN_IN_CANCELED = "sign_in_canceled";
     private static final String ERROR_REASON_SIGN_IN_REQUIRED = "sign_in_required";
+    private static final String ERROR_REASON_SIGN_IN_FAILED = "sign_in_failed";
 
     private static final String STATE_RESOLVING_ERROR = "resolving_error";
 
@@ -401,7 +402,7 @@ public class GoogleSignInPlugin implements MethodCallHandler {
       } else if (statusCode == CommonStatusCodes.SIGN_IN_REQUIRED) {
         return ERROR_REASON_SIGN_IN_REQUIRED;
       } else {
-        return ERROR_REASON_STATUS;
+        return ERROR_REASON_SIGN_IN_FAILED;
       }
     }
 

--- a/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
+++ b/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
@@ -10,13 +10,25 @@
 // for more info.
 static NSString *const kClientIdKey = @"CLIENT_ID";
 
+// These error codes must match with ones declared on Android and Dart sides.
+static NSString *const kErrorReasonSignInRequired = @"sign_in_required";
+static NSString *const kErrorReasonSignInCanceled = @"sign_in_canceled";
+
 @interface NSError (FlutterError)
 @property(readonly, nonatomic) FlutterError *flutterError;
 @end
 
 @implementation NSError (FlutterError)
 - (FlutterError *)flutterError {
-  return [FlutterError errorWithCode:@"exception"
+  NSString *errorCode;
+  if (self.code == kGIDSignInErrorCodeHasNoAuthInKeychain) {
+    errorCode = kErrorReasonSignInRequired;
+  } else if (self.code == kGIDSignInErrorCodeCanceled) {
+    errorCode = kErrorReasonSignInCanceled;
+  } else {
+    errorCode = @"exception";
+  }
+  return [FlutterError errorWithCode:errorCode
                              message:self.domain
                              details:self.localizedDescription];
 }

--- a/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
+++ b/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
@@ -72,9 +72,7 @@ static NSString *const kClientIdKey = @"CLIENT_ID";
       [[GIDSignIn sharedInstance] signInSilently];
     }
   } else if ([call.method isEqualToString:@"isSignedIn"]) {
-    result(@{
-      @"isSignedIn" : @([[GIDSignIn sharedInstance] hasAuthInKeychain]),
-    });
+    result(@([[GIDSignIn sharedInstance] hasAuthInKeychain]));
   } else if ([call.method isEqualToString:@"signIn"]) {
     if ([self setAccountRequest:result]) {
       [[GIDSignIn sharedInstance] signIn];

--- a/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
+++ b/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
@@ -28,9 +28,8 @@ static NSString *const kErrorReasonSignInCanceled = @"sign_in_canceled";
   } else {
     errorCode = @"exception";
   }
-  return [FlutterError errorWithCode:errorCode
-                             message:self.domain
-                             details:self.localizedDescription];
+  return
+      [FlutterError errorWithCode:errorCode message:self.domain details:self.localizedDescription];
 }
 @end
 

--- a/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
+++ b/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
@@ -13,6 +13,7 @@ static NSString *const kClientIdKey = @"CLIENT_ID";
 // These error codes must match with ones declared on Android and Dart sides.
 static NSString *const kErrorReasonSignInRequired = @"sign_in_required";
 static NSString *const kErrorReasonSignInCanceled = @"sign_in_canceled";
+static NSString *const kErrorReasonSignInFailed = @"sign_in_failed";
 
 @interface NSError (FlutterError)
 @property(readonly, nonatomic) FlutterError *flutterError;
@@ -26,7 +27,7 @@ static NSString *const kErrorReasonSignInCanceled = @"sign_in_canceled";
   } else if (self.code == kGIDSignInErrorCodeCanceled) {
     errorCode = kErrorReasonSignInCanceled;
   } else {
-    errorCode = @"exception";
+    errorCode = kErrorReasonSignInFailed;
   }
   return
       [FlutterError errorWithCode:errorCode message:self.domain details:self.localizedDescription];

--- a/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
+++ b/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
@@ -71,6 +71,10 @@ static NSString *const kClientIdKey = @"CLIENT_ID";
     if ([self setAccountRequest:result]) {
       [[GIDSignIn sharedInstance] signInSilently];
     }
+  } else if ([call.method isEqualToString:@"isSignedIn"]) {
+      result(@{
+        @"isSignedIn" : @([[GIDSignIn sharedInstance] hasAuthInKeychain]),
+      });
   } else if ([call.method isEqualToString:@"signIn"]) {
     if ([self setAccountRequest:result]) {
       [[GIDSignIn sharedInstance] signIn];
@@ -133,15 +137,8 @@ static NSString *const kClientIdKey = @"CLIENT_ID";
     didSignInForUser:(GIDGoogleUser *)user
            withError:(NSError *)error {
   if (error != nil) {
-    if (error.code == kGIDSignInErrorCodeHasNoAuthInKeychain ||
-        error.code == kGIDSignInErrorCodeCanceled) {
-      // Occurs when silent sign-in is not possible or user has cancelled sign
-      // in,
-      // return an empty user in this case
-      [self respondWithAccount:nil error:nil];
-    } else {
-      [self respondWithAccount:nil error:error];
-    }
+    // Forward all errors and let Dart side decide how to handle.
+    [self respondWithAccount:nil error:error];
   } else {
     NSURL *photoUrl;
     if (user.profile.hasImage) {

--- a/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
+++ b/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
@@ -72,9 +72,9 @@ static NSString *const kClientIdKey = @"CLIENT_ID";
       [[GIDSignIn sharedInstance] signInSilently];
     }
   } else if ([call.method isEqualToString:@"isSignedIn"]) {
-      result(@{
-        @"isSignedIn" : @([[GIDSignIn sharedInstance] hasAuthInKeychain]),
-      });
+    result(@{
+      @"isSignedIn" : @([[GIDSignIn sharedInstance] hasAuthInKeychain]),
+    });
   } else if ([call.method isEqualToString:@"signIn"]) {
     if ([self setAccountRequest:result]) {
       [[GIDSignIn sharedInstance] signIn];

--- a/packages/google_sign_in/lib/google_sign_in.dart
+++ b/packages/google_sign_in/lib/google_sign_in.dart
@@ -109,6 +109,16 @@ class GoogleSignInAccount implements GoogleIdentity {
 
 /// GoogleSignIn allows you to authenticate Google users.
 class GoogleSignIn {
+  // These error codes must match with ones declared on Android and iOS sides.
+
+  /// Error code indicating there is no signed in user and interactive sign in
+  /// flow is required.
+  static const String kSignInRequiredError = 'sign_in_required';
+
+  /// Error code indicating that interactive sign in process was canceled by the
+  /// user.
+  static const String kSignInCanceledError = 'sign_in_canceled';
+
   /// The [MethodChannel] over which this class communicates.
   @visibleForTesting
   static const MethodChannel channel =

--- a/packages/google_sign_in/lib/google_sign_in.dart
+++ b/packages/google_sign_in/lib/google_sign_in.dart
@@ -236,10 +236,10 @@ class GoogleSignIn {
   ///
   /// Re-authentication can be triggered only after [signOut] or [disconnect].
   ///
-  /// When [suppressErrors] is set to `false` returned Future completes with
-  /// [PlatformException] whose `code` can be either [kSignInRequiredError]
-  /// (when there is no authenticated user) or [kSignInFailedError] (when an
-  /// unknown error occurred).
+  /// When [suppressErrors] is set to `false` and an error occurred during sign in
+  /// returned Future completes with [PlatformException] whose `code` can be
+  /// either [kSignInRequiredError] (when there is no authenticated user) or
+  /// [kSignInFailedError] (when an unknown error occurred).
   Future<GoogleSignInAccount> signInSilently({bool suppressErrors: true}) {
     final Future<GoogleSignInAccount> result = _addMethodCall('signInSilently');
     if (suppressErrors) {
@@ -258,25 +258,18 @@ class GoogleSignIn {
   /// Starts the interactive sign-in process.
   ///
   /// Returned Future resolves to an instance of [GoogleSignInAccount] for a
-  /// successful sign in. When [suppressErrors] is `true` (default) returned
-  /// Future resolves to `null` in case sign in process was aborted.
-  ///
-  /// When [suppressErrors] is set to `false` returned Future completes with
-  /// [PlatformException] whose `code` can be either [kSignInCanceledError]
-  /// (when user canceled sign in process) or [kSignInFailedError] (when an
-  /// unknown error occurred).
+  /// successful sign in or `null` in case sign in process was aborted.
   ///
   /// Authentication process is triggered only if there is no currently signed in
   /// user (that is when `currentUser == null`), otherwise this method returns
   /// a Future which resolves to the same user instance.
   ///
   /// Re-authentication can be triggered only after [signOut] or [disconnect].
-  Future<GoogleSignInAccount> signIn({bool suppressErrors: true}) {
+  Future<GoogleSignInAccount> signIn() {
     final Future<GoogleSignInAccount> result = _addMethodCall('signIn');
-    if (suppressErrors) {
-      return result.catchError((dynamic _) => null);
-    }
-    return result;
+    bool isCanceled(dynamic error) =>
+        error is PlatformException && error.code == kSignInCanceledError;
+    return result.catchError((dynamic _) => null, test: isCanceled);
   }
 
   /// Marks current user as being in the signed out state.

--- a/packages/google_sign_in/lib/google_sign_in.dart
+++ b/packages/google_sign_in/lib/google_sign_in.dart
@@ -233,12 +233,10 @@ class GoogleSignIn {
     return result;
   }
 
-  /// Returns `true` if a user is currently signed in.
+  /// Returns a future that resolves to whether a user is currently signed in.
   Future<bool> isSignedIn() async {
     await _ensureInitialized();
-    final Map<dynamic, dynamic> response =
-        await channel.invokeMethod('isSignedIn');
-    final bool result = response['isSignedIn'];
+    final bool result = await channel.invokeMethod('isSignedIn');
     return result;
   }
 

--- a/packages/google_sign_in/test/google_sign_in_test.dart
+++ b/packages/google_sign_in/test/google_sign_in_test.dart
@@ -22,15 +22,13 @@ void main() {
       "displayName": "John Doe",
     };
 
-    const bool kIsSignedIn = true;
-
     const Map<String, dynamic> kDefaultResponses = const <String, dynamic>{
       'init': null,
       'signInSilently': kUserData,
       'signIn': kUserData,
       'signOut': null,
       'disconnect': null,
-      'isSignedIn': kIsSignedIn,
+      'isSignedIn': true,
     };
 
     final List<MethodCall> log = <MethodCall>[];

--- a/packages/google_sign_in/test/google_sign_in_test.dart
+++ b/packages/google_sign_in/test/google_sign_in_test.dart
@@ -22,12 +22,17 @@ void main() {
       "displayName": "John Doe",
     };
 
+    const Map<String, dynamic> kIsSignedIn = const <String, dynamic>{
+      'isSignedIn': true
+    };
+
     const Map<String, dynamic> kDefaultResponses = const <String, dynamic>{
       'init': null,
       'signInSilently': kUserData,
       'signIn': kUserData,
       'signOut': null,
       'disconnect': null,
+      'isSignedIn': kIsSignedIn,
     };
 
     final List<MethodCall> log = <MethodCall>[];
@@ -115,6 +120,18 @@ void main() {
           isMethodCall('disconnect', arguments: null),
         ],
       );
+    });
+
+    test('isSignedIn', () async {
+      final bool result = await googleSignIn.isSignedIn();
+      expect(result, isTrue);
+      expect(log, <Matcher>[
+        isMethodCall('init', arguments: <String, dynamic>{
+          'scopes': <String>[],
+          'hostedDomain': null,
+        }),
+        isMethodCall('isSignedIn', arguments: null),
+      ]);
     });
 
     test('concurrent calls of the same method trigger sign in once', () async {
@@ -237,11 +254,19 @@ void main() {
       );
     });
 
-    test('signInSilently does not throw on error', () async {
+    test('signInSilently suppresses errors by default', () async {
       channel.setMockMethodCallHandler((MethodCall methodCall) {
         throw "I am an error";
       });
       expect(await googleSignIn.signInSilently(), isNull); // should not throw
+    });
+
+    test('signInSilently forwards errors', () async {
+      channel.setMockMethodCallHandler((MethodCall methodCall) {
+        throw "I am an error";
+      });
+      expect(googleSignIn.signInSilently(suppressErrors: false),
+          throwsA(const isInstanceOf<PlatformException>()));
     });
 
     test('can sign in after init failed before', () async {

--- a/packages/google_sign_in/test/google_sign_in_test.dart
+++ b/packages/google_sign_in/test/google_sign_in_test.dart
@@ -22,9 +22,7 @@ void main() {
       "displayName": "John Doe",
     };
 
-    const Map<String, dynamic> kIsSignedIn = const <String, dynamic>{
-      'isSignedIn': true
-    };
+    const bool kIsSignedIn = true;
 
     const Map<String, dynamic> kDefaultResponses = const <String, dynamic>{
       'init': null,


### PR DESCRIPTION
* Adds `isSignedIn` method to `GoogleSignIn`. Uses `hasAuthInKeychain` for iOS. Android side is not implemented yet but the plan is to use `GoogleSignIn.getLastSignedInAccount` per [this][docs] and [this][so].
* Changes `signInSilently()` to `signInSilently({suppressErrors: true})` to allow client code customize  errors handling (also removes special error handling from native side).

Please consider this a proposal open for discussion. There are a couple benefits here as I see it:

* When all errors are suppressed it is very hard for a developer to investigate why in certain scenarios things don't work the way they should.
* `isSignedIn` provides additional visibility and helps in handling different auth scenarios.

**Example scenario:** when device is offline `signInSilently` fails, meaning it returns `null`. Currently there is no way for Dart code to know whether silent sign failed because there is no authenticated session or because of a network issue. `isSignedIn` allows to distinguish such scenarios and `suppressErrors` provides additional flexibility.

This is especially important when used together with `firebase_auth` plugin. When `isSignedIn` returns `false` we can force sign out on Firebase session as well.

[docs]: https://developers.google.com/games/services/android/signin
[so]: https://stackoverflow.com/a/48968436