### PR TITLE
Upgrade to Xcode 9.3 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ matrix:
       env:
         - SHARD=Build-example-IPAs
       language: generic
-      osx_image: xcode9.2
+      osx_image: xcode9.3
       before_script:
         - brew update
         - brew install libimobiledevice


### PR DESCRIPTION
Attempt to resolve compile error inside `cloud_firestore` dependencies on iOS. Cannot reproduce the error locally, speculating that a new version of Xcode might help.

E.g. https://travis-ci.org/flutter/plugins/jobs/389379744