### PR TITLE
Adds nonPersonalizedAds option to MobileAdTargetingInfo for firebase_admob

### DIFF
--- a/packages/firebase_admob/CHANGELOG.md
+++ b/packages/firebase_admob/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.0
+
+* Add nonPersonalizedAds option to MobileAdTargetingInfo
+
 ## 0.5.7
 
 * Bumped mockito dependency to pick up Dart 2 support.

--- a/packages/firebase_admob/android/src/main/java/io/flutter/plugins/firebaseadmob/AdRequestBuilderFactory.java
+++ b/packages/firebase_admob/android/src/main/java/io/flutter/plugins/firebaseadmob/AdRequestBuilderFactory.java
@@ -5,7 +5,9 @@
 package io.flutter.plugins.firebaseadmob;
 
 import android.util.Log;
+import android.os.Bundle;
 import com.google.android.gms.ads.AdRequest;
+import com.google.ads.mediation.admob.AdMobAdapter;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.Map;
@@ -114,6 +116,14 @@ class AdRequestBuilderFactory {
 
     String requestAgent = getTargetingInfoString("requestAgent", targetingInfo.get("requestAgent"));
     if (requestAgent != null) builder.setRequestAgent(requestAgent);
+
+    Boolean nonPersonalizedAds =
+            getTargetingInfoBoolean("nonPersonalizedAds", targetingInfo.get("nonPersonalizedAds"));
+    if (nonPersonalizedAds != null && nonPersonalizedAds){
+      Bundle extras = new Bundle();
+      extras.putString("npa", "1");
+      builder.addNetworkExtrasBundle(AdMobAdapter.class, extras);
+    }
 
     return builder;
   }

--- a/packages/firebase_admob/android/src/main/java/io/flutter/plugins/firebaseadmob/AdRequestBuilderFactory.java
+++ b/packages/firebase_admob/android/src/main/java/io/flutter/plugins/firebaseadmob/AdRequestBuilderFactory.java
@@ -4,10 +4,10 @@
 
 package io.flutter.plugins.firebaseadmob;
 
-import android.util.Log;
 import android.os.Bundle;
-import com.google.android.gms.ads.AdRequest;
+import android.util.Log;
 import com.google.ads.mediation.admob.AdMobAdapter;
