### PR TITLE
closeWebView fixes for url_launcher

### DIFF
--- a/packages/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.0.2
+* Fixes `closeWebView` failure on iOS.
+
 ## 5.0.1
 
 * Log a more detailed warning at build time about the previous AndroidX

--- a/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
+++ b/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
@@ -45,6 +45,7 @@ API_AVAILABLE(ios(9.0))
 
 - (void)safariViewControllerDidFinish:(SFSafariViewController *)controller API_AVAILABLE(ios(9.0)) {
   [controller dismissViewControllerAnimated:YES completion:nil];
+	self.didFinish();
 }
 
 - (void)close {
@@ -148,12 +149,9 @@ API_AVAILABLE(ios(9.0))
   self.currentSession.didFinish = ^(void) {
       self->_currentSession = nil;
     };
-  __weak typeof(self) weakSelf = self;
   [self.viewController presentViewController:self.currentSession.safari
                                     animated:YES
-                                  completion:^void() {
-                                    weakSelf.currentSession = nil;
-                                  }];
+                                  completion:nil];
 }
 
 - (void)closeWebViewWithResult:(FlutterResult)result API_AVAILABLE(ios(9.0)) {

--- a/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
+++ b/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
@@ -45,7 +45,7 @@ API_AVAILABLE(ios(9.0))
 
 - (void)safariViewControllerDidFinish:(SFSafariViewController *)controller API_AVAILABLE(ios(9.0)) {
   [controller dismissViewControllerAnimated:YES completion:nil];
-	self.didFinish();
+  self.didFinish();
 }
 
 - (void)close {
@@ -147,8 +147,8 @@ API_AVAILABLE(ios(9.0))
   NSURL *url = [NSURL URLWithString:urlString];
   self.currentSession = [[FLTUrlLaunchSession alloc] initWithUrl:url withFlutterResult:result];
   self.currentSession.didFinish = ^(void) {
-      self->_currentSession = nil;
-    };
+    self->_currentSession = nil;
+  };
   [self.viewController presentViewController:self.currentSession.safari
                                     animated:YES
                                   completion:nil];

--- a/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
+++ b/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
@@ -146,8 +146,9 @@ API_AVAILABLE(ios(9.0))
 - (void)launchURLInVC:(NSString *)urlString result:(FlutterResult)result API_AVAILABLE(ios(9.0)) {
   NSURL *url = [NSURL URLWithString:urlString];
   self.currentSession = [[FLTUrlLaunchSession alloc] initWithUrl:url withFlutterResult:result];
+  __weak typeof(self) weakSelf = self;
   self.currentSession.didFinish = ^(void) {
-    self->_currentSession = nil;
+    weakSelf.currentSession = nil;
   };
   [self.viewController presentViewController:self.currentSession.safari
                                     animated:YES

--- a/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
+++ b/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
@@ -12,6 +12,7 @@ API_AVAILABLE(ios(9.0))
 @property(copy, nonatomic) FlutterResult flutterResult;
 @property(strong, nonatomic) NSURL *url;
 @property(strong, nonatomic) SFSafariViewController *safari;
+@property(nonatomic, copy) void (^didFinish)(void);
 
 @end
 
@@ -144,6 +145,9 @@ API_AVAILABLE(ios(9.0))
 - (void)launchURLInVC:(NSString *)urlString result:(FlutterResult)result API_AVAILABLE(ios(9.0)) {
   NSURL *url = [NSURL URLWithString:urlString];
   self.currentSession = [[FLTUrlLaunchSession alloc] initWithUrl:url withFlutterResult:result];
+  self.currentSession.didFinish = ^(void) {
+      self->_currentSession = nil;
+    };
   __weak typeof(self) weakSelf = self;
   [self.viewController presentViewController:self.currentSession.safari
                                     animated:YES

--- a/packages/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for launching a URL on Android and iOS. Supports
   web, phone, SMS, and email schemes.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher
-version: 5.0.1
+version: 5.0.2
 
 flutter:
   plugin:


### PR DESCRIPTION
Fixing some unnoticed issues from #924. Moved the deallocation of the `currentSession` object to a closure that is called when the Safari VC is dismissed. Now it is deallocated if the `closeWebView` function is called, or if the user manually dismissed the VC.

I didn't notice any Android issues while testing. I think sometimes the simulator can take a while to launch a Web View and if it takes longer than 5 seconds it appears like there is a bug, but it is working fine for me.