### PR TITLE
Update dart doc for forceSafariVC for the usage of universal links on iOS

### DIFF
--- a/packages/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/lib/url_launcher.dart
@@ -20,9 +20,10 @@ const MethodChannel _channel = MethodChannel('plugins.flutter.io/url_launcher');
 /// [forceSafariVC] is only used in iOS. If unset, the launcher opens web URLs
 /// in the safari VC, anything else is opened using the default handler on the
 /// platform. If set to true, it opens the URL in the Safari view controller.
-/// If false, the URL is opened in the default browser of the phone. Set this to
-/// false if you want to use the cookies/context of the main browser of the app
-/// (such as SSO flows).
+/// If false, the URL is opened in the default browser of the phone. Note that
+/// to work with universal links, this must be set to false to let the platform
+/// system handle the URL. Set this to false if you want to use the
+/// cookies/context of the main browser of the app(such as SSO flows).
 ///
 /// [forceWebView] is an Android only setting. If null or false, the URL is
 /// always launched with the default browser on device. If set to true, the URL

--- a/packages/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/lib/url_launcher.dart
@@ -21,9 +21,9 @@ const MethodChannel _channel = MethodChannel('plugins.flutter.io/url_launcher');
 /// in the safari VC, anything else is opened using the default handler on the
 /// platform. If set to true, it opens the URL in the Safari view controller.
 /// If false, the URL is opened in the default browser of the phone. Note that
-/// to work with universal links, this must be set to false to let the platform
-/// system handle the URL. Set this to false if you want to use the
-/// cookies/context of the main browser of the app(such as SSO flows).
+/// to work with universal links on iOS, this must be set to false to let
+/// the platform's system handle the URL. Set this to false if you want to
+/// use the cookies/context of the main browser of the app(such as SSO flows).
 ///
 /// [forceWebView] is an Android only setting. If null or false, the URL is
 /// always launched with the default browser on device. If set to true, the URL


### PR DESCRIPTION
There are numbers of users having problem on launch universal links on iOS. 

It is most likely due to the unawareness of forceSafariVC is true by default and safariVC will not handle universal links. 

Adding document to explain this particular usage.  