### PR TITLE
Fix crash when choosing image from downloads on Android using image_picker

### DIFF
--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
@@ -38,9 +38,9 @@ import java.io.OutputStream;
 class FileUtils {
 
   private static final String[] DOWNLOAD_CONTENT_URI_PREFIXES = {
-          "content://downloads/public_downloads",
-          "content://downloads/my_downloads",
-          "content://downloads/all_downloads"
+    "content://downloads/public_downloads",
+    "content://downloads/my_downloads",
+    "content://downloads/all_downloads"
   };
 
   String getPathFromUri(final Context context, final Uri uri) {
@@ -71,12 +71,12 @@ class FileUtils {
           for (String contentUriPrefix : DOWNLOAD_CONTENT_URI_PREFIXES) {
             try {
               final Uri contentUri =
-                      ContentUris.withAppendedId(
-                              Uri.parse(contentUriPrefix), Long.valueOf(id));
+                  ContentUris.withAppendedId(Uri.parse(contentUriPrefix), Long.valueOf(id));
               return getDataColumn(context, contentUri, null, null);
             } catch (NumberFormatException e) {
               return null;
-            } catch (Exception e){}
+            } catch (Exception e) {
+            }
           }
         }
 

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
@@ -37,6 +37,12 @@ import java.io.OutputStream;
 
 class FileUtils {
 
+  private static final String[] DOWNLOAD_CONTENT_URI_PREFIXES = {
+          "content://downloads/public_downloads",
+          "content://downloads/my_downloads",
+          "content://downloads/all_downloads"
+  };
+
   String getPathFromUri(final Context context, final Uri uri) {
     String path = getPathFromLocalUri(context, uri);
     if (path == null) {
@@ -62,13 +68,15 @@ class FileUtils {
         final String id = DocumentsContract.getDocumentId(uri);
 
         if (!TextUtils.isEmpty(id)) {
-          try {
-            final Uri contentUri =
-                ContentUris.withAppendedId(
-                    Uri.parse("content://downloads/public_downloads"), Long.valueOf(id));
-            return getDataColumn(context, contentUri, null, null);
-          } catch (NumberFormatException e) {
-            return null;
+          for (String contentUriPrefix : DOWNLOAD_CONTENT_URI_PREFIXES) {
+            try {
+              final Uri contentUri =
+                      ContentUris.withAppendedId(
+                              Uri.parse(contentUriPrefix), Long.valueOf(id));
+              return getDataColumn(context, contentUri, null, null);
+            } catch (NumberFormatException e) {
+              return null;
+            } catch (Exception e){}
           }
         }
 


### PR DESCRIPTION
### Fix for:
https://github.com/flutter/flutter/issues/21863

### Changes:
- The content uri `content://downloads/public_downloads` doesn't always work, so need to check other options too.
- Added three options `public_downloads`, `my_downloads`, `all_downloads` that will be checked after which the method returns `null`.
- Added a catch for `Exception` class, because IllegalArgumentException is thrown for this case

Please refer https://stackoverflow.com/questions/30671548/unknown-url-content-downloads-my-downloads as the changes I've done are almost identical to the solution to this answer. 

### Testing:
- Tested on Android emulator 9.0 (was crashing before this change)
- OnePlus 5T 8.1.1 (was crashing before this change)

