### PR TITLE
Show https://flutter.io in the webview_flutter example.

### DIFF
--- a/packages/webview_flutter/example/lib/main.dart
+++ b/packages/webview_flutter/example/lib/main.dart
@@ -17,7 +17,7 @@ class WebViewExample extends StatelessWidget {
         actions: <Widget>[const SampleMenu()],
       ),
       body: const WebView(
-        initialUrl: 'https://youtube.com',
+        initialUrl: 'https://flutter.io',
         javaScriptMode: JavaScriptMode.unrestricted,
       ),
     );


### PR DESCRIPTION
It turns out on some devices loading the Youtube site in a webview
results in launching the Youtube app. The Flutter website serves as a
better example.