### PR TITLE
Url launcher ios universallinksonly

### DIFF
--- a/packages/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 4.0.4
+## 4.1.0
 
 * Added `universalLinksOnly` setting.
+* Updated `launch` to return `Future<bool>`.
 
 ## 4.0.3
 

--- a/packages/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.4
+
+* Added `universalLinksOnly` setting.
+
 ## 4.0.3
 
 * Fixed launch url fail for Android: `launch` now assert activity not null and using activity to startActivity.

--- a/packages/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/UrlLauncherPlugin.java
+++ b/packages/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/UrlLauncherPlugin.java
@@ -43,28 +43,9 @@ public class UrlLauncherPlugin implements MethodCallHandler {
     if (call.method.equals("canLaunch")) {
       canLaunch(url, result);
     } else if (call.method.equals("launch")) {
-      Intent launchIntent;
-      boolean useWebView = call.argument("useWebView");
-      boolean enableJavaScript = call.argument("enableJavaScript");
-      Activity activity = mRegistrar.activity();
-      if (activity == null) {
-        result.error("NO_ACTIVITY", "Launching a URL requires a foreground activity.", null);
-        return;
-      }
-      if (useWebView) {
-        launchIntent = new Intent(activity, WebViewActivity.class);
-        launchIntent.putExtra("url", url);
-        launchIntent.putExtra("enableJavaScript", enableJavaScript);
-      } else {
-        launchIntent = new Intent(Intent.ACTION_VIEW);
-        launchIntent.setData(Uri.parse(url));
-      }
-      activity.startActivity(launchIntent);
-      result.success(null);
+      launch(call, result, url);
     } else if (call.method.equals("closeWebView")) {
-      Intent intent = new Intent("close");
-      mRegistrar.context().sendBroadcast(intent);
-      result.success(null);
+      closeWebView(result);
     } else {
       result.notImplemented();
     }
@@ -81,6 +62,33 @@ public class UrlLauncherPlugin implements MethodCallHandler {
             && !"{com.android.fallback/com.android.fallback.Fallback}"
                 .equals(componentName.toShortString());
     result.success(canLaunch);
+  }
+
+  private void launch(MethodCall call, Result result, String url) {
+    Intent launchIntent;
+    boolean useWebView = call.argument("useWebView");
+    boolean enableJavaScript = call.argument("enableJavaScript");
+    Activity activity = mRegistrar.activity();
+    if (activity == null) {
+      result.error("NO_ACTIVITY", "Launching a URL requires a foreground activity.", null);
+      return;
+    }
+    if (useWebView) {
+      launchIntent = new Intent(activity, WebViewActivity.class);
+      launchIntent.putExtra("url", url);
+      launchIntent.putExtra("enableJavaScript", enableJavaScript);
+    } else {
+      launchIntent = new Intent(Intent.ACTION_VIEW);
+      launchIntent.setData(Uri.parse(url));
+    }
+    activity.startActivity(launchIntent);
+    result.success(true);
+  }
+
+  private void closeWebView(Result result) {
+    Intent intent = new Intent("close");
+    mRegistrar.context().sendBroadcast(intent);
+    result.success(null);
   }
 
   /*  Launches WebView activity */

--- a/packages/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/UrlLauncherPlugin.java
+++ b/packages/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/UrlLauncherPlugin.java
@@ -43,9 +43,28 @@ public class UrlLauncherPlugin implements MethodCallHandler {
     if (call.method.equals("canLaunch")) {
       canLaunch(url, result);
     } else if (call.method.equals("launch")) {
-      launch(call, result, url);
+      Intent launchIntent;
+      boolean useWebView = call.argument("useWebView");
+      boolean enableJavaScript = call.argument("enableJavaScript");
+      Activity activity = mRegistrar.activity();
+      if (activity == null) {
+        result.error("NO_ACTIVITY", "Launching a URL requires a foreground activity.", null);
+        return;
+      }
+      if (useWebView) {
+        launchIntent = new Intent(activity, WebViewActivity.class);
+        launchIntent.putExtra("url", url);
+        launchIntent.putExtra("enableJavaScript", enableJavaScript);
+      } else {
+        launchIntent = new Intent(Intent.ACTION_VIEW);
+        launchIntent.setData(Uri.parse(url));
+      }
+      activity.startActivity(launchIntent);
+      result.success(true);
     } else if (call.method.equals("closeWebView")) {
-      closeWebView(result);
+      Intent intent = new Intent("close");
+      mRegistrar.context().sendBroadcast(intent);
+      result.success(null);
     } else {
       result.notImplemented();
     }
@@ -62,33 +81,6 @@ public class UrlLauncherPlugin implements MethodCallHandler {
             && !"{com.android.fallback/com.android.fallback.Fallback}"
                 .equals(componentName.toShortString());
     result.success(canLaunch);
-  }
-
-  private void launch(MethodCall call, Result result, String url) {
-    Intent launchIntent;
-    boolean useWebView = call.argument("useWebView");
-    boolean enableJavaScript = call.argument("enableJavaScript");
-    Activity activity = mRegistrar.activity();
-    if (activity == null) {
-      result.error("NO_ACTIVITY", "Launching a URL requires a foreground activity.", null);
-      return;
-    }
-    if (useWebView) {
-      launchIntent = new Intent(activity, WebViewActivity.class);
-      launchIntent.putExtra("url", url);
-      launchIntent.putExtra("enableJavaScript", enableJavaScript);
-    } else {
-      launchIntent = new Intent(Intent.ACTION_VIEW);
-      launchIntent.setData(Uri.parse(url));
-    }
-    activity.startActivity(launchIntent);
-    result.success(true);
-  }
-
-  private void closeWebView(Result result) {
-    Intent intent = new Intent("close");
-    mRegistrar.context().sendBroadcast(intent);
-    result.success(null);
   }
 
   /*  Launches WebView activity */

--- a/packages/url_launcher/example/lib/main.dart
+++ b/packages/url_launcher/example/lib/main.dart
@@ -65,11 +65,15 @@ class _MyHomePageState extends State<MyHomePage> {
 
   Future<void> _launchUniversalLinkIos(String url) async {
     try {
-      await launch('https://youtube.com',
+      if (await canLaunch('https://youtube.com')) {
+        await launch('https://youtube.com',
           forceSafariVC: false, universalLinksOnly: true);
+      }
     } on Exception {
-      await launch('https://youtube.com',
+      if (await canLaunch('https://youtube.com')) {
+        await launch('https://youtube.com',
           forceSafariVC: true, universalLinksOnly: false);
+      }
     }
   }
 

--- a/packages/url_launcher/example/lib/main.dart
+++ b/packages/url_launcher/example/lib/main.dart
@@ -64,15 +64,17 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 
   Future<void> _launchUniversalLinkIos(String url) async {
-    try {
-      if (await canLaunch('https://youtube.com')) {
-        await launch('https://youtube.com',
-          forceSafariVC: false, universalLinksOnly: true);
-      }
-    } on Exception {
-      if (await canLaunch('https://youtube.com')) {
-        await launch('https://youtube.com',
-          forceSafariVC: true, universalLinksOnly: false);
+    if (await canLaunch('https://youtube.com')) {
+      final bool canLaunchInNativeApp = await launch(
+        'https://youtube.com',
+        forceSafariVC: false,
+        universalLinksOnly: true,
+      );
+      if (!canLaunchInNativeApp) {
+        await launch(
+          'https://youtube.com',
+          forceSafariVC: true,
+        );
       }
     }
   }
@@ -146,7 +148,7 @@ class _MyHomePageState extends State<MyHomePage> {
                     _launched = _launchUniversalLinkIos(toLaunch);
                   }),
               child: const Text(
-                  'Universal link launch native App or fallback to Safari View Controller(Youtube)'),
+                  'Launch a universal link in a native app, fallback to Safari.(Youtube)'),
             ),
             const Padding(padding: EdgeInsets.all(16.0)),
             RaisedButton(

--- a/packages/url_launcher/example/lib/main.dart
+++ b/packages/url_launcher/example/lib/main.dart
@@ -39,8 +39,6 @@ class _MyHomePageState extends State<MyHomePage> {
   Future<void> _launchInBrowser(String url) async {
     if (await canLaunch(url)) {
       await launch(url, forceSafariVC: false, forceWebView: false);
-    } else {
-      throw 'Could not launch $url';
     }
   }
 
@@ -65,6 +63,16 @@ class _MyHomePageState extends State<MyHomePage> {
     }
   }
 
+  Future<void> _launchUniversalLinkIos(String url) async {
+    try {
+      await launch('https://youtube.com',
+          forceSafariVC: false, universalLinksOnly: true);
+    } on Exception {
+      await launch('https://youtube.com',
+          forceSafariVC: true, universalLinksOnly: false);
+    }
+  }
+
   Widget _launchStatus(BuildContext context, AsyncSnapshot<void> snapshot) {
     if (snapshot.hasError) {
       return Text('Error: ${snapshot.error}');
@@ -83,7 +91,7 @@ class _MyHomePageState extends State<MyHomePage> {
 
   @override
   Widget build(BuildContext context) {
-    const String toLaunch = 'https://flutter.io';
+    const String toLaunch = 'https://youtube.com';
     return Scaffold(
       appBar: AppBar(
         title: Text(widget.title),
@@ -128,6 +136,13 @@ class _MyHomePageState extends State<MyHomePage> {
                     _launched = _launchInWebViewWithJavaScript(toLaunch);
                   }),
               child: const Text('Launch in app(JavaScript ON)'),
+            ),
+            RaisedButton(
+              onPressed: () => setState(() {
+                    _launched = _launchUniversalLinkIos(toLaunch);
+                  }),
+              child: const Text(
+                  'Universal link launch native App or fallback to Safari View Controller(Youtube)'),
             ),
             const Padding(padding: EdgeInsets.all(16.0)),
             RaisedButton(

--- a/packages/url_launcher/example/lib/main.dart
+++ b/packages/url_launcher/example/lib/main.dart
@@ -39,6 +39,8 @@ class _MyHomePageState extends State<MyHomePage> {
   Future<void> _launchInBrowser(String url) async {
     if (await canLaunch(url)) {
       await launch(url, forceSafariVC: false, forceWebView: false);
+    } else {
+      throw 'Could not launch $url';
     }
   }
 

--- a/packages/url_launcher/example/lib/main.dart
+++ b/packages/url_launcher/example/lib/main.dart
@@ -67,12 +67,12 @@ class _MyHomePageState extends State<MyHomePage> {
 
   Future<void> _launchUniversalLinkIos(String url) async {
     if (await canLaunch('https://youtube.com')) {
-      final bool canLaunchInNativeApp = await launch(
+      final bool nativeAppLaunchSucceeded = await launch(
         'https://youtube.com',
         forceSafariVC: false,
         universalLinksOnly: true,
       );
-      if (!canLaunchInNativeApp) {
+      if (!nativeAppLaunchSucceeded) {
         await launch(
           'https://youtube.com',
           forceSafariVC: true,

--- a/packages/url_launcher/example/lib/main.dart
+++ b/packages/url_launcher/example/lib/main.dart
@@ -91,7 +91,7 @@ class _MyHomePageState extends State<MyHomePage> {
 
   @override
   Widget build(BuildContext context) {
-    const String toLaunch = 'https://youtube.com';
+    const String toLaunch = 'https://flutter.io';
     return Scaffold(
       appBar: AppBar(
         title: Text(widget.title),

--- a/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
+++ b/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
@@ -37,9 +37,9 @@ API_AVAILABLE(ios(9.0))
   self = [super init];
   if (self) {
     if (@available(iOS 9.0, *)) {
-      _safari = [[SFSafariViewController alloc] initWithURL:url];
+      self.safari = [[SFSafariViewController alloc] initWithURL:url];
     }
-    _safari.delegate = self;
+    self.safari.delegate = self;
   }
   return self;
 }
@@ -61,7 +61,7 @@ API_AVAILABLE(ios(9.0))
 }
 
 - (void)close {
-  [self safariViewControllerDidFinish:_safari];
+  [self safariViewControllerDidFinish:self.safari];
 }
 
 @end

--- a/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
+++ b/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
@@ -6,10 +6,10 @@
 
 #import "UrlLauncherPlugin.h"
 
-@interface FLTUrlLaunchSession: NSObject
+@interface FLTUrlLaunchSession : NSObject
 
-@property (strong, nonatomic) NSURL *url;
-@property (copy, nonatomic) FlutterResult flutterResult;
+@property(strong, nonatomic) NSURL *url;
+@property(copy, nonatomic) FlutterResult flutterResult;
 
 @end
 
@@ -23,7 +23,6 @@
   }
   return self;
 }
-
 
 @end
 
@@ -46,7 +45,7 @@ API_AVAILABLE(ios(9.0))
 }
 
 - (void)safariViewController:(SFSafariViewController *)controller
-      didCompleteInitialLoad:(BOOL)didLoadSuccessfully  API_AVAILABLE(ios(9.0)){
+      didCompleteInitialLoad:(BOOL)didLoadSuccessfully API_AVAILABLE(ios(9.0)) {
   if (didLoadSuccessfully) {
     self.flutterResult(nil);
   } else {
@@ -57,7 +56,7 @@ API_AVAILABLE(ios(9.0))
   }
 }
 
-- (void)safariViewControllerDidFinish:(SFSafariViewController *)controller  API_AVAILABLE(ios(9.0)){
+- (void)safariViewControllerDidFinish:(SFSafariViewController *)controller API_AVAILABLE(ios(9.0)) {
   [controller dismissViewControllerAnimated:YES completion:nil];
 }
 
@@ -67,10 +66,10 @@ API_AVAILABLE(ios(9.0))
 
 @end
 
-@interface FLTUrlLauncherPlugin()
+@interface FLTUrlLauncherPlugin ()
 
-@property (strong, nonatomic) UIViewController *viewController;
-@property (strong, nonatomic) FLTUrlLaunchSession *currentSession;
+@property(strong, nonatomic) UIViewController *viewController;
+@property(strong, nonatomic) FLTUrlLaunchSession *currentSession;
 
 @end
 
@@ -114,7 +113,10 @@ API_AVAILABLE(ios(9.0))
     if (@available(iOS 9.0, *)) {
       [self closeWebViewWithResult:result];
     } else {
-      result([FlutterError errorWithCode:@"API_NOT_AVAILABLE" message:@"SafariViewController related api is not availabe for version <= IOS9" details:nil]);
+      result([FlutterError
+          errorWithCode:@"API_NOT_AVAILABLE"
+                message:@"SafariViewController related api is not availabe for version <= IOS9"
+                details:nil]);
     }
   } else {
     result(FlutterMethodNotImplemented);
@@ -127,37 +129,40 @@ API_AVAILABLE(ios(9.0))
   return [application canOpenURL:url];
 }
 
-- (void)launchURL:(NSString *)urlString call:(FlutterMethodCall *)call result:(FlutterResult)result {
+- (void)launchURL:(NSString *)urlString
+             call:(FlutterMethodCall *)call
+           result:(FlutterResult)result {
   NSURL *url = [NSURL URLWithString:urlString];
   UIApplication *application = [UIApplication sharedApplication];
 
   if (@available(iOS 10.0, *)) {
-    NSNumber *universalLinksOnly = call.arguments[@"universalLinksOnly"]?:@0;
-    NSDictionary *options = @{UIApplicationOpenURLOptionUniversalLinksOnly: universalLinksOnly};
+    NSNumber *universalLinksOnly = call.arguments[@"universalLinksOnly"] ?: @0;
+    NSDictionary *options = @{UIApplicationOpenURLOptionUniversalLinksOnly : universalLinksOnly};
     [application openURL:url
-                   options:options
-         completionHandler:^(BOOL success) {
-           result(@(success));
-     }];
+                  options:options
+        completionHandler:^(BOOL success) {
+          result(@(success));
+        }];
   } else {
     BOOL success = [application openURL:url];
     result(@(success));
   }
 }
 
-- (void)launchURLInVC:(NSString *)urlString result:(FlutterResult)result  API_AVAILABLE(ios(9.0)){
+- (void)launchURLInVC:(NSString *)urlString result:(FlutterResult)result API_AVAILABLE(ios(9.0)) {
   NSURL *url = [NSURL URLWithString:urlString];
-  self.currentSession = [[FLTUrlSafariLaunchSession alloc] initWithUrl:url withFlutterResult:result];
+  self.currentSession = [[FLTUrlSafariLaunchSession alloc] initWithUrl:url
+                                                     withFlutterResult:result];
   FLTUrlSafariLaunchSession *currentSession = (FLTUrlSafariLaunchSession *)self.currentSession;
   __weak typeof(self) weakSelf = self;
   [self.viewController presentViewController:currentSession.safari
-                                animated:YES
-                              completion:^void() {
-                                weakSelf.currentSession = nil;
-                              }];
+                                    animated:YES
+                                  completion:^void() {
+                                    weakSelf.currentSession = nil;
+                                  }];
 }
 
-- (void)closeWebViewWithResult:(FlutterResult)result API_AVAILABLE(ios(9.0)){
+- (void)closeWebViewWithResult:(FlutterResult)result API_AVAILABLE(ios(9.0)) {
   if ([self.currentSession isKindOfClass:[FLTUrlSafariLaunchSession class]]) {
     FLTUrlSafariLaunchSession *currentSession = (FLTUrlSafariLaunchSession *)self.currentSession;
     if (currentSession != nil) {

--- a/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
+++ b/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
@@ -6,66 +6,52 @@
 
 #import "UrlLauncherPlugin.h"
 
-API_AVAILABLE(ios(9.0))
 @interface FLTUrlLaunchSession : NSObject <SFSafariViewControllerDelegate>
-
-@property(copy, nonatomic) FlutterResult flutterResult;
-@property(strong, nonatomic) NSURL *url;
-@property(strong, nonatomic) SFSafariViewController *safari;
-
+@property(strong) SFSafariViewController *safari;
 @end
 
-@implementation FLTUrlLaunchSession
+@implementation FLTUrlLaunchSession {
+  NSURL *_url;
+  FlutterResult _flutterResult;
+}
 
 - (instancetype)initWithUrl:url withFlutterResult:result {
   self = [super init];
   if (self) {
-    self.url = url;
-    self.flutterResult = result;
-    if (@available(iOS 9.0, *)) {
-      self.safari = [[SFSafariViewController alloc] initWithURL:url];
-      self.safari.delegate = self;
-    }
+    _url = url;
+    _flutterResult = result;
+    _safari = [[SFSafariViewController alloc] initWithURL:url];
+    _safari.delegate = self;
   }
   return self;
 }
 
 - (void)safariViewController:(SFSafariViewController *)controller
-      didCompleteInitialLoad:(BOOL)didLoadSuccessfully API_AVAILABLE(ios(9.0)) {
+      didCompleteInitialLoad:(BOOL)didLoadSuccessfully {
   if (didLoadSuccessfully) {
-    self.flutterResult(nil);
+    _flutterResult(nil);
   } else {
-    self.flutterResult([FlutterError
+    _flutterResult([FlutterError
         errorWithCode:@"Error"
-              message:[NSString stringWithFormat:@"Error while launching %@", self.url]
+              message:[NSString stringWithFormat:@"Error while launching %@", _url]
               details:nil]);
   }
 }
 
-- (void)safariViewControllerDidFinish:(SFSafariViewController *)controller API_AVAILABLE(ios(9.0)) {
+- (void)safariViewControllerDidFinish:(SFSafariViewController *)controller {
   [controller dismissViewControllerAnimated:YES completion:nil];
 }
 
 - (void)close {
-  [self safariViewControllerDidFinish:self.safari];
+  [self safariViewControllerDidFinish:_safari];
 }
 
 @end
 
-API_AVAILABLE(ios(9.0))
-@interface FLTUrlLauncherPlugin ()
-
-@property(strong, nonatomic) FLTUrlLaunchSession *currentSession;
-
-@end
-
-@interface FLTUrlLauncherPlugin ()
-
-@property(strong, nonatomic) UIViewController *viewController;
-
-@end
-
-@implementation FLTUrlLauncherPlugin
+@implementation FLTUrlLauncherPlugin {
+  UIViewController *_viewController;
+  FLTUrlLaunchSession *_currentSession;
+}
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
   FlutterMethodChannel *channel =
@@ -81,7 +67,7 @@ API_AVAILABLE(ios(9.0))
 - (instancetype)initWithViewController:(UIViewController *)viewController {
   self = [super init];
   if (self) {
-    self.viewController = viewController;
+    _viewController = viewController;
   }
   return self;
 }
@@ -93,23 +79,12 @@ API_AVAILABLE(ios(9.0))
   } else if ([@"launch" isEqualToString:call.method]) {
     NSNumber *useSafariVC = call.arguments[@"useSafariVC"];
     if (useSafariVC.boolValue) {
-      if (@available(iOS 9.0, *)) {
-        [self launchURLInVC:url result:result];
-      } else {
-        [self launchURL:url call:call result:result];
-      }
+      [self launchURLInVC:url result:result];
     } else {
       [self launchURL:url call:call result:result];
     }
   } else if ([@"closeWebView" isEqualToString:call.method]) {
-    if (@available(iOS 9.0, *)) {
-      [self closeWebViewWithResult:result];
-    } else {
-      result([FlutterError
-          errorWithCode:@"API_NOT_AVAILABLE"
-                message:@"SafariViewController related api is not availabe for version <= IOS9"
-                details:nil]);
-    }
+    [self closeWebView:url result:result];
   } else {
     result(FlutterMethodNotImplemented);
   }
@@ -141,20 +116,19 @@ API_AVAILABLE(ios(9.0))
   }
 }
 
-- (void)launchURLInVC:(NSString *)urlString result:(FlutterResult)result API_AVAILABLE(ios(9.0)) {
+- (void)launchURLInVC:(NSString *)urlString result:(FlutterResult)result {
   NSURL *url = [NSURL URLWithString:urlString];
-  self.currentSession = [[FLTUrlLaunchSession alloc] initWithUrl:url withFlutterResult:result];
-  __weak typeof(self) weakSelf = self;
-  [self.viewController presentViewController:self.currentSession.safari
-                                    animated:YES
-                                  completion:^void() {
-                                    weakSelf.currentSession = nil;
-                                  }];
+  _currentSession = [[FLTUrlLaunchSession alloc] initWithUrl:url withFlutterResult:result];
+  [_viewController presentViewController:_currentSession.safari
+                                animated:YES
+                              completion:^void() {
+                                self->_currentSession = nil;
+                              }];
 }
 
-- (void)closeWebViewWithResult:(FlutterResult)result API_AVAILABLE(ios(9.0)) {
-  if (self.currentSession != nil) {
-    [self.currentSession close];
+- (void)closeWebView:(NSString *)urlString result:(FlutterResult)result {
+  if (_currentSession != nil) {
+    [_currentSession close];
   }
   result(nil);
 }

--- a/packages/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/lib/url_launcher.dart
@@ -85,7 +85,7 @@ Future<bool> launch(
       'enableJavaScript': enableJavaScript ?? false,
       'universalLinksOnly': universalLinksOnly ?? false
     },
-  ).then((void _) {
+  ).then<dynamic>((void _) {
     if (statusBarBrightness != null) {
       WidgetsBinding.instance.renderView.automaticSystemUiAdjustment =
           previousAutomaticSystemUiAdjustment;

--- a/packages/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/lib/url_launcher.dart
@@ -113,7 +113,7 @@ Future<bool> canLaunch(String urlString) async {
 /// Or on IOS systems, if [launch] was called without `forceSafariVC` being set to `true`,
 /// this call will not do anything either, simply because there is no
 /// WebView/SafariViewController available to be closed.
-/// 
+///
 /// SafariViewController is only available on IOS version >= 9.0, this method does not do anything
 /// on IOS version below 9.0
 Future<void> closeWebView() async {

--- a/packages/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/lib/url_launcher.dart
@@ -38,9 +38,9 @@ const MethodChannel _channel = MethodChannel('plugins.flutter.io/url_launcher');
 ///
 /// [forceWebView] is an Android only setting. If null or false, the URL is
 /// always launched with the default browser on device. If set to true, the URL
-/// is launched in a webview. Unlike iOS, browser context is shared across
+/// is launched in a WebView. Unlike iOS, browser context is shared across
 /// WebViews.
-/// [enableJavaScript] is an Android only setting. If true, webview enable
+/// [enableJavaScript] is an Android only setting. If true, WebView enable
 /// javascript.
 ///
 /// Note that if any of the above are set to true but the URL is not a web URL,
@@ -48,10 +48,10 @@ const MethodChannel _channel = MethodChannel('plugins.flutter.io/url_launcher');
 ///
 /// [statusBarBrightness] Sets the status bar brightness of the application
 /// after opening a link on iOS. Does nothing if no value is passed. This does
-/// not handle reseting the previous status bar style.
+/// not handle resetting the previous status bar style.
 ///
-/// Return a Future contains bool value. If ture, launch url is successful; if false,
-/// launch url is failed.
+/// Returns true if launch url is successful; false is only returned when [universalLinksOnly]
+/// is set to true and the universal link is failed to launch.
 Future<bool> launch(
   String urlString, {
   bool forceSafariVC,

--- a/packages/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/lib/url_launcher.dart
@@ -28,7 +28,7 @@ const MethodChannel _channel = MethodChannel('plugins.flutter.io/url_launcher');
 /// and will always launch a web content in the built-in Safari View Controller regardless
 /// if the url is a universal link or not.
 ///
-/// [universalLinksOnly] is only used in iOS with iOS version > 10.0. This setting is only validated
+/// [universalLinksOnly] is only used in iOS with iOS version >= 10.0. This setting is only validated
 /// when [forceSafariVC] is set to false. The default value of this setting is false.
 /// By default (when unset), the launcher will either launch the url in a browser (when the
 /// url is not a universal link), or launch the respective native app content (when

--- a/packages/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/lib/url_launcher.dart
@@ -20,9 +20,10 @@ const MethodChannel _channel = MethodChannel('plugins.flutter.io/url_launcher');
 /// [forceSafariVC] is only used in iOS. If unset, the launcher opens web URLs
 /// in the safari VC, anything else is opened using the default handler on the
 /// platform. If set to true, it opens the URL in the Safari view controller.
-/// If false, the URL is opened in the default browser of the phone. Set this to
-/// false if you want to use the cookies/context of the main browser of the app
-/// (such as SSO flows).
+/// If false, the URL is opened in the default browser of the phone. Note that
+/// to work with universal links, this must be set to false to let the platform
+/// system handle the URL. Set this to false if you want to use the
+/// cookies/context of the main browser of the app(such as SSO flows).
 ///
 /// [forceWebView] is an Android only setting. If null or false, the URL is
 /// always launched with the default browser on device. If set to true, the URL

--- a/packages/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/lib/url_launcher.dart
@@ -24,7 +24,17 @@ const MethodChannel _channel = MethodChannel('plugins.flutter.io/url_launcher');
 /// default browser of the phone. Note that to work with universal links on iOS,
 /// this must be set to false to let the platform's system handle the URL.
 /// Set this to false if you want to use the cookies/context of the main browser
-/// of the app (such as SSO flows).
+/// of the app (such as SSO flows). This setting will nullify [universalLinksOnly]
+/// and will always launch a web content in the built-in Safari View Controller regardless
+/// if the url is a universal link or not.
+///
+/// [universalLinksOnly] is only used in iOS with iOS version > 10.0. This setting is only validated
+/// when [forceSafariVC] is set to false. The default value of this setting is false.
+/// By default (when unset), the launcher will either launch the url in a browser (when the
+/// url is not a universal link), or launch the respective native app content (when
+/// the url is a universal link). If setting to true, the launcher will only launch the
+/// the content if the url is a universal link and the respective app for the universal
+/// link is installed on the user's device; otherwise throw a [PlatformException].
 ///
 /// [forceWebView] is an Android only setting. If null or false, the URL is
 /// always launched with the default browser on device. If set to true, the URL
@@ -44,6 +54,7 @@ Future<void> launch(
   bool forceSafariVC,
   bool forceWebView,
   bool enableJavaScript,
+  bool universalLinksOnly,
   Brightness statusBarBrightness,
 }) {
   assert(urlString != null);
@@ -72,6 +83,7 @@ Future<void> launch(
       'useSafariVC': forceSafariVC ?? isWebURL,
       'useWebView': forceWebView ?? false,
       'enableJavaScript': enableJavaScript ?? false,
+      'universalLinksOnly': universalLinksOnly ?? false
     },
   ).then((void _) {
     if (statusBarBrightness != null) {

--- a/packages/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/lib/url_launcher.dart
@@ -21,9 +21,9 @@ const MethodChannel _channel = MethodChannel('plugins.flutter.io/url_launcher');
 /// in the safari VC, anything else is opened using the default handler on the
 /// platform. If set to true, it opens the URL in the Safari view controller.
 /// If false, the URL is opened in the default browser of the phone. Note that
-/// to work with universal links, this must be set to false to let the platform
-/// system handle the URL. Set this to false if you want to use the
-/// cookies/context of the main browser of the app(such as SSO flows).
+/// to work with universal links on iOS, this must be set to false to let
+/// the platform's system handle the URL. Set this to false if you want to
+/// use the cookies/context of the main browser of the app(such as SSO flows).
 ///
 /// [forceWebView] is an Android only setting. If null or false, the URL is
 /// always launched with the default browser on device. If set to true, the URL

--- a/packages/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/lib/url_launcher.dart
@@ -17,13 +17,13 @@ const MethodChannel _channel = MethodChannel('plugins.flutter.io/url_launcher');
 /// schemes which cannot be handled, that is when [canLaunch] would complete
 /// with false.
 ///
-/// [forceSafariVC] is only used in iOS. If unset, the launcher opens web URLs
-/// in the safari VC, anything else is opened using the default handler on the
-/// platform. If set to true, it opens the URL in the Safari view controller.
+/// [forceSafariVC] is only used in iOS. By default (when unset), the launcher opens web URLs
+/// in the Safari View Controller, anything else is opened using the default handler on the
+/// platform. If set to true, it opens the URL in the Safari View Controller.
 /// If false, the URL is opened in the default browser of the phone. Note that
 /// to work with universal links on iOS, this must be set to false to let
 /// the platform's system handle the URL. Set this to false if you want to
-/// use the cookies/context of the main browser of the app(such as SSO flows).
+/// use the cookies/context of the main browser of the app (such as SSO flows).
 ///
 /// [forceWebView] is an Android only setting. If null or false, the URL is
 /// always launched with the default browser on device. If set to true, the URL

--- a/packages/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/lib/url_launcher.dart
@@ -17,7 +17,7 @@ const MethodChannel _channel = MethodChannel('plugins.flutter.io/url_launcher');
 /// schemes which cannot be handled, that is when [canLaunch] would complete
 /// with false.
 ///
-/// [forceSafariVC] is only used in iOS. By default (when unset), the launcher
+/// [forceSafariVC] is only used in iOS with iOS version >= 9.0. By default (when unset), the launcher
 /// opens web URLs in the Safari View Controller, anything else is opened
 /// using the default handler on the platform. If set to true, it opens the
 /// URL in the Safari View Controller. If false, the URL is opened in the
@@ -32,7 +32,7 @@ const MethodChannel _channel = MethodChannel('plugins.flutter.io/url_launcher');
 /// when [forceSafariVC] is set to false. The default value of this setting is false.
 /// By default (when unset), the launcher will either launch the url in a browser (when the
 /// url is not a universal link), or launch the respective native app content (when
-/// the url is a universal link). If setting to true, the launcher will only launch the
+/// the url is a universal link). When set to true, the launcher will only launch
 /// the content if the url is a universal link and the respective app for the universal
 /// link is installed on the user's device; otherwise throw a [PlatformException].
 ///
@@ -49,7 +49,7 @@ const MethodChannel _channel = MethodChannel('plugins.flutter.io/url_launcher');
 /// [statusBarBrightness] Sets the status bar brightness of the application
 /// after opening a link on iOS. Does nothing if no value is passed. This does
 /// not handle reseting the previous status bar style.
-Future<void> launch(
+Future<bool> launch(
   String urlString, {
   bool forceSafariVC,
   bool forceWebView,
@@ -109,9 +109,13 @@ Future<bool> canLaunch(String urlString) async {
 ///
 /// If [launch] was never called, then this call will not have any effect.
 ///
-/// On Android systems, if [launch] was called without `forceWebView` being set to
-/// `true`, this call will not do anything either, simply because there is no
-/// WebView available to be closed.
+/// On Android systems, if [launch] was called without `forceWebView` being set to `true`
+/// Or on IOS systems, if [launch] was called without `forceSafariVC` being set to `true`,
+/// this call will not do anything either, simply because there is no
+/// WebView/SafariViewController available to be closed.
+/// 
+/// SafariViewController is only available on IOS version >= 9.0, this method does not do anything
+/// on IOS version below 9.0
 Future<void> closeWebView() async {
   return await _channel.invokeMethod('closeWebView');
 }

--- a/packages/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/lib/url_launcher.dart
@@ -51,7 +51,7 @@ const MethodChannel _channel = MethodChannel('plugins.flutter.io/url_launcher');
 /// not handle resetting the previous status bar style.
 ///
 /// Returns true if launch url is successful; false is only returned when [universalLinksOnly]
-/// is set to true and the universal link is failed to launch.
+/// is set to true and the universal link failed to launch.
 Future<bool> launch(
   String urlString, {
   bool forceSafariVC,

--- a/packages/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/lib/url_launcher.dart
@@ -85,7 +85,7 @@ Future<bool> launch(
       'enableJavaScript': enableJavaScript ?? false,
       'universalLinksOnly': universalLinksOnly ?? false
     },
-  ).then<dynamic>((void _) {
+  ).then((void _) {
     if (statusBarBrightness != null) {
       WidgetsBinding.instance.renderView.automaticSystemUiAdjustment =
           previousAutomaticSystemUiAdjustment;

--- a/packages/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/lib/url_launcher.dart
@@ -89,7 +89,7 @@ Future<bool> launch(
       'useSafariVC': forceSafariVC ?? isWebURL,
       'useWebView': forceWebView ?? false,
       'enableJavaScript': enableJavaScript ?? false,
-      'universalLinksOnly': universalLinksOnly ?? false
+      'universalLinksOnly': universalLinksOnly ?? false,
     },
   ).then((void _) {
     if (statusBarBrightness != null) {

--- a/packages/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/lib/url_launcher.dart
@@ -17,13 +17,14 @@ const MethodChannel _channel = MethodChannel('plugins.flutter.io/url_launcher');
 /// schemes which cannot be handled, that is when [canLaunch] would complete
 /// with false.
 ///
-/// [forceSafariVC] is only used in iOS. By default (when unset), the launcher opens web URLs
-/// in the Safari View Controller, anything else is opened using the default handler on the
-/// platform. If set to true, it opens the URL in the Safari View Controller.
-/// If false, the URL is opened in the default browser of the phone. Note that
-/// to work with universal links on iOS, this must be set to false to let
-/// the platform's system handle the URL. Set this to false if you want to
-/// use the cookies/context of the main browser of the app (such as SSO flows).
+/// [forceSafariVC] is only used in iOS. By default (when unset), the launcher
+/// opens web URLs in the Safari View Controller, anything else is opened
+/// using the default handler on the platform. If set to true, it opens the
+/// URL in the Safari View Controller. If false, the URL is opened in the
+/// default browser of the phone. Note that to work with universal links on iOS,
+/// this must be set to false to let the platform's system handle the URL.
+/// Set this to false if you want to use the cookies/context of the main browser
+/// of the app (such as SSO flows).
 ///
 /// [forceWebView] is an Android only setting. If null or false, the URL is
 /// always launched with the default browser on device. If set to true, the URL

--- a/packages/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/lib/url_launcher.dart
@@ -49,6 +49,9 @@ const MethodChannel _channel = MethodChannel('plugins.flutter.io/url_launcher');
 /// [statusBarBrightness] Sets the status bar brightness of the application
 /// after opening a link on iOS. Does nothing if no value is passed. This does
 /// not handle reseting the previous status bar style.
+///
+/// Return a Future contains bool value. If ture, launch url is successful; if false,
+/// launch url is failed.
 Future<bool> launch(
   String urlString, {
   bool forceSafariVC,

--- a/packages/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for launching a URL on Android and iOS. Supports
   web, phone, SMS, and email schemes.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher
-version: 4.0.4
+version: 4.1.0
 
 flutter:
   plugin:

--- a/packages/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for launching a URL on Android and iOS. Supports
   web, phone, SMS, and email schemes.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher
-version: 4.0.3
+version: 4.0.4
 
 flutter:
   plugin:

--- a/packages/url_launcher/test/url_launcher_test.dart
+++ b/packages/url_launcher/test/url_launcher_test.dart
@@ -40,7 +40,7 @@ void main() {
           'useSafariVC': true,
           'useWebView': false,
           'enableJavaScript': false,
-          'universalLinksOnly' :false,
+          'universalLinksOnly': false,
         })
       ],
     );
@@ -56,14 +56,15 @@ void main() {
           'useSafariVC': true,
           'useWebView': false,
           'enableJavaScript': false,
-          'universalLinksOnly' :false,
+          'universalLinksOnly': false,
         })
       ],
     );
   });
 
-    test('launch universal links only', () async {
-    await launch('http://example.com/', forceSafariVC: false, universalLinksOnly: true);
+  test('launch universal links only', () async {
+    await launch('http://example.com/',
+        forceSafariVC: false, universalLinksOnly: true);
     expect(
       log,
       <Matcher>[
@@ -72,7 +73,7 @@ void main() {
           'useSafariVC': false,
           'useWebView': false,
           'enableJavaScript': false,
-          'universalLinksOnly' :true,
+          'universalLinksOnly': true,
         })
       ],
     );
@@ -88,7 +89,7 @@ void main() {
           'useSafariVC': true,
           'useWebView': true,
           'enableJavaScript': false,
-          'universalLinksOnly' :false,
+          'universalLinksOnly': false,
         })
       ],
     );
@@ -105,7 +106,7 @@ void main() {
           'useSafariVC': true,
           'useWebView': true,
           'enableJavaScript': true,
-          'universalLinksOnly' :false,
+          'universalLinksOnly': false,
         })
       ],
     );
@@ -121,7 +122,7 @@ void main() {
           'useSafariVC': false,
           'useWebView': false,
           'enableJavaScript': false,
-          'universalLinksOnly' :false,
+          'universalLinksOnly': false,
         })
       ],
     );

--- a/packages/url_launcher/test/url_launcher_test.dart
+++ b/packages/url_launcher/test/url_launcher_test.dart
@@ -40,6 +40,7 @@ void main() {
           'useSafariVC': true,
           'useWebView': false,
           'enableJavaScript': false,
+          'universalLinksOnly' :false,
         })
       ],
     );
@@ -55,6 +56,23 @@ void main() {
           'useSafariVC': true,
           'useWebView': false,
           'enableJavaScript': false,
+          'universalLinksOnly' :false,
+        })
+      ],
+    );
+  });
+
+    test('launch universal links only', () async {
+    await launch('http://example.com/', forceSafariVC: false, universalLinksOnly: true);
+    expect(
+      log,
+      <Matcher>[
+        isMethodCall('launch', arguments: <String, Object>{
+          'url': 'http://example.com/',
+          'useSafariVC': false,
+          'useWebView': false,
+          'enableJavaScript': false,
+          'universalLinksOnly' :true,
         })
       ],
     );
@@ -70,6 +88,7 @@ void main() {
           'useSafariVC': true,
           'useWebView': true,
           'enableJavaScript': false,
+          'universalLinksOnly' :false,
         })
       ],
     );
@@ -86,6 +105,7 @@ void main() {
           'useSafariVC': true,
           'useWebView': true,
           'enableJavaScript': true,
+          'universalLinksOnly' :false,
         })
       ],
     );
@@ -101,6 +121,7 @@ void main() {
           'useSafariVC': false,
           'useWebView': false,
           'enableJavaScript': false,
+          'universalLinksOnly' :false,
         })
       ],
     );


### PR DESCRIPTION
Added a setting `universalLinksOnly` for IOS with version >= 10.0

With setting this to true, user can now force the URL Launcher to launch universal links only when the app for the universal link is installed. If the app is not installed, a Platform exception will be thrown. By catching the exception, other actions can be performed. E.g. open the URL destination in a Safari View Controller. 
This is an improvement requested in https://github.com/flutter/flutter/issues/25991

Updated the version to 4.1.0 because there is a breaking change updating `launch` to return bool from void