### PR TITLE
use temp image file in cacheDir to allow picking from remote resources

### DIFF
--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
@@ -30,7 +30,11 @@ import android.provider.DocumentsContract;
 import android.provider.MediaStore;
 import android.text.TextUtils;
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 class FileUtils {
 


### PR DESCRIPTION
imagePicker caused flutter app to crash when picking image from a remote source.
Using a temp file to store the inputStream obtained from the content provider solve the problem.
It actually use a temp file in the cachedDir named cachedImage.jpg. 