### PR TITLE
 Add an initialUrl and a javaScriptMode parameters to WebView

### DIFF
--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -10,13 +10,20 @@ import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.platform.PlatformView;
+import java.util.Map;
 
 public class FlutterWebView implements PlatformView, MethodCallHandler {
   private final WebView webView;
   private final MethodChannel methodChannel;
 
-  FlutterWebView(Context context, BinaryMessenger messenger, int id) {
+  @SuppressWarnings("unchecked")
+  FlutterWebView(Context context, BinaryMessenger messenger, int id, Map<String, Object> params) {
     webView = new WebView(context);
+    if (params.containsKey("initialUrl")) {
+      String url = (String) params.get("initialUrl");
+      webView.loadUrl(url);
+    }
+    applySettings((Map<String, Object>) params.get("settings"));
     methodChannel = new MethodChannel(messenger, "plugins.flutter.io/webview_" + id);
     methodChannel.setMethodCallHandler(this);
   }
@@ -32,6 +39,9 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
       case "loadUrl":
         loadUrl(methodCall, result);
         break;
+      case "updateSettings":
+        updateSettings(methodCall, result);
+        break;
       default:
         result.notImplemented();
     }
@@ -41,6 +51,37 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
     String url = (String) methodCall.arguments;
     webView.loadUrl(url);
     result.success(null);
+  }
+
+  @SuppressWarnings("unchecked")
+  private void updateSettings(MethodCall methodCall, Result result) {
+    applySettings((Map<String, Object>) methodCall.arguments);
+    result.success(null);
+  }
+
+  private void applySettings(Map<String, Object> settings) {
+    for (String key : settings.keySet()) {
+      switch (key) {
+        case "jsMode":
+          updateJsMode((Integer) settings.get(key));
+          break;
+        default:
+          throw new IllegalArgumentException("Unknown WebView setting: " + key);
+      }
+    }
+  }
+
+  private void updateJsMode(int mode) {
+    switch (mode) {
+      case 0: // disabled
+        webView.getSettings().setJavaScriptEnabled(false);
+        break;
+      case 1: //unrestricted
+        webView.getSettings().setJavaScriptEnabled(true);
+        break;
+      default:
+        throw new IllegalArgumentException("Trying to set unknown Javascript mode: " + mode);
+    }
   }
 
   @Override

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/WebViewFactory.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/WebViewFactory.java
@@ -5,6 +5,7 @@ import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.StandardMessageCodec;
 import io.flutter.plugin.platform.PlatformView;
 import io.flutter.plugin.platform.PlatformViewFactory;
+import java.util.Map;
 
 public class WebViewFactory extends PlatformViewFactory {
   private final BinaryMessenger messenger;
@@ -14,8 +15,10 @@ public class WebViewFactory extends PlatformViewFactory {
     this.messenger = messenger;
   }
 
+  @SuppressWarnings("unchecked")
   @Override
   public PlatformView create(Context context, int id, Object args) {
-    return new FlutterWebView(context, messenger, id);
+    Map<String, Object> params = (Map<String, Object>) args;
+    return new FlutterWebView(context, messenger, id, params);
   }
 }

--- a/packages/webview_flutter/example/lib/main.dart
+++ b/packages/webview_flutter/example/lib/main.dart
@@ -16,14 +16,11 @@ class WebViewExample extends StatelessWidget {
         // This drop down menu demonstrates that Flutter widgets can be shown over the web view.
         actions: <Widget>[const SampleMenu()],
       ),
-      body: WebView(
-        onWebViewCreated: _onWebViewCreated,
+      body: const WebView(
+        initialUrl: 'https://youtube.com',
+        javaScriptMode: JavaScriptMode.unrestricted,
       ),
     );
-  }
-
-  void _onWebViewCreated(WebViewController controller) {
-    controller.loadUrl('https://flutter.io');
   }
 }
 

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -11,6 +11,14 @@ import 'package:flutter/widgets.dart';
 
 typedef void WebViewCreatedCallback(WebViewController controller);
 
