### PR TITLE
Bring back the google_maps_flutter pub badge.

### DIFF
--- a/packages/google_maps_flutter/README.md
+++ b/packages/google_maps_flutter/README.md
@@ -1,5 +1,6 @@
 # Google Maps for Flutter (Developers Preview)
 
+[![pub package](https://img.shields.io/pub/v/google_maps_flutter.svg)](https://pub.dartlang.org/packages/google_maps_flutter)
 
 A Flutter plugin that provides a [Google Maps](https://developers.google.com/maps/) widget.
 


### PR DESCRIPTION
This was temporarily removed in #925 while the plugin was accidentally
published by a third party.