### PR TITLE
[google_maps_flutter]provide builder class for LatLngBounds

### DIFF
--- a/packages/google_maps_flutter/lib/src/location.dart
+++ b/packages/google_maps_flutter/lib/src/location.dart
@@ -49,6 +49,10 @@ class LatLng {
   int get hashCode => hashValues(latitude, longitude);
 }
 
+/// Provides a way for creating bounds based on a list of [Marker], provided
+/// through the method include.
+/// It will iterate through all the markers and retrieve a new instance of the
+/// class [LatLngBounds] with the southwest and northeast edges.
 class LatLngBoundsBuilder {
   List<LatLng> _positions = <LatLng>[];
 

--- a/packages/google_maps_flutter/lib/src/location.dart
+++ b/packages/google_maps_flutter/lib/src/location.dart
@@ -49,6 +49,39 @@ class LatLng {
   int get hashCode => hashValues(latitude, longitude);
 }
 
+class LatLngBoundsBuilder {
+  List<LatLng> _positions = <LatLng>[];
+
+  LatLngBoundsBuilder include(LatLng marker) {
+    _positions.add(marker);
+    return this;
+  }
+
+  LatLngBounds build() {
+    double south = double.negativeInfinity;
+    double west = double.negativeInfinity;
+    double north = double.maxFinite;
+    double east = double.maxFinite;
+
+    _positions.forEach((LatLng position) {
+      if (south == double.negativeInfinity || position.latitude < south) {
+        south = position.latitude;
+      }
+      if (west == double.negativeInfinity || position.longitude < west) {
+        west = position.longitude;
+      }
+      if (north == double.maxFinite || position.latitude > north) {
+        north = position.latitude;
+      }
+      if (east == double.maxFinite || position.longitude > east) {
+        east = position.longitude;
+      }
+    });
+    return LatLngBounds(
+        southwest: LatLng(south, west), northeast: LatLng(north, east));
+  }
+}
+
 /// A latitude/longitude aligned rectangle.
 ///
 /// The rectangle conceptually includes all points (lat, lng) where
@@ -72,6 +105,10 @@ class LatLngBounds {
 
   /// The northeast corner of the rectangle.
   final LatLng northeast;
+
+  static LatLngBoundsBuilder builder() {
+    return LatLngBoundsBuilder();
+  }
 
   dynamic _toList() {
     return <dynamic>[southwest._toJson(), northeast._toJson()];

--- a/packages/google_maps_flutter/test/google_map_test.dart
+++ b/packages/google_maps_flutter/test/google_map_test.dart
@@ -383,4 +383,18 @@ void main() {
 
     expect(platformGoogleMap.myLocationEnabled, true);
   });
+
+  test('build LatLngBounds', () async {
+    final LatLngBounds bounds = LatLngBoundsBuilder()
+        .include(const LatLng(1, 0))
+        .include(const LatLng(1, 1))
+        .include(const LatLng(0, 1))
+        .include(const LatLng(0, 0))
+        .build();
+
+    expect(
+        bounds,
+        LatLngBounds(
+            southwest: const LatLng(0, 0), northeast: const LatLng(1, 1)));
+  });
 }


### PR DESCRIPTION
Enable the creation of a LatLngBounds object from a list of LatLng instances.

Fixes https://github.com/flutter/flutter/issues/49728