### PR TITLE
Update firebase_remote_config to use latest version

### DIFF
--- a/packages/firebase_remote_config/android/build.gradle
+++ b/packages/firebase_remote_config/android/build.gradle
@@ -32,7 +32,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        api 'com.google.firebase:firebase-config:[11.4.0,12.0['
-        api 'com.google.firebase:firebase-core:[11.4.0,12.0['
+        api 'com.google.firebase:firebase-config:15.+'
+        api 'com.google.firebase:firebase-core:15.+'
     }
 }


### PR DESCRIPTION
Conform with the other FlutterFire packages.

Avoids the error I/zygote64(31757): Rejecting re-init on previously-failed class java.lang.Class<com.google.android.gms.internal.zzexm>: java.lang.NoClassDefFoundError: Failed resolution of: Lcom/google/android/gms/internal/zzfjm;

Fixes https://github.com/flutter/flutter/issues/17188