### PR TITLE
Switch over to new GoogleSignIn APIs

### DIFF
--- a/packages/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
+++ b/packages/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
@@ -18,6 +18,7 @@ import com.google.android.gms.common.api.ApiException;
 import com.google.android.gms.common.api.CommonStatusCodes;
 import com.google.android.gms.common.api.Scope;
 import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.RuntimeExecutionException;
 import com.google.android.gms.tasks.Task;
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
@@ -344,6 +345,8 @@ public class GoogleSignInPlugin implements MethodCallHandler {
         // Forward all errors and let Dart side decide how to handle.
         String errorCode = errorCodeForStatus(e.getStatusCode());
         finishWithError(errorCode, e.toString());
+      } catch (RuntimeExecutionException e) {
+        finishWithError(ERROR_REASON_EXCEPTION, e.toString());
       }
     }
 

--- a/packages/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
+++ b/packages/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
@@ -174,16 +174,10 @@ public class GoogleSignInPlugin implements MethodCallHandler {
     private GoogleSignInClient signInClient;
     private List<String> requestedScopes;
     private PendingOperation pendingOperation;
-    private volatile GoogleSignInAccount currentAccount;
 
     public Delegate(PluginRegistry.Registrar registrar) {
       this.registrar = registrar;
       registrar.addActivityResultListener(this);
-    }
-
-    /** Returns the most recently signed-in account, or null if there was none. */
-    public GoogleSignInAccount getCurrentAccount() {
-      return currentAccount;
     }
 
     private void checkAndSetPendingOperation(String method, Result result) {
@@ -321,7 +315,6 @@ public class GoogleSignInPlugin implements MethodCallHandler {
                 @Override
                 public void onComplete(Task<Void> task) {
                   if (task.isSuccessful()) {
-                    currentAccount = null;
                     finishWithSuccess(null);
                   } else {
                     finishWithError(ERROR_REASON_STATUS, "Failed to disconnect.");
@@ -351,7 +344,6 @@ public class GoogleSignInPlugin implements MethodCallHandler {
     }
 
     private void onSignInAccount(GoogleSignInAccount account) {
-      currentAccount = account;
       Map<String, Object> response = new HashMap<>();
       response.put("email", account.getEmail());
       response.put("id", account.getId());


### PR DESCRIPTION
These significantly simplify the code for GoogleSignIn Android since it uses connectionless `GoogleSignInClient`.