### PR TITLE
Make the description for webview_flutter longer.

### DIFF
--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -1,5 +1,5 @@
 name: webview_flutter
-description: A WebView Plugin for Flutter.
+description: A Flutter plugin that provides a WebView widget on Android and iOS.
 version: 0.0.1+1
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/webview_flutter


### PR DESCRIPTION
Apparently if the description is shorter than 60 characters you lose
maintaenance points on the pub website.