### PR TITLE
[video_player]added adaptive track selector for MPEG-dash format in android

### DIFF
--- a/packages/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -71,17 +71,17 @@ public class VideoPlayerPlugin implements MethodCallHandler {
     private boolean isInitialized = false;
 
     VideoPlayer(
-            Context context,
-            EventChannel eventChannel,
-            TextureRegistry.SurfaceTextureEntry textureEntry,
-            String dataSource,
-            Result result) {
+        Context context,
+        EventChannel eventChannel,
+        TextureRegistry.SurfaceTextureEntry textureEntry,
+        String dataSource,
+        Result result) {
       this.eventChannel = eventChannel;
       this.textureEntry = textureEntry;
 
       BandwidthMeter bandwidthMeter = new DefaultBandwidthMeter.Builder().build();
       TrackSelection.Factory videoTrackSelectionFactory =
-              new AdaptiveTrackSelection.Factory(bandwidthMeter);
+          new AdaptiveTrackSelection.Factory(bandwidthMeter);
       TrackSelector trackSelector = new DefaultTrackSelector(videoTrackSelectionFactory);
       exoPlayer = ExoPlayerFactory.newSimpleInstance(context, trackSelector);
 
@@ -92,16 +92,16 @@ public class VideoPlayerPlugin implements MethodCallHandler {
         dataSourceFactory = new DefaultDataSourceFactory(context, "ExoPlayer");
       } else if (Util.inferContentType(uri.getLastPathSegment()) == C.TYPE_DASH) {
         dataSourceFactory =
-                new DefaultHttpDataSourceFactory(
-                        "ExoPlayer", (TransferListener<? super DataSource>) bandwidthMeter);
+            new DefaultHttpDataSourceFactory(
+                "ExoPlayer", (TransferListener<? super DataSource>) bandwidthMeter);
       } else {
         dataSourceFactory =
-                new DefaultHttpDataSourceFactory(
-                        "ExoPlayer",
-                        null,
-                        DefaultHttpDataSource.DEFAULT_CONNECT_TIMEOUT_MILLIS,
-                        DefaultHttpDataSource.DEFAULT_READ_TIMEOUT_MILLIS,
-                        true);
+            new DefaultHttpDataSourceFactory(
+                "ExoPlayer",
+                null,
+                DefaultHttpDataSource.DEFAULT_CONNECT_TIMEOUT_MILLIS,
+                DefaultHttpDataSource.DEFAULT_READ_TIMEOUT_MILLIS,
+                true);
       }
 
       MediaSource mediaSource = buildMediaSource(uri, dataSourceFactory, context);
@@ -111,81 +111,81 @@ public class VideoPlayerPlugin implements MethodCallHandler {
     }
 
     private MediaSource buildMediaSource(
-            Uri uri, DataSource.Factory mediaDataSourceFactory, Context context) {
+        Uri uri, DataSource.Factory mediaDataSourceFactory, Context context) {
       int type = Util.inferContentType(uri.getLastPathSegment());
       switch (type) {
         case C.TYPE_SS:
           return new SsMediaSource.Factory(
                   new DefaultSsChunkSource.Factory(mediaDataSourceFactory),
                   new DefaultDataSourceFactory(context, null, mediaDataSourceFactory))
-                  .createMediaSource(uri);
+              .createMediaSource(uri);
         case C.TYPE_DASH:
           return new DashMediaSource.Factory(
                   new DefaultDashChunkSource.Factory(mediaDataSourceFactory),
                   new DefaultDataSourceFactory(context, null, mediaDataSourceFactory))
-                  .createMediaSource(uri);
+              .createMediaSource(uri);
         case C.TYPE_HLS:
           return new HlsMediaSource.Factory(mediaDataSourceFactory).createMediaSource(uri);
         case C.TYPE_OTHER:
           return new ExtractorMediaSource.Factory(mediaDataSourceFactory)
-                  .setExtractorsFactory(new DefaultExtractorsFactory())
-                  .createMediaSource(uri);
+              .setExtractorsFactory(new DefaultExtractorsFactory())
+              .createMediaSource(uri);
         default:
-        {
-          throw new IllegalStateException("Unsupported type: " + type);
-        }
+          {
+            throw new IllegalStateException("Unsupported type: " + type);
+          }
       }
     }
 
     private void setupVideoPlayer(
-            EventChannel eventChannel,
-            TextureRegistry.SurfaceTextureEntry textureEntry,
-            Result result) {
+        EventChannel eventChannel,
+        TextureRegistry.SurfaceTextureEntry textureEntry,
+        Result result) {
 
       eventChannel.setStreamHandler(
-              new EventChannel.StreamHandler() {
-                @Override
-                public void onListen(Object o, EventChannel.EventSink sink) {
-                  eventSink.setDelegate(sink);
-                }
+          new EventChannel.StreamHandler() {
+            @Override
+            public void onListen(Object o, EventChannel.EventSink sink) {
+              eventSink.setDelegate(sink);
+            }
 
-                @Override
-                public void onCancel(Object o) {
-                  eventSink.setDelegate(null);
-                }
-              });
+            @Override
+            public void onCancel(Object o) {
+              eventSink.setDelegate(null);
+            }
+          });
 
       surface = new Surface(textureEntry.surfaceTexture());
       exoPlayer.setVideoSurface(surface);
       setAudioAttributes(exoPlayer);
 
       exoPlayer.addListener(
-              new DefaultEventListener() {
+          new DefaultEventListener() {
 
-                @Override
-                public void onPlayerStateChanged(final boolean playWhenReady, final int playbackState) {
-                  super.onPlayerStateChanged(playWhenReady, playbackState);
-                  if (playbackState == Player.STATE_BUFFERING) {
-                    Map<String, Object> event = new HashMap<>();
-                    event.put("event", "bufferingUpdate");
-                    List<Integer> range = Arrays.asList(0, exoPlayer.getBufferedPercentage());
-                    // iOS supports a list of buffered ranges, so here is a list with a single range.
-                    event.put("values", Collections.singletonList(range));
-                    eventSink.success(event);
-                  } else if (playbackState == Player.STATE_READY && !isInitialized) {
-                    isInitialized = true;
-                    sendInitialized();
-                  }
-                }
+            @Override
+            public void onPlayerStateChanged(final boolean playWhenReady, final int playbackState) {
+              super.onPlayerStateChanged(playWhenReady, playbackState);
+              if (playbackState == Player.STATE_BUFFERING) {
+                Map<String, Object> event = new HashMap<>();
+                event.put("event", "bufferingUpdate");
+                List<Integer> range = Arrays.asList(0, exoPlayer.getBufferedPercentage());
+                // iOS supports a list of buffered ranges, so here is a list with a single range.
+                event.put("values", Collections.singletonList(range));
+                eventSink.success(event);
+              } else if (playbackState == Player.STATE_READY && !isInitialized) {
+                isInitialized = true;
+                sendInitialized();
+              }
+            }
 
-                @Override
-                public void onPlayerError(final ExoPlaybackException error) {
-                  super.onPlayerError(error);
-                  if (eventSink != null) {
-                    eventSink.error("VideoError", "Video player had error " + error, null);
-                  }
-                }
-              });
+            @Override
+            public void onPlayerError(final ExoPlaybackException error) {
+              super.onPlayerError(error);
+              if (eventSink != null) {
+                eventSink.error("VideoError", "Video player had error " + error, null);
+              }
+            }
+          });
 
       Map<String, Object> reply = new HashMap<>();
       reply.put("textureId", textureEntry.id());
@@ -196,7 +196,7 @@ public class VideoPlayerPlugin implements MethodCallHandler {
     private static void setAudioAttributes(SimpleExoPlayer exoPlayer) {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
         exoPlayer.setAudioAttributes(
-                new AudioAttributes.Builder().setContentType(C.CONTENT_TYPE_MOVIE).build());
+            new AudioAttributes.Builder().setContentType(C.CONTENT_TYPE_MOVIE).build());
       } else {
         exoPlayer.setAudioStreamType(AudioManager.STREAM_MUSIC);
       }
@@ -258,16 +258,16 @@ public class VideoPlayerPlugin implements MethodCallHandler {
   public static void registerWith(Registrar registrar) {
     final VideoPlayerPlugin plugin = new VideoPlayerPlugin(registrar);
     final MethodChannel channel =
-            new MethodChannel(registrar.messenger(), "flutter.io/videoPlayer");
+        new MethodChannel(registrar.messenger(), "flutter.io/videoPlayer");
     channel.setMethodCallHandler(plugin);
     registrar.addViewDestroyListener(
-            new PluginRegistry.ViewDestroyListener() {
-              @Override
-              public boolean onViewDestroy(FlutterNativeView view) {
-                plugin.onDestroy();
-                return false; // We are not interested in assuming ownership of the NativeView.
-              }
-            });
+        new PluginRegistry.ViewDestroyListener() {
+          @Override
+          public boolean onViewDestroy(FlutterNativeView view) {
+            plugin.onDestroy();
+            return false; // We are not interested in assuming ownership of the NativeView.
+          }
+        });
   }
 
   private VideoPlayerPlugin(Registrar registrar) {
@@ -305,56 +305,56 @@ public class VideoPlayerPlugin implements MethodCallHandler {
         videoPlayers.clear();
         break;
       case "create":
-      {
-        TextureRegistry.SurfaceTextureEntry handle = textures.createSurfaceTexture();
-        EventChannel eventChannel =
-                new EventChannel(
-                        registrar.messenger(), "flutter.io/videoPlayer/videoEvents" + handle.id());
+        {
+          TextureRegistry.SurfaceTextureEntry handle = textures.createSurfaceTexture();
+          EventChannel eventChannel =
+              new EventChannel(
+                  registrar.messenger(), "flutter.io/videoPlayer/videoEvents" + handle.id());
 
-        VideoPlayer player;
-        if (call.argument("asset") != null) {
-          String assetLookupKey;
-          if (call.argument("package") != null) {
-            assetLookupKey =
-                    registrar.lookupKeyForAsset(
-                            (String) call.argument("asset"), (String) call.argument("package"));
+          VideoPlayer player;
+          if (call.argument("asset") != null) {
+            String assetLookupKey;
+            if (call.argument("package") != null) {
+              assetLookupKey =
+                  registrar.lookupKeyForAsset(
+                      (String) call.argument("asset"), (String) call.argument("package"));
+            } else {
+              assetLookupKey = registrar.lookupKeyForAsset((String) call.argument("asset"));
+            }
+            player =
+                new VideoPlayer(
+                    registrar.context(),
+                    eventChannel,
+                    handle,
+                    "asset:///" + assetLookupKey,
+                    result);
+            videoPlayers.put(handle.id(), player);
           } else {
-            assetLookupKey = registrar.lookupKeyForAsset((String) call.argument("asset"));
+            player =
+                new VideoPlayer(
+                    registrar.context(),
+                    eventChannel,
+                    handle,
+                    (String) call.argument("uri"),
+                    result);
+            videoPlayers.put(handle.id(), player);
           }
-          player =
-                  new VideoPlayer(
-                          registrar.context(),
-                          eventChannel,
-                          handle,
-                          "asset:///" + assetLookupKey,
-                          result);
-          videoPlayers.put(handle.id(), player);
-        } else {
-          player =
-                  new VideoPlayer(
-                          registrar.context(),
-                          eventChannel,
-                          handle,
-                          (String) call.argument("uri"),
-                          result);
-          videoPlayers.put(handle.id(), player);
+          break;
         }
-        break;
-      }
       default:
-      {
-        long textureId = ((Number) call.argument("textureId")).longValue();
-        VideoPlayer player = videoPlayers.get(textureId);
-        if (player == null) {
-          result.error(
-                  "Unknown textureId",
-                  "No video player associated with texture id " + textureId,
-                  null);
-          return;
+        {
+          long textureId = ((Number) call.argument("textureId")).longValue();
+          VideoPlayer player = videoPlayers.get(textureId);
+          if (player == null) {
+            result.error(
+                "Unknown textureId",
+                "No video player associated with texture id " + textureId,
+                null);
+            return;
+          }
+          onMethodCall(call, result, textureId, player);
+          break;
         }
-        onMethodCall(call, result, textureId, player);
-        break;
-      }
     }
   }
 


### PR DESCRIPTION
The default implementation was not using adaptive track selector and the player was unable to play resources pointing to a MPD manifest file for MPEG-dash format.
I have used AdaptiveTrackSelection factory as the default TrackSelectionFactory.
Tested against normal MP4 and MPEG-dash formats.