### PR TITLE
Support updateEmail in firebase_auth

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,4 +14,6 @@ Hayden Flinner <haydenflinner@gmail.com>
 Stefano Rodriguez <hlsroddy@gmail.com>
 Salvatore Giordano <salvatoregiordanoo@gmail.com>
 Brian Armstrong <brian@flutter.institute>
-Fabricio Nogueira <feufeu@gmail.com> 
+Fabricio Nogueira <feufeu@gmail.com>
+Ashton Thomas <ashton@acrinta.com>
+Thomas Danner <thmsdnnr@gmail.com>

--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.18
+
+* Adding support for updateEmail in FirebaseAuth.
+
 ## 0.5.17
 
 * Adding support for FirebaseUser.delete. 

--- a/packages/firebase_auth/android/src/main/java/io/flutter/plugins/firebaseauth/FirebaseAuthPlugin.java
+++ b/packages/firebase_auth/android/src/main/java/io/flutter/plugins/firebaseauth/FirebaseAuthPlugin.java
@@ -114,6 +114,9 @@ public class FirebaseAuthPlugin implements MethodCallHandler {
       case "updateProfile":
         handleUpdateProfile(call, result);
         break;
+      case "updateEmail":
+        handleUpdateEmail(call, result);
+        break;
       case "startListeningAuthState":
         handleStartListeningAuthState(call, result);
         break;
@@ -436,6 +439,28 @@ public class FirebaseAuthPlugin implements MethodCallHandler {
     firebaseAuth
         .getCurrentUser()
         .updateProfile(builder.build())
+        .addOnCompleteListener(
+            new OnCompleteListener<Void>() {
+              @Override
+              public void onComplete(@NonNull Task<Void> task) {
+                if (!task.isSuccessful()) {
+                  Exception e = task.getException();
+                  result.error(ERROR_REASON_EXCEPTION, e.getMessage(), null);
+                } else {
+                  result.success(null);
+                }
+              }
+            });
+  }
+
+  private void handleUpdateEmail(MethodCall call, final Result result) {
+    @SuppressWarnings("unchecked")
+    Map<String, String> arguments = (Map<String, String>) call.arguments;
+    String email = arguments.get("email");
+
+    firebaseAuth
+        .getCurrentUser()
+        .updateEmail(email)
         .addOnCompleteListener(
             new OnCompleteListener<Void>() {
               @Override

--- a/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.h
+++ b/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.h
@@ -6,5 +6,5 @@
 
 #import "Firebase/Firebase.h"
 
-@interface FLTFirebaseAuthPlugin : NSObject<FlutterPlugin>
+@interface FLTFirebaseAuthPlugin : NSObject <FlutterPlugin>
 @end

--- a/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.h
+++ b/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.h
@@ -6,5 +6,5 @@
 
 #import "Firebase/Firebase.h"
 
-@interface FLTFirebaseAuthPlugin : NSObject <FlutterPlugin>
+@interface FLTFirebaseAuthPlugin : NSObject<FlutterPlugin>
 @end

--- a/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
+++ b/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
@@ -189,9 +189,10 @@ int nextHandle = 0;
     }];
   } else if ([@"updateEmail" isEqualToString:call.method]) {
     NSString *toEmail = call.arguments[@"email"];
-    [[FIRAuth auth].currentUser updateEmail:toEmail completion:^(NSError *_Nullable error) {
-      [self sendResult:result forUser:nil error:error];
-    }];
+    [[FIRAuth auth].currentUser updateEmail:toEmail
+                                 completion:^(NSError *_Nullable error) {
+                                   [self sendResult:result forUser:nil error:error];
+                                 }];
   } else if ([@"signInWithCustomToken" isEqualToString:call.method]) {
     NSString *token = call.arguments[@"token"];
     [[FIRAuth auth] signInWithCustomToken:token

--- a/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
+++ b/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
@@ -187,6 +187,11 @@ int nextHandle = 0;
     [changeRequest commitChangesWithCompletion:^(NSError *error) {
       [self sendResult:result forUser:nil error:error];
     }];
+  } else if ([@"updateEmail" isEqualToString:call.method]) {
+    NSString *toEmail = call.arguments[@"email"];
+    [[FIRAuth auth].currentUser updateEmail:toEmail completion:^(NSError *_Nullable error) {
+      [self sendResult:result forUser:nil error:error];
+    }];
   } else if ([@"signInWithCustomToken" isEqualToString:call.method]) {
     NSString *token = call.arguments[@"token"];
     [[FIRAuth auth] signInWithCustomToken:token

--- a/packages/firebase_auth/lib/firebase_auth.dart
+++ b/packages/firebase_auth/lib/firebase_auth.dart
@@ -369,6 +369,18 @@ class FirebaseAuth {
     return currentUser;
   }
 
+  Future<void> updateEmail({
+    @required String email,
+  }) async {
+    assert(email != null);
+    return await channel.invokeMethod(
+      'updateEmail',
+      <String, String>{
+        'email': email,
+      },
+    );
+  }
+
   Future<void> updateProfile(UserUpdateInfo userUpdateInfo) async {
     assert(userUpdateInfo != null);
     return await channel.invokeMethod(

--- a/packages/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Firebase Auth, enabling Android and iOS
   like Google, Facebook and Twitter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_auth
-version: 0.5.17
+version: 0.5.18
 
 flutter:
   plugin:

--- a/packages/firebase_auth/test/firebase_auth_test.dart
+++ b/packages/firebase_auth/test/firebase_auth_test.dart
@@ -44,6 +44,9 @@ void main() {
           case "updateProfile":
             return null;
             break;
+          case "updateEmail":
+            return null;
+            break;
           case "fetchProvidersForEmail":
             return new List<String>(0);
             break;
@@ -371,6 +374,20 @@ void main() {
           },
         ),
       ]);
+    });
+
+    test('updateEmail', () async {
+      final String updatedEmail = 'atestemail@gmail.com';
+      auth.updateEmail(email: updatedEmail);
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall(
+            'updateEmail',
+            arguments: <String, String>{'email': updatedEmail},
+          ),
+        ],
+      );
     });
 
     test('signInWithCustomToken', () async {


### PR DESCRIPTION
Updated firebase_auth plugin to expose updateEmail.
- defines an updateEmail method on FirebaseAuth with a named email parameter
- passes back exceptions, including failure to update if current user has not signed in recently e.g.:
```
PlatformException(Error 17014, FIRAuthErrorDomain, 
This operation is sensitive and requires recent authentication.
Log in again before retrying this request.)
```
 
#### Reference:
https://firebase.google.com/docs/auth/android/manage-users#set_a_users_email_address
https://firebase.google.com/docs/auth/ios/manage-users#set_a_users_email_address

#### Related Issues:
https://github.com/flutter/flutter/issues/18959
https://github.com/flutter/flutter/issues/17343
