### PR TITLE
Save photo orientation on iOS

### DIFF
--- a/packages/camera/CHANGELOG.md
+++ b/packages/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.9
+
+* Save photo orientation data on iOS.
+
 ## 0.2.8
 
 * Add access to the image stream from Dart.

--- a/packages/camera/pubspec.yaml
+++ b/packages/camera/pubspec.yaml
@@ -1,7 +1,7 @@
 name: camera
 description: A Flutter plugin for getting information about and controlling the
   camera on Android and iOS. Supports previewing the camera feed and capturing images.
-version: 0.2.8
+version: 0.2.9
 authors:
   - Flutter Team <flutter-dev@googlegroups.com>
   - Luigi Agosti <luigi@tengio.com>


### PR DESCRIPTION
This patch works by calculating the device's physical orientation from
accelerometer data. This is a tricky approach and I'd rather avoid it,
but it looks like a necessary evil based on a few reasons.

1. The specific callback we're registering doesn't give us any EXIF data
   or data on the photo's orientation.
   https://developer.apple.com/documentation/avfoundation/avcapturephotocapturedelegate/1778647-captureoutput?language=objc
2. There is a better callback to use that does give us this data, but
   it's only supported on ios 11.0+ and the camera plugin supports
   10.0+.
   https://developer.apple.com/documentation/avfoundation/avcapturephotocapturedelegate/2873949-captureoutput?language=objc
3. There's a straightforward iOS API that's supposed to give the
   physical device orientation that would normally be perfect for this,
   but it doesn't work when the UI is locked to portrait mode.
   https://developer.apple.com/documentation/uikit/uidevice/1620053-orientation?language=objc
   We've had Android issues in the past based on the Android API we used
   having this same limitation.

fixes flutter/flutter#16587