### PR TITLE
Fix initialUrl null check for webview_flutter

### DIFF
--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0
+
+* Fix null crash when initialUrl is unset on iOS.
+
 ## 0.0.1+1
 
 * Fix case for "FLTWebViewFlutterPlugin" (iOS was failing to buld on case-sensitive file systems).

--- a/packages/webview_flutter/ios/Classes/FlutterWebView.m
+++ b/packages/webview_flutter/ios/Classes/FlutterWebView.m
@@ -50,8 +50,8 @@
     }];
     NSDictionary<NSString*, id>* settings = args[@"settings"];
     [self applySettings:settings];
-    NSString* initialUrl = [args[@"initialUrl"] isEqual:[NSNull null]] ? nil : args[@"initialUrl"];
-    if (initialUrl) {
+    NSString* initialUrl = args[@"initialUrl"];
+    if (initialUrl && initialUrl != [NSNull null]) {
       [self loadUrl:initialUrl];
     }
   }

--- a/packages/webview_flutter/ios/Classes/FlutterWebView.m
+++ b/packages/webview_flutter/ios/Classes/FlutterWebView.m
@@ -50,7 +50,7 @@
     }];
     NSDictionary<NSString*, id>* settings = args[@"settings"];
     [self applySettings:settings];
-    NSString* initialUrl = args[@"initialUrl"];
+    NSString* initialUrl = [args[@"initialUrl"] isEqual:[NSNull null]] ? nil : args[@"initialUrl"];
     if (initialUrl) {
       [self loadUrl:initialUrl];
     }

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
-version: 0.0.1+1
+version: 0.1.0
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/webview_flutter
 


### PR DESCRIPTION
If `initialUrl` is null or unspecified, it will be treated as `NSNull` (not `nil`) on objc and crash on calling `loadUrl`.
So. add checking `initialUrl` and convert `NSNull` to `nil`.
