### PR TITLE
[firebase_auth] Fix codeAutoRetrievalTimeout callback never called (#22725)

### DIFF
--- a/packages/firebase_auth/lib/firebase_auth.dart
+++ b/packages/firebase_auth/lib/firebase_auth.dart
@@ -1025,7 +1025,7 @@ class FirebaseAuth {
       case 'phoneCodeAutoRetrievalTimeout':
         final int handle = call.arguments['handle'];
         final PhoneCodeAutoRetrievalTimeout codeAutoRetrievalTimeout =
-            _phoneAuthCallbacks[handle]['PhoneCodeAutoRetrievealTimeout'];
+            _phoneAuthCallbacks[handle]['PhoneCodeAutoRetrievalTimeout'];
         final String verificationId = call.arguments['verificationId'];
         codeAutoRetrievalTimeout(verificationId);
         break;


### PR DESCRIPTION
Fix misprint that caused codeAutoRetrievalTimeout callback never to be called.
Issue: https://github.com/flutter/flutter/issues/22725