### PR TITLE
Rebuild VideoPlayer once VideoPlayerController finishes initialization.

### DIFF
--- a/packages/video_player/CHANGELOG.md
+++ b/packages/video_player/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.5
+
+* Eliminate race conditions around initialization: now initialization events are queued and guaranteed
+  to be delivered to the Dart side. VideoPlayer widget is rebuilt upon completion of initialization.
+
 ## 0.6.4
 
 * Android: add support for hls, dash and ss video formats.

--- a/packages/video_player/android/src/main/java/io/flutter/plugins/videoplayer/QueuingEventSink.java
+++ b/packages/video_player/android/src/main/java/io/flutter/plugins/videoplayer/QueuingEventSink.java
@@ -1,0 +1,81 @@
+package io.flutter.plugins.videoplayer;
+
+import io.flutter.plugin.common.EventChannel;
+import java.util.ArrayList;
+
+/**
+ * And implementation of {@link EventChannel.EventSink} which can wrap an underlying sink.
+ *
+ * <p>It delivers messages immediately when downstream is available, but it queues messages before
+ * the delegate event sink is set with setDelegate.
+ *
+ * <p>This class is not thread-safe. All calls must be done on the same thread or synchronized
+ * externally.
+ */
+final class QueuingEventSink implements EventChannel.EventSink {
+  private EventChannel.EventSink delegate;
+  private ArrayList<Object> eventQueue = new ArrayList<>();
+  private boolean done = false;
+
+  public void setDelegate(EventChannel.EventSink delegate) {
+    this.delegate = delegate;
+    maybeFlush();
+  }
+
+  @Override
+  public void endOfStream() {
+    enqueue(new EndOfStreamEvent());
+    maybeFlush();
+    done = true;
+  }
+
+  @Override
+  public void error(String code, String message, Object details) {
+    enqueue(new ErrorEvent(code, message, details));
+    maybeFlush();
+  }
+
+  @Override
+  public void success(Object event) {
+    enqueue(event);
+    maybeFlush();
+  }
+
+  private void enqueue(Object event) {
+    if (done) {
+      return;
+    }
+    eventQueue.add(event);
+  }
+
+  private void maybeFlush() {
+    if (delegate == null) {
+      return;
+    }
+    for (Object event : eventQueue) {
+      if (event instanceof EndOfStreamEvent) {
+        delegate.endOfStream();
+      } else if (event instanceof ErrorEvent) {
+        ErrorEvent errorEvent = (ErrorEvent) event;
+        delegate.error(errorEvent.code, errorEvent.message, errorEvent.details);
+      } else {
+        delegate.success(event);
+      }
+    }
+    eventQueue.clear();
+  }
+
+  private static class EndOfStreamEvent {}
+
+  private static class ErrorEvent {
+    String code;
+    String message;
+    Object details;
+
+    ErrorEvent(String code, String message, Object details) {
+      this.code = code;
+      this.message = message;
+      this.details = details;
+    }
+  }
+}

--- a/packages/video_player/lib/video_player.dart
+++ b/packages/video_player/lib/video_player.dart
@@ -420,16 +420,39 @@ class _VideoAppLifeCycleObserver extends WidgetsBindingObserver {
 }
 
 /// Displays the video controlled by [controller].
-class VideoPlayer extends StatelessWidget {
+class VideoPlayer extends StatefulWidget {
   final VideoPlayerController controller;
 
   VideoPlayer(this.controller);
 
   @override
+  _VideoPlayerState createState() => new _VideoPlayerState();
+}
+
+class _VideoPlayerState extends State<VideoPlayer> {
+  int textureId;
+
+  @override
+  void initState() {
+    super.initState();
+    textureId = widget.controller._textureId;
+    // Need to listen for initialization events since the actual texture ID
+    // becomes available after asynchronous initialization finishes.
+    widget.controller.addListener(() {
+      final int newTextureId = widget.controller._textureId;
+      if (newTextureId != textureId) {
+        setState(() {
+          textureId = newTextureId;
+        });
+      }
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return controller._textureId == null
+    return textureId == null
         ? new Container()
-        : new Texture(textureId: controller._textureId);
+        : new Texture(textureId: textureId);
   }
 }
 

--- a/packages/video_player/pubspec.yaml
+++ b/packages/video_player/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player
 description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
-version: 0.6.4
+version: 0.6.5
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player
 
 flutter:


### PR DESCRIPTION
This eliminates [the races](https://github.com/flutter/flutter/issues/21483) in VideoPlayer plugin initialization.