### PR TITLE
_dynamicLink variable was cleared after user get dynamicLink (iOS)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,3 +18,4 @@ Fabricio Nogueira <feufeu@gmail.com>
 Simon Lightfoot <simon@devangels.london>
 Ashton Thomas <ashton@acrinta.com>
 Thomas Danner <thmsdnnr@gmail.com>
+Diego Velásquez <diego.velasquez.lopez@gmail.com>

--- a/packages/firebase_dynamic_links/ios/Classes/FirebaseDynamicLinksPlugin.m
+++ b/packages/firebase_dynamic_links/ios/Classes/FirebaseDynamicLinksPlugin.m
@@ -67,7 +67,7 @@
     if (_dynamicLink.minimumAppVersion) {
       iosData[@"minimumVersion"] = _dynamicLink.minimumAppVersion;
     }
-
+    _dynamicLink = nil;
     dynamicLink[@"ios"] = iosData;
     return dynamicLink;
   } else {


### PR DESCRIPTION
This a fix for this Issue [#19820](https://github.com/flutter/flutter/issues/19820).
The issue only happens in iOS , when the user opens a dynamic link, and after redirecting to the application, the user obtains the link using this code:

> FirebaseDynamicLinks.instance.retrieveDynamicLink ()

The problem is when you call that method again, the expected result must be null since it was previously obtained.

To solve this, after obtaining and returning the link, the _dynamicLink variable is set to null.
