### PR TITLE
Fixes: 'webview_flutter/WebviewFlutterPlugin.h' file not found

### DIFF
--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.1+1
+
+* Fix case for "FLTWebViewFlutterPlugin" (iOS was failing to buld on case-sensitive file systems).
+
 ## 0.0.1
 
-* TODO: Describe initial release.
+* TODO: Initial release.

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/WebViewFlutterPlugin.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/WebViewFlutterPlugin.java
@@ -2,8 +2,8 @@ package io.flutter.plugins.webviewflutter;
 
 import io.flutter.plugin.common.PluginRegistry.Registrar;
 
-/** WebviewFlutterPlugin */
-public class WebviewFlutterPlugin {
+/** WebViewFlutterPlugin */
+public class WebViewFlutterPlugin {
   /** Plugin registration. */
   public static void registerWith(Registrar registrar) {
     registrar

--- a/packages/webview_flutter/ios/Classes/WebViewFlutterPlugin.h
+++ b/packages/webview_flutter/ios/Classes/WebViewFlutterPlugin.h
@@ -4,5 +4,5 @@
 
 #import <Flutter/Flutter.h>
 
-@interface FLTWebviewFlutterPlugin : NSObject <FlutterPlugin>
+@interface FLTWebViewFlutterPlugin : NSObject <FlutterPlugin>
 @end

--- a/packages/webview_flutter/ios/Classes/WebViewFlutterPlugin.m
+++ b/packages/webview_flutter/ios/Classes/WebViewFlutterPlugin.m
@@ -1,7 +1,7 @@
 #import "WebViewFlutterPlugin.h"
 #import "FlutterWebView.h"
 
-@implementation FLTWebviewFlutterPlugin
+@implementation FLTWebViewFlutterPlugin
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
   FLTWebViewFactory* webviewFactory =

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -20,4 +20,4 @@ flutter:
   plugin:
     androidPackage: io.flutter.plugins.webviewflutter
     iosPrefix: FLT
-    pluginClass: WebviewFlutterPlugin
+    pluginClass: WebViewFlutterPlugin

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webview_flutter
 description: A WebView Plugin for Flutter.
-version: 0.0.1
+version: 0.0.1+1
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/webview_flutter
 


### PR DESCRIPTION
iOS build was failing on case-sensitive filesystems as the plugin name "WebviewFlutter" didn't match the case of "WebViewFlutterPlugin.h".