### PR TITLE
Hotfix - iOS Sharing

### DIFF
--- a/packages/share/CHANGELOG.md
+++ b/packages/share/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.2
+
+* Fixes iOS sharing
+
 ## 0.5.1
 
 * Updated Gradle tooling to match Android Studio 3.1.2.

--- a/packages/share/ios/Classes/SharePlugin.m
+++ b/packages/share/ios/Classes/SharePlugin.m
@@ -16,8 +16,12 @@ static NSString *const PLATFORM_CHANNEL = @"plugins.flutter.io/share";
   [shareChannel setMethodCallHandler:^(FlutterMethodCall *call, FlutterResult result) {
     if ([@"share" isEqualToString:call.method]) {
       NSDictionary *arguments = [call arguments];
+      NSString *shareText;
+      if ([arguments[@"text"] isKindOfClass:[NSString class]] == YES) {
+        shareText = arguments[@"text"];
+      }
 
-      if ([arguments[@"text"] length] == 0) {
+      if (shareText.length == 0) {
         result(
             [FlutterError errorWithCode:@"error" message:@"Non-empty text expected" details:nil]);
         return;
@@ -34,7 +38,7 @@ static NSString *const PLATFORM_CHANNEL = @"plugins.flutter.io/share";
                                 [originWidth doubleValue], [originHeight doubleValue]);
       }
 
-      [self share:call.arguments
+      [self share:shareText
           withController:[UIApplication sharedApplication].keyWindow.rootViewController
                 atSource:originRect];
       result(nil);

--- a/packages/share/ios/Classes/SharePlugin.m
+++ b/packages/share/ios/Classes/SharePlugin.m
@@ -16,10 +16,7 @@ static NSString *const PLATFORM_CHANNEL = @"plugins.flutter.io/share";
   [shareChannel setMethodCallHandler:^(FlutterMethodCall *call, FlutterResult result) {
     if ([@"share" isEqualToString:call.method]) {
       NSDictionary *arguments = [call arguments];
-      NSString *shareText;
-      if ([arguments[@"text"] isKindOfClass:[NSString class]] == YES) {
-        shareText = arguments[@"text"];
-      }
+      NSString *shareText = arguments[@"text"];
 
       if (shareText.length == 0) {
         result(

--- a/packages/share/ios/share.podspec
+++ b/packages/share/ios/share.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'share'
-  s.version          = '0.0.1'
+  s.version          = '0.5.2'
   s.summary          = 'A Flutter plugin for sharing content from the Flutter app via the platform share sheet.'
   s.description      = <<-DESC
 A Flutter plugin for sharing content from the Flutter app via the platform share sheet.

--- a/packages/share/pubspec.yaml
+++ b/packages/share/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for sharing content via the platform share UI, using
   the ACTION_SEND intent on Android and UIActivityViewController on iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/share
-version: 0.5.1
+version: 0.5.2
 
 flutter:
   plugin:


### PR DESCRIPTION
* iOS sharing is currently broken
  - Can be observed in `0.5.1` by attempting the *Copy* action - no text will be copied.