### PR TITLE
[firebase_messaging] adding support for deleteInstanceId and setAutoInitEnabled

### DIFF
--- a/packages/firebase_messaging/CHANGELOG.md
+++ b/packages/firebase_messaging/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0
+
+* Adding support for deleteInstanceID(), autoInitEnabled() and setAutoInitEnabled().
+
 ## 2.0.3
 
 * Removing local cache of getToken() in the dart part of the plugin. Now getToken() calls directly its counterparts in the iOS and Android implementations. This enables obtaining its value without calling configure() or having to wait for a new token refresh.

--- a/packages/firebase_messaging/android/src/main/java/io/flutter/plugins/firebasemessaging/FirebaseMessagingPlugin.java
+++ b/packages/firebase_messaging/android/src/main/java/io/flutter/plugins/firebasemessaging/FirebaseMessagingPlugin.java
@@ -25,6 +25,7 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry.NewIntentListener;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -128,6 +129,27 @@ public class FirebaseMessagingPlugin extends BroadcastReceiver
                   result.success(task.getResult().getToken());
                 }
               });
+    } else if ("deleteInstanceID".equals(call.method)) {
+      new Thread(
+              new Runnable() {
+                @Override
+                public void run() {
+                  try {
+                    FirebaseInstanceId.getInstance().deleteInstanceId();
+                    result.success(true);
+                  } catch (IOException ex) {
+                    Log.e(TAG, "deleteInstanceID, error:", ex);
+                    result.success(false);
+                  }
+                }
+              })
+          .start();
+    } else if ("autoInitEnabled".equals(call.method)) {
+      result.success(FirebaseMessaging.getInstance().isAutoInitEnabled());
+    } else if ("setAutoInitEnabled".equals(call.method)) {
+      Boolean isEnabled = (Boolean) call.arguments();
+      FirebaseMessaging.getInstance().setAutoInitEnabled(isEnabled);
+      result.success(null);
     } else {
       result.notImplemented();
     }

--- a/packages/firebase_messaging/ios/Classes/FirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/ios/Classes/FirebaseMessagingPlugin.m
@@ -85,6 +85,23 @@
             result(instanceIDResult.token);
           }
         }];
+  } else if ([@"deleteInstanceID" isEqualToString:method]) {
+    [[FIRInstanceID instanceID] deleteIDWithHandler:^void(NSError *_Nullable error) {
+      if (error.code != 0) {
+        NSLog(@"deleteInstanceID, error: %@", error);
+        result([NSNumber numberWithBool:NO]);
+      } else {
+        [[UIApplication sharedApplication] unregisterForRemoteNotifications];
+        result([NSNumber numberWithBool:YES]);
+      }
+    }];
+  } else if ([@"autoInitEnabled" isEqualToString:method]) {
+    BOOL *value = [[FIRMessaging messaging] isAutoInitEnabled];
+    result([NSNumber numberWithBool:value]);
+  } else if ([@"setAutoInitEnabled" isEqualToString:method]) {
+    NSNumber *value = call.arguments;
+    [FIRMessaging messaging].autoInitEnabled = value.boolValue;
+    result(nil);
   } else {
     result(FlutterMethodNotImplemented);
   }

--- a/packages/firebase_messaging/lib/firebase_messaging.dart
+++ b/packages/firebase_messaging/lib/firebase_messaging.dart
@@ -95,6 +95,25 @@ class FirebaseMessaging {
     _channel.invokeMethod('unsubscribeFromTopic', topic);
   }
 
+  /// Resets Instance ID and revokes all tokens. In iOS, it also unregisters from remote notifications.
+  ///
+  /// A new Instance ID is generated asynchronously if Firebase Cloud Messaging auto-init is enabled.
+  ///
+  /// returns true if the operations executed successfully and false if an error ocurred
+  Future<bool> deleteInstanceID() async {
+    return await _channel.invokeMethod('deleteInstanceID');
+  }
+
+  /// Determine whether FCM auto-initialization is enabled or disabled.
+  Future<bool> autoInitEnabled() async {
+    return await _channel.invokeMethod('autoInitEnabled');
+  }
+
+  /// Enable or disable auto-initialization of Firebase Cloud Messaging.
+  Future<void> setAutoInitEnabled(bool enabled) async {
+    await _channel.invokeMethod('setAutoInitEnabled', enabled);
+  }
+
   Future<dynamic> _handleMethod(MethodCall call) async {
     switch (call.method) {
       case "onToken":

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Cloud Messaging, a cross-platform
   messaging solution that lets you reliably deliver messages on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_messaging
-version: 2.0.3
+version: 2.1.0
 
 flutter:
   plugin:

--- a/packages/firebase_messaging/test/firebase_messaging_test.dart
+++ b/packages/firebase_messaging/test/firebase_messaging_test.dart
@@ -137,6 +137,26 @@ void main() {
     firebaseMessaging.getToken();
     verify(mockChannel.invokeMethod('getToken'));
   });
+
+  test('deleteInstanceID', () {
+    firebaseMessaging.deleteInstanceID();
+    verify(mockChannel.invokeMethod('deleteInstanceID'));
+  });
+
+  test('autoInitEnabled', () {
+    firebaseMessaging.autoInitEnabled();
+    verify(mockChannel.invokeMethod('autoInitEnabled'));
+  });
+
+  test('setAutoInitEnabled', () {
+    bool enabled = true;
+    firebaseMessaging.setAutoInitEnabled(enabled);
+    verify(mockChannel.invokeMethod('setAutoInitEnabled', enabled));
+
+    enabled = false;
+    firebaseMessaging.setAutoInitEnabled(enabled);
+    verify(mockChannel.invokeMethod('setAutoInitEnabled', enabled));
+  });
 }
 
 class MockMethodChannel extends Mock implements MethodChannel {}


### PR DESCRIPTION
fix flutter/flutter#20627

If an app has a basic flow with user login and logout AND receives notifications based on the logged user, the logout method needs to delete the current instanceID connected to Firebase Cloud Messaging. Otherwise, the unauthenticated app (after the user logs out) will still receive notifications from the previous logged user.

As [`deleteInstanceId`](https://firebase.google.com/docs/reference/android/com/google/firebase/iid/FirebaseInstanceId#deleteInstanceId()) might automatically recreate a new one, `autoInitEnabled` and `setAutoInitEnabled` must be provided as well.