### PR TITLE
[camera]Camera: Optional audio permission on android

### DIFF
--- a/packages/camera/example/lib/main.dart
+++ b/packages/camera/example/lib/main.dart
@@ -203,7 +203,11 @@ class _CameraExampleHomeState extends State<CameraExampleHome> {
     if (controller != null) {
       await controller.dispose();
     }
-    controller = CameraController(cameraDescription, ResolutionPreset.high);
+    controller = CameraController(
+      cameraDescription,
+      ResolutionPreset.high,
+      withVideo: true,
+    );
 
     // If the controller is updated then update the UI.
     controller.addListener(() {

--- a/packages/camera/lib/camera.dart
+++ b/packages/camera/lib/camera.dart
@@ -176,11 +176,13 @@ class CameraValue {
 ///
 /// To show the camera preview on the screen use a [CameraPreview] widget.
 class CameraController extends ValueNotifier<CameraValue> {
-  CameraController(this.description, this.resolutionPreset)
+  CameraController(this.description, this.resolutionPreset,
+      {this.withVideo = false})
       : super(const CameraValue.uninitialized());
 
   final CameraDescription description;
   final ResolutionPreset resolutionPreset;
+  final bool withVideo;
 
   int _textureId;
   bool _isDisposed = false;
@@ -201,6 +203,7 @@ class CameraController extends ValueNotifier<CameraValue> {
         <String, dynamic>{
           'cameraName': description.name,
           'resolutionPreset': serializeResolutionPreset(resolutionPreset),
+          'withVideo': withVideo,
         },
       );
       _textureId = reply['textureId'];
@@ -297,6 +300,12 @@ class CameraController extends ValueNotifier<CameraValue> {
       throw CameraException(
         'A video recording is already started.',
         'startVideoRecording was called when a recording is already started.',
+      );
+    }
+    if (!withVideo) {
+      throw CameraException(
+        'CameraController not configured with video support.',
+        'Pass "withVideo: true" on construction.',
       );
     }
     try {


### PR DESCRIPTION
Audio permission is not required if sb. want to take pictures only. This change introduces a parameter in CameraController to enable/disable video support.

On iOS, no changes were needed since iOS asks for permission only once video is actually recorded.