### PR TITLE
[webview_flutter]Adding error message display on iOS WebView

### DIFF
--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.1.0+2
 
-* Add error display on iOS when failing to load.
+* Add error display on both iOS and Android when failing to load (e.g. due to 'ATS' on iOS or ssl error on Android).
 
 ## 0.1.0+1
 

--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0+2
+
+* Add error display on iOS when failing to load.
+
 ## 0.1.0+1
 
 * Fix null crash when initialUrl is unset on iOS.

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -1,8 +1,13 @@
 package io.flutter.plugins.webviewflutter;
 
 import android.content.Context;
+import android.net.http.SslError;
+import android.util.Log;
 import android.view.View;
+import android.webkit.SslErrorHandler;
 import android.webkit.WebView;
+import android.webkit.WebViewClient;
+
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
@@ -18,6 +23,7 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
   @SuppressWarnings("unchecked")
   FlutterWebView(Context context, BinaryMessenger messenger, int id, Map<String, Object> params) {
     webView = new WebView(context);
+    webView.setWebViewClient(new FlutterWebViewClient());
     if (params.containsKey("initialUrl")) {
       String url = (String) params.get("initialUrl");
       webView.loadUrl(url);
@@ -119,4 +125,12 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
 
   @Override
   public void dispose() {}
+}
+
+class FlutterWebViewClient extends WebViewClient {
+    @Override
+    public void onReceivedSslError(WebView view, SslErrorHandler handler, SslError error) {
+        super.onReceivedSslError(view, handler, error);
+        Log.e("webview_flutter",error.toString());
+    }
 }

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -7,7 +7,6 @@ import android.view.View;
 import android.webkit.SslErrorHandler;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
-
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
@@ -128,9 +127,9 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
 }
 
 class FlutterWebViewClient extends WebViewClient {
-    @Override
-    public void onReceivedSslError(WebView view, SslErrorHandler handler, SslError error) {
-        super.onReceivedSslError(view, handler, error);
-        Log.e("webview_flutter",error.toString());
-    }
+  @Override
+  public void onReceivedSslError(WebView view, SslErrorHandler handler, SslError error) {
+    super.onReceivedSslError(view, handler, error);
+    Log.e("webview_flutter", error.toString());
+  }
 }

--- a/packages/webview_flutter/ios/Classes/FlutterWebView.h
+++ b/packages/webview_flutter/ios/Classes/FlutterWebView.h
@@ -3,7 +3,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface FLTWebViewController : NSObject <FlutterPlatformView,WKNavigationDelegate>
+@interface FLTWebViewController : NSObject <FlutterPlatformView, WKNavigationDelegate>
 
 - (instancetype)initWithFrame:(CGRect)frame
                viewIdentifier:(int64_t)viewId

--- a/packages/webview_flutter/ios/Classes/FlutterWebView.h
+++ b/packages/webview_flutter/ios/Classes/FlutterWebView.h
@@ -3,7 +3,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface FLTWebViewController : NSObject <FlutterPlatformView>
+@interface FLTWebViewController : NSObject <FlutterPlatformView,WKNavigationDelegate>
 
 - (instancetype)initWithFrame:(CGRect)frame
                viewIdentifier:(int64_t)viewId

--- a/packages/webview_flutter/ios/Classes/FlutterWebView.m
+++ b/packages/webview_flutter/ios/Classes/FlutterWebView.m
@@ -153,16 +153,16 @@
 
 #pragma mark -
 #pragma mark WKNavigationDelegate
-- (void)webView:(WKWebView *)webView
-didFailNavigation:(WKNavigation *)navigation
-      withError:(NSError *)error{
-    NSLog(@"%@", error.description);
+- (void)webView:(WKWebView*)webView
+    didFailNavigation:(WKNavigation*)navigation
+            withError:(NSError*)error {
+  NSLog(@"%@", error.description);
 }
 
-- (void)webView:(WKWebView *)webView
-didFailProvisionalNavigation:(WKNavigation *)navigation
-      withError:(NSError *)error{
-    NSLog(@"%@", error.description);
+- (void)webView:(WKWebView*)webView
+    didFailProvisionalNavigation:(WKNavigation*)navigation
+                       withError:(NSError*)error {
+  NSLog(@"%@", error.description);
 }
 
 @end

--- a/packages/webview_flutter/ios/Classes/FlutterWebView.m
+++ b/packages/webview_flutter/ios/Classes/FlutterWebView.m
@@ -41,6 +41,7 @@
   if ([super init]) {
     _viewId = viewId;
     _webView = [[WKWebView alloc] initWithFrame:frame];
+    _webView.navigationDelegate = self;
     NSString* channelName = [NSString stringWithFormat:@"plugins.flutter.io/webview_%lld", viewId];
     _channel = [FlutterMethodChannel methodChannelWithName:channelName binaryMessenger:messenger];
     __weak __typeof__(self) weakSelf = self;
@@ -148,6 +149,20 @@
   NSURLRequest* req = [NSURLRequest requestWithURL:nsUrl];
   [_webView loadRequest:req];
   return true;
+}
+
+#pragma mark -
+#pragma mark WKNavigationDelegate
+- (void)webView:(WKWebView *)webView
+didFailNavigation:(WKNavigation *)navigation
+      withError:(NSError *)error{
+    NSLog(@"%@", error.description);
+}
+
+- (void)webView:(WKWebView *)webView
+didFailProvisionalNavigation:(WKNavigation *)navigation
+      withError:(NSError *)error{
+    NSLog(@"%@", error.description);
 }
 
 @end

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
-version: 0.1.0+1
+version: 0.1.0+2
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/webview_flutter
 


### PR DESCRIPTION
On iOS, when WebView failed to load web pages for some reasons(e.g. ['ATS' on iOS](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW33)),there is no process to show error messages to developers in the current version of 'webview_flutter' plugin.
I added error message display especially on iOS so that developers realize the reason why webview fails to load.