### PR TITLE
Added comments explaining the time it take to see results

### DIFF
--- a/packages/firebase_performance/CHANGELOG.md
+++ b/packages/firebase_performance/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.5
+
+Added comments explaining the time it takes to see performance results.
+
 ## 0.0.4
 
 * Formatted code, updated comments, and removed unnecessary files.

--- a/packages/firebase_performance/README.md
+++ b/packages/firebase_performance/README.md
@@ -12,6 +12,8 @@ For Flutter plugins for other Firebase products, see [FlutterFire.md](https://gi
 
 To use this plugin, add `firebase_performance` as a [dependency in your pubspec.yaml file](https://flutter.io/platform-plugins/). You must also configure firebase performance monitoring for each platform project: Android and iOS (see the example folder or https://codelabs.developers.google.com/codelabs/flutter-firebase/#4 for step by step details).
 
+You can confirm that Performance Monitoring results appear in the [Firebase console.](https://console.firebase.google.com/) Results should appear within 12 hours.
+
 ## Define a Custom Trace
 
 A custom trace is a report of performance data associated with some of the code in your app. To learn more about custom traces, see the [Performance Monitoring overview](https://firebase.google.com/docs/perf-mon/#how_does_it_work).

--- a/packages/firebase_performance/lib/src/http_metric.dart
+++ b/packages/firebase_performance/lib/src/http_metric.dart
@@ -12,6 +12,9 @@ part of firebase_performance;
 ///
 /// Data collected is automatically sent to the associated Firebase console
 /// after stop() is called.
+///
+/// You can confirm that Performance Monitoring results appear in the Firebase
+/// console. Results should appear within 12 hours.
 class HttpMetric extends PerformanceAttributes {
   HttpMetric._(this._handle, this._url, this._httpMethod);
 

--- a/packages/firebase_performance/lib/src/trace.dart
+++ b/packages/firebase_performance/lib/src/trace.dart
@@ -15,6 +15,9 @@ part of firebase_performance;
 ///
 /// Data collected is automatically sent to the associated Firebase console
 /// after stop() is called.
+///
+/// You can confirm that Performance Monitoring results appear in the Firebase
+/// console. Results should appear within 12 hours.
 class Trace extends PerformanceAttributes {
   Trace._(this._handle, this._name) {
     assert(_name != null);

--- a/packages/firebase_performance/pubspec.yaml
+++ b/packages/firebase_performance/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Google Performance Monitoring for Firebase, an a
   iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_performance
-version: 0.0.4
+version: 0.0.5
 
 dependencies:
   flutter:


### PR DESCRIPTION
Helps prevent confusion such as:
https://github.com/flutter/flutter/issues/18620#issuecomment-398918148 
https://stackoverflow.com/questions/44591815/unable-to-see-firebase-performance-dashboard-on-console