### PR TITLE
This fixes firebase/firebase#19004

### DIFF
--- a/packages/firebase_messaging/android/build.gradle
+++ b/packages/firebase_messaging/android/build.gradle
@@ -32,6 +32,6 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        api 'com.google.firebase:firebase-messaging:17.1.0'
+        api 'com.google.firebase:firebase-messaging:17.3.0'
     }
 }


### PR DESCRIPTION
There was some bug introduced possibly in firebase messaging package version `17.1.0` which was described in:
* flutter/flutter#19004
* firebase/quickstart-android#588

upgrading to `com.google.firebase:firebase-messaging:17.3.0` fixed it.