### PR TITLE
[url_launcher]fix issue #25721 url_launcher: reset _currentSession only at end of browsing instead of after VC display

### DIFF
--- a/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
+++ b/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
@@ -13,15 +13,17 @@
 @implementation FLTUrlLaunchSession {
   NSURL *_url;
   FlutterResult _flutterResult;
+  void (^_completion)();
 }
 
-- (instancetype)initWithUrl:url withFlutterResult:result {
+- (instancetype)initWithUrl:url withFlutterResult:result completion:completion {
   self = [super init];
   if (self) {
     _url = url;
     _flutterResult = result;
     _safari = [[SFSafariViewController alloc] initWithURL:url];
     _safari.delegate = self;
+    _completion = completion;
   }
   return self;
 }
@@ -39,7 +41,7 @@
 }
 
 - (void)safariViewControllerDidFinish:(SFSafariViewController *)controller {
-  [controller dismissViewControllerAnimated:YES completion:nil];
+  [controller dismissViewControllerAnimated:YES completion:_completion];
 }
 
 - (void)close {
@@ -127,12 +129,14 @@
 
 - (void)launchURLInVC:(NSString *)urlString result:(FlutterResult)result {
   NSURL *url = [NSURL URLWithString:urlString];
-  _currentSession = [[FLTUrlLaunchSession alloc] initWithUrl:url withFlutterResult:result];
+  _currentSession = [[FLTUrlLaunchSession alloc] initWithUrl:url
+                                           withFlutterResult:result
+                                                  completion:^void() {
+                                                    self->_currentSession = nil;
+                                                  }];
   [_viewController presentViewController:_currentSession.safari
                                 animated:YES
-                              completion:^void() {
-                                self->_currentSession = nil;
-                              }];
+                              completion:nil];
 }
 
 - (void)closeWebView:(NSString *)urlString result:(FlutterResult)result {

--- a/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
+++ b/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
@@ -134,9 +134,7 @@
                                                   completion:^void() {
                                                     self->_currentSession = nil;
                                                   }];
-  [_viewController presentViewController:_currentSession.safari
-                                animated:YES
-                              completion:nil];
+  [_viewController presentViewController:_currentSession.safari animated:YES completion:nil];
 }
 
 - (void)closeWebView:(NSString *)urlString result:(FlutterResult)result {


### PR DESCRIPTION
this solves issue https://github.com/flutter/flutter/issues/25721 by having completion code called when user presses the "Done" button (safariViewControllerDidFinish, which calls dismissViewControllerAnimated), allowing closeWebView() to work in iOS.