### PR TITLE
video_player: use exoplayer for better video compatibility

### DIFF
--- a/packages/video_player/CHANGELOG.md
+++ b/packages/video_player/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.5.5
 
-* Android: use ExoPlayer instead of MediaPlayer for better video compatibility
+* Android: use ExoPlayer instead of MediaPlayer for better video format support.
 
 ## 0.5.4
 

--- a/packages/video_player/CHANGELOG.md
+++ b/packages/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.5
+
+* Android: use ExoPlayer instead of MediaPlayer for better video compatibility
+
 ## 0.5.4
 
 * Updated Gradle tooling to match Android Studio 3.1.2.

--- a/packages/video_player/CHANGELOG.md
+++ b/packages/video_player/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.5.5
+## 0.6.0
 
 * Android: use ExoPlayer instead of MediaPlayer for better video format support.
 

--- a/packages/video_player/android/build.gradle
+++ b/packages/video_player/android/build.gradle
@@ -31,4 +31,9 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
+
+    dependencies {
+        implementation 'com.google.android.exoplayer:exoplayer-core:2.8.0'
+    }
+
 }

--- a/packages/video_player/android/build.gradle
+++ b/packages/video_player/android/build.gradle
@@ -35,5 +35,4 @@ android {
     dependencies {
         implementation 'com.google.android.exoplayer:exoplayer-core:2.8.0'
     }
-
 }

