### PR TITLE
Remove unused map id fields.

### DIFF
--- a/packages/google_maps_flutter/ios/Classes/GoogleMapController.h
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapController.h
@@ -24,7 +24,6 @@
 // Defines map overlay controllable from Flutter.
 @interface FLTGoogleMapController
     : NSObject <GMSMapViewDelegate, FLTGoogleMapOptionsSink, FlutterPlatformView>
-@property(atomic, readonly) id mapId;
 - (instancetype)initWithFrame:(CGRect)frame
                viewIdentifier:(int64_t)viewId
                     arguments:(id _Nullable)args

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapController.m
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapController.m
@@ -4,8 +4,6 @@
 
 #import "GoogleMapController.h"
 
-static uint64_t _nextMapId = 0;
-
 #pragma mark - Conversion of JSON-like values sent via platform channels. Forward declarations.
 
 static id positionToJson(GMSCameraPosition* position);


### PR DESCRIPTION
These are remains from the overlay-based implementation.