### PR TITLE
[Firebase Auth] added access to User metadata

### DIFF
--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.2
+
+* Add access to user metadata.
+
 ## 0.6.1
 
 * Adding support for linkWithTwitterCredential in FirebaseAuth.

--- a/packages/firebase_auth/android/src/main/java/io/flutter/plugins/firebaseauth/FirebaseAuthPlugin.java
+++ b/packages/firebase_auth/android/src/main/java/io/flutter/plugins/firebaseauth/FirebaseAuthPlugin.java
@@ -614,6 +614,8 @@ public class FirebaseAuthPlugin implements MethodCallHandler {
         providerData.add(Collections.unmodifiableMap(userInfoToMap(userInfo)));
       }
       Map<String, Object> userMap = userInfoToMap(user);
+      userMap.put("creationTimestamp", user.getMetadata().getCreationTimestamp());
+      userMap.put("lastSignInTimestamp", user.getMetadata().getLastSignInTimestamp());
       userMap.put("isAnonymous", user.isAnonymous());
       userMap.put("isEmailVerified", user.isEmailVerified());
       userMap.put("providerData", Collections.unmodifiableList(providerData));

--- a/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
+++ b/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
@@ -291,7 +291,13 @@ int nextHandle = 0;
   for (id<FIRUserInfo> userInfo in user.providerData) {
     [providerData addObject:toDictionary(userInfo)];
   }
+
+  long creationDate = [user.metadata.creationDate timeIntervalSince1970];
+  long lastSignInDate = [user.metadata.lastSignInDate timeIntervalSince1970];
+
   NSMutableDictionary *userData = [toDictionary(user) mutableCopy];
+  userData[@"creationTimestamp"] = [NSNumber numberWithLong:creationDate];
+  userData[@"lastSignInTimestamp"] = [NSNumber numberWithInt:lastSignInDate];
   userData[@"isAnonymous"] = [NSNumber numberWithBool:user.isAnonymous];
   userData[@"isEmailVerified"] = [NSNumber numberWithBool:user.isEmailVerified];
   userData[@"providerData"] = providerData;

--- a/packages/firebase_auth/lib/firebase_auth.dart
+++ b/packages/firebase_auth/lib/firebase_auth.dart
@@ -73,7 +73,7 @@ class FirebaseUser extends UserInfo {
       : providerData = data['providerData']
             .map<UserInfo>((dynamic item) => UserInfo._(item))
             .toList(),
-        _metadata = new FirebaseUserMetadata._(data),
+        _metadata = FirebaseUserMetadata._(data),
         super._(data);
 
   // Returns true if the user is anonymous; that is, the user account was

--- a/packages/firebase_auth/lib/firebase_auth.dart
+++ b/packages/firebase_auth/lib/firebase_auth.dart
@@ -8,6 +8,16 @@ import 'package:flutter/services.dart';
 import 'package:meta/meta.dart';
 
 /// Represents user data returned from an identity provider.
+
+class FirebaseUserMetadata {
+  final Map<dynamic, dynamic> _data;
+
+  FirebaseUserMetadata._(this._data);
+
+  int get creationTimestamp => _data['creationTimestamp'];
+  int get lastSignInTimestamp => _data['lastSignInTimestamp'];
+}
+
 class UserInfo {
   final Map<dynamic, dynamic> _data;
 
@@ -57,16 +67,20 @@ class UserUpdateInfo {
 /// Represents a user.
 class FirebaseUser extends UserInfo {
   final List<UserInfo> providerData;
+  final FirebaseUserMetadata _metadata;
 
   FirebaseUser._(Map<dynamic, dynamic> data)
       : providerData = data['providerData']
             .map<UserInfo>((dynamic item) => UserInfo._(item))
             .toList(),
+        _metadata = new FirebaseUserMetadata._(data),
         super._(data);
 
   // Returns true if the user is anonymous; that is, the user account was
   // created with signInAnonymously() and has not been linked to another
   // account.
+  FirebaseUserMetadata get metadata => _metadata;
+
   bool get isAnonymous => _data['isAnonymous'];
 
   /// Returns true if the user's email is verified.

--- a/packages/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Firebase Auth, enabling Android and iOS
   like Google, Facebook and Twitter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_auth
-version: 0.6.0
+version: 0.6.2
 
 flutter:
   plugin:


### PR DESCRIPTION
allows to recover the account creation date, and the last sign in date of an user.

With them, you can determine if a user logs in for the first time.
(and then, create a welcome/ setup page, for example)

this metadata field was available in both native API, as shown in the documentation.
https://developers.google.com/android/reference/com/google/firebase/auth/FirebaseUser.html#getMetadata()

I implemented its access in the Dart library.

example usage:
```dart
  final FirebaseAuth _auth = FirebaseAuth.instance;
  FirebaseUser _currentUser = await _auth.currentUser();
  if (user.metadata.creationTimestamp ==  user.metadata.lastSignInTimestamp)
     ...
```