### PR TITLE
Mark textureId as @visibleForTesting.

### DIFF
--- a/packages/video_player/lib/video_player.dart
+++ b/packages/video_player/lib/video_player.dart
@@ -184,7 +184,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
         package = null,
         super(new VideoPlayerValue(duration: null));
 
-  // Visible for testing.
+  @visibleForTesting
   int get textureId => _textureId;
 
   Future<void> initialize() async {


### PR DESCRIPTION
Users should not access the texture ID directly.