### PR TITLE
Run java tests on Travis and Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -17,5 +17,7 @@ task:
       test_script: ./script/incremental_build.sh test
     - name: analyze
       script: ./script/incremental_build.sh analyze
-    - name: build-apks
-      script: ./script/incremental_build.sh build-examples --apk
+    - name: build-apks+java-test
+      script:
+        - ./script/incremental_build.sh build-examples --apk
+        - ./script/incremental_build.sh java-test  # must come after apk build

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,10 +44,10 @@ matrix:
       script:
         - ./script/plugin_tools.sh format --travis --clang-format=clang-format-5.0
         - ./script/plugin_tools.sh test
-    # Job 3) Build example APKs
+    # Job 3) Build example APKs and run Java tests
     - os: linux
       env:
-        - SHARD=Build-example-APKs
+        - SHARD=Build-example-APKs+Java-Tests
       jdk: oraclejdk8
       sudo: false
       addons:
@@ -87,6 +87,7 @@ matrix:
         - pub global activate flutter_plugin_tools
       script:
         - ./script/plugin_tools.sh build-examples --apk
+        - ./script/plugin_tools.sh java-test  # must come after apk build
     # Job 4) Build example IPAs
     - os: osx
       env:


### PR DESCRIPTION
In https://github.com/flutter/plugins/pull/461 java tests for the image_picker plugin were added. This PR runs these tests on Travis and Cirrus CI to ensure they don't break.

Requires https://github.com/flutter/plugin_tools/pull/12 to be submitted and published.

/cc @mravn-google @roughike