### PR TITLE
according to the changelog for 0.7.0

### DIFF
--- a/packages/cloud_firestore/README.md
+++ b/packages/cloud_firestore/README.md
@@ -45,7 +45,7 @@ class BookList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return new StreamBuilder<QuerySnapshot>(
-      stream: Firestore.instance.collection('books').snapshots,
+      stream: Firestore.instance.collection('books').snapshots(),
       builder: (BuildContext context, AsyncSnapshot<QuerySnapshot> snapshot) {
         if (!snapshot.hasData) return new Text('Loading...');
         return new ListView(


### PR DESCRIPTION
> Breaking change. snapshots is now a method instead of a getter.