### PR TITLE
[local_auth]add biometrics support for iOS < 11.0.1

### DIFF
--- a/packages/local_auth/ios/Classes/LocalAuthPlugin.m
+++ b/packages/local_auth/ios/Classes/LocalAuthPlugin.m
@@ -78,7 +78,7 @@
           [biometrics addObject:@"fingerprint"];
         }
       } else {
-          [biometrics addObject:@"fingerprint"];
+        [biometrics addObject:@"fingerprint"];
       }
     }
   } else if (authError.code == LAErrorTouchIDNotEnrolled) {

--- a/packages/local_auth/ios/Classes/LocalAuthPlugin.m
+++ b/packages/local_auth/ios/Classes/LocalAuthPlugin.m
@@ -77,6 +77,8 @@
         } else if (context.biometryType == LABiometryTypeTouchID) {
           [biometrics addObject:@"fingerprint"];
         }
+      } else {
+          [biometrics addObject:@"fingerprint"];
       }
     }
   } else if (authError.code == LAErrorTouchIDNotEnrolled) {


### PR DESCRIPTION
iOS versions below 11.0.+ has TouchID support but not FaceID.

With current implementation it just always return an empty list for those devices.
If you want to support it, you need to add "fingerprint" in a biometrics list in a case if there was no error.