### PR TITLE
Firebase Messaging: fix Android notification body and title not sent to Flutter

### DIFF
--- a/packages/firebase_messaging/CHANGELOG.md
+++ b/packages/firebase_messaging/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.6
+## 2.0.0
 
 * Updated Android to send Remote Message's title and body to Dart.
 

--- a/packages/firebase_messaging/CHANGELOG.md
+++ b/packages/firebase_messaging/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.6
+
+* Updated Android to send Remote Message's title and body to Dart.
+
 ## 1.0.5
 
 * Bumped test and mockito versions to pick up Dart 2 support.

--- a/packages/firebase_messaging/android/src/main/java/io/flutter/plugins/firebasemessaging/FirebaseMessagingPlugin.java
+++ b/packages/firebase_messaging/android/src/main/java/io/flutter/plugins/firebasemessaging/FirebaseMessagingPlugin.java
@@ -9,6 +9,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.v4.content.LocalBroadcastManager;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.messaging.FirebaseMessaging;
@@ -54,23 +55,35 @@ public class FirebaseMessagingPlugin extends BroadcastReceiver
   @Override
   public void onReceive(Context context, Intent intent) {
     String action = intent.getAction();
+
+    if (action == null) {
+      return;
+    }
+
     if (action.equals(FlutterFirebaseInstanceIDService.ACTION_TOKEN)) {
       String token = intent.getStringExtra(FlutterFirebaseInstanceIDService.EXTRA_TOKEN);
       channel.invokeMethod("onToken", token);
     } else if (action.equals(FlutterFirebaseMessagingService.ACTION_REMOTE_MESSAGE)) {
       RemoteMessage message =
           intent.getParcelableExtra(FlutterFirebaseMessagingService.EXTRA_REMOTE_MESSAGE);
-
-      Map<String, Object> content = new HashMap<>();
-      content.put("data", message.getData());
-
-      RemoteMessage.Notification notification = message.getNotification();
-
-      content.put("title", notification.getTitle());
-      content.put("body", notification.getBody());
-
+      Map<String, Object> content = parseRemoteMessage(message);
       channel.invokeMethod("onMessage", content);
     }
+  }
+
+  @NonNull
+  private Map<String, Object> parseRemoteMessage(RemoteMessage message) {
+    Map<String, Object> content = new HashMap<>();
+    content.put("data", message.getData());
+
+    RemoteMessage.Notification notification = message.getNotification();
+
+    String title = notification != null ? notification.getTitle() : null;
+    content.put("title", title);
+
+    String body = notification != null ? notification.getBody() : null;
+    content.put("body", body);
+    return content;
   }
 
   @Override
@@ -109,9 +122,19 @@ public class FirebaseMessagingPlugin extends BroadcastReceiver
         || CLICK_ACTION_VALUE.equals(intent.getStringExtra("click_action"))) {
       Map<String, String> message = new HashMap<>();
       Bundle extras = intent.getExtras();
-      for (String key : extras.keySet()) {
-        message.put(key, extras.get(key).toString());
+
+      if (extras == null) {
+        return false;
       }
+
+      for (String key : extras.keySet()) {
+        Object extra = extras.get(key);
+        if (extra != null) {
+          message.put(key, extra.toString());
+        }
+      }
+
+
       channel.invokeMethod(method, message);
       return true;
     }

--- a/packages/firebase_messaging/android/src/main/java/io/flutter/plugins/firebasemessaging/FirebaseMessagingPlugin.java
+++ b/packages/firebase_messaging/android/src/main/java/io/flutter/plugins/firebasemessaging/FirebaseMessagingPlugin.java
@@ -61,7 +61,7 @@ public class FirebaseMessagingPlugin extends BroadcastReceiver
       RemoteMessage message =
           intent.getParcelableExtra(FlutterFirebaseMessagingService.EXTRA_REMOTE_MESSAGE);
 
-      HashMap<String, Object> content = new HashMap<>();
+      Map<String, Object> content = new HashMap<>();
       content.put("data", message.getData());
 
       RemoteMessage.Notification notification = message.getNotification();
@@ -70,6 +70,7 @@ public class FirebaseMessagingPlugin extends BroadcastReceiver
       content.put("body", notification.getBody());
 
       channel.invokeMethod("onMessage", content);
+    }
   }
 
   @Override

