### PR TITLE
Reconfigure Cirrus to use clang 7

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,10 +14,10 @@ task:
     - name: test+format
       install_script:
         - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-        - sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-5.0 main"
+        - sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main"
         - sudo apt-get update
-        - sudo apt-get install -y --allow-unauthenticated clang-format-5.0
-      format_script: ./script/incremental_build.sh format --travis --clang-format=clang-format-5.0
+        - sudo apt-get install -y --allow-unauthenticated clang-format-7
+      format_script: ./script/incremental_build.sh format --travis --clang-format=clang-format-7
       test_script: ./script/incremental_build.sh test
     - name: analyze
       script: ./script/incremental_build.sh analyze

--- a/packages/android_alarm_manager/ios/Classes/AndroidAlarmManagerPlugin.h
+++ b/packages/android_alarm_manager/ios/Classes/AndroidAlarmManagerPlugin.h
@@ -4,5 +4,5 @@
 
 #import <Flutter/Flutter.h>
 
-@interface FLTAndroidAlarmManagerPlugin : NSObject<FlutterPlugin>
+@interface FLTAndroidAlarmManagerPlugin : NSObject <FlutterPlugin>
 @end

--- a/packages/android_intent/ios/Classes/AndroidIntentPlugin.h
+++ b/packages/android_intent/ios/Classes/AndroidIntentPlugin.h
@@ -4,5 +4,5 @@
 
 #import <Flutter/Flutter.h>
 
-@interface FLTAndroidIntentPlugin : NSObject<FlutterPlugin>
+@interface FLTAndroidIntentPlugin : NSObject <FlutterPlugin>
 @end

--- a/packages/battery/ios/Classes/BatteryPlugin.h
+++ b/packages/battery/ios/Classes/BatteryPlugin.h
@@ -4,5 +4,5 @@
 
 #import <Flutter/Flutter.h>
 
-@interface FLTBatteryPlugin : NSObject<FlutterPlugin>
+@interface FLTBatteryPlugin : NSObject <FlutterPlugin>
 @end

--- a/packages/battery/ios/Classes/BatteryPlugin.m
+++ b/packages/battery/ios/Classes/BatteryPlugin.m
@@ -4,7 +4,7 @@
 
 #import "BatteryPlugin.h"
 
-@interface FLTBatteryPlugin ()<FlutterStreamHandler>
+@interface FLTBatteryPlugin () <FlutterStreamHandler>
 @end
 
 @implementation FLTBatteryPlugin {

--- a/packages/camera/ios/Classes/CameraPlugin.h
+++ b/packages/camera/ios/Classes/CameraPlugin.h
@@ -1,4 +1,4 @@
 #import <Flutter/Flutter.h>
 
-@interface CameraPlugin : NSObject<FlutterPlugin>
+@interface CameraPlugin : NSObject <FlutterPlugin>
 @end

--- a/packages/camera/ios/Classes/CameraPlugin.m
+++ b/packages/camera/ios/Classes/CameraPlugin.m
@@ -14,7 +14,7 @@
 }
 @end
 
-@interface FLTSavePhotoDelegate : NSObject<AVCapturePhotoCaptureDelegate>
+@interface FLTSavePhotoDelegate : NSObject <AVCapturePhotoCaptureDelegate>
 @property(readonly, nonatomic) NSString *path;
 @property(readonly, nonatomic) FlutterResult result;
 
@@ -59,8 +59,10 @@
 }
 @end
 
-@interface FLTCam : NSObject<FlutterTexture, AVCaptureVideoDataOutputSampleBufferDelegate,
-                             AVCaptureAudioDataOutputSampleBufferDelegate, FlutterStreamHandler>
+@interface FLTCam : NSObject <FlutterTexture,
+                              AVCaptureVideoDataOutputSampleBufferDelegate,
+                              AVCaptureAudioDataOutputSampleBufferDelegate,
+                              FlutterStreamHandler>
 @property(readonly, nonatomic) int64_t textureId;
 @property(nonatomic, copy) void (^onFrameAvailable)();
 @property(nonatomic) FlutterEventChannel *eventChannel;
@@ -111,8 +113,8 @@
   _captureSession.sessionPreset = preset;
   _captureDevice = [AVCaptureDevice deviceWithUniqueID:cameraName];
   NSError *localError = nil;
-  _captureVideoInput =
-      [AVCaptureDeviceInput deviceInputWithDevice:_captureDevice error:&localError];
+  _captureVideoInput = [AVCaptureDeviceInput deviceInputWithDevice:_captureDevice
+                                                             error:&localError];
   if (localError) {
     *error = localError;
     return nil;
@@ -123,7 +125,7 @@
 
   _captureVideoOutput = [AVCaptureVideoDataOutput new];
   _captureVideoOutput.videoSettings =
-      @{(NSString *)kCVPixelBufferPixelFormatTypeKey : @(kCVPixelFormatType_32BGRA) };
+      @{(NSString *)kCVPixelBufferPixelFormatTypeKey : @(kCVPixelFormatType_32BGRA)};
   [_captureVideoOutput setAlwaysDiscardsLateVideoFrames:YES];
   [_captureVideoOutput setSampleBufferDelegate:self queue:dispatch_get_main_queue()];
 
@@ -154,9 +156,9 @@
 - (void)captureToFile:(NSString *)path result:(FlutterResult)result {
   AVCapturePhotoSettings *settings = [AVCapturePhotoSettings photoSettings];
   [settings setHighResolutionPhotoEnabled:YES];
-  [_capturePhotoOutput
-      capturePhotoWithSettings:settings
-                      delegate:[[FLTSavePhotoDelegate alloc] initWithPath:path result:result]];
+  [_capturePhotoOutput capturePhotoWithSettings:settings
+                                       delegate:[[FLTSavePhotoDelegate alloc] initWithPath:path
+                                                                                    result:result]];
 }
 
 - (void)captureOutput:(AVCaptureOutput *)output
@@ -330,8 +332,9 @@
   if (!_isAudioSetup) {
     [self setUpCaptureSessionForAudio];
   }
-  _videoWriter =
-      [[AVAssetWriter alloc] initWithURL:outputURL fileType:AVFileTypeQuickTimeMovie error:&error];
+  _videoWriter = [[AVAssetWriter alloc] initWithURL:outputURL
+                                           fileType:AVFileTypeQuickTimeMovie
+                                              error:&error];
   NSParameterAssert(_videoWriter);
   if (error) {
     _eventSink(@{@"event" : @"error", @"errorDescription" : error.description});
@@ -375,8 +378,8 @@
   // Create a device input with the device and add it to the session.
   // Setup the audio input.
   AVCaptureDevice *audioDevice = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeAudio];
-  AVCaptureDeviceInput *audioInput =
-      [AVCaptureDeviceInput deviceInputWithDevice:audioDevice error:&error];
+  AVCaptureDeviceInput *audioInput = [AVCaptureDeviceInput deviceInputWithDevice:audioDevice
+                                                                           error:&error];
   if (error) {
     _eventSink(@{@"event" : @"error", @"errorDescription" : error.description});
   }
@@ -411,8 +414,8 @@
   FlutterMethodChannel *channel =
       [FlutterMethodChannel methodChannelWithName:@"plugins.flutter.io/camera"
                                   binaryMessenger:[registrar messenger]];
-  CameraPlugin *instance =
-      [[CameraPlugin alloc] initWithRegistry:[registrar textures] messenger:[registrar messenger]];
+  CameraPlugin *instance = [[CameraPlugin alloc] initWithRegistry:[registrar textures]
+                                                        messenger:[registrar messenger]];
   [registrar addMethodCallDelegate:instance channel:channel];
 }
 

