### PR TITLE
Update google_maps_flutter.podspec

### DIFF
--- a/packages/google_maps_flutter/ios/google_maps_flutter.podspec
+++ b/packages/google_maps_flutter/ios/google_maps_flutter.podspec
@@ -17,5 +17,6 @@ A new flutter plugin project.
   s.dependency 'Flutter'
   s.dependency 'GoogleMaps'
   s.static_framework = true
+  s.compiler_flags = '-fno-modules'
   s.ios.deployment_target = '8.0'
 end


### PR DESCRIPTION
Solves issue of
fatal error: module 'GoogleMapsBase' not found
@import GoogleMapsBase;