### PR TITLE
Fixed fcm crash

### DIFF
--- a/packages/firebase_messaging/CHANGELOG.md
+++ b/packages/firebase_messaging/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.4
+
+* Bumped Firebase messaging dependency to 17.1.0, Android Studio Gradle plugin 3.1.3 and google-services plugin to 4.0.1.
+
 ## 1.0.3
 
 * Updated iOS token hook from 'didRefreshRegistrationToken' to 'didReceiveRegistrationToken'

--- a/packages/firebase_messaging/android/build.gradle
+++ b/packages/firebase_messaging/android/build.gradle
@@ -32,6 +32,6 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        api 'com.google.firebase:firebase-messaging:15.+'
+        api 'com.google.firebase:firebase-messaging:17.1.0'
     }
 }

--- a/packages/firebase_messaging/android/build.gradle
+++ b/packages/firebase_messaging/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.1.3'
     }
 }
 

--- a/packages/firebase_messaging/example/android/build.gradle
+++ b/packages/firebase_messaging/example/android/build.gradle
@@ -6,8 +6,8 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
-        classpath 'com.google.gms:google-services:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.google.gms:google-services:4.0.1'
     }
 }
 

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Cloud Messaging, a cross-platform
   messaging solution that lets you reliably deliver messages on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_messaging
-version: 1.0.3
+version: 1.0.4
 
 flutter:
   plugin:


### PR DESCRIPTION
I also encountered the same problem as this issue, https://github.com/flutter/flutter/issues/19017.

After updating the com.google.firebase:firebase-messaging version, I will not crash so I will PR.
https://firebase.google.com/docs/cloud-messaging/android/client?hl=en

If you have problems, please close this PR.