--- a/packages/firebase_messaging/android/src/main/java/io/flutter/plugins/firebasemessaging/FirebaseMessagingPlugin.java
+++ b/packages/firebase_messaging/android/src/main/java/io/flutter/plugins/firebasemessaging/FirebaseMessagingPlugin.java
@@ -78,11 +78,15 @@ public class FirebaseMessagingPlugin extends BroadcastReceiver
 
     RemoteMessage.Notification notification = message.getNotification();
 
+    Map<String, Object> notificationMap = new HashMap<>();
+
     String title = notification != null ? notification.getTitle() : null;
-    content.put("title", title);
+    notificationMap.put("title", title);
 
     String body = notification != null ? notification.getBody() : null;
-    content.put("body", body);
+    notificationMap.put("body", body);
+
+    content.put("notification", notificationMap);
     return content;
   }
 

--- a/packages/firebase_messaging/android/src/main/java/io/flutter/plugins/firebasemessaging/FirebaseMessagingPlugin.java
+++ b/packages/firebase_messaging/android/src/main/java/io/flutter/plugins/firebasemessaging/FirebaseMessagingPlugin.java
@@ -134,7 +134,6 @@ public class FirebaseMessagingPlugin extends BroadcastReceiver
         }
       }
 
-
       channel.invokeMethod(method, message);
       return true;
     }

--- a/packages/firebase_messaging/android/src/main/java/io/flutter/plugins/firebasemessaging/FirebaseMessagingPlugin.java
+++ b/packages/firebase_messaging/android/src/main/java/io/flutter/plugins/firebasemessaging/FirebaseMessagingPlugin.java
@@ -60,8 +60,16 @@ public class FirebaseMessagingPlugin extends BroadcastReceiver
     } else if (action.equals(FlutterFirebaseMessagingService.ACTION_REMOTE_MESSAGE)) {
       RemoteMessage message =
           intent.getParcelableExtra(FlutterFirebaseMessagingService.EXTRA_REMOTE_MESSAGE);
-      channel.invokeMethod("onMessage", message.getData());
-    }
+
+      HashMap<String, Object> content = new HashMap<>();
+      content.put("data", message.getData());
+
+      RemoteMessage.Notification notification = message.getNotification();
+
+      content.put("title", notification.getTitle());
+      content.put("body", notification.getBody());
+
+      channel.invokeMethod("onMessage", content);
   }
 
   @Override

--- a/packages/firebase_messaging/example/lib/main.dart
+++ b/packages/firebase_messaging/example/lib/main.dart
@@ -9,9 +9,9 @@ import 'package:flutter/material.dart';
 
 final Map<String, Item> _items = <String, Item>{};
 Item _itemForMessage(Map<String, dynamic> message) {
-  final String itemId = message['id'];
+  final String itemId = message['data']['id'];
   final Item item = _items.putIfAbsent(itemId, () => new Item(itemId: itemId))
-    ..status = message['status'];
+    ..status = message['data']['status'];
   return item;
 }
 

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Cloud Messaging, a cross-platform
   messaging solution that lets you reliably deliver messages on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_messaging
-version: 1.0.5
+version: 2.0.0
 
 flutter:
   plugin:


### PR DESCRIPTION
The Firebase Messaging plugin for Android only seems to send the custom properties that can be included with a push notification to Flutter - it doesn't send any of the core message components, like the title or body.

For example, if you send this message:

title: My Notification
body: Hello World!
customProperty: foo

The flutter plugin will only receive `{"customProperty": "foo"}`

This is not an issue one the iOS side, which sends the entire apns payload to Flutter.

This change just adds the title and body properties for now, but maybe other properties should be added as well?