### PR TITLE
Fix a crash in the snapshot callback

### DIFF
--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.2+1
+
+* Avoid crash in document snapshot callback.
+
 ## 0.8.2
 
 * Added `Firestore.settings`

--- a/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
+++ b/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
@@ -431,8 +431,8 @@ const UInt8 TIMESTAMP = 136;
           [self.channel invokeMethod:@"DocumentSnapshot"
                            arguments:@{
                              @"handle" : handle,
-                             @"path" : snapshot.reference.path,
-                             @"data" : snapshot.exists ? snapshot.data : [NSNull null],
+                             @"path" : snapshot ? snapshot.reference.path : [NSNull null],
+                             @"data" : snapshot && snapshot.exists ? snapshot.data : [NSNull null],
                            }];
         }];
     _listeners[handle] = listener;

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_firestore
-version: 0.8.2
+version: 0.8.2+1
 
 flutter:
   plugin:


### PR DESCRIPTION
The following code causes the snapshot variable to be nil in the callback path.  However the code assumes it is not nil and crashes :)

- (id<FIRListenerRegistration>)
addSnapshotListenerInternalWithOptions:(FSTListenOptions *)internalOptions
                              listener:(FIRDocumentSnapshotBlock)listener {
  FIRFirestore *firestore = self.firestore;
  FSTQuery *query = [FSTQuery queryWithPath:self.key.path()];
  const DocumentKey key = self.key;

  FSTViewSnapshotHandler snapshotHandler = ^(FSTViewSnapshot *snapshot, NSError *error) {
    if (error) {
      listener(nil, error);
      ret