### PR TITLE
video_player: add hls support for android

### DIFF
--- a/packages/video_player/README.md
+++ b/packages/video_player/README.md
@@ -58,6 +58,7 @@ class _VideoAppState extends State<VideoApp> {
   @override
   void initState() {
     super.initState();
+    // Note: if you are trying to play a .m3u8 file you need to pass an additional optional parameter isHls: true.
     _controller = VideoPlayerController.network(
       'http://www.sample-videos.com/video/mp4/720/big_buck_bunny_720p_20mb.mp4',
     )

--- a/packages/video_player/android/build.gradle
+++ b/packages/video_player/android/build.gradle
@@ -34,5 +34,6 @@ android {
 
     dependencies {
         implementation 'com.google.android.exoplayer:exoplayer-core:2.8.0'
+        implementation 'com.google.android.exoplayer:exoplayer-hls:2.8.0'
     }
 }

--- a/packages/video_player/example/lib/main.dart
+++ b/packages/video_player/example/lib/main.dart
@@ -158,15 +158,17 @@ typedef Widget VideoWidgetBuilder(
 abstract class PlayerLifeCycle extends StatefulWidget {
   final VideoWidgetBuilder childBuilder;
   final String dataSource;
+  final bool isHls;
 
-  PlayerLifeCycle(this.dataSource, this.childBuilder);
+  PlayerLifeCycle(this.dataSource, this.isHls, this.childBuilder);
 }
 
 /// A widget connecting its life cycle to a [VideoPlayerController] using
 /// a data source from the network.
 class NetworkPlayerLifeCycle extends PlayerLifeCycle {
-  NetworkPlayerLifeCycle(String dataSource, VideoWidgetBuilder childBuilder)
-      : super(dataSource, childBuilder);
+  NetworkPlayerLifeCycle(
+      String dataSource, bool isHls, VideoWidgetBuilder childBuilder)
+      : super(dataSource, isHls, childBuilder);
 
   @override
   _NetworkPlayerLifeCycleState createState() =>
@@ -176,8 +178,9 @@ class NetworkPlayerLifeCycle extends PlayerLifeCycle {
 /// A widget connecting its life cycle to a [VideoPlayerController] using
 /// an asset as data source
 class AssetPlayerLifeCycle extends PlayerLifeCycle {
-  AssetPlayerLifeCycle(String dataSource, VideoWidgetBuilder childBuilder)
-      : super(dataSource, childBuilder);
+  AssetPlayerLifeCycle(
+      String dataSource, bool isHls, VideoWidgetBuilder childBuilder)
+      : super(dataSource, isHls, childBuilder);
 
   @override
   _AssetPlayerLifeCycleState createState() => new _AssetPlayerLifeCycleState();
@@ -225,14 +228,16 @@ abstract class _PlayerLifeCycleState extends State<PlayerLifeCycle> {
 class _NetworkPlayerLifeCycleState extends _PlayerLifeCycleState {
   @override
   VideoPlayerController createVideoPlayerController() {
-    return new VideoPlayerController.network(widget.dataSource);
+    return new VideoPlayerController.network(widget.dataSource,
+        isHls: widget.isHls);
   }
 }
 
 class _AssetPlayerLifeCycleState extends _PlayerLifeCycleState {
   @override
   VideoPlayerController createVideoPlayerController() {
-    return new VideoPlayerController.asset(widget.dataSource);
+    return new VideoPlayerController.asset(widget.dataSource,
+        isHls: widget.isHls);
   }
 }
 
@@ -373,13 +378,25 @@ void main() {
           ),
           body: new TabBarView(
             children: <Widget>[
-              new NetworkPlayerLifeCycle(
-                'http://www.sample-videos.com/video/mp4/720/big_buck_bunny_720p_20mb.mp4',
-                (BuildContext context, VideoPlayerController controller) =>
-                    new AspectRatioVideo(controller),
+              new Column(
+                children: <Widget>[
+                  new NetworkPlayerLifeCycle(
+                    'http://www.sample-videos.com/video/mp4/720/big_buck_bunny_720p_20mb.mp4',
+                    false,
+                    (BuildContext context, VideoPlayerController controller) =>
+                        new AspectRatioVideo(controller),
+                  ),
+                  new NetworkPlayerLifeCycle(
+                    'http://live.cloud6.in:1935/simskasri/limitless/playlist.m3u8',
+                    true,
+                    (BuildContext context, VideoPlayerController controller) =>
+                        new AspectRatioVideo(controller),
+                  ),
+                ],
               ),
               new AssetPlayerLifeCycle(
                   'assets/Butterfly-209.mp4',
+                  false,
                   (BuildContext context, VideoPlayerController controller) =>
                       new VideoInListOfCards(controller)),
             ],

--- a/packages/video_player/lib/video_player.dart
+++ b/packages/video_player/lib/video_player.dart
@@ -143,6 +143,7 @@ enum DataSourceType { asset, network, file }
 class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   int _textureId;
   final String dataSource;
+  final bool isHls;
 
   /// Describes the type of data source this [VideoPlayerController]
   /// is constructed with.
@@ -160,7 +161,8 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   /// The name of the asset is given by the [dataSource] argument and must not be
   /// null. The [package] argument must be non-null when the asset comes from a
   /// package and null otherwise.
-  VideoPlayerController.asset(this.dataSource, {this.package})
+  VideoPlayerController.asset(this.dataSource,
+      {this.package, this.isHls = false})
       : dataSourceType = DataSourceType.asset,
         super(new VideoPlayerValue(duration: null));
 
@@ -169,7 +171,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   ///
   /// The URI for the video is given by the [dataSource] argument and must not be
   /// null.
-  VideoPlayerController.network(this.dataSource)
+  VideoPlayerController.network(this.dataSource, {this.isHls = false})
       : dataSourceType = DataSourceType.network,
         super(new VideoPlayerValue(duration: null));
 
@@ -177,7 +179,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   ///
   /// This will load the file from the file-URI given by:
   /// `'file://${file.path}'`.
-  VideoPlayerController.file(File file)
+  VideoPlayerController.file(File file, {this.isHls = false})
       : dataSource = 'file://${file.path}',
         dataSourceType = DataSourceType.file,
         super(new VideoPlayerValue(duration: null));
@@ -191,14 +193,21 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
       case DataSourceType.asset:
         dataSourceDescription = <String, dynamic>{
           'asset': dataSource,
-          'package': package
+          'package': package,
+          'isHls': isHls,
         };
         break;
       case DataSourceType.network:
-        dataSourceDescription = <String, dynamic>{'uri': dataSource};
+        dataSourceDescription = <String, dynamic>{
+          'uri': dataSource,
+          'isHls': isHls
+        };
         break;
       case DataSourceType.file:
-        dataSourceDescription = <String, dynamic>{'uri': dataSource};
+        dataSourceDescription = <String, dynamic>{
+          'uri': dataSource,
+          'isHls': isHls
+        };
     }
     final Map<dynamic, dynamic> response = await _channel.invokeMethod(
       'create',

--- a/packages/video_player/pubspec.yaml
+++ b/packages/video_player/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player
 description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
-version: 0.6.0
+version: 0.6.1
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player
 
 flutter:


### PR DESCRIPTION
VideoPlayer constructor now takes an optional isHls parameter to determine whether to use a HlsMediaSource