### PR TITLE
Avoid null pointer exception when playing audio

### DIFF
--- a/packages/video_player/lib/video_player.dart
+++ b/packages/video_player/lib/video_player.dart
@@ -227,7 +227,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
         case 'initialized':
           value = value.copyWith(
             duration: Duration(milliseconds: map['duration']),
-            size: Size(map['width'].toDouble(), map['height'].toDouble()),
+            size: Size(map['width']?.toDouble(), map['height']?.toDouble()),
           );
           initializingCompleter.complete(null);
           _applyLooping();


### PR DESCRIPTION
Audio files do not return a size on Android. On iOS this currently works because width and height are set to 0 instead.