--- a/packages/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -110,14 +110,6 @@ public class VideoPlayerPlugin implements MethodCallHandler {
 
       exoPlayer.addListener(
           new DefaultEventListener() {
-            @Override
-            public void onLoadingChanged(final boolean isLoading) {
-              super.onLoadingChanged(isLoading);
-              if (!isLoading) {
-                isInitialized = true;
-                sendInitialized();
-              }
-            }
 
             @Override
             public void onPlayerStateChanged(final boolean playWhenReady, final int playbackState) {
@@ -131,6 +123,9 @@ public class VideoPlayerPlugin implements MethodCallHandler {
                   event.put("values", Collections.singletonList(range));
                   eventSink.success(event);
                 }
+              } else if (playbackState == Player.STATE_READY && !isInitialized) {
+                isInitialized = true;
+                sendInitialized();
               }
             }
 

--- a/packages/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -42,290 +42,290 @@ import java.util.Map;
 
 public class VideoPlayerPlugin implements MethodCallHandler {
 
-    private static class VideoPlayer {
+  private static class VideoPlayer {
 
-        private SimpleExoPlayer exoPlayer;
+    private SimpleExoPlayer exoPlayer;
 
-        private Surface surface;
+    private Surface surface;
 
-        private final TextureRegistry.SurfaceTextureEntry textureEntry;
+    private final TextureRegistry.SurfaceTextureEntry textureEntry;
 
-        private EventChannel.EventSink eventSink;
+    private EventChannel.EventSink eventSink;
 
-        private final EventChannel eventChannel;
+    private final EventChannel eventChannel;
 
-        private boolean isInitialized = false;
+    private boolean isInitialized = false;
 
-        VideoPlayer(Context context, EventChannel eventChannel, TextureRegistry.SurfaceTextureEntry textureEntry, String dataSource, Result result) {
-            this.eventChannel = eventChannel;
-            this.textureEntry = textureEntry;
+    VideoPlayer(Context context, EventChannel eventChannel, TextureRegistry.SurfaceTextureEntry textureEntry, String dataSource, Result result) {
+      this.eventChannel = eventChannel;
+      this.textureEntry = textureEntry;
 
-            TrackSelector trackSelector = new DefaultTrackSelector();
-            exoPlayer = ExoPlayerFactory.newSimpleInstance(context, trackSelector);
+      TrackSelector trackSelector = new DefaultTrackSelector();
+      exoPlayer = ExoPlayerFactory.newSimpleInstance(context, trackSelector);
 
-            Uri uri = Uri.parse(dataSource);
+      Uri uri = Uri.parse(dataSource);
 
-            DataSource.Factory dataSourceFactory;
-            if (uri.getScheme().equals("asset") || uri.getScheme().equals("file")) {
-                dataSourceFactory = new DefaultDataSourceFactory(context, "ExoPlayer");
-            }
-            else {
-                dataSourceFactory = new DefaultHttpDataSourceFactory("ExoPlayer", null, DefaultHttpDataSource.DEFAULT_CONNECT_TIMEOUT_MILLIS, DefaultHttpDataSource.DEFAULT_READ_TIMEOUT_MILLIS, true);
-            }
+      DataSource.Factory dataSourceFactory;
+      if (uri.getScheme().equals("asset") || uri.getScheme().equals("file")) {
+        dataSourceFactory = new DefaultDataSourceFactory(context, "ExoPlayer");
+      }
+      else {
+        dataSourceFactory = new DefaultHttpDataSourceFactory("ExoPlayer", null, DefaultHttpDataSource.DEFAULT_CONNECT_TIMEOUT_MILLIS, DefaultHttpDataSource.DEFAULT_READ_TIMEOUT_MILLIS, true);
+      }
 
-            MediaSource mediaSource = new ExtractorMediaSource.Factory(dataSourceFactory).createMediaSource(uri);
-            exoPlayer.prepare(mediaSource);
+      MediaSource mediaSource = new ExtractorMediaSource.Factory(dataSourceFactory).createMediaSource(uri);
+      exoPlayer.prepare(mediaSource);
 
-            setupVideoPlayer(eventChannel, textureEntry, result);
-        }
-
-        private void setupVideoPlayer(EventChannel eventChannel, TextureRegistry.SurfaceTextureEntry textureEntry, Result result) {
-
-            eventChannel.setStreamHandler(new EventChannel.StreamHandler() {
-                @Override
-                public void onListen(Object o, EventChannel.EventSink sink) {
-                    eventSink = sink;
-                }
-
-                @Override
-                public void onCancel(Object o) {
-                    eventSink = null;
-                }
-            });
-
-            surface = new Surface(textureEntry.surfaceTexture());
-            exoPlayer.setVideoSurface(surface);
-            exoPlayer.setPlayWhenReady(true);
-
-            exoPlayer.addListener(new EventListener() {
-                @Override
-                public void onTimelineChanged(final Timeline timeline, final Object manifest, final int reason) {
-
-                }
-
-                @Override
-                public void onTracksChanged(final TrackGroupArray trackGroups, final TrackSelectionArray trackSelections) {
-
-                }
-
-                @Override
-                public void onLoadingChanged(final boolean isLoading) {
-
-                    if (!isLoading) {
-
-                        isInitialized = true;
-                        sendInitialized();
-                    }
-                    else {
-                        setVolume(0.0);
-                    }
-                }
-
-                @Override
-                public void onPlayerStateChanged(final boolean playWhenReady, final int playbackState) {
-                    if (playbackState == Player.STATE_BUFFERING) {
-                        if (eventSink != null) {
-                            Map<String, Object> event = new HashMap<>();
-                            event.put("event", "bufferingUpdate");
-                            List<Integer> range = Arrays.asList(0, exoPlayer.getBufferedPercentage());
-                            // iOS supports a list of buffered ranges, so here is a list with a single range.
-                            event.put("values", Collections.singletonList(range));
-                            eventSink.success(event);
-                        }
-                    }
-                }
-
-                @Override
-                public void onRepeatModeChanged(final int repeatMode) {
-
-                }
-
-                @Override
-                public void onShuffleModeEnabledChanged(final boolean shuffleModeEnabled) {
-
-                }
-
-                @Override
-                public void onPlayerError(final ExoPlaybackException error) {
-                    if (eventSink != null) {
-                        eventSink.error("VideoError", "Video player had error " + error, null);
-                    }
-                }
-
-                @Override
-                public void onPositionDiscontinuity(final int reason) {
-
-                }
-
-                @Override
-                public void onPlaybackParametersChanged(final PlaybackParameters playbackParameters) {
-
-                }
-
-                @Override
-                public void onSeekProcessed() {
-
-                }
-            });
-
-            Map<String, Object> reply = new HashMap<>();
-            reply.put("textureId", textureEntry.id());
-            result.success(reply);
-        }
-
-        void play() {
-            exoPlayer.setPlayWhenReady(true);
-        }
-
-        void pause() {
-            exoPlayer.setPlayWhenReady(false);
-        }
-
-        void setLooping(boolean value) {
-            exoPlayer.setRepeatMode(value ? REPEAT_MODE_ALL : REPEAT_MODE_OFF);
-        }
-
-        void setVolume(double value) {
-            float bracketedValue = (float) Math.max(0.0, Math.min(1.0, value));
-            exoPlayer.setVolume(bracketedValue);
-        }
-
-        void seekTo(int location) {
-            exoPlayer.seekTo(location);
-        }
-
-        long getPosition() {
-            return exoPlayer.getCurrentPosition();
-        }
-
-        private void sendInitialized() {
-            if (isInitialized && eventSink != null) {
-                Map<String, Object> event = new HashMap<>();
-                event.put("event", "initialized");
-                event.put("duration", exoPlayer.getDuration());
-                if (exoPlayer.getVideoFormat() != null) {
-                    event.put("width", exoPlayer.getVideoFormat().width);
-                    event.put("height", exoPlayer.getVideoFormat().height);
-                }
-                eventSink.success(event);
-            }
-        }
-
-        void dispose() {
-            if (isInitialized) {
-                exoPlayer.stop();
-            }
-            textureEntry.release();
-            eventChannel.setStreamHandler(null);
-            if (surface != null) {
-                surface.release();
-            }
-            if (exoPlayer != null) {
-                exoPlayer.release();
-            }
-        }
+      setupVideoPlayer(eventChannel, textureEntry, result);
     }
 
-    public static void registerWith(Registrar registrar) {
-        final MethodChannel channel = new MethodChannel(registrar.messenger(), "flutter.io/videoPlayer");
-        channel.setMethodCallHandler(new VideoPlayerPlugin(registrar));
-    }
+    private void setupVideoPlayer(EventChannel eventChannel, TextureRegistry.SurfaceTextureEntry textureEntry, Result result) {
 
-    private VideoPlayerPlugin(Registrar registrar) {
-        this.registrar = registrar;
-        this.videoPlayers = new HashMap<>();
-    }
-
-    private final Map<Long, VideoPlayer> videoPlayers;
-
-    private final Registrar registrar;
-
-    @Override
-    public void onMethodCall(MethodCall call, Result result) {
-        TextureRegistry textures = registrar.textures();
-        if (textures == null) {
-            result.error("no_activity", "video_player plugin requires a foreground activity", null);
-            return;
+      eventChannel.setStreamHandler(new EventChannel.StreamHandler() {
+        @Override
+        public void onListen(Object o, EventChannel.EventSink sink) {
+          eventSink = sink;
         }
-        switch (call.method) {
-            case "init":
-                for (VideoPlayer player : videoPlayers.values()) {
-                    player.dispose();
-                }
-                videoPlayers.clear();
-                break;
-            case "create": {
-                TextureRegistry.SurfaceTextureEntry handle = textures.createSurfaceTexture();
-                EventChannel eventChannel = new EventChannel(registrar.messenger(), "flutter.io/videoPlayer/videoEvents" + handle.id());
 
-                VideoPlayer player;
-                if (call.argument("asset") != null) {
-                    String assetLookupKey;
-                    if (call.argument("package") != null) {
-                        assetLookupKey = registrar.lookupKeyForAsset((String) call.argument("asset"), (String) call.argument("package"));
-                    }
-                    else {
-                        assetLookupKey = registrar.lookupKeyForAsset((String) call.argument("asset"));
-                    }
-                    player = new VideoPlayer(registrar.context(), eventChannel, handle, "asset:///" + assetLookupKey, result);
-                    videoPlayers.put(handle.id(), player);
-                }
-                else {
-                    player = new VideoPlayer(registrar.context(), eventChannel, handle, (String) call.argument("uri"), result);
-                    videoPlayers.put(handle.id(), player);
-                }
-                break;
+        @Override
+        public void onCancel(Object o) {
+          eventSink = null;
+        }
+      });
+
+      surface = new Surface(textureEntry.surfaceTexture());
+      exoPlayer.setVideoSurface(surface);
+      exoPlayer.setPlayWhenReady(true);
+
+      exoPlayer.addListener(new EventListener() {
+        @Override
+        public void onTimelineChanged(final Timeline timeline, final Object manifest, final int reason) {
+
+        }
+
+        @Override
+        public void onTracksChanged(final TrackGroupArray trackGroups, final TrackSelectionArray trackSelections) {
+
+        }
+
+        @Override
+        public void onLoadingChanged(final boolean isLoading) {
+
+          if (!isLoading) {
+
+            isInitialized = true;
+            sendInitialized();
+          }
+          else {
+            setVolume(0.0);
+          }
+        }
+
+        @Override
+        public void onPlayerStateChanged(final boolean playWhenReady, final int playbackState) {
+          if (playbackState == Player.STATE_BUFFERING) {
+            if (eventSink != null) {
+              Map<String, Object> event = new HashMap<>();
+              event.put("event", "bufferingUpdate");
+              List<Integer> range = Arrays.asList(0, exoPlayer.getBufferedPercentage());
+              // iOS supports a list of buffered ranges, so here is a list with a single range.
+              event.put("values", Collections.singletonList(range));
+              eventSink.success(event);
             }
-            default: {
-                long textureId = ((Number) call.argument("textureId")).longValue();
-                VideoPlayer player = videoPlayers.get(textureId);
-                if (player == null) {
-                    result.error("Unknown textureId", "No video player associated with texture id " + textureId, null);
-                    return;
-                }
-                onMethodCall(call, result, textureId, player);
-                break;
-            }
+          }
         }
+
+        @Override
+        public void onRepeatModeChanged(final int repeatMode) {
+
+        }
+
+        @Override
+        public void onShuffleModeEnabledChanged(final boolean shuffleModeEnabled) {
+
+        }
+
+        @Override
+        public void onPlayerError(final ExoPlaybackException error) {
+          if (eventSink != null) {
+            eventSink.error("VideoError", "Video player had error " + error, null);
+          }
+        }
+
+        @Override
+        public void onPositionDiscontinuity(final int reason) {
+
+        }
+
+        @Override
+        public void onPlaybackParametersChanged(final PlaybackParameters playbackParameters) {
+
+        }
+
+        @Override
+        public void onSeekProcessed() {
+
+        }
+      });
+
+      Map<String, Object> reply = new HashMap<>();
+      reply.put("textureId", textureEntry.id());
+      result.success(reply);
     }
 
-    private void onMethodCall(MethodCall call, Result result, long textureId, VideoPlayer player) {
-        switch (call.method) {
-            case "setLooping":
-                player.setLooping((Boolean) call.argument("looping"));
-                result.success(null);
-                break;
-            case "setVolume":
-                player.setVolume((Double) call.argument("volume"));
-                result.success(null);
-                break;
-            case "play":
-                player.play();
-                result.success(null);
-                break;
-            case "pause":
-                player.pause();
-                result.success(null);
-                break;
-            case "seekTo":
-                int location = ((Number) call.argument("location")).intValue();
-                player.seekTo(location);
-                result.success(null);
-                break;
-            case "position":
-                result.success(player.getPosition());
-                break;
-            case "dispose":
-                player.dispose();
-                videoPlayers.remove(textureId);
-                result.success(null);
-                break;
-            case "orientation":
-                result.success(0);
-                break;
-            default:
-                result.notImplemented();
-                break;
-        }
+    void play() {
+      exoPlayer.setPlayWhenReady(true);
     }
+
+    void pause() {
+      exoPlayer.setPlayWhenReady(false);
+    }
+
+    void setLooping(boolean value) {
+      exoPlayer.setRepeatMode(value ? REPEAT_MODE_ALL : REPEAT_MODE_OFF);
+    }
+
+    void setVolume(double value) {
+      float bracketedValue = (float) Math.max(0.0, Math.min(1.0, value));
+      exoPlayer.setVolume(bracketedValue);
+    }
+
+    void seekTo(int location) {
+      exoPlayer.seekTo(location);
+    }
+
+    long getPosition() {
+      return exoPlayer.getCurrentPosition();
+    }
+
+    private void sendInitialized() {
+      if (isInitialized && eventSink != null) {
+        Map<String, Object> event = new HashMap<>();
+        event.put("event", "initialized");
+        event.put("duration", exoPlayer.getDuration());
+        if (exoPlayer.getVideoFormat() != null) {
+          event.put("width", exoPlayer.getVideoFormat().width);
+          event.put("height", exoPlayer.getVideoFormat().height);
+        }
+        eventSink.success(event);
+      }
+    }
+
+    void dispose() {
+      if (isInitialized) {
+        exoPlayer.stop();
+      }
+      textureEntry.release();
+      eventChannel.setStreamHandler(null);
+      if (surface != null) {
+        surface.release();
+      }
+      if (exoPlayer != null) {
+        exoPlayer.release();
+      }
+    }
+  }
+
+  public static void registerWith(Registrar registrar) {
+    final MethodChannel channel = new MethodChannel(registrar.messenger(), "flutter.io/videoPlayer");
+    channel.setMethodCallHandler(new VideoPlayerPlugin(registrar));
+  }
+
+  private VideoPlayerPlugin(Registrar registrar) {
+    this.registrar = registrar;
+    this.videoPlayers = new HashMap<>();
+  }
+
+  private final Map<Long, VideoPlayer> videoPlayers;
+
+  private final Registrar registrar;
+
+  @Override
+  public void onMethodCall(MethodCall call, Result result) {
+    TextureRegistry textures = registrar.textures();
+    if (textures == null) {
+      result.error("no_activity", "video_player plugin requires a foreground activity", null);
+      return;
+    }
+    switch (call.method) {
+      case "init":
+        for (VideoPlayer player : videoPlayers.values()) {
+          player.dispose();
+        }
+        videoPlayers.clear();
+        break;
+      case "create": {
+        TextureRegistry.SurfaceTextureEntry handle = textures.createSurfaceTexture();
+        EventChannel eventChannel = new EventChannel(registrar.messenger(), "flutter.io/videoPlayer/videoEvents" + handle.id());
+
+        VideoPlayer player;
+        if (call.argument("asset") != null) {
+          String assetLookupKey;
+          if (call.argument("package") != null) {
+            assetLookupKey = registrar.lookupKeyForAsset((String) call.argument("asset"), (String) call.argument("package"));
+          }
+          else {
+            assetLookupKey = registrar.lookupKeyForAsset((String) call.argument("asset"));
+          }
+          player = new VideoPlayer(registrar.context(), eventChannel, handle, "asset:///" + assetLookupKey, result);
+          videoPlayers.put(handle.id(), player);
+        }
+        else {
+          player = new VideoPlayer(registrar.context(), eventChannel, handle, (String) call.argument("uri"), result);
+          videoPlayers.put(handle.id(), player);
+        }
+        break;
+      }
+      default: {
+        long textureId = ((Number) call.argument("textureId")).longValue();
+        VideoPlayer player = videoPlayers.get(textureId);
+        if (player == null) {
+          result.error("Unknown textureId", "No video player associated with texture id " + textureId, null);
+          return;
+        }
+        onMethodCall(call, result, textureId, player);
+        break;
+      }
+    }
+  }
+
+  private void onMethodCall(MethodCall call, Result result, long textureId, VideoPlayer player) {
+    switch (call.method) {
+      case "setLooping":
+        player.setLooping((Boolean) call.argument("looping"));
+        result.success(null);
+        break;
+      case "setVolume":
+        player.setVolume((Double) call.argument("volume"));
+        result.success(null);
+        break;
+      case "play":
+        player.play();
+        result.success(null);
+        break;
+      case "pause":
+        player.pause();
+        result.success(null);
+        break;
+      case "seekTo":
+        int location = ((Number) call.argument("location")).intValue();
+        player.seekTo(location);
+        result.success(null);
+        break;
+      case "position":
+        result.success(player.getPosition());
+        break;
+      case "dispose":
+        player.dispose();
+        videoPlayers.remove(textureId);
+        result.success(null);
+        break;
+      case "orientation":
+        result.success(0);
+        break;
+      default:
+        result.notImplemented();
+        break;
+    }
+  }
 }

--- a/packages/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -148,12 +148,12 @@ public class VideoPlayerPlugin implements MethodCallHandler {
     }
 
     @SuppressWarnings("deprecation")
-    private static void setAudioAttributes(SimpleExoPlayer mediaPlayer) {
+    private static void setAudioAttributes(SimpleExoPlayer exoPlayer) {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-        mediaPlayer.setAudioAttributes(
+        exoPlayer.setAudioAttributes(
             new AudioAttributes.Builder().setContentType(C.CONTENT_TYPE_MOVIE).build());
       } else {
-        mediaPlayer.setAudioStreamType(AudioManager.STREAM_MUSIC);
+        exoPlayer.setAudioStreamType(AudioManager.STREAM_MUSIC);
       }
     }
 

--- a/packages/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -4,12 +4,41 @@
 
 package io.flutter.plugins.videoplayer;
 
+import static com.google.android.exoplayer2.Player.REPEAT_MODE_ALL;
+import static com.google.android.exoplayer2.Player.REPEAT_MODE_OFF;
+
+import android.content.Context;
 import android.content.res.AssetFileDescriptor;
 import android.media.AudioAttributes;
 import android.media.AudioManager;
 import android.media.MediaPlayer;
+import android.net.Uri;
 import android.os.Build;
+import android.util.Log;
 import android.view.Surface;
+import com.google.android.exoplayer2.ExoPlaybackException;
+import com.google.android.exoplayer2.ExoPlayer;
+import com.google.android.exoplayer2.ExoPlayerFactory;
+import com.google.android.exoplayer2.PlaybackParameters;
+import com.google.android.exoplayer2.Player;
+import com.google.android.exoplayer2.Player.EventListener;
+import com.google.android.exoplayer2.Player.RepeatMode;
+import com.google.android.exoplayer2.SimpleExoPlayer;
+import com.google.android.exoplayer2.Timeline;
+import com.google.android.exoplayer2.source.ExtractorMediaSource;
+import com.google.android.exoplayer2.source.MediaSource;
+import com.google.android.exoplayer2.source.TrackGroupArray;
+import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
+import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
+import com.google.android.exoplayer2.trackselection.TrackSelector;
+import com.google.android.exoplayer2.upstream.AssetDataSource;
+import com.google.android.exoplayer2.upstream.ContentDataSource;
+import com.google.android.exoplayer2.upstream.DataSource;
+import com.google.android.exoplayer2.upstream.DefaultDataSource;
+import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
+import com.google.android.exoplayer2.upstream.DefaultHttpDataSource;
+import com.google.android.exoplayer2.upstream.DefaultHttpDataSourceFactory;
+import com.google.android.exoplayer2.upstream.RawResourceDataSource;
 import io.flutter.plugin.common.EventChannel;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
@@ -26,202 +55,196 @@ import java.util.Map;
 
 public class VideoPlayerPlugin implements MethodCallHandler {
   private static class VideoPlayer {
+
+    private SimpleExoPlayer exoPlayer;
+
+    private Surface surface;
+
     private final TextureRegistry.SurfaceTextureEntry textureEntry;
-    private final MediaPlayer mediaPlayer;
     private EventChannel.EventSink eventSink;
     private final EventChannel eventChannel;
     private boolean isInitialized = false;
 
     VideoPlayer(
-        EventChannel eventChannel,
-        TextureRegistry.SurfaceTextureEntry textureEntry,
-        AssetFileDescriptor afd,
-        final Result result) {
-      this.eventChannel = eventChannel;
-      this.mediaPlayer = new MediaPlayer();
-      this.textureEntry = textureEntry;
-      try {
-        mediaPlayer.setDataSource(afd.getFileDescriptor(), afd.getStartOffset(), afd.getLength());
-        setupVideoPlayer(eventChannel, textureEntry, mediaPlayer, result);
-      } catch (IOException e) {
-        result.error("VideoError", "IOError when initializing video player " + e.toString(), null);
-      }
-    }
-
-    VideoPlayer(
+        Context context,
         EventChannel eventChannel,
         TextureRegistry.SurfaceTextureEntry textureEntry,
         String dataSource,
+        boolean isAsset,
         Result result) {
       this.eventChannel = eventChannel;
-      this.mediaPlayer = new MediaPlayer();
       this.textureEntry = textureEntry;
-      try {
-        mediaPlayer.setDataSource(dataSource);
-        setupVideoPlayer(eventChannel, textureEntry, mediaPlayer, result);
-      } catch (IOException e) {
-        result.error("VideoError", "IOError when initializing video player " + e.toString(), null);
+
+
+      TrackSelector trackSelector = new DefaultTrackSelector();
+      exoPlayer = ExoPlayerFactory.newSimpleInstance(context, trackSelector);
+
+      Uri uri = Uri.parse(dataSource);
+
+      DataSource.Factory dataSourceFactory;
+      if (isAsset) {
+        dataSourceFactory = new DefaultDataSourceFactory(context, "ExoPlayer");
       }
+      else {
+        dataSourceFactory = new DefaultHttpDataSourceFactory("ExoPlayer", null, DefaultHttpDataSource.DEFAULT_CONNECT_TIMEOUT_MILLIS, DefaultHttpDataSource.DEFAULT_READ_TIMEOUT_MILLIS, true);
+      }
+
+      MediaSource mediaSource = new ExtractorMediaSource.Factory(dataSourceFactory).createMediaSource(uri);
+      exoPlayer.prepare(mediaSource);
+
+      setupVideoPlayer(eventChannel, textureEntry, result);
     }
 
     private void setupVideoPlayer(
         EventChannel eventChannel,
         TextureRegistry.SurfaceTextureEntry textureEntry,
-        final MediaPlayer mediaPlayer,
         Result result) {
 
       eventChannel.setStreamHandler(
-          new EventChannel.StreamHandler() {
-            @Override
-            public void onListen(Object o, EventChannel.EventSink sink) {
-              eventSink = sink;
-              sendInitialized();
-            }
+              new EventChannel.StreamHandler() {
+                @Override
+                public void onListen(Object o, EventChannel.EventSink sink) {
+                  eventSink = sink;
+                }
 
-            @Override
-            public void onCancel(Object o) {
-              eventSink = null;
-            }
-          });
+                @Override
+                public void onCancel(Object o) {
+                  eventSink = null;
+                }
+              });
 
-      mediaPlayer.setSurface(new Surface(textureEntry.surfaceTexture()));
-      setAudioAttributes(mediaPlayer);
-      mediaPlayer.setOnPreparedListener(
-          new MediaPlayer.OnPreparedListener() {
-            @Override
-            public void onPrepared(MediaPlayer mp) {
-              mediaPlayer.setOnBufferingUpdateListener(
-                  new MediaPlayer.OnBufferingUpdateListener() {
-                    @Override
-                    public void onBufferingUpdate(MediaPlayer mediaPlayer, int percent) {
-                      if (eventSink != null) {
-                        Map<String, Object> event = new HashMap<>();
-                        event.put("event", "bufferingUpdate");
-                        List<Integer> range =
-                            Arrays.asList(0, percent * mediaPlayer.getDuration() / 100);
-                        // iOS supports a list of buffered ranges, so here is a list with a single range.
-                        event.put("values", Collections.singletonList(range));
-                        eventSink.success(event);
-                      }
-                    }
-                  });
-              isInitialized = true;
-              sendInitialized();
-            }
-          });
 
-      mediaPlayer.setOnErrorListener(
-          new MediaPlayer.OnErrorListener() {
-            @Override
-            public boolean onError(MediaPlayer mp, int what, int extra) {
-              if (eventSink != null) {
-                eventSink.error(
-                    "VideoError", "Video player had error " + what + " extra " + extra, null);
-              }
-              return true;
-            }
-          });
+      surface = new Surface(textureEntry.surfaceTexture());
+      exoPlayer.setVideoSurface(surface);
+      exoPlayer.setPlayWhenReady(true);
 
-      mediaPlayer.setOnCompletionListener(
-          new MediaPlayer.OnCompletionListener() {
-            @Override
-            public void onCompletion(MediaPlayer mediaPlayer) {
+      exoPlayer.addListener(new EventListener() {
+        @Override
+        public void onTimelineChanged(final Timeline timeline, final Object manifest, final int reason) {
+
+        }
+
+        @Override
+        public void onTracksChanged(final TrackGroupArray trackGroups, final TrackSelectionArray trackSelections) {
+
+        }
+
+        @Override
+        public void onLoadingChanged(final boolean isLoading) {
+
+          if (!isLoading) {
+
+            isInitialized = true;
+            sendInitialized();
+          }
+          else {
+            setVolume(0.0);
+          }
+        }
+
+        @Override
+        public void onPlayerStateChanged(final boolean playWhenReady, final int playbackState) {
+          if (playbackState == Player.STATE_BUFFERING) {
+            if (eventSink != null) {
               Map<String, Object> event = new HashMap<>();
-              event.put("event", "completed");
+              event.put("event", "bufferingUpdate");
+              List<Integer> range = Arrays.asList(0, exoPlayer.getBufferedPercentage());
+              // iOS supports a list of buffered ranges, so here is a list with a single range.
+              event.put("values", Collections.singletonList(range));
               eventSink.success(event);
             }
-          });
+          }
+        }
 
-      mediaPlayer.setOnInfoListener(
-          new MediaPlayer.OnInfoListener() {
-            @Override
-            public boolean onInfo(MediaPlayer mediaPlayer, int what, int extra) {
-              Map<String, Object> event = new HashMap<>();
-              switch (what) {
-                case MediaPlayer.MEDIA_INFO_BUFFERING_START:
-                  {
-                    event.put("event", "bufferingStart");
-                    eventSink.success(event);
-                    return true;
-                  }
-                case MediaPlayer.MEDIA_INFO_BUFFERING_END:
-                  {
-                    event.put("event", "bufferingEnd");
-                    eventSink.success(event);
-                    return true;
-                  }
-              }
-              return false;
-            }
-          });
+        @Override
+        public void onRepeatModeChanged(final int repeatMode) {
 
-      mediaPlayer.prepareAsync();
+        }
+
+        @Override
+        public void onShuffleModeEnabledChanged(final boolean shuffleModeEnabled) {
+
+        }
+
+        @Override
+        public void onPlayerError(final ExoPlaybackException error) {
+          if (eventSink != null) {
+            eventSink.error(
+                    "VideoError", "Video player had error " + error, null);
+          }
+        }
+
+        @Override
+        public void onPositionDiscontinuity(final int reason) {
+
+        }
+
+        @Override
+        public void onPlaybackParametersChanged(final PlaybackParameters playbackParameters) {
+
+        }
+
+        @Override
+        public void onSeekProcessed() {
+
+        }
+      });
 
       Map<String, Object> reply = new HashMap<>();
       reply.put("textureId", textureEntry.id());
       result.success(reply);
     }
 
-    @SuppressWarnings("deprecation")
-    private static void setAudioAttributes(MediaPlayer mediaPlayer) {
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-        mediaPlayer.setAudioAttributes(
-            new AudioAttributes.Builder()
-                .setContentType(AudioAttributes.CONTENT_TYPE_MOVIE)
-                .build());
-      } else {
-        mediaPlayer.setAudioStreamType(AudioManager.STREAM_MUSIC);
-      }
-    }
-
     void play() {
-      if (!mediaPlayer.isPlaying()) {
-        mediaPlayer.start();
-      }
+      exoPlayer.setPlayWhenReady(true);
     }
 
     void pause() {
-      if (mediaPlayer.isPlaying()) {
-        mediaPlayer.pause();
-      }
+      exoPlayer.setPlayWhenReady(false);
     }
 
     void setLooping(boolean value) {
-      mediaPlayer.setLooping(value);
+      exoPlayer.setRepeatMode(value ? REPEAT_MODE_ALL : REPEAT_MODE_OFF);
     }
 
     void setVolume(double value) {
       float bracketedValue = (float) Math.max(0.0, Math.min(1.0, value));
-      mediaPlayer.setVolume(bracketedValue, bracketedValue);
+      exoPlayer.setVolume(bracketedValue);
     }
 
     void seekTo(int location) {
-      mediaPlayer.seekTo(location);
+      exoPlayer.seekTo(location);
     }
 
-    int getPosition() {
-      return mediaPlayer.getCurrentPosition();
+    long getPosition() {
+      return exoPlayer.getCurrentPosition();
     }
 
     private void sendInitialized() {
       if (isInitialized && eventSink != null) {
         Map<String, Object> event = new HashMap<>();
         event.put("event", "initialized");
-        event.put("duration", mediaPlayer.getDuration());
-        event.put("width", mediaPlayer.getVideoWidth());
-        event.put("height", mediaPlayer.getVideoHeight());
+        event.put("duration", exoPlayer.getDuration());
+        if (exoPlayer.getVideoFormat() != null) {
+          event.put("width", exoPlayer.getVideoFormat().width);
+          event.put("height", exoPlayer.getVideoFormat().height);
+        }
         eventSink.success(event);
       }
     }
 
     void dispose() {
-      if (isInitialized && mediaPlayer.isPlaying()) {
-        mediaPlayer.stop();
+      if (isInitialized) {
+        exoPlayer.stop();
       }
-      mediaPlayer.reset();
-      mediaPlayer.release();
       textureEntry.release();
       eventChannel.setStreamHandler(null);
+      if (surface != null) {
+        surface.release();
+      }
+      if (exoPlayer != null) {
+        exoPlayer.release();
+      }
     }
   }
 
@@ -262,29 +285,18 @@ public class VideoPlayerPlugin implements MethodCallHandler {
 
           VideoPlayer player;
           if (call.argument("asset") != null) {
-            try {
-              String assetLookupKey;
-              if (call.argument("package") != null) {
-                assetLookupKey =
-                    registrar.lookupKeyForAsset(
-                        (String) call.argument("asset"), (String) call.argument("package"));
-              } else {
-                assetLookupKey = registrar.lookupKeyForAsset((String) call.argument("asset"));
-              }
-              AssetFileDescriptor fd = registrar.context().getAssets().openFd(assetLookupKey);
-              player = new VideoPlayer(eventChannel, handle, fd, result);
-              videoPlayers.put(handle.id(), player);
-            } catch (IOException e) {
-              result.error(
-                  "IOError",
-                  "Error trying to access asset "
-                      + (String) call.argument("asset")
-                      + ". "
-                      + e.toString(),
-                  null);
+            String assetLookupKey;
+            if (call.argument("package") != null) {
+              assetLookupKey =
+                  registrar.lookupKeyForAsset(
+                      (String) call.argument("asset"), (String) call.argument("package"));
+            } else {
+              assetLookupKey = registrar.lookupKeyForAsset((String) call.argument("asset"));
             }
+            player = new VideoPlayer(registrar.context(), eventChannel, handle, "asset:///" + assetLookupKey, true, result);
+            videoPlayers.put(handle.id(), player);
           } else {
-            player = new VideoPlayer(eventChannel, handle, (String) call.argument("uri"), result);
+            player = new VideoPlayer(registrar.context(), eventChannel, handle, (String) call.argument("uri"), false, result);
             videoPlayers.put(handle.id(), player);
           }
           break;
@@ -336,6 +348,9 @@ public class VideoPlayerPlugin implements MethodCallHandler {
         player.dispose();
         videoPlayers.remove(textureId);
         result.success(null);
+        break;
+      case "orientation":
+        result.success(0);
         break;
       default:
         result.notImplemented();

--- a/packages/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -110,7 +110,6 @@ public class VideoPlayerPlugin implements MethodCallHandler {
 
       surface = new Surface(textureEntry.surfaceTexture());
       exoPlayer.setVideoSurface(surface);
-      exoPlayer.setPlayWhenReady(true);
       setAudioAttributes(exoPlayer);
 
       exoPlayer.addListener(

--- a/packages/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -8,13 +8,17 @@ import static com.google.android.exoplayer2.Player.REPEAT_MODE_ALL;
 import static com.google.android.exoplayer2.Player.REPEAT_MODE_OFF;
 
 import android.content.Context;
+import android.media.AudioManager;
 import android.net.Uri;
+import android.os.Build;
 import android.view.Surface;
+import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.ExoPlaybackException;
 import com.google.android.exoplayer2.ExoPlayerFactory;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.Player.DefaultEventListener;
 import com.google.android.exoplayer2.SimpleExoPlayer;
+import com.google.android.exoplayer2.audio.AudioAttributes;
 import com.google.android.exoplayer2.source.ExtractorMediaSource;
 import com.google.android.exoplayer2.source.MediaSource;
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
@@ -107,6 +111,7 @@ public class VideoPlayerPlugin implements MethodCallHandler {
       surface = new Surface(textureEntry.surfaceTexture());
       exoPlayer.setVideoSurface(surface);
       exoPlayer.setPlayWhenReady(true);
+      setAudioAttributes(exoPlayer);
 
       exoPlayer.addListener(
           new DefaultEventListener() {
@@ -141,6 +146,16 @@ public class VideoPlayerPlugin implements MethodCallHandler {
       Map<String, Object> reply = new HashMap<>();
       reply.put("textureId", textureEntry.id());
       result.success(reply);
+    }
+
+    @SuppressWarnings("deprecation")
+    private static void setAudioAttributes(SimpleExoPlayer mediaPlayer) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+        mediaPlayer.setAudioAttributes(
+            new AudioAttributes.Builder().setContentType(C.CONTENT_TYPE_MOVIE).build());
+      } else {
+        mediaPlayer.setAudioStreamType(AudioManager.STREAM_MUSIC);
+      }
     }
 
     void play() {

--- a/packages/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -8,21 +8,13 @@ import static com.google.android.exoplayer2.Player.REPEAT_MODE_ALL;
 import static com.google.android.exoplayer2.Player.REPEAT_MODE_OFF;
 
 import android.content.Context;
-import android.content.res.AssetFileDescriptor;
-import android.media.AudioAttributes;
-import android.media.AudioManager;
-import android.media.MediaPlayer;
 import android.net.Uri;
-import android.os.Build;
-import android.util.Log;
 import android.view.Surface;
 import com.google.android.exoplayer2.ExoPlaybackException;
-import com.google.android.exoplayer2.ExoPlayer;
 import com.google.android.exoplayer2.ExoPlayerFactory;
 import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.Player.EventListener;
-import com.google.android.exoplayer2.Player.RepeatMode;
 import com.google.android.exoplayer2.SimpleExoPlayer;
 import com.google.android.exoplayer2.Timeline;
 import com.google.android.exoplayer2.source.ExtractorMediaSource;
@@ -31,14 +23,10 @@ import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
 import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
 import com.google.android.exoplayer2.trackselection.TrackSelector;
-import com.google.android.exoplayer2.upstream.AssetDataSource;
-import com.google.android.exoplayer2.upstream.ContentDataSource;
 import com.google.android.exoplayer2.upstream.DataSource;
-import com.google.android.exoplayer2.upstream.DefaultDataSource;
 import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
 import com.google.android.exoplayer2.upstream.DefaultHttpDataSource;
 import com.google.android.exoplayer2.upstream.DefaultHttpDataSourceFactory;
-import com.google.android.exoplayer2.upstream.RawResourceDataSource;
 import io.flutter.plugin.common.EventChannel;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
@@ -46,7 +34,6 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
 import io.flutter.view.TextureRegistry;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -54,307 +41,291 @@ import java.util.List;
 import java.util.Map;
 
 public class VideoPlayerPlugin implements MethodCallHandler {
-  private static class VideoPlayer {
 
-    private SimpleExoPlayer exoPlayer;
+    private static class VideoPlayer {
 
-    private Surface surface;
+        private SimpleExoPlayer exoPlayer;
 
-    private final TextureRegistry.SurfaceTextureEntry textureEntry;
-    private EventChannel.EventSink eventSink;
-    private final EventChannel eventChannel;
-    private boolean isInitialized = false;
+        private Surface surface;
 
-    VideoPlayer(
-        Context context,
-        EventChannel eventChannel,
-        TextureRegistry.SurfaceTextureEntry textureEntry,
-        String dataSource,
-        boolean isAsset,
-        Result result) {
-      this.eventChannel = eventChannel;
-      this.textureEntry = textureEntry;
+        private final TextureRegistry.SurfaceTextureEntry textureEntry;
 
+        private EventChannel.EventSink eventSink;
 
-      TrackSelector trackSelector = new DefaultTrackSelector();
-      exoPlayer = ExoPlayerFactory.newSimpleInstance(context, trackSelector);
+        private final EventChannel eventChannel;
 
-      Uri uri = Uri.parse(dataSource);
+        private boolean isInitialized = false;
 
-      DataSource.Factory dataSourceFactory;
-      if (isAsset) {
-        dataSourceFactory = new DefaultDataSourceFactory(context, "ExoPlayer");
-      }
-      else {
-        dataSourceFactory = new DefaultHttpDataSourceFactory("ExoPlayer", null, DefaultHttpDataSource.DEFAULT_CONNECT_TIMEOUT_MILLIS, DefaultHttpDataSource.DEFAULT_READ_TIMEOUT_MILLIS, true);
-      }
+        VideoPlayer(Context context, EventChannel eventChannel, TextureRegistry.SurfaceTextureEntry textureEntry, String dataSource, Result result) {
+            this.eventChannel = eventChannel;
+            this.textureEntry = textureEntry;
 
-      MediaSource mediaSource = new ExtractorMediaSource.Factory(dataSourceFactory).createMediaSource(uri);
-      exoPlayer.prepare(mediaSource);
+            TrackSelector trackSelector = new DefaultTrackSelector();
+            exoPlayer = ExoPlayerFactory.newSimpleInstance(context, trackSelector);
 
-      setupVideoPlayer(eventChannel, textureEntry, result);
-    }
+            Uri uri = Uri.parse(dataSource);
 
-    private void setupVideoPlayer(
-        EventChannel eventChannel,
-        TextureRegistry.SurfaceTextureEntry textureEntry,
-        Result result) {
+            DataSource.Factory dataSourceFactory;
+            if (uri.getScheme().equals("asset") || uri.getScheme().equals("file")) {
+                dataSourceFactory = new DefaultDataSourceFactory(context, "ExoPlayer");
+            }
+            else {
+                dataSourceFactory = new DefaultHttpDataSourceFactory("ExoPlayer", null, DefaultHttpDataSource.DEFAULT_CONNECT_TIMEOUT_MILLIS, DefaultHttpDataSource.DEFAULT_READ_TIMEOUT_MILLIS, true);
+            }
 
-      eventChannel.setStreamHandler(
-              new EventChannel.StreamHandler() {
+            MediaSource mediaSource = new ExtractorMediaSource.Factory(dataSourceFactory).createMediaSource(uri);
+            exoPlayer.prepare(mediaSource);
+
+            setupVideoPlayer(eventChannel, textureEntry, result);
+        }
+
+        private void setupVideoPlayer(EventChannel eventChannel, TextureRegistry.SurfaceTextureEntry textureEntry, Result result) {
+
+            eventChannel.setStreamHandler(new EventChannel.StreamHandler() {
                 @Override
                 public void onListen(Object o, EventChannel.EventSink sink) {
-                  eventSink = sink;
+                    eventSink = sink;
                 }
 
                 @Override
                 public void onCancel(Object o) {
-                  eventSink = null;
+                    eventSink = null;
                 }
-              });
+            });
 
+            surface = new Surface(textureEntry.surfaceTexture());
+            exoPlayer.setVideoSurface(surface);
+            exoPlayer.setPlayWhenReady(true);
 
-      surface = new Surface(textureEntry.surfaceTexture());
-      exoPlayer.setVideoSurface(surface);
-      exoPlayer.setPlayWhenReady(true);
+            exoPlayer.addListener(new EventListener() {
+                @Override
+                public void onTimelineChanged(final Timeline timeline, final Object manifest, final int reason) {
 
-      exoPlayer.addListener(new EventListener() {
-        @Override
-        public void onTimelineChanged(final Timeline timeline, final Object manifest, final int reason) {
+                }
 
+                @Override
+                public void onTracksChanged(final TrackGroupArray trackGroups, final TrackSelectionArray trackSelections) {
+
+                }
+
+                @Override
+                public void onLoadingChanged(final boolean isLoading) {
+
+                    if (!isLoading) {
+
+                        isInitialized = true;
+                        sendInitialized();
+                    }
+                    else {
+                        setVolume(0.0);
+                    }
+                }
+
+                @Override
+                public void onPlayerStateChanged(final boolean playWhenReady, final int playbackState) {
+                    if (playbackState == Player.STATE_BUFFERING) {
+                        if (eventSink != null) {
+                            Map<String, Object> event = new HashMap<>();
+                            event.put("event", "bufferingUpdate");
+                            List<Integer> range = Arrays.asList(0, exoPlayer.getBufferedPercentage());
+                            // iOS supports a list of buffered ranges, so here is a list with a single range.
+                            event.put("values", Collections.singletonList(range));
+                            eventSink.success(event);
+                        }
+                    }
+                }
+
+                @Override
+                public void onRepeatModeChanged(final int repeatMode) {
+
+                }
+
+                @Override
+                public void onShuffleModeEnabledChanged(final boolean shuffleModeEnabled) {
+
+                }
+
+                @Override
+                public void onPlayerError(final ExoPlaybackException error) {
+                    if (eventSink != null) {
+                        eventSink.error("VideoError", "Video player had error " + error, null);
+                    }
+                }
+
+                @Override
+                public void onPositionDiscontinuity(final int reason) {
+
+                }
+
+                @Override
+                public void onPlaybackParametersChanged(final PlaybackParameters playbackParameters) {
+
+                }
+
+                @Override
+                public void onSeekProcessed() {
+
+                }
+            });
+
+            Map<String, Object> reply = new HashMap<>();
+            reply.put("textureId", textureEntry.id());
+            result.success(reply);
         }
 
-        @Override
-        public void onTracksChanged(final TrackGroupArray trackGroups, final TrackSelectionArray trackSelections) {
-
+        void play() {
+            exoPlayer.setPlayWhenReady(true);
         }
 
-        @Override
-        public void onLoadingChanged(final boolean isLoading) {
-
-          if (!isLoading) {
-
-            isInitialized = true;
-            sendInitialized();
-          }
-          else {
-            setVolume(0.0);
-          }
+        void pause() {
+            exoPlayer.setPlayWhenReady(false);
         }
 
-        @Override
-        public void onPlayerStateChanged(final boolean playWhenReady, final int playbackState) {
-          if (playbackState == Player.STATE_BUFFERING) {
-            if (eventSink != null) {
-              Map<String, Object> event = new HashMap<>();
-              event.put("event", "bufferingUpdate");
-              List<Integer> range = Arrays.asList(0, exoPlayer.getBufferedPercentage());
-              // iOS supports a list of buffered ranges, so here is a list with a single range.
-              event.put("values", Collections.singletonList(range));
-              eventSink.success(event);
+        void setLooping(boolean value) {
+            exoPlayer.setRepeatMode(value ? REPEAT_MODE_ALL : REPEAT_MODE_OFF);
+        }
+
+        void setVolume(double value) {
+            float bracketedValue = (float) Math.max(0.0, Math.min(1.0, value));
+            exoPlayer.setVolume(bracketedValue);
+        }
+
+        void seekTo(int location) {
+            exoPlayer.seekTo(location);
+        }
+
+        long getPosition() {
+            return exoPlayer.getCurrentPosition();
+        }
+
+        private void sendInitialized() {
+            if (isInitialized && eventSink != null) {
+                Map<String, Object> event = new HashMap<>();
+                event.put("event", "initialized");
+                event.put("duration", exoPlayer.getDuration());
+                if (exoPlayer.getVideoFormat() != null) {
+                    event.put("width", exoPlayer.getVideoFormat().width);
+                    event.put("height", exoPlayer.getVideoFormat().height);
+                }
+                eventSink.success(event);
             }
-          }
         }
 
-        @Override
-        public void onRepeatModeChanged(final int repeatMode) {
-
-        }
-
-        @Override
-        public void onShuffleModeEnabledChanged(final boolean shuffleModeEnabled) {
-
-        }
-
-        @Override
-        public void onPlayerError(final ExoPlaybackException error) {
-          if (eventSink != null) {
-            eventSink.error(
-                    "VideoError", "Video player had error " + error, null);
-          }
-        }
-
-        @Override
-        public void onPositionDiscontinuity(final int reason) {
-
-        }
-
-        @Override
-        public void onPlaybackParametersChanged(final PlaybackParameters playbackParameters) {
-
-        }
-
-        @Override
-        public void onSeekProcessed() {
-
-        }
-      });
-
-      Map<String, Object> reply = new HashMap<>();
-      reply.put("textureId", textureEntry.id());
-      result.success(reply);
-    }
-
-    void play() {
-      exoPlayer.setPlayWhenReady(true);
-    }
-
-    void pause() {
-      exoPlayer.setPlayWhenReady(false);
-    }
-
-    void setLooping(boolean value) {
-      exoPlayer.setRepeatMode(value ? REPEAT_MODE_ALL : REPEAT_MODE_OFF);
-    }
-
-    void setVolume(double value) {
-      float bracketedValue = (float) Math.max(0.0, Math.min(1.0, value));
-      exoPlayer.setVolume(bracketedValue);
-    }
-
-    void seekTo(int location) {
-      exoPlayer.seekTo(location);
-    }
-
-    long getPosition() {
-      return exoPlayer.getCurrentPosition();
-    }
-
-    private void sendInitialized() {
-      if (isInitialized && eventSink != null) {
-        Map<String, Object> event = new HashMap<>();
-        event.put("event", "initialized");
-        event.put("duration", exoPlayer.getDuration());
-        if (exoPlayer.getVideoFormat() != null) {
-          event.put("width", exoPlayer.getVideoFormat().width);
-          event.put("height", exoPlayer.getVideoFormat().height);
-        }
-        eventSink.success(event);
-      }
-    }
-
-    void dispose() {
-      if (isInitialized) {
-        exoPlayer.stop();
-      }
-      textureEntry.release();
-      eventChannel.setStreamHandler(null);
-      if (surface != null) {
-        surface.release();
-      }
-      if (exoPlayer != null) {
-        exoPlayer.release();
-      }
-    }
-  }
-
-  public static void registerWith(Registrar registrar) {
-    final MethodChannel channel =
-        new MethodChannel(registrar.messenger(), "flutter.io/videoPlayer");
-    channel.setMethodCallHandler(new VideoPlayerPlugin(registrar));
-  }
-
-  private VideoPlayerPlugin(Registrar registrar) {
-    this.registrar = registrar;
-    this.videoPlayers = new HashMap<>();
-  }
-
-  private final Map<Long, VideoPlayer> videoPlayers;
-  private final Registrar registrar;
-
-  @Override
-  public void onMethodCall(MethodCall call, Result result) {
-    TextureRegistry textures = registrar.textures();
-    if (textures == null) {
-      result.error("no_activity", "video_player plugin requires a foreground activity", null);
-      return;
-    }
-    switch (call.method) {
-      case "init":
-        for (VideoPlayer player : videoPlayers.values()) {
-          player.dispose();
-        }
-        videoPlayers.clear();
-        break;
-      case "create":
-        {
-          TextureRegistry.SurfaceTextureEntry handle = textures.createSurfaceTexture();
-          EventChannel eventChannel =
-              new EventChannel(
-                  registrar.messenger(), "flutter.io/videoPlayer/videoEvents" + handle.id());
-
-          VideoPlayer player;
-          if (call.argument("asset") != null) {
-            String assetLookupKey;
-            if (call.argument("package") != null) {
-              assetLookupKey =
-                  registrar.lookupKeyForAsset(
-                      (String) call.argument("asset"), (String) call.argument("package"));
-            } else {
-              assetLookupKey = registrar.lookupKeyForAsset((String) call.argument("asset"));
+        void dispose() {
+            if (isInitialized) {
+                exoPlayer.stop();
             }
-            player = new VideoPlayer(registrar.context(), eventChannel, handle, "asset:///" + assetLookupKey, true, result);
-            videoPlayers.put(handle.id(), player);
-          } else {
-            player = new VideoPlayer(registrar.context(), eventChannel, handle, (String) call.argument("uri"), false, result);
-            videoPlayers.put(handle.id(), player);
-          }
-          break;
+            textureEntry.release();
+            eventChannel.setStreamHandler(null);
+            if (surface != null) {
+                surface.release();
+            }
+            if (exoPlayer != null) {
+                exoPlayer.release();
+            }
         }
-      default:
-        {
-          long textureId = ((Number) call.argument("textureId")).longValue();
-          VideoPlayer player = videoPlayers.get(textureId);
-          if (player == null) {
-            result.error(
-                "Unknown textureId",
-                "No video player associated with texture id " + textureId,
-                null);
+    }
+
+    public static void registerWith(Registrar registrar) {
+        final MethodChannel channel = new MethodChannel(registrar.messenger(), "flutter.io/videoPlayer");
+        channel.setMethodCallHandler(new VideoPlayerPlugin(registrar));
+    }
+
+    private VideoPlayerPlugin(Registrar registrar) {
+        this.registrar = registrar;
+        this.videoPlayers = new HashMap<>();
+    }
+
+    private final Map<Long, VideoPlayer> videoPlayers;
+
+    private final Registrar registrar;
+
+    @Override
+    public void onMethodCall(MethodCall call, Result result) {
+        TextureRegistry textures = registrar.textures();
+        if (textures == null) {
+            result.error("no_activity", "video_player plugin requires a foreground activity", null);
             return;
-          }
-          onMethodCall(call, result, textureId, player);
-          break;
+        }
+        switch (call.method) {
+            case "init":
+                for (VideoPlayer player : videoPlayers.values()) {
+                    player.dispose();
+                }
+                videoPlayers.clear();
+                break;
+            case "create": {
+                TextureRegistry.SurfaceTextureEntry handle = textures.createSurfaceTexture();
+                EventChannel eventChannel = new EventChannel(registrar.messenger(), "flutter.io/videoPlayer/videoEvents" + handle.id());
+
+                VideoPlayer player;
+                if (call.argument("asset") != null) {
+                    String assetLookupKey;
+                    if (call.argument("package") != null) {
+                        assetLookupKey = registrar.lookupKeyForAsset((String) call.argument("asset"), (String) call.argument("package"));
+                    }
+                    else {
+                        assetLookupKey = registrar.lookupKeyForAsset((String) call.argument("asset"));
+                    }
+                    player = new VideoPlayer(registrar.context(), eventChannel, handle, "asset:///" + assetLookupKey, result);
+                    videoPlayers.put(handle.id(), player);
+                }
+                else {
+                    player = new VideoPlayer(registrar.context(), eventChannel, handle, (String) call.argument("uri"), result);
+                    videoPlayers.put(handle.id(), player);
+                }
+                break;
+            }
+            default: {
+                long textureId = ((Number) call.argument("textureId")).longValue();
+                VideoPlayer player = videoPlayers.get(textureId);
+                if (player == null) {
+                    result.error("Unknown textureId", "No video player associated with texture id " + textureId, null);
+                    return;
+                }
+                onMethodCall(call, result, textureId, player);
+                break;
+            }
         }
     }
-  }
 
-  private void onMethodCall(MethodCall call, Result result, long textureId, VideoPlayer player) {
-    switch (call.method) {
-      case "setLooping":
-        player.setLooping((Boolean) call.argument("looping"));
-        result.success(null);
-        break;
-      case "setVolume":
-        player.setVolume((Double) call.argument("volume"));
-        result.success(null);
-        break;
-      case "play":
-        player.play();
-        result.success(null);
-        break;
-      case "pause":
-        player.pause();
-        result.success(null);
-        break;
-      case "seekTo":
-        int location = ((Number) call.argument("location")).intValue();
-        player.seekTo(location);
-        result.success(null);
-        break;
-      case "position":
-        result.success(player.getPosition());
-        break;
-      case "dispose":
-        player.dispose();
-        videoPlayers.remove(textureId);
-        result.success(null);
-        break;
-      case "orientation":
-        result.success(0);
-        break;
-      default:
-        result.notImplemented();
-        break;
+    private void onMethodCall(MethodCall call, Result result, long textureId, VideoPlayer player) {
+        switch (call.method) {
+            case "setLooping":
+                player.setLooping((Boolean) call.argument("looping"));
+                result.success(null);
+                break;
+            case "setVolume":
+                player.setVolume((Double) call.argument("volume"));
+                result.success(null);
+                break;
+            case "play":
+                player.play();
+                result.success(null);
+                break;
+            case "pause":
+                player.pause();
+                result.success(null);
+                break;
+            case "seekTo":
+                int location = ((Number) call.argument("location")).intValue();
+                player.seekTo(location);
+                result.success(null);
+                break;
+            case "position":
+                result.success(player.getPosition());
+                break;
+            case "dispose":
+                player.dispose();
+                videoPlayers.remove(textureId);
+                result.success(null);
+                break;
+            case "orientation":
+                result.success(0);
+                break;
+            default:
+                result.notImplemented();
+                break;
+        }
     }
-  }
 }

--- a/packages/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -12,16 +12,12 @@ import android.net.Uri;
 import android.view.Surface;
 import com.google.android.exoplayer2.ExoPlaybackException;
 import com.google.android.exoplayer2.ExoPlayerFactory;
-import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.Player;
-import com.google.android.exoplayer2.Player.EventListener;
+import com.google.android.exoplayer2.Player.DefaultEventListener;
 import com.google.android.exoplayer2.SimpleExoPlayer;
-import com.google.android.exoplayer2.Timeline;
 import com.google.android.exoplayer2.source.ExtractorMediaSource;
 import com.google.android.exoplayer2.source.MediaSource;
-import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
-import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
 import com.google.android.exoplayer2.trackselection.TrackSelector;
 import com.google.android.exoplayer2.upstream.DataSource;
 import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
@@ -113,29 +109,19 @@ public class VideoPlayerPlugin implements MethodCallHandler {
       exoPlayer.setPlayWhenReady(true);
 
       exoPlayer.addListener(
-          new EventListener() {
-            @Override
-            public void onTimelineChanged(
-                final Timeline timeline, final Object manifest, final int reason) {}
-
-            @Override
-            public void onTracksChanged(
-                final TrackGroupArray trackGroups, final TrackSelectionArray trackSelections) {}
-
+          new DefaultEventListener() {
             @Override
             public void onLoadingChanged(final boolean isLoading) {
-
+              super.onLoadingChanged(isLoading);
               if (!isLoading) {
-
                 isInitialized = true;
                 sendInitialized();
-              } else {
-                setVolume(0.0);
               }
             }
 
             @Override
             public void onPlayerStateChanged(final boolean playWhenReady, final int playbackState) {
+              super.onPlayerStateChanged(playWhenReady, playbackState);
               if (playbackState == Player.STATE_BUFFERING) {
                 if (eventSink != null) {
                   Map<String, Object> event = new HashMap<>();
@@ -149,26 +135,12 @@ public class VideoPlayerPlugin implements MethodCallHandler {
             }
 
             @Override
-            public void onRepeatModeChanged(final int repeatMode) {}
-
-            @Override
-            public void onShuffleModeEnabledChanged(final boolean shuffleModeEnabled) {}
-
-            @Override
             public void onPlayerError(final ExoPlaybackException error) {
+              super.onPlayerError(error);
               if (eventSink != null) {
                 eventSink.error("VideoError", "Video player had error " + error, null);
               }
             }
-
-            @Override
-            public void onPositionDiscontinuity(final int reason) {}
-
-            @Override
-            public void onPlaybackParametersChanged(final PlaybackParameters playbackParameters) {}
-
-            @Override
-            public void onSeekProcessed() {}
           });
 
       Map<String, Object> reply = new HashMap<>();
@@ -342,9 +314,6 @@ public class VideoPlayerPlugin implements MethodCallHandler {
         player.dispose();
         videoPlayers.remove(textureId);
         result.success(null);
-        break;
-      case "orientation":
-        result.success(0);
         break;
       default:
         result.notImplemented();

--- a/packages/video_player/pubspec.yaml
+++ b/packages/video_player/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player
 description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
-version: 0.5.5
+version: 0.6.0
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player
 
 flutter:

--- a/packages/video_player/pubspec.yaml
+++ b/packages/video_player/pubspec.yaml
@@ -2,8 +2,8 @@ name: video_player
 description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
+version: 0.5.5
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player
-version: 0.5.4
 
 flutter:
   plugin:


### PR DESCRIPTION
The default Android implementation using the `MediaPlayer` had different playback / codec problems on different devices. We mostly saw problems with a few Samsung phones. 

By using the `ExoPlayer` library playback works fine on all devices we tested so far.