### PR TITLE
Add missing await to for transaction in Firestore README

### DIFF
--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.0+2
+
+* Update transactions example in README to add `await`.
+
 ## 0.7.0+1
 
 * Add transactions example to README.

--- a/packages/cloud_firestore/README.md
+++ b/packages/cloud_firestore/README.md
@@ -69,7 +69,7 @@ final DocumentReference postRef = Firestore.instance.document('posts/123');
 Firestore.instance.runTransaction((Transaction tx) async {
   DocumentSnapshot postSnapshot = await tx.get(postRef);
   if (postSnapshot.exists) {
-    tx.update(postRef, <String, dynamic>{'likesCount': postSnapshot.data['likesCount'] + 1});
+    await tx.update(postRef, <String, dynamic>{'likesCount': postSnapshot.data['likesCount'] + 1});
   }
 });
 ```

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_firestore
-version: 0.7.0+1
+version: 0.7.0+2
 
 flutter:
   plugin:


### PR DESCRIPTION
Must use `await` for set, update, delete and get.