### PR TITLE
Keep a reference to the plugin registrar in `FLTGoogleMapController`.

### DIFF
--- a/packages/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 0.0.3+1
+
 * Bug fix: custom marker images were not working on iOS as we were not keeping
   a reference to the plugin registrar so couldn't fetch assets.
+
 ## 0.0.3
 
 * Don't export `dart:async`.

--- a/packages/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.0.3+1
+* Bug fix: custom marker images were not working on iOS as we were not keeping
+  a reference to the plugin registrar so couldn't fetch assets.
 ## 0.0.3
 
 * Don't export `dart:async`.

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapController.m
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapController.m
@@ -74,6 +74,7 @@ static void interpretMarkerOptions(id json, id<FLTGoogleMapMarkerOptionsSink> si
       }
     }];
     _mapView.delegate = weakSelf;
+    _registrar = registrar;
   }
   return self;
 }

--- a/packages/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter
-version: 0.0.3
+version: 0.0.3+1
 
 dependencies:
   flutter:
@@ -13,6 +13,7 @@ flutter:
     androidPackage: io.flutter.plugins.googlemaps
     iosPrefix: FLT
     pluginClass: GoogleMapsPlugin
+
 
 environment:
   sdk: ">=2.0.0-dev.47.0 <3.0.0"


### PR DESCRIPTION
The `_registrar` field was never set in `FLTGoogleMapController`.
This made asset lookup return nil in `interepretMapOptions` resulting in
custom marker images not working.