### PR TITLE
[camera]Nickcullen darkcamera fix

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -27,8 +27,20 @@ task:
           PLUGIN_SHARDING: "--shardIndex 0 --shardCount 2"
           PLUGIN_SHARDING: "--shardIndex 1 --shardCount 2"
       script:
+        # Unsetting CIRRUS_CHANGE_MESSAGE and CIRRUS_COMMIT_MESSAGE as they
+        # might include non-ASCII characters which makes Gradle crash.
+        # See: https://github.com/flutter/flutter/issues/24935
+        # This is a temporary workaround until we figure how to properly configure
+        # a UTF8 locale on Cirrus (or until the Gradle bug is fixed).
+        # TODO(amirh): Set the locale to UTF8.
+        - echo "$CIRRUS_CHANGE_MESSAGE" > /tmp/cirrus_change_message.txt
+        - echo "$CIRRUS_COMMIT_MESSAGE" > /tmp/cirrus_commit_message.txt
+        - export CIRRUS_CHANGE_MESSAGE=""
+        - export CIRRUS_COMMIT_MESSAGE=""
         - ./script/incremental_build.sh build-examples --apk
         - ./script/incremental_build.sh java-test  # must come after apk build
+        - export CIRRUS_CHANGE_MESSAGE=`cat /tmp/cirrus_change_message.txt`
+        - export CIRRUS_COMMIT_MESSAGE=`cat /tmp/cirrus_commit_message.txt`
 
 task:
   name: build-ipas

--- a/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
+++ b/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
@@ -39,7 +39,6 @@ import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
 import io.flutter.view.FlutterView;
-
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -401,23 +400,23 @@ public class CameraPlugin implements MethodCallHandler {
     }
 
     private void setBestAERange(CameraCharacteristics characteristics) {
-      Range<Integer>[] fpsRanges = characteristics.get(CameraCharacteristics.CONTROL_AE_AVAILABLE_TARGET_FPS_RANGES);
-      
-      if(fpsRanges.length <= 0) {
+      Range<Integer>[] fpsRanges =
+          characteristics.get(CameraCharacteristics.CONTROL_AE_AVAILABLE_TARGET_FPS_RANGES);
+
+      if (fpsRanges.length <= 0) {
         return;
       }
 
       Integer idx = 0;
       Integer biggestDiference = 0;
 
-      for(Integer i = 0; i < fpsRanges.length; i++) {
+      for (Integer i = 0; i < fpsRanges.length; i++) {
         Integer currentDifference = fpsRanges[i].getUpper() - fpsRanges[i].getLower();
 
-        if(currentDifference > biggestDiference) {
+        if (currentDifference > biggestDiference) {
           idx = i;
           biggestDiference = currentDifference;
         }
-
       }
 
       aeFPSRange = fpsRanges[idx];
@@ -770,9 +769,9 @@ public class CameraPlugin implements MethodCallHandler {
                 captureRequestBuilder.set(
                     CaptureRequest.CONTROL_MODE, CameraMetadata.CONTROL_MODE_AUTO);
 
-                if(Camera.this.aeFPSRange != null) {
+                if (Camera.this.aeFPSRange != null) {
                   captureRequestBuilder.set(
-                    CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE, Camera.this.aeFPSRange);
+                      CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE, Camera.this.aeFPSRange);
                 }
 
                 cameraCaptureSession.setRepeatingRequest(captureRequestBuilder.build(), null, null);

--- a/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
+++ b/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
@@ -26,6 +26,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.util.Range;
 import android.util.Size;
 import android.view.Display;
 import android.view.OrientationEventListener;
@@ -39,7 +40,6 @@ import io.flutter.plugin.common.PluginRegistry;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
 import io.flutter.view.FlutterView;
 
-import java.awt.font.NumericShaper.Range;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -51,8 +51,6 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 public class CameraPlugin implements MethodCallHandler {
 
@@ -293,7 +291,7 @@ public class CameraPlugin implements MethodCallHandler {
     private Size videoSize;
     private MediaRecorder mediaRecorder;
     private boolean recordingVideo;
-    private android.util.Range<Integer> aeFPSRange;
+    private Range<Integer> aeFPSRange;
 
     Camera(final String cameraName, final String resolutionPreset, @NonNull final Result result) {
 
@@ -403,7 +401,7 @@ public class CameraPlugin implements MethodCallHandler {
     }
 
     private void setBestAERange(CameraCharacteristics characteristics) {
-      android.util.Range<Integer>[] fpsRanges = characteristics.get(CameraCharacteristics.CONTROL_AE_AVAILABLE_TARGET_FPS_RANGES);
+      Range<Integer>[] fpsRanges = characteristics.get(CameraCharacteristics.CONTROL_AE_AVAILABLE_TARGET_FPS_RANGES);
       
       if(fpsRanges.length > 0) {
         aeFPSRange = fpsRanges[0];

--- a/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
+++ b/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
@@ -403,9 +403,24 @@ public class CameraPlugin implements MethodCallHandler {
     private void setBestAERange(CameraCharacteristics characteristics) {
       Range<Integer>[] fpsRanges = characteristics.get(CameraCharacteristics.CONTROL_AE_AVAILABLE_TARGET_FPS_RANGES);
       
-      if(fpsRanges.length > 0) {
-        aeFPSRange = fpsRanges[0];
+      if(fpsRanges.length <= 0) {
+        return;
       }
+
+      Integer idx = 0;
+      Integer biggestDiference = 0;
+
+      for(Integer i = 0; i < fpsRanges.length; i++) {
+        Integer currentDifference = fpsRanges[i].getUpper() - fpsRanges[i].getLower();
+
+        if(currentDifference > biggestDiference) {
+          idx = i;
+          biggestDiference = currentDifference;
+        }
+
+      }
+
+      aeFPSRange = fpsRanges[idx];
     }
 
     private void computeBestPreviewAndRecordingSize(


### PR DESCRIPTION
Fixed camera preview darkness (my test device is a Samsung Galaxy Tab A).

The issue was that the FPS of the preview camera was too high and the auto exposure capability couldn't keep up which resulted in it 'giving up'. This only seems to be an issue on low end devices such as this and I've noticed the level of darkness varies between devices. 

PLEASE NOTE: On low end devices (such as the Samsung Galaxy Tab A) this does make the camera preview feel choppy (after all... the frame rate _had_ to be reduced). If I open the stock camera app on this device, the frame rate is identical. Meaning that they're also compensating FPS for exposure gains (so you can actually see what you're about to take a photo of).
