### PR TITLE
Ban string values which clash with special prefixes

### DIFF
--- a/packages/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.3
+
+* Prevent strings that match special prefixes from being saved. This is a bugfix that prevents apps from accidentally setting special values that would be interpreted incorrectly.
+
 ## 0.4.2
 
 * Updated Gradle tooling to match Android Studio 3.1.2.

--- a/packages/shared_preferences/android/src/main/java/io/flutter/plugins/sharedpreferences/SharedPreferencesPlugin.java
+++ b/packages/shared_preferences/android/src/main/java/io/flutter/plugins/sharedpreferences/SharedPreferencesPlugin.java
@@ -137,7 +137,15 @@ public class SharedPreferencesPlugin implements MethodCallHandler {
           status = editor.commit();
           break;
         case "setString":
-          status = preferences.edit().putString(key, (String) call.argument("value")).commit();
+          String value = (String) call.argument("value");
+          if (value.startsWith(LIST_IDENTIFIER) || value.startsWith(BIG_INTEGER_PREFIX)) {
+            result.error(
+                "StorageError",
+                "This string cannot be stored as it clashes with special identifier prefixes.",
+                null);
+            return;
+          }
+          status = preferences.edit().putString(key, value).commit();
           break;
         case "setStringList":
           List<String> list = call.argument("value");

--- a/packages/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for reading and writing simple key-value pairs.
   Wraps NSUserDefaults on iOS and SharedPreferences on Android.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/shared_preferences
-version: 0.4.2
+version: 0.4.3
 
 flutter:
   plugin:


### PR DESCRIPTION
This is the result of security review. We don't want apps to maliciously store values that will be interpreted differently when read.