### PR TITLE
Share Plugin: Add .shareFile() method (Android & iOS)

### DIFF
--- a/packages/share/android/build.gradle
+++ b/packages/share/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
     
     defaultConfig {
         minSdkVersion 16
@@ -31,4 +31,8 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
+}
+
+dependencies {
+    implementation 'com.android.support:support-compat:28.0.0'
 }

--- a/packages/share/android/src/main/AndroidManifest.xml
+++ b/packages/share/android/src/main/AndroidManifest.xml
@@ -1,3 +1,14 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="io.flutter.plugins.share">
+    <application>
+        <provider
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="${applicationId}.flutter.share.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/flutter_share_file_paths"/>
+        </provider>
+    </application>
 </manifest>

--- a/packages/share/android/src/main/java/io/flutter/plugins/share/SharePlugin.java
+++ b/packages/share/android/src/main/java/io/flutter/plugins/share/SharePlugin.java
@@ -5,9 +5,12 @@
 package io.flutter.plugins.share;
 
 import android.content.Intent;
+import android.support.v4.content.FileProvider;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
+import android.net.Uri;
+import java.io.File;
 import java.util.Map;
 
 /** Plugin method host for presenting a share sheet via Intent */
@@ -30,14 +33,23 @@ public class SharePlugin implements MethodChannel.MethodCallHandler {
   @Override
   public void onMethodCall(MethodCall call, MethodChannel.Result result) {
     if (call.method.equals("share")) {
-      if (!(call.arguments instanceof Map)) {
-        throw new IllegalArgumentException("Map argument expected");
-      }
+      expectMapArguments(call);
       // Android does not support showing the share sheet at a particular point on screen.
       share((String) call.argument("text"));
       result.success(null);
+    } else if (call.method.equals("shareFile")) {
+      expectMapArguments(call);
+      // Android does not support showing the share sheet at a particular point on screen.
+      shareFile((String) call.argument("path"), (String) call.argument("mimeType"));
+      result.success(null);
     } else {
       result.notImplemented();
+    }
+  }
+
+  private void expectMapArguments(MethodCall call) throws IllegalArgumentException {
+    if (!(call.arguments instanceof Map)) {
+      throw new IllegalArgumentException("Map argument expected");
     }
   }
 
@@ -50,6 +62,31 @@ public class SharePlugin implements MethodChannel.MethodCallHandler {
     shareIntent.setAction(Intent.ACTION_SEND);
     shareIntent.putExtra(Intent.EXTRA_TEXT, text);
     shareIntent.setType("text/plain");
+    Intent chooserIntent = Intent.createChooser(shareIntent, null /* dialog title optional */);
+    if (mRegistrar.activity() != null) {
+      mRegistrar.activity().startActivity(chooserIntent);
+    } else {
+      chooserIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+      mRegistrar.context().startActivity(chooserIntent);
+    }
+  }
+
+  private void shareFile(String path, String mimeType) {
+    if (path == null || path.isEmpty()) {
+      throw new IllegalArgumentException("Non-empty path expected");
+    }
+
+    Uri uri = FileProvider.getUriForFile(
+      mRegistrar.context(),
+      mRegistrar.context().getPackageName() + ".flutter.share.provider",
+      new File(path));
+
+    Intent shareIntent = new Intent();
+    shareIntent.setAction(Intent.ACTION_SEND);
+    shareIntent.putExtra(Intent.EXTRA_STREAM, uri);
+    shareIntent.putExtra(Intent.EXTRA_SUBJECT, "subject");
+    shareIntent.putExtra(Intent.EXTRA_TEXT, "text");
+    shareIntent.setType(mimeType != null ? mimeType : "*/*");
     Intent chooserIntent = Intent.createChooser(shareIntent, null /* dialog title optional */);
     if (mRegistrar.activity() != null) {
       mRegistrar.activity().startActivity(chooserIntent);

--- a/packages/share/android/src/main/res/xml/flutter_share_file_paths.xml
+++ b/packages/share/android/src/main/res/xml/flutter_share_file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <external-path name="external_files" path="." />
+</paths>

--- a/packages/share/ios/Classes/SharePlugin.m
+++ b/packages/share/ios/Classes/SharePlugin.m
@@ -14,8 +14,19 @@ static NSString *const PLATFORM_CHANNEL = @"plugins.flutter.io/share";
                                   binaryMessenger:registrar.messenger];
 
   [shareChannel setMethodCallHandler:^(FlutterMethodCall *call, FlutterResult result) {
+    NSDictionary *arguments = [call arguments];
+    NSNumber *originX = arguments[@"originX"];
+    NSNumber *originY = arguments[@"originY"];
+    NSNumber *originWidth = arguments[@"originWidth"];
+    NSNumber *originHeight = arguments[@"originHeight"];
+
+    CGRect originRect;
+    if (originX != nil && originY != nil && originWidth != nil && originHeight != nil) {
+      originRect = CGRectMake([originX doubleValue], [originY doubleValue],
+                              [originWidth doubleValue], [originHeight doubleValue]);
+    }
+
     if ([@"share" isEqualToString:call.method]) {
-      NSDictionary *arguments = [call arguments];
       NSString *shareText = arguments[@"text"];
 
       if (shareText.length == 0) {
@@ -24,18 +35,22 @@ static NSString *const PLATFORM_CHANNEL = @"plugins.flutter.io/share";
         return;
       }
 
-      NSNumber *originX = arguments[@"originX"];
-      NSNumber *originY = arguments[@"originY"];
-      NSNumber *originWidth = arguments[@"originWidth"];
-      NSNumber *originHeight = arguments[@"originHeight"];
+      [self share:shareText
+          withController:[UIApplication sharedApplication].keyWindow.rootViewController
+                atSource:originRect];
+      result(nil);
+    } else if ([@"shareFile" isEqualToString:call.method]) {
+      NSString *path = arguments[@"path"];
+      NSString *mimeType = arguments[@"mimeType"];
 
-      CGRect originRect;
-      if (originX != nil && originY != nil && originWidth != nil && originHeight != nil) {
-        originRect = CGRectMake([originX doubleValue], [originY doubleValue],
-                                [originWidth doubleValue], [originHeight doubleValue]);
+      if (path.length == 0) {
+        result(
+            [FlutterError errorWithCode:@"error" message:@"Non-empty path expected" details:nil]);
+        return;
       }
 
-      [self share:shareText
+      [self shareFile:path
+            withMimeType:mimeType
           withController:[UIApplication sharedApplication].keyWindow.rootViewController
                 atSource:originRect];
       result(nil);
@@ -50,6 +65,31 @@ static NSString *const PLATFORM_CHANNEL = @"plugins.flutter.io/share";
           atSource:(CGRect)origin {
   UIActivityViewController *activityViewController =
       [[UIActivityViewController alloc] initWithActivityItems:@[ sharedItems ]
+                                        applicationActivities:nil];
+  activityViewController.popoverPresentationController.sourceView = controller.view;
+  if (!CGRectIsEmpty(origin)) {
+    activityViewController.popoverPresentationController.sourceRect = origin;
+  }
+  [controller presentViewController:activityViewController animated:YES completion:nil];
+}
+
++ (void)shareFile:(id)path
+      withMimeType:(id)mimeType
+    withController:(UIViewController *)controller
+          atSource:(CGRect)origin {
+  NSMutableArray *items = [[NSMutableArray alloc]init];
+
+  // TODO maybe we can just call share here?
+  if([mimeType hasPrefix:@"image/"]) {
+    UIImage *image = [UIImage imageWithContentsOfFile:path];
+    [items addObject:image];
+  } else {
+    NSURL *url = [NSURL fileURLWithPath:path];
+    [items addObject:url];
+  }
+
+  UIActivityViewController *activityViewController =
+      [[UIActivityViewController alloc] initWithActivityItems:items
                                         applicationActivities:nil];
   activityViewController.popoverPresentationController.sourceView = controller.view;
   if (!CGRectIsEmpty(origin)) {

--- a/packages/share/lib/share.dart
+++ b/packages/share/lib/share.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io';
 import 'dart:ui';
 
 import 'package:flutter/services.dart';
@@ -42,5 +43,88 @@ class Share {
     }
 
     return channel.invokeMethod('share', params);
+  }
+
+  /// Summons the platform's share sheet to share a file.
+  ///
+  /// Wraps the platform's native share dialog. Can share a file.
+  /// It uses the ACTION_SEND Intent on Android and UIActivityViewController
+  /// on iOS.
+  ///
+  /// The optional `sharePositionOrigin` parameter can be used to specify a global
+  /// origin rect for the share sheet to popover from on iPads. It has no effect
+  /// on non-iPads.
+  ///
+  /// May throw [PlatformException] or [FormatException]
+  /// from [MethodChannel].
+  static Future<void> shareFile(File file,
+      {String mimeType, Rect sharePositionOrigin}) {
+    assert(file != null);
+    assert(file.existsSync());
+    final Map<String, dynamic> params = <String, dynamic>{
+      'path': file.path,
+      'mimeType': mimeType ?? _mimeTypeForFile(file),
+    };
+
+    if (sharePositionOrigin != null) {
+      params['originX'] = sharePositionOrigin.left;
+      params['originY'] = sharePositionOrigin.top;
+      params['originWidth'] = sharePositionOrigin.width;
+      params['originHeight'] = sharePositionOrigin.height;
+    }
+
+    return channel.invokeMethod('shareFile', params);
+  }
+
+  static String _mimeTypeForFile(File file) {
+    assert(file != null);
+    final String path = file.path;
+
+    final int extensionIndex = path.lastIndexOf("\.");
+    if (extensionIndex == -1 || extensionIndex == 0) {
+      return null;
+    }
+
+    final String extension = path.substring(extensionIndex + 1);
+    switch (extension) {
+      // image
+      case 'jpeg':
+      case 'jpg':
+        return 'image/jpeg';
+      case 'gif':
+        return 'image/gif';
+      case 'png':
+        return 'image/png';
+      case 'svg':
+        return 'image/svg+xml';
+      case 'tif':
+      case 'tiff':
+        return 'image/tiff';
+      // audio
+      case 'aac':
+        return 'audio/aac';
+      case 'oga':
+        return 'audio/ogg';
+      // video
+      case 'avi':
+        return 'video/x-msvideo';
+      case 'mpeg':
+        return 'video/mpeg';
+      case 'ogv':
+        return 'video/ogg';
+      // other
+      case 'csv':
+        return 'text/csv';
+      case 'htm':
+      case 'html':
+        return 'text/html';
+      case 'json':
+        return 'application/json';
+      case 'pdf':
+        return 'application/pdf';
+      case 'txt':
+        return 'text/plain';
+    }
+    return null;
   }
 }

--- a/packages/share/test/share_test.dart
+++ b/packages/share/test/share_test.dart
@@ -2,13 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
 import 'dart:ui';
 
+import 'package:flutter/services.dart';
 import 'package:mockito/mockito.dart';
 import 'package:share/share.dart';
 import 'package:test/test.dart';
-
-import 'package:flutter/services.dart';
 
 void main() {
   MockMethodChannel mockChannel;
@@ -49,6 +49,58 @@ void main() {
       'originWidth': 3.0,
       'originHeight': 4.0,
     }));
+  });
+
+  test('sharing null file fails', () {
+    expect(
+      () => Share.shareFile(null),
+      throwsA(const TypeMatcher<AssertionError>()),
+    );
+    verifyZeroInteractions(mockChannel);
+  });
+
+  test('sharing empty file fails', () {
+    expect(
+      () => Share.shareFile(null),
+      throwsA(const TypeMatcher<AssertionError>()),
+    );
+    verifyZeroInteractions(mockChannel);
+  });
+
+  test('sharing non existing file fails', () {
+    expect(
+      () => Share.shareFile(File('/sdcard/nofile.txt')),
+      throwsA(const TypeMatcher<AssertionError>()),
+    );
+    verifyZeroInteractions(mockChannel);
+  });
+
+  test('sharing file sets correct mimeType', () async {
+    final File file = File('tempfile-83649a.png');
+    try {
+      file.createSync();
+      await Share.shareFile(file);
+      verify(mockChannel.invokeMethod('shareFile', <String, dynamic>{
+        'file': file.path,
+        'mimeType': 'image/png',
+      }));
+    } finally {
+      file.deleteSync();
+    }
+  });
+
+  test('sharing file sets passed mimeType', () async {
+    final File file = File('tempfile-83649a.png');
+    try {
+      file.createSync();
+      await Share.shareFile(file, mimeType: '*/*');
+      verify(mockChannel.invokeMethod('shareFile', <String, dynamic>{
+        'file': file.path,
+        'mimeType': '*/*',
+      }));
+    } finally {
+      file.deleteSync();
+    }
   });
 }
 


### PR DESCRIPTION
First implementation for Share.shareFile()

iOS: Works for files in getApplicationDocumentsDirectory() (path_provider)
Android: Works for files in getExternalStorageDirectory() (path_provider)

Uses the FileProvider of support-compat 28.0.0.