### PR TITLE
use WidgetsBindingObserver as a mixin

### DIFF
--- a/packages/video_player/lib/video_player.dart
+++ b/packages/video_player/lib/video_player.dart
@@ -393,7 +393,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   }
 }
 
-class _VideoAppLifeCycleObserver extends WidgetsBindingObserver {
+class _VideoAppLifeCycleObserver extends Object with WidgetsBindingObserver {
   bool _wasPlayingBeforePause = false;
   final VideoPlayerController _controller;
 


### PR DESCRIPTION
This change is fully backwards-compatible. The reason I'm doing it is that Flutter is converting to the new `mixin` syntax, which forbids extending mixins.

See also: https://github.com/flutter/flutter/pull/22290