### PR TITLE
Fail call when trying to recover auth with backgrounded app

### DIFF
--- a/packages/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
+++ b/packages/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
@@ -36,8 +36,6 @@ import java.util.concurrent.Future;
 
 /** Google sign-in plugin for Flutter. */
 public class GoogleSignInPlugin implements MethodCallHandler {
-  private static final String TAG = "flutter";
-  
   private static final String CHANNEL_NAME = "plugins.flutter.io/google_sign_in";
 
   private static final String METHOD_INIT = "init";
@@ -473,8 +471,11 @@ public class GoogleSignInPlugin implements MethodCallHandler {
                   if (shouldRecoverAuth && pendingOperation == null) {
                     Activity activity = registrar.activity();
                     if (activity == null) {
-                      Log.w(TAG, "Cannot recover auth because app is not in foreground");
-                      result.error(ERROR_USER_RECOVERABLE_AUTH, e.getLocalizedMessage(), null);
+                      result.error(
+                          ERROR_USER_RECOVERABLE_AUTH,
+                          "Cannot recover auth because app is not in foreground. "
+                              + e.getLocalizedMessage(),
+                          null);
                     } else {
                       checkAndSetPendingOperation(METHOD_GET_TOKENS, result, email);
                       Intent recoveryIntent =


### PR DESCRIPTION
We noticed some Android (native) crashes in our application when we're trying to call the get token method when our app is in the background. This is easy to prevent by returning a failed result.