### PR TITLE
image_picker fixes: file suffix, permissions redirect, video resize

### DIFF
--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
@@ -67,8 +67,10 @@ public class ImagePickerDelegate
         PluginRegistry.RequestPermissionsResultListener {
   @VisibleForTesting static final int REQUEST_CODE_CHOOSE_FROM_GALLERY = 2342;
   @VisibleForTesting static final int REQUEST_CODE_TAKE_WITH_CAMERA = 2343;
-  @VisibleForTesting static final int REQUEST_EXTERNAL_STORAGE_PERMISSION = 2344;
-  @VisibleForTesting static final int REQUEST_CAMERA_PERMISSION = 2345;
+  @VisibleForTesting static final int REQUEST_EXTERNAL_IMAGE_STORAGE_PERMISSION = 2344;
+  @VisibleForTesting static final int REQUEST_CAMERA_IMAGE_PERMISSION = 2345;
+  @VisibleForTesting static final int REQUEST_EXTERNAL_VIDEO_STORAGE_PERMISSION = 2354;
+  @VisibleForTesting static final int REQUEST_CAMERA_VIDEO_PERMISSION = 2355;
 
   @VisibleForTesting final String fileProviderName;
 
@@ -188,7 +190,7 @@ public class ImagePickerDelegate
 
     if (!permissionManager.isPermissionGranted(Manifest.permission.READ_EXTERNAL_STORAGE)) {
       permissionManager.askForPermission(
-          Manifest.permission.READ_EXTERNAL_STORAGE, REQUEST_EXTERNAL_STORAGE_PERMISSION);
+          Manifest.permission.READ_EXTERNAL_STORAGE, REQUEST_EXTERNAL_VIDEO_STORAGE_PERMISSION);
       return;
     }
 
@@ -209,7 +211,8 @@ public class ImagePickerDelegate
     }
 
     if (!permissionManager.isPermissionGranted(Manifest.permission.CAMERA)) {
-      permissionManager.askForPermission(Manifest.permission.CAMERA, REQUEST_CAMERA_PERMISSION);
+      permissionManager.askForPermission(
+          Manifest.permission.CAMERA, REQUEST_CAMERA_VIDEO_PERMISSION);
       return;
     }
 
@@ -243,7 +246,7 @@ public class ImagePickerDelegate
 
     if (!permissionManager.isPermissionGranted(Manifest.permission.READ_EXTERNAL_STORAGE)) {
       permissionManager.askForPermission(
-          Manifest.permission.READ_EXTERNAL_STORAGE, REQUEST_EXTERNAL_STORAGE_PERMISSION);
+          Manifest.permission.READ_EXTERNAL_STORAGE, REQUEST_EXTERNAL_IMAGE_STORAGE_PERMISSION);
       return;
     }
 
@@ -264,7 +267,8 @@ public class ImagePickerDelegate
     }
 
     if (!permissionManager.isPermissionGranted(Manifest.permission.CAMERA)) {
-      permissionManager.askForPermission(Manifest.permission.CAMERA, REQUEST_CAMERA_PERMISSION);
+      permissionManager.askForPermission(
+          Manifest.permission.CAMERA, REQUEST_CAMERA_IMAGE_PERMISSION);
       return;
     }
 
@@ -330,22 +334,36 @@ public class ImagePickerDelegate
     boolean permissionGranted =
         grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED;
 
-    if (requestCode == REQUEST_EXTERNAL_STORAGE_PERMISSION) {
-      if (permissionGranted) {
-        launchPickImageFromGalleryIntent();
-      } else {
-        finishWithSuccess(null);
-      }
-      return true;
-    } else if (requestCode == REQUEST_CAMERA_PERMISSION) {
-      if (permissionGranted) {
-        launchTakeImageWithCameraIntent();
-      } else {
-        finishWithSuccess(null);
-      }
-      return true;
+    switch (requestCode) {
+      case REQUEST_EXTERNAL_IMAGE_STORAGE_PERMISSION:
+        if (permissionGranted) {
+          launchPickImageFromGalleryIntent();
+        }
+        break;
+      case REQUEST_EXTERNAL_VIDEO_STORAGE_PERMISSION:
+        if (permissionGranted) {
+          launchPickVideoFromGalleryIntent();
+        }
+        break;
+      case REQUEST_CAMERA_IMAGE_PERMISSION:
+        if (permissionGranted) {
+          launchTakeImageWithCameraIntent();
+        }
+        break;
+      case REQUEST_CAMERA_VIDEO_PERMISSION:
+        if (permissionGranted) {
+          launchTakeVideoWithCameraIntent();
+        }
+        break;
+      default:
+        return false;
     }
-    return false;
+
+    if (!permissionGranted) {
+      finishWithSuccess(null);
+    }
+
+    return true;
   }
 
   @Override

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
@@ -225,7 +225,7 @@ public class ImagePickerDelegate
       return;
     }
 
