### PR TITLE
Fixed type error for firebase_auth photoUrl on iOS

### DIFF
--- a/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
+++ b/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
@@ -182,7 +182,7 @@ int nextHandle = 0;
       changeRequest.displayName = call.arguments[@"displayName"];
     }
     if (call.arguments[@"photoUrl"]) {
-      changeRequest.photoURL = call.arguments[@"photoUrl"];
+      changeRequest.photoURL = [NSURL URLWithString:call.arguments[@"photoUrl"]];
     }
     [changeRequest commitChangesWithCompletion:^(NSError *error) {
       [self sendResult:result forUser:nil error:error];


### PR DESCRIPTION
The platform is expecting NSURL where it got a string.

Fixes flutter/flutter#16309