### PR TITLE
Bump google_maps_flutter version to 0.0.2 (pre release).

### DIFF
--- a/packages/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,3 @@
-## 0.0.1
+## 0.0.2
 
-* Initial release.
+* Initial developers preview release.

--- a/packages/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter
-version: 0.0.1
+version: 0.0.2
 
 dependencies:
   flutter:


### PR DESCRIPTION
Doing this to prevent confusion with the 0.0.1 google_maps_flutter package
which was accidentally published by a third-party.