### PR TITLE
Workaround the Gradle crash due to non ASCII characters.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -27,8 +27,20 @@ task:
           PLUGIN_SHARDING: "--shardIndex 0 --shardCount 2"
           PLUGIN_SHARDING: "--shardIndex 1 --shardCount 2"
       script:
+        # Unsetting CIRRUS_CHANGE_MESSAGE and CIRRUS_COMMIT_MESSAGE as they
+        # might include non-ASCII characters which makes Gradle crash.
+        # See: https://github.com/flutter/flutter/issues/24935
+        # This is a temporary workaround until we figure how to properly configure
+        # a UTF8 locale on Cirrus (or until the Gradle bug is fixed).
+        # TODO(amirh): Set the locale to UTF8.
+        - echo "$CIRRUS_CHANGE_MESSAGE" > /tmp/cirrus_change_message.txt
+        - echo "$CIRRUS_COMMIT_MESSAGE" > /tmp/cirrus_commit_message.txt
+        - export CIRRUS_CHANGE_MESSAGE=""
+        - export CIRRUS_COMMIT_MESSAGE=""
         - ./script/incremental_build.sh build-examples --apk
         - ./script/incremental_build.sh java-test  # must come after apk build
+        - export CIRRUS_CHANGE_MESSAGE=`cat /tmp/cirrus_change_message.txt`
+        - export CIRRUS_COMMIT_MESSAGE=`cat /tmp/cirrus_commit_message.txt`
 
 task:
   name: build-ipas


### PR DESCRIPTION
Cirrus puts the PR description and commit message in environment
variables.
These messages tend to have non ASCII characters sometimes (like
emojis), which triggers a Gradle bug (gradle/gradle#3117) resulting
in Gradle crashing without a helpful error message.

The real solution to this problem should be fixing the Gradle bug.
The better workaround on the Flutter side would be to set a UTF8 locale
on the Cirrus machine, but I have yet figured out how to do it.
For now to avoid more people from hitting this I'm working around by
temporarily unsetting the Cirrus environment variables with the PR
description and commit message.

A non ASCII character to make sure it works: 😄

More details (including my failed attempts to set a UTF8 locale on Cirrus) here: https://github.com/flutter/flutter/issues/24935