### PR TITLE
Use video_player.dart

### DIFF
--- a/packages/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
+++ b/packages/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
@@ -36,8 +36,6 @@ import java.util.concurrent.Future;
 
 /** Google sign-in plugin for Flutter. */
 public class GoogleSignInPlugin implements MethodCallHandler {
-  private static final String TAG = "flutter";
-  
   private static final String CHANNEL_NAME = "plugins.flutter.io/google_sign_in";
 
   private static final String METHOD_INIT = "init";
@@ -473,8 +471,11 @@ public class GoogleSignInPlugin implements MethodCallHandler {
                   if (shouldRecoverAuth && pendingOperation == null) {
                     Activity activity = registrar.activity();
                     if (activity == null) {
-                      Log.w(TAG, "Cannot recover auth because app is not in foreground");
-                      result.error(ERROR_USER_RECOVERABLE_AUTH, e.getLocalizedMessage(), null);
+                      result.error(
+                          ERROR_USER_RECOVERABLE_AUTH,
+                          "Cannot recover auth because app is not in foreground. "
+                              + e.getLocalizedMessage(),
+                          null);
                     } else {
                       checkAndSetPendingOperation(METHOD_GET_TOKENS, result, email);
                       Intent recoveryIntent =


### PR DESCRIPTION
Use example URL:https://www.sample-videos.com/video123/mp4/360/big_buck_bunny_360p_10mb.mp4 is ok
But use localhost URL: http://127.0.0.1:8080/reborn/bbb.mp4

```
I/ExoPlayerImpl(21741): Init d92617a [ExoPlayerLib/2.8.0] [generic_x86, Android SDK built for x86, Google, 28]
I/ExoPlayerImpl(21741): Init 551b46 [ExoPlayerLib/2.8.0] [generic_x86, Android SDK built for x86, Google, 28]
I/ExoPlayerImpl(21741): Release 41017be [ExoPlayerLib/2.8.0] [generic_x86, Android SDK built for x86, Google, 28] [goog.exo.core]
I/ExoPlayerImpl(21741): Release efa1f6c [ExoPlayerLib/2.8.0] [generic_x86, Android SDK built for x86, Google, 28] [goog.exo.core]
I/ExoPlayerImpl(21741): Release 551b46 [ExoPlayerLib/2.8.0] [generic_x86, Android SDK built for x86, Google, 28] [goog.exo.core]
E/ExoPlayerImplInternal(21741): Source error.
E/ExoPlayerImplInternal(21741): com.google.android.exoplayer2.upstream.HttpDataSource$HttpDataSourceException: Unable to connect to http://127.0.0.1:8080/reborn/bbb.mp4
E/ExoPlayerImplInternal(21741): 	at com.google.android.exoplayer2.upstream.DefaultHttpDataSource.open(DefaultHttpDataSource.java:194)
E/ExoPlayerImplInternal(21741): 	at com.google.android.exoplayer2.source.ExtractorMediaPeriod$ExtractingLoadable.load(ExtractorMediaPeriod.java:848)
E/ExoPlayerImplInternal(21741): 	at com.google.android.exoplayer2.upstream.Loader$LoadTask.run(Loader.java:317)
E/ExoPlayerImplInternal(21741): 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
E/ExoPlayerImplInternal(21741): 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
E/ExoPlayerImplInternal(21741): 	at java.lang.Thread.run(Thread.java:764)
E/ExoPlayerImplInternal(21741): Caused by: java.net.ConnectException: Failed to connect to /127.0.0.1:8080
E/ExoPlayerImplInternal(21741): 	at com.android.okhttp.internal.io.RealConnection.connectSocket(RealConnection.java:143)
E/ExoPlayerImplInternal(21741): 	at com.android.okhttp.internal.io.RealConnection.connect(RealConnection.java:112)
E/ExoPlayerImplInternal(21741): 	at com.android.okhttp.internal.http.StreamAllocation.findConnection(StreamAllocation.java:184)
E/ExoPlayerImplInternal(21741): 	at com.android.okhttp.internal.http.StreamAllocation.findHealthyConnection(StreamAllocation.java:126)
E/ExoPlayerImplInternal(21741): 	at com.android.okhttp.internal.http.StreamAllocation.newStream(StreamAllocation.java:95)
E/ExoPlayerImplInternal(21741): 	at com.android.okhttp.internal.http.HttpEngine.connect(HttpEngine.java:281)
E/ExoPlayerImplInternal(21741): 	at com.android.okhttp.internal.http.HttpEngine.sendRequest(HttpEngine.java:224)
E/ExoPlayerImplInternal(21741): 	at com.android.okhttp.internal.huc.HttpURLConnectionImpl.execute(HttpURLConnectionImpl.java:461)
E/ExoPlayerImplInternal(21741): 	at com.android.okhttp.internal.huc.HttpURLConnectionImpl.connect(HttpURLConnectionImpl.java:127)
E/ExoPlayerImplInternal(21741): 	at com.google.android.exoplayer2.upstream.DefaultHttpDataSource.makeConnection(DefaultHttpDataSource.java:429)
E/ExoPlayerImplInternal(21741): 	at com.google.android.exoplayer2.upstream.DefaultHttpDataSource.makeConnection(DefaultHttpDataSource.java:356)
E/ExoPlayerImplInternal(21741): 	at com.google.android.exoplayer2.upstream.DefaultHttpDataSource.open(DefaultHttpDataSource.java:192)
E/ExoPlayerImplInternal(21741): 	... 5 more
I/flutter (21741): Video player had error com.google.android.exoplayer2.ExoPlaybackException


```

It's normal to use chrome access