### PR TITLE
Adding null-safe handling for Transaction.get in cloud_firestore

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,3 +12,4 @@ Pol Batlló <pol.batllo@gmail.com>
 Anatoly Pulyaevskiy
 Stefano Rodriguez <hlsroddy@gmail.com>
 Salvatore Giordano <salvatoregiordanoo@gmail.com>
+Brian Armstrong <brian@flutter.institute>

--- a/packages/cloud_firestore/lib/src/transaction.dart
+++ b/packages/cloud_firestore/lib/src/transaction.dart
@@ -22,7 +22,7 @@ class Transaction {
     });
     if (result != null) {
       return new DocumentSnapshot._(documentReference.path,
-          result['data'].cast<String, dynamic>(), Firestore.instance);
+          result['data']?.cast<String, dynamic>(), Firestore.instance);
     } else {
       return null;
     }

--- a/packages/cloud_firestore/test/cloud_firestore_test.dart
+++ b/packages/cloud_firestore/test/cloud_firestore_test.dart
@@ -105,10 +105,15 @@ void main() {
           case 'Firestore#runTransaction':
             return <String, dynamic>{'1': 3};
           case 'Transaction#get':
-            return <String, dynamic>{
-              'path': 'foo/bar',
-              'data': <String, dynamic>{'key1': 'val1'}
-            };
+            if (methodCall.arguments['path'] == 'foo/bar') {
+              return <String, dynamic>{
+                'path': 'foo/bar',
+                'data': <String, dynamic>{'key1': 'val1'}
+              };
+            } else if (methodCall.arguments['path'] == 'foo/notExists') {
+              return <String, dynamic>{'path': 'foo/notExists', 'data': null};
+            }
+            throw new PlatformException(code: 'UNKNOWN_PATH');
           case 'Transaction#set':
             return null;
           case 'Transaction#update':
@@ -149,6 +154,19 @@ void main() {
       test('get', () async {
         final DocumentReference documentReference =
             firestore.document('foo/bar');
+        await transaction.get(documentReference);
+        expect(log, <Matcher>[
+          isMethodCall('Transaction#get', arguments: <String, dynamic>{
+            'app': app.name,
+            'transactionId': 0,
+            'path': documentReference.path
+          })
+        ]);
+      });
+
+      test('get notExists', () async {
+        final DocumentReference documentReference =
+            firestore.document('foo/notExists');
         await transaction.get(documentReference);
         expect(log, <Matcher>[
           isMethodCall('Transaction#get', arguments: <String, dynamic>{


### PR DESCRIPTION
If you `.get` a document that doesn't exist, the result's `data` is `null`. This is expected behavior.
Transactions were attempting to `.cast` this to a Map without null-safety.
This caused an error in transactions when getting a document that doesn't exist.
A unit test was added to verify the fix.