### PR TITLE
[firebase_messaging] changing getToken to rely on platform's getToken (2)

### DIFF
--- a/packages/firebase_messaging/CHANGELOG.md
+++ b/packages/firebase_messaging/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.3
+
+* Removing local cache of getToken() in the dart part of the plugin. Now getToken() calls directly its counterparts in the iOS and Android implementations. This enables obtaining its value without calling configure() or having to wait for a new token refresh.
+
 ## 2.0.2
 
 * Use boolean values when checking for notification types on iOS.

--- a/packages/firebase_messaging/android/src/main/java/io/flutter/plugins/firebasemessaging/FirebaseMessagingPlugin.java
+++ b/packages/firebase_messaging/android/src/main/java/io/flutter/plugins/firebasemessaging/FirebaseMessagingPlugin.java
@@ -11,7 +11,10 @@ import android.content.IntentFilter;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.content.LocalBroadcastManager;
+import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.firebase.FirebaseApp;
+import com.google.firebase.iid.FirebaseInstanceId;
+import com.google.firebase.iid.InstanceIdResult;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.RemoteMessage;
 import io.flutter.plugin.common.MethodCall;
@@ -91,7 +94,7 @@ public class FirebaseMessagingPlugin extends BroadcastReceiver
   }
 
   @Override
-  public void onMethodCall(MethodCall call, Result result) {
+  public void onMethodCall(final MethodCall call, final Result result) {
     if ("configure".equals(call.method)) {
       FlutterFirebaseInstanceIDService.broadcastToken(registrar.context());
       if (registrar.activity() != null) {
@@ -106,6 +109,16 @@ public class FirebaseMessagingPlugin extends BroadcastReceiver
       String topic = call.arguments();
       FirebaseMessaging.getInstance().unsubscribeFromTopic(topic);
       result.success(null);
+    } else if ("getToken".equals(call.method)) {
+      FirebaseInstanceId.getInstance()
+          .getInstanceId()
+          .addOnSuccessListener(
+              new OnSuccessListener<InstanceIdResult>() {
+                @Override
+                public void onSuccess(InstanceIdResult instanceIdResult) {
+                  result.success(instanceIdResult.getToken());
+                }
+              });
     } else {
       result.notImplemented();
     }

--- a/packages/firebase_messaging/example/android/build.gradle
+++ b/packages/firebase_messaging/example/android/build.gradle
@@ -2,7 +2,6 @@ buildscript {
     repositories {
         google()
         jcenter()
-        mavenLocal()
     }
 
     dependencies {
@@ -15,7 +14,6 @@ allprojects {
     repositories {
         google()
         jcenter()
-        mavenLocal()
     }
 }
 

--- a/packages/firebase_messaging/ios/Classes/FirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/ios/Classes/FirebaseMessagingPlugin.m
@@ -75,7 +75,16 @@
     [[FIRMessaging messaging] unsubscribeFromTopic:topic];
     result(nil);
   } else if ([@"getToken" isEqualToString:method]) {
-    result([[FIRMessaging messaging] FCMToken]);
+    [[FIRInstanceID instanceID]
+        instanceIDWithHandler:^(FIRInstanceIDResult *_Nullable instanceIDResult,
+                                NSError *_Nullable error) {
+          if (error != nil) {
+            NSLog(@"getToken, error fetching instanceID: %@", error);
+            result(nil);
+          } else {
+            result(instanceIDResult.token);
+          }
+        }];
   } else {
     result(FlutterMethodNotImplemented);
   }

--- a/packages/firebase_messaging/ios/Classes/FirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/ios/Classes/FirebaseMessagingPlugin.m
@@ -74,6 +74,8 @@
     NSString *topic = call.arguments;
     [[FIRMessaging messaging] unsubscribeFromTopic:topic];
     result(nil);
+  } else if ([@"getToken" isEqualToString:method]) {
+    result([[FIRMessaging messaging] FCMToken]);
   } else {
     result(FlutterMethodNotImplemented);
   }

--- a/packages/firebase_messaging/lib/firebase_messaging.dart
+++ b/packages/firebase_messaging/lib/firebase_messaging.dart
@@ -32,7 +32,6 @@ class FirebaseMessaging {
   MessageHandler _onMessage;
   MessageHandler _onLaunch;
   MessageHandler _onResume;
-  String _token;
 
   /// On iOS, prompts the user for notification permissions the first time
   /// it is called.
@@ -79,8 +78,8 @@ class FirebaseMessaging {
   }
 
   /// Returns the FCM token.
-  Future<String> getToken() {
-    return _token != null ? Future<String>.value(_token) : onTokenRefresh.first;
+  Future<String> getToken() async {
+    return await _channel.invokeMethod('getToken');
   }
 
   /// Subscribe to topic in background.
@@ -100,10 +99,7 @@ class FirebaseMessaging {
     switch (call.method) {
       case "onToken":
         final String token = call.arguments;
-        if (_token != token) {
-          _token = token;
-          _tokenStreamController.add(_token);
-        }
+        _tokenStreamController.add(token);
         return null;
       case "onIosSettingsRegistered":
         _iosSettingsStreamController.add(IosNotificationSettings._fromMap(

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Cloud Messaging, a cross-platform
   messaging solution that lets you reliably deliver messages on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_messaging
-version: 2.0.2
+version: 2.0.3
 
 flutter:
   plugin:

--- a/packages/firebase_messaging/test/firebase_messaging_test.dart
+++ b/packages/firebase_messaging/test/firebase_messaging_test.dart
@@ -64,13 +64,11 @@ void main() {
     Future<String> tokenFromStream = firebaseMessaging.onTokenRefresh.first;
     await handler(MethodCall('onToken', token1));
 
-    expect(await firebaseMessaging.getToken(), token1);
     expect(await tokenFromStream, token1);
 
     tokenFromStream = firebaseMessaging.onTokenRefresh.first;
     await handler(MethodCall('onToken', token2));
 
-    expect(await firebaseMessaging.getToken(), token2);
     expect(await tokenFromStream, token2);
   });
 
@@ -133,6 +131,11 @@ void main() {
   test('unsubscribe from topic', () {
     firebaseMessaging.unsubscribeFromTopic(myTopic);
     verify(mockChannel.invokeMethod('unsubscribeFromTopic', myTopic));
+  });
+
+  test('getToken', () {
+    firebaseMessaging.getToken();
+    verify(mockChannel.invokeMethod('getToken'));
   });
 }
 


### PR DESCRIPTION
intends to fix flutter/flutter#17699 and fix flutter/flutter#20378

Removing local cache of getToken() in the dart part of the plugin. Now getToken() calls directly its counterparts in the iOS and Android implementations. This enables obtaining its value without calling configure() or having to wait for a new token refresh.

replaces PR #789 

@Hixie 

@philipgiuliani
@calebisstupid
@beardo01
@muirandy


