### PR TITLE
Don't export dart:async by the Google Maps plugin.

### DIFF
--- a/packages/google_maps_flutter/lib/google_maps_flutter.dart
+++ b/packages/google_maps_flutter/lib/google_maps_flutter.dart
@@ -12,8 +12,6 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-export 'dart:async';
-
 part 'src/bitmap.dart';
 part 'src/callbacks.dart';
 part 'src/camera.dart';


### PR DESCRIPTION
This was done in #463, not sure why, but I don't think we should export
it (and it makes Dartdoc complain).