### PR TITLE
Firebase Messaging : On Android, when the Activity is killed, the onLaunch is never using the correct Intent

### DIFF
--- a/packages/firebase_messaging/CHANGELOG.md
+++ b/packages/firebase_messaging/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+* Fix for Android where the onLaunch event is not triggered when the Activity is killed by the OS (or if the Don't keep activities toggle is enabled)
+
 ## 1.0.0
 
 * Bump to released version

--- a/packages/firebase_messaging/android/src/main/java/io/flutter/plugins/firebasemessaging/FirebaseMessagingPlugin.java
+++ b/packages/firebase_messaging/android/src/main/java/io/flutter/plugins/firebasemessaging/FirebaseMessagingPlugin.java
@@ -87,7 +87,11 @@ public class FirebaseMessagingPlugin extends BroadcastReceiver
 
   @Override
   public boolean onNewIntent(Intent intent) {
-    return sendMessageFromIntent("onResume", intent);
+    boolean res = sendMessageFromIntent("onResume", intent);
+    if (res && registrar.activity() != null) {
+      registrar.activity().setIntent(intent);
+    }
+    return res;
   }
 
   /** @return true if intent contained a message to send. */

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Cloud Messaging, a cross-platform
   messaging solution that lets you reliably deliver messages on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_messaging
-version: 1.0.0
+version: 1.0.1
 
 flutter:
   plugin:


### PR DESCRIPTION
This is a fix for the following issue: https://github.com/flutter/flutter/issues/17839

To sum up: when the Activity is killed (or the Don't keep Activities is set to ON in the Developer options) and the user clicks on a notification, the Dart code will never be notified in the `onLaunch`.

The fix is pretty simple, just call:
```java
registrar.activity().setIntent(intent);
```

In the `onNewIntent` method of the [FirebaseMessagingPlugin.java](https://github.com/flutter/plugins/blob/master/packages/firebase_messaging/android/src/main/java/io/flutter/plugins/firebasemessaging/FirebaseMessagingPlugin.java).