### PR TITLE
Rev the mockito version

### DIFF
--- a/packages/battery/pubspec.yaml
+++ b/packages/battery/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   meta: "^1.0.5"
 
 dev_dependencies:
-  mockito: "^2.0.2"
+  mockito: 3.0.0
   flutter_test:
     sdk: flutter
 

--- a/packages/firebase_admob/pubspec.yaml
+++ b/packages/firebase_admob/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  mockito: ^2.0.2
+  mockito: 3.0.0
   flutter_test:
     sdk: flutter
 

--- a/packages/firebase_analytics/pubspec.yaml
+++ b/packages/firebase_analytics/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  mockito: ^2.0.2
+  mockito: 3.0.0
   flutter_test:
     sdk: flutter
 

--- a/packages/firebase_database/pubspec.yaml
+++ b/packages/firebase_database/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   firebase_core: ^0.2.2
 
 dev_dependencies:
-  mockito: ^2.0.2
+  mockito: 3.0.0
   flutter_test:
     sdk: flutter
 

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  mockito: ^2.0.2
+  mockito: 3.0.0
   flutter_test:
     sdk: flutter
 

--- a/packages/share/pubspec.yaml
+++ b/packages/share/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  mockito: ^2.2.3
+  mockito: 3.0.0
   flutter_test:
     sdk: flutter
 


### PR DESCRIPTION
Now that plugins is on Dart 2, we need Mockito 3.0.0. flutter/flutter has already made this change.