### PR TITLE
Fixed a typo that was causing rewarded video failure event to be called on the wrong listener

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,3 +10,4 @@ larsenthomasj@gmail.com
 Ali Bitek <alibitek@protonmail.ch>
 Pol Batlló <pol.batllo@gmail.com>
 Anatoly Pulyaevskiy
+Stefano Rodriguez <hlsroddy@gmail.com>

--- a/packages/firebase_admob/CHANGELOG.md
+++ b/packages/firebase_admob/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.5.4
+* Fixed a bug that was causing rewarded video failure event to be called on the wrong listener.
+
 ## 0.5.3
 
 * Updated Google Play Services dependencies to version 15.0.0.

--- a/packages/firebase_admob/CHANGELOG.md
+++ b/packages/firebase_admob/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 0.5.4
+
 * Fixed a bug that was causing rewarded video failure event to be called on the wrong listener.
 
 ## 0.5.3

--- a/packages/firebase_admob/android/src/main/java/io/flutter/plugins/firebaseadmob/RewardedVideoAdWrapper.java
+++ b/packages/firebase_admob/android/src/main/java/io/flutter/plugins/firebaseadmob/RewardedVideoAdWrapper.java
@@ -65,7 +65,7 @@ public class RewardedVideoAdWrapper implements RewardedVideoAdListener {
   public void onRewardedVideoAdFailedToLoad(int errorCode) {
     Log.w(TAG, "onRewardedVideoAdFailedToLoad: " + errorCode);
     status = Status.FAILED;
-    channel.invokeMethod("onAdFailedToLoad", argumentsMap("errorCode", errorCode));
+    channel.invokeMethod("onRewardedVideoAdFailedToLoad", argumentsMap("errorCode", errorCode));
   }
 
   enum Status {

--- a/packages/firebase_admob/ios/Classes/FLTRewardedVideoAdWrapper.m
+++ b/packages/firebase_admob/ios/Classes/FLTRewardedVideoAdWrapper.m
@@ -83,7 +83,7 @@ FLTRewardedVideoAdStatus _rewardedStatus;
   NSLog(@"interstitial:didFailToReceiveAdWithError: %@ (MobileAd %@)", [error localizedDescription],
         self);
   _rewardedStatus = FLTRewardedVideoAdStatusFailed;
-  [_rewardedChannel invokeMethod:@"onAdFailedToLoad" arguments:@{}];
+  [_rewardedChannel invokeMethod:@"onRewardedVideoAdFailedToLoad" arguments:@{}];
 }
 
 - (void)rewardBasedVideoAdDidReceiveAd:(nonnull GADRewardBasedVideoAd *)rewardBasedVideoAd {

--- a/packages/firebase_admob/pubspec.yaml
+++ b/packages/firebase_admob/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_admob
 description: Firebase AdMob plugin for Flutter applications.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_admob
-version: 0.5.3
+version: 0.5.4
 
 flutter:
   plugin:


### PR DESCRIPTION
This PR fixes a typo on the rewarded video platform side of the code that was causing the wrong listeners to be called on the failure event.