### PR TITLE
[image_picker]Fixed losing transparency of PNGs

### DIFF
--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImageResizer.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImageResizer.java
@@ -85,9 +85,8 @@ class ImageResizer {
 
     Bitmap scaledBmp = Bitmap.createScaledBitmap(bmp, width.intValue(), height.intValue(), false);
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-    boolean isPNG = path.toLowerCase().endsWith("png");
-    scaledBmp.compress(
-        isPNG ? Bitmap.CompressFormat.PNG : Bitmap.CompressFormat.JPEG, 100, outputStream);
+    boolean saveAsPNG = bmp.hasAlpha();
+    scaledBmp.compress(saveAsPNG ? Bitmap.CompressFormat.PNG : Bitmap.CompressFormat.JPEG, 100, outputStream);
 
     String[] pathParts = path.split("/");
     String imageName = pathParts[pathParts.length - 1];

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImageResizer.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImageResizer.java
@@ -87,7 +87,7 @@ class ImageResizer {
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
     boolean saveAsPNG = bmp.hasAlpha();
     scaledBmp.compress(
-      saveAsPNG ? Bitmap.CompressFormat.PNG : Bitmap.CompressFormat.JPEG, 100, outputStream);
+        saveAsPNG ? Bitmap.CompressFormat.PNG : Bitmap.CompressFormat.JPEG, 100, outputStream);
 
     String[] pathParts = path.split("/");
     String imageName = pathParts[pathParts.length - 1];

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImageResizer.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImageResizer.java
@@ -86,7 +86,8 @@ class ImageResizer {
     Bitmap scaledBmp = Bitmap.createScaledBitmap(bmp, width.intValue(), height.intValue(), false);
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
     boolean saveAsPNG = bmp.hasAlpha();
-    scaledBmp.compress(saveAsPNG ? Bitmap.CompressFormat.PNG : Bitmap.CompressFormat.JPEG, 100, outputStream);
+    scaledBmp.compress(
+      saveAsPNG ? Bitmap.CompressFormat.PNG : Bitmap.CompressFormat.JPEG, 100, outputStream);
 
     String[] pathParts = path.split("/");
     String imageName = pathParts[pathParts.length - 1];

--- a/packages/image_picker/ios/Classes/ImagePickerPlugin.m
+++ b/packages/image_picker/ios/Classes/ImagePickerPlugin.m
@@ -162,9 +162,11 @@ static const int SOURCE_GALLERY = 1;
       image = [self scaledImage:image maxWidth:maxWidth maxHeight:maxHeight];
     }
 
-    NSData *data = UIImagePNGRepresentation(image);
+    BOOL saveAsPNG = [self hasAlpha:image];
+    NSData *data = saveAsPNG ? UIImagePNGRepresentation(image) : UIImageJPEGRepresentation(image, 1.0);
+    NSString *fileExtension = saveAsPNG ? @"image_picker_%@.png" : @"image_picker_%@.jpg";
     NSString *guid = [[NSProcessInfo processInfo] globallyUniqueString];
-    NSString *tmpFile = [NSString stringWithFormat:@"image_picker_%@.png", guid];
+    NSString *tmpFile = [NSString stringWithFormat:fileExtension, guid];
     NSString *tmpDirectory = NSTemporaryDirectory();
     NSString *tmpPath = [tmpDirectory stringByAppendingPathComponent:tmpFile];
 
@@ -252,6 +254,15 @@ static const int SOURCE_GALLERY = 1;
   UIGraphicsEndImageContext();
 
   return scaledImage;
+}
+
+// Returns true if the image has an alpha layer
+- (BOOL)hasAlpha:(UIImage *)image {
+    CGImageAlphaInfo alpha = CGImageGetAlphaInfo(image.CGImage);
+    return (alpha == kCGImageAlphaFirst ||
+            alpha == kCGImageAlphaLast ||
+            alpha == kCGImageAlphaPremultipliedFirst ||
+            alpha == kCGImageAlphaPremultipliedLast);
 }
 
 @end

--- a/packages/image_picker/ios/Classes/ImagePickerPlugin.m
+++ b/packages/image_picker/ios/Classes/ImagePickerPlugin.m
@@ -163,7 +163,8 @@ static const int SOURCE_GALLERY = 1;
     }
 
     BOOL saveAsPNG = [self hasAlpha:image];
-    NSData *data = saveAsPNG ? UIImagePNGRepresentation(image) : UIImageJPEGRepresentation(image, 1.0);
+    NSData *data =
+        saveAsPNG ? UIImagePNGRepresentation(image) : UIImageJPEGRepresentation(image, 1.0);
     NSString *fileExtension = saveAsPNG ? @"image_picker_%@.png" : @"image_picker_%@.jpg";
     NSString *guid = [[NSProcessInfo processInfo] globallyUniqueString];
     NSString *tmpFile = [NSString stringWithFormat:fileExtension, guid];
@@ -258,11 +259,9 @@ static const int SOURCE_GALLERY = 1;
 
 // Returns true if the image has an alpha layer
 - (BOOL)hasAlpha:(UIImage *)image {
-    CGImageAlphaInfo alpha = CGImageGetAlphaInfo(image.CGImage);
-    return (alpha == kCGImageAlphaFirst ||
-            alpha == kCGImageAlphaLast ||
-            alpha == kCGImageAlphaPremultipliedFirst ||
-            alpha == kCGImageAlphaPremultipliedLast);
+  CGImageAlphaInfo alpha = CGImageGetAlphaInfo(image.CGImage);
+  return (alpha == kCGImageAlphaFirst || alpha == kCGImageAlphaLast ||
+          alpha == kCGImageAlphaPremultipliedFirst || alpha == kCGImageAlphaPremultipliedLast);
 }
 
 @end


### PR DESCRIPTION
When the user picks a png that has transparent pixels, these are then lost (made black). This was caused by always saving the image as JPEG when resizing. 

At first I always saved the image as PNG, but that did not work very well for Android, where the JPEG format carried important rotation (EXIF) information. So for Android I am deciding the output format based on the file extension. For iOS things are a bit simpler and we can just always save as png.