### PR TITLE
Update location_background

### DIFF
--- a/packages/location_background/ios/Classes/LocationBackgroundPlugin.m
+++ b/packages/location_background/ios/Classes/LocationBackgroundPlugin.m
@@ -8,7 +8,7 @@
 
 @implementation LocationBackgroundPlugin {
   CLLocationManager *_locationManager;
-  FlutterEngine *_headlessRunner;
+  FlutterEngine *_headlessEngine;
   FlutterMethodChannel *_callbackChannel;
   FlutterMethodChannel *_mainChannel;
   NSObject<FlutterPluginRegistrar> *_registrar;
@@ -99,7 +99,7 @@ static LocationBackgroundPlugin *instance = nil;
   [_locationManager setDelegate:self];
   [_locationManager requestAlwaysAuthorization];
 
-  _headlessRunner =
+  _headlessEngine =
       [[FlutterEngine alloc] initWithName:@"io.flutter.plugins.location_background" project:nil];
   _registrar = registrar;
 
@@ -116,7 +116,7 @@ static LocationBackgroundPlugin *instance = nil;
   // `startHeadlessService` below.
   _callbackChannel = [FlutterMethodChannel
       methodChannelWithName:@"plugins.flutter.io/ios_background_location_callback"
-            binaryMessenger:_headlessRunner];
+            binaryMessenger:_headlessEngine];
   return self;
 }
 
@@ -181,7 +181,7 @@ static LocationBackgroundPlugin *instance = nil;
 
   // Here we actually launch the background isolate to start executing our
   // callback dispatcher, `_backgroundCallbackDispatcher`, in Dart.
-  [_headlessRunner runWithEntrypoint:entrypoint libraryURI:uri];
+  [_headlessEngine runWithEntrypoint:entrypoint libraryURI:uri];
 
   // The headless runner needs to be initialized before we can register it as a
   // MethodCallDelegate or else we get an illegal memory access. If we don't

--- a/packages/location_background/ios/Classes/LocationBackgroundPlugin.m
+++ b/packages/location_background/ios/Classes/LocationBackgroundPlugin.m
@@ -99,8 +99,8 @@ static LocationBackgroundPlugin *instance = nil;
   [_locationManager setDelegate:self];
   [_locationManager requestAlwaysAuthorization];
 
-  _headlessRunner = [[FlutterEngine alloc] initWithName:@"io.flutter.plugins.location_background"
-                                                project:nil];
+  _headlessRunner =
+      [[FlutterEngine alloc] initWithName:@"io.flutter.plugins.location_background" project:nil];
   _registrar = registrar;
 
   // This is the method channel used to communicate with the UI Isolate.

--- a/packages/location_background/ios/Classes/LocationBackgroundPlugin.m
+++ b/packages/location_background/ios/Classes/LocationBackgroundPlugin.m
@@ -8,7 +8,7 @@
 
 @implementation LocationBackgroundPlugin {
   CLLocationManager *_locationManager;
-  FlutterHeadlessDartRunner *_headlessRunner;
+  FlutterEngine *_headlessRunner;
   FlutterMethodChannel *_callbackChannel;
   FlutterMethodChannel *_mainChannel;
   NSObject<FlutterPluginRegistrar> *_registrar;
@@ -48,7 +48,9 @@ static LocationBackgroundPlugin *instance = nil;
       _locationManager.showsBackgroundLocationIndicator =
           [self getShowsBackgroundLocationIndicator];
     }
-    _locationManager.allowsBackgroundLocationUpdates = YES;
+    if (@available(iOS 9.0, *)) {
+      _locationManager.allowsBackgroundLocationUpdates = YES;
+    }
     // Finally, restart monitoring for location changes to get our location.
     [self->_locationManager startMonitoringSignificantLocationChanges];
   }
@@ -97,7 +99,8 @@ static LocationBackgroundPlugin *instance = nil;
   [_locationManager setDelegate:self];
   [_locationManager requestAlwaysAuthorization];
 
-  _headlessRunner = [[FlutterHeadlessDartRunner alloc] init];
+  _headlessRunner = [[FlutterEngine alloc] initWithName:@"io.flutter.plugins.location_background"
+                                                project:nil];
   _registrar = registrar;
 
   // This is the method channel used to communicate with the UI Isolate.
@@ -178,7 +181,7 @@ static LocationBackgroundPlugin *instance = nil;
 
   // Here we actually launch the background isolate to start executing our
   // callback dispatcher, `_backgroundCallbackDispatcher`, in Dart.
-  [_headlessRunner runWithEntrypointAndLibraryUri:entrypoint libraryUri:uri];
+  [_headlessRunner runWithEntrypoint:entrypoint libraryURI:uri];
 
   // The headless runner needs to be initialized before we can register it as a
   // MethodCallDelegate or else we get an illegal memory access. If we don't
@@ -194,12 +197,14 @@ static LocationBackgroundPlugin *instance = nil;
   _locationManager.pausesLocationUpdatesAutomatically = arguments[1];
   if (@available(iOS 11.0, *)) {
     _locationManager.showsBackgroundLocationIndicator = arguments[2];
+    [self setShowsBackgroundLocationIndicator:_locationManager.showsBackgroundLocationIndicator];
   }
   _locationManager.activityType = [arguments[3] integerValue];
-  _locationManager.allowsBackgroundLocationUpdates = YES;
+  if (@available(iOS 9.0, *)) {
+    _locationManager.allowsBackgroundLocationUpdates = YES;
+  }
 
   [self setPausesLocationUpdatesAutomatically:_locationManager.pausesLocationUpdatesAutomatically];
-  [self setShowsBackgroundLocationIndicator:_locationManager.showsBackgroundLocationIndicator];
   [self->_locationManager startMonitoringSignificantLocationChanges];
 }
 


### PR DESCRIPTION
FlutterHeadlessDartRunner is now deprecated and effectively a typedef for FlutterEngine.

One method got renamed.  This PR also adds some guards around API calls that need it.

This will have to be landed on red to fix the build.