### PR TITLE
[video_player]Update video_player docs: Add note about Java 8

### DIFF
--- a/packages/video_player/README.md
+++ b/packages/video_player/README.md
@@ -40,6 +40,18 @@ Ensure the following permission is present in your Android Manifest file, locate
 
 The Flutter project template adds it, so it may already be there.
 
+The Android ExoPlayer dependency requires Java 8 desugaring to be enabled. Ensure that this
+is .present in your Gradle configuration, located in `<project root>/android/app/build.gradle:
+
+```groovy
+android {
+    compileOptions {
+        sourceCompatibility 1.8
+        targetCompatibility 1.8
+    }
+}
+```
+
 ### Example
 
 ```dart


### PR DESCRIPTION
The current flutter template project in Android studio does not enable Java 8 desugaring by default, which causes a build error when trying to include the ExoPlayer dependency. This patch updates the installation instructions to reflect this.