### PR TITLE
Add flutter_test dev dependency

### DIFF
--- a/packages/battery/pubspec.yaml
+++ b/packages/battery/pubspec.yaml
@@ -17,9 +17,9 @@ dependencies:
   meta: "^1.0.5"
 
 dev_dependencies:
-   test: 0.12.30+4
-   mockito: "^2.0.2"
-   async: "^2.0.4"
+  mockito: "^2.0.2"
+  flutter_test:
+    sdk: flutter
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"

--- a/packages/firebase_analytics/pubspec.yaml
+++ b/packages/firebase_analytics/pubspec.yaml
@@ -18,7 +18,8 @@ dependencies:
 
 dev_dependencies:
   mockito: ^2.0.2
-  test: 0.12.30+4
+  flutter_test:
+    sdk: flutter
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"

--- a/packages/firebase_database/pubspec.yaml
+++ b/packages/firebase_database/pubspec.yaml
@@ -18,7 +18,6 @@ dependencies:
 
 dev_dependencies:
   mockito: ^2.0.2
-  test:
   flutter_test:
     sdk: flutter
 

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -19,7 +19,8 @@ dependencies:
 
 dev_dependencies:
   mockito: ^2.0.2
-  test: 0.12.30+4
+  flutter_test:
+    sdk: flutter
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"

--- a/packages/share/pubspec.yaml
+++ b/packages/share/pubspec.yaml
@@ -18,7 +18,8 @@ dependencies:
 
 dev_dependencies:
   mockito: ^2.2.3
-  test: ^0.12.33
+  flutter_test:
+    sdk: flutter
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"


### PR DESCRIPTION
`flutter test` now expects
```yaml
dev_dependencies:
  flutter_test:
    sdk: flutter
```
Test execution fails with dependency on only the `test` package.