-    File imageFile = createTemporaryWritableImageFile();
+    File imageFile = createTemporaryWritableVideoFile();
     pendingCameraImageUri = Uri.parse("file:" + imageFile.getAbsolutePath());
 
     Uri imageUri = fileUriResolver.resolveFileProviderUriForFile(fileProviderName, imageFile);
@@ -291,11 +291,19 @@ public class ImagePickerDelegate
   }
 
   private File createTemporaryWritableImageFile() {
+    return createTemporaryWritableFile(".jpg");
+  }
+
+  private File createTemporaryWritableVideoFile() {
+    return createTemporaryWritableFile(".mp4");
+  }
+
+  private File createTemporaryWritableFile(String suffix) {
     String filename = UUID.randomUUID().toString();
     File image;
 
     try {
-      image = File.createTempFile(filename, ".png", externalFilesDirectory);
+      image = File.createTempFile(filename, suffix, externalFilesDirectory);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/packages/image_picker/example/android/app/src/test/java/io/flutter/plugins/imagepicker/ImagePickerDelegateTest.java
+++ b/packages/image_picker/example/android/app/src/test/java/io/flutter/plugins/imagepicker/ImagePickerDelegateTest.java
@@ -184,7 +184,7 @@ public class ImagePickerDelegateTest {
 
   @Test
   public void
-      onRequestPermissionsResult_WhenReadExternalStorageGranted_LaunchesChooseFromGalleryIntent() {
+      onRequestChooseImagePermissionsResult_WhenReadExternalStorageGranted_LaunchesChooseImageFromGalleryIntent() {
     ImagePickerDelegate delegate = createDelegateWithPendingResultAndMethodCall();
 
     delegate.onRequestPermissionsResult(
@@ -195,6 +195,21 @@ public class ImagePickerDelegateTest {
     verify(mockActivity)
         .startActivityForResult(
             any(Intent.class), eq(ImagePickerDelegate.REQUEST_CODE_CHOOSE_IMAGE_FROM_GALLERY));
+  }
+
+  @Test
+  public void
+      onRequestChooseVideoPermissionsResult_WhenReadExternalStorageGranted_LaunchesChooseVideoFromGalleryIntent() {
+    ImagePickerDelegate delegate = createDelegateWithPendingResultAndMethodCall();
+
+    delegate.onRequestPermissionsResult(
+        ImagePickerDelegate.REQUEST_EXTERNAL_VIDEO_STORAGE_PERMISSION,
+        new String[] {Manifest.permission.READ_EXTERNAL_STORAGE},
+        new int[] {PackageManager.PERMISSION_GRANTED});
+
+    verify(mockActivity)
+        .startActivityForResult(
+            any(Intent.class), eq(ImagePickerDelegate.REQUEST_CODE_CHOOSE_VIDEO_FROM_GALLERY));
   }
 
   @Test
@@ -212,7 +227,23 @@ public class ImagePickerDelegateTest {
 
   @Test
   public void
-      onRequestPermissionsResult_WhenCameraPermissionGranted_LaunchesTakeWithCameraIntent() {
+      onRequestTakeVideoPermissionsResult_WhenCameraPermissionGranted_LaunchesTakeVideoWithCameraIntent() {
+    when(mockIntentResolver.resolveActivity(any(Intent.class))).thenReturn(true);
+
+    ImagePickerDelegate delegate = createDelegateWithPendingResultAndMethodCall();
+    delegate.onRequestPermissionsResult(
+        ImagePickerDelegate.REQUEST_CAMERA_VIDEO_PERMISSION,
+        new String[] {Manifest.permission.CAMERA},
+        new int[] {PackageManager.PERMISSION_GRANTED});
+
+    verify(mockActivity)
+        .startActivityForResult(
+            any(Intent.class), eq(ImagePickerDelegate.REQUEST_CODE_TAKE_VIDEO_WITH_CAMERA));
+  }
+
+  @Test
+  public void
+      onRequestTakeImagePermissionsResult_WhenCameraPermissionGranted_LaunchesTakeWithCameraIntent() {
     when(mockIntentResolver.resolveActivity(any(Intent.class))).thenReturn(true);
 
     ImagePickerDelegate delegate = createDelegateWithPendingResultAndMethodCall();
@@ -263,6 +294,19 @@ public class ImagePickerDelegateTest {
   }
 
   @Test
+  public void
+      onActivityResult_WhenVideoPickedFromGallery_AndResizeParametersSupplied_FinishesWithFilePath() {
+    when(mockMethodCall.argument("maxWidth")).thenReturn(WIDTH);
+
+    ImagePickerDelegate delegate = createDelegateWithPendingResultAndMethodCall();
+    delegate.onActivityResult(
+        ImagePickerDelegate.REQUEST_CODE_CHOOSE_VIDEO_FROM_GALLERY, Activity.RESULT_OK, mockIntent);
+
+    verify(mockResult).success("pathFromUri");
+    verifyNoMoreInteractions(mockResult);
+  }
+
+  @Test
   public void onActivityResult_WhenTakeImageWithCameraCanceled_FinishesWithNull() {
     ImagePickerDelegate delegate = createDelegateWithPendingResultAndMethodCall();
 
@@ -294,6 +338,19 @@ public class ImagePickerDelegateTest {
         ImagePickerDelegate.REQUEST_CODE_TAKE_IMAGE_WITH_CAMERA, Activity.RESULT_OK, mockIntent);
 
     verify(mockResult).success("scaledPath");
+    verifyNoMoreInteractions(mockResult);
+  }
+
+  @Test
+  public void
+      onActivityResult_WhenVideoTakenWithCamera_AndResizeParametersSupplied_FinishesWithFilePath() {
+    when(mockMethodCall.argument("maxWidth")).thenReturn(WIDTH);
+
+    ImagePickerDelegate delegate = createDelegateWithPendingResultAndMethodCall();
+    delegate.onActivityResult(
+        ImagePickerDelegate.REQUEST_CODE_TAKE_VIDEO_WITH_CAMERA, Activity.RESULT_OK, mockIntent);
+
+    verify(mockResult).success("pathFromUri");
     verifyNoMoreInteractions(mockResult);
   }
 

--- a/packages/image_picker/example/android/app/src/test/java/io/flutter/plugins/imagepicker/ImagePickerDelegateTest.java
+++ b/packages/image_picker/example/android/app/src/test/java/io/flutter/plugins/imagepicker/ImagePickerDelegateTest.java
@@ -115,7 +115,7 @@ public class ImagePickerDelegateTest {
 
     verify(mockActivity)
         .startActivityForResult(
-            any(Intent.class), eq(ImagePickerDelegate.REQUEST_CODE_CHOOSE_FROM_GALLERY));
+            any(Intent.class), eq(ImagePickerDelegate.REQUEST_CODE_CHOOSE_IMAGE_FROM_GALLERY));
   }
 
   @Test
@@ -151,7 +151,7 @@ public class ImagePickerDelegateTest {
 
     verify(mockActivity)
         .startActivityForResult(
-            any(Intent.class), eq(ImagePickerDelegate.REQUEST_CODE_TAKE_WITH_CAMERA));
+            any(Intent.class), eq(ImagePickerDelegate.REQUEST_CODE_TAKE_IMAGE_WITH_CAMERA));
   }
 
   @Test
@@ -194,7 +194,7 @@ public class ImagePickerDelegateTest {
 
     verify(mockActivity)
         .startActivityForResult(
-            any(Intent.class), eq(ImagePickerDelegate.REQUEST_CODE_CHOOSE_FROM_GALLERY));
+            any(Intent.class), eq(ImagePickerDelegate.REQUEST_CODE_CHOOSE_IMAGE_FROM_GALLERY));
   }
 
   @Test
@@ -223,7 +223,7 @@ public class ImagePickerDelegateTest {
 
     verify(mockActivity)
         .startActivityForResult(
-            any(Intent.class), eq(ImagePickerDelegate.REQUEST_CODE_TAKE_WITH_CAMERA));
+            any(Intent.class), eq(ImagePickerDelegate.REQUEST_CODE_TAKE_IMAGE_WITH_CAMERA));
   }
 
   @Test
@@ -231,7 +231,7 @@ public class ImagePickerDelegateTest {
     ImagePickerDelegate delegate = createDelegateWithPendingResultAndMethodCall();
 
     delegate.onActivityResult(
-        ImagePickerDelegate.REQUEST_CODE_CHOOSE_FROM_GALLERY, Activity.RESULT_CANCELED, null);
+        ImagePickerDelegate.REQUEST_CODE_CHOOSE_IMAGE_FROM_GALLERY, Activity.RESULT_CANCELED, null);
 
     verify(mockResult).success(null);
     verifyNoMoreInteractions(mockResult);
@@ -243,7 +243,7 @@ public class ImagePickerDelegateTest {
     ImagePickerDelegate delegate = createDelegateWithPendingResultAndMethodCall();
 
     delegate.onActivityResult(
-        ImagePickerDelegate.REQUEST_CODE_CHOOSE_FROM_GALLERY, Activity.RESULT_OK, mockIntent);
+        ImagePickerDelegate.REQUEST_CODE_CHOOSE_IMAGE_FROM_GALLERY, Activity.RESULT_OK, mockIntent);
 
     verify(mockResult).success("originalPath");
     verifyNoMoreInteractions(mockResult);
@@ -256,7 +256,7 @@ public class ImagePickerDelegateTest {
 
     ImagePickerDelegate delegate = createDelegateWithPendingResultAndMethodCall();
     delegate.onActivityResult(
-        ImagePickerDelegate.REQUEST_CODE_CHOOSE_FROM_GALLERY, Activity.RESULT_OK, mockIntent);
+        ImagePickerDelegate.REQUEST_CODE_CHOOSE_IMAGE_FROM_GALLERY, Activity.RESULT_OK, mockIntent);
 
     verify(mockResult).success("scaledPath");
     verifyNoMoreInteractions(mockResult);
@@ -267,7 +267,7 @@ public class ImagePickerDelegateTest {
     ImagePickerDelegate delegate = createDelegateWithPendingResultAndMethodCall();
 
     delegate.onActivityResult(
-        ImagePickerDelegate.REQUEST_CODE_TAKE_WITH_CAMERA, Activity.RESULT_CANCELED, null);
+        ImagePickerDelegate.REQUEST_CODE_TAKE_IMAGE_WITH_CAMERA, Activity.RESULT_CANCELED, null);
 
     verify(mockResult).success(null);
     verifyNoMoreInteractions(mockResult);
@@ -278,7 +278,7 @@ public class ImagePickerDelegateTest {
     ImagePickerDelegate delegate = createDelegateWithPendingResultAndMethodCall();
 
     delegate.onActivityResult(
-        ImagePickerDelegate.REQUEST_CODE_TAKE_WITH_CAMERA, Activity.RESULT_OK, mockIntent);
+        ImagePickerDelegate.REQUEST_CODE_TAKE_IMAGE_WITH_CAMERA, Activity.RESULT_OK, mockIntent);
 
     verify(mockResult).success("originalPath");
     verifyNoMoreInteractions(mockResult);
@@ -291,7 +291,7 @@ public class ImagePickerDelegateTest {
 
     ImagePickerDelegate delegate = createDelegateWithPendingResultAndMethodCall();
     delegate.onActivityResult(
-        ImagePickerDelegate.REQUEST_CODE_TAKE_WITH_CAMERA, Activity.RESULT_OK, mockIntent);
+        ImagePickerDelegate.REQUEST_CODE_TAKE_IMAGE_WITH_CAMERA, Activity.RESULT_OK, mockIntent);
 
     verify(mockResult).success("scaledPath");
     verifyNoMoreInteractions(mockResult);

--- a/packages/image_picker/example/android/app/src/test/java/io/flutter/plugins/imagepicker/ImagePickerDelegateTest.java
+++ b/packages/image_picker/example/android/app/src/test/java/io/flutter/plugins/imagepicker/ImagePickerDelegateTest.java
@@ -101,7 +101,7 @@ public class ImagePickerDelegateTest {
     verify(mockPermissionManager)
         .askForPermission(
             Manifest.permission.READ_EXTERNAL_STORAGE,
-            ImagePickerDelegate.REQUEST_EXTERNAL_STORAGE_PERMISSION);
+            ImagePickerDelegate.REQUEST_EXTERNAL_IMAGE_STORAGE_PERMISSION);
   }
 
   @Test
@@ -137,7 +137,7 @@ public class ImagePickerDelegateTest {
 
     verify(mockPermissionManager)
         .askForPermission(
-            Manifest.permission.CAMERA, ImagePickerDelegate.REQUEST_CAMERA_PERMISSION);
+            Manifest.permission.CAMERA, ImagePickerDelegate.REQUEST_CAMERA_IMAGE_PERMISSION);
   }
 
   @Test
@@ -174,7 +174,7 @@ public class ImagePickerDelegateTest {
     ImagePickerDelegate delegate = createDelegateWithPendingResultAndMethodCall();
 
     delegate.onRequestPermissionsResult(
-        ImagePickerDelegate.REQUEST_EXTERNAL_STORAGE_PERMISSION,
+        ImagePickerDelegate.REQUEST_EXTERNAL_IMAGE_STORAGE_PERMISSION,
         new String[] {Manifest.permission.READ_EXTERNAL_STORAGE},
         new int[] {PackageManager.PERMISSION_DENIED});
 
@@ -188,7 +188,7 @@ public class ImagePickerDelegateTest {
     ImagePickerDelegate delegate = createDelegateWithPendingResultAndMethodCall();
 
     delegate.onRequestPermissionsResult(
-        ImagePickerDelegate.REQUEST_EXTERNAL_STORAGE_PERMISSION,
+        ImagePickerDelegate.REQUEST_EXTERNAL_IMAGE_STORAGE_PERMISSION,
         new String[] {Manifest.permission.READ_EXTERNAL_STORAGE},
         new int[] {PackageManager.PERMISSION_GRANTED});
 
@@ -202,7 +202,7 @@ public class ImagePickerDelegateTest {
     ImagePickerDelegate delegate = createDelegateWithPendingResultAndMethodCall();
 
     delegate.onRequestPermissionsResult(
-        ImagePickerDelegate.REQUEST_CAMERA_PERMISSION,
+        ImagePickerDelegate.REQUEST_CAMERA_IMAGE_PERMISSION,
         new String[] {Manifest.permission.CAMERA},
         new int[] {PackageManager.PERMISSION_DENIED});
 
@@ -217,7 +217,7 @@ public class ImagePickerDelegateTest {
 
     ImagePickerDelegate delegate = createDelegateWithPendingResultAndMethodCall();
     delegate.onRequestPermissionsResult(
-        ImagePickerDelegate.REQUEST_CAMERA_PERMISSION,
+        ImagePickerDelegate.REQUEST_CAMERA_IMAGE_PERMISSION,
         new String[] {Manifest.permission.CAMERA},
         new int[] {PackageManager.PERMISSION_GRANTED});
 


### PR DESCRIPTION
This PR is for three bugs relating to image picker.  I found the latter two when fixing the first.  I'm happy to split this up if that's easier.

- (android) image_picker saves both captured images and captured video with a `.png` extension.  I'm not 100% sure that `.jpg` and `.mp4` are correct -- I couldn't find an authoritative source -- but that's what most information seemed to point towards.
- (android) if the initial request from an app is for either video capture or the video gallery, after permission is granted, image_picker redirects to image capture or the image gallery.
- (android) image_picker attempts to resize video if any of the resize parameters (maxWidth, maxHeight) are provided