### PR TITLE
Add gravity-independent-accelerometer support to sensors.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,6 +10,7 @@ larsenthomasj@gmail.com
 Ali Bitek <alibitek@protonmail.ch>
 Pol Batlló <pol.batllo@gmail.com>
 Anatoly Pulyaevskiy
+Hayden Flinner <haydenflinner@gmail.com>
 Stefano Rodriguez <hlsroddy@gmail.com>
 Salvatore Giordano <salvatoregiordanoo@gmail.com>
 Brian Armstrong <brian@flutter.institute>

--- a/packages/sensors/CHANGELOG.md
+++ b/packages/sensors/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.2
+
+* Added user acceleration sensor events (i.e. accelerometer without gravity).
+
 ## 0.3.1
 
 * Fixed Dart 2 type error with iOS sensor events.

--- a/packages/sensors/android/src/main/java/io/flutter/plugins/sensors/SensorsPlugin.java
+++ b/packages/sensors/android/src/main/java/io/flutter/plugins/sensors/SensorsPlugin.java
@@ -14,8 +14,11 @@ import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 /** SensorsPlugin */
 public class SensorsPlugin implements EventChannel.StreamHandler {
-  private static final String ACCELEROMETER_CHANNEL_NAME = "plugins.flutter.io/accelerometer";
-  private static final String GYROSCOPE_CHANNEL_NAME = "plugins.flutter.io/gyroscope";
+  private static final String ACCELEROMETER_CHANNEL_NAME =
+      "plugins.flutter.io/sensors/accelerometer";
+  private static final String GYROSCOPE_CHANNEL_NAME = "plugins.flutter.io/sensors/gyroscope";
+  private static final String USER_ACCELEROMETER_CHANNEL_NAME =
+      "plugins.flutter.io/sensors/user_accel";
 
   /** Plugin registration. */
   public static void registerWith(Registrar registrar) {
@@ -23,6 +26,11 @@ public class SensorsPlugin implements EventChannel.StreamHandler {
         new EventChannel(registrar.messenger(), ACCELEROMETER_CHANNEL_NAME);
     accelerometerChannel.setStreamHandler(
         new SensorsPlugin(registrar.context(), Sensor.TYPE_ACCELEROMETER));
+
+    final EventChannel userAccelChannel =
+        new EventChannel(registrar.messenger(), USER_ACCELEROMETER_CHANNEL_NAME);
+    userAccelChannel.setStreamHandler(
+        new SensorsPlugin(registrar.context(), Sensor.TYPE_LINEAR_ACCELERATION));
 
     final EventChannel gyroscopeChannel =
         new EventChannel(registrar.messenger(), GYROSCOPE_CHANNEL_NAME);

--- a/packages/sensors/example/lib/main.dart
+++ b/packages/sensors/example/lib/main.dart
@@ -40,6 +40,7 @@ class _MyHomePageState extends State<MyHomePage> {
   static const double _snakeCellSize = 10.0;
 
   List<double> _accelerometerValues;
+  List<double> _userAccelerometerValues;
   List<double> _gyroscopeValues;
   List<StreamSubscription<dynamic>> _streamSubscriptions =
       <StreamSubscription<dynamic>>[];
@@ -50,6 +51,9 @@ class _MyHomePageState extends State<MyHomePage> {
         _accelerometerValues?.map((double v) => v.toStringAsFixed(1))?.toList();
     final List<String> gyroscope =
         _gyroscopeValues?.map((double v) => v.toStringAsFixed(1))?.toList();
+    final List<String> userAccelerometer = _userAccelerometerValues
+        ?.map((double v) => v.toStringAsFixed(1))
+        ?.toList();
 
     return new Scaffold(
       appBar: new AppBar(
@@ -79,6 +83,15 @@ class _MyHomePageState extends State<MyHomePage> {
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: <Widget>[
                 new Text('Accelerometer: $accelerometer'),
+              ],
+            ),
+            padding: const EdgeInsets.all(16.0),
+          ),
+          new Padding(
+            child: new Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: <Widget>[
+                new Text('UserAccelerometer: $userAccelerometer'),
               ],
             ),
             padding: const EdgeInsets.all(16.0),
@@ -117,6 +130,12 @@ class _MyHomePageState extends State<MyHomePage> {
     _streamSubscriptions.add(gyroscopeEvents.listen((GyroscopeEvent event) {
       setState(() {
         _gyroscopeValues = <double>[event.x, event.y, event.z];
+      });
+    }));
+    _streamSubscriptions
+        .add(userAccelerometerEvents.listen((UserAccelerometerEvent event) {
+      setState(() {
+        _userAccelerometerValues = <double>[event.x, event.y, event.z];
       });
     }));
   }

--- a/packages/sensors/ios/Classes/SensorsPlugin.h
+++ b/packages/sensors/ios/Classes/SensorsPlugin.h
@@ -7,6 +7,9 @@
 @interface FLTSensorsPlugin : NSObject<FlutterPlugin>
 @end
 
+@interface FLTUserAccelStreamHandler : NSObject<FlutterStreamHandler>
+@end
+
 @interface FLTAccelerometerStreamHandler : NSObject<FlutterStreamHandler>
 @end
 

--- a/packages/sensors/lib/sensors.dart
+++ b/packages/sensors/lib/sensors.dart
@@ -1,12 +1,14 @@
 import 'dart:async';
-
 import 'package:flutter/services.dart';
 
 const EventChannel _accelerometerEventChannel =
-    const EventChannel('plugins.flutter.io/accelerometer');
+    const EventChannel('plugins.flutter.io/sensors/accelerometer');
+
+const EventChannel _userAccelerometerEventChannel =
+    const EventChannel('plugins.flutter.io/sensors/user_accel');
 
 const EventChannel _gyroscopeEventChannel =
-    const EventChannel('plugins.flutter.io/gyroscope');
+    const EventChannel('plugins.flutter.io/sensors/gyroscope');
 
 class AccelerometerEvent {
   /// Acceleration force along the x axis (including gravity) measured in m/s^2.
@@ -40,8 +42,28 @@ class GyroscopeEvent {
   String toString() => '[GyroscopeEvent (x: $x, y: $y, z: $z)]';
 }
 
+class UserAccelerometerEvent {
+  /// Acceleration force along the x axis (excluding gravity) measured in m/s^2.
+  final double x;
+
+  /// Acceleration force along the y axis (excluding gravity) measured in m/s^2.
+  final double y;
+
+  /// Acceleration force along the z axis (excluding gravity) measured in m/s^2.
+  final double z;
+
+  UserAccelerometerEvent(this.x, this.y, this.z);
+
+  @override
+  String toString() => '[UserAccelerometerEvent (x: $x, y: $y, z: $z)]';
+}
+
 AccelerometerEvent _listToAccelerometerEvent(List<double> list) {
   return new AccelerometerEvent(list[0], list[1], list[2]);
+}
+
+UserAccelerometerEvent _listToUserAccelerometerEvent(List<double> list) {
+  return new UserAccelerometerEvent(list[0], list[1], list[2]);
 }
 
 GyroscopeEvent _listToGyroscopeEvent(List<double> list) {
@@ -50,6 +72,7 @@ GyroscopeEvent _listToGyroscopeEvent(List<double> list) {
 
 Stream<AccelerometerEvent> _accelerometerEvents;
 Stream<GyroscopeEvent> _gyroscopeEvents;
+Stream<UserAccelerometerEvent> _userAccelerometerEvents;
 
 /// A broadcast stream of events from the device accelerometer.
 Stream<AccelerometerEvent> get accelerometerEvents {
@@ -69,4 +92,14 @@ Stream<GyroscopeEvent> get gyroscopeEvents {
         .map((dynamic event) => _listToGyroscopeEvent(event));
   }
   return _gyroscopeEvents;
+}
+
+/// Events from the device accelerometer with gravity removed.
+Stream<UserAccelerometerEvent> get userAccelerometerEvents {
+  if (_userAccelerometerEvents == null) {
+    _userAccelerometerEvents = _userAccelerometerEventChannel
+        .receiveBroadcastStream()
+        .map((dynamic event) => _listToUserAccelerometerEvent(event));
+  }
+  return _userAccelerometerEvents;
 }

--- a/packages/sensors/pubspec.yaml
+++ b/packages/sensors/pubspec.yaml
@@ -1,7 +1,7 @@
 name: sensors
 description: Flutter plugin for accessing the Android and iOS accelerometer and
   gyroscope sensors.
-version: 0.3.1
+version: 0.3.2
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/sensors
 


### PR DESCRIPTION
Works great on Android, example code added.

I won't be able to track down a MacOS device / setup Xcode on it for at least a few days, so I'm putting the pull request out there now in case anyone wants to spare me the labor of setting up all of that just to write a couple lines of code. Line 82 in SensorPlugins.m is what needs work.