### PR TITLE
Fix build error Android dependency 'com.android.support:appcompat-v7'…

### DIFF
--- a/packages/image_picker/android/build.gradle
+++ b/packages/image_picker/android/build.gradle
@@ -34,5 +34,5 @@ android {
 }
 
 dependencies {
-    api 'com.android.support:appcompat-v7:27.1.0'
+    api 'com.android.support:appcompat-v7:27.1.1'
 }


### PR DESCRIPTION
… has different version for the compile (27.1.0) and runtime (27.1.1) classpath. You should manually set the same version via DependencyResolution