### PR TITLE
local_auth: Use minimal support library

### DIFF
--- a/packages/local_auth/android/build.gradle
+++ b/packages/local_auth/android/build.gradle
@@ -34,5 +34,5 @@ android {
 }
 
 dependencies {
-    implementation "com.android.support:support-v4:26.1.0"
+    implementation "com.android.support:support-compat:27.1.1"
 }

--- a/packages/local_auth/android/build.gradle
+++ b/packages/local_auth/android/build.gradle
@@ -34,5 +34,5 @@ android {
 }
 
 dependencies {
-    implementation "com.android.support:support-compat:27.1.1"
+    api "com.android.support:support-compat:27.1.1"
 }


### PR DESCRIPTION
The 'support-v4' package is a meta package with all support library packages included. This plugin only uses classes from 'support-compat', so this can be used instead.