### PR TITLE
Fix crash when repeating detection

### DIFF
--- a/packages/firebase_ml_vision/android/src/main/java/io/flutter/plugins/firebasemlvision/BarcodeDetector.java
+++ b/packages/firebase_ml_vision/android/src/main/java/io/flutter/plugins/firebasemlvision/BarcodeDetector.java
@@ -11,22 +11,41 @@ import com.google.firebase.ml.vision.barcode.FirebaseVisionBarcodeDetector;
 import com.google.firebase.ml.vision.barcode.FirebaseVisionBarcodeDetectorOptions;
 import com.google.firebase.ml.vision.common.FirebaseVisionImage;
 import io.flutter.plugin.common.MethodChannel;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 class BarcodeDetector implements Detector {
-  public static final BarcodeDetector instance = new BarcodeDetector();
+  static final BarcodeDetector instance = new BarcodeDetector();
 
   private BarcodeDetector() {}
+
+  private FirebaseVisionBarcodeDetector detector;
+  private Map<String, Object> lastOptions;
 
   @Override
   public void handleDetection(
       FirebaseVisionImage image, Map<String, Object> options, final MethodChannel.Result result) {
 
-    FirebaseVisionBarcodeDetector detector =
-        FirebaseVision.getInstance().getVisionBarcodeDetector(parseOptions(options));
+    // Use instantiated detector if the options are the same. Otherwise, close and instantiate new
+    // options.
+
+    if (detector == null) {
+      lastOptions = options;
+      detector = FirebaseVision.getInstance().getVisionBarcodeDetector(parseOptions(lastOptions));
+    } else if (!options.equals(lastOptions)) {
+      try {
+        detector.close();
+      } catch (IOException e) {
+        result.error("barcodeDetectorIOError", e.getLocalizedMessage(), null);
+        return;
+      }
+
+      lastOptions = options;
+      detector = FirebaseVision.getInstance().getVisionBarcodeDetector(parseOptions(lastOptions));
+    }
 
     detector
         .detectInImage(image)

--- a/packages/firebase_ml_vision/android/src/main/java/io/flutter/plugins/firebasemlvision/CloudLabelDetector.java
+++ b/packages/firebase_ml_vision/android/src/main/java/io/flutter/plugins/firebasemlvision/CloudLabelDetector.java
@@ -32,7 +32,8 @@ class CloudLabelDetector implements Detector {
 
     if (detector == null) {
       lastOptions = options;
-      detector = FirebaseVision.getInstance().getVisionCloudLabelDetector(parseOptions(lastOptions));
+      detector =
+          FirebaseVision.getInstance().getVisionCloudLabelDetector(parseOptions(lastOptions));
     } else if (!options.equals(lastOptions)) {
       try {
         detector.close();
@@ -42,7 +43,8 @@ class CloudLabelDetector implements Detector {
       }
 
       lastOptions = options;
-      detector = FirebaseVision.getInstance().getVisionCloudLabelDetector(parseOptions(lastOptions));
+      detector =
+          FirebaseVision.getInstance().getVisionCloudLabelDetector(parseOptions(lastOptions));
     }
 
     detector

--- a/packages/firebase_ml_vision/android/src/main/java/io/flutter/plugins/firebasemlvision/CloudLabelDetector.java
+++ b/packages/firebase_ml_vision/android/src/main/java/io/flutter/plugins/firebasemlvision/CloudLabelDetector.java
@@ -9,21 +9,42 @@ import com.google.firebase.ml.vision.cloud.label.FirebaseVisionCloudLabel;
 import com.google.firebase.ml.vision.cloud.label.FirebaseVisionCloudLabelDetector;
 import com.google.firebase.ml.vision.common.FirebaseVisionImage;
 import io.flutter.plugin.common.MethodChannel;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 class CloudLabelDetector implements Detector {
-  public static final CloudLabelDetector instance = new CloudLabelDetector();
+  static final CloudLabelDetector instance = new CloudLabelDetector();
 
   private CloudLabelDetector() {}
+
+  private FirebaseVisionCloudLabelDetector detector;
+  private Map<String, Object> lastOptions;
 
   @Override
   public void handleDetection(
       FirebaseVisionImage image, Map<String, Object> options, final MethodChannel.Result result) {
-    FirebaseVisionCloudLabelDetector detector =
-        FirebaseVision.getInstance().getVisionCloudLabelDetector(parseOptions(options));
+
+    // Use instantiated detector if the options are the same. Otherwise, close and instantiate new
+    // options.
+
+    if (detector == null) {
+      lastOptions = options;
+      detector = FirebaseVision.getInstance().getVisionCloudLabelDetector(parseOptions(lastOptions));
+    } else if (!options.equals(lastOptions)) {
+      try {
+        detector.close();
+      } catch (IOException e) {
+        result.error("cloudLabelDetectorIOError", e.getLocalizedMessage(), null);
+        return;
+      }
+
+      lastOptions = options;
+      detector = FirebaseVision.getInstance().getVisionCloudLabelDetector(parseOptions(lastOptions));
+    }
+
     detector
         .detectInImage(image)
         .addOnSuccessListener(

--- a/packages/firebase_ml_vision/android/src/main/java/io/flutter/plugins/firebasemlvision/FaceDetector.java
+++ b/packages/firebase_ml_vision/android/src/main/java/io/flutter/plugins/firebasemlvision/FaceDetector.java
@@ -19,6 +19,8 @@ import java.util.Map;
 class FaceDetector implements Detector {
   static final FaceDetector instance = new FaceDetector();
 
+  private FaceDetector() {}
+
   private FirebaseVisionFaceDetector detector;
   private Map<String, Object> lastOptions;
 

--- a/packages/firebase_ml_vision/android/src/main/java/io/flutter/plugins/firebasemlvision/FaceDetector.java
+++ b/packages/firebase_ml_vision/android/src/main/java/io/flutter/plugins/firebasemlvision/FaceDetector.java
@@ -10,25 +10,38 @@ import com.google.firebase.ml.vision.face.FirebaseVisionFaceDetector;
 import com.google.firebase.ml.vision.face.FirebaseVisionFaceDetectorOptions;
 import com.google.firebase.ml.vision.face.FirebaseVisionFaceLandmark;
 import io.flutter.plugin.common.MethodChannel;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 class FaceDetector implements Detector {
-  public static final FaceDetector instance = new FaceDetector();
+  static final FaceDetector instance = new FaceDetector();
 
-  private FaceDetector() {}
+  private FirebaseVisionFaceDetector detector;
+  private Map<String, Object> lastOptions;
 
   @Override
   public void handleDetection(
       FirebaseVisionImage image, Map<String, Object> options, final MethodChannel.Result result) {
 
-    FirebaseVisionFaceDetector detector;
-    if (options == null) {
-      detector = FirebaseVision.getInstance().getVisionFaceDetector();
-    } else {
-      detector = FirebaseVision.getInstance().getVisionFaceDetector(parseOptions(options));
+    // Use instantiated detector if the options are the same. Otherwise, close and instantiate new
+    // options.
+
+    if (detector == null) {
+      lastOptions = options;
+      detector = FirebaseVision.getInstance().getVisionFaceDetector(parseOptions(lastOptions));
+    } else if (!options.equals(lastOptions)) {
+      try {
+        detector.close();
+      } catch (IOException e) {
+        result.error("faceDetectorIOError", e.getLocalizedMessage(), null);
+        return;
+      }
+
+      lastOptions = options;
+      detector = FirebaseVision.getInstance().getVisionFaceDetector(parseOptions(lastOptions));
     }
 
     detector

--- a/packages/firebase_ml_vision/android/src/main/java/io/flutter/plugins/firebasemlvision/LabelDetector.java
+++ b/packages/firebase_ml_vision/android/src/main/java/io/flutter/plugins/firebasemlvision/LabelDetector.java
@@ -9,21 +9,42 @@ import com.google.firebase.ml.vision.label.FirebaseVisionLabel;
 import com.google.firebase.ml.vision.label.FirebaseVisionLabelDetector;
 import com.google.firebase.ml.vision.label.FirebaseVisionLabelDetectorOptions;
 import io.flutter.plugin.common.MethodChannel;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 class LabelDetector implements Detector {
-  public static final LabelDetector instance = new LabelDetector();
+  static final LabelDetector instance = new LabelDetector();
 
   private LabelDetector() {}
+
+  private FirebaseVisionLabelDetector detector;
+  private Map<String, Object> lastOptions;
 
   @Override
   public void handleDetection(
       FirebaseVisionImage image, Map<String, Object> options, final MethodChannel.Result result) {
-    FirebaseVisionLabelDetector detector =
-        FirebaseVision.getInstance().getVisionLabelDetector(parseOptions(options));
+
+    // Use instantiated detector if the options are the same. Otherwise, close and instantiate new
+    // options.
+
+    if (detector == null) {
+      lastOptions = options;
+      detector = FirebaseVision.getInstance().getVisionLabelDetector(parseOptions(lastOptions));
+    } else if (!options.equals(lastOptions)) {
+      try {
+        detector.close();
+      } catch (IOException e) {
+        result.error("labelDetectorIOError", e.getLocalizedMessage(), null);
+        return;
+      }
+
+      lastOptions = options;
+      detector = FirebaseVision.getInstance().getVisionLabelDetector(parseOptions(lastOptions));
+    }
+
     detector
         .detectInImage(image)
         .addOnSuccessListener(

--- a/packages/firebase_ml_vision/android/src/main/java/io/flutter/plugins/firebasemlvision/TextRecognizer.java
+++ b/packages/firebase_ml_vision/android/src/main/java/io/flutter/plugins/firebasemlvision/TextRecognizer.java
@@ -35,7 +35,7 @@ public class TextRecognizer implements Detector {
     if (textRecognizer == null) {
       lastOptions = options;
       textRecognizer = FirebaseVision.getInstance().getOnDeviceTextRecognizer();
-    } else if (options != null && !options.equals(lastOptions)) {
+    } else if (!options.equals(lastOptions)) {
       try {
         textRecognizer.close();
       } catch (IOException e) {

--- a/packages/firebase_ml_vision/android/src/main/java/io/flutter/plugins/firebasemlvision/TextRecognizer.java
+++ b/packages/firebase_ml_vision/android/src/main/java/io/flutter/plugins/firebasemlvision/TextRecognizer.java
@@ -11,21 +11,42 @@ import com.google.firebase.ml.vision.text.FirebaseVisionText;
 import com.google.firebase.ml.vision.text.FirebaseVisionTextRecognizer;
 import com.google.firebase.ml.vision.text.RecognizedLanguage;
 import io.flutter.plugin.common.MethodChannel;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class TextRecognizer implements Detector {
-  public static final TextRecognizer instance = new TextRecognizer();
+  static final TextRecognizer instance = new TextRecognizer();
 
   private TextRecognizer() {}
+
+  private FirebaseVisionTextRecognizer textRecognizer;
+  private Map<String, Object> lastOptions;
 
   @Override
   public void handleDetection(
       FirebaseVisionImage image, Map<String, Object> options, final MethodChannel.Result result) {
-    FirebaseVisionTextRecognizer textRecognizer =
-        FirebaseVision.getInstance().getOnDeviceTextRecognizer();
+
+    // Use instantiated detector if the options are the same. Otherwise, close and instantiate new
+    // options.
+
+    if (textRecognizer == null) {
+      lastOptions = options;
+      textRecognizer = FirebaseVision.getInstance().getOnDeviceTextRecognizer();
+    } else if (options != null && !options.equals(lastOptions)) {
+      try {
+        textRecognizer.close();
+      } catch (IOException e) {
+        result.error("textRecognizerIOError", e.getLocalizedMessage(), null);
+        return;
+      }
+
+      lastOptions = options;
+      textRecognizer = FirebaseVision.getInstance().getOnDeviceTextRecognizer();
+    }
+
     textRecognizer
         .processImage(image)
         .addOnSuccessListener(


### PR DESCRIPTION
If you attempt to use a Detector multiple times on Android without calling `detector.close()` eventually the app will crash. This happens because a new detector is instantiated for each `detectInImage` is called. I'm assuming the crash is from running out of memory (I get a seg fault error) because each detector loads a hefty model. 

iOS version doesn't have a close method, so I'm assuming it handles it's models differently.

My solution for this problem keeps one instance in memory to reuse. However, if the user wants to create a detector with different options, I close the previous instance and instantiate a new detector. 

The other option would be to give each instantiated detector a handle, but closing and instantiating a new one doesn't take very long if there is a use case where multiple detectors are needed.