### PR TITLE
[shared_preference]Adding an API to shared preference to reset the singleton instance in test

### DIFF
--- a/packages/shared_preferences/README.md
+++ b/packages/shared_preferences/README.md
@@ -8,11 +8,12 @@ Neither platform can guarantee that writes will be persisted to disk after
 returning and this plugin must not be used for storing critical data.
 
 ## Usage
+
 To use this plugin, add `shared_preferences` as a [dependency in your pubspec.yaml file](https://flutter.io/platform-plugins/).
 
 ### Example
 
-``` dart
+```dart
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -49,4 +50,12 @@ const MethodChannel('plugins.flutter.io/shared_preferences')
     }
     return null;
   });
+```
+
+You can reset `SharedPreferences` singleton instance by this code, so the value won't pollute other tests:
+
+```dart
+tearDown(() {
+  SharedPreferences.resetInstance();
+});
 ```

--- a/packages/shared_preferences/lib/shared_preferences.dart
+++ b/packages/shared_preferences/lib/shared_preferences.dart
@@ -150,4 +150,9 @@ class SharedPreferences {
       return null;
     });
   }
+
+  @visibleForTesting
+  static void resetInstance() {
+    _instance = null;
+  }
 }

--- a/packages/shared_preferences/test/shared_preferences_test.dart
+++ b/packages/shared_preferences/test/shared_preferences_test.dart
@@ -140,5 +140,11 @@ void main() {
       SharedPreferences.setMockInitialValues(kTestValues2);
       expect(await channel.invokeMethod('getAll'), kTestValues2);
     });
+
+    test('reset instance', () async {
+      SharedPreferences.resetInstance();
+      final newInstance = await SharedPreferences.getInstance();
+      expect(newInstance, isNot(same(preferences)));
+    });
   });
 }

--- a/packages/shared_preferences/test/shared_preferences_test.dart
+++ b/packages/shared_preferences/test/shared_preferences_test.dart
@@ -143,7 +143,8 @@ void main() {
 
     test('reset instance', () async {
       SharedPreferences.resetInstance();
-      final newInstance = await SharedPreferences.getInstance();
+      final SharedPreferences newInstance =
+          await SharedPreferences.getInstance();
       expect(newInstance, isNot(same(preferences)));
     });
   });


### PR DESCRIPTION
This PR is to fix https://github.com/flutter/flutter/issues/25407

Propose to to add API for test in sharedPreferences:
```dart
 @visibleForTesting
  static void resetSharedPreferences() {
       _instance = null;
  }
```
I'm writing on some test around my code wrapped around SharedPreferences.

I created a class that simulated the native side of the channel:

```dart
class FakeSharedPreferences {
  final Map<String, Object> data;

  FakeSharedPreferences(MethodChannel channel, this.data) {
    channel.setMockMethodCallHandler(handler);
  }

  Future<dynamic> handler(MethodCall methodCall) async {
    print("RPC: $methodCall");

    switch (methodCall.method) {
      case 'getAll':
        return data;
      case 'setString':
      case 'setStringList':
        data[methodCall.arguments['key']] = methodCall.arguments['value'];
        return true;
      case 'remove':
        data.remove(methodCall.arguments['key']);
        return true;
      case 'clear':
        data.clear();
        return true;
      default:
        print("Not implemented ${methodCall.method}");
    }
  }
}
```

I'll reset the fake class in every test, but I found my tests still failing due to the _instance singleton instance. It is so bad, that my different tests might heavily impact on each other. But it can be fixed quite easily