### PR TITLE
Re-hook the Google Map callbacks on iOS(and some cleanups).

### DIFF
--- a/packages/google_maps_flutter/ios/Classes/GoogleMapController.h
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapController.h
@@ -6,15 +6,6 @@
 #import <GoogleMaps/GoogleMaps.h>
 #import "GoogleMapMarkerController.h"
 
-// Defines events to be sent to Flutter.
-@protocol FLTGoogleMapDelegate
-- (void)onCameraMoveStartedOnMap:(id)mapId gesture:(BOOL)gesture;
-- (void)onCameraMoveOnMap:(id)mapId cameraPosition:(GMSCameraPosition*)cameraPosition;
-- (void)onCameraIdleOnMap:(id)mapId;
-- (void)onMarkerTappedOnMap:(id)mapId marker:(NSString*)markerId;
-- (void)onInfoWindowTappedOnMap:(id)mapId marker:(NSString*)markerId;
-@end
-
 // Defines map UI options writable from Flutter.
 @protocol FLTGoogleMapOptionsSink
 - (void)setCamera:(GMSCameraPosition*)camera;
@@ -33,14 +24,11 @@
 // Defines map overlay controllable from Flutter.
 @interface FLTGoogleMapController
     : NSObject <GMSMapViewDelegate, FLTGoogleMapOptionsSink, FlutterPlatformView>
-@property(atomic) id<FLTGoogleMapDelegate> delegate;
 @property(atomic, readonly) id mapId;
 - (instancetype)initWithFrame:(CGRect)frame
                viewIdentifier:(int64_t)viewId
                     arguments:(id _Nullable)args
                     registrar:(NSObject<FlutterPluginRegistrar>*)registrar;
-- (void)addToView:(UIView*)view;
-- (void)removeFromView;
 - (void)showAtX:(CGFloat)x Y:(CGFloat)y;
 - (void)hide;
 - (void)animateWithCameraUpdate:(GMSCameraUpdate*)cameraUpdate;

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapController.m
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapController.m
@@ -75,6 +75,7 @@ static void interpretMarkerOptions(id json, id<FLTGoogleMapMarkerOptionsSink> si
         [weakSelf onMethodCall:call result:result];
       }
     }];
+    _mapView.delegate = weakSelf;
   }
   return self;
 }
@@ -116,17 +117,6 @@ static void interpretMarkerOptions(id json, id<FLTGoogleMapMarkerOptionsSink> si
   } else {
     result(FlutterMethodNotImplemented);
   }
-}
-
-- (void)addToView:(UIView*)view {
-  _mapView.hidden = YES;
-  _mapView.delegate = self;
-  [view addSubview:_mapView];
-}
-
-- (void)removeFromView {
-  [_mapView removeFromSuperview];
-  _mapView.delegate = nil;
 }
 
 - (void)showAtX:(CGFloat)x Y:(CGFloat)y {
@@ -224,29 +214,30 @@ static void interpretMarkerOptions(id json, id<FLTGoogleMapMarkerOptionsSink> si
 #pragma mark - GMSMapViewDelegate methods
 
 - (void)mapView:(GMSMapView*)mapView willMove:(BOOL)gesture {
-  [_delegate onCameraMoveStartedOnMap:_mapId gesture:gesture];
+  [_channel invokeMethod:@"camera#onMoveStarted" arguments:@{@"isGesture" : @(gesture)}];
 }
 
 - (void)mapView:(GMSMapView*)mapView didChangeCameraPosition:(GMSCameraPosition*)position {
   if (_trackCameraPosition) {
-    [_delegate onCameraMoveOnMap:_mapId cameraPosition:position];
+    [_channel invokeMethod:@"camera#onMove" arguments:@{@"position" : positionToJson(position)}];
   }
 }
 
 - (void)mapView:(GMSMapView*)mapView idleAtCameraPosition:(GMSCameraPosition*)position {
-  [_delegate onCameraIdleOnMap:_mapId];
+  [_channel invokeMethod:@"camera#onIdle" arguments:@{}];
 }
 
 - (BOOL)mapView:(GMSMapView*)mapView didTapMarker:(GMSMarker*)marker {
   NSString* markerId = marker.userData[0];
-  [_delegate onMarkerTappedOnMap:_mapId marker:markerId];
+  [_channel invokeMethod:@"marker#onTap" arguments:@{@"marker" : markerId}];
   return [marker.userData[1] boolValue];
 }
 
-- (void)mapView:(GMSMapView*)mapView didTapInfoWindow:(GMSMarker*)marker {
+- (void)mapView:(GMSMapView*)mapView didTapInfoWindowOfMarker:(GMSMarker*)marker {
   NSString* markerId = marker.userData[0];
-  [_delegate onInfoWindowTappedOnMap:_mapId marker:markerId];
+  [_channel invokeMethod:@"infoWindow#onTap" arguments:@{@"marker" : markerId}];
 }
+
 @end
 
 #pragma mark - Implementations of JSON conversion functions.

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapsPlugin.h
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapsPlugin.h
@@ -7,5 +7,5 @@
 #import "GoogleMapController.h"
 #import "GoogleMapMarkerController.h"
 
-@interface FLTGoogleMapsPlugin : NSObject <FlutterPlugin, FLTGoogleMapDelegate>
+@interface FLTGoogleMapsPlugin : NSObject <FlutterPlugin>
 @end


### PR DESCRIPTION
The refactoring in #892 left the callbacks defined in `FLTGoogleMapDelegate` unhooked.
Fixes flutter/flutter#24520.

This change also removes the `FLTGoogleMapDelegate` protocol, it was used to
delegate map callbacks from the map controller to `FLTGoogleMapsPlugin`
which was the owner of the only method channel. As we now have a method
channel per map controller there is no need for a delegate.

This also renames `didTapInfoWindow` to `didTapInfoWindowForMarker` in
`FLTGoogleMapController`. This was just a typo when the code was first
introduced, and fixes flutter/flutter#20178.

Additionally this change cleans up the no longer used `addToView` and
`removeFromView` method from `FLTGoogleMapController`. These were
used by the overlay-based implementation, in the `UiKitView`
implementation the view is added and removed by the Flutter Engine.