### PR TITLE
[camera] Fix issue with crash when the physical device's orientation is unknown on Android.

### DIFF
--- a/packages/camera/CHANGELOG.md
+++ b/packages/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.7
+
+* Fix issue with crash when the physical device's orientation is unknown.
+
 ## 0.2.6
 
 * Update the camera to use the physical device's orientation instead of the UI

--- a/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
+++ b/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
@@ -767,8 +767,8 @@ public class CameraPlugin implements MethodCallHandler {
     }
 
     private int getMediaOrientation() {
-      final int sensorOrientationOffset =
-          (isFrontFacing) ? -currentOrientation : currentOrientation;
+      final int sensorOrientationOffset = (currentOrientation == ORIENTATION_UNKNOWN) ? 0
+          : (isFrontFacing) ? -currentOrientation : currentOrientation;
       return (sensorOrientationOffset + sensorOrientation + 360) % 360;
     }
   }

--- a/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
+++ b/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
@@ -767,8 +767,10 @@ public class CameraPlugin implements MethodCallHandler {
     }
 
     private int getMediaOrientation() {
-      final int sensorOrientationOffset = (currentOrientation == ORIENTATION_UNKNOWN) ? 0
-          : (isFrontFacing) ? -currentOrientation : currentOrientation;
+      final int sensorOrientationOffset =
+          (currentOrientation == ORIENTATION_UNKNOWN)
+              ? 0
+              : (isFrontFacing) ? -currentOrientation : currentOrientation;
       return (sensorOrientationOffset + sensorOrientation + 360) % 360;
     }
   }

--- a/packages/camera/pubspec.yaml
+++ b/packages/camera/pubspec.yaml
@@ -1,7 +1,7 @@
 name: camera
 description: A Flutter plugin for getting information about and controlling the
   camera on Android and iOS. Supports previewing the camera feed and capturing images.
-version: 0.2.6
+version: 0.2.7
 authors:
   - Flutter Team <flutter-dev@googlegroups.com>
   - Luigi Agosti <luigi@tengio.com>


### PR DESCRIPTION
This fixes https://github.com/flutter/flutter/issues/25105.

The error was caused by the following:

> In the plugin the currentOrientation property is set to the constant ORIENTATION_UNKNOWN by default, which results in -1. When your orientation updates, it is set to the actual value. The setOrientationHint function only accepts 0, 90, 180 and 270 as argument. When calculating the orientation it adds the 1 or -1 (depending on whether you are using the back or front camera). That resulted in 271, which isn't accepted and caused your error. 

Fixed it by checking the value in ``getMediaOrientation()``.  If the orientation is unknown, it will be set to 0. 