### PR TITLE
Add example query to Firestore documentation

### DIFF
--- a/packages/cloud_firestore/README.md
+++ b/packages/cloud_firestore/README.md
@@ -62,6 +62,16 @@ class BookList extends StatelessWidget {
 }
 ```
 
+Performing a query:
+```dart
+Firestore.instance
+    .collection('talks')
+    .where("topic", isEqualTo: "flutter")
+    .snapshots()
+    .listen((data) =>
+        data.documents.forEach((doc) => print(doc["title"])));
+```
+
 Running a transaction:
 
 ```dart


### PR DESCRIPTION
Both README and Example app doesn't have an example of a simple Firestore query.

Changelog:
 * Add an example of a query to Firestore README