### PR TITLE
Camera uses the device orientation on Android

### DIFF
--- a/packages/camera/CHANGELOG.md
+++ b/packages/camera/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.6
+
+* Update the camera to use the physical device's orientation instead of the UI
+  orientation on Android.
+
 ## 0.2.5
 
 * Fix preview and video size with satisfying conditions of multiple outputs.

--- a/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
+++ b/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
@@ -1,5 +1,7 @@
 package io.flutter.plugins.camera;
 
+import static android.view.OrientationEventListener.ORIENTATION_UNKNOWN;
+
 import android.Manifest;
 import android.app.Activity;
 import android.app.Application;
@@ -63,7 +65,7 @@ public class CameraPlugin implements MethodCallHandler {
   private Runnable cameraPermissionContinuation;
   private boolean requestingPermission;
   private final OrientationEventListener orientationEventListener;
-  private int currentOrientation;
+  private int currentOrientation = ORIENTATION_UNKNOWN;
 
   private CameraPlugin(Registrar registrar, FlutterView view, Activity activity) {
     this.registrar = registrar;
@@ -74,6 +76,9 @@ public class CameraPlugin implements MethodCallHandler {
         new OrientationEventListener(activity.getApplicationContext()) {
           @Override
           public void onOrientationChanged(int i) {
+            if (i == ORIENTATION_UNKNOWN) {
+              return;
+            }
             // Convert the raw deg angle to the nearest multiple of 90.
             currentOrientation = (int) Math.round(i / 90.0) * 90;
           }

--- a/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
+++ b/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
@@ -28,7 +28,6 @@ import android.util.Size;
 import android.view.Display;
 import android.view.OrientationEventListener;
 import android.view.Surface;
-
 import io.flutter.plugin.common.EventChannel;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
@@ -71,13 +70,14 @@ public class CameraPlugin implements MethodCallHandler {
     this.view = view;
     this.activity = activity;
 
-    orientationEventListener = new OrientationEventListener(activity.getApplicationContext()) {
-      @Override
-      public void onOrientationChanged(int i) {
-        // Convert the raw deg angle to the nearest multiple of 90.
-        currentOrientation = ((i + 45) / 90) * 90;
-      }
-    };
+    orientationEventListener =
+        new OrientationEventListener(activity.getApplicationContext()) {
+          @Override
+          public void onOrientationChanged(int i) {
+            // Convert the raw deg angle to the nearest multiple of 90.
+            currentOrientation = ((i + 45) / 90) * 90;
+          }
+        };
 
     registrar.addRequestPermissionsResultListener(new CameraRequestPermissionsListener());
 
@@ -445,7 +445,8 @@ public class CameraPlugin implements MethodCallHandler {
       mediaRecorder.setVideoSize(videoSize.getWidth(), videoSize.getHeight());
       mediaRecorder.setOutputFile(outputFilePath);
 
-      final int sensorOrientationOffset = (isFrontFacing) ? -currentOrientation : currentOrientation;
+      final int sensorOrientationOffset =
+          (isFrontFacing) ? -currentOrientation : currentOrientation;
       mediaRecorder.setOrientationHint((sensorOrientationOffset + sensorOrientation + 360) % 360);
 
       mediaRecorder.prepare();
@@ -572,9 +573,11 @@ public class CameraPlugin implements MethodCallHandler {
         captureBuilder.addTarget(imageReader.getSurface());
 
         // Set image orientation
-        final int sensorOrientationOffset = (isFrontFacing) ? -currentOrientation : currentOrientation;
+        final int sensorOrientationOffset =
+            (isFrontFacing) ? -currentOrientation : currentOrientation;
         captureBuilder.set(
-            CaptureRequest.JPEG_ORIENTATION, (sensorOrientationOffset + sensorOrientation + 360) % 360);
+            CaptureRequest.JPEG_ORIENTATION,
+            (sensorOrientationOffset + sensorOrientation + 360) % 360);
 
         cameraCaptureSession.capture(
             captureBuilder.build(),

--- a/packages/camera/pubspec.yaml
+++ b/packages/camera/pubspec.yaml
@@ -1,7 +1,7 @@
 name: camera
 description: A Flutter plugin for getting information about and controlling the
   camera on Android and iOS. Supports previewing the camera feed and capturing images.
-version: 0.2.5
+version: 0.2.6
 authors:
   - Flutter Team <flutter-dev@googlegroups.com>
   - Luigi Agosti <luigi@tengio.com>


### PR DESCRIPTION
Update the camera to use the physical device's orientation instead of
the UI orientation. Fixes issue where captured media is orientated to
match the screen UI at the time, instead of the actual device rotation.

Fixes flutter/flutter#18391