### PR TITLE
[firebase_analytics] Allow setUserID input to be null

### DIFF
--- a/packages/firebase_analytics/lib/firebase_analytics.dart
+++ b/packages/firebase_analytics/lib/firebase_analytics.dart
@@ -67,10 +67,6 @@ class FirebaseAnalytics {
   ///
   /// [1]: https://www.google.com/policies/privacy/
   Future<void> setUserId(String id) async {
-    if (id == null) {
-      throw ArgumentError.notNull('id');
-    }
-
     await _channel.invokeMethod('setUserId', id);
   }
 


### PR DESCRIPTION
See the below reference guide links, setting userID to null is equivalent to signing a user out.

https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics#setUserId(java.lang.String)

https://firebase.google.com/docs/reference/ios/firebaseanalytics/api/reference/Classes/FIRAnalytics#setuserid