### PR TITLE
[firebase_admob]Destroy adView Before contentView Checking

### DIFF
--- a/packages/firebase_admob/android/src/main/java/io/flutter/plugins/firebaseadmob/MobileAd.java
+++ b/packages/firebase_admob/android/src/main/java/io/flutter/plugins/firebaseadmob/MobileAd.java
@@ -177,10 +177,10 @@ abstract class MobileAd extends AdListener {
     void dispose() {
       super.dispose();
 
+      adView.destroy();
+
       View contentView = activity.findViewById(id);
       if (contentView == null || !(contentView.getParent() instanceof ViewGroup)) return;
-
-      adView.destroy();
 
       ViewGroup contentParent = (ViewGroup) (contentView.getParent());
       contentParent.removeView(contentView);


### PR DESCRIPTION
When displaying an advertisement using firebase_admob, advertisement may remain displayed if transitioning from a screen displaying a banner advertisement to a screen not displaying.
Specifically, if you call "dispose ()" immediately after "load ()" and "show ()" the ad, it will return by checking contentView and the ad may not be destroyed.

This can be reproduced by creating a screen using Tabbar, tapping Tabbar and quickly transitioning the screen.

Therefore, in order to solve this phenomenon, I send a pull request.
Even if this fix is not approved, I'd like to solve this problem somehow.
