### PR TITLE
Add Infowindow tapped handler; also rev. google play services to 15.+…

### DIFF
--- a/packages/google_maps_flutter/android/build.gradle
+++ b/packages/google_maps_flutter/android/build.gradle
@@ -33,6 +33,6 @@ android {
     }
 
     dependencies {
-        implementation 'com.google.android.gms:play-services-maps:11.8.0'
+        implementation 'com.google.android.gms:play-services-maps:15.+'
     }
 }

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
@@ -98,6 +98,7 @@ final class GoogleMapController
   void setOnMarkerTappedListener(OnMarkerTappedListener listener) {
     this.onMarkerTappedListener = listener;
   }
+
   void setOnInfoWindowTappedListener(OnInfoWindowTappedListener listener) {
     this.onInfoWindowTappedListener = listener;
   }

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
@@ -45,6 +45,7 @@ final class GoogleMapController
         GoogleMapOptionsSink,
         OnMapReadyCallback,
         GoogleMap.SnapshotReadyCallback,
+        GoogleMap.OnInfoWindowClickListener,
         GoogleMap.OnMarkerClickListener,
         GoogleMap.OnCameraMoveStartedListener,
         GoogleMap.OnCameraMoveListener,
@@ -62,6 +63,7 @@ final class GoogleMapController
   private final Map<String, MarkerController> markers;
   private OnMarkerTappedListener onMarkerTappedListener;
   private OnCameraMoveListener onCameraMoveListener;
+  private OnInfoWindowTappedListener onInfoWindowTappedListener;
   private GoogleMap googleMap;
   private Surface surface;
   private boolean trackCameraPosition = false;
@@ -95,6 +97,9 @@ final class GoogleMapController
 
   void setOnMarkerTappedListener(OnMarkerTappedListener listener) {
     this.onMarkerTappedListener = listener;
+  }
+  void setOnInfoWindowTappedListener(OnInfoWindowTappedListener listener) {
+    this.onInfoWindowTappedListener = listener;
   }
 
   void init() {
@@ -206,6 +211,7 @@ final class GoogleMapController
   public void onMapReady(GoogleMap googleMap) {
     this.googleMap = googleMap;
     result.success(id());
+    googleMap.setOnInfoWindowClickListener(this);
     googleMap.setOnCameraMoveStartedListener(this);
     googleMap.setOnCameraMoveListener(this);
     googleMap.setOnCameraIdleListener(this);
@@ -223,6 +229,11 @@ final class GoogleMapController
     onCameraMoveListener.onCameraMoveStarted(
         reason == GoogleMap.OnCameraMoveStartedListener.REASON_GESTURE);
     cancelSnapshotTimerTasks();
+  }
+
+  @Override
+  public void onInfoWindowClick(Marker marker) {
+    onInfoWindowTappedListener.onInfoWindowTapped(marker);
   }
 
   @Override

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapsPlugin.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapsPlugin.java
@@ -109,6 +109,16 @@ public class GoogleMapsPlugin implements MethodCallHandler, Application.Activity
                   channel.invokeMethod("marker#onTap", arguments);
                 }
               });
+          controller.setOnInfoWindowTappedListener(
+              new OnInfoWindowTappedListener() {
+                @Override
+                public void onInfoWindowTapped(Marker marker) {
+                  final Map<String, Object> arguments = new HashMap<>(2);
+                  arguments.put("map", controller.id());
+                  arguments.put("marker", marker.getId());
+                  channel.invokeMethod("infowindow#onTap", arguments);
+                }
+              });
           // result.success is called from controller when the GoogleMaps instance
           // is ready
           break;

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapsPlugin.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapsPlugin.java
@@ -116,7 +116,7 @@ public class GoogleMapsPlugin implements MethodCallHandler, Application.Activity
                   final Map<String, Object> arguments = new HashMap<>(2);
                   arguments.put("map", controller.id());
                   arguments.put("marker", marker.getId());
-                  channel.invokeMethod("infowindow#onTap", arguments);
+                  channel.invokeMethod("infoWindow#onTap", arguments);
                 }
               });
           // result.success is called from controller when the GoogleMaps instance

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/OnInfoWindowTappedListener.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/OnInfoWindowTappedListener.java
@@ -1,3 +1,7 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package io.flutter.plugins.googlemaps;
 
 import com.google.android.gms.maps.model.Marker;

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/OnInfoWindowTappedListener.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/OnInfoWindowTappedListener.java
@@ -1,0 +1,7 @@
+package io.flutter.plugins.googlemaps;
+
+import com.google.android.gms.maps.model.Marker;
+
+public interface OnInfoWindowTappedListener {
+  void onInfoWindowTapped(Marker marker);
+}

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapController.h
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapController.h
@@ -12,6 +12,7 @@
 - (void)onCameraMoveOnMap:(id)mapId cameraPosition:(GMSCameraPosition*)cameraPosition;
 - (void)onCameraIdleOnMap:(id)mapId;
 - (void)onMarkerTappedOnMap:(id)mapId marker:(NSString*)markerId;