+enum JavaScriptMode {
+  /// JavaScript execution is disabled.
+  disabled,
+
+  /// JavaScript execution is not restricted.
+  unrestricted,
+}
+
 /// A web view widget for showing html content.
 class WebView extends StatefulWidget {
   /// Creates a new web view.
@@ -18,12 +26,15 @@ class WebView extends StatefulWidget {
   /// The web view can be controlled using a `WebViewController` that is passed to the
   /// `onWebViewCreated` callback once the web view is created.
   ///
-  /// The `gestureRecognizers` parameter must not be null;
+  /// The `gestureRecognizers` and `javaScriptMode` parameters must not be null.
   const WebView({
     Key key,
     this.onWebViewCreated,
+    this.initialUrl,
+    this.javaScriptMode = JavaScriptMode.disabled,
     this.gestureRecognizers = const <OneSequenceGestureRecognizer>[],
   })  : assert(gestureRecognizers != null),
+        assert(javaScriptMode != null),
         super(key: key);
 
   /// If not null invoked once the web view is created.
@@ -40,11 +51,22 @@ class WebView extends StatefulWidget {
   /// were not claimed by any other gesture recognizer.
   final List<OneSequenceGestureRecognizer> gestureRecognizers;
 
+  /// The initial URL to load.
+  final String initialUrl;
+
+  /// Whether JavaScript execution is enabled.
+  final JavaScriptMode javaScriptMode;
+
   @override
   State<StatefulWidget> createState() => _WebViewState();
 }
 
 class _WebViewState extends State<WebView> {
+  final Completer<WebViewController> _controller =
+      new Completer<WebViewController>();
+
+  _WebSettings _settings;
+
   @override
   Widget build(BuildContext context) {
     if (defaultTargetPlatform == TargetPlatform.android) {
@@ -63,6 +85,8 @@ class _WebViewState extends State<WebView> {
           // we explicitly set it here so that the widget doesn't require an ambient
           // directionality.
           layoutDirection: TextDirection.rtl,
+          creationParams: _CreationParams.fromWidget(widget).toMap(),
+          creationParamsCodec: const StandardMessageCodec(),
         ),
       );
     }
@@ -70,11 +94,84 @@ class _WebViewState extends State<WebView> {
         '$defaultTargetPlatform is not yet supported by the webview_flutter plugin');
   }
 
-  void _onPlatformViewCreated(int id) {
-    if (widget.onWebViewCreated == null) {
+  @override
+  void initState() {
+    super.initState();
+    _settings = _WebSettings.fromWidget(widget);
+  }
+
+  @override
+  void didUpdateWidget(WebView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final _WebSettings newSettings = _WebSettings.fromWidget(widget);
+    final Map<String, dynamic> settingsUpdate =
+        _settings.updatesMap(newSettings);
+    _updateSettings(settingsUpdate);
+    _settings = newSettings;
+  }
+
+  Future<void> _updateSettings(Map<String, dynamic> update) async {
+    if (update == null) {
       return;
     }
-    widget.onWebViewCreated(new WebViewController._(id));
+    final WebViewController controller = await _controller.future;
+    controller._updateSettings(update);
+  }
+
+  void _onPlatformViewCreated(int id) {
+    final WebViewController controller = new WebViewController._(id);
+    _controller.complete(controller);
+    if (widget.onWebViewCreated != null) {
+      widget.onWebViewCreated(controller);
+    }
+  }
+}
+
+class _CreationParams {
+  _CreationParams({this.initialUrl, this.settings});
+
+  static _CreationParams fromWidget(WebView widget) {
+    return new _CreationParams(
+      initialUrl: widget.initialUrl,
+      settings: _WebSettings.fromWidget(widget),
+    );
+  }
+
+  final String initialUrl;
+  final _WebSettings settings;
+
+  Map<String, dynamic> toMap() {
+    return <String, dynamic>{
+      'initialUrl': initialUrl,
+      'settings': settings.toMap(),
+    };
+  }
+}
+
+class _WebSettings {
+  _WebSettings({
+    this.javaScriptMode,
+  });
+
+  static _WebSettings fromWidget(WebView widget) {
+    return new _WebSettings(javaScriptMode: widget.javaScriptMode);
+  }
+
+  final JavaScriptMode javaScriptMode;
+
+  Map<String, dynamic> toMap() {
+    return <String, dynamic>{
+      'jsMode': javaScriptMode.index,
+    };
+  }
+
+  Map<String, dynamic> updatesMap(_WebSettings newSettings) {
+    if (javaScriptMode == newSettings.javaScriptMode) {
+      return null;
+    }
+    return <String, dynamic>{
+      'jsMode': newSettings.javaScriptMode.index,
+    };
   }
 }
 
@@ -97,6 +194,10 @@ class WebViewController {
     assert(url != null);
     _validateUrlString(url);
     return _channel.invokeMethod('loadUrl', url);
+  }
+
+  Future<void> _updateSettings(Map<String, dynamic> update) async {
+    return _channel.invokeMethod('updateSettings', update);
   }
 }
 

--- a/packages/webview_flutter/test/webview_flutter_test.dart
+++ b/packages/webview_flutter/test/webview_flutter_test.dart
@@ -2,21 +2,60 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:typed_data';
+
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
 void main() {
+  final _FakePlatformViewsController fakePlatformViewsController =
+      new _FakePlatformViewsController();
+
   setUpAll(() {
-    SystemChannels.platform_views
-        .setMockMethodCallHandler(_fakePlatformViewsMethodHandler);
+    SystemChannels.platform_views.setMockMethodCallHandler(
+        fakePlatformViewsController.fakePlatformViewsMethodHandler);
   });
+
+  setUp(() {
+    fakePlatformViewsController.reset();
+  });
+
   testWidgets('Create WebView', (WidgetTester tester) async {
     await tester.pumpWidget(const WebView());
   });
 
+  testWidgets('Initial url', (WidgetTester tester) async {
+    await tester.pumpWidget(const WebView(
+      initialUrl: 'https://youtube.com',
+    ));
+
+    final FakePlatformWebView platformWebView =
+        fakePlatformViewsController.lastCreatedView;
+
+    expect(platformWebView.lastUrlLoaded, 'https://youtube.com');
+  });
+
+  testWidgets('JavaScript mode', (WidgetTester tester) async {
+    await tester.pumpWidget(const WebView(
+      initialUrl: 'https://youtube.com',
+      javaScriptMode: JavaScriptMode.unrestricted,
+    ));
+
+    final FakePlatformWebView platformWebView =
+        fakePlatformViewsController.lastCreatedView;
+
+    expect(platformWebView.javaScriptMode, JavaScriptMode.unrestricted);
+
+    await tester.pumpWidget(const WebView(
+      initialUrl: 'https://youtube.com',
+      javaScriptMode: JavaScriptMode.disabled,
+    ));
+
+    expect(platformWebView.javaScriptMode, JavaScriptMode.disabled);
+  });
+
   testWidgets('Load url', (WidgetTester tester) async {
-    final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
     WebViewController controller;
     await tester.pumpWidget(
       WebView(
@@ -29,7 +68,7 @@ void main() {
     expect(controller, isNotNull);
 
     final FakePlatformWebView platformWebView =
-        new FakePlatformWebView(currentViewId + 1);
+        fakePlatformViewsController.lastCreatedView;
 
     controller.loadUrl('https://flutter.io');
 
@@ -37,7 +76,6 @@ void main() {
   });
 
   testWidgets('Invald urls', (WidgetTester tester) async {
-    final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
     WebViewController controller;
     await tester.pumpWidget(
       WebView(
@@ -50,7 +88,7 @@ void main() {
     expect(controller, isNotNull);
 
     final FakePlatformWebView platformWebView =
-        new FakePlatformWebView(currentViewId + 1);
+        fakePlatformViewsController.lastCreatedView;
 
     expect(() => controller.loadUrl(null), throwsA(anything));
     expect(platformWebView.lastUrlLoaded, isNull);
@@ -65,7 +103,11 @@ void main() {
 }
 
 class FakePlatformWebView {
-  FakePlatformWebView(int id) {
+  FakePlatformWebView(int id, Map<dynamic, dynamic> params) {
+    if (params.containsKey('initialUrl')) {
+      lastUrlLoaded = params['initialUrl'];
+      javaScriptMode = JavaScriptMode.values[params['settings']['jsMode']];
+    }
     channel = new MethodChannel(
         'plugins.flutter.io/webview_$id', const StandardMethodCodec());
     channel.setMockMethodCallHandler(onMethodCall);
@@ -74,23 +116,52 @@ class FakePlatformWebView {
   MethodChannel channel;
 
   String lastUrlLoaded;
+  JavaScriptMode javaScriptMode;
 
   Future<dynamic> onMethodCall(MethodCall call) {
     switch (call.method) {
       case 'loadUrl':
         lastUrlLoaded = call.arguments;
         return new Future<Null>.sync(() => null);
+      case 'updateSettings':
+        if (call.arguments['jsMode'] == null) {
+          break;
+        }
+        javaScriptMode = JavaScriptMode.values[call.arguments['jsMode']];
+        break;
+    }
+    return new Future<Null>.sync(() => null);
+  }
+}
+
+class _FakePlatformViewsController {
+  FakePlatformWebView lastCreatedView;
+
+  Future<dynamic> fakePlatformViewsMethodHandler(MethodCall call) {
+    switch (call.method) {
+      case 'create':
+        final Map<dynamic, dynamic> args = call.arguments;
+        final Map<dynamic, dynamic> params = _decodeParams(args['params']);
+        lastCreatedView = new FakePlatformWebView(
+          args['id'],
+          params,
+        );
+        return Future<int>.sync(() => 1);
       default:
         return new Future<Null>.sync(() => null);
     }
   }
+
+  void reset() {
+    lastCreatedView = null;
+  }
 }
 
-Future<dynamic> _fakePlatformViewsMethodHandler(MethodCall call) {
-  switch (call.method) {
-    case 'create':
-      return Future<int>.sync(() => 1);
-    default:
-      return new Future<Null>.sync(() => null);
-  }
+Map<dynamic, dynamic> _decodeParams(Uint8List paramsMessage) {
+  final ByteBuffer buffer = paramsMessage.buffer;
+  final ByteData messageBytes = buffer.asByteData(
+    paramsMessage.offsetInBytes,
+    paramsMessage.lengthInBytes,
+  );
+  return const StandardMessageCodec().decodeMessage(messageBytes);
 }


### PR DESCRIPTION
Adding just these 2 parameters to set up the skeleton for webview
settings and initial parameters.

Settings (like javaScriptMode) are set and updated by rebuilding the
widget.

initialUrl is a covinience parameter for simple use cases, as the
WebView's loadUrl method cannot be modeled nicely as a widget parameter
(e.g when the widget is rebuilt with the same url value there is no nice
way to tell if you should load that url again or not).
These kind of "edge triggers" fit in the WevView's controller.
initialUrl is completely ignored when the widget is rebuilt.
