### PR TITLE
Add AspectFill to the preview of Camera in iOS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ Hayden Flinner <haydenflinner@gmail.com>
 Stefano Rodriguez <hlsroddy@gmail.com>
 Salvatore Giordano <salvatoregiordanoo@gmail.com>
 Brian Armstrong <brian@flutter.institute>
+Facundo Medica <facundolmedica@gmail.com>

--- a/packages/camera/ios/Classes/CameraPlugin.m
+++ b/packages/camera/ios/Classes/CameraPlugin.m
@@ -339,6 +339,7 @@
       dictionaryWithObjectsAndKeys:AVVideoCodecH264, AVVideoCodecKey,
                                    [NSNumber numberWithInt:_previewSize.height], AVVideoWidthKey,
                                    [NSNumber numberWithInt:_previewSize.width], AVVideoHeightKey,
+                                   AVVideoScalingModeKey, AVVideoScalingModeResizeAspectFill,
                                    nil];
   _videoWriterInput = [AVAssetWriterInput assetWriterInputWithMediaType:AVMediaTypeVideo
                                                          outputSettings:videoSettings];


### PR DESCRIPTION
This key adds an AspectFill to the preview, so it doesn't get distorted. Also I added myself to the authors file as requested in https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md

More info:

I tested the example on an iPhone 7 Plus and the image was "thinned" and this fixed it. 