### PR TITLE
image_picker: Use FileProvider subclass to avoid collisions

### DIFF
--- a/packages/image_picker/android/src/main/AndroidManifest.xml
+++ b/packages/image_picker/android/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
 
     <application>
         <provider
-            android:name="android.support.v4.content.FileProvider"
+            android:name="io.flutter.plugins.imagepicker.ImagePickerFileProvider"
             android:authorities="${applicationId}.flutter.image_provider"
             android:exported="false"
             android:grantUriPermissions="true">

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerFileProvider.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerFileProvider.java
@@ -1,0 +1,11 @@
+package io.flutter.plugins.imagepicker;
+
+import android.support.v4.content.FileProvider;
+
+/**
+ * Providing a custom {@code FileProvider} prevents manifest {@code <provider>} name collisions.
+ * <p>
+ * See https://developer.android.com/guide/topics/manifest/provider-element.html for details.
+ */
+public class ImagePickerFileProvider extends FileProvider {
+}

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerFileProvider.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerFileProvider.java
@@ -4,8 +4,7 @@ import android.support.v4.content.FileProvider;
 
 /**
  * Providing a custom {@code FileProvider} prevents manifest {@code <provider>} name collisions.
- * <p>
- * See https://developer.android.com/guide/topics/manifest/provider-element.html for details.
+ *
+ * <p>See https://developer.android.com/guide/topics/manifest/provider-element.html for details.
  */
-public class ImagePickerFileProvider extends FileProvider {
-}
+public class ImagePickerFileProvider extends FileProvider {}


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/20481

> There can only be one declaration for each `FileProvider` subclass. That means to declare multiple file providers without collisions, one must create a (empty) subclass of `android.support.v4.content.FileProvider` and use that as the provider `name` in the manifest.
> 
> In my opinion, `android.support.v4.content.FileProvider` should be reserved for the app itself so that developers can easily add a file provider to their app, without subclassing `FileProvider`. It's also used in the Android documentation and in StackOverflow answers. 
> 
> image_picker and other plugins should subclass `FileProvider` to prevent collisions (also collisions between plugins).
> 
> [This issue](https://github.com/stkent/bugshaker-android/issues/108) describes a similar problem in an Android library.