### PR TITLE
Fix the break in PackageInfo

### DIFF
--- a/packages/package_info/example/ios/Runner/Info.plist
+++ b/packages/package_info/example/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+        <key>CFBundleDisplayName</key>
+        <string>Package Info Example</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>

--- a/packages/package_info/ios/Classes/PackageInfoPlugin.m
+++ b/packages/package_info/ios/Classes/PackageInfoPlugin.m
@@ -15,8 +15,13 @@
 
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
   if ([call.method isEqualToString:@"getAll"]) {
+    NSString *displayName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
+    // Cannot put nil into a map so return an empty string.
+    if (displayName == nil) {
+      displayName = @"";
+    }
     result(@{
-      @"appName" : [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"],
+      @"appName" : displayName,
       @"packageName" : [[NSBundle mainBundle] bundleIdentifier],
       @"version" : [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"],
       @"buildNumber" : [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"]


### PR DESCRIPTION
CFBundleDisplayName is not a required key in iOS setup which would cause PackageInfo plugin to crash the app.