### PR TITLE
video_player: Allow audio playback in silent mode

### DIFF
--- a/packages/video_player/CHANGELOG.md
+++ b/packages/video_player/CHANGELOG.md
@@ -1,7 +1,10 @@
-## 0.6.2
+## 0.6.3
 
 * iOS: Allow audio playback in silent mode.
-* `VideoPlayerController.seekTo.()` is now frame accurate on both platforms.
+
+## 0.6.2
+
+* `VideoPlayerController.seekTo()` is now frame accurate on both platforms.
 
 ## 0.6.1
 

--- a/packages/video_player/CHANGELOG.md
+++ b/packages/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.2
+
+* iOS: Allow audio playback in silent mode.
+
 ## 0.6.1
 
 * iOS: add missing observer removals to prevent crashes on deallocation. 

--- a/packages/video_player/ios/Classes/VideoPlayerPlugin.m
+++ b/packages/video_player/ios/Classes/VideoPlayerPlugin.m
@@ -313,6 +313,9 @@ static void* playbackBufferFullContext = &playbackBufferFullContext;
 
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
   if ([@"init" isEqualToString:call.method]) {
+    // Allow audio playback when the Ring/Silent switch is set to silent
+    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:nil];
+
     for (NSNumber* textureId in _players) {
       [_registry unregisterTexture:[textureId unsignedIntegerValue]];
       [[_players objectForKey:textureId] dispose];

--- a/packages/video_player/pubspec.yaml
+++ b/packages/video_player/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player
 description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
-version: 0.6.1
+version: 0.6.2
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player
 
 flutter:

--- a/packages/video_player/pubspec.yaml
+++ b/packages/video_player/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player
 description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
-version: 0.6.2
+version: 0.6.3
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player
 
 flutter:


### PR DESCRIPTION
This is the default behaviour of video apps on iOS. 
(fixes https://github.com/flutter/flutter/issues/17911)

I considered setting the category back to `AVAudioSessionCategorySoloAmbient` on `dispose` but this led to race conditions when switching between videos.