### PR TITLE
Fix auto phone auth

### DIFF
--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.5.13
+## 0.5.14
 
 * Fixed handling of auto phone number verification.
 

--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.5.13
 
+* Fixed handling of auto phone number verification.
+
+## 0.5.13
+
 * Add support for phone number authentication.
 
 ## 0.5.12

--- a/packages/firebase_auth/android/src/main/java/io/flutter/plugins/firebaseauth/FirebaseAuthPlugin.java
+++ b/packages/firebase_auth/android/src/main/java/io/flutter/plugins/firebaseauth/FirebaseAuthPlugin.java
@@ -151,17 +151,19 @@ public class FirebaseAuthPlugin implements MethodCallHandler {
         new PhoneAuthProvider.OnVerificationStateChangedCallbacks() {
           @Override
           public void onVerificationCompleted(PhoneAuthCredential phoneAuthCredential) {
-            firebaseAuth.signInWithCredential(phoneAuthCredential).addOnCompleteListener(
+            firebaseAuth
+                .signInWithCredential(phoneAuthCredential)
+                .addOnCompleteListener(
                     new OnCompleteListener<AuthResult>() {
-              @Override
-              public void onComplete(@NonNull Task<AuthResult> task) {
-                if (task.isSuccessful()) {
-                  Map<String, Object> arguments = new HashMap<>();
-                  arguments.put("handle", handle);
-                  channel.invokeMethod("phoneVerificationCompleted", arguments);
-                }
-              }
-            });
+                      @Override
+                      public void onComplete(@NonNull Task<AuthResult> task) {
+                        if (task.isSuccessful()) {
+                          Map<String, Object> arguments = new HashMap<>();
+                          arguments.put("handle", handle);
+                          channel.invokeMethod("phoneVerificationCompleted", arguments);
+                        }
+                      }
+                    });
           }
 
           @Override

--- a/packages/firebase_auth/android/src/main/java/io/flutter/plugins/firebaseauth/FirebaseAuthPlugin.java
+++ b/packages/firebase_auth/android/src/main/java/io/flutter/plugins/firebaseauth/FirebaseAuthPlugin.java
@@ -151,9 +151,17 @@ public class FirebaseAuthPlugin implements MethodCallHandler {
         new PhoneAuthProvider.OnVerificationStateChangedCallbacks() {
           @Override
           public void onVerificationCompleted(PhoneAuthCredential phoneAuthCredential) {
-            Map<String, Object> arguments = new HashMap<>();
-            arguments.put("handle", handle);
-            channel.invokeMethod("phoneVerificationCompleted", arguments);
+            firebaseAuth.signInWithCredential(phoneAuthCredential).addOnCompleteListener(
+                    new OnCompleteListener<AuthResult>() {
+              @Override
+              public void onComplete(@NonNull Task<AuthResult> task) {
+                if (task.isSuccessful()) {
+                  Map<String, Object> arguments = new HashMap<>();
+                  arguments.put("handle", handle);
+                  channel.invokeMethod("phoneVerificationCompleted", arguments);
+                }
+              }
+            });
           }
 
           @Override

--- a/packages/firebase_auth/example/lib/main.dart
+++ b/packages/firebase_auth/example/lib/main.dart
@@ -90,7 +90,8 @@ class _MyHomePageState extends State<MyHomePage> {
     final PhoneVerificationCompleted verificationCompleted =
         (FirebaseUser user) {
       setState(() {
-        _message = Future<String>.value('signInWithPhoneNumber auto succeeded: $user');
+        _message =
+            Future<String>.value('signInWithPhoneNumber auto succeeded: $user');
       });
     };
 
@@ -98,8 +99,8 @@ class _MyHomePageState extends State<MyHomePage> {
         (AuthException authException) {
       setState(() {
         _message = Future<String>.value(
-        'Phone numbber verification failed. Code: ${authException
-            .code}. Message: ${authException.message}');
+            'Phone numbber verification failed. Code: ${authException
+                .code}. Message: ${authException.message}');
       });
     };
 

--- a/packages/firebase_auth/example/lib/main.dart
+++ b/packages/firebase_auth/example/lib/main.dart
@@ -89,14 +89,18 @@ class _MyHomePageState extends State<MyHomePage> {
   Future<void> _testVerifyPhoneNumber() async {
     final PhoneVerificationCompleted verificationCompleted =
         (FirebaseUser user) {
-      _message = Future<String>.value('signInWithPhoneNumber succeeded: $user');
+      setState(() {
+        _message = Future<String>.value('signInWithPhoneNumber auto succeeded: $user');
+      });
     };
 
     final PhoneVerificationFailed verificationFailed =
         (AuthException authException) {
-      _message = Future<String>.value(
-          'Phone numbber verification failed. Code: ${authException
-              .code}. Message: ${authException.message}');
+      setState(() {
+        _message = Future<String>.value(
+        'Phone numbber verification failed. Code: ${authException
+            .code}. Message: ${authException.message}');
+      });
     };
 
     final PhoneCodeSent codeSent =
@@ -113,7 +117,7 @@ class _MyHomePageState extends State<MyHomePage> {
 
     await _auth.verifyPhoneNumber(
         phoneNumber: testPhoneNumber,
-        timeout: const Duration(seconds: 0),
+        timeout: const Duration(seconds: 5),
         verificationCompleted: verificationCompleted,
         verificationFailed: verificationFailed,
         codeSent: codeSent,

--- a/packages/firebase_auth/lib/firebase_auth.dart
+++ b/packages/firebase_auth/lib/firebase_auth.dart
@@ -426,7 +426,7 @@ class FirebaseAuth {
         final int handle = call.arguments['handle'];
         final PhoneVerificationFailed verificationFailed =
             _phoneAuthCallbacks[handle]['PhoneVerificationFailed'];
-        final Map<String, String> exception = call.arguments['exception'];
+        final Map<dynamic, dynamic> exception = call.arguments['exception'];
         verificationFailed(
             new AuthException(exception['code'], exception['message']));
         break;

--- a/packages/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Firebase Auth, enabling Android and iOS
   like Google, Facebook and Twitter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_auth
-version: 0.5.13
+version: 0.5.14
 
 flutter:
   plugin:


### PR DESCRIPTION
When a phone number auth code is automatically used to create a credential, the firebase_auth plugin should use that credential to automatically create a user. This fixes the issue of a null user being returned instead.