### PR TITLE
[firebase_auth] adding return to verifyPhoneNumber

### DIFF
--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.5
+
+* Fixing async method `verifyPhoneNumber`, that would never return even in a successful call.
+
 ## 0.6.4
 
 * Added support for Github signin and linking Github accounts to existing users.

--- a/packages/firebase_auth/android/src/main/java/io/flutter/plugins/firebaseauth/FirebaseAuthPlugin.java
+++ b/packages/firebase_auth/android/src/main/java/io/flutter/plugins/firebaseauth/FirebaseAuthPlugin.java
@@ -243,6 +243,8 @@ public class FirebaseAuthPlugin implements MethodCallHandler {
               registrar.activity(),
               verificationCallbacks);
     }
+
+    result.success(null);
   }
 
   private Map<String, Object> getVerifyPhoneNumberExceptionMap(FirebaseException e) {

--- a/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
+++ b/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
@@ -303,6 +303,7 @@ int nextHandle = 0;
                           arguments:@{@"verificationId" : verificationID, @"handle" : handle}];
                  }
                }];
+    result(nil);
   } else if ([@"signInWithPhoneNumber" isEqualToString:call.method]) {
     NSString *verificationId = call.arguments[@"verificationId"];
     NSString *smsCode = call.arguments[@"smsCode"];

--- a/packages/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Firebase Auth, enabling Android and iOS
   like Google, Facebook and Twitter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_auth
-version: 0.6.4
+version: 0.6.5
 
 flutter:
   plugin:


### PR DESCRIPTION
fixes flutter/flutter#23332

`verifyPhoneNumber()` is supposed to be used with the callbacks passed in its arguments.

However, this method returns `Future<void>`, and using `await verifyPhoneNumber(...)` hangs as neither Android or iOS implementations ever return anything for this method call. 

Adding a `null` return so that the method returns after the callbacks are registered.