### PR TITLE
cloud_firestore: prevent crash DocumentSnapshot is null

### DIFF
--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.4
+
+* Fixes crash on Android if a FirebaseFirestoreException happened.
+
 ## 0.6.3
 
 * Updated Google Play Services dependencies to version 15.0.0.

--- a/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
+++ b/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
@@ -194,6 +194,11 @@ public class CloudFirestorePlugin implements MethodCallHandler {
 
     @Override
     public void onEvent(DocumentSnapshot documentSnapshot, FirebaseFirestoreException e) {
+      if (e != null) {
+        // TODO: send error
+        System.out.println(e);
+        return;
+      }
       Map<String, Object> arguments = new HashMap<>();
       arguments.put("handle", handle);
       if (documentSnapshot.exists()) {
@@ -219,6 +224,7 @@ public class CloudFirestorePlugin implements MethodCallHandler {
       if (e != null) {
         // TODO: send error
         System.out.println(e);
+        return;
       }
 
       Map<String, Object> arguments = parseQuerySnapshot(querySnapshot);

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_firestore
-version: 0.6.3
+version: 0.6.4
 
 flutter:
   plugin:


### PR DESCRIPTION
Apps will crash if a FirebaseFirestoreException happened (e.g. if user logged out during request) because the plugin still want's to access the DocumentSnapshot:

```
E/AndroidRuntime(24141): java.lang.NullPointerException: Attempt to invoke virtual method 'boolean com.google.firebase.firestore.DocumentSnapshot.exists()' on a null object reference
E/AndroidRuntime(24141): 	at io.flutter.plugins.firebase.cloudfirestore.CloudFirestorePlugin$DocumentObserver.onEvent(CloudFirestorePlugin.java:199)
E/AndroidRuntime(24141): 	at io.flutter.plugins.firebase.cloudfirestore.CloudFirestorePlugin$DocumentObserver.onEvent(CloudFirestorePlugin.java:188)
```