--- a/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.h
+++ b/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.h
@@ -4,5 +4,5 @@
 
 #import <Flutter/Flutter.h>
 
-@interface FLTCloudFirestorePlugin : NSObject<FlutterPlugin>
+@interface FLTCloudFirestorePlugin : NSObject <FlutterPlugin>
 @end

--- a/packages/cloud_functions/ios/Classes/CloudFunctionsPlugin.h
+++ b/packages/cloud_functions/ios/Classes/CloudFunctionsPlugin.h
@@ -1,4 +1,4 @@
 #import <Flutter/Flutter.h>
 
-@interface CloudFunctionsPlugin : NSObject<FlutterPlugin>
+@interface CloudFunctionsPlugin : NSObject <FlutterPlugin>
 @end

--- a/packages/cloud_functions/ios/Classes/CloudFunctionsPlugin.m
+++ b/packages/cloud_functions/ios/Classes/CloudFunctionsPlugin.m
@@ -56,8 +56,9 @@
                                         message:@"Firebase function failed with exception."
                                         details:details];
               } else {
-                flutterError =
-                    [FlutterError errorWithCode:nil message:error.localizedDescription details:nil];
+                flutterError = [FlutterError errorWithCode:nil
+                                                   message:error.localizedDescription
+                                                   details:nil];
               }
               result(flutterError);
             } else {

--- a/packages/connectivity/ios/Classes/ConnectivityPlugin.h
+++ b/packages/connectivity/ios/Classes/ConnectivityPlugin.h
@@ -4,5 +4,5 @@
 
 #import <Flutter/Flutter.h>
 
-@interface FLTConnectivityPlugin : NSObject<FlutterPlugin>
+@interface FLTConnectivityPlugin : NSObject <FlutterPlugin>
 @end

--- a/packages/connectivity/ios/Classes/ConnectivityPlugin.m
+++ b/packages/connectivity/ios/Classes/ConnectivityPlugin.m
@@ -8,7 +8,7 @@
 
 #import "SystemConfiguration/CaptiveNetwork.h"
 
-@interface FLTConnectivityPlugin ()<FlutterStreamHandler>
+@interface FLTConnectivityPlugin () <FlutterStreamHandler>
 @end
 
 @implementation FLTConnectivityPlugin {

--- a/packages/device_info/ios/Classes/DeviceInfoPlugin.h
+++ b/packages/device_info/ios/Classes/DeviceInfoPlugin.h
@@ -4,5 +4,5 @@
 
 #import <Flutter/Flutter.h>
 
-@interface FLTDeviceInfoPlugin : NSObject<FlutterPlugin>
+@interface FLTDeviceInfoPlugin : NSObject <FlutterPlugin>
 @end

--- a/packages/firebase_admob/ios/Classes/FLTMobileAd.h
+++ b/packages/firebase_admob/ios/Classes/FLTMobileAd.h
@@ -23,12 +23,12 @@ typedef enum : NSUInteger {
 - (void)dispose;
 @end
 
-@interface FLTBannerAd : FLTMobileAd<GADBannerViewDelegate>
+@interface FLTBannerAd : FLTMobileAd <GADBannerViewDelegate>
 + (instancetype)withId:(NSNumber *)mobileAdId
                 adSize:(GADAdSize)adSize
                channel:(FlutterMethodChannel *)channel;
 @end
 
-@interface FLTInterstitialAd : FLTMobileAd<GADInterstitialDelegate>
+@interface FLTInterstitialAd : FLTMobileAd <GADInterstitialDelegate>
 + (instancetype)withId:(NSNumber *)mobileAdId channel:(FlutterMethodChannel *)channel;
 @end

--- a/packages/firebase_admob/ios/Classes/FLTRequestFactory.m
+++ b/packages/firebase_admob/ios/Classes/FLTRequestFactory.m
@@ -121,8 +121,8 @@ NSDictionary *_targetingInfo;
     request.requestAgent = requestAgent;
   }
 
-  NSNumber *nonPersonalizedAds =
-      [self targetingInfoBoolForKey:@"nonPersonalizedAds" info:_targetingInfo];
+  NSNumber *nonPersonalizedAds = [self targetingInfoBoolForKey:@"nonPersonalizedAds"
+                                                          info:_targetingInfo];
   if (nonPersonalizedAds != nil && [nonPersonalizedAds boolValue]) {
     GADExtras *extras = [[GADExtras alloc] init];
     extras.additionalParameters = @{@"npa" : @"1"};

--- a/packages/firebase_admob/ios/Classes/FLTRewardedVideoAdWrapper.m
+++ b/packages/firebase_admob/ios/Classes/FLTRewardedVideoAdWrapper.m
@@ -8,7 +8,7 @@
 
 static NSDictionary *rewardedStatusToString = nil;
 
-@interface FLTRewardedVideoAdWrapper ()<GADRewardBasedVideoAdDelegate>
+@interface FLTRewardedVideoAdWrapper () <GADRewardBasedVideoAdDelegate>
 @end
 
 @implementation FLTRewardedVideoAdWrapper

--- a/packages/firebase_admob/ios/Classes/FirebaseAdMobPlugin.h
+++ b/packages/firebase_admob/ios/Classes/FirebaseAdMobPlugin.h
@@ -4,8 +4,7 @@
 
 #import <Flutter/Flutter.h>
 
-#define FLTLogWarning(format, ...) \
-  NSLog((@"FirebaseAdMobPlugin <warning> " format), ##__VA_ARGS__)
+#define FLTLogWarning(format, ...) NSLog((@"FirebaseAdMobPlugin <warning> " format), ##__VA_ARGS__)
 
-@interface FLTFirebaseAdMobPlugin : NSObject<FlutterPlugin>
+@interface FLTFirebaseAdMobPlugin : NSObject <FlutterPlugin>
 @end

--- a/packages/firebase_admob/ios/Classes/FirebaseAdMobPlugin.m
+++ b/packages/firebase_admob/ios/Classes/FirebaseAdMobPlugin.m
@@ -271,10 +271,9 @@
 
   NSNumber *mobileAdId = (NSNumber *)call.arguments[@"id"];
   if (mobileAdId == nil) {
-    NSString *message =
-        @"FirebaseAdMobPlugin method calls for banners and "
-        @"interstitials must specify an "
-        @"integer mobile ad id";
+    NSString *message = @"FirebaseAdMobPlugin method calls for banners and "
+                        @"interstitials must specify an "
+                        @"integer mobile ad id";
     result([FlutterError errorWithCode:@"no_id" message:message details:nil]);
     return;
   }

--- a/packages/firebase_analytics/ios/Classes/FirebaseAnalyticsPlugin.h
+++ b/packages/firebase_analytics/ios/Classes/FirebaseAnalyticsPlugin.h
@@ -4,5 +4,5 @@
 
 #import <Flutter/Flutter.h>
 
-@interface FLTFirebaseAnalyticsPlugin : NSObject<FlutterPlugin>
+@interface FLTFirebaseAnalyticsPlugin : NSObject <FlutterPlugin>
 @end

--- a/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.h
+++ b/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.h
@@ -4,5 +4,5 @@
 
 #import <Flutter/Flutter.h>
 
-@interface FLTFirebaseAuthPlugin : NSObject<FlutterPlugin>
+@interface FLTFirebaseAuthPlugin : NSObject <FlutterPlugin>
 @end

--- a/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
+++ b/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
@@ -79,8 +79,8 @@ int nextHandle = 0;
   } else if ([@"signInWithGoogle" isEqualToString:call.method]) {
     NSString *idToken = call.arguments[@"idToken"];
     NSString *accessToken = call.arguments[@"accessToken"];
-    FIRAuthCredential *credential =
-        [FIRGoogleAuthProvider credentialWithIDToken:idToken accessToken:accessToken];
+    FIRAuthCredential *credential = [FIRGoogleAuthProvider credentialWithIDToken:idToken
+                                                                     accessToken:accessToken];
     [[self getAuth:call.arguments] signInWithCredential:credential
                                              completion:^(FIRUser *user, NSError *error) {
                                                [self sendResult:result forUser:user error:error];
@@ -95,8 +95,8 @@ int nextHandle = 0;
   } else if ([@"signInWithTwitter" isEqualToString:call.method]) {
     NSString *authToken = call.arguments[@"authToken"];
     NSString *authTokenSecret = call.arguments[@"authTokenSecret"];
-    FIRAuthCredential *credential =
-        [FIRTwitterAuthProvider credentialWithToken:authToken secret:authTokenSecret];
+    FIRAuthCredential *credential = [FIRTwitterAuthProvider credentialWithToken:authToken
+                                                                         secret:authTokenSecret];
     [[self getAuth:call.arguments] signInWithCredential:credential
                                              completion:^(FIRUser *user, NSError *error) {
                                                [self sendResult:result forUser:user error:error];
@@ -139,11 +139,12 @@ int nextHandle = 0;
     }];
   } else if ([@"sendPasswordResetEmail" isEqualToString:call.method]) {
     NSString *email = call.arguments[@"email"];
-    [[self getAuth:call.arguments]
-        sendPasswordResetWithEmail:email
-                        completion:^(NSError *error) {
-                          [self sendResult:result forUser:nil error:error];
-                        }];
+    [[self getAuth:call.arguments] sendPasswordResetWithEmail:email
+                                                   completion:^(NSError *error) {
+                                                     [self sendResult:result
+                                                              forUser:nil
+                                                                error:error];
+                                                   }];
   } else if ([@"signInWithEmailAndPassword" isEqualToString:call.method]) {
     NSString *email = call.arguments[@"email"];
     NSString *password = call.arguments[@"password"];
@@ -171,49 +172,54 @@ int nextHandle = 0;
   } else if ([@"linkWithEmailAndPassword" isEqualToString:call.method]) {
     NSString *email = call.arguments[@"email"];
     NSString *password = call.arguments[@"password"];
-    FIRAuthCredential *credential =
-        [FIREmailAuthProvider credentialWithEmail:email password:password];
-    [[self getAuth:call.arguments].currentUser
-        linkWithCredential:credential
-                completion:^(FIRUser *user, NSError *error) {
-                  [self sendResult:result forUser:user error:error];
-                }];
+    FIRAuthCredential *credential = [FIREmailAuthProvider credentialWithEmail:email
+                                                                     password:password];
+    [[self getAuth:call.arguments].currentUser linkWithCredential:credential
+                                                       completion:^(FIRUser *user, NSError *error) {
+                                                         [self sendResult:result
+                                                                  forUser:user
+                                                                    error:error];
+                                                       }];
   } else if ([@"linkWithGoogleCredential" isEqualToString:call.method]) {
     NSString *idToken = call.arguments[@"idToken"];
     NSString *accessToken = call.arguments[@"accessToken"];
-    FIRAuthCredential *credential =
-        [FIRGoogleAuthProvider credentialWithIDToken:idToken accessToken:accessToken];
-    [[self getAuth:call.arguments].currentUser
-        linkWithCredential:credential
-                completion:^(FIRUser *user, NSError *error) {
-                  [self sendResult:result forUser:user error:error];
-                }];
+    FIRAuthCredential *credential = [FIRGoogleAuthProvider credentialWithIDToken:idToken
+                                                                     accessToken:accessToken];
+    [[self getAuth:call.arguments].currentUser linkWithCredential:credential
+                                                       completion:^(FIRUser *user, NSError *error) {
+                                                         [self sendResult:result
+                                                                  forUser:user
+                                                                    error:error];
+                                                       }];
   } else if ([@"linkWithFacebookCredential" isEqualToString:call.method]) {
     NSString *accessToken = call.arguments[@"accessToken"];
     FIRAuthCredential *credential = [FIRFacebookAuthProvider credentialWithAccessToken:accessToken];
-    [[self getAuth:call.arguments].currentUser
-        linkWithCredential:credential
-                completion:^(FIRUser *user, NSError *error) {
-                  [self sendResult:result forUser:user error:error];
-                }];
+    [[self getAuth:call.arguments].currentUser linkWithCredential:credential
+                                                       completion:^(FIRUser *user, NSError *error) {
+                                                         [self sendResult:result
+                                                                  forUser:user
+                                                                    error:error];
+                                                       }];
   } else if ([@"linkWithTwitterCredential" isEqualToString:call.method]) {
     NSString *authToken = call.arguments[@"authToken"];
     NSString *authTokenSecret = call.arguments[@"authTokenSecret"];
-    FIRAuthCredential *credential =
-        [FIRTwitterAuthProvider credentialWithToken:authToken secret:authTokenSecret];
-    [[self getAuth:call.arguments].currentUser
-        linkWithCredential:credential
-                completion:^(FIRUser *user, NSError *error) {
-                  [self sendResult:result forUser:user error:error];
-                }];
+    FIRAuthCredential *credential = [FIRTwitterAuthProvider credentialWithToken:authToken
+                                                                         secret:authTokenSecret];
+    [[self getAuth:call.arguments].currentUser linkWithCredential:credential
+                                                       completion:^(FIRUser *user, NSError *error) {
+                                                         [self sendResult:result
+                                                                  forUser:user
+                                                                    error:error];
+                                                       }];
   } else if ([@"linkWithGithubCredential" isEqualToString:call.method]) {
     NSString *token = call.arguments[@"token"];
     FIRAuthCredential *credential = [FIRGitHubAuthProvider credentialWithToken:token];
-    [[self getAuth:call.arguments].currentUser
-        linkWithCredential:credential
-                completion:^(FIRUser *user, NSError *error) {
-                  [self sendResult:result forUser:user error:error];
-                }];
+    [[self getAuth:call.arguments].currentUser linkWithCredential:credential
+                                                       completion:^(FIRUser *user, NSError *error) {
+                                                         [self sendResult:result
+                                                                  forUser:user
+                                                                    error:error];
+                                                       }];
   } else if ([@"updateEmail" isEqualToString:call.method]) {
     NSString *email = call.arguments[@"email"];
     [[self getAuth:call.arguments].currentUser updateEmail:email
@@ -222,11 +228,12 @@ int nextHandle = 0;
                                                 }];
   } else if ([@"updatePassword" isEqualToString:call.method]) {
     NSString *password = call.arguments[@"password"];
-    [[self getAuth:call.arguments].currentUser
-        updatePassword:password
-            completion:^(NSError *error) {
-              [self sendResult:result forUser:nil error:error];
-            }];
+    [[self getAuth:call.arguments].currentUser updatePassword:password
+                                                   completion:^(NSError *error) {
+                                                     [self sendResult:result
+                                                              forUser:nil
+                                                                error:error];
+                                                   }];
   } else if ([@"updateProfile" isEqualToString:call.method]) {
     FIRUserProfileChangeRequest *changeRequest =
         [[self getAuth:call.arguments].currentUser profileChangeRequest];

--- a/packages/firebase_core/ios/Classes/FirebaseCorePlugin.h
+++ b/packages/firebase_core/ios/Classes/FirebaseCorePlugin.h
@@ -4,5 +4,5 @@
 
 #import <Flutter/Flutter.h>
 
-@interface FLTFirebaseCorePlugin : NSObject<FlutterPlugin>
+@interface FLTFirebaseCorePlugin : NSObject <FlutterPlugin>
 @end

--- a/packages/firebase_database/ios/Classes/FirebaseDatabasePlugin.h
+++ b/packages/firebase_database/ios/Classes/FirebaseDatabasePlugin.h
@@ -4,7 +4,7 @@
 
 #import <Flutter/Flutter.h>
 
-@interface FLTFirebaseDatabasePlugin : NSObject<FlutterPlugin>
+@interface FLTFirebaseDatabasePlugin : NSObject <FlutterPlugin>
 
 @property(nonatomic) NSMutableDictionary *updatedSnapshots;
 

--- a/packages/firebase_database/ios/Classes/FirebaseDatabasePlugin.m
+++ b/packages/firebase_database/ios/Classes/FirebaseDatabasePlugin.m
@@ -221,58 +221,60 @@ id roundDoubles(id value) {
     [getReference(database, call.arguments) setPriority:call.arguments[@"priority"]
                                     withCompletionBlock:defaultCompletionBlock];
   } else if ([@"DatabaseReference#runTransaction" isEqualToString:call.method]) {
-    [getReference(database, call.arguments) runTransactionBlock:^FIRTransactionResult *_Nonnull(
-                                                FIRMutableData *_Nonnull currentData) {
-      // Create semaphore to allow native side to wait while snapshot
-      // updates occur on the Dart side.
-      dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+    [getReference(database, call.arguments)
+        runTransactionBlock:^FIRTransactionResult *_Nonnull(FIRMutableData *_Nonnull currentData) {
+          // Create semaphore to allow native side to wait while snapshot
+          // updates occur on the Dart side.
+          dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-      NSObject *snapshot =
-          @{@"key" : currentData.key ?: [NSNull null], @"value" : currentData.value};
+          NSObject *snapshot =
+              @{@"key" : currentData.key ?: [NSNull null], @"value" : currentData.value};
 
-      __block bool shouldAbort = false;
+          __block bool shouldAbort = false;
 
-      [self.channel invokeMethod:@"DoTransaction"
-                       arguments:@{
-                         @"transactionKey" : call.arguments[@"transactionKey"],
-                         @"snapshot" : snapshot
-                       }
-                          result:^(id _Nullable result) {
-                            if ([result isKindOfClass:[FlutterError class]]) {
-                              FlutterError *flutterError = ((FlutterError *)result);
-                              NSLog(@"Error code: %@", flutterError.code);
-                              NSLog(@"Error message: %@", flutterError.message);
-                              NSLog(@"Error details: %@", flutterError.details);
-                              shouldAbort = true;
-                            } else if ([result isEqual:FlutterMethodNotImplemented]) {
-                              NSLog(@"DoTransaction not implemented on the Dart side.");
-                              shouldAbort = true;
-                            } else {
-                              [self.updatedSnapshots setObject:result
-                                                        forKey:call.arguments[@"transactionKey"]];
-                            }
-                            dispatch_semaphore_signal(semaphore);
-                          }];
+          [self.channel invokeMethod:@"DoTransaction"
+                           arguments:@{
+                             @"transactionKey" : call.arguments[@"transactionKey"],
+                             @"snapshot" : snapshot
+                           }
+                              result:^(id _Nullable result) {
+                                if ([result isKindOfClass:[FlutterError class]]) {
+                                  FlutterError *flutterError = ((FlutterError *)result);
+                                  NSLog(@"Error code: %@", flutterError.code);
+                                  NSLog(@"Error message: %@", flutterError.message);
+                                  NSLog(@"Error details: %@", flutterError.details);
+                                  shouldAbort = true;
+                                } else if ([result isEqual:FlutterMethodNotImplemented]) {
+                                  NSLog(@"DoTransaction not implemented on the Dart side.");
+                                  shouldAbort = true;
+                                } else {
+                                  [self.updatedSnapshots
+                                      setObject:result
+                                         forKey:call.arguments[@"transactionKey"]];
+                                }
+                                dispatch_semaphore_signal(semaphore);
+                              }];
 
-      // Wait while Dart side updates the snapshot. Incoming transactionTimeout is in milliseconds
-      // so converting to nanoseconds for use with dispatch_semaphore_wait.
-      long result = dispatch_semaphore_wait(
-          semaphore, dispatch_time(DISPATCH_TIME_NOW,
-                                   [call.arguments[@"transactionTimeout"] integerValue] * 1000000));
+          // Wait while Dart side updates the snapshot. Incoming transactionTimeout is in
+          // milliseconds so converting to nanoseconds for use with dispatch_semaphore_wait.
+          long result = dispatch_semaphore_wait(
+              semaphore,
+              dispatch_time(DISPATCH_TIME_NOW,
+                            [call.arguments[@"transactionTimeout"] integerValue] * 1000000));
 
-      if (result == 0 && !shouldAbort) {
-        // Set FIRMutableData value to value returned from the Dart side.
-        currentData.value =
-            [self.updatedSnapshots objectForKey:call.arguments[@"transactionKey"]][@"value"];
-      } else {
-        if (result != 0) {
-          NSLog(@"Transaction at %@ timed out.", [getReference(database, call.arguments) URL]);
+          if (result == 0 && !shouldAbort) {
+            // Set FIRMutableData value to value returned from the Dart side.
+            currentData.value =
+                [self.updatedSnapshots objectForKey:call.arguments[@"transactionKey"]][@"value"];
+          } else {
+            if (result != 0) {
+              NSLog(@"Transaction at %@ timed out.", [getReference(database, call.arguments) URL]);
+            }
+            return [FIRTransactionResult abort];
+          }
+
+          return [FIRTransactionResult successWithValue:currentData];
         }
-        return [FIRTransactionResult abort];
-      }
-
-      return [FIRTransactionResult successWithValue:currentData];
-    }
         andCompletionBlock:^(NSError *_Nullable error, BOOL committed,
                              FIRDataSnapshot *_Nullable snapshot) {
           // Invoke transaction completion on the Dart side.

--- a/packages/firebase_dynamic_links/ios/Classes/FirebaseDynamicLinksPlugin.h
+++ b/packages/firebase_dynamic_links/ios/Classes/FirebaseDynamicLinksPlugin.h
@@ -1,4 +1,4 @@
 #import <Flutter/Flutter.h>
 
-@interface FLTFirebaseDynamicLinksPlugin : NSObject<FlutterPlugin>
+@interface FLTFirebaseDynamicLinksPlugin : NSObject <FlutterPlugin>
 @end

--- a/packages/firebase_dynamic_links/ios/Classes/FirebaseDynamicLinksPlugin.m
+++ b/packages/firebase_dynamic_links/ios/Classes/FirebaseDynamicLinksPlugin.m
@@ -147,8 +147,8 @@
   NSURL *link = [NSURL URLWithString:arguments[@"link"]];
   NSString *domain = arguments[@"domain"];
 
-  FIRDynamicLinkComponents *components =
-      [FIRDynamicLinkComponents componentsWithLink:link domain:domain];
+  FIRDynamicLinkComponents *components = [FIRDynamicLinkComponents componentsWithLink:link
+                                                                               domain:domain];
 
   if (![arguments[@"androidParameters"] isEqual:[NSNull null]]) {
     NSDictionary *params = arguments[@"androidParameters"];

--- a/packages/firebase_messaging/ios/Classes/FirebaseMessagingPlugin.h
+++ b/packages/firebase_messaging/ios/Classes/FirebaseMessagingPlugin.h
@@ -4,5 +4,5 @@
 
 #import <Flutter/Flutter.h>
 
-@interface FLTFirebaseMessagingPlugin : NSObject<FlutterPlugin>
+@interface FLTFirebaseMessagingPlugin : NSObject <FlutterPlugin>
 @end

--- a/packages/firebase_messaging/ios/Classes/FirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/ios/Classes/FirebaseMessagingPlugin.m
@@ -7,7 +7,7 @@
 #import "Firebase/Firebase.h"
 
 #if defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
-@interface FLTFirebaseMessagingPlugin ()<FIRMessagingDelegate>
+@interface FLTFirebaseMessagingPlugin () <FIRMessagingDelegate>
 @end
 #endif
 

--- a/packages/firebase_ml_vision/ios/Classes/FaceDetector.m
+++ b/packages/firebase_ml_vision/ios/Classes/FaceDetector.m
@@ -42,26 +42,26 @@ static FIRVisionFaceDetector *faceDetector;
               @"rightEyeOpenProbability" : rightProb,
               @"trackingId" : face.hasTrackingID ? @(face.trackingID) : [NSNull null],
               @"landmarks" : @{
-                @"bottomMouth" :
-                    [FaceDetector getLandmarkPosition:face landmark:FIRFaceLandmarkTypeMouthBottom],
-                @"leftCheek" :
-                    [FaceDetector getLandmarkPosition:face landmark:FIRFaceLandmarkTypeLeftCheek],
-                @"leftEar" :
-                    [FaceDetector getLandmarkPosition:face landmark:FIRFaceLandmarkTypeLeftEar],
-                @"leftEye" :
-                    [FaceDetector getLandmarkPosition:face landmark:FIRFaceLandmarkTypeLeftEye],
-                @"leftMouth" :
-                    [FaceDetector getLandmarkPosition:face landmark:FIRFaceLandmarkTypeMouthLeft],
-                @"noseBase" :
-                    [FaceDetector getLandmarkPosition:face landmark:FIRFaceLandmarkTypeNoseBase],
-                @"rightCheek" :
-                    [FaceDetector getLandmarkPosition:face landmark:FIRFaceLandmarkTypeRightCheek],
-                @"rightEar" :
-                    [FaceDetector getLandmarkPosition:face landmark:FIRFaceLandmarkTypeRightEar],
-                @"rightEye" :
-                    [FaceDetector getLandmarkPosition:face landmark:FIRFaceLandmarkTypeRightEye],
-                @"rightMouth" :
-                    [FaceDetector getLandmarkPosition:face landmark:FIRFaceLandmarkTypeMouthRight],
+                @"bottomMouth" : [FaceDetector getLandmarkPosition:face
+                                                          landmark:FIRFaceLandmarkTypeMouthBottom],
+                @"leftCheek" : [FaceDetector getLandmarkPosition:face
+                                                        landmark:FIRFaceLandmarkTypeLeftCheek],
+                @"leftEar" : [FaceDetector getLandmarkPosition:face
+                                                      landmark:FIRFaceLandmarkTypeLeftEar],
+                @"leftEye" : [FaceDetector getLandmarkPosition:face
+                                                      landmark:FIRFaceLandmarkTypeLeftEye],
+                @"leftMouth" : [FaceDetector getLandmarkPosition:face
+                                                        landmark:FIRFaceLandmarkTypeMouthLeft],
+                @"noseBase" : [FaceDetector getLandmarkPosition:face
+                                                       landmark:FIRFaceLandmarkTypeNoseBase],
+                @"rightCheek" : [FaceDetector getLandmarkPosition:face
+                                                         landmark:FIRFaceLandmarkTypeRightCheek],
+                @"rightEar" : [FaceDetector getLandmarkPosition:face
+                                                       landmark:FIRFaceLandmarkTypeRightEar],
+                @"rightEye" : [FaceDetector getLandmarkPosition:face
+                                                       landmark:FIRFaceLandmarkTypeRightEye],
+                @"rightMouth" : [FaceDetector getLandmarkPosition:face
+                                                         landmark:FIRFaceLandmarkTypeMouthRight],
               },
             };
 

--- a/packages/firebase_ml_vision/ios/Classes/FirebaseMlVisionPlugin.h
+++ b/packages/firebase_ml_vision/ios/Classes/FirebaseMlVisionPlugin.h
@@ -2,7 +2,7 @@
 
 #import "Firebase/Firebase.h"
 
-@interface FLTFirebaseMlVisionPlugin : NSObject<FlutterPlugin>
+@interface FLTFirebaseMlVisionPlugin : NSObject <FlutterPlugin>
 + (void)handleError:(NSError *)error result:(FlutterResult)result;
 @end
 
@@ -14,17 +14,17 @@
 @optional
 @end
 
-@interface BarcodeDetector : NSObject<Detector>
+@interface BarcodeDetector : NSObject <Detector>
 @end
 
-@interface FaceDetector : NSObject<Detector>
+@interface FaceDetector : NSObject <Detector>
 @end
 
-@interface LabelDetector : NSObject<Detector>
+@interface LabelDetector : NSObject <Detector>
 @end
 
-@interface CloudLabelDetector : NSObject<Detector>
+@interface CloudLabelDetector : NSObject <Detector>
 @end
 
-@interface TextRecognizer : NSObject<Detector>
+@interface TextRecognizer : NSObject <Detector>
 @end

--- a/packages/firebase_ml_vision/ios/Classes/TextRecognizer.m
+++ b/packages/firebase_ml_vision/ios/Classes/TextRecognizer.m
@@ -15,7 +15,7 @@ static FIRVisionTextRecognizer *recognizer;
                     [FLTFirebaseMlVisionPlugin handleError:error result:result];
                     return;
                   } else if (!visionText) {
-                    result(@{ @"text" : @"", @"blocks" : @[] });
+                    result(@{@"text" : @"", @"blocks" : @[]});
                     return;
                   }
 

--- a/packages/firebase_performance/ios/Classes/FirebasePerformancePlugin.h
+++ b/packages/firebase_performance/ios/Classes/FirebasePerformancePlugin.h
@@ -1,4 +1,4 @@
 #import <Flutter/Flutter.h>
 
-@interface FLTFirebasePerformancePlugin : NSObject<FlutterPlugin>
+@interface FLTFirebasePerformancePlugin : NSObject <FlutterPlugin>
 @end

--- a/packages/firebase_remote_config/ios/Classes/FirebaseRemoteConfigPlugin.h
+++ b/packages/firebase_remote_config/ios/Classes/FirebaseRemoteConfigPlugin.h
@@ -1,4 +1,4 @@
 #import <Flutter/Flutter.h>
 
-@interface FirebaseRemoteConfigPlugin : NSObject<FlutterPlugin>
+@interface FirebaseRemoteConfigPlugin : NSObject <FlutterPlugin>
 @end

--- a/packages/firebase_remote_config/ios/Classes/FirebaseRemoteConfigPlugin.m
+++ b/packages/firebase_remote_config/ios/Classes/FirebaseRemoteConfigPlugin.m
@@ -81,9 +81,8 @@
                                                            message:errorMessage
                                                            details:resultDict];
                       } else {
-                        NSString *errorMessage =
-                            @"Unable to complete fetch. Reason is unknown "
-                             "but this could be due to lack of connectivity.";
+                        NSString *errorMessage = @"Unable to complete fetch. Reason is unknown "
+                                                  "but this could be due to lack of connectivity.";
                         flutterError = [FlutterError errorWithCode:@"fetchFailed"
                                                            message:errorMessage
                                                            details:resultDict];

--- a/packages/firebase_storage/ios/Classes/FirebaseStoragePlugin.h
+++ b/packages/firebase_storage/ios/Classes/FirebaseStoragePlugin.h
@@ -4,5 +4,5 @@
 
 #import <Flutter/Flutter.h>
 
-@interface FLTFirebaseStoragePlugin : NSObject<FlutterPlugin>
+@interface FLTFirebaseStoragePlugin : NSObject <FlutterPlugin>
 @end

--- a/packages/firebase_storage/ios/Classes/FirebaseStoragePlugin.m
+++ b/packages/firebase_storage/ios/Classes/FirebaseStoragePlugin.m
@@ -391,7 +391,7 @@ typedef NS_ENUM(NSUInteger, StorageTaskEventType) {
   }];
 }
 
-- (void) delete:(FlutterMethodCall *)call result:(FlutterResult)result {
+- (void)delete:(FlutterMethodCall *)call result:(FlutterResult)result {
   NSString *path = call.arguments[@"path"];
   FIRStorageReference *ref = [storage.reference child:path];
   [ref deleteWithCompletion:^(NSError *error) {

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapController.h
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapController.h
@@ -31,7 +31,7 @@
 
 // Defines map overlay controllable from Flutter.
 @interface FLTGoogleMapController
-    : NSObject<GMSMapViewDelegate, FLTGoogleMapOptionsSink, FlutterPlatformView>
+    : NSObject <GMSMapViewDelegate, FLTGoogleMapOptionsSink, FlutterPlatformView>
 @property(atomic) id<FLTGoogleMapDelegate> delegate;
 @property(atomic, readonly) id mapId;
 - (instancetype)initWithFrame:(CGRect)frame
@@ -51,6 +51,6 @@
 @end
 
 // Allows the engine to create new Google Map instances.
-@interface FLTGoogleMapFactory : NSObject<FlutterPlatformViewFactory>
+@interface FLTGoogleMapFactory : NSObject <FlutterPlatformViewFactory>
 - (instancetype)initWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar;
 @end

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapController.m
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapController.m
@@ -426,8 +426,8 @@ static void interpretMarkerOptions(id json, id<FLTGoogleMapMarkerOptionsSink> si
       if (iconData.count == 2) {
         image = [UIImage imageNamed:[registrar lookupKeyForAsset:iconData[1]]];
       } else {
-        image =
-            [UIImage imageNamed:[registrar lookupKeyForAsset:iconData[1] fromPackage:iconData[2]]];
+        image = [UIImage imageNamed:[registrar lookupKeyForAsset:iconData[1]
+                                                     fromPackage:iconData[2]]];
       }
     }
     [sink setIcon:image];

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapMarkerController.h
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapMarkerController.h
@@ -22,7 +22,7 @@
 @end
 
 // Defines marker controllable by Flutter.
-@interface FLTGoogleMapMarkerController : NSObject<FLTGoogleMapMarkerOptionsSink>
+@interface FLTGoogleMapMarkerController : NSObject <FLTGoogleMapMarkerOptionsSink>
 @property(atomic, readonly) NSString* markerId;
 - (instancetype)initWithPosition:(CLLocationCoordinate2D)position mapView:(GMSMapView*)mapView;
 @end

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapsPlugin.h
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapsPlugin.h
@@ -7,5 +7,5 @@
 #import "GoogleMapController.h"
 #import "GoogleMapMarkerController.h"
 
-@interface FLTGoogleMapsPlugin : NSObject<FlutterPlugin, FLTGoogleMapDelegate>
+@interface FLTGoogleMapsPlugin : NSObject <FlutterPlugin, FLTGoogleMapDelegate>
 @end

--- a/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.h
+++ b/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.h
@@ -4,5 +4,5 @@
 
 #import <Flutter/Flutter.h>
 
-@interface FLTGoogleSignInPlugin : NSObject<FlutterPlugin>
+@interface FLTGoogleSignInPlugin : NSObject <FlutterPlugin>
 @end

--- a/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
+++ b/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
@@ -29,12 +29,13 @@ static NSString *const kErrorReasonSignInFailed = @"sign_in_failed";
   } else {
     errorCode = kErrorReasonSignInFailed;
   }
-  return
-      [FlutterError errorWithCode:errorCode message:self.domain details:self.localizedDescription];
+  return [FlutterError errorWithCode:errorCode
+                             message:self.domain
+                             details:self.localizedDescription];
 }
 @end
 
-@interface FLTGoogleSignInPlugin ()<GIDSignInDelegate, GIDSignInUIDelegate>
+@interface FLTGoogleSignInPlugin () <GIDSignInDelegate, GIDSignInUIDelegate>
 @end
 
 @implementation FLTGoogleSignInPlugin {
@@ -73,8 +74,8 @@ static NSString *const kErrorReasonSignInFailed = @"sign_in_failed";
                                  message:@"Games sign in is not supported on iOS"
                                  details:nil]);
     } else {
-      NSString *path =
-          [[NSBundle mainBundle] pathForResource:@"GoogleService-Info" ofType:@"plist"];
+      NSString *path = [[NSBundle mainBundle] pathForResource:@"GoogleService-Info"
+                                                       ofType:@"plist"];
       if (path) {
         NSMutableDictionary *plist = [[NSMutableDictionary alloc] initWithContentsOfFile:path];
         [GIDSignIn sharedInstance].clientID = plist[kClientIdKey];

--- a/packages/image_picker/ios/Classes/ImagePickerPlugin.h
+++ b/packages/image_picker/ios/Classes/ImagePickerPlugin.h
@@ -4,5 +4,5 @@
 
 #import <Flutter/Flutter.h>
 
-@interface FLTImagePickerPlugin : NSObject<FlutterPlugin>
+@interface FLTImagePickerPlugin : NSObject <FlutterPlugin>
 @end

--- a/packages/image_picker/ios/Classes/ImagePickerPlugin.m
+++ b/packages/image_picker/ios/Classes/ImagePickerPlugin.m
@@ -8,7 +8,7 @@
 #import <Photos/Photos.h>
 #import <UIKit/UIKit.h>
 
-@interface FLTImagePickerPlugin ()<UINavigationControllerDelegate, UIImagePickerControllerDelegate>
+@interface FLTImagePickerPlugin () <UINavigationControllerDelegate, UIImagePickerControllerDelegate>
 @end
 
 static const int SOURCE_CAMERA = 0;

--- a/packages/in_app_purchase/ios/Classes/InAppPurchasePlugin.h
+++ b/packages/in_app_purchase/ios/Classes/InAppPurchasePlugin.h
@@ -1,4 +1,4 @@
 #import <Flutter/Flutter.h>
 
-@interface InAppPurchasePlugin : NSObject<FlutterPlugin>
+@interface InAppPurchasePlugin : NSObject <FlutterPlugin>
 @end

--- a/packages/local_auth/ios/Classes/LocalAuthPlugin.h
+++ b/packages/local_auth/ios/Classes/LocalAuthPlugin.h
@@ -4,5 +4,5 @@
 
 #import <Flutter/Flutter.h>
 
-@interface FLTLocalAuthPlugin : NSObject<FlutterPlugin>
+@interface FLTLocalAuthPlugin : NSObject <FlutterPlugin>
 @end

--- a/packages/location_background/ios/Classes/LocationBackgroundPlugin.h
+++ b/packages/location_background/ios/Classes/LocationBackgroundPlugin.h
@@ -6,7 +6,6 @@
 
 #import <CoreLocation/CoreLocation.h>
 
-@interface LocationBackgroundPlugin
-    : NSObject<FlutterPlugin, CLLocationManagerDelegate> {
+@interface LocationBackgroundPlugin : NSObject <FlutterPlugin, CLLocationManagerDelegate> {
 }
 @end

--- a/packages/location_background/ios/Classes/LocationBackgroundPlugin.m
+++ b/packages/location_background/ios/Classes/LocationBackgroundPlugin.m
@@ -99,8 +99,8 @@ static LocationBackgroundPlugin *instance = nil;
   [_locationManager setDelegate:self];
   [_locationManager requestAlwaysAuthorization];
 
-  _headlessEngine =
-      [[FlutterEngine alloc] initWithName:@"io.flutter.plugins.location_background" project:nil];
+  _headlessEngine = [[FlutterEngine alloc] initWithName:@"io.flutter.plugins.location_background"
+                                                project:nil];
   _registrar = registrar;
 
   // This is the method channel used to communicate with the UI Isolate.

--- a/packages/package_info/ios/Classes/PackageInfoPlugin.h
+++ b/packages/package_info/ios/Classes/PackageInfoPlugin.h
@@ -4,5 +4,5 @@
 
 #import <Flutter/Flutter.h>
 
-@interface FLTPackageInfoPlugin : NSObject<FlutterPlugin>
+@interface FLTPackageInfoPlugin : NSObject <FlutterPlugin>
 @end

--- a/packages/path_provider/ios/Classes/PathProviderPlugin.h
+++ b/packages/path_provider/ios/Classes/PathProviderPlugin.h
@@ -4,5 +4,5 @@
 
 #import <Flutter/Flutter.h>
 
-@interface FLTPathProviderPlugin : NSObject<FlutterPlugin>
+@interface FLTPathProviderPlugin : NSObject <FlutterPlugin>
 @end

--- a/packages/quick_actions/ios/Classes/QuickActionsPlugin.h
+++ b/packages/quick_actions/ios/Classes/QuickActionsPlugin.h
@@ -4,5 +4,5 @@
 
 #import <Flutter/Flutter.h>
 
-@interface FLTQuickActionsPlugin : NSObject<FlutterPlugin>
+@interface FLTQuickActionsPlugin : NSObject <FlutterPlugin>
 @end

--- a/packages/sensors/ios/Classes/SensorsPlugin.h
+++ b/packages/sensors/ios/Classes/SensorsPlugin.h
@@ -4,14 +4,14 @@
 
 #import <Flutter/Flutter.h>
 
-@interface FLTSensorsPlugin : NSObject<FlutterPlugin>
+@interface FLTSensorsPlugin : NSObject <FlutterPlugin>
 @end
 
-@interface FLTUserAccelStreamHandler : NSObject<FlutterStreamHandler>
+@interface FLTUserAccelStreamHandler : NSObject <FlutterStreamHandler>
 @end
 
-@interface FLTAccelerometerStreamHandler : NSObject<FlutterStreamHandler>
+@interface FLTAccelerometerStreamHandler : NSObject <FlutterStreamHandler>
 @end
 
-@interface FLTGyroscopeStreamHandler : NSObject<FlutterStreamHandler>
+@interface FLTGyroscopeStreamHandler : NSObject <FlutterStreamHandler>
 @end

--- a/packages/share/ios/Classes/SharePlugin.h
+++ b/packages/share/ios/Classes/SharePlugin.h
@@ -4,5 +4,5 @@
 
 #import <Flutter/Flutter.h>
 
-@interface FLTSharePlugin : NSObject<FlutterPlugin>
+@interface FLTSharePlugin : NSObject <FlutterPlugin>
 @end

--- a/packages/share/ios/Classes/SharePlugin.m
+++ b/packages/share/ios/Classes/SharePlugin.m
@@ -19,8 +19,9 @@ static NSString *const PLATFORM_CHANNEL = @"plugins.flutter.io/share";
       NSString *shareText = arguments[@"text"];
 
       if (shareText.length == 0) {
-        result(
-            [FlutterError errorWithCode:@"error" message:@"Non-empty text expected" details:nil]);
+        result([FlutterError errorWithCode:@"error"
+                                   message:@"Non-empty text expected"
+                                   details:nil]);
         return;
       }
 

--- a/packages/shared_preferences/ios/Classes/SharedPreferencesPlugin.h
+++ b/packages/shared_preferences/ios/Classes/SharedPreferencesPlugin.h
@@ -4,5 +4,5 @@
 
 #import <Flutter/Flutter.h>
 
-@interface FLTSharedPreferencesPlugin : NSObject<FlutterPlugin>
+@interface FLTSharedPreferencesPlugin : NSObject <FlutterPlugin>
 @end

--- a/packages/shared_preferences/ios/Classes/SharedPreferencesPlugin.m
+++ b/packages/shared_preferences/ios/Classes/SharedPreferencesPlugin.m
@@ -9,8 +9,8 @@ static NSString *const CHANNEL_NAME = @"plugins.flutter.io/shared_preferences";
 @implementation FLTSharedPreferencesPlugin
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
-  FlutterMethodChannel *channel =
-      [FlutterMethodChannel methodChannelWithName:CHANNEL_NAME binaryMessenger:registrar.messenger];
+  FlutterMethodChannel *channel = [FlutterMethodChannel methodChannelWithName:CHANNEL_NAME
+                                                              binaryMessenger:registrar.messenger];
   [channel setMethodCallHandler:^(FlutterMethodCall *call, FlutterResult result) {
     NSString *method = [call method];
     NSDictionary *arguments = [call arguments];

--- a/packages/url_launcher/ios/Classes/UrlLauncherPlugin.h
+++ b/packages/url_launcher/ios/Classes/UrlLauncherPlugin.h
@@ -4,5 +4,5 @@
 
 #import <Flutter/Flutter.h>
 
-@interface FLTUrlLauncherPlugin : NSObject<FlutterPlugin>
+@interface FLTUrlLauncherPlugin : NSObject <FlutterPlugin>
 @end

--- a/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
+++ b/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
@@ -6,7 +6,7 @@
 
 #import "UrlLauncherPlugin.h"
 
-@interface FLTUrlLaunchSession : NSObject<SFSafariViewControllerDelegate>
+@interface FLTUrlLaunchSession : NSObject <SFSafariViewControllerDelegate>
 @end
 
 @implementation FLTUrlLaunchSession {
@@ -92,7 +92,7 @@
   UIApplication *application = [UIApplication sharedApplication];
   if ([application respondsToSelector:@selector(openURL:options:completionHandler:)]) {
     [application openURL:url
-        options:@{}
+                  options:@{}
         completionHandler:^(BOOL success) {
           if (success) {
             result(nil);

--- a/packages/video_player/ios/Classes/VideoPlayerPlugin.h
+++ b/packages/video_player/ios/Classes/VideoPlayerPlugin.h
@@ -4,5 +4,5 @@
 
 #import <Flutter/Flutter.h>
 
-@interface FLTVideoPlayerPlugin : NSObject<FlutterPlugin>
+@interface FLTVideoPlayerPlugin : NSObject <FlutterPlugin>
 @end

--- a/packages/video_player/ios/Classes/VideoPlayerPlugin.m
+++ b/packages/video_player/ios/Classes/VideoPlayerPlugin.m
@@ -26,7 +26,7 @@ int64_t FLTCMTimeToMillis(CMTime time) { return time.value * 1000 / time.timesca
 }
 @end
 
-@interface FLTVideoPlayer : NSObject<FlutterTexture, FlutterStreamHandler>
+@interface FLTVideoPlayer : NSObject <FlutterTexture, FlutterStreamHandler>
 @property(readonly, nonatomic) AVPlayer* player;
 @property(readonly, nonatomic) AVPlayerItemVideoOutput* videoOutput;
 @property(readonly, nonatomic) CADisplayLink* displayLink;
@@ -113,8 +113,8 @@ static void* playbackBufferFullContext = &playbackBufferFullContext;
         AVAssetTrack* videoTrack = [tracks objectAtIndex:0];
         void (^trackCompletionHandler)(void) = ^{
           if (_disposed) return;
-          if ([videoTrack statusOfValueForKey:@"preferredTransform" error:nil] ==
-              AVKeyValueStatusLoaded) {
+          if ([videoTrack statusOfValueForKey:@"preferredTransform"
+                                        error:nil] == AVKeyValueStatusLoaded) {
             dispatch_async(dispatch_get_main_queue(), ^{
               [_player replaceCurrentItemWithPlayerItem:item];
             });
@@ -126,8 +126,8 @@ static void* playbackBufferFullContext = &playbackBufferFullContext;
     }
   };
   [asset loadValuesAsynchronouslyForKeys:@[ @"tracks" ] completionHandler:assetCompletionHandler];
-  _displayLink =
-      [CADisplayLink displayLinkWithTarget:frameUpdater selector:@selector(onDisplayLink:)];
+  _displayLink = [CADisplayLink displayLinkWithTarget:frameUpdater
+                                             selector:@selector(onDisplayLink:)];
   [_displayLink addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
   _displayLink.paused = YES;
   return self;
@@ -352,7 +352,7 @@ static void* playbackBufferFullContext = &playbackBufferFullContext;
     [eventChannel setStreamHandler:player];
     player.eventChannel = eventChannel;
     _players[@(textureId)] = player;
-    result(@{ @"textureId" : @(textureId) });
+    result(@{@"textureId" : @(textureId)});
   } else {
     NSDictionary* argsMap = call.arguments;
     int64_t textureId = ((NSNumber*)argsMap[@"textureId"]).unsignedIntegerValue;

--- a/packages/webview_flutter/ios/Classes/FlutterWebView.h
+++ b/packages/webview_flutter/ios/Classes/FlutterWebView.h
@@ -3,7 +3,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface FLTWebViewController : NSObject<FlutterPlatformView>
+@interface FLTWebViewController : NSObject <FlutterPlatformView>
 
 - (instancetype)initWithWithFrame:(CGRect)frame
                    viewIdentifier:(int64_t)viewId
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (UIView*)view;
 @end
 
-@interface FLTWebViewFactory : NSObject<FlutterPlatformViewFactory>
+@interface FLTWebViewFactory : NSObject <FlutterPlatformViewFactory>
 - (instancetype)initWithMessenger:(NSObject<FlutterBinaryMessenger>*)messenger;
 @end
 

--- a/packages/webview_flutter/ios/Classes/WebViewFlutterPlugin.h
+++ b/packages/webview_flutter/ios/Classes/WebViewFlutterPlugin.h
@@ -4,5 +4,5 @@
 
 #import <Flutter/Flutter.h>
 
-@interface FLTWebviewFlutterPlugin : NSObject<FlutterPlugin>
+@interface FLTWebviewFlutterPlugin : NSObject <FlutterPlugin>
 @end


### PR DESCRIPTION
clang-format 5.0 formats ObjC files differently than newer versions, which results in the CI failing the format check for PRs formatted locally with a recent clang version.

The latest clang version available on the Ubuntu repositories for the Cirrus machines is 7, upgrading to that seems to be consistent with what I locally get with clang-format 8.0.

This PR also reformats all files with the new clang style.