### PR TITLE
Ensure we fail if we cannot close file

### DIFF
--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.6
+
+* Added support for picking remote images.
+
 ## 0.4.5
 
 * Bugfixes, code cleanup, more test coverage.

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
@@ -454,7 +454,7 @@ public class ImagePickerDelegate
       String finalImagePath = imageResizer.resizeImageIfNeeded(path, maxWidth, maxHeight);
       finishWithSuccess(finalImagePath);
     } else {
-      throw new IllegalStateException("Received images from picker that were not requested");
+      throw new IllegalStateException("Received image from picker that was not requested");
     }
   }
 
@@ -462,7 +462,7 @@ public class ImagePickerDelegate
     if (pendingResult != null) {
       finishWithSuccess(path);
     } else {
-      throw new IllegalStateException("Received images from picker that were not requested");
+      throw new IllegalStateException("Received video from picker that was not requested");
     }
   }
 

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -5,7 +5,7 @@ authors:
   - Flutter Team <flutter-dev@googlegroups.com>
   - Rhodes Davis Jr. <rody.davis.jr@gmail.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.4.5
+version: 0.4.6
 
 flutter:
   plugin:


### PR DESCRIPTION
`OutputStream.flush` is not guaranteed to move bytes all the way to storage media, so if `OutputStream.close` fails, we need to return `null`.

Sigh. Try-with-resources and `java.nio.file.Files` wft!

Follow-up of https://github.com/flutter/plugins/pull/513