### PR TITLE
Added getter for Marker ID in maps package

### DIFF
--- a/packages/google_maps_flutter/lib/src/marker.dart
+++ b/packages/google_maps_flutter/lib/src/marker.dart
@@ -15,6 +15,10 @@ class Marker {
   @visibleForTesting
   Marker(this._id, this._options);
 
+  /// The id parameter is intended to uniquely identify a marker.
+  /// Note the formatting is not patented to be in any particular format, 
+  /// so don't bet on any consistency particular format.
+
   final String _id;
   String get id => _id;
 

--- a/packages/google_maps_flutter/lib/src/marker.dart
+++ b/packages/google_maps_flutter/lib/src/marker.dart
@@ -17,7 +17,7 @@ class Marker {
 
   final String _id;
   String get id => _id;
-  
+
   MarkerOptions _options;
 
   /// The marker configuration options most recently applied programmatically

--- a/packages/google_maps_flutter/lib/src/marker.dart
+++ b/packages/google_maps_flutter/lib/src/marker.dart
@@ -16,8 +16,7 @@ class Marker {
   Marker(this._id, this._options);
 
   /// The id parameter is intended to uniquely identify a marker.
-  /// Note the formatting is not patented to be in any particular format, 
-  /// so don't bet on any consistency particular format.
+  /// Note the formatting is not guaranteed to be in any particular format.
   final String _id;
   String get id => _id;
 

--- a/packages/google_maps_flutter/lib/src/marker.dart
+++ b/packages/google_maps_flutter/lib/src/marker.dart
@@ -16,6 +16,8 @@ class Marker {
   Marker(this._id, this._options);
 
   final String _id;
+  String get id => _id;
+  
   MarkerOptions _options;
 
   /// The marker configuration options most recently applied programmatically

--- a/packages/google_maps_flutter/lib/src/marker.dart
+++ b/packages/google_maps_flutter/lib/src/marker.dart
@@ -18,7 +18,6 @@ class Marker {
   /// The id parameter is intended to uniquely identify a marker.
   /// Note the formatting is not patented to be in any particular format, 
   /// so don't bet on any consistency particular format.
-
   final String _id;
   String get id => _id;
 


### PR DESCRIPTION
Did this to align with the android SDK and also open up a way to associate meta data with a marker, such as linking to the underlying model associated to a marker.