### PR TITLE
Remove unused navigatorObservers from the Google Maps example.

### DIFF
--- a/packages/google_maps_flutter/example/lib/main.dart
+++ b/packages/google_maps_flutter/example/lib/main.dart
@@ -42,6 +42,5 @@ class MapsDemo extends StatelessWidget {
 }
 
 void main() {
-  final List<NavigatorObserver> observers = <NavigatorObserver>[];
-  runApp(MaterialApp(home: MapsDemo(), navigatorObservers: observers));
+  runApp(MaterialApp(home: MapsDemo()));
 }


### PR DESCRIPTION
This is no longer used since #743, the empty list was just a
left over.