### PR TITLE
[google_maps_flutter] Relax Flutter version requirement to 0.11.9

### DIFF
--- a/packages/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.3+3
+
+* Relax Flutter version requirement to 0.11.9.
+
 ## 0.0.3+2
 
 * Update README to recommend using the package from pub.

--- a/packages/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter
-version: 0.0.3+2
+version: 0.0.3+3
 
 dependencies:
   flutter:
@@ -17,4 +17,4 @@ flutter:
 
 environment:
   sdk: ">=2.0.0-dev.47.0 <3.0.0"
-  flutter: ">=0.11.10 <2.0.0"
+  flutter: ">=0.11.9 <2.0.0"


### PR DESCRIPTION
This is the latest version currently available for pub health checks.
We should increase the requirement once pub updates its Flutter version
(to make sure we're running with the recent Skia texture fixes).