### PR TITLE
Bump firebase_analytics version to 1.0.6

### DIFF
--- a/packages/firebase_analytics/CHANGELOG.md
+++ b/packages/firebase_analytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.6
+
+* Allow user ID to be set to null.
+
 ## 1.0.5
 
 * Update the `METHOD` Android constant used for `logSignUp` method.

--- a/packages/firebase_analytics/pubspec.yaml
+++ b/packages/firebase_analytics/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Analytics for Firebase, an app measuremen
   solution that provides insight on app usage and user engagement on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_analytics
-version: 1.0.5
+version: 1.0.6
 
 flutter:
   plugin:


### PR DESCRIPTION
Bumping version of firebase_analytics plugin so change from [PR](https://github.com/flutter/plugins/pull/888) can be published.