### PR TITLE
[cloud_functions]Adding error code because 'Code cannot be nil'

### DIFF
--- a/packages/cloud_functions/CHANGELOG.md
+++ b/packages/cloud_functions/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.5+1
+
+* Fix crash due to use of null error code when encountering generic errors.
+
 ## 0.0.5
 
 * Set iOS deployment target to 8.0 (minimum supported by both Firebase SDKs and Flutter), fixes compilation errors.

--- a/packages/cloud_functions/android/src/main/java/io/flutter/plugins/firebase/cloudfunctions/cloudfunctions/CloudFunctionsPlugin.java
+++ b/packages/cloud_functions/android/src/main/java/io/flutter/plugins/firebase/cloudfunctions/cloudfunctions/CloudFunctionsPlugin.java
@@ -57,7 +57,7 @@ public class CloudFunctionsPlugin implements MethodCallHandler {
                             exceptionMap);
                       } else {
                         Exception exception = task.getException();
-                        result.error(null, exception.getMessage(), null);
+                        result.error("genericError", exception.getMessage(), null);
                       }
                     }
                   }

--- a/packages/cloud_functions/ios/Classes/CloudFunctionsPlugin.m
+++ b/packages/cloud_functions/ios/Classes/CloudFunctionsPlugin.m
@@ -56,7 +56,7 @@
                                         message:@"Firebase function failed with exception."
                                         details:details];
               } else {
-                flutterError = [FlutterError errorWithCode:@"formattingError"
+                flutterError = [FlutterError errorWithCode:@"genericError"
                                                    message:error.localizedDescription
                                                    details:nil];
               }

--- a/packages/cloud_functions/ios/Classes/CloudFunctionsPlugin.m
+++ b/packages/cloud_functions/ios/Classes/CloudFunctionsPlugin.m
@@ -56,7 +56,7 @@
                                         message:@"Firebase function failed with exception."
                                         details:details];
               } else {
-                flutterError = [FlutterError errorWithCode:nil
+                flutterError = [FlutterError errorWithCode:@"formattingError"
                                                    message:error.localizedDescription
                                                    details:nil];
               }

--- a/packages/cloud_functions/pubspec.yaml
+++ b/packages/cloud_functions/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cloud_functions
 description: Flutter plugin for Cloud Functions.
-version: 0.0.5
+version: 0.0.5+1
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_functions
 


### PR DESCRIPTION
If the app reaches this line it crashes because FlutterError asserts a non-null code. On the dart side this is referred to as a. 'generic error', so that is what I'm naming the code. The localized description should describe what exactly went wrong.