### PR TITLE
Increase play-services-auth dependency

### DIFF
--- a/packages/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.3
+
+* Increase play-services-auth version to 16.0.1
+
 ## 3.2.2
 
 * Don't use the result code when handling signin. This results in better error codes because result code always returns "cancelled".

--- a/packages/google_sign_in/android/build.gradle
+++ b/packages/google_sign_in/android/build.gradle
@@ -34,6 +34,6 @@ android {
 }
 
 dependencies {
-    api 'com.google.android.gms:play-services-auth:15.+'
+    api 'com.google.android.gms:play-services-auth:16.0.0'
     implementation 'com.google.guava:guava:20.0'
 }

--- a/packages/google_sign_in/android/build.gradle
+++ b/packages/google_sign_in/android/build.gradle
@@ -34,6 +34,6 @@ android {
 }
 
 dependencies {
-    api 'com.google.android.gms:play-services-auth:16.0.0'
+    api 'com.google.android.gms:play-services-auth:16.0.1'
     implementation 'com.google.guava:guava:20.0'
 }

--- a/packages/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_sign_in
-version: 3.2.2
+version: 3.2.3
 
 flutter:
   plugin:


### PR DESCRIPTION
Increasing the dependency for `com.google.android.gms:play-services-auth` to `16.0.1` in `google_sign_in`.