### PR TITLE
[camera]Fix Black Preview On Camera Open

### DIFF
--- a/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
+++ b/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
@@ -383,7 +383,7 @@ public class CameraPlugin implements MethodCallHandler {
       Display display = activity.getWindowManager().getDefaultDisplay();
       display.getRealSize(screenResolution);
 
-      // Camera sizes and minPreviewSize are both in landscape mode and
+      // Camera sizes and minPreviewSize are both in landscape mode so
       // screenResolution needs to be as well.
       final boolean swapWH = screenResolution.x < screenResolution.y;
       int screenWidth = swapWH ? screenResolution.y : screenResolution.x;

--- a/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
+++ b/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
@@ -385,7 +385,7 @@ public class CameraPlugin implements MethodCallHandler {
 
       // Camera sizes and minPreviewSize are both in landscape mode and
       // screenResolution needs to be as well.
-      final boolean swapWH = screenResolution.x < screeResolution.y;
+      final boolean swapWH = screenResolution.x < screenResolution.y;
       int screenWidth = swapWH ? screenResolution.y : screenResolution.x;
       int screenHeight = swapWH ? screenResolution.x : screenResolution.y;
 

--- a/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
+++ b/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
@@ -383,7 +383,9 @@ public class CameraPlugin implements MethodCallHandler {
       Display display = activity.getWindowManager().getDefaultDisplay();
       display.getRealSize(screenResolution);
 
-      final boolean swapWH = getMediaOrientation() % 180 == 90;
+      // Camera sizes and minPreviewSize are both in landscape mode and
+      // screenResolution needs to be as well.
+      final boolean swapWH = screenResolution.x < screeResolution.y;
       int screenWidth = swapWH ? screenResolution.y : screenResolution.x;
       int screenHeight = swapWH ? screenResolution.x : screenResolution.y;
 
@@ -393,12 +395,13 @@ public class CameraPlugin implements MethodCallHandler {
             && minPreviewSize.getHeight() < s.getHeight()
             && s.getWidth() <= screenWidth
             && s.getHeight() <= screenHeight
-            && s.getHeight() <= 1080) {
+            && (s.getHeight() <= 1080 || s.getWidth() <= 1080)) {
           goodEnough.add(s);
         }
       }
 
       Collections.sort(goodEnough, new CompareSizesByArea());
+      Collections.reverse(goodEnough);
 
       if (goodEnough.isEmpty()) {
         previewSize = sizes[0];

--- a/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
+++ b/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
@@ -401,7 +401,6 @@ public class CameraPlugin implements MethodCallHandler {
       }
 
       Collections.sort(goodEnough, new CompareSizesByArea());
-      Collections.reverse(goodEnough);
 
       if (goodEnough.isEmpty()) {
         previewSize = sizes[0];


### PR DESCRIPTION
minPreviewSize and camera sizes are in reported in landscape more. The screen size needs to be reported in landscape mode as well so that the constraints are more likely to be met. Otherwise it is very possible for the preview configuration to not be valid for the hardware and show a black preview.

Also using the highest resolution preview/camera that meets the size constraints.