### PR TITLE
Bump http version to match flutter_test

### DIFF
--- a/packages/firebase_performance/example/pubspec.yaml
+++ b/packages/firebase_performance/example/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_performance_example
 description: Demonstrates how to use the firebase_performance plugin.
 
 dependencies:
-  http: "0.11.3+16"
+  http: "0.11.3+17"
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
Resolves issue with `packages get` for perf since it used a version of http that was different from flutter_test.