### PR TITLE
[video_player] Update video buffering status event for ExoPlayer

### DIFF
--- a/packages/video_player/CHANGELOG.md
+++ b/packages/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.5
+
+* Android: update video buffering status event for ExoPlayer.
+
 ## 0.6.4
 
 * Android: add support for hls, dash and ss video formats.

--- a/packages/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -153,11 +153,21 @@ public class VideoPlayerPlugin implements MethodCallHandler {
                   // iOS supports a list of buffered ranges, so here is a list with a single range.
                   event.put("values", Collections.singletonList(range));
                   eventSink.success(event);
+                  event.clear();
+                  event.put("event", "bufferingStart");
+                  eventSink.success(event);
                 }
-              } else if (playbackState == Player.STATE_READY && !isInitialized) {
-                isInitialized = true;
-                sendInitialized();
-              }
+              } else if (playbackState == Player.STATE_READY) {
+                if (!isInitialized) {
+                  isInitialized = true;
+                  sendInitialized();
+                }
+                if (eventSink != null) {
+                  Map<String, Object> event = new HashMap<>();
+                  event.put("event", "bufferingEnd");
+                  eventSink.success(event);
+                }
+              } 
             }
 
             @Override

--- a/packages/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -167,7 +167,7 @@ public class VideoPlayerPlugin implements MethodCallHandler {
                   event.put("event", "bufferingEnd");
                   eventSink.success(event);
                 }
-              } 
+              }
             }
 
             @Override


### PR DESCRIPTION
Since there were changes in Android implementation of video_player (using `ExoPlayer` instead of `MediaPlayer`) the buffering status events (`bufferingStart` and `bufferingEnd`) is no longer fired.

This PR update Android implementation to fire those events.