### PR TITLE
Implement imagePickerControllerDidCancel for image_picker on iOS

### DIFF
--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.3
+
+* Bugfix: on iOS the `pickVideo` method will now return null when the user cancels picking a video.
+
 ## 0.4.2
 
 * Added support for picking videos.
@@ -11,11 +15,11 @@
 ## 0.4.0
 
 * **Breaking change**. The `source` parameter for the `pickImage` is now required. Also, the `ImageSource.any` option doesn't exist anymore.
-* Use the native Android image gallery for picking images instead of a custom UI. 
+* Use the native Android image gallery for picking images instead of a custom UI.
 
 ## 0.3.1
 
-* Bugfix: Android version correctly asks for runtime camera permission when using `ImageSource.camera`. 
+* Bugfix: Android version correctly asks for runtime camera permission when using `ImageSource.camera`.
 
 ## 0.3.0
 

--- a/packages/image_picker/ios/Classes/ImagePickerPlugin.m
+++ b/packages/image_picker/ios/Classes/ImagePickerPlugin.m
@@ -176,6 +176,14 @@ static const int SOURCE_GALLERY = 1;
   _arguments = nil;
 }
 
+- (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker {
+  [_imagePickerController dismissViewControllerAnimated:YES completion:nil];
+  _result(nil);
+
+  _result = nil;
+  _arguments = nil;
+}
+
 // The way we save images to the tmp dir currently throws away all EXIF data
 // (including the orientation of the image). That means, pics taken in portrait
 // will not be orientated correctly as is. To avoid that, we rotate the actual

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -1,11 +1,11 @@
 name: image_picker
 description: Flutter plugin for selecting images from the Android and iOS image
   library, and taking new pictures with the camera.
-authors: 
+authors:
   - Flutter Team <flutter-dev@googlegroups.com>
   - Rhodes Davis Jr. <rody.davis.jr@gmail.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.4.2
+version: 0.4.3
 
 flutter:
   plugin:


### PR DESCRIPTION
Without this repeated calls to `pickVideo` throw an exception when the request was cancelled during the previous call.

Fixes https://github.com/flutter/flutter/issues/18095.