+import com.google.android.gms.ads.AdRequest;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.Map;
@@ -118,8 +118,8 @@ class AdRequestBuilderFactory {
     if (requestAgent != null) builder.setRequestAgent(requestAgent);
 
     Boolean nonPersonalizedAds =
-            getTargetingInfoBoolean("nonPersonalizedAds", targetingInfo.get("nonPersonalizedAds"));
-    if (nonPersonalizedAds != null && nonPersonalizedAds){
+        getTargetingInfoBoolean("nonPersonalizedAds", targetingInfo.get("nonPersonalizedAds"));
+    if (nonPersonalizedAds != null && nonPersonalizedAds) {
       Bundle extras = new Bundle();
       extras.putString("npa", "1");
       builder.addNetworkExtrasBundle(AdMobAdapter.class, extras);

--- a/packages/firebase_admob/example/lib/main.dart
+++ b/packages/firebase_admob/example/lib/main.dart
@@ -22,6 +22,7 @@ class _MyAppState extends State<MyApp> {
     birthday: new DateTime.now(),
     childDirected: true,
     gender: MobileAdGender.male,
+    nonPersonalizedAds: true,
   );
 
   BannerAd _bannerAd;

--- a/packages/firebase_admob/ios/Classes/FLTRequestFactory.m
+++ b/packages/firebase_admob/ios/Classes/FLTRequestFactory.m
@@ -4,8 +4,8 @@
 
 #import "FLTRequestFactory.h"
 #import "FirebaseAdMobPlugin.h"
-#import "GoogleMobileAds/GoogleMobileAds.h"
 #import "GoogleMobileAds/GADExtras.h"
+#import "GoogleMobileAds/GoogleMobileAds.h"
 
 @implementation FLTRequestFactory
 
@@ -121,10 +121,11 @@ NSDictionary *_targetingInfo;
     request.requestAgent = requestAgent;
   }
 
-  NSNumber *nonPersonalizedAds = [self targetingInfoBoolForKey:@"nonPersonalizedAds" info:_targetingInfo];
+  NSNumber *nonPersonalizedAds =
+      [self targetingInfoBoolForKey:@"nonPersonalizedAds" info:_targetingInfo];
   if (nonPersonalizedAds != nil && [nonPersonalizedAds boolValue]) {
     GADExtras *extras = [[GADExtras alloc] init];
-    extras.additionalParameters = @{@"npa": @"1"};
+    extras.additionalParameters = @{@"npa" : @"1"};
     [request registerAdNetworkExtras:extras];
   }
 

--- a/packages/firebase_admob/ios/Classes/FLTRequestFactory.m
+++ b/packages/firebase_admob/ios/Classes/FLTRequestFactory.m
@@ -5,6 +5,7 @@
 #import "FLTRequestFactory.h"
 #import "FirebaseAdMobPlugin.h"
 #import "GoogleMobileAds/GoogleMobileAds.h"
+#import "GoogleMobileAds/GADExtras.h"
 
 @implementation FLTRequestFactory
 
@@ -118,6 +119,13 @@ NSDictionary *_targetingInfo;
   NSString *requestAgent = [self targetingInfoStringForKey:@"requestAgent" info:_targetingInfo];
   if (requestAgent != nil) {
     request.requestAgent = requestAgent;
+  }
+
+  NSNumber *nonPersonalizedAds = [self targetingInfoBoolForKey:@"nonPersonalizedAds" info:_targetingInfo];
+  if (nonPersonalizedAds != nil && [nonPersonalizedAds boolValue]) {
+    GADExtras *extras = [[GADExtras alloc] init];
+    extras.additionalParameters = @{@"npa": @"1"};
+    [request registerAdNetworkExtras:extras];
   }
 
   return request;

--- a/packages/firebase_admob/lib/firebase_admob.dart
+++ b/packages/firebase_admob/lib/firebase_admob.dart
@@ -39,16 +39,15 @@ typedef void MobileAdListener(MobileAdEvent event);
 /// This class's properties mirror the native AdRequest API. See for example:
 /// [AdRequest.Builder for Android](https://firebase.google.com/docs/reference/android/com/google/android/gms/ads/AdRequest.Builder).
 class MobileAdTargetingInfo {
-  const MobileAdTargetingInfo({
-    this.keywords,
-    this.contentUrl,
-    this.birthday,
-    this.gender,
-    this.designedForFamilies,
-    this.childDirected,
-    this.testDevices,
-    this.nonPersonalizedAds
-  });
+  const MobileAdTargetingInfo(
+      {this.keywords,
+      this.contentUrl,
+      this.birthday,
+      this.gender,
+      this.designedForFamilies,
+      this.childDirected,
+      this.testDevices,
+      this.nonPersonalizedAds});
 
   final List<String> keywords;
   final String contentUrl;

--- a/packages/firebase_admob/lib/firebase_admob.dart
+++ b/packages/firebase_admob/lib/firebase_admob.dart
@@ -47,6 +47,7 @@ class MobileAdTargetingInfo {
     this.designedForFamilies,
     this.childDirected,
     this.testDevices,
+    this.nonPersonalizedAds
   });
 
   final List<String> keywords;
@@ -56,6 +57,7 @@ class MobileAdTargetingInfo {
   final bool designedForFamilies;
   final bool childDirected;
   final List<String> testDevices;
+  final bool nonPersonalizedAds;
 
   Map<String, dynamic> toJson() {
     final Map<String, dynamic> json = <String, dynamic>{
@@ -66,6 +68,8 @@ class MobileAdTargetingInfo {
       assert(keywords.every((String s) => s != null && s.isNotEmpty));
       json['keywords'] = keywords;
     }
+    if (nonPersonalizedAds != null)
+      json['nonPersonalizedAds'] = nonPersonalizedAds;
     if (contentUrl != null && contentUrl.isNotEmpty)
       json['contentUrl'] = contentUrl;
     if (birthday != null) json['birthday'] = birthday.millisecondsSinceEpoch;

--- a/packages/firebase_admob/pubspec.yaml
+++ b/packages/firebase_admob/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_admob
 description: Firebase AdMob plugin for Flutter applications.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_admob
-version: 0.5.7
+version: 0.6.0
 
 flutter:
   plugin:


### PR DESCRIPTION
In the light of recent events, namely GDPR, I was missing the functionality to request non-personalized ads in the firebase_admob plugin. This PR adds this option and the respective Android/iOS platform specific code (as described in the Google Mobile Ads SDK).
I also added `nonPersonalizedAds: true` to the example. Unfortunately there currently is no way in the GMA SDK to programmatically check if the requested ad is in fact non-personalized - so no test exists right now. 

This is my first contribution, so it's likely I missed something. Please let me know if that's the case - thanks! 👍 

This feature was requested/asked for in [Issue #17542 [main flutter repo]](https://github.com/flutter/flutter/issues/17542).