### PR TITLE
Add `closeWebView` to `url_launcher`

### DIFF
--- a/packages/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/UrlLauncherPlugin.java
+++ b/packages/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/UrlLauncherPlugin.java
@@ -23,7 +23,6 @@ import io.flutter.plugin.common.PluginRegistry.Registrar;
 /** UrlLauncherPlugin */
 public class UrlLauncherPlugin implements MethodCallHandler {
   private final Registrar mRegistrar;
-  private Intent launchIntent = null;
 
   public static void registerWith(Registrar registrar) {
     MethodChannel channel =
@@ -42,6 +41,7 @@ public class UrlLauncherPlugin implements MethodCallHandler {
     if (call.method.equals("canLaunch")) {
       canLaunch(url, result);
     } else if (call.method.equals("launch")) {
+      Intent launchIntent;
       boolean useWebView = call.argument("useWebView");
       Context context;
       if (mRegistrar.activity() != null) {
@@ -82,7 +82,7 @@ public class UrlLauncherPlugin implements MethodCallHandler {
   }
 
   private void closeWebView(Result result) {
-
+    
   }
 
   /*  Launches WebView activity */

--- a/packages/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/UrlLauncherPlugin.java
+++ b/packages/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/UrlLauncherPlugin.java
@@ -62,7 +62,7 @@ public class UrlLauncherPlugin implements MethodCallHandler {
       context.startActivity(launchIntent);
       result.success(null);
     } else if (call.method.equals("closeWebView")) {
-      closeWebView();
+      closeWebView(result);
     } else {
       result.notImplemented();
     }

--- a/packages/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/UrlLauncherPlugin.java
+++ b/packages/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/UrlLauncherPlugin.java
@@ -23,6 +23,7 @@ import io.flutter.plugin.common.PluginRegistry.Registrar;
 /** UrlLauncherPlugin */
 public class UrlLauncherPlugin implements MethodCallHandler {
   private final Registrar mRegistrar;
+  private Intent launchIntent = null;
 
   public static void registerWith(Registrar registrar) {
     MethodChannel channel =
@@ -41,7 +42,6 @@ public class UrlLauncherPlugin implements MethodCallHandler {
     if (call.method.equals("canLaunch")) {
       canLaunch(url, result);
     } else if (call.method.equals("launch")) {
-      Intent launchIntent;
       boolean useWebView = call.argument("useWebView");
       Context context;
       if (mRegistrar.activity() != null) {
@@ -79,6 +79,10 @@ public class UrlLauncherPlugin implements MethodCallHandler {
             && !"{com.android.fallback/com.android.fallback.Fallback}"
                 .equals(componentName.toShortString());
     result.success(canLaunch);
+  }
+
+  private void closeWebView(Result result) {
+
   }
 
   /*  Launches WebView activity */

--- a/packages/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/UrlLauncherPlugin.java
+++ b/packages/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/UrlLauncherPlugin.java
@@ -61,6 +61,8 @@ public class UrlLauncherPlugin implements MethodCallHandler {
       }
       context.startActivity(launchIntent);
       result.success(null);
+    } else if (call.method.equals("closeWebView")) {
+      closeWebView();
     } else {
       result.notImplemented();
     }

--- a/packages/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/UrlLauncherPlugin.java
+++ b/packages/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/UrlLauncherPlugin.java
@@ -82,7 +82,11 @@ public class UrlLauncherPlugin implements MethodCallHandler {
   }
 
   private void closeWebView(Result result) {
-    
+    Activity activity = mRegistrar.activity();
+
+    if (activity != null) {
+      activity.finish();
+    }
   }
 
   /*  Launches WebView activity */

--- a/packages/url_launcher/example/lib/main.dart
+++ b/packages/url_launcher/example/lib/main.dart
@@ -91,7 +91,10 @@ class _MyHomePageState extends State<MyHomePage> {
             new RaisedButton(
               onPressed: () => setState(() {
                     _launched = _launchInWebViewOrVC(toLaunch);
-                    new Timer(const Duration(seconds: 15), closeWebView);
+                    new Timer(const Duration(seconds: 15), () {
+                      print('Closing WebView after 15 seconds...');
+                      closeWebView();
+                    });
                   }),
               child: const Text('Launch in app + close after 15 seconds'),
             ),

--- a/packages/url_launcher/example/lib/main.dart
+++ b/packages/url_launcher/example/lib/main.dart
@@ -88,6 +88,14 @@ class _MyHomePageState extends State<MyHomePage> {
               child: const Text('Launch in app'),
             ),
             const Padding(padding: const EdgeInsets.all(16.0)),
+            new RaisedButton(
+              onPressed: () => setState(() {
+                    _launched = _launchInWebViewOrVC(toLaunch);
+                    new Timer(const Duration(seconds: 15), closeWebView);
+                  }),
+              child: const Text('Launch in app + close after 15 seconds'),
+            ),
+            const Padding(padding: const EdgeInsets.all(16.0)),
             new FutureBuilder<Null>(future: _launched, builder: _launchStatus),
           ],
         ),

--- a/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
+++ b/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
@@ -13,6 +13,7 @@
 @implementation FLTUrlLaunchSession {
   NSURL *_url;
   FlutterResult _flutterResult;
+  @public SFSafariViewController *safari;
 }
 
 - (instancetype)initWithUrl:url withFlutterResult:result {
@@ -42,6 +43,10 @@
 
 - (void)safariViewControllerDidFinish:(SFSafariViewController *)controller {
   [controller dismissViewControllerAnimated:YES completion:nil];
+}
+
+- (void)close {
+  [self safariViewControllerDidFinish:safari];
 }
 
 @end
@@ -90,6 +95,8 @@
     } else {
       [self launchURL:url result:result];
     }
+  } else if ([@"closeWebView" isEqualToString:call.method]) {
+      [self closeWebView:url result:result];
   } else {
     result(FlutterMethodNotImplemented);
   }
@@ -141,7 +148,16 @@
   _currentSession = [[FLTUrlLaunchSession alloc] initWithUrl:url withFlutterResult:result];
   _currentSession.previousStatusBarStyle = _previousStatusBarStyle;
   safari.delegate = _currentSession;
+  _currentSession->safari = safari;
   [_viewController presentViewController:safari animated:YES completion:nil];
+}
+
+- (void)closeWebView:(NSString *)urlString result:(FlutterResult)result {
+    if (_currentSession != nil) {
+        [_currentSession close];
+    }
+    
+    result(nil);
 }
 
 @end

--- a/packages/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/lib/url_launcher.dart
@@ -83,4 +83,4 @@ Future<bool> canLaunch(String urlString) async {
 /// WebView available to be closed.
 Future<void> closeWebView() async {
   return await _channel.invokeMethod('closeWebView');
-} 
+}

--- a/packages/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/lib/url_launcher.dart
@@ -73,3 +73,12 @@ Future<bool> canLaunch(String urlString) async {
     <String, Object>{'url': urlString},
   );
 }
+
+/// Closes the current WebView, if one was previously opened via a call to [launch].
+///
+/// If [launch] was never called, then this call will not have any effect.
+///
+/// On Android systems, if [launch] was called without `forceWebView` being set to
+/// `true`, this call will not do anything either, simply because there is no
+/// WebView available to be closed.
+Future<void> closeWebView() async {}

--- a/packages/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/lib/url_launcher.dart
@@ -81,4 +81,6 @@ Future<bool> canLaunch(String urlString) async {
 /// On Android systems, if [launch] was called without `forceWebView` being set to
 /// `true`, this call will not do anything either, simply because there is no
 /// WebView available to be closed.
-Future<void> closeWebView() async {}
+Future<void> closeWebView() async {
+  return await _channel.invokeMethod('closeWebView');
+}

--- a/packages/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/lib/url_launcher.dart
@@ -83,4 +83,4 @@ Future<bool> canLaunch(String urlString) async {
 /// WebView available to be closed.
 Future<void> closeWebView() async {
   return await _channel.invokeMethod('closeWebView');
-}
+} 

--- a/packages/url_launcher/test/url_launcher_test.dart
+++ b/packages/url_launcher/test/url_launcher_test.dart
@@ -99,7 +99,7 @@ void main() {
     await closeWebView();
     expect(
       log,
-      <Matcher>[isMethodCall('closeWebView', arguments: <String, Object>{})],
+      <Matcher>[isMethodCall('closeWebView', arguments: null)],
     );
   });
 }

--- a/packages/url_launcher/test/url_launcher_test.dart
+++ b/packages/url_launcher/test/url_launcher_test.dart
@@ -94,4 +94,12 @@ void main() {
     expect(() async => await launch('tel:555-555-5555', forceWebView: true),
         throwsA(isInstanceOf<PlatformException>()));
   });
+
+  test('closeWebView default behavior', () async {
+    await closeWebView();
+    expect(
+      log,
+      <Matcher>[isMethodCall('closeWebView', arguments: <String, Object>{})],
+    );
+  });
 }


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/19357.

TLDR; Adds a top-level `closeWebView` function to `package:url_launcher`, so that callers can close the opened WebView, i.e. during an OAuth flow.

I've put more details in the issue linked above.