### PR TITLE
Use api to allow support-v4 version resolution.

### DIFF
--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.11
+
+* Use `api` to define `support-v4` dependency to allow automatic version resolution.
+
 ## 0.4.10
 
 * Depend on full `support-v4` library for ease of use (fixes conflicts with Firebase and libraries)

--- a/packages/image_picker/android/build.gradle
+++ b/packages/image_picker/android/build.gradle
@@ -34,5 +34,5 @@ android {
 }
 
 dependencies {
-    implementation 'com.android.support:support-v4:27.1.1'
+    api 'com.android.support:support-v4:27.1.1'
 }

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -5,7 +5,7 @@ authors:
   - Flutter Team <flutter-dev@googlegroups.com>
   - Rhodes Davis Jr. <rody.davis.jr@gmail.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.4.10
+version: 0.4.11
 
 flutter:
   plugin:


### PR DESCRIPTION
If apps use image_picker and another plugin that uses a different
version of support-v4 it should be visible to gradle to allow
resolution to the latest version.