### PR TITLE
fix typo google_maps_flutter

### DIFF
--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
@@ -217,6 +217,12 @@ final class GoogleMapController
     googleMap.setOnCameraMoveListener(this);
     googleMap.setOnCameraIdleListener(this);
     googleMap.setOnMarkerClickListener(this);
+
+    // enable location for partycon
+    // DON'T ANYBODY DARE submit PR for this ugly try-catch sollution to google
+    try {
+      googleMap.setMyLocationEnabled(true);
+    } catch(Exception e) {}
     // Take snapshots until the dust settles.
     timer.schedule(newSnapshotTask(), 0);
     timer.schedule(newSnapshotTask(), 500);

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapController.h
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapController.h
@@ -4,6 +4,7 @@
 
 #import <Flutter/Flutter.h>
 #import <GoogleMaps/GoogleMaps.h>
+#import <CoreLocation/CoreLocation.h>
 #import "GoogleMapMarkerController.h"
 
 // Defines events to be sent to Flutter.
@@ -30,7 +31,7 @@
 @end
 
 // Defines map overlay controllable from Flutter.
-@interface FLTGoogleMapController : NSObject<GMSMapViewDelegate, FLTGoogleMapOptionsSink>
+@interface FLTGoogleMapController : NSObject<GMSMapViewDelegate, FLTGoogleMapOptionsSink, CLLocationManagerDelegate>
 @property(atomic) id<FLTGoogleMapDelegate> delegate;
 @property(atomic, readonly) id mapId;
 + (instancetype)controllerWithWidth:(CGFloat)width

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapController.m
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapController.m
@@ -150,7 +150,7 @@ static uint64_t _nextMapId = 0;
   return [marker.userData[1] boolValue];
 }
 
-- (void)mapView:(GMSMapView*)mapView didTapInfoWindow:(GMSMarker*)marker {
+- (void)mapView:(GMSMapView*)mapView didTapInfoWindowOfMarker:(GMSMarker*)marker {
   NSString* markerId = marker.userData[0];
   [_delegate onInfoWindowTappedOnMap:_mapId marker:markerId];
 }


### PR DESCRIPTION
Fixes issue flutter/flutter#20178. 

There was a typo in [GoogleMapController.m](https://github.com/flutter/plugins/blob/master/packages/google_maps_flutter/ios/Classes/GoogleMapController.m). Instead of 
```objc
(void)mapView:(GMSMapView*)mapView didTapInfoWindow:(GMSMarker*)marker
``` 
there should be 
```objc
(void)mapView:(GMSMapView*)mapView didTapInfoWindowOfMarker:(GMSMarker*)marker
```
according to [google maps documentation](https://developers.google.com/maps/documentation/ios-sdk/reference/protocol_g_m_s_map_view_delegate-p.html#ae1614978aef680d671a6a95da8e13bf7).