### PR TITLE
GoogleMaps on iOS

### DIFF
--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/Convert.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/Convert.java
@@ -37,10 +37,6 @@ class Convert {
           return BitmapDescriptorFactory.fromAsset(
               FlutterMain.getLookupKeyForAsset(toString(data.get(1)), toString(data.get(2))));
         }
-      case "fromFile":
-        return BitmapDescriptorFactory.fromFile(toString(data.get(1)));
-      case "fromPath":
-        return BitmapDescriptorFactory.fromPath(toString(data.get(1)));
     }
     throw new IllegalArgumentException("Cannot interpret " + o + " as BitmapDescriptor");
   }
@@ -168,14 +164,14 @@ class Convert {
     if (cameraPosition != null) {
       sink.setCameraPosition(toCameraPosition(cameraPosition));
     }
+    final Object cameraTargetBounds = data.get("cameraTargetBounds");
+    if (cameraTargetBounds != null) {
+      final List<?> targetData = toList(cameraTargetBounds);
+      sink.setCameraTargetBounds(toLatLngBounds(targetData.get(0)));
+    }
     final Object compassEnabled = data.get("compassEnabled");
     if (compassEnabled != null) {
       sink.setCompassEnabled(toBoolean(compassEnabled));
-    }
-    final Object latLngCameraTargetBounds = data.get("latLngCameraTargetBounds");
-    if (latLngCameraTargetBounds != null) {
-      final List<?> targetData = toList(latLngCameraTargetBounds);
-      sink.setLatLngBoundsForCameraTarget(toLatLngBounds(targetData.get(0)));
     }
     final Object mapType = data.get("mapType");
     if (mapType != null) {
@@ -223,7 +219,7 @@ class Convert {
     }
     final Object consumesTapEvents = data.get("consumesTapEvents");
     if (consumesTapEvents != null) {
-      sink.setConsumesTapEvents(toBoolean(consumesTapEvents));
+      sink.setConsumeTapEvents(toBoolean(consumesTapEvents));
     }
     final Object draggable = data.get("draggable");
     if (draggable != null) {
@@ -241,10 +237,6 @@ class Convert {
     if (infoWindowAnchor != null) {
       final List<?> anchorData = toList(infoWindowAnchor);
       sink.setInfoWindowAnchor(toFloat(anchorData.get(0)), toFloat(anchorData.get(1)));
-    }
-    final Object infoWindowShown = data.get("infoWindowShown");
-    if (infoWindowShown != null) {
-      sink.setInfoWindowShown(toBoolean(infoWindowShown));
     }
     final Object infoWindowText = data.get("infoWindowText");
     if (infoWindowText != null) {

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/Convert.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/Convert.java
@@ -67,7 +67,8 @@ class Convert {
       case "newLatLng":
         return CameraUpdateFactory.newLatLng(toLatLng(data.get(1)));
       case "newLatLngBounds":
-        return CameraUpdateFactory.newLatLngBounds(toLatLngBounds(data.get(1)), toPixels(data.get(2), density));
+        return CameraUpdateFactory.newLatLngBounds(
+            toLatLngBounds(data.get(1)), toPixels(data.get(2), density));
       case "newLatLngZoom":
         return CameraUpdateFactory.newLatLngZoom(toLatLng(data.get(1)), toFloat(data.get(2)));
       case "scrollBy":

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/Convert.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/Convert.java
@@ -59,7 +59,7 @@ class Convert {
     return builder.build();
   }
 
-  static CameraUpdate toCameraUpdate(Object o) {
+  static CameraUpdate toCameraUpdate(Object o, float density) {
     final List<?> data = toList(o);
     switch (toString(data.get(0))) {
       case "newCameraPosition":
@@ -67,16 +67,18 @@ class Convert {
       case "newLatLng":
         return CameraUpdateFactory.newLatLng(toLatLng(data.get(1)));
       case "newLatLngBounds":
-        return CameraUpdateFactory.newLatLngBounds(toLatLngBounds(data.get(1)), toInt(data.get(2)));
+        return CameraUpdateFactory.newLatLngBounds(toLatLngBounds(data.get(1)), toPixels(data.get(2), density));
       case "newLatLngZoom":
         return CameraUpdateFactory.newLatLngZoom(toLatLng(data.get(1)), toFloat(data.get(2)));
       case "scrollBy":
-        return CameraUpdateFactory.scrollBy(toFloat(data.get(1)), toFloat(data.get(2)));
+        return CameraUpdateFactory.scrollBy( //
+            toFractionalPixels(data.get(1), density), //
+            toFractionalPixels(data.get(2), density));
       case "zoomBy":
         if (data.size() == 2) {
           return CameraUpdateFactory.zoomBy(toFloat(data.get(1)));
         } else {
-          return CameraUpdateFactory.zoomBy(toFloat(data.get(1)), toPoint(data.get(2)));
+          return CameraUpdateFactory.zoomBy(toFloat(data.get(1)), toPoint(data.get(2), density));
         }
       case "zoomIn":
         return CameraUpdateFactory.zoomIn();
@@ -142,9 +144,17 @@ class Convert {
     return (Map<?, ?>) o;
   }
 
-  private static Point toPoint(Object o) {
+  private static float toFractionalPixels(Object o, float density) {
+    return toFloat(o) * density;
+  }
+
+  static int toPixels(Object o, float density) {
+    return (int) toFractionalPixels(o, density);
+  }
+
+  private static Point toPoint(Object o, float density) {
     final List<?> data = toList(o);
-    return new Point(toInt(data.get(0)), toInt(data.get(1)));
+    return new Point(toPixels(data.get(0), density), toPixels(data.get(1), density));
   }
 
   private static String toString(Object o) {

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapBuilder.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapBuilder.java
@@ -39,7 +39,7 @@ class GoogleMapBuilder implements GoogleMapOptionsSink {
   }
 
   @Override
-  public void setLatLngBoundsForCameraTarget(LatLngBounds bounds) {
+  public void setCameraTargetBounds(LatLngBounds bounds) {
     options.latLngBoundsForCameraTarget(bounds);
   }
 

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapBuilder.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapBuilder.java
@@ -15,12 +15,8 @@ class GoogleMapBuilder implements GoogleMapOptionsSink {
   private final GoogleMapOptions options = new GoogleMapOptions();
   private boolean trackCameraPosition = false;
 
-  GoogleMapController build(
-      AtomicInteger state,
-      PluginRegistry.Registrar registrar,
-      int width,
-      int height,
-      MethodChannel.Result result) {
+  GoogleMapController build(AtomicInteger state, PluginRegistry.Registrar registrar, int width,
+      int height, MethodChannel.Result result) {
     final GoogleMapController controller =
         new GoogleMapController(state, registrar, width, height, options, result);
     controller.init();

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapBuilder.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapBuilder.java
@@ -15,8 +15,12 @@ class GoogleMapBuilder implements GoogleMapOptionsSink {
   private final GoogleMapOptions options = new GoogleMapOptions();
   private boolean trackCameraPosition = false;
 
-  GoogleMapController build(AtomicInteger state, PluginRegistry.Registrar registrar, int width,
-      int height, MethodChannel.Result result) {
+  GoogleMapController build(
+      AtomicInteger state,
+      PluginRegistry.Registrar registrar,
+      int width,
+      int height,
+      MethodChannel.Result result) {
     final GoogleMapController controller =
         new GoogleMapController(state, registrar, width, height, options, result);
     controller.init();

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
@@ -41,10 +41,14 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 /** Controller of a single GoogleMaps MapView instance. */
 final class GoogleMapController
-    implements Application.ActivityLifecycleCallbacks, GoogleMapOptionsSink, OnMapReadyCallback,
-               GoogleMap.SnapshotReadyCallback, GoogleMap.OnMarkerClickListener,
-               GoogleMap.OnCameraMoveStartedListener, GoogleMap.OnCameraMoveListener,
-               GoogleMap.OnCameraIdleListener {
+    implements Application.ActivityLifecycleCallbacks,
+        GoogleMapOptionsSink,
+        OnMapReadyCallback,
+        GoogleMap.SnapshotReadyCallback,
+        GoogleMap.OnMarkerClickListener,
+        GoogleMap.OnCameraMoveStartedListener,
+        GoogleMap.OnCameraMoveListener,
+        GoogleMap.OnCameraIdleListener {
   private final AtomicInteger activityState;
   private final FrameLayout parent;
   private final PluginRegistry.Registrar registrar;
@@ -63,8 +67,13 @@ final class GoogleMapController
   private boolean trackCameraPosition = false;
   private boolean disposed = false;
 
-  GoogleMapController(AtomicInteger activityState, PluginRegistry.Registrar registrar, int width,
-      int height, GoogleMapOptions options, MethodChannel.Result result) {
+  GoogleMapController(
+      AtomicInteger activityState,
+      PluginRegistry.Registrar registrar,
+      int width,
+      int height,
+      GoogleMapOptions options,
+      MethodChannel.Result result) {
     this.activityState = activityState;
     this.registrar = registrar;
     this.width = width;

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
@@ -216,7 +216,7 @@ final class GoogleMapController
 
   @Override
   public void onCameraMoveStarted(int reason) {
-    onCameraMoveListener.onCameraMoveStarted(reason);
+    onCameraMoveListener.onCameraMoveStarted(reason == GoogleMap.OnCameraMoveStartedListener.REASON_GESTURE);
     cancelSnapshotTimerTasks();
   }
 

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
@@ -41,14 +41,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 /** Controller of a single GoogleMaps MapView instance. */
 final class GoogleMapController
-    implements Application.ActivityLifecycleCallbacks,
-        GoogleMapOptionsSink,
-        OnMapReadyCallback,
-        GoogleMap.SnapshotReadyCallback,
-        GoogleMap.OnMarkerClickListener,
-        GoogleMap.OnCameraMoveStartedListener,
-        GoogleMap.OnCameraMoveListener,
-        GoogleMap.OnCameraIdleListener {
+    implements Application.ActivityLifecycleCallbacks, GoogleMapOptionsSink, OnMapReadyCallback,
+               GoogleMap.SnapshotReadyCallback, GoogleMap.OnMarkerClickListener,
+               GoogleMap.OnCameraMoveStartedListener, GoogleMap.OnCameraMoveListener,
+               GoogleMap.OnCameraIdleListener {
   private final AtomicInteger activityState;
   private final FrameLayout parent;
   private final PluginRegistry.Registrar registrar;
@@ -67,13 +63,8 @@ final class GoogleMapController
   private boolean trackCameraPosition = false;
   private boolean disposed = false;
 
-  GoogleMapController(
-      AtomicInteger activityState,
-      PluginRegistry.Registrar registrar,
-      int width,
-      int height,
-      GoogleMapOptions options,
-      MethodChannel.Result result) {
+  GoogleMapController(AtomicInteger activityState, PluginRegistry.Registrar registrar, int width,
+      int height, GoogleMapOptions options, MethodChannel.Result result) {
     this.activityState = activityState;
     this.registrar = registrar;
     this.width = width;
@@ -216,7 +207,8 @@ final class GoogleMapController
 
   @Override
   public void onCameraMoveStarted(int reason) {
-    onCameraMoveListener.onCameraMoveStarted(reason == GoogleMap.OnCameraMoveStartedListener.REASON_GESTURE);
+    onCameraMoveListener.onCameraMoveStarted(
+        reason == GoogleMap.OnCameraMoveStartedListener.REASON_GESTURE);
     cancelSnapshotTimerTasks();
   }
 

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
@@ -349,6 +349,11 @@ final class GoogleMapController
   }
 
   @Override
+  public void setCameraTargetBounds(LatLngBounds bounds) {
+    googleMap.setLatLngBoundsForCameraTarget(bounds);
+  }
+
+  @Override
   public void setCompassEnabled(boolean compassEnabled) {
     googleMap.getUiSettings().setCompassEnabled(compassEnabled);
   }
@@ -356,11 +361,6 @@ final class GoogleMapController
   @Override
   public void setMapType(int mapType) {
     googleMap.setMapType(mapType);
-  }
-
-  @Override
-  public void setLatLngBoundsForCameraTarget(LatLngBounds bounds) {
-    googleMap.setLatLngBoundsForCameraTarget(bounds);
   }
 
   @Override

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapOptionsSink.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapOptionsSink.java
@@ -11,13 +11,13 @@ import com.google.android.gms.maps.model.LatLngBounds;
 interface GoogleMapOptionsSink {
   void setCameraPosition(CameraPosition position);
 
-  void setLatLngBoundsForCameraTarget(LatLngBounds bounds);
+  void setCameraTargetBounds(LatLngBounds bounds);
 
   void setCompassEnabled(boolean compassEnabled);
 
   void setMapType(int mapType);
 
-  void setTrackCameraPosition(boolean reportCameraMoveEvents);
+  void setMinMaxZoomPreference(Float min, Float max);
 
   void setRotateGesturesEnabled(boolean rotateGesturesEnabled);
 
@@ -25,7 +25,7 @@ interface GoogleMapOptionsSink {
 
   void setTiltGesturesEnabled(boolean tiltGesturesEnabled);
 
-  void setMinMaxZoomPreference(Float min, Float max);
+  void setTrackCameraPosition(boolean trackCameraPosition);
 
   void setZoomGesturesEnabled(boolean zoomGesturesEnabled);
 }

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapsPlugin.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapsPlugin.java
@@ -36,6 +36,7 @@ public class GoogleMapsPlugin implements MethodCallHandler, Application.Activity
   private final Map<Long, GoogleMapController> googleMaps = new HashMap<>();
   private final Registrar registrar;
   private final MethodChannel channel;
+  private final float density;
   private final AtomicInteger state = new AtomicInteger(0);
 
   public static void registerWith(Registrar registrar) {
@@ -49,6 +50,7 @@ public class GoogleMapsPlugin implements MethodCallHandler, Application.Activity
   private GoogleMapsPlugin(Registrar registrar, MethodChannel channel) {
     this.registrar = registrar;
     this.channel = channel;
+    this.density = registrar.context().getResources().getDisplayMetrics().density;
   }
 
   @Override
@@ -65,8 +67,8 @@ public class GoogleMapsPlugin implements MethodCallHandler, Application.Activity
         }
       case "createMap":
         {
-          final int width = Convert.toInt(call.argument("width"));
-          final int height = Convert.toInt(call.argument("height"));
+          final int width = Convert.toPixels(call.argument("width"), density);
+          final int height = Convert.toPixels(call.argument("height"), density);
           final Map<?, ?> options = Convert.toMap(call.argument("options"));
           final GoogleMapBuilder builder = new GoogleMapBuilder();
           Convert.interpretGoogleMapOptions(options, builder);
@@ -110,7 +112,7 @@ public class GoogleMapsPlugin implements MethodCallHandler, Application.Activity
           // result.success is called from controller when the GoogleMaps instance is ready
           break;
         }
-      case "setMapOptions":
+      case "updateMapOptions":
         {
           final GoogleMapController controller = mapsController(call);
           Convert.interpretGoogleMapOptions(call.argument("options"), controller);
@@ -120,7 +122,7 @@ public class GoogleMapsPlugin implements MethodCallHandler, Application.Activity
       case "moveCamera":
         {
           final GoogleMapController controller = mapsController(call);
-          final CameraUpdate cameraUpdate = Convert.toCameraUpdate(call.argument("cameraUpdate"));
+          final CameraUpdate cameraUpdate = Convert.toCameraUpdate(call.argument("cameraUpdate"), density);
           controller.moveCamera(cameraUpdate);
           result.success(null);
           break;
@@ -128,7 +130,7 @@ public class GoogleMapsPlugin implements MethodCallHandler, Application.Activity
       case "animateCamera":
         {
           final GoogleMapController controller = mapsController(call);
-          final CameraUpdate cameraUpdate = Convert.toCameraUpdate(call.argument("cameraUpdate"));
+          final CameraUpdate cameraUpdate = Convert.toCameraUpdate(call.argument("cameraUpdate"), density);
           controller.animateCamera(cameraUpdate);
           result.success(null);
           break;
@@ -162,8 +164,8 @@ public class GoogleMapsPlugin implements MethodCallHandler, Application.Activity
       case "showMapOverlay":
         {
           final GoogleMapController controller = mapsController(call);
-          final int x = Convert.toInt(call.argument("x"));
-          final int y = Convert.toInt(call.argument("y"));
+          final int x = Convert.toPixels(call.argument("x"), density);
+          final int y = Convert.toPixels(call.argument("y"), density);
           controller.showOverlay(x, y);
           result.success(null);
           break;

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapsPlugin.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapsPlugin.java
@@ -56,134 +56,123 @@ public class GoogleMapsPlugin implements MethodCallHandler, Application.Activity
   @Override
   public void onMethodCall(MethodCall call, Result result) {
     switch (call.method) {
-      case "init":
-        {
-          for (GoogleMapController controller : googleMaps.values()) {
-            controller.dispose();
-          }
-          googleMaps.clear();
-          result.success(null);
-          break;
-        }
-      case "createMap":
-        {
-          final int width = Convert.toPixels(call.argument("width"), density);
-          final int height = Convert.toPixels(call.argument("height"), density);
-          final Map<?, ?> options = Convert.toMap(call.argument("options"));
-          final GoogleMapBuilder builder = new GoogleMapBuilder();
-          Convert.interpretGoogleMapOptions(options, builder);
-          final GoogleMapController controller =
-              builder.build(state, registrar, width, height, result);
-          googleMaps.put(controller.id(), controller);
-          controller.setOnCameraMoveListener(
-              new OnCameraMoveListener() {
-                @Override
-                public void onCameraMoveStarted(boolean isGesture) {
-                  final Map<String, Object> arguments = new HashMap<>(2);
-                  arguments.put("map", controller.id());
-                  arguments.put("isGesture", isGesture);
-                  channel.invokeMethod("map#onCameraMoveStarted", arguments);
-                }
-
-                @Override
-                public void onCameraMove(CameraPosition position) {
-                  final Map<String, Object> arguments = new HashMap<>(2);
-                  arguments.put("map", controller.id());
-                  arguments.put("position", Convert.toJson(position));
-                  channel.invokeMethod("map#onCameraMove", arguments);
-                }
-
-                @Override
-                public void onCameraIdle() {
-                  channel.invokeMethod(
-                      "map#onCameraIdle", Collections.singletonMap("map", controller.id()));
-                }
-              });
-          controller.setOnMarkerTappedListener(
-              new OnMarkerTappedListener() {
-                @Override
-                public void onMarkerTapped(Marker marker) {
-                  final Map<String, Object> arguments = new HashMap<>(2);
-                  arguments.put("map", controller.id());
-                  arguments.put("marker", marker.getId());
-                  channel.invokeMethod("marker#onTap", arguments);
-                }
-              });
-          // result.success is called from controller when the GoogleMaps instance is ready
-          break;
-        }
-      case "updateMapOptions":
-        {
-          final GoogleMapController controller = mapsController(call);
-          Convert.interpretGoogleMapOptions(call.argument("options"), controller);
-          result.success(null);
-          break;
-        }
-      case "moveCamera":
-        {
-          final GoogleMapController controller = mapsController(call);
-          final CameraUpdate cameraUpdate = Convert.toCameraUpdate(call.argument("cameraUpdate"), density);
-          controller.moveCamera(cameraUpdate);
-          result.success(null);
-          break;
-        }
-      case "animateCamera":
-        {
-          final GoogleMapController controller = mapsController(call);
-          final CameraUpdate cameraUpdate = Convert.toCameraUpdate(call.argument("cameraUpdate"), density);
-          controller.animateCamera(cameraUpdate);
-          result.success(null);
-          break;
-        }
-      case "addMarker":
-        {
-          final GoogleMapController controller = mapsController(call);
-          final MarkerBuilder markerBuilder = controller.newMarkerBuilder();
-          Convert.interpretMarkerOptions(call.argument("options"), markerBuilder);
-          final String markerId = markerBuilder.build();
-          result.success(markerId);
-          break;
-        }
-      case "marker#remove":
-        {
-          final GoogleMapController controller = mapsController(call);
-          final String markerId = call.argument("marker");
-          controller.removeMarker(markerId);
-          result.success(null);
-          break;
-        }
-      case "marker#update":
-        {
-          final GoogleMapController controller = mapsController(call);
-          final String markerId = call.argument("marker");
-          final MarkerController marker = controller.marker(markerId);
-          Convert.interpretMarkerOptions(call.argument("options"), marker);
-          result.success(null);
-          break;
-        }
-      case "showMapOverlay":
-        {
-          final GoogleMapController controller = mapsController(call);
-          final int x = Convert.toPixels(call.argument("x"), density);
-          final int y = Convert.toPixels(call.argument("y"), density);
-          controller.showOverlay(x, y);
-          result.success(null);
-          break;
-        }
-      case "hideMapOverlay":
-        {
-          final GoogleMapController controller = mapsController(call);
-          controller.hideOverlay();
-          result.success(null);
-          break;
-        }
-      case "disposeMap":
-        {
-          final GoogleMapController controller = mapsController(call);
+      case "init": {
+        for (GoogleMapController controller : googleMaps.values()) {
           controller.dispose();
-          result.success(null);
-          break;
         }
+        googleMaps.clear();
+        result.success(null);
+        break;
+      }
+      case "createMap": {
+        final int width = Convert.toPixels(call.argument("width"), density);
+        final int height = Convert.toPixels(call.argument("height"), density);
+        final Map<?, ?> options = Convert.toMap(call.argument("options"));
+        final GoogleMapBuilder builder = new GoogleMapBuilder();
+        Convert.interpretGoogleMapOptions(options, builder);
+        final GoogleMapController controller =
+            builder.build(state, registrar, width, height, result);
+        googleMaps.put(controller.id(), controller);
+        controller.setOnCameraMoveListener(new OnCameraMoveListener() {
+          @Override
+          public void onCameraMoveStarted(boolean isGesture) {
+            final Map<String, Object> arguments = new HashMap<>(2);
+            arguments.put("map", controller.id());
+            arguments.put("isGesture", isGesture);
+            channel.invokeMethod("map#onCameraMoveStarted", arguments);
+          }
+
+          @Override
+          public void onCameraMove(CameraPosition position) {
+            final Map<String, Object> arguments = new HashMap<>(2);
+            arguments.put("map", controller.id());
+            arguments.put("position", Convert.toJson(position));
+            channel.invokeMethod("map#onCameraMove", arguments);
+          }
+
+          @Override
+          public void onCameraIdle() {
+            channel.invokeMethod(
+                "map#onCameraIdle", Collections.singletonMap("map", controller.id()));
+          }
+        });
+        controller.setOnMarkerTappedListener(new OnMarkerTappedListener() {
+          @Override
+          public void onMarkerTapped(Marker marker) {
+            final Map<String, Object> arguments = new HashMap<>(2);
+            arguments.put("map", controller.id());
+            arguments.put("marker", marker.getId());
+            channel.invokeMethod("marker#onTap", arguments);
+          }
+        });
+        // result.success is called from controller when the GoogleMaps instance is ready
+        break;
+      }
+      case "updateMapOptions": {
+        final GoogleMapController controller = mapsController(call);
+        Convert.interpretGoogleMapOptions(call.argument("options"), controller);
+        result.success(null);
+        break;
+      }
+      case "moveCamera": {
+        final GoogleMapController controller = mapsController(call);
+        final CameraUpdate cameraUpdate =
+            Convert.toCameraUpdate(call.argument("cameraUpdate"), density);
+        controller.moveCamera(cameraUpdate);
+        result.success(null);
+        break;
+      }
+      case "animateCamera": {
+        final GoogleMapController controller = mapsController(call);
+        final CameraUpdate cameraUpdate =
+            Convert.toCameraUpdate(call.argument("cameraUpdate"), density);
+        controller.animateCamera(cameraUpdate);
+        result.success(null);
+        break;
+      }
+      case "addMarker": {
+        final GoogleMapController controller = mapsController(call);
+        final MarkerBuilder markerBuilder = controller.newMarkerBuilder();
+        Convert.interpretMarkerOptions(call.argument("options"), markerBuilder);
+        final String markerId = markerBuilder.build();
+        result.success(markerId);
+        break;
+      }
+      case "marker#remove": {
+        final GoogleMapController controller = mapsController(call);
+        final String markerId = call.argument("marker");
+        controller.removeMarker(markerId);
+        result.success(null);
+        break;
+      }
+      case "marker#update": {
+        final GoogleMapController controller = mapsController(call);
+        final String markerId = call.argument("marker");
+        final MarkerController marker = controller.marker(markerId);
+        Convert.interpretMarkerOptions(call.argument("options"), marker);
+        result.success(null);
+        break;
+      }
+      case "showMapOverlay": {
+        final GoogleMapController controller = mapsController(call);
+        final int x = Convert.toPixels(call.argument("x"), density);
+        final int y = Convert.toPixels(call.argument("y"), density);
+        controller.showOverlay(x, y);
+        result.success(null);
+        break;
+      }
+      case "hideMapOverlay": {
+        final GoogleMapController controller = mapsController(call);
+        controller.hideOverlay();
+        result.success(null);
+        break;
+      }
+      case "disposeMap": {
+        final GoogleMapController controller = mapsController(call);
+        controller.dispose();
+        result.success(null);
+        break;
+      }
       default:
         result.notImplemented();
     }

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapsPlugin.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapsPlugin.java
@@ -56,123 +56,137 @@ public class GoogleMapsPlugin implements MethodCallHandler, Application.Activity
   @Override
   public void onMethodCall(MethodCall call, Result result) {
     switch (call.method) {
-      case "init": {
-        for (GoogleMapController controller : googleMaps.values()) {
-          controller.dispose();
+      case "init":
+        {
+          for (GoogleMapController controller : googleMaps.values()) {
+            controller.dispose();
+          }
+          googleMaps.clear();
+          result.success(null);
+          break;
         }
-        googleMaps.clear();
-        result.success(null);
-        break;
-      }
-      case "createMap": {
-        final int width = Convert.toPixels(call.argument("width"), density);
-        final int height = Convert.toPixels(call.argument("height"), density);
-        final Map<?, ?> options = Convert.toMap(call.argument("options"));
-        final GoogleMapBuilder builder = new GoogleMapBuilder();
-        Convert.interpretGoogleMapOptions(options, builder);
-        final GoogleMapController controller =
-            builder.build(state, registrar, width, height, result);
-        googleMaps.put(controller.id(), controller);
-        controller.setOnCameraMoveListener(new OnCameraMoveListener() {
-          @Override
-          public void onCameraMoveStarted(boolean isGesture) {
-            final Map<String, Object> arguments = new HashMap<>(2);
-            arguments.put("map", controller.id());
-            arguments.put("isGesture", isGesture);
-            channel.invokeMethod("map#onCameraMoveStarted", arguments);
-          }
+      case "createMap":
+        {
+          final int width = Convert.toPixels(call.argument("width"), density);
+          final int height = Convert.toPixels(call.argument("height"), density);
+          final Map<?, ?> options = Convert.toMap(call.argument("options"));
+          final GoogleMapBuilder builder = new GoogleMapBuilder();
+          Convert.interpretGoogleMapOptions(options, builder);
+          final GoogleMapController controller =
+              builder.build(state, registrar, width, height, result);
+          googleMaps.put(controller.id(), controller);
+          controller.setOnCameraMoveListener(
+              new OnCameraMoveListener() {
+                @Override
+                public void onCameraMoveStarted(boolean isGesture) {
+                  final Map<String, Object> arguments = new HashMap<>(2);
+                  arguments.put("map", controller.id());
+                  arguments.put("isGesture", isGesture);
+                  channel.invokeMethod("map#onCameraMoveStarted", arguments);
+                }
 
-          @Override
-          public void onCameraMove(CameraPosition position) {
-            final Map<String, Object> arguments = new HashMap<>(2);
-            arguments.put("map", controller.id());
-            arguments.put("position", Convert.toJson(position));
-            channel.invokeMethod("map#onCameraMove", arguments);
-          }
+                @Override
+                public void onCameraMove(CameraPosition position) {
+                  final Map<String, Object> arguments = new HashMap<>(2);
+                  arguments.put("map", controller.id());
+                  arguments.put("position", Convert.toJson(position));
+                  channel.invokeMethod("map#onCameraMove", arguments);
+                }
 
-          @Override
-          public void onCameraIdle() {
-            channel.invokeMethod(
-                "map#onCameraIdle", Collections.singletonMap("map", controller.id()));
-          }
-        });
-        controller.setOnMarkerTappedListener(new OnMarkerTappedListener() {
-          @Override
-          public void onMarkerTapped(Marker marker) {
-            final Map<String, Object> arguments = new HashMap<>(2);
-            arguments.put("map", controller.id());
-            arguments.put("marker", marker.getId());
-            channel.invokeMethod("marker#onTap", arguments);
-          }
-        });
-        // result.success is called from controller when the GoogleMaps instance is ready
-        break;
-      }
-      case "updateMapOptions": {
-        final GoogleMapController controller = mapsController(call);
-        Convert.interpretGoogleMapOptions(call.argument("options"), controller);
-        result.success(null);
-        break;
-      }
-      case "moveCamera": {
-        final GoogleMapController controller = mapsController(call);
-        final CameraUpdate cameraUpdate =
-            Convert.toCameraUpdate(call.argument("cameraUpdate"), density);
-        controller.moveCamera(cameraUpdate);
-        result.success(null);
-        break;
-      }
-      case "animateCamera": {
-        final GoogleMapController controller = mapsController(call);
-        final CameraUpdate cameraUpdate =
-            Convert.toCameraUpdate(call.argument("cameraUpdate"), density);
-        controller.animateCamera(cameraUpdate);
-        result.success(null);
-        break;
-      }
-      case "addMarker": {
-        final GoogleMapController controller = mapsController(call);
-        final MarkerBuilder markerBuilder = controller.newMarkerBuilder();
-        Convert.interpretMarkerOptions(call.argument("options"), markerBuilder);
-        final String markerId = markerBuilder.build();
-        result.success(markerId);
-        break;
-      }
-      case "marker#remove": {
-        final GoogleMapController controller = mapsController(call);
-        final String markerId = call.argument("marker");
-        controller.removeMarker(markerId);
-        result.success(null);
-        break;
-      }
-      case "marker#update": {
-        final GoogleMapController controller = mapsController(call);
-        final String markerId = call.argument("marker");
-        final MarkerController marker = controller.marker(markerId);
-        Convert.interpretMarkerOptions(call.argument("options"), marker);
-        result.success(null);
-        break;
-      }
-      case "showMapOverlay": {
-        final GoogleMapController controller = mapsController(call);
-        final int x = Convert.toPixels(call.argument("x"), density);
-        final int y = Convert.toPixels(call.argument("y"), density);
-        controller.showOverlay(x, y);
-        result.success(null);
-        break;
-      }
-      case "hideMapOverlay": {
-        final GoogleMapController controller = mapsController(call);
-        controller.hideOverlay();
-        result.success(null);
-        break;
-      }
-      case "disposeMap": {
-        final GoogleMapController controller = mapsController(call);
-        controller.dispose();
-        result.success(null);
-        break;
-      }
+                @Override
+                public void onCameraIdle() {
+                  channel.invokeMethod(
+                      "map#onCameraIdle", Collections.singletonMap("map", controller.id()));
+                }
+              });
+          controller.setOnMarkerTappedListener(
+              new OnMarkerTappedListener() {
+                @Override
+                public void onMarkerTapped(Marker marker) {
+                  final Map<String, Object> arguments = new HashMap<>(2);
+                  arguments.put("map", controller.id());
+                  arguments.put("marker", marker.getId());
+                  channel.invokeMethod("marker#onTap", arguments);
+                }
+              });
+          // result.success is called from controller when the GoogleMaps instance
+          // is ready
+          break;
+        }
+      case "updateMapOptions":
+        {
+          final GoogleMapController controller = mapsController(call);
+          Convert.interpretGoogleMapOptions(call.argument("options"), controller);
+          result.success(null);
+          break;
+        }
+      case "moveCamera":
+        {
+          final GoogleMapController controller = mapsController(call);
+          final CameraUpdate cameraUpdate =
+              Convert.toCameraUpdate(call.argument("cameraUpdate"), density);
+          controller.moveCamera(cameraUpdate);
+          result.success(null);
+          break;
+        }
+      case "animateCamera":
+        {
+          final GoogleMapController controller = mapsController(call);
+          final CameraUpdate cameraUpdate =
+              Convert.toCameraUpdate(call.argument("cameraUpdate"), density);
+          controller.animateCamera(cameraUpdate);
+          result.success(null);
+          break;
+        }
+      case "addMarker":
+        {
+          final GoogleMapController controller = mapsController(call);
+          final MarkerBuilder markerBuilder = controller.newMarkerBuilder();
+          Convert.interpretMarkerOptions(call.argument("options"), markerBuilder);
+          final String markerId = markerBuilder.build();
+          result.success(markerId);
+          break;
+        }
+      case "marker#remove":
+        {
+          final GoogleMapController controller = mapsController(call);
+          final String markerId = call.argument("marker");
+          controller.removeMarker(markerId);
+          result.success(null);
+          break;
+        }
+      case "marker#update":
+        {
+          final GoogleMapController controller = mapsController(call);
+          final String markerId = call.argument("marker");
+          final MarkerController marker = controller.marker(markerId);
+          Convert.interpretMarkerOptions(call.argument("options"), marker);
+          result.success(null);
+          break;
+        }
+      case "showMapOverlay":
+        {
+          final GoogleMapController controller = mapsController(call);
+          final int x = Convert.toPixels(call.argument("x"), density);
+          final int y = Convert.toPixels(call.argument("y"), density);
+          controller.showOverlay(x, y);
+          result.success(null);
+          break;
+        }
+      case "hideMapOverlay":
+        {
+          final GoogleMapController controller = mapsController(call);
+          controller.hideOverlay();
+          result.success(null);
+          break;
+        }
+      case "disposeMap":
+        {
+          final GoogleMapController controller = mapsController(call);
+          controller.dispose();
+          result.success(null);
+          break;
+        }
       default:
         result.notImplemented();
     }

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapsPlugin.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapsPlugin.java
@@ -78,10 +78,10 @@ public class GoogleMapsPlugin implements MethodCallHandler, Application.Activity
           controller.setOnCameraMoveListener(
               new OnCameraMoveListener() {
                 @Override
-                public void onCameraMoveStarted(int reason) {
+                public void onCameraMoveStarted(boolean isGesture) {
                   final Map<String, Object> arguments = new HashMap<>(2);
                   arguments.put("map", controller.id());
-                  arguments.put("reason", reason);
+                  arguments.put("isGesture", isGesture);
                   channel.invokeMethod("map#onCameraMoveStarted", arguments);
                 }
 

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/MarkerBuilder.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/MarkerBuilder.java
@@ -13,7 +13,6 @@ class MarkerBuilder implements MarkerOptionsSink {
   private final GoogleMapController mapController;
   private final MarkerOptions markerOptions;
   private boolean consumesTapEvents;
-  private boolean infoWindowShown;
 
   MarkerBuilder(GoogleMapController mapController) {
     this.mapController = mapController;
@@ -22,9 +21,6 @@ class MarkerBuilder implements MarkerOptionsSink {
 
   String build() {
     final Marker marker = mapController.addMarker(markerOptions, consumesTapEvents);
-    if (infoWindowShown) {
-      marker.showInfoWindow();
-    }
     return marker.getId();
   }
 
@@ -39,7 +35,7 @@ class MarkerBuilder implements MarkerOptionsSink {
   }
 
   @Override
-  public void setConsumesTapEvents(boolean consumesTapEvents) {
+  public void setConsumeTapEvents(boolean consumesTapEvents) {
     this.consumesTapEvents = consumesTapEvents;
   }
 
@@ -61,11 +57,6 @@ class MarkerBuilder implements MarkerOptionsSink {
   @Override
   public void setInfoWindowAnchor(float u, float v) {
     markerOptions.infoWindowAnchor(u, v);
-  }
-
-  @Override
-  public void setInfoWindowShown(boolean infoWindowShown) {
-    this.infoWindowShown = infoWindowShown;
   }
 
   @Override

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/MarkerController.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/MarkerController.java
@@ -12,12 +12,12 @@ import com.google.android.gms.maps.model.Marker;
 class MarkerController implements MarkerOptionsSink {
   private final Marker marker;
   private final OnMarkerTappedListener onTappedListener;
-  private boolean consumesTapEvents;
+  private boolean consumeTapEvents;
 
   MarkerController(
-      Marker marker, boolean consumesTapEvents, OnMarkerTappedListener onTappedListener) {
+      Marker marker, boolean consumeTapEvents, OnMarkerTappedListener onTappedListener) {
     this.marker = marker;
-    this.consumesTapEvents = consumesTapEvents;
+    this.consumeTapEvents = consumeTapEvents;
     this.onTappedListener = onTappedListener;
   }
 
@@ -25,7 +25,7 @@ class MarkerController implements MarkerOptionsSink {
     if (onTappedListener != null) {
       onTappedListener.onMarkerTapped(marker);
     }
-    return consumesTapEvents;
+    return consumeTapEvents;
   }
 
   void remove() {
@@ -43,8 +43,8 @@ class MarkerController implements MarkerOptionsSink {
   }
 
   @Override
-  public void setConsumesTapEvents(boolean consumesTapEvents) {
-    this.consumesTapEvents = consumesTapEvents;
+  public void setConsumeTapEvents(boolean consumeTapEvents) {
+    this.consumeTapEvents = consumeTapEvents;
   }
 
   @Override
@@ -65,15 +65,6 @@ class MarkerController implements MarkerOptionsSink {
   @Override
   public void setInfoWindowAnchor(float u, float v) {
     marker.setInfoWindowAnchor(u, v);
-  }
-
-  @Override
-  public void setInfoWindowShown(boolean infoWindowShown) {
-    if (infoWindowShown) {
-      marker.showInfoWindow();
-    } else {
-      marker.hideInfoWindow();
-    }
   }
 
   @Override

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/MarkerOptionsSink.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/MarkerOptionsSink.java
@@ -13,7 +13,7 @@ interface MarkerOptionsSink {
 
   void setAnchor(float u, float v);
 
-  void setConsumesTapEvents(boolean consumesTapEvents);
+  void setConsumeTapEvents(boolean consumesTapEvents);
 
   void setDraggable(boolean draggable);
 
@@ -22,8 +22,6 @@ interface MarkerOptionsSink {
   void setIcon(BitmapDescriptor bitmapDescriptor);
 
   void setInfoWindowAnchor(float u, float v);
-
-  void setInfoWindowShown(boolean shown);
 
   void setInfoWindowText(String title, String snippet);
 

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/OnCameraMoveListener.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/OnCameraMoveListener.java
@@ -7,7 +7,7 @@ package io.flutter.plugins.googlemaps;
 import com.google.android.gms.maps.model.CameraPosition;
 
 interface OnCameraMoveListener {
-  void onCameraMoveStarted(int reason);
+  void onCameraMoveStarted(boolean isGesture);
 
   void onCameraMove(CameraPosition newPosition);
 

--- a/packages/google_maps_flutter/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/google_maps_flutter/example/ios/Runner.xcodeproj/project.pbxproj
@@ -183,7 +183,6 @@
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
 						CreatedOnToolsVersion = 7.3.1;
-						DevelopmentTeam = AQ7UHDBEXJ;
 					};
 				};
 			};
@@ -448,7 +447,6 @@
 			buildSettings = {
 				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = AQ7UHDBEXJ;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -471,7 +469,6 @@
 			buildSettings = {
 				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = AQ7UHDBEXJ;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/packages/google_maps_flutter/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/google_maps_flutter/example/ios/Runner.xcodeproj/project.pbxproj
@@ -183,6 +183,7 @@
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
 						CreatedOnToolsVersion = 7.3.1;
+						DevelopmentTeam = AQ7UHDBEXJ;
 					};
 				};
 			};
@@ -447,7 +448,7 @@
 			buildSettings = {
 				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = AQ7UHDBEXJ;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -470,7 +471,7 @@
 			buildSettings = {
 				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = AQ7UHDBEXJ;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/packages/google_maps_flutter/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/google_maps_flutter/example/ios/Runner.xcodeproj/project.pbxproj
@@ -161,6 +161,7 @@
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				FE7DE34E225BB9A5F4DB58C6 /* [CP] Embed Pods Frameworks */,
+				BB6BD9A1101E970BEF85B6D2 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -266,6 +267,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		BB6BD9A1101E970BEF85B6D2 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-Runner/Pods-Runner-resources.sh",
+				"${PODS_ROOT}/GoogleMaps/Maps/Frameworks/GoogleMaps.framework/Resources/GoogleMaps.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/GoogleMaps.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 		FE7DE34E225BB9A5F4DB58C6 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -428,6 +447,7 @@
 			buildSettings = {
 				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -450,6 +470,7 @@
 			buildSettings = {
 				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/packages/google_maps_flutter/example/ios/Runner/AppDelegate.h
+++ b/packages/google_maps_flutter/example/ios/Runner/AppDelegate.h
@@ -1,6 +1,8 @@
 #import <Flutter/Flutter.h>
 #import <UIKit/UIKit.h>
 
+static NSString *const kAPIKey = @"AIzaSyBCGQ3UNVvpeJTUr07qcEmtHQmllJs4SV0";
+
 @interface AppDelegate : FlutterAppDelegate
 
 @end

--- a/packages/google_maps_flutter/example/ios/Runner/AppDelegate.m
+++ b/packages/google_maps_flutter/example/ios/Runner/AppDelegate.m
@@ -1,10 +1,12 @@
 #include "AppDelegate.h"
 #include "GeneratedPluginRegistrant.h"
+#import "GoogleMaps/GoogleMaps.h"
 
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application
     didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+  [GMSServices provideAPIKey:kAPIKey];
   [GeneratedPluginRegistrant registerWithRegistry:self];
   // Override point for customization after application launch.
   return [super application:application didFinishLaunchingWithOptions:launchOptions];

--- a/packages/google_maps_flutter/example/lib/map_ui.dart
+++ b/packages/google_maps_flutter/example/lib/map_ui.dart
@@ -47,6 +47,7 @@ class MapUiBody extends StatefulWidget {
 class MapUiBodyState extends State<MapUiBody> {
   CameraPosition _position;
   GoogleMapOptions _options;
+  bool _isMoving;
 
   @override
   void initState() {
@@ -56,10 +57,12 @@ class MapUiBodyState extends State<MapUiBody> {
       setState(() {
         _options = mapController.options;
         _position = mapController.cameraPosition;
+        _isMoving = mapController.isCameraMoving;
       });
     });
     _options = mapController.options;
     _position = mapController.cameraPosition;
+    _isMoving = mapController.isCameraMoving;
   }
 
   Widget _compassToggler() {
@@ -200,6 +203,7 @@ class MapUiBodyState extends State<MapUiBody> {
                 '${_position.target.longitude.toStringAsFixed(4)}'),
             new Text('camera zoom: ${_position.zoom}'),
             new Text('camera tilt: ${_position.tilt}'),
+            new Text(_isMoving ? '(Camera moving)' : '(Camera idle)'),
             _compassToggler(),
             _latLngBoundsToggler(),
             _mapTypeCycler(),

--- a/packages/google_maps_flutter/example/lib/map_ui.dart
+++ b/packages/google_maps_flutter/example/lib/map_ui.dart
@@ -80,17 +80,17 @@ class MapUiBodyState extends State<MapUiBody> {
   Widget _latLngBoundsToggler() {
     return new FlatButton(
       child: new Text(
-        _options.latLngCameraTargetBounds.bounds == null
+        _options.cameraTargetBounds.bounds == null
             ? 'bound camera target'
             : 'release camera target',
       ),
       onPressed: () {
         widget.controller.mapController.updateMapOptions(
           new GoogleMapOptions(
-            latLngCameraTargetBounds:
-                _options.latLngCameraTargetBounds.bounds == null
-                    ? const LatLngCameraTargetBounds(sydneyBounds)
-                    : LatLngCameraTargetBounds.unbounded,
+            cameraTargetBounds:
+                _options.cameraTargetBounds.bounds == null
+                    ? const CameraTargetBounds(sydneyBounds)
+                    : CameraTargetBounds.unbounded,
           ),
         );
       },

--- a/packages/google_maps_flutter/example/lib/map_ui.dart
+++ b/packages/google_maps_flutter/example/lib/map_ui.dart
@@ -87,10 +87,9 @@ class MapUiBodyState extends State<MapUiBody> {
       onPressed: () {
         widget.controller.mapController.updateMapOptions(
           new GoogleMapOptions(
-            cameraTargetBounds:
-                _options.cameraTargetBounds.bounds == null
-                    ? const CameraTargetBounds(sydneyBounds)
-                    : CameraTargetBounds.unbounded,
+            cameraTargetBounds: _options.cameraTargetBounds.bounds == null
+                ? const CameraTargetBounds(sydneyBounds)
+                : CameraTargetBounds.unbounded,
           ),
         );
       },

--- a/packages/google_maps_flutter/example/lib/place_marker.dart
+++ b/packages/google_maps_flutter/example/lib/place_marker.dart
@@ -134,13 +134,6 @@ class PlaceMarkerBodyState extends State<PlaceMarkerBody> {
     ));
   }
 
-  Future<void> _toggleInfoShown() async {
-    _selectedMarker.update(
-      new MarkerOptions(
-          infoWindowShown: !_selectedMarker.options.infoWindowShown),
-    );
-  }
-
   Future<void> _changeAlpha() async {
     final double current = _selectedMarker.options.alpha;
     _selectedMarker.update(
@@ -197,11 +190,6 @@ class PlaceMarkerBodyState extends State<PlaceMarkerBody> {
                       child: const Text('change info anchor'),
                       onPressed:
                           (_selectedMarker == null) ? null : _changeInfoAnchor,
-                    ),
-                    new FlatButton(
-                      child: const Text('toggle info shown'),
-                      onPressed:
-                          (_selectedMarker == null) ? null : _toggleInfoShown,
                     ),
                   ],
                 ),

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapController.h
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapController.h
@@ -1,0 +1,45 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <Flutter/Flutter.h>
+#import <GoogleMaps/GoogleMaps.h>
+#import "GoogleMapMarkerController.h"
+
+// Defines events to be sent to Flutter.
+@protocol FLTGoogleMapDelegate
+-(void)onCameraMoveStartedOnMap:(id)mapId gesture:(BOOL)gesture;
+-(void)onCameraMoveOnMap:(id)mapId cameraPosition:(GMSCameraPosition*)cameraPosition;
+-(void)onCameraIdleOnMap:(id)mapId;
+-(void)onMarkerTappedOnMap:(id)mapId marker:(NSString*)markerId;
+@end
+
+// Defines map UI options writable from Flutter.
+@protocol FLTGoogleMapOptionsSink
+-(void)setCamera:(GMSCameraPosition*)camera;
+-(void)setCameraTargetBounds:(GMSCoordinateBounds*)bounds;
+-(void)setCompassEnabled:(BOOL)enabled;
+-(void)setMapType:(GMSMapViewType)type;
+-(void)setMinZoom:(float)minZoom maxZoom:(float)maxZoom;
+-(void)setRotateGesturesEnabled:(BOOL)enabled;
+-(void)setScrollGesturesEnabled:(BOOL)enabled;
+-(void)setTiltGesturesEnabled:(BOOL)enabled;
+-(void)setTrackCameraPosition:(BOOL)enabled;
+-(void)setZoomGesturesEnabled:(BOOL)enabled;
+@end
+
+// Defines map overlay controllable from Flutter.
+@interface FLTGoogleMapController : NSObject<GMSMapViewDelegate, FLTGoogleMapOptionsSink>
+@property (atomic) id<FLTGoogleMapDelegate> delegate;
+@property (atomic, readonly) id mapId;
++(instancetype)controllerWithWidth:(CGFloat)width height:(CGFloat)height camera:(GMSCameraPosition*)camera;
+-(void)addToView:(UIView*)view;
+-(void)removeFromView;
+-(void)showAtX:(CGFloat)x Y:(CGFloat)y;
+-(void)hide;
+-(void)animateWithCameraUpdate:(GMSCameraUpdate*)cameraUpdate;
+-(void)moveWithCameraUpdate:(GMSCameraUpdate*)cameraUpdate;
+-(NSString*)addMarkerWithPosition:(CLLocationCoordinate2D)position;
+-(FLTGoogleMapMarkerController*)markerWithId:(NSString*)markerId;
+-(void)removeMarkerWithId:(NSString*)markerId;
+@end

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapController.h
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapController.h
@@ -29,7 +29,7 @@
 @end
 
 // Defines map overlay controllable from Flutter.
-@interface FLTGoogleMapController : NSObject <GMSMapViewDelegate, FLTGoogleMapOptionsSink>
+@interface FLTGoogleMapController : NSObject<GMSMapViewDelegate, FLTGoogleMapOptionsSink>
 @property(atomic) id<FLTGoogleMapDelegate> delegate;
 @property(atomic, readonly) id mapId;
 + (instancetype)controllerWithWidth:(CGFloat)width

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapController.h
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapController.h
@@ -8,38 +8,40 @@
 
 // Defines events to be sent to Flutter.
 @protocol FLTGoogleMapDelegate
--(void)onCameraMoveStartedOnMap:(id)mapId gesture:(BOOL)gesture;
--(void)onCameraMoveOnMap:(id)mapId cameraPosition:(GMSCameraPosition*)cameraPosition;
--(void)onCameraIdleOnMap:(id)mapId;
--(void)onMarkerTappedOnMap:(id)mapId marker:(NSString*)markerId;
+- (void)onCameraMoveStartedOnMap:(id)mapId gesture:(BOOL)gesture;
+- (void)onCameraMoveOnMap:(id)mapId cameraPosition:(GMSCameraPosition*)cameraPosition;
+- (void)onCameraIdleOnMap:(id)mapId;
+- (void)onMarkerTappedOnMap:(id)mapId marker:(NSString*)markerId;
 @end
 
 // Defines map UI options writable from Flutter.
 @protocol FLTGoogleMapOptionsSink
--(void)setCamera:(GMSCameraPosition*)camera;
--(void)setCameraTargetBounds:(GMSCoordinateBounds*)bounds;
--(void)setCompassEnabled:(BOOL)enabled;
--(void)setMapType:(GMSMapViewType)type;
--(void)setMinZoom:(float)minZoom maxZoom:(float)maxZoom;
--(void)setRotateGesturesEnabled:(BOOL)enabled;
--(void)setScrollGesturesEnabled:(BOOL)enabled;
--(void)setTiltGesturesEnabled:(BOOL)enabled;
--(void)setTrackCameraPosition:(BOOL)enabled;
--(void)setZoomGesturesEnabled:(BOOL)enabled;
+- (void)setCamera:(GMSCameraPosition*)camera;
+- (void)setCameraTargetBounds:(GMSCoordinateBounds*)bounds;
+- (void)setCompassEnabled:(BOOL)enabled;
+- (void)setMapType:(GMSMapViewType)type;
+- (void)setMinZoom:(float)minZoom maxZoom:(float)maxZoom;
+- (void)setRotateGesturesEnabled:(BOOL)enabled;
+- (void)setScrollGesturesEnabled:(BOOL)enabled;
+- (void)setTiltGesturesEnabled:(BOOL)enabled;
+- (void)setTrackCameraPosition:(BOOL)enabled;
+- (void)setZoomGesturesEnabled:(BOOL)enabled;
 @end
 
 // Defines map overlay controllable from Flutter.
-@interface FLTGoogleMapController : NSObject<GMSMapViewDelegate, FLTGoogleMapOptionsSink>
-@property (atomic) id<FLTGoogleMapDelegate> delegate;
-@property (atomic, readonly) id mapId;
-+(instancetype)controllerWithWidth:(CGFloat)width height:(CGFloat)height camera:(GMSCameraPosition*)camera;
--(void)addToView:(UIView*)view;
--(void)removeFromView;
--(void)showAtX:(CGFloat)x Y:(CGFloat)y;
--(void)hide;
--(void)animateWithCameraUpdate:(GMSCameraUpdate*)cameraUpdate;
--(void)moveWithCameraUpdate:(GMSCameraUpdate*)cameraUpdate;
--(NSString*)addMarkerWithPosition:(CLLocationCoordinate2D)position;
--(FLTGoogleMapMarkerController*)markerWithId:(NSString*)markerId;
--(void)removeMarkerWithId:(NSString*)markerId;
+@interface FLTGoogleMapController : NSObject <GMSMapViewDelegate, FLTGoogleMapOptionsSink>
+@property(atomic) id<FLTGoogleMapDelegate> delegate;
+@property(atomic, readonly) id mapId;
++ (instancetype)controllerWithWidth:(CGFloat)width
+                             height:(CGFloat)height
+                             camera:(GMSCameraPosition*)camera;
+- (void)addToView:(UIView*)view;
+- (void)removeFromView;
+- (void)showAtX:(CGFloat)x Y:(CGFloat)y;
+- (void)hide;
+- (void)animateWithCameraUpdate:(GMSCameraUpdate*)cameraUpdate;
+- (void)moveWithCameraUpdate:(GMSCameraUpdate*)cameraUpdate;
+- (NSString*)addMarkerWithPosition:(CLLocationCoordinate2D)position;
+- (FLTGoogleMapMarkerController*)markerWithId:(NSString*)markerId;
+- (void)removeMarkerWithId:(NSString*)markerId;
 @end

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapController.m
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapController.m
@@ -61,7 +61,7 @@ static uint64_t _nextMapId = 0;
 
 - (NSString*)addMarkerWithPosition:(CLLocationCoordinate2D)position {
   FLTGoogleMapMarkerController* markerController =
-  [[FLTGoogleMapMarkerController alloc] initWithPosition:position mapView:_mapView];
+      [[FLTGoogleMapMarkerController alloc] initWithPosition:position mapView:_mapView];
   _markers[markerController.markerId] = markerController;
   return markerController.markerId;
 }

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapController.m
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapController.m
@@ -12,13 +12,14 @@ static uint64_t _nextMapId = 0;
   BOOL _trackCameraPosition;
 }
 
-+(instancetype)controllerWithWidth:(CGFloat)width height:(CGFloat)height camera:(GMSCameraPosition*)camera {
-  GMSMapView* mapView = [GMSMapView mapWithFrame:CGRectMake(0.0, 0.0, width, height)
-                                          camera:camera];
++ (instancetype)controllerWithWidth:(CGFloat)width
+                             height:(CGFloat)height
+                             camera:(GMSCameraPosition*)camera {
+  GMSMapView* mapView = [GMSMapView mapWithFrame:CGRectMake(0.0, 0.0, width, height) camera:camera];
   return [[FLTGoogleMapController alloc] initWithMapView:mapView mapId:@(_nextMapId++)];
 }
 
--(instancetype)initWithMapView:(GMSMapView*)mapView mapId:(id)mapId {
+- (instancetype)initWithMapView:(GMSMapView*)mapView mapId:(id)mapId {
   self = [super init];
   if (self) {
     _mapView = mapView;
@@ -29,85 +30,87 @@ static uint64_t _nextMapId = 0;
   return self;
 }
 
--(void)addToView:(UIView*)view {
+- (void)addToView:(UIView*)view {
   _mapView.hidden = YES;
   _mapView.delegate = self;
   [view addSubview:_mapView];
 }
 
--(void)removeFromView {
+- (void)removeFromView {
   [_mapView removeFromSuperview];
   _mapView.delegate = nil;
 }
 
--(void)showAtX:(CGFloat)x Y:(CGFloat)y {
-  _mapView.frame = CGRectMake(x, y, CGRectGetWidth(_mapView.frame), CGRectGetHeight(_mapView.frame));
+- (void)showAtX:(CGFloat)x Y:(CGFloat)y {
+  _mapView.frame =
+      CGRectMake(x, y, CGRectGetWidth(_mapView.frame), CGRectGetHeight(_mapView.frame));
   _mapView.hidden = NO;
 }
 
--(void)hide {
+- (void)hide {
   _mapView.hidden = YES;
 }
 
--(void)setCamera:(GMSCameraPosition*)camera {
+- (void)setCamera:(GMSCameraPosition*)camera {
   _mapView.camera = camera;
 }
 
--(void)setCameraTargetBounds:(GMSCoordinateBounds*)bounds {
+- (void)setCameraTargetBounds:(GMSCoordinateBounds*)bounds {
   _mapView.cameraTargetBounds = bounds;
 }
 
--(void)setCompassEnabled:(BOOL)enabled {
+- (void)setCompassEnabled:(BOOL)enabled {
   _mapView.settings.compassButton = enabled;
 }
 
--(void)setMapType:(GMSMapViewType)mapType {
+- (void)setMapType:(GMSMapViewType)mapType {
   _mapView.mapType = mapType;
 }
 
--(void)setMinZoom:(float)minZoom maxZoom:(float)maxZoom {
+- (void)setMinZoom:(float)minZoom maxZoom:(float)maxZoom {
   [_mapView setMinZoom:minZoom maxZoom:maxZoom];
 }
 
--(void)setRotateGesturesEnabled:(BOOL)enabled {
+- (void)setRotateGesturesEnabled:(BOOL)enabled {
   _mapView.settings.rotateGestures = enabled;
 }
 
--(void)setScrollGesturesEnabled:(BOOL)enabled {
+- (void)setScrollGesturesEnabled:(BOOL)enabled {
   _mapView.settings.scrollGestures = enabled;
 }
 
--(void)setTiltGesturesEnabled:(BOOL)enabled {
+- (void)setTiltGesturesEnabled:(BOOL)enabled {
   _mapView.settings.tiltGestures = enabled;
 }
 
--(void)setTrackCameraPosition:(BOOL)enabled {
+- (void)setTrackCameraPosition:(BOOL)enabled {
   _trackCameraPosition = enabled;
 }
 
--(void)setZoomGesturesEnabled:(BOOL)enabled {
+- (void)setZoomGesturesEnabled:(BOOL)enabled {
   _mapView.settings.zoomGestures = enabled;
 }
 
--(void)animateWithCameraUpdate:(GMSCameraUpdate*)cameraUpdate {
+- (void)animateWithCameraUpdate:(GMSCameraUpdate*)cameraUpdate {
   [_mapView animateWithCameraUpdate:cameraUpdate];
 }
 
--(void)moveWithCameraUpdate:(GMSCameraUpdate*)cameraUpdate {
+- (void)moveWithCameraUpdate:(GMSCameraUpdate*)cameraUpdate {
   [_mapView moveCamera:cameraUpdate];
 }
 
--(NSString*)addMarkerWithPosition:(CLLocationCoordinate2D)position {
-  FLTGoogleMapMarkerController* markerController = [[FLTGoogleMapMarkerController alloc] initWithPosition:position mapView:_mapView];
+- (NSString*)addMarkerWithPosition:(CLLocationCoordinate2D)position {
+  FLTGoogleMapMarkerController* markerController =
+      [[FLTGoogleMapMarkerController alloc] initWithPosition:position mapView:_mapView];
   _markers[markerController.markerId] = markerController;
   return markerController.markerId;
 }
 
--(FLTGoogleMapMarkerController*)markerWithId:(NSString*)markerId {
+- (FLTGoogleMapMarkerController*)markerWithId:(NSString*)markerId {
   return _markers[markerId];
 }
 
--(void)removeMarkerWithId:(NSString*)markerId {
+- (void)removeMarkerWithId:(NSString*)markerId {
   FLTGoogleMapMarkerController* markerController = _markers[markerId];
   if (markerController) {
     [markerController setVisible:NO];
@@ -137,4 +140,3 @@ static uint64_t _nextMapId = 0;
   return [marker.userData[1] boolValue];
 }
 @end
-

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapController.m
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapController.m
@@ -51,6 +51,35 @@ static uint64_t _nextMapId = 0;
   _mapView.hidden = YES;
 }
 
+- (void)animateWithCameraUpdate:(GMSCameraUpdate*)cameraUpdate {
+  [_mapView animateWithCameraUpdate:cameraUpdate];
+}
+
+- (void)moveWithCameraUpdate:(GMSCameraUpdate*)cameraUpdate {
+  [_mapView moveCamera:cameraUpdate];
+}
+
+- (NSString*)addMarkerWithPosition:(CLLocationCoordinate2D)position {
+  FLTGoogleMapMarkerController* markerController =
+  [[FLTGoogleMapMarkerController alloc] initWithPosition:position mapView:_mapView];
+  _markers[markerController.markerId] = markerController;
+  return markerController.markerId;
+}
+
+- (FLTGoogleMapMarkerController*)markerWithId:(NSString*)markerId {
+  return _markers[markerId];
+}
+
+- (void)removeMarkerWithId:(NSString*)markerId {
+  FLTGoogleMapMarkerController* markerController = _markers[markerId];
+  if (markerController) {
+    [markerController setVisible:NO];
+    [_markers removeObjectForKey:markerId];
+  }
+}
+
+#pragma mark - FLTGoogleMapOptionsSink methods
+
 - (void)setCamera:(GMSCameraPosition*)camera {
   _mapView.camera = camera;
 }
@@ -91,34 +120,7 @@ static uint64_t _nextMapId = 0;
   _mapView.settings.zoomGestures = enabled;
 }
 
-- (void)animateWithCameraUpdate:(GMSCameraUpdate*)cameraUpdate {
-  [_mapView animateWithCameraUpdate:cameraUpdate];
-}
-
-- (void)moveWithCameraUpdate:(GMSCameraUpdate*)cameraUpdate {
-  [_mapView moveCamera:cameraUpdate];
-}
-
-- (NSString*)addMarkerWithPosition:(CLLocationCoordinate2D)position {
-  FLTGoogleMapMarkerController* markerController =
-      [[FLTGoogleMapMarkerController alloc] initWithPosition:position mapView:_mapView];
-  _markers[markerController.markerId] = markerController;
-  return markerController.markerId;
-}
-
-- (FLTGoogleMapMarkerController*)markerWithId:(NSString*)markerId {
-  return _markers[markerId];
-}
-
-- (void)removeMarkerWithId:(NSString*)markerId {
-  FLTGoogleMapMarkerController* markerController = _markers[markerId];
-  if (markerController) {
-    [markerController setVisible:NO];
-    [_markers removeObjectForKey:markerId];
-  }
-}
-
-// GMSMapViewDelegate methods
+#pragma mark - GMSMapViewDelegate methods
 
 - (void)mapView:(GMSMapView*)mapView willMove:(BOOL)gesture {
   [_delegate onCameraMoveStartedOnMap:_mapId gesture:gesture];

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapController.m
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapController.m
@@ -1,0 +1,140 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "GoogleMapController.h"
+
+static uint64_t _nextMapId = 0;
+
+@implementation FLTGoogleMapController {
+  GMSMapView* _mapView;
+  NSMutableDictionary* _markers;
+  BOOL _trackCameraPosition;
+}
+
++(instancetype)controllerWithWidth:(CGFloat)width height:(CGFloat)height camera:(GMSCameraPosition*)camera {
+  GMSMapView* mapView = [GMSMapView mapWithFrame:CGRectMake(0.0, 0.0, width, height)
+                                          camera:camera];
+  return [[FLTGoogleMapController alloc] initWithMapView:mapView mapId:@(_nextMapId++)];
+}
+
+-(instancetype)initWithMapView:(GMSMapView*)mapView mapId:(id)mapId {
+  self = [super init];
+  if (self) {
+    _mapView = mapView;
+    _mapId = mapId;
+    _markers = [NSMutableDictionary dictionaryWithCapacity:1];
+    _trackCameraPosition = NO;
+  }
+  return self;
+}
+
+-(void)addToView:(UIView*)view {
+  _mapView.hidden = YES;
+  _mapView.delegate = self;
+  [view addSubview:_mapView];
+}
+
+-(void)removeFromView {
+  [_mapView removeFromSuperview];
+  _mapView.delegate = nil;
+}
+
+-(void)showAtX:(CGFloat)x Y:(CGFloat)y {
+  _mapView.frame = CGRectMake(x, y, CGRectGetWidth(_mapView.frame), CGRectGetHeight(_mapView.frame));
+  _mapView.hidden = NO;
+}
+
+-(void)hide {
+  _mapView.hidden = YES;
+}
+
+-(void)setCamera:(GMSCameraPosition*)camera {
+  _mapView.camera = camera;
+}
+
+-(void)setCameraTargetBounds:(GMSCoordinateBounds*)bounds {
+  _mapView.cameraTargetBounds = bounds;
+}
+
+-(void)setCompassEnabled:(BOOL)enabled {
+  _mapView.settings.compassButton = enabled;
+}
+
+-(void)setMapType:(GMSMapViewType)mapType {
+  _mapView.mapType = mapType;
+}
+
+-(void)setMinZoom:(float)minZoom maxZoom:(float)maxZoom {
+  [_mapView setMinZoom:minZoom maxZoom:maxZoom];
+}
+
+-(void)setRotateGesturesEnabled:(BOOL)enabled {
+  _mapView.settings.rotateGestures = enabled;
+}
+
+-(void)setScrollGesturesEnabled:(BOOL)enabled {
+  _mapView.settings.scrollGestures = enabled;
+}
+
+-(void)setTiltGesturesEnabled:(BOOL)enabled {
+  _mapView.settings.tiltGestures = enabled;
+}
+
+-(void)setTrackCameraPosition:(BOOL)enabled {
+  _trackCameraPosition = enabled;
+}
+
+-(void)setZoomGesturesEnabled:(BOOL)enabled {
+  _mapView.settings.zoomGestures = enabled;
+}
+
+-(void)animateWithCameraUpdate:(GMSCameraUpdate*)cameraUpdate {
+  [_mapView animateWithCameraUpdate:cameraUpdate];
+}
+
+-(void)moveWithCameraUpdate:(GMSCameraUpdate*)cameraUpdate {
+  [_mapView moveCamera:cameraUpdate];
+}
+
+-(NSString*)addMarkerWithPosition:(CLLocationCoordinate2D)position {
+  FLTGoogleMapMarkerController* markerController = [[FLTGoogleMapMarkerController alloc] initWithPosition:position mapView:_mapView];
+  _markers[markerController.markerId] = markerController;
+  return markerController.markerId;
+}
+
+-(FLTGoogleMapMarkerController*)markerWithId:(NSString*)markerId {
+  return _markers[markerId];
+}
+
+-(void)removeMarkerWithId:(NSString*)markerId {
+  FLTGoogleMapMarkerController* markerController = _markers[markerId];
+  if (markerController) {
+    [markerController setVisible:NO];
+    [_markers removeObjectForKey:markerId];
+  }
+}
+
+// GMSMapViewDelegate methods
+
+- (void)mapView:(GMSMapView*)mapView willMove:(BOOL)gesture {
+  [_delegate onCameraMoveStartedOnMap:_mapId gesture:gesture];
+}
+
+- (void)mapView:(GMSMapView*)mapView didChangeCameraPosition:(GMSCameraPosition*)position {
+  if (_trackCameraPosition) {
+    [_delegate onCameraMoveOnMap:_mapId cameraPosition:position];
+  }
+}
+
+- (void)mapView:(GMSMapView*)mapView idleAtCameraPosition:(GMSCameraPosition*)position {
+  [_delegate onCameraIdleOnMap:_mapId];
+}
+
+- (BOOL)mapView:(GMSMapView*)mapView didTapMarker:(GMSMarker*)marker {
+  NSString* markerId = marker.userData[0];
+  [_delegate onMarkerTappedOnMap:_mapId marker:markerId];
+  return [marker.userData[1] boolValue];
+}
+@end
+

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapMarkerController.h
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapMarkerController.h
@@ -21,7 +21,7 @@
 @end
 
 // Defines marker controllable by Flutter.
-@interface FLTGoogleMapMarkerController : NSObject <FLTGoogleMapMarkerOptionsSink>
+@interface FLTGoogleMapMarkerController : NSObject<FLTGoogleMapMarkerOptionsSink>
 @property(atomic, readonly) NSString* markerId;
 - (instancetype)initWithPosition:(CLLocationCoordinate2D)position mapView:(GMSMapView*)mapView;
 @end

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapMarkerController.h
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapMarkerController.h
@@ -1,0 +1,27 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <Flutter/Flutter.h>
+#import <GoogleMaps/GoogleMaps.h>
+
+// Defines marker UI options writable from Flutter.
+@protocol FLTGoogleMapMarkerOptionsSink
+-(void)setAlpha:(float)alpha;
+-(void)setAnchor:(CGPoint)anchor;
+-(void)setConsumeTapEvents:(BOOL)consume;
+-(void)setDraggable:(BOOL)draggable;
+-(void)setFlat:(BOOL)flat;
+-(void)setIcon:(UIImage*)icon;
+-(void)setInfoWindowAnchor:(CGPoint)anchor;
+-(void)setInfoWindowTitle:(NSString*)title snippet:(NSString*)snippet;
+-(void)setRotation:(CLLocationDegrees)rotation;
+-(void)setVisible:(BOOL)visible;
+-(void)setZIndex:(int)zIndex;
+@end
+
+// Defines marker controllable by Flutter.
+@interface FLTGoogleMapMarkerController : NSObject<FLTGoogleMapMarkerOptionsSink>
+@property (atomic, readonly) NSString* markerId;
+-(instancetype)initWithPosition:(CLLocationCoordinate2D)position mapView:(GMSMapView*)mapView;
+@end

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapMarkerController.h
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapMarkerController.h
@@ -7,21 +7,21 @@
 
 // Defines marker UI options writable from Flutter.
 @protocol FLTGoogleMapMarkerOptionsSink
--(void)setAlpha:(float)alpha;
--(void)setAnchor:(CGPoint)anchor;
--(void)setConsumeTapEvents:(BOOL)consume;
--(void)setDraggable:(BOOL)draggable;
--(void)setFlat:(BOOL)flat;
--(void)setIcon:(UIImage*)icon;
--(void)setInfoWindowAnchor:(CGPoint)anchor;
--(void)setInfoWindowTitle:(NSString*)title snippet:(NSString*)snippet;
--(void)setRotation:(CLLocationDegrees)rotation;
--(void)setVisible:(BOOL)visible;
--(void)setZIndex:(int)zIndex;
+- (void)setAlpha:(float)alpha;
+- (void)setAnchor:(CGPoint)anchor;
+- (void)setConsumeTapEvents:(BOOL)consume;
+- (void)setDraggable:(BOOL)draggable;
+- (void)setFlat:(BOOL)flat;
+- (void)setIcon:(UIImage*)icon;
+- (void)setInfoWindowAnchor:(CGPoint)anchor;
+- (void)setInfoWindowTitle:(NSString*)title snippet:(NSString*)snippet;
+- (void)setRotation:(CLLocationDegrees)rotation;
+- (void)setVisible:(BOOL)visible;
+- (void)setZIndex:(int)zIndex;
 @end
 
 // Defines marker controllable by Flutter.
-@interface FLTGoogleMapMarkerController : NSObject<FLTGoogleMapMarkerOptionsSink>
-@property (atomic, readonly) NSString* markerId;
--(instancetype)initWithPosition:(CLLocationCoordinate2D)position mapView:(GMSMapView*)mapView;
+@interface FLTGoogleMapMarkerController : NSObject <FLTGoogleMapMarkerOptionsSink>
+@property(atomic, readonly) NSString* markerId;
+- (instancetype)initWithPosition:(CLLocationCoordinate2D)position mapView:(GMSMapView*)mapView;
 @end

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapMarkerController.m
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapMarkerController.m
@@ -1,0 +1,57 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "GoogleMapMarkerController.h"
+
+static uint64_t _nextMarkerId = 0;
+
+@implementation FLTGoogleMapMarkerController {
+  GMSMarker* _marker;
+  GMSMapView* _mapView;
+}
+-(instancetype)initWithPosition:(CLLocationCoordinate2D)position mapView:(GMSMapView*)mapView {
+  self = [super init];
+  if (self) {
+    _marker = [GMSMarker markerWithPosition:position];
+    _mapView = mapView;
+    _markerId = [NSString stringWithFormat:@"%lld", _nextMarkerId++];
+    _marker.userData = @[_markerId, @(NO)];
+  }
+  return self;
+}
+-(void)setAlpha:(float)alpha {
+  _marker.opacity = alpha;
+}
+-(void)setAnchor:(CGPoint)anchor {
+  _marker.groundAnchor = anchor;
+}
+-(void)setConsumeTapEvents:(BOOL)consumes {
+  _marker.userData[1] = @(consumes);
+}
+-(void)setDraggable:(BOOL)draggable {
+  _marker.draggable = draggable;
+}
+-(void)setFlat:(BOOL)flat {
+  _marker.flat = flat;
+}
+-(void)setIcon:(UIImage*)icon {
+  _marker.icon = icon;
+}
+-(void)setInfoWindowAnchor:(CGPoint)anchor {
+  _marker.infoWindowAnchor = anchor;
+}
+-(void)setInfoWindowTitle:(NSString*)title snippet:(NSString*)snippet {
+  _marker.title = title;
+  _marker.snippet = snippet;
+}
+-(void)setRotation:(CLLocationDegrees)rotation {
+  _marker.rotation = rotation;
+}
+-(void)setVisible:(BOOL)visible {
+  _marker.map = visible ? _mapView : nil;
+}
+-(void)setZIndex:(int)zIndex {
+  _marker.zIndex = zIndex;
+}
+@end

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapMarkerController.m
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapMarkerController.m
@@ -10,48 +10,48 @@ static uint64_t _nextMarkerId = 0;
   GMSMarker* _marker;
   GMSMapView* _mapView;
 }
--(instancetype)initWithPosition:(CLLocationCoordinate2D)position mapView:(GMSMapView*)mapView {
+- (instancetype)initWithPosition:(CLLocationCoordinate2D)position mapView:(GMSMapView*)mapView {
   self = [super init];
   if (self) {
     _marker = [GMSMarker markerWithPosition:position];
     _mapView = mapView;
     _markerId = [NSString stringWithFormat:@"%lld", _nextMarkerId++];
-    _marker.userData = @[_markerId, @(NO)];
+    _marker.userData = @[ _markerId, @(NO) ];
   }
   return self;
 }
--(void)setAlpha:(float)alpha {
+- (void)setAlpha:(float)alpha {
   _marker.opacity = alpha;
 }
--(void)setAnchor:(CGPoint)anchor {
+- (void)setAnchor:(CGPoint)anchor {
   _marker.groundAnchor = anchor;
 }
--(void)setConsumeTapEvents:(BOOL)consumes {
+- (void)setConsumeTapEvents:(BOOL)consumes {
   _marker.userData[1] = @(consumes);
 }
--(void)setDraggable:(BOOL)draggable {
+- (void)setDraggable:(BOOL)draggable {
   _marker.draggable = draggable;
 }
--(void)setFlat:(BOOL)flat {
+- (void)setFlat:(BOOL)flat {
   _marker.flat = flat;
 }
--(void)setIcon:(UIImage*)icon {
+- (void)setIcon:(UIImage*)icon {
   _marker.icon = icon;
 }
--(void)setInfoWindowAnchor:(CGPoint)anchor {
+- (void)setInfoWindowAnchor:(CGPoint)anchor {
   _marker.infoWindowAnchor = anchor;
 }
--(void)setInfoWindowTitle:(NSString*)title snippet:(NSString*)snippet {
+- (void)setInfoWindowTitle:(NSString*)title snippet:(NSString*)snippet {
   _marker.title = title;
   _marker.snippet = snippet;
 }
--(void)setRotation:(CLLocationDegrees)rotation {
+- (void)setRotation:(CLLocationDegrees)rotation {
   _marker.rotation = rotation;
 }
--(void)setVisible:(BOOL)visible {
+- (void)setVisible:(BOOL)visible {
   _marker.map = visible ? _mapView : nil;
 }
--(void)setZIndex:(int)zIndex {
+- (void)setZIndex:(int)zIndex {
   _marker.zIndex = zIndex;
 }
 @end

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapMarkerController.m
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapMarkerController.m
@@ -20,6 +20,9 @@ static uint64_t _nextMarkerId = 0;
   }
   return self;
 }
+
+#pragma mark - FLTGoogleMapMarkerOptionsSink methods
+
 - (void)setAlpha:(float)alpha {
   _marker.opacity = alpha;
 }

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapsPlugin.h
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapsPlugin.h
@@ -7,6 +7,5 @@
 #import "GoogleMapController.h"
 #import "GoogleMapMarkerController.h"
 
-@interface FLTGoogleMapsPlugin : NSObject<FlutterPlugin, FLTGoogleMapDelegate>
+@interface FLTGoogleMapsPlugin : NSObject <FlutterPlugin, FLTGoogleMapDelegate>
 @end
-

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapsPlugin.h
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapsPlugin.h
@@ -7,5 +7,5 @@
 #import "GoogleMapController.h"
 #import "GoogleMapMarkerController.h"
 
-@interface FLTGoogleMapsPlugin : NSObject <FlutterPlugin, FLTGoogleMapDelegate>
+@interface FLTGoogleMapsPlugin : NSObject<FlutterPlugin, FLTGoogleMapDelegate>
 @end

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapsPlugin.h
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapsPlugin.h
@@ -1,4 +1,5 @@
 #import <Flutter/Flutter.h>
+#import <GoogleMaps/GoogleMaps.h>
 
 @interface FLTGoogleMapsPlugin : NSObject<FlutterPlugin>
 @end

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapsPlugin.h
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapsPlugin.h
@@ -1,5 +1,12 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #import <Flutter/Flutter.h>
 #import <GoogleMaps/GoogleMaps.h>
+#import "GoogleMapController.h"
+#import "GoogleMapMarkerController.h"
 
-@interface FLTGoogleMapsPlugin : NSObject<FlutterPlugin>
+@interface FLTGoogleMapsPlugin : NSObject<FlutterPlugin, FLTGoogleMapDelegate>
 @end
+

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapsPlugin.m
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapsPlugin.m
@@ -1,151 +1,134 @@
 #import "GoogleMapsPlugin.h"
-#import "GoogleMaps/GoogleMaps.h"
 
-@implementation FLTGoogleMapsPlugin {
-  NSMutableDictionary* _mapViews;
-  NSObject<FlutterPluginRegistrar>* _registrar;
+// JSON conversion
+
+static bool toBool(id json) {
+  NSNumber* data = json;
+  return data.boolValue;
 }
 
-+ (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
-  FlutterMethodChannel* channel =
-      [FlutterMethodChannel methodChannelWithName:@"plugins.flutter.io/google_maps"
-                                  binaryMessenger:[registrar messenger]];
-  FLTGoogleMapsPlugin* instance = [[FLTGoogleMapsPlugin alloc] initWithRegistrar:registrar];
-  [registrar addMethodCallDelegate:instance channel:channel];
+static int toInt(id json) {
+  NSNumber* data = json;
+  return data.intValue;
 }
 
-- (instancetype)initWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
-  self = [super init];
-  if (self) {
-    _registrar = registrar;
-    _mapViews = [NSMutableDictionary dictionaryWithCapacity:1];
-  }
-  return self;
+static double toDouble(id json) {
+  NSNumber* data = json;
+  return data.doubleValue;
 }
 
-- (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
-  if ([call.method isEqualToString:@"init"]) {
-    // TODO(mravn): clear all map views
-    result(nil);
-  } else if ([call.method isEqualToString:@"createMap"]) {
-    NSNumber* width = call.arguments[@"width"];
-    NSNumber* height = call.arguments[@"height"];
-    NSDictionary* options = call.arguments[@"options"];
-    UIView* flutterView = [UIApplication sharedApplication].delegate.window.rootViewController.view;
-    GMSMapView* mapView = [GMSMapView mapWithFrame:CGRectMake(0.0f, 0.0f, width.floatValue, height.floatValue)
-                                            camera:toOptionalCameraPosition(options[@"cameraPosition"])];
-    updateMapOptions(options, mapView);
-    mapView.hidden = YES;
-    _mapViews[@1] = mapView;
-    [flutterView addSubview:mapView];
-    result(@1);
-  } else if ([call.method isEqualToString:@"showMapOverlay"]) {
-    GMSMapView* mapView = _mapViews[call.arguments[@"map"]];
-    NSNumber* x = call.arguments[@"x"];
-    NSNumber* y = call.arguments[@"y"];
-    mapView.frame = CGRectMake(x.floatValue, y.floatValue, CGRectGetWidth(mapView.frame), CGRectGetHeight(mapView.frame));
-    mapView.hidden = NO;
-  } else if ([call.method isEqualToString:@"hideMapOverlay"]) {
-    FlutterError* error;
-    GMSMapView* mapView = [self mapFromCall:call error:&error];
-    if (mapView) {
-      mapView.hidden = YES;
-      result(nil);
-    } else {
-      result(error);
-    }
-  } else if ([call.method isEqualToString:@"animateCamera"]) {
-    FlutterError* error;
-    GMSMapView* mapView = [self mapFromCall:call error:&error];
-    if (mapView) {
-      [mapView animateWithCameraUpdate:toCameraUpdate(call.arguments[@"cameraUpdate"])];
-      result(nil);
-    } else {
-      result(error);
-    }
-  } else if ([call.method isEqualToString:@"moveCamera"]) {
-    FlutterError* error;
-    GMSMapView* mapView = [self mapFromCall:call error:&error];
-    if (mapView) {
-      [mapView moveCamera:toCameraUpdate(call.arguments[@"cameraUpdate"])];
-      result(nil);
-    } else {
-      result(error);
-    }
-  } else if ([call.method isEqualToString:@"updateMapOptions"]) {
-    FlutterError* error;
-    GMSMapView* mapView = [self mapFromCall:call error:&error];
-    if (mapView) {
-      updateMapOptions(call.arguments[@"options"], mapView);
-      result(nil);
-    } else {
-      result(error);
-    }
-  } else {
-    result(FlutterMethodNotImplemented);
-  }
+static float toFloat(id json) {
+  NSNumber* data = json;
+  return data.floatValue;
 }
 
-- (GMSMapView* _Nonnull) mapFromCall:(FlutterMethodCall*)call error:(FlutterError**)error {
-  id mapId = call.arguments[@"map"];
-  GMSMapView* mapView = _mapViews[mapId];
-  if (!mapView && error) {
-    *error = [FlutterError errorWithCode:@"unknown_map" message:nil details:mapId];
-  }
-  return mapView;
+static CLLocationCoordinate2D toLocation(id json) {
+  NSArray* data = json;
+  return CLLocationCoordinate2DMake(toDouble(data[0]), toDouble(data[1]));
 }
 
-static void updateMapOptions(id json, GMSMapView* mapView) {
+static id locationToJson(CLLocationCoordinate2D position) {
+  return @[@(position.latitude), @(position.longitude)];
+}
+
+static CGPoint toPoint(id json) {
+  NSArray* data = json;
+  return CGPointMake(toDouble(data[0]), toDouble(data[1]));
+}
+
+static GMSCameraPosition* toCameraPosition(id json) {
   NSDictionary* data = json;
-  GMSUISettings* settings = mapView.settings;
-  id cameraPosition = data[@"cameraPosition"];
-  if (cameraPosition) {
-    [mapView setCamera:toCameraPosition(cameraPosition)];
+  return [GMSCameraPosition cameraWithTarget:toLocation(data[@"target"])
+                                        zoom:toFloat(data[@"zoom"])
+                                     bearing:toDouble(data[@"bearing"])
+                                viewingAngle:toDouble(data[@"tilt"])];
+}
+
+static id positionToJson(GMSCameraPosition* position) {
+  return @{
+           @"target": locationToJson([position target]),
+           @"zoom": @([position zoom]),
+           @"bearing": @([position bearing]),
+           @"tilt": @([position viewingAngle]),
+           };
+}
+
+static GMSCameraPosition* toOptionalCameraPosition(id json) {
+  return json ? toCameraPosition(json) : nil;
+}
+
+static GMSCoordinateBounds* toBounds(id json) {
+  NSArray* data = json;
+  return [[GMSCoordinateBounds alloc] initWithCoordinate:toLocation(data[0]) coordinate:toLocation(data[1])];
+}
+
+static GMSMapViewType toMapViewType(id json) {
+  int value = toInt(json);
+  return (GMSMapViewType) (value == 0 ? 5 : value);
+}
+
+static void updateMarkerOptions(id json, GMSMarker* marker, GMSMapView* mapView, NSObject<FlutterPluginRegistrar>* registrar) {
+  NSDictionary* data = json;
+  id alpha = data[@"alpha"];
+  if (alpha) {
+    marker.opacity = toFloat(alpha);
   }
-  id cameraTargetBounds = data[@"cameraTargetBounds"];
-  if (cameraTargetBounds) {
-    [mapView setCameraTargetBounds:toBounds(cameraTargetBounds)];
+  id anchor = data[@"anchor"];
+  if (anchor) {
+    marker.groundAnchor = toPoint(anchor);
   }
-  id compassEnabled = data[@"compassEnabled"];
-  if (compassEnabled) {
-    settings.compassButton = toBool(compassEnabled);
+  id draggable = data[@"draggable"];
+  if (draggable) {
+    marker.draggable = toBool(draggable);
   }
-  id mapType = data[@"mapType"];
-  if (mapType) {
-    [mapView setMapType:toMapViewType(mapType)];
-  }
-  id minMaxZoomPreference = data[@"minMaxZoomPreference"];
-  if (minMaxZoomPreference) {
-    NSArray* zoomData = minMaxZoomPreference;
-    float minZoom = kGMSMinZoomLevel;
-    float maxZoom = kGMSMaxZoomLevel;
-    if (![zoomData[0] isEqual:[NSNull null]]) {
-      minZoom = toFloat(zoomData[0]);
+  id icon = data[@"icon"];
+  if (icon) {
+    NSArray* iconData = icon;
+    if ([iconData[0] isEqualToString:@"defaultMarker"]) {
+      CGFloat hue = (iconData.count == 1) ? 0.0f : toDouble(iconData[1]);
+      marker.icon = [GMSMarker markerImageWithColor:[UIColor colorWithHue:hue / 360.0
+                                                               saturation:1.0
+                                                               brightness:0.7
+                                                                    alpha:1.0]];
+    } else if ([iconData[0] isEqualToString:@"fromAsset"]) {
+      if (iconData.count == 2) {
+        marker.icon = [UIImage imageNamed:[registrar lookupKeyForAsset:iconData[1]]];
+      } else {
+        marker.icon = [UIImage imageNamed:[registrar lookupKeyForAsset:iconData[1] fromPackage:iconData[2]]];
+      }
+      // TODO(mravn): handle file-based icons
     }
-    if (![zoomData[1] isEqual:[NSNull null]]) {
-      maxZoom = toFloat(zoomData[1]);
-    }
-    [mapView setMinZoom:minZoom maxZoom:maxZoom];
   }
-  id rotateGesturesEnabled = data[@"rotateGesturesEnabled"];
-  if (rotateGesturesEnabled) {
-    settings.rotateGestures = toBool(rotateGesturesEnabled);
+  id flat = data[@"flat"];
+  if (flat) {
+    marker.flat = toBool(flat);
   }
-  id scrollGesturesEnabled = data[@"scrollGesturesEnabled"];
-  if (scrollGesturesEnabled) {
-    settings.scrollGestures = toBool(scrollGesturesEnabled);
+  id infoWindowAnchor = data[@"infoWindowAnchor"];
+  if (infoWindowAnchor) {
+    marker.infoWindowAnchor = toPoint(infoWindowAnchor);
   }
-  id tiltGesturesEnabled = data[@"tiltGesturesEnabled"];
-  if (tiltGesturesEnabled) {
-    settings.tiltGestures = toBool(tiltGesturesEnabled);
+  // TODO(mravn): handle infoWindowShown
+  id infoWindowText = data[@"infoWindowText"];
+  if (infoWindowText) {
+    NSArray* infoWindowTextData = infoWindowText;
+    marker.title = [infoWindowTextData[0] isEqual:[NSNull null]] ? nil : infoWindowTextData[0];
+    marker.snippet = [infoWindowTextData[1] isEqual:[NSNull null]] ? nil : infoWindowTextData[1];
   }
-  id zoomGesturesEnabled = data[@"zoomGesturesEnabled"];
-  if (zoomGesturesEnabled) {
-    settings.zoomGestures = toBool(zoomGesturesEnabled);
+  id rotation = data[@"rotation"];
+  if (rotation) {
+    marker.rotation = toDouble(rotation);
+  }
+  id visible = data[@"visible"];
+  if (visible) {
+    marker.map = toBool(visible) ? mapView : nil;
+  }
+  id zIndex = data[@"zIndex"];
+  if (zIndex) {
+    marker.zIndex = toInt(zIndex);
   }
 }
 
-static GMSCameraUpdate* _Nonnull toCameraUpdate(id json) {
+static GMSCameraUpdate* toCameraUpdate(id json) {
   NSArray* data = json;
   NSString* update = data[0];
   if ([update isEqualToString:@"newCameraPosition"]) {
@@ -174,55 +157,308 @@ static GMSCameraUpdate* _Nonnull toCameraUpdate(id json) {
   return nil;
 }
 
-static GMSCameraPosition* _Nonnull toCameraPosition(id json) {
+// Controller interfaces
+
+@interface FLTGoogleMapController : NSObject<GMSMapViewDelegate>
+@property (atomic, readonly) GMSMapView* mapView;
+@property (atomic, readonly) id mapId;
+@property (atomic) BOOL tracksCameraPosition;
++(instancetype)controllerWithWidth:(CGFloat)width height:(CGFloat)height options:(id)json channel:(FlutterMethodChannel*)channel registrar:(NSObject<FlutterPluginRegistrar>*)registrar;
+-(void)updateMapOptions:(id)json;
+-(void)showAtX:(CGFloat)x Y:(CGFloat)y;
+-(void)hide;
+-(void)animateWithCameraUpdate:(GMSCameraUpdate*)cameraUpdate;
+-(void)moveWithCameraUpdate:(GMSCameraUpdate*)cameraUpdate;
+-(NSString*)addMarkerWithPosition:(CLLocationCoordinate2D)position;
+-(GMSMarker*)markerWithId:(NSString*)markerId;
+-(void)removeMarkerWithId:(NSString*)markerId;
+@end
+
+@interface FLTGoogleMapMarkerController : NSObject
+@property (atomic, readonly) GMSMarker* marker;
+@property (atomic, readonly) NSString* markerId;
+@property (atomic) BOOL consumesTapEvents;
+@end
+
+// Controller implementations
+
+static uint64_t _nextMap = 1;
+
+@implementation FLTGoogleMapController {
+  NSObject<FlutterPluginRegistrar>* _registrar;
+  FlutterMethodChannel* _channel;
+  NSMutableDictionary* _markers;
+  uint64_t _nextMarker;
+  BOOL _trackCameraPosition;
+}
+
++(instancetype)controllerWithWidth:(CGFloat)width height:(CGFloat)height options:(id)json channel:(FlutterMethodChannel*)channel registrar:(NSObject<FlutterPluginRegistrar>*)registrar {
   NSDictionary* data = json;
-  return [GMSCameraPosition cameraWithTarget:toLocation(data[@"target"])
-                                        zoom:toFloat(data[@"zoom"])
-                                     bearing:toDouble(data[@"bearing"])
-                                viewingAngle:toDouble(data[@"tilt"])];
+  GMSCameraPosition* camera = toOptionalCameraPosition(data[@"cameraPosition"]);
+  GMSMapView* mapView = [GMSMapView mapWithFrame:CGRectMake(0.0, 0.0, width, height)
+                                          camera:camera];
+  FLTGoogleMapController* controller = [[FLTGoogleMapController alloc] initWithMapView:mapView mapId:@(_nextMap++) channel:channel registrar:registrar];
+  mapView.hidden = YES;
+  mapView.delegate = controller;
+  [controller updateMapOptions:data];
+  return controller;
 }
 
-static GMSCameraPosition* _Nullable toOptionalCameraPosition(id json) {
-  return json ? toCameraPosition(json) : nil;
+-(instancetype)initWithMapView:(GMSMapView*)mapView mapId:(id)mapId channel:(FlutterMethodChannel*)channel registrar:(NSObject<FlutterPluginRegistrar>*)registrar {
+  self = [super init];
+  if (self) {
+    _registrar = registrar;
+    _mapView = mapView;
+    _channel = channel;
+    _mapId = mapId;
+    _nextMarker = 0;
+    _markers = [NSMutableDictionary dictionaryWithCapacity:1];
+    _tracksCameraPosition = false;
+  }
+  return self;
 }
 
-static GMSCoordinateBounds* _Nonnull toBounds(id json) {
-  NSArray* data = json;
-  return [[GMSCoordinateBounds alloc] initWithCoordinate:toLocation(data[0]) coordinate:toLocation(data[1])];
+-(void)showAtX:(CGFloat)x Y:(CGFloat)y {
+  _mapView.frame = CGRectMake(x, y, CGRectGetWidth(_mapView.frame), CGRectGetHeight(_mapView.frame));
+  _mapView.hidden = NO;
 }
 
-static CLLocationCoordinate2D toLocation(id json) {
-  NSArray* data = json;
-  return CLLocationCoordinate2DMake(toDouble(data[0]), toDouble(data[1]));
+-(void)hide {
+  _mapView.hidden = YES;
 }
 
-static GMSMapViewType toMapViewType(id json) {
-  int value = toInt(json);
-  return (GMSMapViewType) (value == 0 ? 5 : value);
+-(void)updateMapOptions:(id)json {
+  NSDictionary* data = json;
+  GMSUISettings* settings = _mapView.settings;
+  id cameraPosition = data[@"cameraPosition"];
+  if (cameraPosition) {
+    [_mapView setCamera:toCameraPosition(cameraPosition)];
+  }
+  id cameraTargetBounds = data[@"cameraTargetBounds"];
+  if (cameraTargetBounds) {
+    [_mapView setCameraTargetBounds:toBounds(cameraTargetBounds)];
+  }
+  id compassEnabled = data[@"compassEnabled"];
+  if (compassEnabled) {
+    settings.compassButton = toBool(compassEnabled);
+  }
+  id mapType = data[@"mapType"];
+  if (mapType) {
+    [_mapView setMapType:toMapViewType(mapType)];
+  }
+  id minMaxZoomPreference = data[@"minMaxZoomPreference"];
+  if (minMaxZoomPreference) {
+    NSArray* zoomData = minMaxZoomPreference;
+    float minZoom = kGMSMinZoomLevel;
+    float maxZoom = kGMSMaxZoomLevel;
+    if (![zoomData[0] isEqual:[NSNull null]]) {
+      minZoom = toFloat(zoomData[0]);
+    }
+    if (![zoomData[1] isEqual:[NSNull null]]) {
+      maxZoom = toFloat(zoomData[1]);
+    }
+    [_mapView setMinZoom:minZoom maxZoom:maxZoom];
+  }
+  id rotateGesturesEnabled = data[@"rotateGesturesEnabled"];
+  if (rotateGesturesEnabled) {
+    settings.rotateGestures = toBool(rotateGesturesEnabled);
+  }
+  id scrollGesturesEnabled = data[@"scrollGesturesEnabled"];
+  if (scrollGesturesEnabled) {
+    settings.scrollGestures = toBool(scrollGesturesEnabled);
+  }
+  id tiltGesturesEnabled = data[@"tiltGesturesEnabled"];
+  if (tiltGesturesEnabled) {
+    settings.tiltGestures = toBool(tiltGesturesEnabled);
+  }
+  id trackCameraPosition = data[@"trackCameraPosition"];
+  if (trackCameraPosition) {
+    _trackCameraPosition = toBool(trackCameraPosition);
+  }
+  id zoomGesturesEnabled = data[@"zoomGesturesEnabled"];
+  if (zoomGesturesEnabled) {
+    settings.zoomGestures = toBool(zoomGesturesEnabled);
+  }
 }
 
-static CGPoint toPoint(id json) {
-  NSArray* data = json;
-  return CGPointMake(toDouble(data[0]), toDouble(data[1]));
+-(void)animateWithCameraUpdate:(GMSCameraUpdate*)cameraUpdate {
+  [_mapView animateWithCameraUpdate:cameraUpdate];
 }
 
-static bool toBool(id json) {
-  NSNumber* data = json;
-  return data.boolValue;
+-(void)moveWithCameraUpdate:(GMSCameraUpdate*)cameraUpdate {
+  [_mapView moveCamera:cameraUpdate];
 }
 
-static int toInt(id json) {
-  NSNumber* data = json;
-  return data.intValue;
+-(NSString*)addMarkerWithPosition:(CLLocationCoordinate2D)position {
+  NSString* markerId = [NSString stringWithFormat:@"%lld", _nextMarker++];
+  GMSMarker* marker = [GMSMarker markerWithPosition:position];
+  _markers[markerId] = marker;
+  marker.map = _mapView;
+  marker.userData = @{@"map":_mapId, @"marker":markerId};
+  return markerId;
 }
 
-static double toDouble(id json) {
-  NSNumber* data = json;
-  return data.doubleValue;
+-(GMSMarker*)markerWithId:(NSString*)markerId {
+  return _markers[markerId];
 }
 
-static float toFloat(id json) {
-  NSNumber* data = json;
-  return data.floatValue;
+-(void)removeMarkerWithId:(NSString*)markerId {
+  GMSMarker* marker = _markers[markerId];
+  if (marker) {
+    marker.map = nil;
+    [_markers removeObjectForKey:markerId];
+  }
+}
+
+// GMSMapViewDelegate methods
+
+- (void)mapView:(GMSMapView*)mapView willMove:(BOOL)gesture {
+  [_channel invokeMethod:@"map#onCameraMoveStarted" arguments:@{@"map":_mapId, @"isGesture":@(gesture)}];
+}
+
+- (void)mapView:(GMSMapView*)mapView didChangeCameraPosition:(GMSCameraPosition*)position {
+  [_channel invokeMethod:@"map#onCameraMove" arguments:@{@"map":_mapId, @"position":positionToJson(position)}];
+}
+
+- (void)mapView:(GMSMapView*)mapView idleAtCameraPosition:(GMSCameraPosition*)position {
+  [_channel invokeMethod:@"map#onCameraIdle" arguments:@{@"map":_mapId}];
+}
+
+- (BOOL)mapView:(GMSMapView*)mapView didTapMarker:(GMSMarker*)marker {
+  [_channel invokeMethod:@"marker#onTap" arguments:marker.userData];
+  return NO;
+}
+@end
+
+// Plugin implementation
+
+@implementation FLTGoogleMapsPlugin {
+  NSObject<FlutterPluginRegistrar>* _registrar;
+  FlutterMethodChannel* _channel;
+  NSMutableDictionary* _mapControllers;
+}
+
++ (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
+  FlutterMethodChannel* channel =
+      [FlutterMethodChannel methodChannelWithName:@"plugins.flutter.io/google_maps"
+                                  binaryMessenger:[registrar messenger]];
+  FLTGoogleMapsPlugin* instance = [[FLTGoogleMapsPlugin alloc] initWithRegistrar:registrar channel:channel];
+  [registrar addMethodCallDelegate:instance channel:channel];
+}
+
+- (instancetype)initWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar channel:(FlutterMethodChannel*)channel {
+  self = [super init];
+  if (self) {
+    _registrar = registrar;
+    _channel = channel;
+    _mapControllers = [NSMutableDictionary dictionaryWithCapacity:1];
+  }
+  return self;
+}
+
+- (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
+  if ([call.method isEqualToString:@"init"]) {
+    for (FLTGoogleMapController* controller in _mapControllers.allValues) {
+      [controller.mapView removeFromSuperview];
+      controller.mapView.delegate = nil; // Breaks retain cycle mapView->delegate->mapView.
+    }
+    [_mapControllers removeAllObjects];
+    result(nil);
+  } else if ([call.method isEqualToString:@"createMap"]) {
+    UIView* flutterView = [UIApplication sharedApplication].delegate.window.rootViewController.view;
+    FLTGoogleMapController* controller = [FLTGoogleMapController controllerWithWidth:toDouble(call.arguments[@"width"])
+                                                                              height:toDouble(call.arguments[@"height"])
+                                                                             options:call.arguments[@"options"]
+                                                                             channel:_channel
+                                                                           registrar:_registrar];
+    _mapControllers[controller.mapId] = controller;
+    [flutterView addSubview:controller.mapView];
+    result(controller.mapId);
+  } else if ([call.method isEqualToString:@"showMapOverlay"]) {
+    FlutterError* error;
+    FLTGoogleMapController* controller = [self mapFromCall:call error:&error];
+    if (controller) {
+      [controller showAtX:toDouble(call.arguments[@"x"]) Y:toDouble(call.arguments[@"y"])];
+      result(nil);
+    } else {
+      result(error);
+    }
+  } else if ([call.method isEqualToString:@"hideMapOverlay"]) {
+    FlutterError* error;
+    FLTGoogleMapController* controller = [self mapFromCall:call error:&error];
+    if (controller) {
+      [controller hide];
+      result(nil);
+    } else {
+      result(error);
+    }
+  } else if ([call.method isEqualToString:@"animateCamera"]) {
+    FlutterError* error;
+    FLTGoogleMapController* controller = [self mapFromCall:call error:&error];
+    if (controller) {
+      [controller animateWithCameraUpdate:toCameraUpdate(call.arguments[@"cameraUpdate"])];
+      result(nil);
+    } else {
+      result(error);
+    }
+  } else if ([call.method isEqualToString:@"moveCamera"]) {
+    FlutterError* error;
+    FLTGoogleMapController* controller = [self mapFromCall:call error:&error];
+    if (controller) {
+      [controller moveWithCameraUpdate:toCameraUpdate(call.arguments[@"cameraUpdate"])];
+      result(nil);
+    } else {
+      result(error);
+    }
+  } else if ([call.method isEqualToString:@"updateMapOptions"]) {
+    FlutterError* error;
+    FLTGoogleMapController* controller = [self mapFromCall:call error:&error];
+    if (controller) {
+      [controller updateMapOptions:call.arguments[@"options"]];
+      result(nil);
+    } else {
+      result(error);
+    }
+  } else if ([call.method isEqualToString:@"addMarker"]) {
+    NSDictionary* options = call.arguments[@"options"];
+    FlutterError* error;
+    FLTGoogleMapController* controller = [self mapFromCall:call error:&error];
+    if (controller) {
+      id markerId = [controller addMarkerWithPosition:toLocation(options[@"position"])];
+      updateMarkerOptions(options, [controller markerWithId:markerId], controller.mapView, _registrar);
+      result([NSString stringWithFormat:@"%@", markerId]);
+    } else {
+      result(error);
+    }
+  } else if ([call.method isEqualToString:@"marker#update"]) {
+    FlutterError* error;
+    FLTGoogleMapController* controller = [self mapFromCall:call error:&error];
+    if (controller) {
+      updateMarkerOptions(call.arguments[@"options"], [controller markerWithId:call.arguments[@"marker"]], controller.mapView, _registrar);
+      result(nil);
+    } else {
+      result(error);
+    }
+  } else if ([call.method isEqualToString:@"marker#remove"]) {
+    FlutterError* error;
+    FLTGoogleMapController* controller = [self mapFromCall:call error:&error];
+    if (controller) {
+      [controller removeMarkerWithId:call.arguments[@"marker"]];
+      result(nil);
+    } else {
+      result(error);
+    }
+  } else {
+    result(FlutterMethodNotImplemented);
+  }
+}
+
+- (FLTGoogleMapController*) mapFromCall:(FlutterMethodCall*)call error:(FlutterError**)error {
+  id mapId = call.arguments[@"map"];
+  FLTGoogleMapController* controller = _mapControllers[mapId];
+  if (!controller && error) {
+    *error = [FlutterError errorWithCode:@"unknown_map" message:nil details:mapId];
+  }
+  return controller;
 }
 @end

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapsPlugin.m
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapsPlugin.m
@@ -95,7 +95,7 @@ static void interpretMarkerOptions(id json, id<FLTGoogleMapMarkerOptionsSink> si
       result(markerId);
     } else if ([call.method isEqualToString:@"marker#update"]) {
       interpretMarkerOptions(call.arguments[@"options"],
-                         [controller markerWithId:call.arguments[@"marker"]], _registrar);
+                             [controller markerWithId:call.arguments[@"marker"]], _registrar);
       result(nil);
     } else if ([call.method isEqualToString:@"marker#remove"]) {
       [controller removeMarkerWithId:call.arguments[@"marker"]];

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapsPlugin.m
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapsPlugin.m
@@ -1,16 +1,228 @@
 #import "GoogleMapsPlugin.h"
+#import "GoogleMaps/GoogleMaps.h"
 
-@implementation FLTGoogleMapsPlugin
+@implementation FLTGoogleMapsPlugin {
+  NSMutableDictionary* _mapViews;
+  NSObject<FlutterPluginRegistrar>* _registrar;
+}
+
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
   FlutterMethodChannel* channel =
       [FlutterMethodChannel methodChannelWithName:@"plugins.flutter.io/google_maps"
                                   binaryMessenger:[registrar messenger]];
-  FLTGoogleMapsPlugin* instance = [[FLTGoogleMapsPlugin alloc] init];
+  FLTGoogleMapsPlugin* instance = [[FLTGoogleMapsPlugin alloc] initWithRegistrar:registrar];
   [registrar addMethodCallDelegate:instance channel:channel];
 }
 
-- (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
-  result(FlutterMethodNotImplemented);
+- (instancetype)initWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
+  self = [super init];
+  if (self) {
+    _registrar = registrar;
+    _mapViews = [NSMutableDictionary dictionaryWithCapacity:1];
+  }
+  return self;
 }
 
+- (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
+  if ([call.method isEqualToString:@"init"]) {
+    // TODO(mravn): clear all map views
+    result(nil);
+  } else if ([call.method isEqualToString:@"createMap"]) {
+    NSNumber* width = call.arguments[@"width"];
+    NSNumber* height = call.arguments[@"height"];
+    NSDictionary* options = call.arguments[@"options"];
+    UIView* flutterView = [UIApplication sharedApplication].delegate.window.rootViewController.view;
+    GMSMapView* mapView = [GMSMapView mapWithFrame:CGRectMake(0.0f, 0.0f, width.floatValue, height.floatValue)
+                                            camera:toOptionalCameraPosition(options[@"cameraPosition"])];
+    updateMapOptions(options, mapView);
+    mapView.hidden = YES;
+    _mapViews[@1] = mapView;
+    [flutterView addSubview:mapView];
+    result(@1);
+  } else if ([call.method isEqualToString:@"showMapOverlay"]) {
+    GMSMapView* mapView = _mapViews[call.arguments[@"map"]];
+    NSNumber* x = call.arguments[@"x"];
+    NSNumber* y = call.arguments[@"y"];
+    mapView.frame = CGRectMake(x.floatValue, y.floatValue, CGRectGetWidth(mapView.frame), CGRectGetHeight(mapView.frame));
+    mapView.hidden = NO;
+  } else if ([call.method isEqualToString:@"hideMapOverlay"]) {
+    FlutterError* error;
+    GMSMapView* mapView = [self mapFromCall:call error:&error];
+    if (mapView) {
+      mapView.hidden = YES;
+      result(nil);
+    } else {
+      result(error);
+    }
+  } else if ([call.method isEqualToString:@"animateCamera"]) {
+    FlutterError* error;
+    GMSMapView* mapView = [self mapFromCall:call error:&error];
+    if (mapView) {
+      [mapView animateWithCameraUpdate:toCameraUpdate(call.arguments[@"cameraUpdate"])];
+      result(nil);
+    } else {
+      result(error);
+    }
+  } else if ([call.method isEqualToString:@"moveCamera"]) {
+    FlutterError* error;
+    GMSMapView* mapView = [self mapFromCall:call error:&error];
+    if (mapView) {
+      [mapView moveCamera:toCameraUpdate(call.arguments[@"cameraUpdate"])];
+      result(nil);
+    } else {
+      result(error);
+    }
+  } else if ([call.method isEqualToString:@"updateMapOptions"]) {
+    FlutterError* error;
+    GMSMapView* mapView = [self mapFromCall:call error:&error];
+    if (mapView) {
+      updateMapOptions(call.arguments[@"options"], mapView);
+      result(nil);
+    } else {
+      result(error);
+    }
+  } else {
+    result(FlutterMethodNotImplemented);
+  }
+}
+
+- (GMSMapView* _Nonnull) mapFromCall:(FlutterMethodCall*)call error:(FlutterError**)error {
+  id mapId = call.arguments[@"map"];
+  GMSMapView* mapView = _mapViews[mapId];
+  if (!mapView && error) {
+    *error = [FlutterError errorWithCode:@"unknown_map" message:nil details:mapId];
+  }
+  return mapView;
+}
+
+static void updateMapOptions(id json, GMSMapView* mapView) {
+  NSDictionary* data = json;
+  GMSUISettings* settings = mapView.settings;
+  id cameraPosition = data[@"cameraPosition"];
+  if (cameraPosition) {
+    [mapView setCamera:toCameraPosition(cameraPosition)];
+  }
+  id cameraTargetBounds = data[@"cameraTargetBounds"];
+  if (cameraTargetBounds) {
+    [mapView setCameraTargetBounds:toBounds(cameraTargetBounds)];
+  }
+  id compassEnabled = data[@"compassEnabled"];
+  if (compassEnabled) {
+    settings.compassButton = toBool(compassEnabled);
+  }
+  id mapType = data[@"mapType"];
+  if (mapType) {
+    [mapView setMapType:toMapViewType(mapType)];
+  }
+  id minMaxZoomPreference = data[@"minMaxZoomPreference"];
+  if (minMaxZoomPreference) {
+    NSArray* zoomData = minMaxZoomPreference;
+    float minZoom = kGMSMinZoomLevel;
+    float maxZoom = kGMSMaxZoomLevel;
+    if (![zoomData[0] isEqual:[NSNull null]]) {
+      minZoom = toFloat(zoomData[0]);
+    }
+    if (![zoomData[1] isEqual:[NSNull null]]) {
+      maxZoom = toFloat(zoomData[1]);
+    }
+    [mapView setMinZoom:minZoom maxZoom:maxZoom];
+  }
+  id rotateGesturesEnabled = data[@"rotateGesturesEnabled"];
+  if (rotateGesturesEnabled) {
+    settings.rotateGestures = toBool(rotateGesturesEnabled);
+  }
+  id scrollGesturesEnabled = data[@"scrollGesturesEnabled"];
+  if (scrollGesturesEnabled) {
+    settings.scrollGestures = toBool(scrollGesturesEnabled);
+  }
+  id tiltGesturesEnabled = data[@"tiltGesturesEnabled"];
+  if (tiltGesturesEnabled) {
+    settings.tiltGestures = toBool(tiltGesturesEnabled);
+  }
+  id zoomGesturesEnabled = data[@"zoomGesturesEnabled"];
+  if (zoomGesturesEnabled) {
+    settings.zoomGestures = toBool(zoomGesturesEnabled);
+  }
+}
+
+static GMSCameraUpdate* _Nonnull toCameraUpdate(id json) {
+  NSArray* data = json;
+  NSString* update = data[0];
+  if ([update isEqualToString:@"newCameraPosition"]) {
+    return [GMSCameraUpdate setCamera:toCameraPosition(data[1])];
+  } else if ([update isEqualToString:@"newLatLng"]) {
+    return [GMSCameraUpdate setTarget:toLocation(data[1])];
+  } else if ([update isEqualToString:@"newLatLngBounds"]) {
+    return [GMSCameraUpdate fitBounds:toBounds(data[1]) withPadding:toDouble(data[2])];
+  } else if ([update isEqualToString:@"newLatLngZoom"]) {
+    return [GMSCameraUpdate setTarget:toLocation(data[1]) zoom:toFloat(data[2])];
+  } else if ([update isEqualToString:@"scrollBy"]) {
+    return [GMSCameraUpdate scrollByX:toDouble(data[1]) Y:toDouble(data[2])];
+  } else if ([update isEqualToString:@"zoomBy"]) {
+    if (data.count == 2) {
+      return [GMSCameraUpdate zoomBy:toFloat(data[1])];
+    } else {
+      return [GMSCameraUpdate zoomBy:toFloat(data[1]) atPoint:toPoint(data[2])];
+    }
+  } else if ([update isEqualToString:@"zoomIn"]) {
+    return [GMSCameraUpdate zoomIn];
+  } else if ([update isEqualToString:@"zoomOut"]) {
+    return [GMSCameraUpdate zoomOut];
+  } else if ([update isEqualToString:@"zoomTo"]) {
+    return [GMSCameraUpdate zoomTo:toFloat(data[1])];
+  }
+  return nil;
+}
+
+static GMSCameraPosition* _Nonnull toCameraPosition(id json) {
+  NSDictionary* data = json;
+  return [GMSCameraPosition cameraWithTarget:toLocation(data[@"target"])
+                                        zoom:toFloat(data[@"zoom"])
+                                     bearing:toDouble(data[@"bearing"])
+                                viewingAngle:toDouble(data[@"tilt"])];
+}
+
+static GMSCameraPosition* _Nullable toOptionalCameraPosition(id json) {
+  return json ? toCameraPosition(json) : nil;
+}
+
+static GMSCoordinateBounds* _Nonnull toBounds(id json) {
+  NSArray* data = json;
+  return [[GMSCoordinateBounds alloc] initWithCoordinate:toLocation(data[0]) coordinate:toLocation(data[1])];
+}
+
+static CLLocationCoordinate2D toLocation(id json) {
+  NSArray* data = json;
+  return CLLocationCoordinate2DMake(toDouble(data[0]), toDouble(data[1]));
+}
+
+static GMSMapViewType toMapViewType(id json) {
+  int value = toInt(json);
+  return (GMSMapViewType) (value == 0 ? 5 : value);
+}
+
+static CGPoint toPoint(id json) {
+  NSArray* data = json;
+  return CGPointMake(toDouble(data[0]), toDouble(data[1]));
+}
+
+static bool toBool(id json) {
+  NSNumber* data = json;
+  return data.boolValue;
+}
+
+static int toInt(id json) {
+  NSNumber* data = json;
+  return data.intValue;
+}
+
+static double toDouble(id json) {
+  NSNumber* data = json;
+  return data.doubleValue;
+}
+
+static float toFloat(id json) {
+  NSNumber* data = json;
+  return data.floatValue;
+}
 @end

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapsPlugin.m
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapsPlugin.m
@@ -1,336 +1,24 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "GoogleMapController.h"
+#import "GoogleMapMarkerController.h"
 #import "GoogleMapsPlugin.h"
 
-// JSON conversion
+// Conversion functions between iOS types and JSON-like values sent via platform channels.
+// Forward declarations.
 
-static bool toBool(id json) {
-  NSNumber* data = json;
-  return data.boolValue;
-}
+static id positionToJson(GMSCameraPosition* position);
+static double toDouble(id json);
+static CLLocationCoordinate2D toLocation(id json);
+static GMSCameraPosition* toOptionalCameraPosition(id json);
+static GMSCoordinateBounds* toOptionalBounds(id json);
+static GMSCameraUpdate* toCameraUpdate(id json);
+static void writeMapOptions(id json, id<FLTGoogleMapOptionsSink> sink);
+static void writeMarkerOptions(id json, id<FLTGoogleMapMarkerOptionsSink> sink, NSObject<FlutterPluginRegistrar>* registrar);
 
-static int toInt(id json) {
-  NSNumber* data = json;
-  return data.intValue;
-}
-
-static double toDouble(id json) {
-  NSNumber* data = json;
-  return data.doubleValue;
-}
-
-static float toFloat(id json) {
-  NSNumber* data = json;
-  return data.floatValue;
-}
-
-static CLLocationCoordinate2D toLocation(id json) {
-  NSArray* data = json;
-  return CLLocationCoordinate2DMake(toDouble(data[0]), toDouble(data[1]));
-}
-
-static id locationToJson(CLLocationCoordinate2D position) {
-  return @[@(position.latitude), @(position.longitude)];
-}
-
-static CGPoint toPoint(id json) {
-  NSArray* data = json;
-  return CGPointMake(toDouble(data[0]), toDouble(data[1]));
-}
-
-static GMSCameraPosition* toCameraPosition(id json) {
-  NSDictionary* data = json;
-  return [GMSCameraPosition cameraWithTarget:toLocation(data[@"target"])
-                                        zoom:toFloat(data[@"zoom"])
-                                     bearing:toDouble(data[@"bearing"])
-                                viewingAngle:toDouble(data[@"tilt"])];
-}
-
-static id positionToJson(GMSCameraPosition* position) {
-  return @{
-           @"target": locationToJson([position target]),
-           @"zoom": @([position zoom]),
-           @"bearing": @([position bearing]),
-           @"tilt": @([position viewingAngle]),
-           };
-}
-
-static GMSCameraPosition* toOptionalCameraPosition(id json) {
-  return json ? toCameraPosition(json) : nil;
-}
-
-static GMSCoordinateBounds* toBounds(id json) {
-  NSArray* data = json;
-  return [[GMSCoordinateBounds alloc] initWithCoordinate:toLocation(data[0]) coordinate:toLocation(data[1])];
-}
-
-static GMSMapViewType toMapViewType(id json) {
-  int value = toInt(json);
-  return (GMSMapViewType) (value == 0 ? 5 : value);
-}
-
-static void updateMarkerOptions(id json, GMSMarker* marker, GMSMapView* mapView, NSObject<FlutterPluginRegistrar>* registrar) {
-  NSDictionary* data = json;
-  id alpha = data[@"alpha"];
-  if (alpha) {
-    marker.opacity = toFloat(alpha);
-  }
-  id anchor = data[@"anchor"];
-  if (anchor) {
-    marker.groundAnchor = toPoint(anchor);
-  }
-  id draggable = data[@"draggable"];
-  if (draggable) {
-    marker.draggable = toBool(draggable);
-  }
-  id icon = data[@"icon"];
-  if (icon) {
-    NSArray* iconData = icon;
-    if ([iconData[0] isEqualToString:@"defaultMarker"]) {
-      CGFloat hue = (iconData.count == 1) ? 0.0f : toDouble(iconData[1]);
-      marker.icon = [GMSMarker markerImageWithColor:[UIColor colorWithHue:hue / 360.0
-                                                               saturation:1.0
-                                                               brightness:0.7
-                                                                    alpha:1.0]];
-    } else if ([iconData[0] isEqualToString:@"fromAsset"]) {
-      if (iconData.count == 2) {
-        marker.icon = [UIImage imageNamed:[registrar lookupKeyForAsset:iconData[1]]];
-      } else {
-        marker.icon = [UIImage imageNamed:[registrar lookupKeyForAsset:iconData[1] fromPackage:iconData[2]]];
-      }
-      // TODO(mravn): handle file-based icons
-    }
-  }
-  id flat = data[@"flat"];
-  if (flat) {
-    marker.flat = toBool(flat);
-  }
-  id infoWindowAnchor = data[@"infoWindowAnchor"];
-  if (infoWindowAnchor) {
-    marker.infoWindowAnchor = toPoint(infoWindowAnchor);
-  }
-  // TODO(mravn): handle infoWindowShown
-  id infoWindowText = data[@"infoWindowText"];
-  if (infoWindowText) {
-    NSArray* infoWindowTextData = infoWindowText;
-    marker.title = [infoWindowTextData[0] isEqual:[NSNull null]] ? nil : infoWindowTextData[0];
-    marker.snippet = [infoWindowTextData[1] isEqual:[NSNull null]] ? nil : infoWindowTextData[1];
-  }
-  id rotation = data[@"rotation"];
-  if (rotation) {
-    marker.rotation = toDouble(rotation);
-  }
-  id visible = data[@"visible"];
-  if (visible) {
-    marker.map = toBool(visible) ? mapView : nil;
-  }
-  id zIndex = data[@"zIndex"];
-  if (zIndex) {
-    marker.zIndex = toInt(zIndex);
-  }
-}
-
-static GMSCameraUpdate* toCameraUpdate(id json) {
-  NSArray* data = json;
-  NSString* update = data[0];
-  if ([update isEqualToString:@"newCameraPosition"]) {
-    return [GMSCameraUpdate setCamera:toCameraPosition(data[1])];
-  } else if ([update isEqualToString:@"newLatLng"]) {
-    return [GMSCameraUpdate setTarget:toLocation(data[1])];
-  } else if ([update isEqualToString:@"newLatLngBounds"]) {
-    return [GMSCameraUpdate fitBounds:toBounds(data[1]) withPadding:toDouble(data[2])];
-  } else if ([update isEqualToString:@"newLatLngZoom"]) {
-    return [GMSCameraUpdate setTarget:toLocation(data[1]) zoom:toFloat(data[2])];
-  } else if ([update isEqualToString:@"scrollBy"]) {
-    return [GMSCameraUpdate scrollByX:toDouble(data[1]) Y:toDouble(data[2])];
-  } else if ([update isEqualToString:@"zoomBy"]) {
-    if (data.count == 2) {
-      return [GMSCameraUpdate zoomBy:toFloat(data[1])];
-    } else {
-      return [GMSCameraUpdate zoomBy:toFloat(data[1]) atPoint:toPoint(data[2])];
-    }
-  } else if ([update isEqualToString:@"zoomIn"]) {
-    return [GMSCameraUpdate zoomIn];
-  } else if ([update isEqualToString:@"zoomOut"]) {
-    return [GMSCameraUpdate zoomOut];
-  } else if ([update isEqualToString:@"zoomTo"]) {
-    return [GMSCameraUpdate zoomTo:toFloat(data[1])];
-  }
-  return nil;
-}
-
-// Controller interfaces
-
-@interface FLTGoogleMapController : NSObject<GMSMapViewDelegate>
-@property (atomic, readonly) GMSMapView* mapView;
-@property (atomic, readonly) id mapId;
-@property (atomic) BOOL tracksCameraPosition;
-+(instancetype)controllerWithWidth:(CGFloat)width height:(CGFloat)height options:(id)json channel:(FlutterMethodChannel*)channel registrar:(NSObject<FlutterPluginRegistrar>*)registrar;
--(void)updateMapOptions:(id)json;
--(void)showAtX:(CGFloat)x Y:(CGFloat)y;
--(void)hide;
--(void)animateWithCameraUpdate:(GMSCameraUpdate*)cameraUpdate;
--(void)moveWithCameraUpdate:(GMSCameraUpdate*)cameraUpdate;
--(NSString*)addMarkerWithPosition:(CLLocationCoordinate2D)position;
--(GMSMarker*)markerWithId:(NSString*)markerId;
--(void)removeMarkerWithId:(NSString*)markerId;
-@end
-
-@interface FLTGoogleMapMarkerController : NSObject
-@property (atomic, readonly) GMSMarker* marker;
-@property (atomic, readonly) NSString* markerId;
-@property (atomic) BOOL consumesTapEvents;
-@end
-
-// Controller implementations
-
-static uint64_t _nextMap = 1;
-
-@implementation FLTGoogleMapController {
-  NSObject<FlutterPluginRegistrar>* _registrar;
-  FlutterMethodChannel* _channel;
-  NSMutableDictionary* _markers;
-  uint64_t _nextMarker;
-  BOOL _trackCameraPosition;
-}
-
-+(instancetype)controllerWithWidth:(CGFloat)width height:(CGFloat)height options:(id)json channel:(FlutterMethodChannel*)channel registrar:(NSObject<FlutterPluginRegistrar>*)registrar {
-  NSDictionary* data = json;
-  GMSCameraPosition* camera = toOptionalCameraPosition(data[@"cameraPosition"]);
-  GMSMapView* mapView = [GMSMapView mapWithFrame:CGRectMake(0.0, 0.0, width, height)
-                                          camera:camera];
-  FLTGoogleMapController* controller = [[FLTGoogleMapController alloc] initWithMapView:mapView mapId:@(_nextMap++) channel:channel registrar:registrar];
-  mapView.hidden = YES;
-  mapView.delegate = controller;
-  [controller updateMapOptions:data];
-  return controller;
-}
-
--(instancetype)initWithMapView:(GMSMapView*)mapView mapId:(id)mapId channel:(FlutterMethodChannel*)channel registrar:(NSObject<FlutterPluginRegistrar>*)registrar {
-  self = [super init];
-  if (self) {
-    _registrar = registrar;
-    _mapView = mapView;
-    _channel = channel;
-    _mapId = mapId;
-    _nextMarker = 0;
-    _markers = [NSMutableDictionary dictionaryWithCapacity:1];
-    _tracksCameraPosition = false;
-  }
-  return self;
-}
-
--(void)showAtX:(CGFloat)x Y:(CGFloat)y {
-  _mapView.frame = CGRectMake(x, y, CGRectGetWidth(_mapView.frame), CGRectGetHeight(_mapView.frame));
-  _mapView.hidden = NO;
-}
-
--(void)hide {
-  _mapView.hidden = YES;
-}
-
--(void)updateMapOptions:(id)json {
-  NSDictionary* data = json;
-  GMSUISettings* settings = _mapView.settings;
-  id cameraPosition = data[@"cameraPosition"];
-  if (cameraPosition) {
-    [_mapView setCamera:toCameraPosition(cameraPosition)];
-  }
-  id cameraTargetBounds = data[@"cameraTargetBounds"];
-  if (cameraTargetBounds) {
-    [_mapView setCameraTargetBounds:toBounds(cameraTargetBounds)];
-  }
-  id compassEnabled = data[@"compassEnabled"];
-  if (compassEnabled) {
-    settings.compassButton = toBool(compassEnabled);
-  }
-  id mapType = data[@"mapType"];
-  if (mapType) {
-    [_mapView setMapType:toMapViewType(mapType)];
-  }
-  id minMaxZoomPreference = data[@"minMaxZoomPreference"];
-  if (minMaxZoomPreference) {
-    NSArray* zoomData = minMaxZoomPreference;
-    float minZoom = kGMSMinZoomLevel;
-    float maxZoom = kGMSMaxZoomLevel;
-    if (![zoomData[0] isEqual:[NSNull null]]) {
-      minZoom = toFloat(zoomData[0]);
-    }
-    if (![zoomData[1] isEqual:[NSNull null]]) {
-      maxZoom = toFloat(zoomData[1]);
-    }
-    [_mapView setMinZoom:minZoom maxZoom:maxZoom];
-  }
-  id rotateGesturesEnabled = data[@"rotateGesturesEnabled"];
-  if (rotateGesturesEnabled) {
-    settings.rotateGestures = toBool(rotateGesturesEnabled);
-  }
-  id scrollGesturesEnabled = data[@"scrollGesturesEnabled"];
-  if (scrollGesturesEnabled) {
-    settings.scrollGestures = toBool(scrollGesturesEnabled);
-  }
-  id tiltGesturesEnabled = data[@"tiltGesturesEnabled"];
-  if (tiltGesturesEnabled) {
-    settings.tiltGestures = toBool(tiltGesturesEnabled);
-  }
-  id trackCameraPosition = data[@"trackCameraPosition"];
-  if (trackCameraPosition) {
-    _trackCameraPosition = toBool(trackCameraPosition);
-  }
-  id zoomGesturesEnabled = data[@"zoomGesturesEnabled"];
-  if (zoomGesturesEnabled) {
-    settings.zoomGestures = toBool(zoomGesturesEnabled);
-  }
-}
-
--(void)animateWithCameraUpdate:(GMSCameraUpdate*)cameraUpdate {
-  [_mapView animateWithCameraUpdate:cameraUpdate];
-}
-
--(void)moveWithCameraUpdate:(GMSCameraUpdate*)cameraUpdate {
-  [_mapView moveCamera:cameraUpdate];
-}
-
--(NSString*)addMarkerWithPosition:(CLLocationCoordinate2D)position {
-  NSString* markerId = [NSString stringWithFormat:@"%lld", _nextMarker++];
-  GMSMarker* marker = [GMSMarker markerWithPosition:position];
-  _markers[markerId] = marker;
-  marker.map = _mapView;
-  marker.userData = @{@"map":_mapId, @"marker":markerId};
-  return markerId;
-}
-
--(GMSMarker*)markerWithId:(NSString*)markerId {
-  return _markers[markerId];
-}
-
--(void)removeMarkerWithId:(NSString*)markerId {
-  GMSMarker* marker = _markers[markerId];
-  if (marker) {
-    marker.map = nil;
-    [_markers removeObjectForKey:markerId];
-  }
-}
-
-// GMSMapViewDelegate methods
-
-- (void)mapView:(GMSMapView*)mapView willMove:(BOOL)gesture {
-  [_channel invokeMethod:@"map#onCameraMoveStarted" arguments:@{@"map":_mapId, @"isGesture":@(gesture)}];
-}
-
-- (void)mapView:(GMSMapView*)mapView didChangeCameraPosition:(GMSCameraPosition*)position {
-  [_channel invokeMethod:@"map#onCameraMove" arguments:@{@"map":_mapId, @"position":positionToJson(position)}];
-}
-
-- (void)mapView:(GMSMapView*)mapView idleAtCameraPosition:(GMSCameraPosition*)position {
-  [_channel invokeMethod:@"map#onCameraIdle" arguments:@{@"map":_mapId}];
-}
-
-- (BOOL)mapView:(GMSMapView*)mapView didTapMarker:(GMSMarker*)marker {
-  [_channel invokeMethod:@"marker#onTap" arguments:marker.userData];
-  return NO;
-}
-@end
-
-// Plugin implementation
+// GoogleMaps plugin implementation
 
 @implementation FLTGoogleMapsPlugin {
   NSObject<FlutterPluginRegistrar>* _registrar;
@@ -359,20 +47,21 @@ static uint64_t _nextMap = 1;
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
   if ([call.method isEqualToString:@"init"]) {
     for (FLTGoogleMapController* controller in _mapControllers.allValues) {
-      [controller.mapView removeFromSuperview];
-      controller.mapView.delegate = nil; // Breaks retain cycle mapView->delegate->mapView.
+      [controller removeFromView];
     }
     [_mapControllers removeAllObjects];
     result(nil);
   } else if ([call.method isEqualToString:@"createMap"]) {
-    UIView* flutterView = [UIApplication sharedApplication].delegate.window.rootViewController.view;
+    NSDictionary* options = call.arguments[@"options"];
+    GMSCameraPosition* camera = toOptionalCameraPosition(options[@"cameraPosition"]);
     FLTGoogleMapController* controller = [FLTGoogleMapController controllerWithWidth:toDouble(call.arguments[@"width"])
                                                                               height:toDouble(call.arguments[@"height"])
-                                                                             options:call.arguments[@"options"]
-                                                                             channel:_channel
-                                                                           registrar:_registrar];
+                                                                              camera:camera];
     _mapControllers[controller.mapId] = controller;
-    [flutterView addSubview:controller.mapView];
+    writeMapOptions(options, controller);
+    UIView* flutterView = [UIApplication sharedApplication].delegate.window.rootViewController.view;
+    [controller addToView:flutterView];
+    controller.delegate = self;
     result(controller.mapId);
   } else if ([call.method isEqualToString:@"showMapOverlay"]) {
     FlutterError* error;
@@ -414,7 +103,7 @@ static uint64_t _nextMap = 1;
     FlutterError* error;
     FLTGoogleMapController* controller = [self mapFromCall:call error:&error];
     if (controller) {
-      [controller updateMapOptions:call.arguments[@"options"]];
+      writeMapOptions(call.arguments[@"options"], controller);
       result(nil);
     } else {
       result(error);
@@ -424,9 +113,9 @@ static uint64_t _nextMap = 1;
     FlutterError* error;
     FLTGoogleMapController* controller = [self mapFromCall:call error:&error];
     if (controller) {
-      id markerId = [controller addMarkerWithPosition:toLocation(options[@"position"])];
-      updateMarkerOptions(options, [controller markerWithId:markerId], controller.mapView, _registrar);
-      result([NSString stringWithFormat:@"%@", markerId]);
+      NSString* markerId = [controller addMarkerWithPosition:toLocation(options[@"position"])];
+      writeMarkerOptions(options, [controller markerWithId:markerId], _registrar);
+      result(markerId);
     } else {
       result(error);
     }
@@ -434,7 +123,7 @@ static uint64_t _nextMap = 1;
     FlutterError* error;
     FLTGoogleMapController* controller = [self mapFromCall:call error:&error];
     if (controller) {
-      updateMarkerOptions(call.arguments[@"options"], [controller markerWithId:call.arguments[@"marker"]], controller.mapView, _registrar);
+      writeMarkerOptions(call.arguments[@"options"], [controller markerWithId:call.arguments[@"marker"]], _registrar);
       result(nil);
     } else {
       result(error);
@@ -461,4 +150,242 @@ static uint64_t _nextMap = 1;
   }
   return controller;
 }
+
+// FLTGoogleMapsDelegate methods, used to send platform messages to Flutter.
+
+-(void)onCameraMoveStartedOnMap:(id)mapId gesture:(BOOL)gesture {
+  [_channel invokeMethod:@"map#onCameraMoveStarted" arguments:@{@"map":mapId, @"isGesture":@(gesture)}];
+}
+
+-(void)onCameraMoveOnMap:(id)mapId cameraPosition:(GMSCameraPosition*)cameraPosition {
+  [_channel invokeMethod:@"map#onCameraMove" arguments:@{@"map":mapId, @"position":positionToJson(cameraPosition)}];
+}
+
+-(void)onCameraIdleOnMap:(id)mapId {
+  [_channel invokeMethod:@"map#onCameraIdle" arguments:@{@"map":mapId}];
+}
+
+-(void)onMarkerTappedOnMap:(id)mapId marker:(NSString*)markerId {
+  [_channel invokeMethod:@"marker#onTap" arguments:@{@"map":mapId, @"marker":markerId}];
+}
 @end
+
+// Implementations of JSON conversion functions.
+
+static id locationToJson(CLLocationCoordinate2D position) {
+  return @[@(position.latitude), @(position.longitude)];
+}
+
+static id positionToJson(GMSCameraPosition* position) {
+  return @{
+           @"target": locationToJson([position target]),
+           @"zoom": @([position zoom]),
+           @"bearing": @([position bearing]),
+           @"tilt": @([position viewingAngle]),
+           };
+}
+
+static bool toBool(id json) {
+  NSNumber* data = json;
+  return data.boolValue;
+}
+
+static int toInt(id json) {
+  NSNumber* data = json;
+  return data.intValue;
+}
+
+static double toDouble(id json) {
+  NSNumber* data = json;
+  return data.doubleValue;
+}
+
+static float toFloat(id json) {
+  NSNumber* data = json;
+  return data.floatValue;
+}
+
+static CLLocationCoordinate2D toLocation(id json) {
+  NSArray* data = json;
+  return CLLocationCoordinate2DMake(toDouble(data[0]), toDouble(data[1]));
+}
+
+static CGPoint toPoint(id json) {
+  NSArray* data = json;
+  return CGPointMake(toDouble(data[0]), toDouble(data[1]));
+}
+
+static GMSCameraPosition* toCameraPosition(id json) {
+  NSDictionary* data = json;
+  return [GMSCameraPosition cameraWithTarget:toLocation(data[@"target"])
+                                        zoom:toFloat(data[@"zoom"])
+                                     bearing:toDouble(data[@"bearing"])
+                                viewingAngle:toDouble(data[@"tilt"])];
+}
+
+static GMSCameraPosition* toOptionalCameraPosition(id json) {
+  return json ? toCameraPosition(json) : nil;
+}
+
+static GMSCoordinateBounds* toBounds(id json) {
+  NSArray* data = json;
+  return [[GMSCoordinateBounds alloc] initWithCoordinate:toLocation(data[0]) coordinate:toLocation(data[1])];
+}
+
+static GMSCoordinateBounds* toOptionalBounds(id json) {
+  NSArray* data = json;
+  if ([data[0] isEqual:[NSNull null]]) {
+    return nil;
+  } else {
+    return toBounds(data[0]);
+  }
+}
+
+static GMSMapViewType toMapViewType(id json) {
+  int value = toInt(json);
+  return (GMSMapViewType) (value == 0 ? 5 : value);
+}
+
+static GMSCameraUpdate* toCameraUpdate(id json) {
+  NSArray* data = json;
+  NSString* update = data[0];
+  if ([update isEqualToString:@"newCameraPosition"]) {
+    return [GMSCameraUpdate setCamera:toCameraPosition(data[1])];
+  } else if ([update isEqualToString:@"newLatLng"]) {
+    return [GMSCameraUpdate setTarget:toLocation(data[1])];
+  } else if ([update isEqualToString:@"newLatLngBounds"]) {
+    return [GMSCameraUpdate fitBounds:toBounds(data[1]) withPadding:toDouble(data[2])];
+  } else if ([update isEqualToString:@"newLatLngZoom"]) {
+    return [GMSCameraUpdate setTarget:toLocation(data[1]) zoom:toFloat(data[2])];
+  } else if ([update isEqualToString:@"scrollBy"]) {
+    return [GMSCameraUpdate scrollByX:toDouble(data[1]) Y:toDouble(data[2])];
+  } else if ([update isEqualToString:@"zoomBy"]) {
+    if (data.count == 2) {
+      return [GMSCameraUpdate zoomBy:toFloat(data[1])];
+    } else {
+      return [GMSCameraUpdate zoomBy:toFloat(data[1]) atPoint:toPoint(data[2])];
+    }
+  } else if ([update isEqualToString:@"zoomIn"]) {
+    return [GMSCameraUpdate zoomIn];
+  } else if ([update isEqualToString:@"zoomOut"]) {
+    return [GMSCameraUpdate zoomOut];
+  } else if ([update isEqualToString:@"zoomTo"]) {
+    return [GMSCameraUpdate zoomTo:toFloat(data[1])];
+  }
+  return nil;
+}
+
+static void writeMapOptions(id json, id<FLTGoogleMapOptionsSink> sink) {
+  NSDictionary* data = json;
+  id cameraPosition = data[@"cameraPosition"];
+  if (cameraPosition) {
+    [sink setCamera:toCameraPosition(cameraPosition)];
+  }
+  id compassEnabled = data[@"compassEnabled"];
+  if (compassEnabled) {
+    [sink setCompassEnabled:toBool(compassEnabled)];
+  }
+  id cameraTargetBounds = data[@"latLngCameraTargetBounds"];
+  if (cameraTargetBounds) {
+    [sink setCameraTargetBounds:toOptionalBounds(cameraTargetBounds)];
+  }
+  id mapType = data[@"mapType"];
+  if (mapType) {
+    [sink setMapType:toMapViewType(mapType)];
+  }
+  id minMaxZoomPreference = data[@"minMaxZoomPreference"];
+  if (minMaxZoomPreference) {
+    NSArray* zoomData = minMaxZoomPreference;
+    float minZoom = kGMSMinZoomLevel;
+    float maxZoom = kGMSMaxZoomLevel;
+    if (![zoomData[0] isEqual:[NSNull null]]) {
+      minZoom = toFloat(zoomData[0]);
+    }
+    if (![zoomData[1] isEqual:[NSNull null]]) {
+      maxZoom = toFloat(zoomData[1]);
+    }
+    [sink setMinZoom:minZoom maxZoom:maxZoom];
+  }
+  id rotateGesturesEnabled = data[@"rotateGesturesEnabled"];
+  if (rotateGesturesEnabled) {
+    [sink setRotateGesturesEnabled:toBool(rotateGesturesEnabled)];
+  }
+  id scrollGesturesEnabled = data[@"scrollGesturesEnabled"];
+  if (scrollGesturesEnabled) {
+    [sink setScrollGesturesEnabled:toBool(scrollGesturesEnabled)];
+  }
+  id tiltGesturesEnabled = data[@"tiltGesturesEnabled"];
+  if (tiltGesturesEnabled) {
+    [sink setTiltGesturesEnabled:toBool(tiltGesturesEnabled)];
+  }
+  id trackCameraPosition = data[@"trackCameraPosition"];
+  if (trackCameraPosition) {
+    [sink setTrackCameraPosition:toBool(trackCameraPosition)];
+  }
+  id zoomGesturesEnabled = data[@"zoomGesturesEnabled"];
+  if (zoomGesturesEnabled) {
+    [sink setZoomGesturesEnabled:toBool(zoomGesturesEnabled)];
+  }
+}
+
+static void writeMarkerOptions(id json, id<FLTGoogleMapMarkerOptionsSink> sink, NSObject<FlutterPluginRegistrar>* registrar) {
+  NSDictionary* data = json;
+  id alpha = data[@"alpha"];
+  if (alpha) {
+    [sink setAlpha:toFloat(alpha)];
+  }
+  id anchor = data[@"anchor"];
+  if (anchor) {
+    [sink setAnchor:toPoint(anchor)];
+  }
+  id draggable = data[@"draggable"];
+  if (draggable) {
+    [sink setDraggable:toBool(draggable)];
+  }
+  id icon = data[@"icon"];
+  if (icon) {
+    NSArray* iconData = icon;
+    UIImage* image;
+    if ([iconData[0] isEqualToString:@"defaultMarker"]) {
+      CGFloat hue = (iconData.count == 1) ? 0.0f : toDouble(iconData[1]);
+      image = [GMSMarker markerImageWithColor:[UIColor colorWithHue:hue / 360.0
+                                                         saturation:1.0
+                                                         brightness:0.7
+                                                              alpha:1.0]];
+    } else if ([iconData[0] isEqualToString:@"fromAsset"]) {
+      if (iconData.count == 2) {
+        image = [UIImage imageNamed:[registrar lookupKeyForAsset:iconData[1]]];
+      } else {
+        image = [UIImage imageNamed:[registrar lookupKeyForAsset:iconData[1] fromPackage:iconData[2]]];
+      }
+    }
+    [sink setIcon:image];
+  }
+  id flat = data[@"flat"];
+  if (flat) {
+    [sink setFlat:toBool(flat)];
+  }
+  id infoWindowAnchor = data[@"infoWindowAnchor"];
+  if (infoWindowAnchor) {
+    [sink setInfoWindowAnchor:toPoint(infoWindowAnchor)];
+  }
+  id infoWindowText = data[@"infoWindowText"];
+  if (infoWindowText) {
+    NSArray* infoWindowTextData = infoWindowText;
+    NSString* title = [infoWindowTextData[0] isEqual:[NSNull null]] ? nil : infoWindowTextData[0];
+    NSString* snippet = [infoWindowTextData[1] isEqual:[NSNull null]] ? nil : infoWindowTextData[1];
+    [sink setInfoWindowTitle:title snippet:snippet];
+  }
+  id rotation = data[@"rotation"];
+  if (rotation) {
+    [sink setRotation:toDouble(rotation)];
+  }
+  id visible = data[@"visible"];
+  if (visible) {
+    [sink setVisible:toBool(visible)];
+  }
+  id zIndex = data[@"zIndex"];
+  if (zIndex) {
+    [sink setZIndex:toInt(zIndex)];
+  }
+}

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapsPlugin.m
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapsPlugin.m
@@ -6,8 +6,7 @@
 #import "GoogleMapController.h"
 #import "GoogleMapMarkerController.h"
 
-// Conversion functions between iOS types and JSON-like values sent via platform channels.
-// Forward declarations.
+#pragma mark - Conversion of JSON-like values sent via platform channels. Forward declarations.
 
 static id positionToJson(GMSCameraPosition* position);
 static double toDouble(id json);
@@ -19,7 +18,7 @@ static void writeMapOptions(id json, id<FLTGoogleMapOptionsSink> sink);
 static void writeMarkerOptions(id json, id<FLTGoogleMapMarkerOptionsSink> sink,
                                NSObject<FlutterPluginRegistrar>* registrar);
 
-// GoogleMaps plugin implementation
+#pragma mark - GoogleMaps plugin implementation
 
 @implementation FLTGoogleMapsPlugin {
   NSObject<FlutterPluginRegistrar>* _registrar;
@@ -156,7 +155,7 @@ static void writeMarkerOptions(id json, id<FLTGoogleMapMarkerOptionsSink> sink,
   return controller;
 }
 
-// FLTGoogleMapsDelegate methods, used to send platform messages to Flutter.
+#pragma mark - FLTGoogleMapsDelegate methods, used to send platform messages to Flutter
 
 - (void)onCameraMoveStartedOnMap:(id)mapId gesture:(BOOL)gesture {
   [_channel invokeMethod:@"map#onCameraMoveStarted"
@@ -180,7 +179,7 @@ static void writeMarkerOptions(id json, id<FLTGoogleMapMarkerOptionsSink> sink,
 }
 @end
 
-// Implementations of JSON conversion functions.
+#pragma mark - Implementations of JSON conversion functions.
 
 static id locationToJson(CLLocationCoordinate2D position) {
   return @[ @(position.latitude), @(position.longitude) ];
@@ -292,13 +291,13 @@ static void writeMapOptions(id json, id<FLTGoogleMapOptionsSink> sink) {
   if (cameraPosition) {
     [sink setCamera:toCameraPosition(cameraPosition)];
   }
+  id cameraTargetBounds = data[@"cameraTargetBounds"];
+  if (cameraTargetBounds) {
+    [sink setCameraTargetBounds:toOptionalBounds(cameraTargetBounds)];
+  }
   id compassEnabled = data[@"compassEnabled"];
   if (compassEnabled) {
     [sink setCompassEnabled:toBool(compassEnabled)];
-  }
-  id cameraTargetBounds = data[@"latLngCameraTargetBounds"];
-  if (cameraTargetBounds) {
-    [sink setCameraTargetBounds:toOptionalBounds(cameraTargetBounds)];
   }
   id mapType = data[@"mapType"];
   if (mapType) {

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapsPlugin.m
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapsPlugin.m
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#import "GoogleMapsPlugin.h"
 #import "GoogleMapController.h"
 #import "GoogleMapMarkerController.h"
-#import "GoogleMapsPlugin.h"
 
 // Conversion functions between iOS types and JSON-like values sent via platform channels.
 // Forward declarations.
@@ -16,7 +16,8 @@ static GMSCameraPosition* toOptionalCameraPosition(id json);
 static GMSCoordinateBounds* toOptionalBounds(id json);
 static GMSCameraUpdate* toCameraUpdate(id json);
 static void writeMapOptions(id json, id<FLTGoogleMapOptionsSink> sink);
-static void writeMarkerOptions(id json, id<FLTGoogleMapMarkerOptionsSink> sink, NSObject<FlutterPluginRegistrar>* registrar);
+static void writeMarkerOptions(id json, id<FLTGoogleMapMarkerOptionsSink> sink,
+                               NSObject<FlutterPluginRegistrar>* registrar);
 
 // GoogleMaps plugin implementation
 
@@ -30,11 +31,13 @@ static void writeMarkerOptions(id json, id<FLTGoogleMapMarkerOptionsSink> sink, 
   FlutterMethodChannel* channel =
       [FlutterMethodChannel methodChannelWithName:@"plugins.flutter.io/google_maps"
                                   binaryMessenger:[registrar messenger]];
-  FLTGoogleMapsPlugin* instance = [[FLTGoogleMapsPlugin alloc] initWithRegistrar:registrar channel:channel];
+  FLTGoogleMapsPlugin* instance =
+      [[FLTGoogleMapsPlugin alloc] initWithRegistrar:registrar channel:channel];
   [registrar addMethodCallDelegate:instance channel:channel];
 }
 
-- (instancetype)initWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar channel:(FlutterMethodChannel*)channel {
+- (instancetype)initWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar
+                          channel:(FlutterMethodChannel*)channel {
   self = [super init];
   if (self) {
     _registrar = registrar;
@@ -54,9 +57,10 @@ static void writeMarkerOptions(id json, id<FLTGoogleMapMarkerOptionsSink> sink, 
   } else if ([call.method isEqualToString:@"createMap"]) {
     NSDictionary* options = call.arguments[@"options"];
     GMSCameraPosition* camera = toOptionalCameraPosition(options[@"cameraPosition"]);
-    FLTGoogleMapController* controller = [FLTGoogleMapController controllerWithWidth:toDouble(call.arguments[@"width"])
-                                                                              height:toDouble(call.arguments[@"height"])
-                                                                              camera:camera];
+    FLTGoogleMapController* controller =
+        [FLTGoogleMapController controllerWithWidth:toDouble(call.arguments[@"width"])
+                                             height:toDouble(call.arguments[@"height"])
+                                             camera:camera];
     _mapControllers[controller.mapId] = controller;
     writeMapOptions(options, controller);
     UIView* flutterView = [UIApplication sharedApplication].delegate.window.rootViewController.view;
@@ -123,7 +127,8 @@ static void writeMarkerOptions(id json, id<FLTGoogleMapMarkerOptionsSink> sink, 
     FlutterError* error;
     FLTGoogleMapController* controller = [self mapFromCall:call error:&error];
     if (controller) {
-      writeMarkerOptions(call.arguments[@"options"], [controller markerWithId:call.arguments[@"marker"]], _registrar);
+      writeMarkerOptions(call.arguments[@"options"],
+                         [controller markerWithId:call.arguments[@"marker"]], _registrar);
       result(nil);
     } else {
       result(error);
@@ -142,7 +147,7 @@ static void writeMarkerOptions(id json, id<FLTGoogleMapMarkerOptionsSink> sink, 
   }
 }
 
-- (FLTGoogleMapController*) mapFromCall:(FlutterMethodCall*)call error:(FlutterError**)error {
+- (FLTGoogleMapController*)mapFromCall:(FlutterMethodCall*)call error:(FlutterError**)error {
   id mapId = call.arguments[@"map"];
   FLTGoogleMapController* controller = _mapControllers[mapId];
   if (!controller && error) {
@@ -153,36 +158,41 @@ static void writeMarkerOptions(id json, id<FLTGoogleMapMarkerOptionsSink> sink, 
 
 // FLTGoogleMapsDelegate methods, used to send platform messages to Flutter.
 
--(void)onCameraMoveStartedOnMap:(id)mapId gesture:(BOOL)gesture {
-  [_channel invokeMethod:@"map#onCameraMoveStarted" arguments:@{@"map":mapId, @"isGesture":@(gesture)}];
+- (void)onCameraMoveStartedOnMap:(id)mapId gesture:(BOOL)gesture {
+  [_channel invokeMethod:@"map#onCameraMoveStarted"
+               arguments:@{
+                 @"map" : mapId,
+                 @"isGesture" : @(gesture)
+               }];
 }
 
--(void)onCameraMoveOnMap:(id)mapId cameraPosition:(GMSCameraPosition*)cameraPosition {
-  [_channel invokeMethod:@"map#onCameraMove" arguments:@{@"map":mapId, @"position":positionToJson(cameraPosition)}];
+- (void)onCameraMoveOnMap:(id)mapId cameraPosition:(GMSCameraPosition*)cameraPosition {
+  [_channel invokeMethod:@"map#onCameraMove"
+               arguments:@{@"map" : mapId, @"position" : positionToJson(cameraPosition)}];
 }
 
--(void)onCameraIdleOnMap:(id)mapId {
-  [_channel invokeMethod:@"map#onCameraIdle" arguments:@{@"map":mapId}];
+- (void)onCameraIdleOnMap:(id)mapId {
+  [_channel invokeMethod:@"map#onCameraIdle" arguments:@{@"map" : mapId}];
 }
 
--(void)onMarkerTappedOnMap:(id)mapId marker:(NSString*)markerId {
-  [_channel invokeMethod:@"marker#onTap" arguments:@{@"map":mapId, @"marker":markerId}];
+- (void)onMarkerTappedOnMap:(id)mapId marker:(NSString*)markerId {
+  [_channel invokeMethod:@"marker#onTap" arguments:@{@"map" : mapId, @"marker" : markerId}];
 }
 @end
 
 // Implementations of JSON conversion functions.
 
 static id locationToJson(CLLocationCoordinate2D position) {
-  return @[@(position.latitude), @(position.longitude)];
+  return @[ @(position.latitude), @(position.longitude) ];
 }
 
 static id positionToJson(GMSCameraPosition* position) {
   return @{
-           @"target": locationToJson([position target]),
-           @"zoom": @([position zoom]),
-           @"bearing": @([position bearing]),
-           @"tilt": @([position viewingAngle]),
-           };
+    @"target" : locationToJson([position target]),
+    @"zoom" : @([position zoom]),
+    @"bearing" : @([position bearing]),
+    @"tilt" : @([position viewingAngle]),
+  };
 }
 
 static bool toBool(id json) {
@@ -229,7 +239,8 @@ static GMSCameraPosition* toOptionalCameraPosition(id json) {
 
 static GMSCoordinateBounds* toBounds(id json) {
   NSArray* data = json;
-  return [[GMSCoordinateBounds alloc] initWithCoordinate:toLocation(data[0]) coordinate:toLocation(data[1])];
+  return [[GMSCoordinateBounds alloc] initWithCoordinate:toLocation(data[0])
+                                              coordinate:toLocation(data[1])];
 }
 
 static GMSCoordinateBounds* toOptionalBounds(id json) {
@@ -243,7 +254,7 @@ static GMSCoordinateBounds* toOptionalBounds(id json) {
 
 static GMSMapViewType toMapViewType(id json) {
   int value = toInt(json);
-  return (GMSMapViewType) (value == 0 ? 5 : value);
+  return (GMSMapViewType)(value == 0 ? 5 : value);
 }
 
 static GMSCameraUpdate* toCameraUpdate(id json) {
@@ -328,7 +339,8 @@ static void writeMapOptions(id json, id<FLTGoogleMapOptionsSink> sink) {
   }
 }
 
-static void writeMarkerOptions(id json, id<FLTGoogleMapMarkerOptionsSink> sink, NSObject<FlutterPluginRegistrar>* registrar) {
+static void writeMarkerOptions(id json, id<FLTGoogleMapMarkerOptionsSink> sink,
+                               NSObject<FlutterPluginRegistrar>* registrar) {
   NSDictionary* data = json;
   id alpha = data[@"alpha"];
   if (alpha) {
@@ -356,7 +368,8 @@ static void writeMarkerOptions(id json, id<FLTGoogleMapMarkerOptionsSink> sink, 
       if (iconData.count == 2) {
         image = [UIImage imageNamed:[registrar lookupKeyForAsset:iconData[1]]];
       } else {
-        image = [UIImage imageNamed:[registrar lookupKeyForAsset:iconData[1] fromPackage:iconData[2]]];
+        image =
+            [UIImage imageNamed:[registrar lookupKeyForAsset:iconData[1] fromPackage:iconData[2]]];
       }
     }
     [sink setIcon:image];

--- a/packages/google_maps_flutter/ios/google_maps_flutter.podspec
+++ b/packages/google_maps_flutter/ios/google_maps_flutter.podspec
@@ -15,7 +15,7 @@ A new flutter plugin project.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  
+  s.dependency 'GoogleMaps'
+  s.compiler_flags = '-fno-modules'
   s.ios.deployment_target = '8.0'
 end
-

--- a/packages/google_maps_flutter/ios/google_maps_flutter.podspec
+++ b/packages/google_maps_flutter/ios/google_maps_flutter.podspec
@@ -16,6 +16,7 @@ A new flutter plugin project.
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.dependency 'GoogleMaps'
+  # Alternatively to the flag: use GoogleMaps as a static framework.
   s.compiler_flags = '-fno-modules'
   s.ios.deployment_target = '8.0'
 end

--- a/packages/google_maps_flutter/lib/src/bitmap.dart
+++ b/packages/google_maps_flutter/lib/src/bitmap.dart
@@ -43,17 +43,6 @@ class BitmapDescriptor {
     }
   }
 
-  /// Creates a BitmapDescriptor using the name of a bitmap image file located
-  /// in storage private to the app.
-  static BitmapDescriptor fromFile(String fileName) {
-    return new BitmapDescriptor._(<dynamic>['fromFile', fileName]);
-  }
-
-  /// Creates a BitmapDescriptor from the absolute file path of a bitmap image.
-  static BitmapDescriptor fromPath(String path) {
-    return new BitmapDescriptor._(<dynamic>['fromPath', path]);
-  }
-
   final dynamic _json;
 
   dynamic _toJson() => _json;

--- a/packages/google_maps_flutter/lib/src/camera.dart
+++ b/packages/google_maps_flutter/lib/src/camera.dart
@@ -59,7 +59,7 @@ class CameraUpdate {
     return new CameraUpdate._(<dynamic>[
       'newLatLngBounds',
       bounds._toJson(),
-      padding * window.devicePixelRatio,
+      padding,
     ]);
   }
 
@@ -69,13 +69,9 @@ class CameraUpdate {
     );
   }
 
-  static CameraUpdate scrollBy(double xPixel, double yPixel) {
+  static CameraUpdate scrollBy(double dx, double dy) {
     return new CameraUpdate._(
-      <dynamic>[
-        'scrollBy',
-        xPixel * window.devicePixelRatio,
-        yPixel * window.devicePixelRatio,
-      ],
+      <dynamic>['scrollBy', dx, dy],
     );
   }
 
@@ -83,7 +79,6 @@ class CameraUpdate {
     if (focus == null) {
       return new CameraUpdate._(<dynamic>['zoomBy', amount]);
     } else {
-      focus *= window.devicePixelRatio;
       return new CameraUpdate._(<dynamic>[
         'zoomBy',
         amount,

--- a/packages/google_maps_flutter/lib/src/controller.dart
+++ b/packages/google_maps_flutter/lib/src/controller.dart
@@ -72,22 +72,22 @@ class GoogleMapController extends ChangeNotifier {
 
   void _handleMethodCall(MethodCall call) {
     switch (call.method) {
-      case "marker#onTap":
+      case 'marker#onTap':
         final String markerId = call.arguments['marker'];
         final Marker marker = _markers[markerId];
         if (marker != null) {
           onMarkerTapped(marker);
         }
         break;
-      case "map#onCameraMoveStarted":
+      case 'map#onCameraMoveStarted':
         _isCameraMoving = true;
         notifyListeners();
         break;
-      case "map#onCameraMove":
+      case 'map#onCameraMove':
         _cameraPosition = CameraPosition._fromJson(call.arguments['position']);
         notifyListeners();
         break;
-      case "map#onCameraIdle":
+      case 'map#onCameraIdle':
         _isCameraMoving = false;
         notifyListeners();
         break;

--- a/packages/google_maps_flutter/lib/src/controller.dart
+++ b/packages/google_maps_flutter/lib/src/controller.dart
@@ -99,7 +99,7 @@ class GoogleMapController extends ChangeNotifier {
   Future<void> updateMapOptions(GoogleMapOptions options) async {
     assert(options != null);
     final int id = await this.id;
-    await _channel.invokeMethod('setMapOptions', <String, dynamic>{
+    await _channel.invokeMethod('updateMapOptions', <String, dynamic>{
       'map': id,
       'options': options._toJson(),
     });
@@ -220,22 +220,22 @@ class _GoogleMapsPlatformOverlay extends PlatformOverlay {
   Completer<int> _textureId = new Completer<int>();
 
   @override
-  Future<int> create(Size physicalSize) {
+  Future<int> create(Size size) {
     _textureId.complete(_channel.invokeMethod('createMap', <String, dynamic>{
-      'width': physicalSize.width,
-      'height': physicalSize.height,
+      'width': size.width,
+      'height': size.height,
       'options': options._toJson(),
     }).then<int>((dynamic value) => value));
     return _textureId.future;
   }
 
   @override
-  Future<void> show(Offset physicalOffset) async {
+  Future<void> show(Offset offset) async {
     final int id = await _textureId.future;
     _channel.invokeMethod('showMapOverlay', <String, dynamic>{
       'map': id,
-      'x': physicalOffset.dx,
-      'y': physicalOffset.dy,
+      'x': offset.dx,
+      'y': offset.dy,
     });
   }
 

--- a/packages/google_maps_flutter/lib/src/marker.dart
+++ b/packages/google_maps_flutter/lib/src/marker.dart
@@ -33,7 +33,12 @@ class Marker {
   MarkerOptions get options => _options;
 }
 
-dynamic _offsetToJson(Offset offset) => <dynamic>[offset.dx, offset.dy];
+dynamic _offsetToJson(Offset offset) {
+  if (offset == null) {
+    return null;
+  }
+  return <dynamic>[offset.dx, offset.dy];
+}
 
 /// Text labels for a [Marker] info window.
 class InfoWindowText {
@@ -54,12 +59,11 @@ class InfoWindowText {
 class MarkerOptions {
   final double alpha;
   final Offset anchor;
-  final bool consumesTapEvents;
+  final bool consumeTapEvents;
   final bool draggable;
   final bool flat;
   final BitmapDescriptor icon;
   final Offset infoWindowAnchor;
-  final bool infoWindowShown;
   final InfoWindowText infoWindowText;
   final LatLng position;
   final double rotation;
@@ -69,12 +73,11 @@ class MarkerOptions {
   const MarkerOptions({
     this.alpha,
     this.anchor,
-    this.consumesTapEvents,
+    this.consumeTapEvents,
     this.draggable,
     this.flat,
     this.icon,
     this.infoWindowAnchor,
-    this.infoWindowShown,
     this.infoWindowText,
     this.position,
     this.rotation,
@@ -85,12 +88,11 @@ class MarkerOptions {
   static const MarkerOptions defaultOptions = const MarkerOptions(
     alpha: 1.0,
     anchor: const Offset(0.5, 1.0),
-    consumesTapEvents: false,
+    consumeTapEvents: false,
     draggable: false,
     flat: false,
     icon: BitmapDescriptor.defaultMarker,
     infoWindowAnchor: const Offset(0.5, 0.0),
-    infoWindowShown: false,
     infoWindowText: InfoWindowText.noText,
     rotation: 0.0,
     visible: true,
@@ -101,12 +103,11 @@ class MarkerOptions {
     return new MarkerOptions(
       alpha: changes.alpha ?? alpha,
       anchor: changes.anchor ?? anchor,
-      consumesTapEvents: changes.consumesTapEvents ?? consumesTapEvents,
+      consumeTapEvents: changes.consumeTapEvents ?? consumeTapEvents,
       draggable: changes.draggable ?? draggable,
       flat: changes.flat ?? flat,
       icon: changes.icon ?? icon,
       infoWindowAnchor: changes.infoWindowAnchor ?? infoWindowAnchor,
-      infoWindowShown: changes.infoWindowShown ?? infoWindowShown,
       infoWindowText: changes.infoWindowText ?? infoWindowText,
       position: changes.position ?? position,
       rotation: changes.rotation ?? rotation,
@@ -117,22 +118,25 @@ class MarkerOptions {
 
   dynamic _toJson() {
     final Map<String, dynamic> json = <String, dynamic>{};
-    if (alpha != null) json['alpha'] = alpha;
-    if (anchor != null) json['anchor'] = _offsetToJson(anchor);
-    if (consumesTapEvents != null)
-      json['consumesTapEvents'] = consumesTapEvents;
-    if (draggable != null) json['draggable'] = draggable;
-    if (flat != null) json['flat'] = flat;
-    if (icon != null) json['icon'] = icon._toJson();
-    if (infoWindowAnchor != null)
-      json['infoWindowAnchor'] = _offsetToJson(infoWindowAnchor);
-    if (infoWindowShown != null) json['infoWindowShown'] = infoWindowShown;
-    if (infoWindowText != null)
-      json['infoWindowText'] = infoWindowText._toJson();
-    if (position != null) json['position'] = position._toJson();
-    if (rotation != null) json['rotation'] = rotation;
-    if (visible != null) json['visible'] = visible;
-    if (zIndex != null) json['zIndex'] = zIndex;
+
+    void addIfPresent(String fieldName, dynamic value) {
+      if (value != null) {
+        json[fieldName] = value;
+      }
+    }
+
+    addIfPresent('alpha', alpha);
+    addIfPresent('anchor', _offsetToJson(anchor));
+    addIfPresent('consumeTapEvents', consumeTapEvents);
+    addIfPresent('draggable', draggable);
+    addIfPresent('flat', flat);
+    addIfPresent('icon', icon?._toJson());
+    addIfPresent('infoWindowAnchor', _offsetToJson(infoWindowAnchor));
+    addIfPresent('infoWindowText', infoWindowText?._toJson());
+    addIfPresent('position', position?._toJson());
+    addIfPresent('rotation', rotation);
+    addIfPresent('visible', visible);
+    addIfPresent('zIndex', zIndex);
     return json;
   }
 }

--- a/packages/google_maps_flutter/lib/src/marker.dart
+++ b/packages/google_maps_flutter/lib/src/marker.dart
@@ -128,7 +128,7 @@ class MarkerOptions {
     if (flat != null)
       json['flat'] = flat;
     if (icon != null)
-      json['icon'] = icon?._toJson();
+      json['icon'] = icon._toJson();
     if (infoWindowAnchor != null)
       json['infoWindowAnchor'] = _offsetToJson(infoWindowAnchor);
     if (infoWindowShown != null)

--- a/packages/google_maps_flutter/lib/src/marker.dart
+++ b/packages/google_maps_flutter/lib/src/marker.dart
@@ -33,8 +33,7 @@ class Marker {
   MarkerOptions get options => _options;
 }
 
-dynamic _offsetToJson(Offset offset) =>
-    offset == null ? null : <dynamic>[offset.dx, offset.dy];
+dynamic _offsetToJson(Offset offset) => <dynamic>[offset.dx, offset.dy];
 
 /// Text labels for a [Marker] info window.
 class InfoWindowText {
@@ -51,8 +50,7 @@ class InfoWindowText {
 /// Configuration options for [Marker] instances.
 ///
 /// When used to change configuration, null values will be interpreted as
-/// "do not change this configuration item". When used to represent current
-/// configuration, all values will be non-null.
+/// "do not change this configuration item".
 class MarkerOptions {
   final double alpha;
   final Offset anchor;
@@ -118,20 +116,33 @@ class MarkerOptions {
   }
 
   dynamic _toJson() {
-    return <String, dynamic>{
-      'alpha': alpha,
-      'anchor': _offsetToJson(anchor),
-      'consumesTapEvents': consumesTapEvents,
-      'draggable': draggable,
-      'flat': flat,
-      'icon': icon?._toJson(),
-      'infoWindowAnchor': _offsetToJson(infoWindowAnchor),
-      'infoWindowShown': infoWindowShown,
-      'infoWindowText': infoWindowText?._toJson(),
-      'position': position?._toJson(),
-      'rotation': rotation,
-      'visible': visible,
-      'zIndex': zIndex,
-    };
+    final Map<String, dynamic> json = <String, dynamic>{};
+    if (alpha != null)
+      json['alpha'] = alpha;
+    if (anchor != null)
+      json['anchor'] = _offsetToJson(anchor);
+    if (consumesTapEvents != null)
+      json['consumesTapEvents'] = consumesTapEvents;
+    if (draggable != null)
+      json['draggable'] = draggable;
+    if (flat != null)
+      json['flat'] = flat;
+    if (icon != null)
+      json['icon'] = icon?._toJson();
+    if (infoWindowAnchor != null)
+      json['infoWindowAnchor'] = _offsetToJson(infoWindowAnchor);
+    if (infoWindowShown != null)
+      json['infoWindowShown'] = infoWindowShown;
+    if (infoWindowText != null)
+      json['infoWindowText'] = infoWindowText._toJson();
+    if (position != null)
+      json['position'] = position._toJson();
+    if (rotation != null)
+      json['rotation'] = rotation;
+    if (visible != null)
+      json['visible'] = visible;
+    if (zIndex != null)
+      json['zIndex'] = zIndex;
+    return json;
   }
 }

--- a/packages/google_maps_flutter/lib/src/marker.dart
+++ b/packages/google_maps_flutter/lib/src/marker.dart
@@ -117,32 +117,22 @@ class MarkerOptions {
 
   dynamic _toJson() {
     final Map<String, dynamic> json = <String, dynamic>{};
-    if (alpha != null)
-      json['alpha'] = alpha;
-    if (anchor != null)
-      json['anchor'] = _offsetToJson(anchor);
+    if (alpha != null) json['alpha'] = alpha;
+    if (anchor != null) json['anchor'] = _offsetToJson(anchor);
     if (consumesTapEvents != null)
       json['consumesTapEvents'] = consumesTapEvents;
-    if (draggable != null)
-      json['draggable'] = draggable;
-    if (flat != null)
-      json['flat'] = flat;
-    if (icon != null)
-      json['icon'] = icon._toJson();
+    if (draggable != null) json['draggable'] = draggable;
+    if (flat != null) json['flat'] = flat;
+    if (icon != null) json['icon'] = icon._toJson();
     if (infoWindowAnchor != null)
       json['infoWindowAnchor'] = _offsetToJson(infoWindowAnchor);
-    if (infoWindowShown != null)
-      json['infoWindowShown'] = infoWindowShown;
+    if (infoWindowShown != null) json['infoWindowShown'] = infoWindowShown;
     if (infoWindowText != null)
       json['infoWindowText'] = infoWindowText._toJson();
-    if (position != null)
-      json['position'] = position._toJson();
-    if (rotation != null)
-      json['rotation'] = rotation;
-    if (visible != null)
-      json['visible'] = visible;
-    if (zIndex != null)
-      json['zIndex'] = zIndex;
+    if (position != null) json['position'] = position._toJson();
+    if (rotation != null) json['rotation'] = rotation;
+    if (visible != null) json['visible'] = visible;
+    if (zIndex != null) json['zIndex'] = zIndex;
     return json;
   }
 }

--- a/packages/google_maps_flutter/lib/src/platform_overlay.dart
+++ b/packages/google_maps_flutter/lib/src/platform_overlay.dart
@@ -63,8 +63,7 @@ class PlatformOverlayController extends NavigatorObserver
         return;
       }
       if (!_overlayIdCompleter.isCompleted) {
-        _overlayIdCompleter.complete(
-            overlay.create(new Size(width, height) * window.devicePixelRatio));
+        _overlayIdCompleter.complete(overlay.create(new Size(width, height)));
       }
     });
   }
@@ -88,7 +87,7 @@ class PlatformOverlayController extends NavigatorObserver
         final RenderObject object = _context?.findRenderObject();
         Offset offset;
         if (object is RenderBox) {
-          offset = object.localToGlobal(Offset.zero) * window.devicePixelRatio;
+          offset = object.localToGlobal(Offset.zero);
         } else {
           offset = Offset.zero;
         }
@@ -207,15 +206,14 @@ class PlatformOverlayController extends NavigatorObserver
 
 /// Platform overlay.
 abstract class PlatformOverlay {
-  /// Creates a platform view of the specified [physicalSize] (in device pixels).
+  /// Creates a platform view of the specified [size].
   ///
   /// The platform view should remain hidden until explicitly shown by calling
   /// [showOverlay].
-  Future<int> create(Size physicalSize);
+  Future<int> create(Size size);
 
-  /// Shows the platform view at the specified [physicalOffset] (in device
-  /// pixels).
-  Future<void> show(Offset physicalOffset);
+  /// Shows the platform view at the specified [offset].
+  Future<void> show(Offset offset);
 
   /// Hides the platform view.
   Future<void> hide();

--- a/packages/google_maps_flutter/lib/src/ui.dart
+++ b/packages/google_maps_flutter/lib/src/ui.dart
@@ -18,14 +18,14 @@ enum MapType {
 }
 
 /// Bounds for the map camera target.
-class LatLngCameraTargetBounds {
-  const LatLngCameraTargetBounds(this.bounds);
+class CameraTargetBounds {
+  const CameraTargetBounds(this.bounds);
 
   /// The current bounds or null, if the camera target is unbounded.
   final LatLngBounds bounds;
 
-  static const LatLngCameraTargetBounds unbounded =
-      const LatLngCameraTargetBounds(null);
+  static const CameraTargetBounds unbounded =
+      const CameraTargetBounds(null);
 
   dynamic _toJson() => <dynamic>[bounds?._toJson()];
 }
@@ -54,7 +54,7 @@ class MinMaxZoomPreference {
 class GoogleMapOptions {
   final CameraPosition cameraPosition;
   final bool compassEnabled;
-  final LatLngCameraTargetBounds latLngCameraTargetBounds;
+  final CameraTargetBounds cameraTargetBounds;
   final MapType mapType;
   final MinMaxZoomPreference minMaxZoomPreference;
   final bool rotateGesturesEnabled;
@@ -66,7 +66,7 @@ class GoogleMapOptions {
   const GoogleMapOptions({
     this.cameraPosition,
     this.compassEnabled,
-    this.latLngCameraTargetBounds,
+    this.cameraTargetBounds,
     this.mapType,
     this.minMaxZoomPreference,
     this.rotateGesturesEnabled,
@@ -78,7 +78,7 @@ class GoogleMapOptions {
 
   static const GoogleMapOptions defaultOptions = const GoogleMapOptions(
     compassEnabled: true,
-    latLngCameraTargetBounds: LatLngCameraTargetBounds.unbounded,
+    cameraTargetBounds: CameraTargetBounds.unbounded,
     mapType: MapType.normal,
     minMaxZoomPreference: MinMaxZoomPreference.unbounded,
     rotateGesturesEnabled: true,
@@ -92,8 +92,7 @@ class GoogleMapOptions {
     return new GoogleMapOptions(
       cameraPosition: change.cameraPosition ?? cameraPosition,
       compassEnabled: change.compassEnabled ?? compassEnabled,
-      latLngCameraTargetBounds:
-          change.latLngCameraTargetBounds ?? latLngCameraTargetBounds,
+      cameraTargetBounds: change.cameraTargetBounds ?? cameraTargetBounds,
       mapType: change.mapType ?? mapType,
       minMaxZoomPreference: change.minMaxZoomPreference ?? minMaxZoomPreference,
       rotateGesturesEnabled:
@@ -108,24 +107,23 @@ class GoogleMapOptions {
 
   dynamic _toJson() {
     final Map<String, dynamic> json = <String, dynamic>{};
-    if (cameraPosition != null)
-      json['cameraPosition'] = cameraPosition._toJson();
-    if (compassEnabled != null) json['compassEnabled'] = compassEnabled;
-    if (latLngCameraTargetBounds != null)
-      json['latLngCameraTargetBounds'] = latLngCameraTargetBounds._toJson();
-    if (mapType != null) json['mapType'] = mapType.index;
-    if (minMaxZoomPreference != null)
-      json['minMaxZoomPreference'] = minMaxZoomPreference._toJson();
-    if (rotateGesturesEnabled != null)
-      json['rotateGesturesEnabled'] = rotateGesturesEnabled;
-    if (scrollGesturesEnabled != null)
-      json['scrollGesturesEnabled'] = scrollGesturesEnabled;
-    if (tiltGesturesEnabled != null)
-      json['tiltGesturesEnabled'] = tiltGesturesEnabled;
-    if (trackCameraPosition != null)
-      json['trackCameraPosition'] = trackCameraPosition;
-    if (zoomGesturesEnabled != null)
-      json['zoomGesturesEnabled'] = zoomGesturesEnabled;
+
+    void addIfPresent(String fieldName, dynamic value) {
+      if (value != null) {
+        json[fieldName] = value;
+      }
+    }
+
+    addIfPresent('cameraPosition', cameraPosition?._toJson());
+    addIfPresent('compassEnabled', compassEnabled);
+    addIfPresent('cameraTargetBounds', cameraTargetBounds?._toJson());
+    addIfPresent('mapType', mapType?.index);
+    addIfPresent('minMaxZoomPreference', minMaxZoomPreference?._toJson());
+    addIfPresent('rotateGesturesEnabled', rotateGesturesEnabled);
+    addIfPresent('scrollGesturesEnabled', scrollGesturesEnabled);
+    addIfPresent('tiltGesturesEnabled', tiltGesturesEnabled);
+    addIfPresent('trackCameraPosition', trackCameraPosition);
+    addIfPresent('zoomGesturesEnabled', zoomGesturesEnabled);
     return json;
   }
 }

--- a/packages/google_maps_flutter/lib/src/ui.dart
+++ b/packages/google_maps_flutter/lib/src/ui.dart
@@ -50,8 +50,7 @@ class MinMaxZoomPreference {
 /// Configuration options for the GoogleMaps user interface.
 ///
 /// When used to change configuration, null values will be interpreted as
-/// "do not change this configuration item". When used to represent current
-/// configuration, all values will be non-null.
+/// "do not change this configuration item".
 class GoogleMapOptions {
   final CameraPosition cameraPosition;
   final bool compassEnabled;
@@ -109,17 +108,26 @@ class GoogleMapOptions {
 
   dynamic _toJson() {
     final Map<String, dynamic> json = <String, dynamic>{};
-    json['cameraPosition'] = cameraPosition?._toJson();
-    json['compassEnabled'] = compassEnabled;
-    json['latLngCameraTargetBounds'] = latLngCameraTargetBounds?._toJson();
-    json['mapType'] = mapType?.index;
-    json['minMaxZoomPreference'] = minMaxZoomPreference?._toJson();
-    json['reportCameraMoveEvents'] = trackCameraPosition;
-    json['rotateGesturesEnabled'] = rotateGesturesEnabled;
-    json['scrollGesturesEnabled'] = scrollGesturesEnabled;
-    json['tiltGesturesEnabled'] = tiltGesturesEnabled;
-    json['trackCameraPosition'] = trackCameraPosition;
-    json['zoomGesturesEnabled'] = zoomGesturesEnabled;
+    if (cameraPosition != null)
+      json['cameraPosition'] = cameraPosition._toJson();
+    if (compassEnabled != null)
+      json['compassEnabled'] = compassEnabled;
+    if (latLngCameraTargetBounds != null)
+      json['latLngCameraTargetBounds'] = latLngCameraTargetBounds._toJson();
+    if (mapType != null)
+      json['mapType'] = mapType.index;
+    if (minMaxZoomPreference != null)
+      json['minMaxZoomPreference'] = minMaxZoomPreference._toJson();
+    if (rotateGesturesEnabled != null)
+      json['rotateGesturesEnabled'] = rotateGesturesEnabled;
+    if (scrollGesturesEnabled != null)
+      json['scrollGesturesEnabled'] = scrollGesturesEnabled;
+    if (tiltGesturesEnabled != null)
+      json['tiltGesturesEnabled'] = tiltGesturesEnabled;
+    if (trackCameraPosition != null)
+      json['trackCameraPosition'] = trackCameraPosition;
+    if (zoomGesturesEnabled != null)
+      json['zoomGesturesEnabled'] = zoomGesturesEnabled;
     return json;
   }
 }

--- a/packages/google_maps_flutter/lib/src/ui.dart
+++ b/packages/google_maps_flutter/lib/src/ui.dart
@@ -24,8 +24,7 @@ class CameraTargetBounds {
   /// The current bounds or null, if the camera target is unbounded.
   final LatLngBounds bounds;
 
-  static const CameraTargetBounds unbounded =
-      const CameraTargetBounds(null);
+  static const CameraTargetBounds unbounded = const CameraTargetBounds(null);
 
   dynamic _toJson() => <dynamic>[bounds?._toJson()];
 }

--- a/packages/google_maps_flutter/lib/src/ui.dart
+++ b/packages/google_maps_flutter/lib/src/ui.dart
@@ -110,12 +110,10 @@ class GoogleMapOptions {
     final Map<String, dynamic> json = <String, dynamic>{};
     if (cameraPosition != null)
       json['cameraPosition'] = cameraPosition._toJson();
-    if (compassEnabled != null)
-      json['compassEnabled'] = compassEnabled;
+    if (compassEnabled != null) json['compassEnabled'] = compassEnabled;
     if (latLngCameraTargetBounds != null)
       json['latLngCameraTargetBounds'] = latLngCameraTargetBounds._toJson();
-    if (mapType != null)
-      json['mapType'] = mapType.index;
+    if (mapType != null) json['mapType'] = mapType.index;
     if (minMaxZoomPreference != null)
       json['minMaxZoomPreference'] = minMaxZoomPreference._toJson();
     if (rotateGesturesEnabled != null)


### PR DESCRIPTION
* Initial iOS support:
  * Showing and configuring GoogleMaps, no texture snapshotting yet.
  * Adding and configuring markers.
  * Event handling: camera movements and marker taps.
* Dart/Android changes:
  * Don't premultiply with screen density on Dart side.
  * Reason for camera movement now just a boolean value indicating if it was a user gesture.
  * Avoid making null-valued options part of JSON (so we don't have to worry about `[NSNull null]` values on iOS side).
  * Example app now also reflects camera move started/camera idle events.

TBD (later PR): unify API coverage, add tests, texture snapshotting on iOS.