### PR TITLE
[android_alarm_manager] bump firebase_auth dependencies

### DIFF
--- a/packages/android_alarm_manager/CHANGELOG.md
+++ b/packages/android_alarm_manager/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.2
+* Update dependencies for example to point to published versions of firebase_auth
+
 ## 0.2.1
 * Update dependencies for example to point to published versions of firebase_auth
   and google_sign_in.

--- a/packages/android_alarm_manager/example/pubspec.yaml
+++ b/packages/android_alarm_manager/example/pubspec.yaml
@@ -6,8 +6,8 @@ dependencies:
     sdk: flutter
   android_alarm_manager:
     path: ../
-  firebase_auth: ^0.5.18
-  google_sign_in: ^3.0.4
+  firebase_auth: ^0.6.6
+  google_sign_in: ^3.2.4
 
 dev_dependencies:
   flutter_test:

--- a/packages/android_alarm_manager/pubspec.yaml
+++ b/packages/android_alarm_manager/pubspec.yaml
@@ -1,12 +1,12 @@
 name: android_alarm_manager
 description: Flutter plugin for accessing the Android AlarmManager service, and
   running Dart code in the background when alarms fire.
-version: 0.2.1
+version: 0.2.2
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/android_alarm_manager
 
 dependencies:
-  firebase_auth: ^0.5.18
+  firebase_auth: ^0.6.6
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
Update internal dependencies for alarm manager.
Looks like this is needed in order to get #917 to go green.