### PR TITLE
import flutter/material

### DIFF
--- a/packages/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/lib/url_launcher.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 const MethodChannel _channel =


### PR DESCRIPTION
The Brightness enum requires the material package, which isn't imported.