### PR TITLE
fix https://github.com/flutter/flutter/issues/21863 image_picker: FATAL EXCEPTION when choosing an image from downloads

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,3 +22,4 @@ Thomas Danner <thmsdnnr@gmail.com>
 Diego Velásquez <diego.velasquez.lopez@gmail.com>
 Hajime Nakamura <nkmrhj@gmail.com>
 Tuyển Vũ Xuân <netsoft1985@gmail.com>
+TruongSinh Tran-Nguyen <i@truongsinh.pro>

--- a/packages/image_picker/android/build.gradle
+++ b/packages/image_picker/android/build.gradle
@@ -2,6 +2,7 @@ group 'io.flutter.plugins.imagepicker'
 version '1.0-SNAPSHOT'
 
 buildscript {
+    ext.kotlin_version = '1.3.11'
     repositories {
         google()
         jcenter()
@@ -9,6 +10,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
@@ -23,6 +25,7 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 27
@@ -38,4 +41,7 @@ android {
 
 dependencies {
     api 'com.android.support:support-v4:27.1.1'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-core:2.17.0'
 }

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
@@ -106,7 +106,7 @@ class FileUtils {
     return null;
   }
 
-  private static String getDataColumn(
+  protected static String getDataColumn(
       Context context, Uri uri, String selection, String[] selectionArgs) {
     Cursor cursor = null;
 

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
@@ -119,6 +119,8 @@ class FileUtils {
         final int column_index = cursor.getColumnIndexOrThrow(column);
         return cursor.getString(column_index);
       }
+    } catch (Exception e) {
+      // ignore
     } finally {
       if (cursor != null) {
         cursor.close();

--- a/packages/image_picker/android/src/test/java/io/flutter/plugins/imagepicker/FileUtilsTest.kt
+++ b/packages/image_picker/android/src/test/java/io/flutter/plugins/imagepicker/FileUtilsTest.kt
@@ -1,0 +1,14 @@
+package io.flutter.plugins.imagepicker
+
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class FileUtilsTest {
+
+	@Test
+	fun returnNullIfCannotGetCursor() {
+		val nullString = FileUtils.getDataColumn(null, null, null,null)
+		assertNull(nullString)
+	}
+
+}


### PR DESCRIPTION
fix https://github.com/flutter/flutter/issues/21863 image_picker: FATAL EXCEPTION when choosing an image from downloads. It's likely previous code author(s) forgot to catch exception.