### PR TITLE
Fix image picker crash on IOS

### DIFF
--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.12
+
+* Fix a crash when user tap the image mutiple times.
+
 ## 0.4.11
 
 * Use `api` to define `support-v4` dependency to allow automatic version resolution.

--- a/packages/image_picker/ios/Classes/ImagePickerPlugin.m
+++ b/packages/image_picker/ios/Classes/ImagePickerPlugin.m
@@ -129,7 +129,9 @@ static const int SOURCE_GALLERY = 1;
   NSURL *videoURL = [info objectForKey:UIImagePickerControllerMediaURL];
   UIImage *image = [info objectForKey:UIImagePickerControllerEditedImage];
   [_imagePickerController dismissViewControllerAnimated:YES completion:nil];
-
+  if (!_result) {
+    return;
+  }
   if (videoURL != nil) {
     NSData *data = [NSData dataWithContentsOfURL:videoURL];
     NSString *guid = [[NSProcessInfo processInfo] globallyUniqueString];

--- a/packages/image_picker/ios/Classes/ImagePickerPlugin.m
+++ b/packages/image_picker/ios/Classes/ImagePickerPlugin.m
@@ -129,6 +129,8 @@ static const int SOURCE_GALLERY = 1;
   NSURL *videoURL = [info objectForKey:UIImagePickerControllerMediaURL];
   UIImage *image = [info objectForKey:UIImagePickerControllerEditedImage];
   [_imagePickerController dismissViewControllerAnimated:YES completion:nil];
+  // dismissViewControllerAnimated does not immediately prevents furture didFinishPickingMediaWithInfo infvocations. 
+  // A nil check is necessary to prevent below code to be unwantly executed multiple times and cause a crash. 
   if (!_result) {
     return;
   }

--- a/packages/image_picker/ios/Classes/ImagePickerPlugin.m
+++ b/packages/image_picker/ios/Classes/ImagePickerPlugin.m
@@ -129,8 +129,9 @@ static const int SOURCE_GALLERY = 1;
   NSURL *videoURL = [info objectForKey:UIImagePickerControllerMediaURL];
   UIImage *image = [info objectForKey:UIImagePickerControllerEditedImage];
   [_imagePickerController dismissViewControllerAnimated:YES completion:nil];
-  // The method dismissViewControllerAnimated does not immediately prevents furture didFinishPickingMediaWithInfo infvocations. 
-  // A nil check is necessary to prevent below code to be unwantly executed multiple times and cause a crash.
+  // The method dismissViewControllerAnimated does not immediately prevents further
+  // didFinishPickingMediaWithInfo invocations. A nil check is necessary to prevent below code to
+  // be unwantly executed multiple times and cause a crash.
   if (!_result) {
     return;
   }

--- a/packages/image_picker/ios/Classes/ImagePickerPlugin.m
+++ b/packages/image_picker/ios/Classes/ImagePickerPlugin.m
@@ -129,7 +129,7 @@ static const int SOURCE_GALLERY = 1;
   NSURL *videoURL = [info objectForKey:UIImagePickerControllerMediaURL];
   UIImage *image = [info objectForKey:UIImagePickerControllerEditedImage];
   [_imagePickerController dismissViewControllerAnimated:YES completion:nil];
-  // dismissViewControllerAnimated does not immediately prevents furture didFinishPickingMediaWithInfo infvocations. 
+  // The method dismissViewControllerAnimated does not immediately prevents furture didFinishPickingMediaWithInfo infvocations. 
   // A nil check is necessary to prevent below code to be unwantly executed multiple times and cause a crash.
   if (!_result) {
     return;

--- a/packages/image_picker/ios/Classes/ImagePickerPlugin.m
+++ b/packages/image_picker/ios/Classes/ImagePickerPlugin.m
@@ -129,7 +129,7 @@ static const int SOURCE_GALLERY = 1;
   NSURL *videoURL = [info objectForKey:UIImagePickerControllerMediaURL];
   UIImage *image = [info objectForKey:UIImagePickerControllerEditedImage];
   [_imagePickerController dismissViewControllerAnimated:YES completion:nil];
-  // The method dismissViewControllerAnimated does not immediately prevents further
+  // The method dismissViewControllerAnimated does not immediately prevent further
   // didFinishPickingMediaWithInfo invocations. A nil check is necessary to prevent below code to
   // be unwantly executed multiple times and cause a crash.
   if (!_result) {

--- a/packages/image_picker/ios/Classes/ImagePickerPlugin.m
+++ b/packages/image_picker/ios/Classes/ImagePickerPlugin.m
@@ -130,7 +130,7 @@ static const int SOURCE_GALLERY = 1;
   UIImage *image = [info objectForKey:UIImagePickerControllerEditedImage];
   [_imagePickerController dismissViewControllerAnimated:YES completion:nil];
   // dismissViewControllerAnimated does not immediately prevents furture didFinishPickingMediaWithInfo infvocations. 
-  // A nil check is necessary to prevent below code to be unwantly executed multiple times and cause a crash. 
+  // A nil check is necessary to prevent below code to be unwantly executed multiple times and cause a crash.
   if (!_result) {
     return;
   }

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -5,7 +5,7 @@ authors:
   - Flutter Team <flutter-dev@googlegroups.com>
   - Rhodes Davis Jr. <rody.davis.jr@gmail.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.4.11
+version: 0.4.12
 
 flutter:
   plugin:


### PR DESCRIPTION
fix an IOS crash when the image picker got tapped multiple times. flutter/flutter#20214

When the image in the imagePicker was tapped multiple times, the delegate method didFinishPickingMediaWithInfo gets called multiple times. _result is set to nil at the end of the didFinishPickingMediaWithInfo call.
When the second didFinishPickingMediaWithInfo gets triggered, because _result is nil, crash is caused.

We can also fix it by putting the code after selection inside the completion handler, it will cause a little delay in image showing up after completion. So directly checking if _result is nil and stop the process would be more efficient. 