### PR TITLE
[video_player]add http headers option when loading network data source

### DIFF
--- a/packages/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -11,8 +11,8 @@ import android.content.Context;
 import android.media.AudioManager;
 import android.net.Uri;
 import android.os.Build;
-import android.view.Surface;
 import android.support.annotation.Nullable;
+import android.view.Surface;
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.ExoPlaybackException;
 import com.google.android.exoplayer2.ExoPlayerFactory;
@@ -33,9 +33,7 @@ import com.google.android.exoplayer2.trackselection.TrackSelector;
 import com.google.android.exoplayer2.upstream.DataSource;
 import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
 import com.google.android.exoplayer2.upstream.DefaultHttpDataSource;
-import com.google.android.exoplayer2.upstream.DefaultHttpDataSourceFactory;
 import com.google.android.exoplayer2.upstream.HttpDataSource.BaseFactory;
-import com.google.android.exoplayer2.upstream.HttpDataSource.Factory;
 import com.google.android.exoplayer2.upstream.HttpDataSource.RequestProperties;
 import com.google.android.exoplayer2.upstream.TransferListener;
 import com.google.android.exoplayer2.util.Util;
@@ -63,7 +61,6 @@ public class VideoPlayerPlugin implements MethodCallHandler {
     private final int connectTimeoutMillis;
     private final int readTimeoutMillis;
     private final boolean allowCrossProtocolRedirects;
-    
     private final Map<String, String> headers;
 
     public VideoPlayerHttpDataSourceFactory(
@@ -93,13 +90,13 @@ public class VideoPlayerPlugin implements MethodCallHandler {
         }
       }
       DefaultHttpDataSource dataSource =
-        new DefaultHttpDataSource(
-            userAgent,
-            /* contentTypePredicate= */ null,
-            connectTimeoutMillis,
-            readTimeoutMillis,
-            allowCrossProtocolRedirects,
-            defaultRequestProperties);
+          new DefaultHttpDataSource(
+              userAgent,
+              /* contentTypePredicate= */ null,
+              connectTimeoutMillis,
+              readTimeoutMillis,
+              allowCrossProtocolRedirects,
+              defaultRequestProperties);
       if (listener != null) {
         dataSource.addTransferListener(listener);
       }

--- a/packages/video_player/ios/Classes/VideoPlayerPlugin.m
+++ b/packages/video_player/ios/Classes/VideoPlayerPlugin.m
@@ -36,7 +36,9 @@ int64_t FLTCMTimeToMillis(CMTime time) { return time.value * 1000 / time.timesca
 @property(nonatomic, readonly) bool isPlaying;
 @property(nonatomic, readonly) bool isLooping;
 @property(nonatomic, readonly) bool isInitialized;
-- (instancetype)initWithURL:(NSURL*)url headers:(NSDictionary*)headers frameUpdater:(FLTFrameUpdater*)frameUpdater;
+- (instancetype)initWithURL:(NSURL*)url
+                    headers:(NSDictionary*)headers
+               frameUpdater:(FLTFrameUpdater*)frameUpdater;
 - (void)play;
 - (void)pause;
 - (void)setIsLooping:(bool)isLooping;

--- a/packages/video_player/ios/Classes/VideoPlayerPlugin.m
+++ b/packages/video_player/ios/Classes/VideoPlayerPlugin.m
@@ -36,7 +36,7 @@ int64_t FLTCMTimeToMillis(CMTime time) { return time.value * 1000 / time.timesca
 @property(nonatomic, readonly) bool isPlaying;
 @property(nonatomic, readonly) bool isLooping;
 @property(nonatomic, readonly) bool isInitialized;
-- (instancetype)initWithURL:(NSURL*)url frameUpdater:(FLTFrameUpdater*)frameUpdater;
+- (instancetype)initWithURL:(NSURL*)url headers:nil frameUpdater:(FLTFrameUpdater*)frameUpdater;
 - (void)play;
 - (void)pause;
 - (void)setIsLooping:(bool)isLooping;
@@ -55,7 +55,9 @@ static void* playbackBufferFullContext = &playbackBufferFullContext;
   return [self initWithURL:[NSURL fileURLWithPath:path] headers:nil frameUpdater:frameUpdater];
 }
 
-- (instancetype)initWithURL:(NSURL*)url headers:(NSDictionary*)headers frameUpdater:(FLTFrameUpdater*)frameUpdater {
+- (instancetype)initWithURL:(NSURL*)url
+                    headers:(NSDictionary*)headers
+               frameUpdater:(FLTFrameUpdater*)frameUpdater {
   self = [super init];
   NSAssert(self, @"super init cannot be nil");
   _isInitialized = false;
@@ -64,7 +66,8 @@ static void* playbackBufferFullContext = &playbackBufferFullContext;
 
   AVPlayerItem* item;
   if (headers) {
-    AVURLAsset * asset = [AVURLAsset URLAssetWithURL:url options:@{@"AVURLAssetHTTPHeaderFieldsKey" : headers}];
+    AVURLAsset* asset = [AVURLAsset URLAssetWithURL:url
+                                            options:@{@"AVURLAssetHTTPHeaderFieldsKey" : headers}];
     item = [AVPlayerItem playerItemWithAsset:asset];
   } else {
     item = [AVPlayerItem playerItemWithURL:url];
@@ -347,7 +350,8 @@ static void* playbackBufferFullContext = &playbackBufferFullContext;
     } else {
       dataSource = argsMap[@"uri"];
       NSDictionary* headers = argsMap[@"headers"];
-      player = [[FLTVideoPlayer alloc] initWithURL:[NSURL URLWithString:dataSource] headers:headers
+      player = [[FLTVideoPlayer alloc] initWithURL:[NSURL URLWithString:dataSource]
+                                           headers:headers
                                       frameUpdater:frameUpdater];
     }
     int64_t textureId = [_registry registerTexture:player];

--- a/packages/video_player/ios/Classes/VideoPlayerPlugin.m
+++ b/packages/video_player/ios/Classes/VideoPlayerPlugin.m
@@ -36,7 +36,7 @@ int64_t FLTCMTimeToMillis(CMTime time) { return time.value * 1000 / time.timesca
 @property(nonatomic, readonly) bool isPlaying;
 @property(nonatomic, readonly) bool isLooping;
 @property(nonatomic, readonly) bool isInitialized;
-- (instancetype)initWithURL:(NSURL*)url headers:nil frameUpdater:(FLTFrameUpdater*)frameUpdater;
+- (instancetype)initWithURL:(NSURL*)url headers:(NSDictionary*)headers frameUpdater:(FLTFrameUpdater*)frameUpdater;
 - (void)play;
 - (void)pause;
 - (void)setIsLooping:(bool)isLooping;

--- a/packages/video_player/lib/video_player.dart
+++ b/packages/video_player/lib/video_player.dart
@@ -148,6 +148,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   /// package and null otherwise.
   VideoPlayerController.asset(this.dataSource, {this.package})
       : dataSourceType = DataSourceType.asset,
+        headers = null,
         super(VideoPlayerValue(duration: null));
 
   /// Constructs a [VideoPlayerController] playing a video from obtained from
@@ -155,7 +156,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   ///
   /// The URI for the video is given by the [dataSource] argument and must not be
   /// null.
-  VideoPlayerController.network(this.dataSource)
+  VideoPlayerController.network(this.dataSource, {this.headers})
       : dataSourceType = DataSourceType.network,
         package = null,
         super(VideoPlayerValue(duration: null));
@@ -168,10 +169,12 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
       : dataSource = 'file://${file.path}',
         dataSourceType = DataSourceType.file,
         package = null,
+        headers = null,
         super(VideoPlayerValue(duration: null));
 
   int _textureId;
   final String dataSource;
+  final Map<String, String> headers;
 
   /// Describes the type of data source this [VideoPlayerController]
   /// is constructed with.
@@ -200,7 +203,10 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
         };
         break;
       case DataSourceType.network:
-        dataSourceDescription = <String, dynamic>{'uri': dataSource};
+        dataSourceDescription = <String, dynamic>{
+          'uri': dataSource,
+          'headers': headers
+        };
         break;
       case DataSourceType.file:
         dataSourceDescription = <String, dynamic>{'uri': dataSource};

--- a/packages/video_player/test/video_player_test.dart
+++ b/packages/video_player/test/video_player_test.dart
@@ -19,6 +19,8 @@ class FakeController extends ValueNotifier<VideoPlayerValue>
   @override
   String get dataSource => '';
   @override
+  Map<String, String> get headers => null;
+  @override
   DataSourceType get dataSourceType => DataSourceType.file;
   @override
   String get package => null;


### PR DESCRIPTION
I added optional request headers to VideoPlayerController.network contructor for video_player plugin. I did not see an obvious place to create a test for these changes, but happy to do so if you would like. I did manually test these changes on iOS and Android emulator. 