### PR TITLE
video_player: iOS add missing observer removals 

### DIFF
--- a/packages/video_player/CHANGELOG.md
+++ b/packages/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.1
+
+* iOS: add missing observer removals to prevent crashes on deallocation. 
+
 ## 0.6.0
 
 * Android: use ExoPlayer instead of MediaPlayer for better video format support.

--- a/packages/video_player/ios/Classes/VideoPlayerPlugin.m
+++ b/packages/video_player/ios/Classes/VideoPlayerPlugin.m
@@ -271,6 +271,12 @@ static void* playbackBufferFullContext = &playbackBufferFullContext;
   [[_player currentItem] removeObserver:self
                              forKeyPath:@"playbackLikelyToKeepUp"
                                 context:playbackLikelyToKeepUpContext];
+  [[_player currentItem] removeObserver:self
+                             forKeyPath:@"playbackBufferEmpty"
+                                context:playbackBufferEmptyContext];
+  [[_player currentItem] removeObserver:self
+                             forKeyPath:@"playbackBufferFull"
+                                context:playbackBufferFullContext];
   [_player replaceCurrentItemWithPlayerItem:nil];
   [[NSNotificationCenter defaultCenter] removeObserver:self];
   [_eventChannel setStreamHandler:nil];

--- a/packages/video_player/pubspec.yaml
+++ b/packages/video_player/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player
 description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
-version: 0.6.0
+version: 0.6.1
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player
 
 flutter:


### PR DESCRIPTION
Add missing observer removals to prevent crashes on deallocation. Crashes were seen with an iPhone 5.