### PR TITLE
[path_provider] Android: Support multiple external storage options.

### DIFF
--- a/packages/path_provider/CHANGELOG.md
+++ b/packages/path_provider/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.2
+
+* Support Android devices with multiple external storage options.
+
 ## 0.4.1
 
 * Updated Gradle tooling to match Android Studio 3.1.2.

--- a/packages/path_provider/android/src/main/java/io/flutter/plugins/pathprovider/PathProviderPlugin.java
+++ b/packages/path_provider/android/src/main/java/io/flutter/plugins/pathprovider/PathProviderPlugin.java
@@ -4,6 +4,8 @@
 
 package io.flutter.plugins.pathprovider;
 
+import android.os.Build.VERSION;
+import android.os.Build.VERSION_CODES;
 import android.os.Environment;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
@@ -11,8 +13,12 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
 import io.flutter.util.PathUtils;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 public class PathProviderPlugin implements MethodCallHandler {
+
   private final Registrar mRegistrar;
 
   public static void registerWith(Registrar registrar) {
@@ -38,6 +44,13 @@ public class PathProviderPlugin implements MethodCallHandler {
       case "getStorageDirectory":
         result.success(getPathProviderStorageDirectory());
         break;
+      case "getExternalCacheDirectories":
+        result.success(getPathProviderExternalCacheDirectories());
+        break;
+      case "getExternalStorageDirectories":
+        final String type = call.argument("type");
+        result.success(getPathProviderExternalStorageDirectories(type));
+        break;
       default:
         result.notImplemented();
     }
@@ -53,5 +66,43 @@ public class PathProviderPlugin implements MethodCallHandler {
 
   private String getPathProviderStorageDirectory() {
     return Environment.getExternalStorageDirectory().getAbsolutePath();
+  }
+
+  private List<String> getPathProviderExternalCacheDirectories() {
+    final List<String> paths = new ArrayList<>();
+
+    if (VERSION.SDK_INT >= VERSION_CODES.KITKAT) {
+      for (File dir : mRegistrar.context().getExternalCacheDirs()) {
+        if (dir != null) {
+          paths.add(dir.getAbsolutePath());
+        }
+      }
+    } else {
+      File dir = mRegistrar.context().getExternalCacheDir();
+      if (dir != null) {
+        paths.add(dir.getAbsolutePath());
+      }
+    }
+
+    return paths;
+  }
+
+  private List<String> getPathProviderExternalStorageDirectories(String type) {
+    final List<String> paths = new ArrayList<>();
+
+    if (VERSION.SDK_INT >= VERSION_CODES.KITKAT) {
+      for (File dir : mRegistrar.context().getExternalFilesDirs(type)) {
+        if (dir != null) {
+          paths.add(dir.getAbsolutePath());
+        }
+      }
+    } else {
+      File dir = mRegistrar.context().getExternalFilesDir(type);
+      if (dir != null) {
+        paths.add(dir.getAbsolutePath());
+      }
+    }
+
+    return paths;
   }
 }

--- a/packages/path_provider/example/lib/main.dart
+++ b/packages/path_provider/example/lib/main.dart
@@ -37,6 +37,8 @@ class _MyHomePageState extends State<MyHomePage> {
   Future<Directory> _tempDirectory;
   Future<Directory> _appDocumentsDirectory;
   Future<Directory> _externalDocumentsDirectory;
+  Future<List<Directory>> _externalStorageDirectories;
+  Future<List<Directory>> _externalCacheDirectories;
 
   void _requestTempDirectory() {
     setState(() {
@@ -59,6 +61,23 @@ class _MyHomePageState extends State<MyHomePage> {
     return Padding(padding: const EdgeInsets.all(16.0), child: text);
   }
 
+  Widget _buildDirectories(
+      BuildContext context, AsyncSnapshot<List<Directory>> snapshot) {
+    Text text = const Text('');
+    if (snapshot.connectionState == ConnectionState.done) {
+      if (snapshot.hasError) {
+        text = Text('Error: ${snapshot.error}');
+      } else if (snapshot.hasData) {
+        final String combined =
+            snapshot.data.map((Directory d) => d.path).join(', ');
+        text = Text('paths: $combined');
+      } else {
+        text = const Text('path unavailable');
+      }
+    }
+    return Padding(padding: const EdgeInsets.all(16.0), child: text);
+  }
+
   void _requestAppDocumentsDirectory() {
     setState(() {
       _appDocumentsDirectory = getApplicationDocumentsDirectory();
@@ -71,13 +90,25 @@ class _MyHomePageState extends State<MyHomePage> {
     });
   }
 
+  void _requestExternalStorageDirectories(String type) {
+    setState(() {
+      _externalStorageDirectories = getExternalStorageDirectories(type);
+    });
+  }
+
+  void _requestExternalCacheDirectories() {
+    setState(() {
+      _externalCacheDirectories = getExternalCacheDirectories();
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         title: Text(widget.title),
       ),
-      body: Center(
+      body: SingleChildScrollView(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
           children: <Widget>[
@@ -92,10 +123,8 @@ class _MyHomePageState extends State<MyHomePage> {
                 ),
               ],
             ),
-            Expanded(
-              child: FutureBuilder<Directory>(
-                  future: _tempDirectory, builder: _buildDirectory),
-            ),
+            FutureBuilder<Directory>(
+                future: _tempDirectory, builder: _buildDirectory),
             Column(
               children: <Widget>[
                 Padding(
@@ -107,10 +136,8 @@ class _MyHomePageState extends State<MyHomePage> {
                 ),
               ],
             ),
-            Expanded(
-              child: FutureBuilder<Directory>(
-                  future: _appDocumentsDirectory, builder: _buildDirectory),
-            ),
+            FutureBuilder<Directory>(
+                future: _appDocumentsDirectory, builder: _buildDirectory),
             Column(children: <Widget>[
               Padding(
                 padding: const EdgeInsets.all(16.0),
@@ -122,11 +149,36 @@ class _MyHomePageState extends State<MyHomePage> {
                 ),
               ),
             ]),
-            Expanded(
-              child: FutureBuilder<Directory>(
-                  future: _externalDocumentsDirectory,
-                  builder: _buildDirectory),
-            ),
+            FutureBuilder<Directory>(
+                future: _externalDocumentsDirectory, builder: _buildDirectory),
+            Column(children: <Widget>[
+              Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: RaisedButton(
+                  child: Text(
+                      '${Platform.isIOS ? "External directories are unavailable " "on iOS" : "Get External Storage Directories"}'),
+                  onPressed: Platform.isIOS
+                      ? null
+                      : () => _requestExternalStorageDirectories(null),
+                ),
+              ),
+            ]),
+            FutureBuilder<List<Directory>>(
+                future: _externalStorageDirectories,
+                builder: _buildDirectories),
+            Column(children: <Widget>[
+              Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: RaisedButton(
+                  child: Text(
+                      '${Platform.isIOS ? "External directories are unavailable " "on iOS" : "Get External Cache Directories"}'),
+                  onPressed:
+                      Platform.isIOS ? null : _requestExternalCacheDirectories,
+                ),
+              ),
+            ]),
+            FutureBuilder<List<Directory>>(
+                future: _externalCacheDirectories, builder: _buildDirectories),
           ],
         ),
       ),

--- a/packages/path_provider/lib/path_provider.dart
+++ b/packages/path_provider/lib/path_provider.dart
@@ -61,3 +61,51 @@ Future<Directory> getExternalStorageDirectory() async {
   }
   return Directory(path);
 }
+
+/// Paths to directories where application specific cache data can be stored.
+/// These paths typically reside on external storage like separate partitions
+/// or SD cards. Phones may have multiple storage directories available.
+///
+/// The current operating system should be determined before issuing this
+/// function call, as this functionality is only available on Android.
+///
+/// On iOS, this function throws an UnsupportedError as it is not possible
+/// to access outside the app's sandbox.
+///
+/// On Android this returns Context.getExternalCacheDirs() or
+/// Context.getExternalCacheDir() on API levels below 19.
+Future<List<Directory>> getExternalCacheDirectories() async {
+  if (Platform.isIOS)
+    throw UnsupportedError("Functionality not available on iOS");
+  final List<dynamic> paths =
+      await _channel.invokeMethod('getExternalCacheDirectories');
+
+  return paths.map((dynamic path) => Directory(path)).toList();
+}
+
+/// Paths to directories where application specific data can be stored.
+/// These paths typically reside on external storage like separate partitions
+/// or SD cards. Phones may have multiple storage directories available.
+///
+/// The current operating system should be determined before issuing this
+/// function call, as this functionality is only available on Android.
+///
+/// On iOS, this function throws an UnsupportedError as it is not possible
+/// to access outside the app's sandbox.
+///
+/// The parameter type is optional. If it is set, it must be one of the
+/// "DIRECTORY" constants defined in `android.os.Environment`, e.g.
+/// https://developer.android.com/reference/android/os/Environment#DIRECTORY_MUSIC
+///
+/// On Android this returns Context.getExternalFilesDirs(String type) or
+/// Context.getExternalFilesDir(String type) on API levels below 19.
+Future<List<Directory>> getExternalStorageDirectories(String type) async {
+  if (Platform.isIOS)
+    throw UnsupportedError("Functionality not available on iOS");
+  final List<dynamic> paths = await _channel.invokeMethod(
+    'getExternalStorageDirectories',
+    <String, String>{"type": type},
+  );
+
+  return paths.map((dynamic path) => Directory(path)).toList();
+}

--- a/packages/path_provider/pubspec.yaml
+++ b/packages/path_provider/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for getting commonly used locations on the Android &
   iOS file systems, such as the temp and app data directories.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/path_provider
-version: 0.4.1
+version: 0.4.2
 
 flutter:
   plugin:


### PR DESCRIPTION
Most Android phones have, despite a single hardware storage, an internal/external partition layout.
Additionally, some phones support external SD cards for storing files.

Apps may store files onto the internal and external storage folders. For external storage, permissions can not be strongly enforced (hence Android's requirement for the WRITE_EXTERNAL_STORAGE permission) - yet if an App stores files into the app-specific folder, that folder can be cleaned up when an App is uninstalled.

The path_provider was missing 3 parts to work this out which have been addressed by the PR:
 1. Devices with multiple external storage options (like a Sony XZ performance w/ SD card) are now supported and developers can choose to store files on either storage option. 
 1. A direct link into the apps specific files & cache folders was missing, thus requiring developers to build it themselves. E.g. `/storage/emulated/0` is different than `/storage/emulated/0/Android/data/...`. Developers should by default use the latter because it should be cleaned up automatically by the Android system when an App is uninstalled
 1. The App specific folder actually supports standard folder types like `Music`, `Photos`, `Podcasts`. Developers can now request this type in the API.

Screenshot on Pixel 2:
<img src="https://user-images.githubusercontent.com/269860/49627305-1d72f680-fa19-11e8-8bb7-7b24c4e68bc8.png" width=300 />

Screenshot on Sony XZ performance w/ additional SD card inserted:
<img src="https://user-images.githubusercontent.com/269860/49627319-2a8fe580-fa19-11e8-8177-ece25a78d61c.png" width=300 />