### PR TITLE
Remove firebase_auth dependency from android_alarm_manager library and add initialize step to readme

### DIFF
--- a/packages/android_alarm_manager/README.md
+++ b/packages/android_alarm_manager/README.md
@@ -29,6 +29,7 @@ void printHello() {
 
 main() async {
   final int helloAlarmID = 0;
+  await AndroidAlarmManager.initialize();
   runApp(...);
   await AndroidAlarmManager.periodic(const Duration(minutes: 1), helloAlarmID, printHello);
 }

--- a/packages/android_alarm_manager/pubspec.yaml
+++ b/packages/android_alarm_manager/pubspec.yaml
@@ -6,7 +6,6 @@ author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/android_alarm_manager
 
 dependencies:
-  firebase_auth: ^0.6.6
   flutter:
     sdk: flutter
 

--- a/packages/android_alarm_manager/pubspec.yaml
+++ b/packages/android_alarm_manager/pubspec.yaml
@@ -9,6 +9,9 @@ dependencies:
   flutter:
     sdk: flutter
 
+dev_dependencies:
+  firebase_auth: ^0.6.6
+
 flutter:
   plugin:
     androidPackage: io.flutter.plugins.androidalarmmanager


### PR DESCRIPTION
The Android_Alarm_Manager-Plugin is not working for me because it has `firebase_auth` as a dependency, but the dependency seems to be not needed. It's only being used in the example, which has its own `pubspec.yaml` file.

In the readme, there was also the initialization for the plugin missing, which has now been added.