### PR TITLE
[Image Picker] - Add contract tests for Android implementation

### DIFF
--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -6,7 +6,6 @@ package io.flutter.plugins.imagepicker;
 
 import android.os.Environment;
 import android.support.annotation.VisibleForTesting;
-
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.PluginRegistry;

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -5,6 +5,8 @@
 package io.flutter.plugins.imagepicker;
 
 import android.os.Environment;
+import android.support.annotation.VisibleForTesting;
+
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.PluginRegistry;
@@ -36,7 +38,8 @@ public class ImagePickerPlugin implements MethodChannel.MethodCallHandler {
     channel.setMethodCallHandler(instance);
   }
 
-  private ImagePickerPlugin(PluginRegistry.Registrar registrar, ImagePickerDelegate delegate) {
+  @VisibleForTesting
+  ImagePickerPlugin(PluginRegistry.Registrar registrar, ImagePickerDelegate delegate) {
     this.registrar = registrar;
     this.delegate = delegate;
   }

--- a/packages/image_picker/example/android/app/src/test/java/io/flutter/plugins/imagepicker/ImagePickerPluginTest.java
+++ b/packages/image_picker/example/android/app/src/test/java/io/flutter/plugins/imagepicker/ImagePickerPluginTest.java
@@ -1,7 +1,14 @@
 package io.flutter.plugins.imagepicker;
 
-import android.app.Activity;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
 
+import android.app.Activity;
+import io.flutter.plugin.common.MethodCall;
+import io.flutter.plugin.common.MethodChannel;
+import io.flutter.plugin.common.PluginRegistry;
+import java.util.HashMap;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -9,22 +16,11 @@ import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import java.util.HashMap;
-
-import io.flutter.plugin.common.MethodCall;
-import io.flutter.plugin.common.MethodChannel;
-import io.flutter.plugin.common.PluginRegistry;
-
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
-
 public class ImagePickerPluginTest {
   private static final int SOURCE_CAMERA = 0;
   private static final int SOURCE_GALLERY = 1;
 
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
+  @Rule public ExpectedException exception = ExpectedException.none();
 
   @Mock PluginRegistry.Registrar mockRegistrar;
   @Mock Activity mockActivity;
@@ -47,7 +43,8 @@ public class ImagePickerPluginTest {
 
     plugin.onMethodCall(call, mockResult);
 
-    verify(mockResult).error("no_activity", "image_picker plugin requires a foreground activity.", null);
+    verify(mockResult)
+        .error("no_activity", "image_picker plugin requires a foreground activity.", null);
     verifyZeroInteractions(mockImagePickerDelegate);
   }
 
@@ -98,9 +95,12 @@ public class ImagePickerPluginTest {
   }
 
   private MethodCall buildMethodCall(final int source) {
-    final HashMap<String, Object> arguments = new HashMap<String, Object>() {{
-      put("source", source);
-    }};
+    final HashMap<String, Object> arguments =
+        new HashMap<String, Object>() {
+          {
+            put("source", source);
+          }
+        };
 
     return new MethodCall("pickImage", arguments);
   }

--- a/packages/image_picker/example/android/app/src/test/java/io/flutter/plugins/imagepicker/ImagePickerPluginTest.java
+++ b/packages/image_picker/example/android/app/src/test/java/io/flutter/plugins/imagepicker/ImagePickerPluginTest.java
@@ -1,0 +1,107 @@
+package io.flutter.plugins.imagepicker;
+
+import android.app.Activity;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.HashMap;
+
+import io.flutter.plugin.common.MethodCall;
+import io.flutter.plugin.common.MethodChannel;
+import io.flutter.plugin.common.PluginRegistry;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+public class ImagePickerPluginTest {
+  private static final int SOURCE_CAMERA = 0;
+  private static final int SOURCE_GALLERY = 1;
+
+  @Rule
+  public ExpectedException exception = ExpectedException.none();
+
+  @Mock PluginRegistry.Registrar mockRegistrar;
+  @Mock Activity mockActivity;
+  @Mock ImagePickerDelegate mockImagePickerDelegate;
+  @Mock MethodChannel.Result mockResult;
+
+  ImagePickerPlugin plugin;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+
+    plugin = new ImagePickerPlugin(mockRegistrar, mockImagePickerDelegate);
+  }
+
+  @Test
+  public void onMethodCall_WhenActivityIsNull_FinishesWithForegroundActivityRequiredError() {
+    when(mockRegistrar.activity()).thenReturn(null);
+    MethodCall call = buildMethodCall(SOURCE_GALLERY);
+
+    plugin.onMethodCall(call, mockResult);
+
+    verify(mockResult).error("no_activity", "image_picker plugin requires a foreground activity.", null);
+    verifyZeroInteractions(mockImagePickerDelegate);
+  }
+
+  @Test
+  public void onMethodCall_WhenCalledWithUnknownMethod_ThrowsException() {
+    when(mockRegistrar.activity()).thenReturn(mockActivity);
+    exception.expect(IllegalArgumentException.class);
+    exception.expectMessage("Unknown method test");
+
+    plugin.onMethodCall(new MethodCall("test", null), mockResult);
+
+    verifyZeroInteractions(mockImagePickerDelegate);
+    verifyZeroInteractions(mockResult);
+  }
+
+  @Test
+  public void onMethodCall_WhenCalledWithUnknownImageSource_ThrowsException() {
+    when(mockRegistrar.activity()).thenReturn(mockActivity);
+    exception.expect(IllegalArgumentException.class);
+    exception.expectMessage("Invalid image source: -1");
+
+    plugin.onMethodCall(buildMethodCall(-1), mockResult);
+
+    verifyZeroInteractions(mockImagePickerDelegate);
+    verifyZeroInteractions(mockResult);
+  }
+
+  @Test
+  public void onMethodCall_WhenSourceIsGallery_InvokesChooseImageFromGallery() {
+    when(mockRegistrar.activity()).thenReturn(mockActivity);
+    MethodCall call = buildMethodCall(SOURCE_GALLERY);
+
+    plugin.onMethodCall(call, mockResult);
+
+    verify(mockImagePickerDelegate).chooseImageFromGallery(call, mockResult);
+    verifyZeroInteractions(mockResult);
+  }
+
+  @Test
+  public void onMethodCall_WhenSourceIsCamera_InvokesTakeImageWithCamera() {
+    when(mockRegistrar.activity()).thenReturn(mockActivity);
+    MethodCall call = buildMethodCall(SOURCE_CAMERA);
+
+    plugin.onMethodCall(call, mockResult);
+
+    verify(mockImagePickerDelegate).takeImageWithCamera(call, mockResult);
+    verifyZeroInteractions(mockResult);
+  }
+
+  private MethodCall buildMethodCall(final int source) {
+    final HashMap<String, Object> arguments = new HashMap<String, Object>() {{
+      put("source", source);
+    }};
+
+    return new MethodCall("pickImage", arguments);
+  }
+}

--- a/packages/image_picker/example/android/app/src/test/java/io/flutter/plugins/imagepicker/ImagePickerPluginTest.java
+++ b/packages/image_picker/example/android/app/src/test/java/io/flutter/plugins/imagepicker/ImagePickerPluginTest.java
@@ -9,6 +9,7 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.PluginRegistry;
 import java.util.HashMap;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -95,12 +96,8 @@ public class ImagePickerPluginTest {
   }
 
   private MethodCall buildMethodCall(final int source) {
-    final HashMap<String, Object> arguments =
-        new HashMap<String, Object>() {
-          {
-            put("source", source);
-          }
-        };
+    final Map<String, Object> arguments = new HashMap<>();
+    arguments.put("source", source);
 
     return new MethodCall("pickImage", arguments);
   }


### PR DESCRIPTION
Another day, another set of tests! This makes sure that the `onMethodCall` method and the `switch` case in it behave as expected.

For example, these are the constants for image sources in this plugin:

```java
  private static final int SOURCE_CAMERA = 0;
  private static final int SOURCE_GALLERY = 1;
```

If somebody were to accidentally flip these the other way around:

```java
  private static final int SOURCE_GALLERY = 0;
  private static final int SOURCE_CAMERA = 1;
```

These tests would catch that:

<img width="969" alt="screen shot 2018-04-22 at 2 42 40 pm" src="https://user-images.githubusercontent.com/13744304/39094639-724cb868-463b-11e8-9a62-55ae163b3021.png">

I'll try to come up with a clean way of testing the `registerWith` method in a separate PR.