### PR TITLE
[image_picker] original file is leaking by resize.

### DIFF
--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
@@ -420,7 +420,7 @@ public class ImagePickerDelegate
             @Override
             public void onPathReady(String path) {
               String ansPath = handleImageResult(path);
-              if(!path.equals(ansPath)){
+              if (!path.equals(ansPath)) {
                 File oldFile = new File(path);
                 oldFile.delete();
               }

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
@@ -419,7 +419,11 @@ public class ImagePickerDelegate
           new OnPathReadyListener() {
             @Override
             public void onPathReady(String path) {
-              handleImageResult(path);
+              String ansPath = handleImageResult(path);
+              if(!path.equals(ansPath)){
+                File oldFile = new File(path);
+                oldFile.delete();
+              }
             }
           });
       return;
@@ -446,13 +450,14 @@ public class ImagePickerDelegate
     finishWithSuccess(null);
   }
 
-  private void handleImageResult(String path) {
+  private String handleImageResult(String path) {
     if (pendingResult != null) {
       Double maxWidth = methodCall.argument("maxWidth");
       Double maxHeight = methodCall.argument("maxHeight");
 
       String finalImagePath = imageResizer.resizeImageIfNeeded(path, maxWidth, maxHeight);
       finishWithSuccess(finalImagePath);
+      return finalImagePath;
     } else {
       throw new IllegalStateException("Received image from picker that was not requested");
     }


### PR DESCRIPTION
I discovered that the application size gets bigger every time I acquire an image with image_picker.

There are three reasons for this.

1. The quality setting of jpeg is bad. https://github.com/flutter/plugins/pull/855
2. When resizing the taken picture, the original picture was not deleted. and The access path to that picture is in the dark...
3. I forgot to delete the picture acquired from native by flutter.

This pr is solve the second reason.

ps. I think that it need a code to delete the acquired picture in the sample code.