### PR TITLE
[camera] Check audio perm when opening on Android

### DIFF
--- a/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
+++ b/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
@@ -430,6 +430,8 @@ public class CameraPlugin implements MethodCallHandler {
     private void open(@Nullable final Result result) {
       if (!hasCameraPermission()) {
         if (result != null) result.error("cameraPermission", "Camera permission not granted", null);
+      } else if (!hasAudioPermission()) {
+        if (result != null) result.error("cameraPermission", "Audio permission not granted", null);
       } else {
         try {
           imageReader =


### PR DESCRIPTION
Since we always require both camera and audio permissions, it's better to
check both in case the user rejected audio permissions alone.