### PR TITLE
Avoids open_file conflict (error described below)

### DIFF
--- a/packages/image_picker/android/src/main/AndroidManifest.xml
+++ b/packages/image_picker/android/src/main/AndroidManifest.xml
@@ -9,10 +9,12 @@
             android:name="android.support.v4.content.FileProvider"
             android:authorities="${applicationId}.flutter.image_provider"
             android:exported="false"
+            tools:replace="android:authorities"
             android:grantUriPermissions="true">
             <meta-data
                 android:name="android.support.FILE_PROVIDER_PATHS"
-                android:resource="@xml/flutter_image_picker_file_paths"/>
+                android:resource="@xml/flutter_image_picker_file_paths"
+                tools:replace="android:resource" />
         </provider>
     </application>
 </manifest>


### PR DESCRIPTION
/Users/vibhavkotriwala/Desktop/work/4ceed_app/android/app/src/main/AndroidManifest.xml:14:13-74 Error:
	Attribute provider#android.support.v4.content.FileProvider@authorities value=(com.example.myapp.flutter.image_provider) from [:image_picker] AndroidManifest.xml:14:13-74
	is also present at [:open_file] AndroidManifest.xml:12:13-64 value=(com.example.myapp.fileProvider).
	Suggestion: add 'tools:replace="android:authorities"' to <provider> element at AndroidManifest.xml:12:9-20:20 to override.
/Users/vibhavkotriwala/Desktop/work/4ceed_app/android/app/src/main/AndroidManifest.xml:19:17-72 Error:
	Attribute meta-data#android.support.FILE_PROVIDER_PATHS@resource value=(@xml/flutter_image_picker_file_paths) from [:image_picker] AndroidManifest.xml:19:17-72
	is also present at [:open_file] AndroidManifest.xml:17:17-50 value=(@xml/filepaths).
	Suggestion: add 'tools:replace="android:resource"' to <meta-data> element at AndroidManifest.xml to override.