### PR TITLE
Remove useless code that was causing a crash

### DIFF
--- a/packages/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.1
+
+* Fix a crash during Safari view controller dismiss.
+
 ## 3.0.0
 
 * **Breaking change**. Set SDK constraints to match the Flutter beta release.

--- a/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
+++ b/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
@@ -37,8 +37,6 @@
 
 - (void)safariViewControllerDidFinish:(SFSafariViewController *)controller {
   [controller dismissViewControllerAnimated:YES completion:nil];
-  _url = nil;
-  _flutterResult = nil;
 }
 
 @end

--- a/packages/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/pubspec.yaml
@@ -1,7 +1,7 @@
 name: url_launcher
 description: Flutter plugin for launching a URL on Android and iOS. Supports
   web, phone, SMS, and email schemes.
-version: 3.0.0
+version: 3.0.1
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher
 


### PR DESCRIPTION
Removing these two lines should cause no harm (as the object is anyways deallocated as soon as the animation completes) and prevents a crash that happened when a user dismissed the view controller just before the first page was fully loaded.
