### PR TITLE
Allow null value for startAt, endAt and equalTo database queries on Android

### DIFF
--- a/packages/firebase_database/CHANGELOG.md
+++ b/packages/firebase_database/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.6
+
+* Allow null value for `startAt`, `endAt` and `equalTo` queries on Android.
+
 ## 0.4.5
 
 * Updated Google Play Services dependencies to version 15.0.0.

--- a/packages/firebase_database/android/src/main/java/io/flutter/plugins/firebase/database/FirebaseDatabasePlugin.java
+++ b/packages/firebase_database/android/src/main/java/io/flutter/plugins/firebase/database/FirebaseDatabasePlugin.java
@@ -83,14 +83,12 @@ public class FirebaseDatabasePlugin implements MethodCallHandler {
       Object startAt = parameters.get("startAt");
       if (parameters.containsKey("startAtKey")) {
         String startAtKey = (String) parameters.get("startAtKey");
-        if (startAt == null) {
-          query = query.startAt(null, startAtKey);
-        } else if (startAt instanceof Boolean) {
+        if (startAt instanceof Boolean) {
           query = query.startAt((Boolean) startAt, startAtKey);
-        } else if (startAt instanceof String) {
-          query = query.startAt((String) startAt, startAtKey);
-        } else {
+        } else if (startAt instanceof Number) {
           query = query.startAt(((Number) startAt).doubleValue(), startAtKey);
+        } else {
+          query = query.startAt((String) startAt, startAtKey);
         }
       } else {
         if (startAt instanceof Boolean) {
@@ -106,14 +104,12 @@ public class FirebaseDatabasePlugin implements MethodCallHandler {
       Object endAt = parameters.get("endAt");
       if (parameters.containsKey("endAtKey")) {
         String endAtKey = (String) parameters.get("endAtKey");
-        if (endAt == null) {
-          query = query.endAt(null, endAtKey);
-        } else if (endAt instanceof Boolean) {
+        if (endAt instanceof Boolean) {
           query = query.endAt((Boolean) endAt, endAtKey);
-        } else if (endAt instanceof String) {
-          query = query.endAt((String) endAt, endAtKey);
-        } else {
+        } else if (endAt instanceof Number) {
           query = query.endAt(((Number) endAt).doubleValue(), endAtKey);
+        } else {
+          query = query.endAt((String) endAt, endAtKey);
         }
       } else {
         if (endAt instanceof Boolean) {
@@ -129,14 +125,12 @@ public class FirebaseDatabasePlugin implements MethodCallHandler {
       Object equalTo = parameters.get("equalTo");
       if (parameters.containsKey("equalToKey")) {
         String equalToKey = (String) parameters.get("equalToKey");
-        if (equalTo == null) {
-          query = query.equalTo(null, equalToKey);
-        } else if (equalTo instanceof Boolean) {
+        if (equalTo instanceof Boolean) {
           query = query.equalTo((Boolean) equalTo, equalToKey);
-        } else if (equalTo instanceof String) {
-          query = query.equalTo((String) equalTo, equalToKey);
-        } else {
+        } else if (equalTo instanceof Number) {
           query = query.equalTo(((Number) equalTo).doubleValue(), equalToKey);
+        } else {
+          query = query.equalTo((String) equalTo, equalToKey);
         }
       } else {
         if (equalTo instanceof Boolean) {

--- a/packages/firebase_database/android/src/main/java/io/flutter/plugins/firebase/database/FirebaseDatabasePlugin.java
+++ b/packages/firebase_database/android/src/main/java/io/flutter/plugins/firebase/database/FirebaseDatabasePlugin.java
@@ -83,7 +83,9 @@ public class FirebaseDatabasePlugin implements MethodCallHandler {
       Object startAt = parameters.get("startAt");
       if (parameters.containsKey("startAtKey")) {
         String startAtKey = (String) parameters.get("startAtKey");
-        if (startAt instanceof Boolean) {
+        if (startAt == null) {
+          query = query.startAt(null, startAtKey);
+        } else if (startAt instanceof Boolean) {
           query = query.startAt((Boolean) startAt, startAtKey);
         } else if (startAt instanceof String) {
           query = query.startAt((String) startAt, startAtKey);
@@ -104,7 +106,9 @@ public class FirebaseDatabasePlugin implements MethodCallHandler {
       Object endAt = parameters.get("endAt");
       if (parameters.containsKey("endAtKey")) {
         String endAtKey = (String) parameters.get("endAtKey");
-        if (endAt instanceof Boolean) {
+        if (endAt == null) {
+          query = query.endAt(null, endAtKey);
+        } else if (endAt instanceof Boolean) {
           query = query.endAt((Boolean) endAt, endAtKey);
         } else if (endAt instanceof String) {
           query = query.endAt((String) endAt, endAtKey);
@@ -123,12 +127,25 @@ public class FirebaseDatabasePlugin implements MethodCallHandler {
     }
     if (parameters.containsKey("equalTo")) {
       Object equalTo = parameters.get("equalTo");
-      if (equalTo instanceof Boolean) {
-        query = query.equalTo((Boolean) equalTo);
-      } else if (equalTo instanceof String) {
-        query = query.equalTo((String) equalTo);
+      if (parameters.containsKey("equalToKey")) {
+        String equalToKey = (String) parameters.get("equalToKey");
+        if (equalTo == null) {
+          query = query.equalTo(null, equalToKey);
+        } else if (equalTo instanceof Boolean) {
+          query = query.equalTo((Boolean) equalTo, equalToKey);
+        } else if (equalTo instanceof String) {
+          query = query.equalTo((String) equalTo, equalToKey);
+        } else {
+          query = query.equalTo(((Number) equalTo).doubleValue(), equalToKey);
+        }
       } else {
-        query = query.equalTo(((Number) equalTo).doubleValue());
+        if (equalTo instanceof Boolean) {
+          query = query.equalTo((Boolean) equalTo);
+        } else if (equalTo instanceof String) {
+          query = query.equalTo((String) equalTo);
+        } else {
+          query = query.equalTo(((Number) equalTo).doubleValue());
+        }
       }
     }
     if (parameters.containsKey("limitToFirst")) {

--- a/packages/firebase_database/android/src/main/java/io/flutter/plugins/firebase/database/FirebaseDatabasePlugin.java
+++ b/packages/firebase_database/android/src/main/java/io/flutter/plugins/firebase/database/FirebaseDatabasePlugin.java
@@ -93,10 +93,10 @@ public class FirebaseDatabasePlugin implements MethodCallHandler {
       } else {
         if (startAt instanceof Boolean) {
           query = query.startAt((Boolean) startAt);
-        } else if (startAt instanceof String) {
-          query = query.startAt((String) startAt);
-        } else {
+        } else if (startAt instanceof Number) {
           query = query.startAt(((Number) startAt).doubleValue());
+        } else {
+          query = query.startAt((String) startAt);
         }
       }
     }
@@ -114,10 +114,10 @@ public class FirebaseDatabasePlugin implements MethodCallHandler {
       } else {
         if (endAt instanceof Boolean) {
           query = query.endAt((Boolean) endAt);
-        } else if (endAt instanceof String) {
-          query = query.endAt((String) endAt);
-        } else {
+        } else if (endAt instanceof Number) {
           query = query.endAt(((Number) endAt).doubleValue());
+        } else {
+          query = query.endAt((String) endAt);
         }
       }
     }
@@ -135,10 +135,10 @@ public class FirebaseDatabasePlugin implements MethodCallHandler {
       } else {
         if (equalTo instanceof Boolean) {
           query = query.equalTo((Boolean) equalTo);
-        } else if (equalTo instanceof String) {
-          query = query.equalTo((String) equalTo);
-        } else {
+        } else if (equalTo instanceof Number) {
           query = query.equalTo(((Number) equalTo).doubleValue());
+        } else {
+          query = query.equalTo((String) equalTo);
         }
       }
     }

--- a/packages/firebase_database/ios/Classes/FirebaseDatabasePlugin.m
+++ b/packages/firebase_database/ios/Classes/FirebaseDatabasePlugin.m
@@ -70,7 +70,12 @@ FIRDatabaseQuery *getDatabaseQuery(FIRDatabase *database, NSDictionary *argument
   }
   id equalTo = parameters[@"equalTo"];
   if (equalTo) {
-    query = [query queryEqualToValue:equalTo];
+    id equalToKey = parameters[@"equalToKey"];
+    if (equalToKey) {
+      query = [query queryEqualToValue:equalTo childKey:equalToKey];
+    } else {
+      query = [query queryEqualToValue:equalTo];
+    }
   }
   NSNumber *limitToFirst = parameters[@"limitToFirst"];
   if (limitToFirst) {

--- a/packages/firebase_database/lib/src/query.dart
+++ b/packages/firebase_database/lib/src/query.dart
@@ -141,9 +141,9 @@ class Query {
         value is double ||
         value is int ||
         value == null);
-    return _copyWithParameters(
-      <String, dynamic>{'equalTo': value, 'equalToKey': key},
-    );
+    final Map<String, dynamic> parameters = <String, dynamic>{'equalTo': value};
+    if (key != null) parameters['equalToKey'] = key;
+    return _copyWithParameters(parameters);
   }
 
   /// Create a query with limit and anchor it to the start of the window.

--- a/packages/firebase_database/pubspec.yaml
+++ b/packages/firebase_database/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Database, a cloud-hosted NoSQL database
   with realtime data syncing across Android and iOS clients, and offline access.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_database
-version: 0.4.5
+version: 0.4.6
 
 flutter:
   plugin:


### PR DESCRIPTION
This is a companion for https://github.com/flutter/plugins/pull/353 which fixes null value handling on Android side. There are some minor cleanups on iOS and Dart side as well.

Tested behavior of null `startAt` on Android and it works as expected.