### PR TITLE
[local_auth] Add null checking for getAvailableBiometrics method call

### DIFF
--- a/packages/local_auth/lib/local_auth.dart
+++ b/packages/local_auth/lib/local_auth.dart
@@ -78,8 +78,11 @@ class LocalAuthentication {
   /// Returns true if device is capable of checking biometrics
   ///
   /// Returns a [Future] bool true or false:
-  Future<bool> get canCheckBiometrics async =>
-      (await _channel.invokeMethod('getAvailableBiometrics')).isNotEmpty;
+  Future<bool> get canCheckBiometrics async {
+    final dynamic result =
+        await _channel.invokeMethod('getAvailableBiometrics');
+    return result != null && result.isNotEmpty;
+  }
 
   /// Returns a list of enrolled biometrics
   ///


### PR DESCRIPTION
InvokeMethod may return null and then calling isNotEmpty throws a null exception.
I propose to return false when the null is returned because MissingPluginException is thrown