### PR TITLE
[firebase_auth] Check user metadata for null

### DIFF
--- a/packages/firebase_auth/android/src/main/java/io/flutter/plugins/firebaseauth/FirebaseAuthPlugin.java
+++ b/packages/firebase_auth/android/src/main/java/io/flutter/plugins/firebaseauth/FirebaseAuthPlugin.java
@@ -624,8 +624,10 @@ public class FirebaseAuthPlugin implements MethodCallHandler {
         providerData.add(Collections.unmodifiableMap(userInfoToMap(userInfo)));
       }
       Map<String, Object> userMap = userInfoToMap(user);
-      userMap.put("creationTimestamp", user.getMetadata().getCreationTimestamp());
-      userMap.put("lastSignInTimestamp", user.getMetadata().getLastSignInTimestamp());
+      if (user.getMetadata() != null) {
+        userMap.put("creationTimestamp", user.getMetadata().getCreationTimestamp());
+        userMap.put("lastSignInTimestamp", user.getMetadata().getLastSignInTimestamp());
+      }
       userMap.put("isAnonymous", user.isAnonymous());
       userMap.put("isEmailVerified", user.isEmailVerified());
       userMap.put("providerData", Collections.unmodifiableList(providerData));


### PR DESCRIPTION
https://stackoverflow.com/questions/48079683
Fixes the problem from the issue above. Check for null
before getting data

firebase_auth version: 0.6.6

![null_user_metadata](https://user-images.githubusercontent.com/6387464/50547977-66e3e980-0c45-11e9-903a-f38d32fa673d.png)
