### PR TITLE
Add environment to Remote Config plugin pubspec

### DIFF
--- a/packages/firebase_remote_config/pubspec.yaml
+++ b/packages/firebase_remote_config/pubspec.yaml
@@ -8,7 +8,6 @@ homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_remot
 dependencies:
   flutter:
     sdk: flutter
-  collection: '^1.14.6'
 
 dev_dependencies:
   flutter_test:
@@ -18,3 +17,7 @@ flutter:
   plugin:
     androidPackage: io.flutter.plugins.firebase.firebaseremoteconfig
     pluginClass: FirebaseRemoteConfigPlugin
+
+environment:
+  sdk: ">=2.0.0-dev.28.0 <3.0.0"
+  flutter: ">=0.1.4 <2.0.0"


### PR DESCRIPTION
https://www.dartlang.org/tools/pub/pubspec#sdk-constraints indicates that an environment variable must be set.