### PR TITLE
[firebase_messaging]Added modern iOS notification types 

### DIFF
--- a/packages/firebase_messaging/example/lib/main.dart
+++ b/packages/firebase_messaging/example/lib/main.dart
@@ -152,7 +152,14 @@ class _PushMessagingExampleState extends State<PushMessagingExample> {
       },
     );
     _firebaseMessaging.requestNotificationPermissions(
-        const IosNotificationSettings(sound: true, badge: true, alert: true));
+        const IosNotificationSettings(
+            sound: true,
+            badge: true,
+            alert: true,
+            provisional: false,
+            carPlay: false,
+            notificationSetting: false,
+            criticalAlert: false));
     _firebaseMessaging.onIosSettingsRegistered
         .listen((IosNotificationSettings settings) {
       print("Settings registered: $settings");

--- a/packages/firebase_messaging/ios/Classes/FirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/ios/Classes/FirebaseMessagingPlugin.m
@@ -263,7 +263,7 @@
 // UNUserNotificationCenter with completion handler is used instead
 #else
 - (void)application:(UIApplication *)application
-    didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings API_UNAVAILABLE(ios(10)) {
+    didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings {
 
     [_channel invokeMethod:@"onIosSettingsRegistered"
                arguments:[self notificationTypeStringRepresentation: notificationSettings.types]];

--- a/packages/firebase_messaging/ios/Classes/FirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/ios/Classes/FirebaseMessagingPlugin.m
@@ -38,11 +38,19 @@
     _resumingFromBackground = NO;
       
      if (@available(iOS 10, *)) {
-        _authorizationOptions = @{
-                              @"sound": @(UNAuthorizationOptionSound),
-                              @"alert": @(UNAuthorizationOptionAlert),
-                              @"badge": @(UNAuthorizationOptionBadge)
-                              };
+         NSMutableDictionary<NSString*, NSNumber*> *authOptions =
+         [[NSMutableDictionary<NSString*, NSNumber*> alloc] initWithDictionary: @{@"sound": @(UNAuthorizationOptionSound),
+                                                                                  @"alert": @(UNAuthorizationOptionAlert),
+                                                                                  @"badge": @(UNAuthorizationOptionBadge),
+                                                                                  @"carPlay": @(UNAuthorizationOptionCarPlay),
+                                                                                  }];
+         if (@available(iOS 12, *)) {
+             authOptions[@"provisional"] = @(UNAuthorizationOptionProvisional);
+             authOptions[@"criticalAlert"] = @(UNAuthorizationOptionCriticalAlert);
+             authOptions[@"notificationSetting"] = @(UNAuthorizationOptionProvidesAppNotificationSettings);
+         }
+         
+         _authorizationOptions = [authOptions copy];
      } else {
          _authorizationOptions = @{
                                    @"sound" : @(UIUserNotificationTypeSound),

--- a/packages/firebase_messaging/ios/Classes/FirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/ios/Classes/FirebaseMessagingPlugin.m
@@ -15,9 +15,9 @@
   FlutterMethodChannel *_channel;
   NSDictionary *_launchNotification;
   BOOL _resumingFromBackground;
-    
+
   /// used for UNAuthorizationOptions(>= iOS 10) or older UIUserNotificationTypes(< iOS 10)
-  NSDictionary<NSString*, NSNumber*> *_authorizationOptions;
+  NSDictionary<NSString *, NSNumber *> *_authorizationOptions;
 }
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
@@ -36,29 +36,31 @@
   if (self) {
     _channel = channel;
     _resumingFromBackground = NO;
-      
-     if (@available(iOS 10, *)) {
-         NSMutableDictionary<NSString*, NSNumber*> *authOptions =
-         [[NSMutableDictionary<NSString*, NSNumber*> alloc] initWithDictionary: @{@"sound": @(UNAuthorizationOptionSound),
-                                                                                  @"alert": @(UNAuthorizationOptionAlert),
-                                                                                  @"badge": @(UNAuthorizationOptionBadge),
-                                                                                  @"carPlay": @(UNAuthorizationOptionCarPlay),
-                                                                                  }];
-         if (@available(iOS 12, *)) {
-             authOptions[@"provisional"] = @(UNAuthorizationOptionProvisional);
-             authOptions[@"criticalAlert"] = @(UNAuthorizationOptionCriticalAlert);
-             authOptions[@"notificationSetting"] = @(UNAuthorizationOptionProvidesAppNotificationSettings);
-         }
-         
-         _authorizationOptions = [authOptions copy];
-     } else {
-         _authorizationOptions = @{
-                                   @"sound" : @(UIUserNotificationTypeSound),
-                                   @"badge" : @(UIUserNotificationTypeBadge),
-                                   @"alert" : @(UIUserNotificationTypeAlert)
-                                   };
-     }
-      
+
+    if (@available(iOS 10, *)) {
+      NSMutableDictionary<NSString *, NSNumber *> *authOptions =
+          [[NSMutableDictionary<NSString *, NSNumber *> alloc] initWithDictionary:@{
+            @"sound" : @(UNAuthorizationOptionSound),
+            @"alert" : @(UNAuthorizationOptionAlert),
+            @"badge" : @(UNAuthorizationOptionBadge),
+            @"carPlay" : @(UNAuthorizationOptionCarPlay),
+          }];
+      if (@available(iOS 12, *)) {
+        authOptions[@"provisional"] = @(UNAuthorizationOptionProvisional);
+        authOptions[@"criticalAlert"] = @(UNAuthorizationOptionCriticalAlert);
+        authOptions[@"notificationSetting"] =
+            @(UNAuthorizationOptionProvidesAppNotificationSettings);
+      }
+
+      _authorizationOptions = [authOptions copy];
+    } else {
+      _authorizationOptions = @{
+        @"sound" : @(UIUserNotificationTypeSound),
+        @"badge" : @(UIUserNotificationTypeBadge),
+        @"alert" : @(UIUserNotificationTypeAlert)
+      };
+    }
+
     if (![FIRApp defaultApp]) {
       [FIRApp configure];
     }
@@ -70,7 +72,7 @@
 - (void)handleMethodCall:(FlutterMethodCall *)call result:(FlutterResult)result {
   NSString *method = call.method;
   if ([@"requestNotificationPermissions" isEqualToString:method]) {
-      [self requestNotificationPermissions:call result:result];
+    [self requestNotificationPermissions:call result:result];
   } else if ([@"configure" isEqualToString:method]) {
     [[UIApplication sharedApplication] registerForRemoteNotifications];
     if (_launchNotification != nil) {
@@ -119,77 +121,95 @@
 }
 
 - (void)requestNotificationPermissions:(FlutterMethodCall *)call result:(FlutterResult)result {
-    NSDictionary *arguments = call.arguments;
-    
-    if (@available(iOS 10, *)) {
-      UNAuthorizationOptions authorizationOptions = [self mapAuthorizationOptions:arguments];
-      [UNUserNotificationCenter.currentNotificationCenter
-       requestAuthorizationWithOptions: authorizationOptions
-       completionHandler:^(BOOL granted, NSError * _Nullable error) {
-           
-        if (granted) {
-          [self->_channel invokeMethod:@"onIosSettingsRegistered"
-                             arguments:[self authorizationOptionsStringRepresentation: authorizationOptions]];
-          } else {
-               // there is no callback for failed notification permission requests
-          }
+  NSDictionary *arguments = call.arguments;
 
-          result(nil);
-       }];
-    } else {
-      UIUserNotificationSettings *settings = [UIUserNotificationSettings
-                                              settingsForTypes:[self mapNotificationTypes:arguments]
-                                              categories:nil];
-      [[UIApplication sharedApplication] registerUserNotificationSettings:settings];
-        
-      result(nil);
+  if (@available(iOS 10, *)) {
+    UNAuthorizationOptions authorizationOptions = [self mapAuthorizationOptions:arguments];
+    [UNUserNotificationCenter.currentNotificationCenter
+        requestAuthorizationWithOptions:authorizationOptions
+                      completionHandler:^(BOOL granted, NSError *_Nullable error) {
+                        if (granted) {
+                          [self->_channel
+                              invokeMethod:@"onIosSettingsRegistered"
+                                 arguments:[self authorizationOptionsStringRepresentation:
+                                                     authorizationOptions]];
+                        } else {
+                          // there is no callback for failed notification permission requests
+                        }
+
+                        result(nil);
+                      }];
+  } else {
+    UIUserNotificationSettings *settings =
+        [UIUserNotificationSettings settingsForTypes:[self mapNotificationTypes:arguments]
+                                          categories:nil];
+    [[UIApplication sharedApplication] registerUserNotificationSettings:settings];
+
+    result(nil);
   }
 }
 
-- (NSDictionary *)authorizationOptionsStringRepresentation:(UNAuthorizationOptions)options API_AVAILABLE(ios(10)) {
-    __block NSMutableDictionary<NSString*, NSNumber*> *authorizationOptionsDic = [[NSMutableDictionary<NSString*, NSNumber*> alloc] initWithCapacity:_authorizationOptions.allKeys.count];
-    
-    [_authorizationOptions enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull authOptionKey, NSNumber * _Nonnull authOption, BOOL * _Nonnull stop) {
-        authorizationOptionsDic[authOptionKey] = [NSNumber numberWithBool: options & authOption.unsignedIntegerValue];
-    }];
-    
-    return [authorizationOptionsDic copy];
+- (NSDictionary *)authorizationOptionsStringRepresentation:(UNAuthorizationOptions)options
+    API_AVAILABLE(ios(10)) {
+  __block NSMutableDictionary<NSString *, NSNumber *> *authorizationOptionsDic =
+      [[NSMutableDictionary<NSString *, NSNumber *> alloc]
+          initWithCapacity:_authorizationOptions.allKeys.count];
+
+  [_authorizationOptions
+      enumerateKeysAndObjectsUsingBlock:^(NSString *_Nonnull authOptionKey,
+                                          NSNumber *_Nonnull authOption, BOOL *_Nonnull stop) {
+        authorizationOptionsDic[authOptionKey] =
+            [NSNumber numberWithBool:options & authOption.unsignedIntegerValue];
+      }];
+
+  return [authorizationOptionsDic copy];
 }
 
-- (NSDictionary<NSString*, NSNumber*> *)notificationTypeStringRepresentation:(UIUserNotificationType)notificationTypes {
-    __block NSMutableDictionary<NSString*, NSNumber*> *notificationTypeDic = [[NSMutableDictionary<NSString*, NSNumber*> alloc] initWithCapacity:_authorizationOptions.allKeys.count];
+- (NSDictionary<NSString *, NSNumber *> *)notificationTypeStringRepresentation:
+    (UIUserNotificationType)notificationTypes {
+  __block NSMutableDictionary<NSString *, NSNumber *> *notificationTypeDic =
+      [[NSMutableDictionary<NSString *, NSNumber *> alloc]
+          initWithCapacity:_authorizationOptions.allKeys.count];
 
-    [_authorizationOptions enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull notificationTypeKey, NSNumber * _Nonnull notificationType, BOOL * _Nonnull stop) {
-        // notificationTypeDic[notificationTypeKey] = @(notificationTypes & notificationType.unsignedIntegerValue);
-        notificationTypeDic[notificationTypeKey] = [NSNumber numberWithBool: notificationTypes & notificationType.unsignedIntegerValue];
+  [_authorizationOptions enumerateKeysAndObjectsUsingBlock:^(NSString *_Nonnull notificationTypeKey,
+                                                             NSNumber *_Nonnull notificationType,
+                                                             BOOL *_Nonnull stop) {
+    // notificationTypeDic[notificationTypeKey] = @(notificationTypes &
+    // notificationType.unsignedIntegerValue);
+    notificationTypeDic[notificationTypeKey] =
+        [NSNumber numberWithBool:notificationTypes & notificationType.unsignedIntegerValue];
+  }];
 
-    }];
-
-    return [notificationTypeDic copy];
+  return [notificationTypeDic copy];
 }
 
 - (UIUserNotificationType)mapNotificationTypes:(nullable NSDictionary *)arguments {
-    __block UIUserNotificationType notificationTypes = 0;
+  __block UIUserNotificationType notificationTypes = 0;
 
-    [_authorizationOptions enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull notificationTypeKey, NSNumber * _Nonnull notificationType, BOOL * _Nonnull stop) {
-      if ([arguments[notificationTypeKey] boolValue]) {
-        notificationTypes |= notificationType.unsignedIntegerValue;
-      }
-    }];
+  [_authorizationOptions enumerateKeysAndObjectsUsingBlock:^(NSString *_Nonnull notificationTypeKey,
+                                                             NSNumber *_Nonnull notificationType,
+                                                             BOOL *_Nonnull stop) {
+    if ([arguments[notificationTypeKey] boolValue]) {
+      notificationTypes |= notificationType.unsignedIntegerValue;
+    }
+  }];
 
-    return notificationTypes;
+  return notificationTypes;
 }
 
-- (UNAuthorizationOptions)mapAuthorizationOptions:(nullable NSDictionary *)arguments API_AVAILABLE(ios(10)) {
-    __block UNAuthorizationOptions options = 0;
-    
-    [_authorizationOptions enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull authOptionKey, NSNumber * _Nonnull authOption, BOOL * _Nonnull stop) {
-      if ([arguments[authOptionKey] boolValue]) {
-        options |= authOption.unsignedIntegerValue;
-      }
-    }];
-    
-    return options;
+- (UNAuthorizationOptions)mapAuthorizationOptions:(nullable NSDictionary *)arguments
+    API_AVAILABLE(ios(10)) {
+  __block UNAuthorizationOptions options = 0;
+
+  [_authorizationOptions
+      enumerateKeysAndObjectsUsingBlock:^(NSString *_Nonnull authOptionKey,
+                                          NSNumber *_Nonnull authOption, BOOL *_Nonnull stop) {
+        if ([arguments[authOptionKey] boolValue]) {
+          options |= authOption.unsignedIntegerValue;
+        }
+      }];
+
+  return options;
 }
 
 #if defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
@@ -264,9 +284,8 @@
 #else
 - (void)application:(UIApplication *)application
     didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings {
-
-    [_channel invokeMethod:@"onIosSettingsRegistered"
-               arguments:[self notificationTypeStringRepresentation: notificationSettings.types]];
+  [_channel invokeMethod:@"onIosSettingsRegistered"
+               arguments:[self notificationTypeStringRepresentation:notificationSettings.types]];
 }
 #endif
 

--- a/packages/firebase_messaging/lib/firebase_messaging.dart
+++ b/packages/firebase_messaging/lib/firebase_messaging.dart
@@ -141,20 +141,40 @@ class IosNotificationSettings {
     this.sound = true,
     this.alert = true,
     this.badge = true,
+    this.provisional = false,
+    this.carPlay = false,
+    this.criticalAlert = false,
+    this.notificationSetting = false,
   });
 
   IosNotificationSettings._fromMap(Map<String, bool> settings)
       : sound = settings['sound'],
         alert = settings['alert'],
-        badge = settings['badge'];
+        badge = settings['badge'],
+        provisional = settings['provisional'],
+        carPlay = settings['carPlay'],
+        criticalAlert = settings['criticalAlert'],
+        notificationSetting = settings['notificationSetting'];
 
   final bool sound;
   final bool alert;
   final bool badge;
+  final bool provisional;
+  final bool carPlay;
+  final bool criticalAlert;
+  final bool notificationSetting;
 
   @visibleForTesting
   Map<String, dynamic> toMap() {
-    return <String, bool>{'sound': sound, 'alert': alert, 'badge': badge};
+    return <String, bool>{
+      'sound': sound,
+      'alert': alert,
+      'badge': badge,
+      'provisional': provisional,
+      'carPlay': carPlay,
+      'criticalAlert': criticalAlert,
+      'notificationSetting': notificationSetting,
+    };
   }
 
   @override

--- a/packages/firebase_messaging/test/firebase_messaging_test.dart
+++ b/packages/firebase_messaging/test/firebase_messaging_test.dart
@@ -22,15 +22,31 @@ void main() {
 
   test('requestNotificationPermissions on ios with default permissions', () {
     firebaseMessaging.requestNotificationPermissions();
-    verify(mockChannel.invokeMethod('requestNotificationPermissions',
-        <String, bool>{'sound': true, 'badge': true, 'alert': true}));
+    verify(mockChannel
+        .invokeMethod('requestNotificationPermissions', <String, bool>{
+      'sound': true,
+      'badge': true,
+      'alert': true,
+      'provisional': false,
+      'carPlay': false,
+      'criticalAlert': false,
+      'notificationSetting': false
+    }));
   });
 
   test('requestNotificationPermissions on ios with custom permissions', () {
     firebaseMessaging.requestNotificationPermissions(
-        const IosNotificationSettings(sound: false));
-    verify(mockChannel.invokeMethod('requestNotificationPermissions',
-        <String, bool>{'sound': false, 'badge': true, 'alert': true}));
+        const IosNotificationSettings(sound: false, provisional: true));
+    verify(mockChannel
+        .invokeMethod('requestNotificationPermissions', <String, bool>{
+      'sound': false,
+      'badge': true,
+      'alert': true,
+      'provisional': true,
+      'carPlay': false,
+      'criticalAlert': false,
+      'notificationSetting': false
+    }));
   });
 
   test('requestNotificationPermissions on android', () {


### PR DESCRIPTION
New authorization options (formerly known as `UIUserNotificationType`) have been provided by apple with iOS10 and iOS12: 
`provisional` (aka: silent notification), `criticalAlert`, `notificationSetting` and `carPlay`

This pull request intends to be backwards compatible until iOS8. Registering of any `UIUserNotificationType` or `UNAuthorizationOptions` is possible, if the operating system supports it.

A basic implementation of `UNUserNotificationCenter` for iOS10+ was necessary to request permission for these new types.