+- (void)onInfoWindowTappedOnMap:(id)mapId marker:(NSString*)markerId;
 @end
 
 // Defines map UI options writable from Flutter.

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapController.m
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapController.m
@@ -149,4 +149,9 @@ static uint64_t _nextMapId = 0;
   [_delegate onMarkerTappedOnMap:_mapId marker:markerId];
   return [marker.userData[1] boolValue];
 }
+
+- (void)mapView:(GMSMapView*)mapView didTapInfoWindow:(GMSMarker*)marker {
+  NSString* markerId = marker.userData[0];
+  [_delegate onInfoWindowTappedOnMap:_mapId marker:markerId];
+}
 @end

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapsPlugin.m
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapsPlugin.m
@@ -138,7 +138,7 @@ static void interpretMarkerOptions(id json, id<FLTGoogleMapMarkerOptionsSink> si
   [_channel invokeMethod:@"marker#onTap" arguments:@{@"map" : mapId, @"marker" : markerId}];
 }
 - (void)onInfoWindowTappedOnMap:(id)mapId marker:(NSString*)markerId {
-  [_channel invokeMethod:@"infowindow#onTap" arguments:@{@"map" : mapId, @"marker" : markerId}];
+  [_channel invokeMethod:@"infoWindow#onTap" arguments:@{@"map" : mapId, @"marker" : markerId}];
 }
 @end
 

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapsPlugin.m
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapsPlugin.m
@@ -137,6 +137,9 @@ static void interpretMarkerOptions(id json, id<FLTGoogleMapMarkerOptionsSink> si
 - (void)onMarkerTappedOnMap:(id)mapId marker:(NSString*)markerId {
   [_channel invokeMethod:@"marker#onTap" arguments:@{@"map" : mapId, @"marker" : markerId}];
 }
+- (void)onInfoWindowTappedOnMap:(id)mapId marker:(NSString*)markerId {
+  [_channel invokeMethod:@"infowindow#onTap" arguments:@{@"map" : mapId, @"marker" : markerId}];
+}
 @end
 
 #pragma mark - Implementations of JSON conversion functions.

--- a/packages/google_maps_flutter/lib/src/controller.dart
+++ b/packages/google_maps_flutter/lib/src/controller.dart
@@ -37,6 +37,8 @@ class GoogleMapController extends ChangeNotifier {
   /// Callbacks to receive tap events for markers placed on this map.
   final ArgumentCallbacks<Marker> onMarkerTapped =
       new ArgumentCallbacks<Marker>();
+
+  /// Callbacks to receive tap events for info windows on markers
   final ArgumentCallbacks<Marker> onInfoWindowTapped =
       new ArgumentCallbacks<Marker>();
 
@@ -84,7 +86,7 @@ class GoogleMapController extends ChangeNotifier {
 
   void _handleMethodCall(MethodCall call) {
     switch (call.method) {
-      case 'infowindow#onTap':
+      case 'infoWindow#onTap':
         final String markerId = call.arguments['marker'];
         final Marker marker = _markers[markerId];
         if (marker != null) {

--- a/packages/google_maps_flutter/lib/src/controller.dart
+++ b/packages/google_maps_flutter/lib/src/controller.dart
@@ -37,6 +37,8 @@ class GoogleMapController extends ChangeNotifier {
   /// Callbacks to receive tap events for markers placed on this map.
   final ArgumentCallbacks<Marker> onMarkerTapped =
       new ArgumentCallbacks<Marker>();
+  final ArgumentCallbacks<Marker> onInfoWindowTapped =
+      new ArgumentCallbacks<Marker>();
 
   /// The configuration options most recently applied via controller
   /// initialization or [updateMapOptions].
@@ -82,6 +84,14 @@ class GoogleMapController extends ChangeNotifier {
 
   void _handleMethodCall(MethodCall call) {
     switch (call.method) {
+      case 'infowindow#onTap':
+        final String markerId = call.arguments['marker'];
+        final Marker marker = _markers[markerId];
+        if (marker != null) {
+          onInfoWindowTapped(marker);
+        }
+        break;
+
       case 'marker#onTap':
         final String markerId = call.arguments['marker'];
         final Marker marker = _markers[markerId];


### PR DESCRIPTION
This pull request adds in a callback for clicking on the map info window. It also updates the google play services to 15.+ to avoid runtime issues with other plugins using a later version of google play.

To use the callback just do something like this in your flutter code:

```
controller.onInfoWindowTapped.add((Marker marker) {
});
```

Note that this feature was mention in this issue: [#17730](https://github.com/flutter/flutter/issues/17730)

The google play issue was mentioned in this issue: [#17926](https://github.com/flutter/flutter/issues/17926)
