### PR TITLE
[cloud_functions]Add SocketTimeoutException for Cloud Functions

### DIFF
--- a/packages/cloud_functions/android/src/main/java/io/flutter/plugins/firebase/cloudfunctions/cloudfunctions/CloudFunctionsPlugin.java
+++ b/packages/cloud_functions/android/src/main/java/io/flutter/plugins/firebase/cloudfunctions/cloudfunctions/CloudFunctionsPlugin.java
@@ -5,14 +5,12 @@
 package io.flutter.plugins.firebase.cloudfunctions.cloudfunctions;
 
 import android.support.annotation.NonNull;
-
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.functions.FirebaseFunctions;
 import com.google.firebase.functions.FirebaseFunctionsException;
 import com.google.firebase.functions.HttpsCallableReference;
 import com.google.firebase.functions.HttpsCallableResult;
-
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
@@ -27,63 +25,63 @@ import java.util.Map;
  * CloudFunctionsPlugin
  */
 public class CloudFunctionsPlugin implements MethodCallHandler {
-    /**
-     * Plugin registration.
-     */
-    public static void registerWith(Registrar registrar) {
-        final MethodChannel channel = new MethodChannel(registrar.messenger(), "cloud_functions");
-        channel.setMethodCallHandler(new CloudFunctionsPlugin());
-    }
+ /**
+  * Plugin registration.
+  */
+ public static void registerWith(Registrar registrar) {
+  final MethodChannel channel = new MethodChannel(registrar.messenger(), "cloud_functions");
+  channel.setMethodCallHandler(new CloudFunctionsPlugin());
+ }
 
-    @Override
-    public void onMethodCall(MethodCall call, final Result result) {
-        switch (call.method) {
-            case "CloudFunctions#call":
-                String functionName = call.argument("functionName");
-                HttpsCallableReference httpsCallableReference =
-                        FirebaseFunctions.getInstance().getHttpsCallable(functionName);
-                Map<String, Object> parameters = call.argument("parameters");
-                httpsCallableReference
-                        .call(parameters)
-                        .addOnCompleteListener(
-                                new OnCompleteListener<HttpsCallableResult>() {
-                                    @Override
-                                    public void onComplete(@NonNull Task<HttpsCallableResult> task) {
-                                        if (task.isSuccessful()) {
-                                            result.success(task.getResult().getData());
-                                        } else {
-                                            if (task.getException() instanceof FirebaseFunctionsException) {
-                                                FirebaseFunctionsException exception =
-                                                        (FirebaseFunctionsException) task.getException();
-                                                Map<String, Object> exceptionMap = new HashMap<>();
-                                                exceptionMap.put("code", exception.getCode().name());
-                                                exceptionMap.put("message", exception.getMessage());
-                                                exceptionMap.put("details", exception.getDetails());
-                                                result.error(
-                                                        "functionsError",
-                                                        "Cloud function failed with exception.",
-                                                        exceptionMap);
-                                            } else if (task.getException() instanceof SocketTimeoutException) {
-                                                SocketTimeoutException exception =
-                                                        (SocketTimeoutException) task.getException();
-                                                Map<String, Object> exceptionMap = new HashMap<>();
-                                                exceptionMap.put("code", FirebaseFunctionsException.Code.DEADLINE_EXCEEDED.name());
-                                                exceptionMap.put("message", exception.getMessage());
-                                                exceptionMap.put("details", "SocketTimeoutException");
-                                                result.error(
-                                                        "functionsError",
-                                                        "Cloud function failed with exception.",
-                                                        exceptionMap);
-                                            } else {
-                                                Exception exception = task.getException();
-                                                result.error(null, exception.getMessage(), null);
-                                            }
-                                        }
-                                    }
-                                });
-                break;
-            default:
-                result.notImplemented();
+ @Override
+ public void onMethodCall(MethodCall call, final Result result) {
+  switch (call.method) {
+   case "CloudFunctions#call":
+    String functionName = call.argument("functionName");
+    HttpsCallableReference httpsCallableReference =
+     FirebaseFunctions.getInstance().getHttpsCallable(functionName);
+    Map < String, Object > parameters = call.argument("parameters");
+    httpsCallableReference
+     .call(parameters)
+     .addOnCompleteListener(
+      new OnCompleteListener < HttpsCallableResult > () {
+       @Override
+       public void onComplete(@NonNull Task < HttpsCallableResult > task) {
+        if (task.isSuccessful()) {
+         result.success(task.getResult().getData());
+        } else {
+         if (task.getException() instanceof FirebaseFunctionsException) {
+          FirebaseFunctionsException exception =
+           (FirebaseFunctionsException) task.getException();
+          Map < String, Object > exceptionMap = new HashMap < > ();
+          exceptionMap.put("code", exception.getCode().name());
+          exceptionMap.put("message", exception.getMessage());
+          exceptionMap.put("details", exception.getDetails());
+          result.error(
+           "functionsError",
+           "Cloud function failed with exception.",
+           exceptionMap);
+         } else if (task.getException() instanceof SocketTimeoutException) {
+          SocketTimeoutException exception =
+           (SocketTimeoutException) task.getException();
+          Map < String, Object > exceptionMap = new HashMap < > ();
+          exceptionMap.put("code", FirebaseFunctionsException.Code.DEADLINE_EXCEEDED.name());
+          exceptionMap.put("message", exception.getMessage());
+          exceptionMap.put("details", "SocketTimeoutException");
+          result.error(
+           "functionsError",
+           "Cloud function failed with exception.",
+           exceptionMap);
+         } else {
+          Exception exception = task.getException();
+          result.error(null, exception.getMessage(), null);
+         }
         }
-    }
+       }
+      });
+    break;
+   default:
+    result.notImplemented();
+  }
+ }
 }

--- a/packages/cloud_functions/android/src/main/java/io/flutter/plugins/firebase/cloudfunctions/cloudfunctions/CloudFunctionsPlugin.java
+++ b/packages/cloud_functions/android/src/main/java/io/flutter/plugins/firebase/cloudfunctions/cloudfunctions/CloudFunctionsPlugin.java
@@ -5,66 +5,85 @@
 package io.flutter.plugins.firebase.cloudfunctions.cloudfunctions;
 
 import android.support.annotation.NonNull;
+
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.functions.FirebaseFunctions;
 import com.google.firebase.functions.FirebaseFunctionsException;
 import com.google.firebase.functions.HttpsCallableReference;
 import com.google.firebase.functions.HttpsCallableResult;
+
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
+
+import java.net.SocketTimeoutException;
 import java.util.HashMap;
 import java.util.Map;
 
-/** CloudFunctionsPlugin */
+/**
+ * CloudFunctionsPlugin
+ */
 public class CloudFunctionsPlugin implements MethodCallHandler {
-  /** Plugin registration. */
-  public static void registerWith(Registrar registrar) {
-    final MethodChannel channel = new MethodChannel(registrar.messenger(), "cloud_functions");
-    channel.setMethodCallHandler(new CloudFunctionsPlugin());
-  }
-
-  @Override
-  public void onMethodCall(MethodCall call, final Result result) {
-    switch (call.method) {
-      case "CloudFunctions#call":
-        String functionName = call.argument("functionName");
-        HttpsCallableReference httpsCallableReference =
-            FirebaseFunctions.getInstance().getHttpsCallable(functionName);
-        Map<String, Object> parameters = call.argument("parameters");
-        httpsCallableReference
-            .call(parameters)
-            .addOnCompleteListener(
-                new OnCompleteListener<HttpsCallableResult>() {
-                  @Override
-                  public void onComplete(@NonNull Task<HttpsCallableResult> task) {
-                    if (task.isSuccessful()) {
-                      result.success(task.getResult().getData());
-                    } else {
-                      if (task.getException() instanceof FirebaseFunctionsException) {
-                        FirebaseFunctionsException exception =
-                            (FirebaseFunctionsException) task.getException();
-                        Map<String, Object> exceptionMap = new HashMap<>();
-                        exceptionMap.put("code", exception.getCode().name());
-                        exceptionMap.put("message", exception.getMessage());
-                        exceptionMap.put("details", exception.getDetails());
-                        result.error(
-                            "functionsError",
-                            "Cloud function failed with exception.",
-                            exceptionMap);
-                      } else {
-                        Exception exception = task.getException();
-                        result.error(null, exception.getMessage(), null);
-                      }
-                    }
-                  }
-                });
-        break;
-      default:
-        result.notImplemented();
+    /**
+     * Plugin registration.
+     */
+    public static void registerWith(Registrar registrar) {
+        final MethodChannel channel = new MethodChannel(registrar.messenger(), "cloud_functions");
+        channel.setMethodCallHandler(new CloudFunctionsPlugin());
     }
-  }
+
+    @Override
+    public void onMethodCall(MethodCall call, final Result result) {
+        switch (call.method) {
+            case "CloudFunctions#call":
+                String functionName = call.argument("functionName");
+                HttpsCallableReference httpsCallableReference =
+                        FirebaseFunctions.getInstance().getHttpsCallable(functionName);
+                Map<String, Object> parameters = call.argument("parameters");
+                httpsCallableReference
+                        .call(parameters)
+                        .addOnCompleteListener(
+                                new OnCompleteListener<HttpsCallableResult>() {
+                                    @Override
+                                    public void onComplete(@NonNull Task<HttpsCallableResult> task) {
+                                        if (task.isSuccessful()) {
+                                            result.success(task.getResult().getData());
+                                        } else {
+                                            if (task.getException() instanceof FirebaseFunctionsException) {
+                                                FirebaseFunctionsException exception =
+                                                        (FirebaseFunctionsException) task.getException();
+                                                Map<String, Object> exceptionMap = new HashMap<>();
+                                                exceptionMap.put("code", exception.getCode().name());
+                                                exceptionMap.put("message", exception.getMessage());
+                                                exceptionMap.put("details", exception.getDetails());
+                                                result.error(
+                                                        "functionsError",
+                                                        "Cloud function failed with exception.",
+                                                        exceptionMap);
+                                            } else if (task.getException() instanceof SocketTimeoutException) {
+                                                SocketTimeoutException exception =
+                                                        (SocketTimeoutException) task.getException();
+                                                Map<String, Object> exceptionMap = new HashMap<>();
+                                                exceptionMap.put("code", FirebaseFunctionsException.Code.DEADLINE_EXCEEDED.name());
+                                                exceptionMap.put("message", exception.getMessage());
+                                                exceptionMap.put("details", "SocketTimeoutException");
+                                                result.error(
+                                                        "functionsError",
+                                                        "Cloud function failed with exception.",
+                                                        exceptionMap);
+                                            } else {
+                                                Exception exception = task.getException();
+                                                result.error(null, exception.getMessage(), null);
+                                            }
+                                        }
+                                    }
+                                });
+                break;
+            default:
+                result.notImplemented();
+        }
+    }
 }


### PR DESCRIPTION
On android, usually much sooner than firebase timeout, socket timeout exception occurs. This is not handled properly and invalid format envelope exception is thrown. Exception is not handled and whole call is interrupted as non handled dart exception.

https://github.com/pulyaevskiy/firebase-functions-interop/issues/43
https://github.com/flutter/flutter/issues/24997