### PR TITLE
Bump firebase_core Android dependencies to latest

### DIFF
--- a/packages/firebase_core/CHANGELOG.md
+++ b/packages/firebase_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.5+1
+
+* Bump Android dependencies to latest.
+
 ## 0.2.5
 
 * Bump Android and Firebase dependency versions.

--- a/packages/firebase_core/android/build.gradle
+++ b/packages/firebase_core/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:3.2.0'
     }
 }
 
@@ -32,6 +32,6 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        api 'com.google.firebase:firebase-core:16.0.1'
+        api 'com.google.firebase:firebase-core:16.0.4'
     }
 }

--- a/packages/firebase_core/example/android/build.gradle
+++ b/packages/firebase_core/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:3.2.0'
     }
 }
 

--- a/packages/firebase_core/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/firebase_core/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip

--- a/packages/firebase_core/pubspec.yaml
+++ b/packages/firebase_core/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Core, enabling connecting to multiple
   Firebase apps.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_core
-version: 0.2.5
+version: 0.2.5+1
 
 flutter:
   plugin:


### PR DESCRIPTION
In an effort to bump the Android dependencies of all Firebase plugins it would be cleaner to bump core independently since all other firebase plugins depend on this one.