### PR TITLE
url_launcher: Add statusBarBrightness field to launch for iOS

### DIFF
--- a/packages/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.3
+
+* Added statusBarBrightness field to `launch` to set iOS status bar brightness.
+
 ## 3.0.2
 
 * Updated Gradle tooling to match Android Studio 3.1.2.

--- a/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
+++ b/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
@@ -7,6 +7,7 @@
 #import "UrlLauncherPlugin.h"
 
 @interface FLTUrlLaunchSession : NSObject<SFSafariViewControllerDelegate>
+@property (nonatomic) UIStatusBarStyle previousStatusBarStyle;
 @end
 
 @implementation FLTUrlLaunchSession {
@@ -25,6 +26,10 @@
 
 - (void)safariViewController:(SFSafariViewController *)controller
       didCompleteInitialLoad:(BOOL)didLoadSuccessfully {
+  if (_previousStatusBarStyle != nil) {
+    UIApplication *application = [UIApplication sharedApplication];
+    application.statusBarStyle = _previousStatusBarStyle;
+  }
   if (didLoadSuccessfully) {
     _flutterResult(nil);
   } else {
@@ -44,6 +49,7 @@
 @implementation FLTUrlLauncherPlugin {
   UIViewController *_viewController;
   FLTUrlLaunchSession *_currentSession;
+  UIStatusBarStyle _previousStatusBarStyle;
 }
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
@@ -71,6 +77,14 @@
     result(@([self canLaunchURL:url]));
   } else if ([@"launch" isEqualToString:call.method]) {
     NSNumber *useSafariVC = call.arguments[@"useSafariVC"];
+    NSString *brightness = call.arguments[@"statusBarBrightness"];
+    UIApplication *application = [UIApplication sharedApplication];
+    _previousStatusBarStyle = application.statusBarStyle;
+    if ([brightness isEqualToString:@"Brightness.light"]) {
+      application.statusBarStyle = UIStatusBarStyleDefault;
+    } else if ([brightness isEqualToString:@"Brightness.dark"]) {
+      application.statusBarStyle = UIStatusBarStyleLightContent;
+    }
     if (useSafariVC.boolValue) {
       [self launchURLInVC:url result:result];
     } else {
@@ -94,6 +108,10 @@
     [application openURL:url
         options:@{}
         completionHandler:^(BOOL success) {
+          if (self->_previousStatusBarStyle != nil) {
+            UIApplication *application = [UIApplication sharedApplication];
+            application.statusBarStyle = self->_previousStatusBarStyle;
+          }
           if (success) {
             result(nil);
           } else {
@@ -121,6 +139,7 @@
 
   SFSafariViewController *safari = [[SFSafariViewController alloc] initWithURL:url];
   _currentSession = [[FLTUrlLaunchSession alloc] initWithUrl:url withFlutterResult:result];
+  _currentSession.previousStatusBarStyle = _previousStatusBarStyle;
   safari.delegate = _currentSession;
   [_viewController presentViewController:safari animated:YES completion:nil];
 }

--- a/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
+++ b/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
@@ -7,7 +7,7 @@
 #import "UrlLauncherPlugin.h"
 
 @interface FLTUrlLaunchSession : NSObject<SFSafariViewControllerDelegate>
-@property (nonatomic) UIStatusBarStyle previousStatusBarStyle;
+@property(nonatomic) UIStatusBarStyle previousStatusBarStyle;
 @end
 
 @implementation FLTUrlLaunchSession {

--- a/packages/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/lib/url_launcher.dart
@@ -27,13 +27,20 @@ const MethodChannel _channel =
 /// always launched with the default browser on device. If set to true, the URL
 /// is launched in a webview. Unlike iOS, browser context is shared across
 /// WebViews.
-///
+/// 
 /// Note that if any of the above are set to true but the URL is not a web URL,
 /// this will throw a [PlatformException].
+/// 
+/// [statusBarBrightness] is only used in iOS. Sets the status bar brightness
+/// of the application after opening a link. The previous value will be 
+/// automatically restored if used with `forceSafariVC` or on iOS version 10.0 
+/// and greater. Defaults to [Brightness.light] if unset, or does nothing if 
+/// null is passed.
 Future<void> launch(
   String urlString, {
   bool forceSafariVC,
   bool forceWebView,
+  Brightness statusBarBrightness = Brightness.light,
 }) {
   assert(urlString != null);
   final Uri url = Uri.parse(urlString.trimLeft());
@@ -50,6 +57,7 @@ Future<void> launch(
       'url': urlString,
       'useSafariVC': forceSafariVC ?? isWebURL,
       'useWebView': forceWebView ?? false,
+      'statusBarBrightness': statusBarBrightness?.toString(),
     },
   );
 }

--- a/packages/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/lib/url_launcher.dart
@@ -27,14 +27,14 @@ const MethodChannel _channel =
 /// always launched with the default browser on device. If set to true, the URL
 /// is launched in a webview. Unlike iOS, browser context is shared across
 /// WebViews.
-/// 
+///
 /// Note that if any of the above are set to true but the URL is not a web URL,
 /// this will throw a [PlatformException].
-/// 
+///
 /// [statusBarBrightness] is only used in iOS. Sets the status bar brightness
-/// of the application after opening a link. The previous value will be 
-/// automatically restored if used with `forceSafariVC` or on iOS version 10.0 
-/// and greater. Defaults to [Brightness.light] if unset, or does nothing if 
+/// of the application after opening a link. The previous value will be
+/// automatically restored if used with `forceSafariVC` or on iOS version 10.0
+/// and greater. Defaults to [Brightness.light] if unset, or does nothing if
 /// null is passed.
 Future<void> launch(
   String urlString, {

--- a/packages/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/lib/url_launcher.dart
@@ -32,10 +32,10 @@ const MethodChannel _channel =
 /// this will throw a [PlatformException].
 ///
 /// [statusBarBrightness] is only used in iOS. Sets the status bar brightness
-/// of the application after opening a link. The previous value will be
-/// automatically restored if used with `forceSafariVC` or on iOS version 10.0
-/// and greater. Defaults to [Brightness.light] if unset, or does nothing if
-/// null is passed.
+/// of the application after opening a link. The previous value of the status
+/// bar is stored on the platform side and restored when returning to Flutter
+/// if used with `forceSafariVC` or on iOS version 10.0 and greater. Defaults
+/// to [Brightness.light] if unset, or does nothing if null is passed.
 Future<void> launch(
   String urlString, {
   bool forceSafariVC,

--- a/packages/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for launching a URL on Android and iOS. Supports
   web, phone, SMS, and email schemes.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher
-version: 3.0.2
+version: 3.0.3
 
 flutter:
   plugin:

--- a/packages/url_launcher/test/url_launcher_test.dart
+++ b/packages/url_launcher/test/url_launcher_test.dart
@@ -39,6 +39,7 @@ void main() {
           'url': 'http://example.com/',
           'useSafariVC': true,
           'useWebView': false,
+          'statusBarBrightness': Brightness.light.toString(),
         })
       ],
     );
@@ -53,6 +54,7 @@ void main() {
           'url': 'http://example.com/',
           'useSafariVC': true,
           'useWebView': false,
+          'statusBarBrightness': Brightness.light.toString(),
         })
       ],
     );
@@ -67,6 +69,7 @@ void main() {
           'url': 'http://example.com/',
           'useSafariVC': true,
           'useWebView': true,
+          'statusBarBrightness': Brightness.light.toString(),
         })
       ],
     );
@@ -81,6 +84,7 @@ void main() {
           'url': 'http://example.com/',
           'useSafariVC': false,
           'useWebView': false,
+          'statusBarBrightness': Brightness.light.toString(),
         })
       ],
     );


### PR DESCRIPTION
Launching from a dark background to a light background webview doesn't automatically update the status bar on iOS.  Adds an optional argument to set the status bar color, and restore the previous value.


Fixes: https://github.com/flutter/flutter/issues/19172

