### PR TITLE
[cloud_functions] Fix crash when `error.userInfo[FIRFunctionsErrorDetailsKey]` is nil

### DIFF
--- a/packages/cloud_functions/ios/Classes/CloudFunctionsPlugin.m
+++ b/packages/cloud_functions/ios/Classes/CloudFunctionsPlugin.m
@@ -49,6 +49,7 @@
                                           @"code" : [self mapFunctionsErrorCodes:error.code],
                                           @"message" : error.localizedDescription,
                                           @"details" : error.userInfo[FIRFunctionsErrorDetailsKey]
+                                              ?: [NSNull null]
                                         }];
               } else {
                 flutterError =


### PR DESCRIPTION
Resolve crash when not specified `details` parameter at server's `functions.https.HttpsError`