### PR TITLE
Add ability to clear auth cache on Android

### DIFF
--- a/packages/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.0
+
+* Add support for clearing authentication cache for Android.
+
 ## 3.1.0
 
 * Add support to recover authentication for Android.

--- a/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
+++ b/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
@@ -113,6 +113,10 @@ static NSString *const kErrorReasonSignInFailed = @"sign_in_failed";
     if ([self setAccountRequest:result]) {
       [[GIDSignIn sharedInstance] disconnect];
     }
+  } else if ([call.method isEqualToString:@"clearAuthCache"]) {
+    // There's nothing to be done here on iOS since the expired/invalid
+    // tokens are refreshed automatically by getTokensWithHandler.
+    result(nil);
   } else {
     result(FlutterMethodNotImplemented);
   }

--- a/packages/google_sign_in/lib/google_sign_in.dart
+++ b/packages/google_sign_in/lib/google_sign_in.dart
@@ -102,6 +102,18 @@ class GoogleSignInAccount implements GoogleIdentity {
     };
   }
 
+  /// Clears any client side cache that might be holding invalid tokens.
+  ///
+  /// If client runs into 401 errors using a token, it is expected to call
+  /// this method and grab `authHeaders` once again.
+  Future<void> clearAuthCache() async {
+    final String token = (await authentication).accessToken;
+    await GoogleSignIn.channel.invokeMethod(
+      'clearAuthCache',
+      <String, dynamic>{'token': token},
+    );
+  }
+
   @override
   bool operator ==(dynamic other) {
     if (identical(this, other)) return true;

--- a/packages/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_sign_in
-version: 3.1.0
+version: 3.2.0
 
 flutter:
   plugin:


### PR DESCRIPTION
This is needed for when the returned token is invalid. The app has to be able to clear the authentication cache.