### PR TITLE
[device_info]add android id

### DIFF
--- a/packages/device_info/android/src/main/java/io/flutter/plugins/deviceinfo/DeviceInfoPlugin.java
+++ b/packages/device_info/android/src/main/java/io/flutter/plugins/deviceinfo/DeviceInfoPlugin.java
@@ -4,9 +4,11 @@
 
 package io.flutter.plugins.deviceinfo;
 
+import android.annotation.SuppressLint;
 import android.os.Build;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
+import android.provider.Settings.Secure;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
@@ -26,11 +28,15 @@ public class DeviceInfoPlugin implements MethodCallHandler {
   public static void registerWith(Registrar registrar) {
     final MethodChannel channel =
         new MethodChannel(registrar.messenger(), "plugins.flutter.io/device_info");
-    channel.setMethodCallHandler(new DeviceInfoPlugin());
+    channel.setMethodCallHandler(new DeviceInfoPlugin(registrar));
   }
 
+  private Registrar registrar;
+
   /** Do not allow direct instantiation. */
-  private DeviceInfoPlugin() {}
+  private DeviceInfoPlugin(Registrar registrar) {
+    this.registrar = registrar;
+  }
 
   @Override
   public void onMethodCall(MethodCall call, Result result) {
@@ -60,6 +66,9 @@ public class DeviceInfoPlugin implements MethodCallHandler {
       build.put("tags", Build.TAGS);
       build.put("type", Build.TYPE);
       build.put("isPhysicalDevice", !isEmulator());
+
+      @SuppressLint("HardwareIds") String androidId = Secure.getString(registrar.context().getContentResolver(), Secure.ANDROID_ID);
+      build.put("androidId", androidId);
 
       Map<String, Object> version = new HashMap<>();
       if (VERSION.SDK_INT >= VERSION_CODES.M) {

--- a/packages/device_info/android/src/main/java/io/flutter/plugins/deviceinfo/DeviceInfoPlugin.java
+++ b/packages/device_info/android/src/main/java/io/flutter/plugins/deviceinfo/DeviceInfoPlugin.java
@@ -67,7 +67,9 @@ public class DeviceInfoPlugin implements MethodCallHandler {
       build.put("type", Build.TYPE);
       build.put("isPhysicalDevice", !isEmulator());
 
-      @SuppressLint("HardwareIds") String androidId = Secure.getString(registrar.context().getContentResolver(), Secure.ANDROID_ID);
+      @SuppressLint("HardwareIds")
+      String androidId =
+          Secure.getString(registrar.context().getContentResolver(), Secure.ANDROID_ID);
       build.put("androidId", androidId);
 
       Map<String, Object> version = new HashMap<>();

--- a/packages/device_info/example/lib/main.dart
+++ b/packages/device_info/example/lib/main.dart
@@ -82,6 +82,7 @@ class _MyAppState extends State<MyApp> {
       'tags': build.tags,
       'type': build.type,
       'isPhysicalDevice': build.isPhysicalDevice,
+      'androidId': build.androidId,
     };
   }
 

--- a/packages/device_info/lib/device_info.dart
+++ b/packages/device_info/lib/device_info.dart
@@ -58,6 +58,7 @@ class AndroidDeviceInfo {
     this.tags,
     this.type,
     this.isPhysicalDevice,
+    this.androidId,
   })  : supported32BitAbis = new List<String>.unmodifiable(supported32BitAbis),
         supported64BitAbis = new List<String>.unmodifiable(supported64BitAbis),
         supportedAbis = new List<String>.unmodifiable(supportedAbis);
@@ -119,6 +120,20 @@ class AndroidDeviceInfo {
   /// `false` if the application is running in an emulator, `true` otherwise.
   final bool isPhysicalDevice;
 
+  /// On Android 8.0 (API level 26) and higher versions of the platform,
+  /// a 64-bit number (expressed as a hexadecimal string), unique to each
+  /// combination of app-signing key, user, and device. Values of ANDROID_ID
+  /// are scoped by signing key and user. The value may change if a factory
+  /// reset is performed on the device or if an APK signing key changes.
+  ///
+  /// In versions of the platform lower than Android 8.0 (API level 26),
+  /// a 64-bit number (expressed as a hexadecimal string) that is randomly
+  /// generated when the user first sets up the device and should remain
+  /// constant for the lifetime of the user's device. On devices that have
+  /// multiple users, each user appears as a completely separate device,
+  /// so the ANDROID_ID value is unique to each user.
+  final String androidId;
+
   /// Deserializes from the message received from [_kChannel].
   static AndroidDeviceInfo _fromMap(dynamic message) {
     final Map<dynamic, dynamic> map = message;
@@ -142,6 +157,7 @@ class AndroidDeviceInfo {
       tags: map['tags'],
       type: map['type'],
       isPhysicalDevice: map['isPhysicalDevice'],
+      androidId: map['androidId'],
     );
   }
 

--- a/packages/device_info/lib/device_info.dart
+++ b/packages/device_info/lib/device_info.dart
@@ -120,18 +120,7 @@ class AndroidDeviceInfo {
   /// `false` if the application is running in an emulator, `true` otherwise.
   final bool isPhysicalDevice;
 
-  /// On Android 8.0 (API level 26) and higher versions of the platform,
-  /// a 64-bit number (expressed as a hexadecimal string), unique to each
-  /// combination of app-signing key, user, and device. Values of ANDROID_ID
-  /// are scoped by signing key and user. The value may change if a factory
-  /// reset is performed on the device or if an APK signing key changes.
-  ///
-  /// In versions of the platform lower than Android 8.0 (API level 26),
-  /// a 64-bit number (expressed as a hexadecimal string) that is randomly
-  /// generated when the user first sets up the device and should remain
-  /// constant for the lifetime of the user's device. On devices that have
-  /// multiple users, each user appears as a completely separate device,
-  /// so the ANDROID_ID value is unique to each user.
+  /// A unique 64-bit encoded identifier provided by the platform.
   final String androidId;
 
   /// Deserializes from the message received from [_kChannel].


### PR DESCRIPTION
On iOS we have the identifierForVendor to identify the current device. The Secure.ANDROID_ID is the way to do it in Android. 
https://developer.android.com/reference/android/provider/Settings.Secure#ANDROID_ID