### PR TITLE
[google_sign_in] Provide ProGuard rules

### DIFF
--- a/packages/google_sign_in/android/build.gradle
+++ b/packages/google_sign_in/android/build.gradle
@@ -27,6 +27,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles 'lib-proguard-rules.txt'
     }
     lintOptions {
         disable 'InvalidPackage'
@@ -34,6 +35,6 @@ android {
 }
 
 dependencies {
-    api 'com.google.android.gms:play-services-auth:15.+'
-    implementation 'com.google.guava:guava:20.0'
+    api 'com.google.android.gms:play-services-auth:16.0.0'
+    api 'com.google.guava:guava:26.0-android'
 }

--- a/packages/google_sign_in/android/lib-proguard-rules.txt
+++ b/packages/google_sign_in/android/lib-proguard-rules.txt
@@ -1,0 +1,7 @@
+# Guava
+-dontwarn afu.org.checkerframework.**
+-dontwarn org.checkerframework.**
+-dontwarn com.google.errorprone.**
+-dontwarn com.google.errorprone.annotations.**
+-dontwarn sun.misc.Unsafe
+-dontwarn com.google.common.util.concurrent.FuturesGetChecked**


### PR DESCRIPTION
Guava does not work well with ProGuard without configuration. Following the steps described in the docs[0] will work now when this plugin is added.

[0] https://flutter.io/android-release/#enabling-proguard