### PR TITLE
Use context() instead of activity()

### DIFF
--- a/packages/device_info/android/src/main/java/io/flutter/plugins/deviceinfo/DeviceInfoPlugin.java
+++ b/packages/device_info/android/src/main/java/io/flutter/plugins/deviceinfo/DeviceInfoPlugin.java
@@ -30,7 +30,7 @@ public class DeviceInfoPlugin implements MethodCallHandler {
   public static void registerWith(Registrar registrar) {
     final MethodChannel channel =
         new MethodChannel(registrar.messenger(), "plugins.flutter.io/device_info");
-    channel.setMethodCallHandler(new DeviceInfoPlugin(registrar.activity()));
+    channel.setMethodCallHandler(new DeviceInfoPlugin(registrar.context()));
   }
 
   /** Do not allow direct instantiation. */


### PR DESCRIPTION
Using activity() causes a crash if the plugin is registered before the activity.

Fixes https://github.com/flutter/flutter/issues/24633