### PR TITLE
[firebase_ml_vision] Rotate images for iOS when image orientation is not set as UP

### DIFF
--- a/packages/firebase_ml_vision/ios/Classes/FirebaseMlVisionPlugin.m
+++ b/packages/firebase_ml_vision/ios/Classes/FirebaseMlVisionPlugin.m
@@ -58,11 +58,8 @@
 
   if (image.imageOrientation != UIImageOrientationUp) {
     CGImageRef imgRef = image.CGImage;
-    CGFloat width = CGImageGetWidth(imgRef);
-    CGFloat height = CGImageGetHeight(imgRef);
-    CGRect bounds = CGRectMake(0, 0, width, height);
+    CGRect bounds = CGRectMake(0, 0, CGImageGetWidth(imgRef), CGImageGetHeight(imgRef));
     UIGraphicsBeginImageContext(bounds.size);
-    UIGraphicsBeginImageContext(CGSizeMake(height, width));
     CGContextDrawImage(UIGraphicsGetCurrentContext(), bounds, imgRef);
     UIImage *newImage = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();

--- a/packages/firebase_ml_vision/ios/Classes/FirebaseMlVisionPlugin.m
+++ b/packages/firebase_ml_vision/ios/Classes/FirebaseMlVisionPlugin.m
@@ -55,22 +55,22 @@
 
 - (FIRVisionImage *)filePathToVisionImage:(NSString *)path {
   UIImage *image = [UIImage imageWithContentsOfFile:path];
-  
-  if (image.imageOrientation != UIImageOrientationUp) {
-      CGImageRef imgRef = image.CGImage;
-      CGFloat width = CGImageGetWidth(imgRef);
-      CGFloat height = CGImageGetHeight(imgRef);
-      CGRect bounds = CGRectMake(0, 0, width, height);
-      UIGraphicsBeginImageContext(bounds.size);
-      CGSize size = image.size;
-      UIGraphicsBeginImageContext(CGSizeMake(height, width));
-      CGContextDrawImage(UIGraphicsGetCurrentContext(), CGRectMake(0, 0, width, height), imgRef);
-      UIImage* newImage = UIGraphicsGetImageFromCurrentImageContext();
-      UIGraphicsEndImageContext();
 
-      image = newImage;
+  if (image.imageOrientation != UIImageOrientationUp) {
+    CGImageRef imgRef = image.CGImage;
+    CGFloat width = CGImageGetWidth(imgRef);
+    CGFloat height = CGImageGetHeight(imgRef);
+    CGRect bounds = CGRectMake(0, 0, width, height);
+    UIGraphicsBeginImageContext(bounds.size);
+    CGSize size = image.size;
+    UIGraphicsBeginImageContext(CGSizeMake(height, width));
+    CGContextDrawImage(UIGraphicsGetCurrentContext(), CGRectMake(0, 0, width, height), imgRef);
+    UIImage *newImage = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+
+    image = newImage;
   }
-  
+
   return [[FIRVisionImage alloc] initWithImage:image];
 }
 @end

--- a/packages/firebase_ml_vision/ios/Classes/FirebaseMlVisionPlugin.m
+++ b/packages/firebase_ml_vision/ios/Classes/FirebaseMlVisionPlugin.m
@@ -62,9 +62,8 @@
     CGFloat height = CGImageGetHeight(imgRef);
     CGRect bounds = CGRectMake(0, 0, width, height);
     UIGraphicsBeginImageContext(bounds.size);
-    CGSize size = image.size;
     UIGraphicsBeginImageContext(CGSizeMake(height, width));
-    CGContextDrawImage(UIGraphicsGetCurrentContext(), CGRectMake(0, 0, width, height), imgRef);
+    CGContextDrawImage(UIGraphicsGetCurrentContext(), bounds, imgRef);
     UIImage *newImage = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();
 

--- a/packages/firebase_ml_vision/ios/Classes/FirebaseMlVisionPlugin.m
+++ b/packages/firebase_ml_vision/ios/Classes/FirebaseMlVisionPlugin.m
@@ -55,6 +55,22 @@
 
 - (FIRVisionImage *)filePathToVisionImage:(NSString *)path {
   UIImage *image = [UIImage imageWithContentsOfFile:path];
+  
+  if (image.imageOrientation != UIImageOrientationUp) {
+      CGImageRef imgRef = image.CGImage;
+      CGFloat width = CGImageGetWidth(imgRef);
+      CGFloat height = CGImageGetHeight(imgRef);
+      CGRect bounds = CGRectMake(0, 0, width, height);
+      UIGraphicsBeginImageContext(bounds.size);
+      CGSize size = image.size;
+      UIGraphicsBeginImageContext(CGSizeMake(height, width));
+      CGContextDrawImage(UIGraphicsGetCurrentContext(), CGRectMake(0, 0, width, height), imgRef);
+      UIImage* newImage = UIGraphicsGetImageFromCurrentImageContext();
+      UIGraphicsEndImageContext();
+
+      image = newImage;
+  }
+  
   return [[FIRVisionImage alloc] initWithImage:image];
 }
 @end


### PR DESCRIPTION
Rotate images that were captured on iOS devices, if required, because device orientation is not necessarily reflected in the orientation of the image that is saved, some images are saved in unexpected rotations. Not sure if this behaviour is persistent across all models of iOS devices (or even all devices), but this PR seems to solve the problem I encountered on two of my own devices.

Prior to including this image rotation code, all images I tried to run through the face detector failed, and the base64 encoding of the image always rendered as if the camera was saving left-landscape orientation regardless of device orientation.