### PR TITLE
Supress `strong_mode_implicit_dynamic_method` for `invokeMethod` calls.

### DIFF
--- a/packages/android_alarm_manager/lib/android_alarm_manager.dart
+++ b/packages/android_alarm_manager/lib/android_alarm_manager.dart
@@ -43,6 +43,9 @@ void _alarmManagerCallbackDispatcher() {
 
   // Once we've finished initializing, let the native portion of the plugin
   // know that it can start scheduling alarms.
+  // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+  // https://github.com/flutter/flutter/issues/26431
+  // ignore: strong_mode_implicit_dynamic_method
   _channel.invokeMethod('AlarmService.initialized');
 }
 
@@ -67,6 +70,9 @@ class AndroidAlarmManager {
       return false;
     }
     final dynamic r = await _channel
+        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
         .invokeMethod('AlarmService.start', <dynamic>[handle.toRawHandle()]);
     return r ?? false;
   }
@@ -106,6 +112,9 @@ class AndroidAlarmManager {
     if (handle == null) {
       return false;
     }
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     final dynamic r = await _channel.invokeMethod('Alarm.oneShot', <dynamic>[
       id,
       exact,
@@ -152,6 +161,9 @@ class AndroidAlarmManager {
     if (handle == null) {
       return false;
     }
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     final dynamic r = await _channel.invokeMethod('Alarm.periodic',
         <dynamic>[id, exact, wakeup, first, period, handle.toRawHandle()]);
     return (r == null) ? false : r;
@@ -166,6 +178,9 @@ class AndroidAlarmManager {
   /// failure.
   static Future<bool> cancel(int id) async {
     final dynamic r =
+        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
         await _channel.invokeMethod('Alarm.cancel', <dynamic>[id]);
     return (r == null) ? false : r;
   }

--- a/packages/android_intent/lib/android_intent.dart
+++ b/packages/android_intent/lib/android_intent.dart
@@ -57,6 +57,9 @@ class AndroidIntent {
     if (package != null) {
       args['package'] = package;
     }
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     await _channel.invokeMethod('launch', args);
   }
 }

--- a/packages/battery/lib/battery.dart
+++ b/packages/battery/lib/battery.dart
@@ -33,6 +33,9 @@ class Battery {
 
   /// Returns the current battery level in percent.
   Future<int> get batteryLevel => _methodChannel
+      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+      // https://github.com/flutter/flutter/issues/26431
+      // ignore: strong_mode_implicit_dynamic_method
       .invokeMethod('getBatteryLevel')
       .then<int>((dynamic result) => result);
 

--- a/packages/battery/test/battery_test.dart
+++ b/packages/battery/test/battery_test.dart
@@ -22,6 +22,9 @@ void main() {
   });
 
   test('batteryLevel', () async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     when(methodChannel.invokeMethod('getBatteryLevel'))
         .thenAnswer((Invocation invoke) => Future<int>.value(42));
     expect(await battery.batteryLevel, 42);

--- a/packages/camera/lib/camera.dart
+++ b/packages/camera/lib/camera.dart
@@ -11,6 +11,9 @@ import 'package:flutter/widgets.dart';
 part 'camera_image.dart';
 
 final MethodChannel _channel = const MethodChannel('plugins.flutter.io/camera')
+  // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+  // https://github.com/flutter/flutter/issues/26431
+  // ignore: strong_mode_implicit_dynamic_method
   ..invokeMethod('init');
 
 enum CameraLensDirection { front, back, external }
@@ -50,6 +53,9 @@ CameraLensDirection _parseCameraLensDirection(String string) {
 Future<List<CameraDescription>> availableCameras() async {
   try {
     final List<dynamic> cameras =
+        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
         await _channel.invokeMethod('availableCameras');
     return cameras.map((dynamic camera) {
       return CameraDescription(
@@ -214,6 +220,9 @@ class CameraController extends ValueNotifier<CameraValue> {
     }
     try {
       _creatingCompleter = Completer<void>();
+      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+      // https://github.com/flutter/flutter/issues/26431
+      // ignore: strong_mode_implicit_dynamic_method
       final Map<dynamic, dynamic> reply = await _channel.invokeMethod(
         'initialize',
         <String, dynamic>{
@@ -283,6 +292,9 @@ class CameraController extends ValueNotifier<CameraValue> {
     }
     try {
       value = value.copyWith(isTakingPicture: true);
+      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+      // https://github.com/flutter/flutter/issues/26431
+      // ignore: strong_mode_implicit_dynamic_method
       await _channel.invokeMethod(
         'takePicture',
         <String, dynamic>{'textureId': _textureId, 'path': path},
@@ -328,6 +340,9 @@ class CameraController extends ValueNotifier<CameraValue> {
     }
 
     try {
+      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+      // https://github.com/flutter/flutter/issues/26431
+      // ignore: strong_mode_implicit_dynamic_method
       await _channel.invokeMethod('startImageStream');
       value = value.copyWith(isStreamingImages: true);
     } on PlatformException catch (e) {
@@ -369,6 +384,9 @@ class CameraController extends ValueNotifier<CameraValue> {
 
     try {
       value = value.copyWith(isStreamingImages: false);
+      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+      // https://github.com/flutter/flutter/issues/26431
+      // ignore: strong_mode_implicit_dynamic_method
       await _channel.invokeMethod('stopImageStream');
     } on PlatformException catch (e) {
       throw CameraException(e.code, e.message);
@@ -409,6 +427,9 @@ class CameraController extends ValueNotifier<CameraValue> {
     }
 
     try {
+      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+      // https://github.com/flutter/flutter/issues/26431
+      // ignore: strong_mode_implicit_dynamic_method
       await _channel.invokeMethod(
         'startVideoRecording',
         <String, dynamic>{'textureId': _textureId, 'filePath': filePath},
@@ -435,6 +456,9 @@ class CameraController extends ValueNotifier<CameraValue> {
     }
     try {
       value = value.copyWith(isRecordingVideo: false);
+      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+      // https://github.com/flutter/flutter/issues/26431
+      // ignore: strong_mode_implicit_dynamic_method
       await _channel.invokeMethod(
         'stopVideoRecording',
         <String, dynamic>{'textureId': _textureId},
@@ -454,6 +478,9 @@ class CameraController extends ValueNotifier<CameraValue> {
     super.dispose();
     if (_creatingCompleter != null) {
       await _creatingCompleter.future;
+      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+      // https://github.com/flutter/flutter/issues/26431
+      // ignore: strong_mode_implicit_dynamic_method
       await _channel.invokeMethod(
         'dispose',
         <String, dynamic>{'textureId': _textureId},

--- a/packages/cloud_firestore/lib/src/document_reference.dart
+++ b/packages/cloud_firestore/lib/src/document_reference.dart
@@ -40,6 +40,9 @@ class DocumentReference {
   /// If [merge] is true, the provided data will be merged into an
   /// existing document instead of overwriting.
   Future<void> setData(Map<String, dynamic> data, {bool merge = false}) {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return Firestore.channel.invokeMethod(
       'DocumentReference#setData',
       <String, dynamic>{
@@ -58,6 +61,9 @@ class DocumentReference {
   ///
   /// If no document exists yet, the update will fail.
   Future<void> updateData(Map<String, dynamic> data) {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return Firestore.channel.invokeMethod(
       'DocumentReference#updateData',
       <String, dynamic>{
@@ -72,6 +78,9 @@ class DocumentReference {
   ///
   /// If no document exists, the read will return null.
   Future<DocumentSnapshot> get() async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     final Map<dynamic, dynamic> data = await Firestore.channel.invokeMethod(
       'DocumentReference#get',
       <String, dynamic>{'app': firestore.app.name, 'path': path},
@@ -85,6 +94,9 @@ class DocumentReference {
 
   /// Deletes the document referred to by this [DocumentReference].
   Future<void> delete() {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return Firestore.channel.invokeMethod(
       'DocumentReference#delete',
       <String, dynamic>{'app': firestore.app.name, 'path': path},
@@ -108,6 +120,9 @@ class DocumentReference {
     StreamController<DocumentSnapshot> controller; // ignore: close_sinks
     controller = StreamController<DocumentSnapshot>.broadcast(
       onListen: () {
+        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
         _handle = Firestore.channel.invokeMethod(
           'Query#addDocumentListener',
           <String, dynamic>{
@@ -121,6 +136,9 @@ class DocumentReference {
       },
       onCancel: () {
         _handle.then((int handle) async {
+          // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+          // https://github.com/flutter/flutter/issues/26431
+          // ignore: strong_mode_implicit_dynamic_method
           await Firestore.channel.invokeMethod(
             'Query#removeListener',
             <String, dynamic>{'handle': handle},

--- a/packages/cloud_firestore/lib/src/firestore.dart
+++ b/packages/cloud_firestore/lib/src/firestore.dart
@@ -111,6 +111,9 @@ class Firestore {
     final int transactionId = _transactionHandlerId++;
     _transactionHandlers[transactionId] = transactionHandler;
     final Map<dynamic, dynamic> result = await channel
+        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
         .invokeMethod('Firestore#runTransaction', <String, dynamic>{
       'app': app.name,
       'transactionId': transactionId,
@@ -122,6 +125,9 @@ class Firestore {
   @deprecated
   Future<void> enablePersistence(bool enable) async {
     assert(enable != null);
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     await channel.invokeMethod('Firestore#enablePersistence', <String, dynamic>{
       'app': app.name,
       'enable': enable,
@@ -133,6 +139,9 @@ class Firestore {
       String host,
       bool sslEnabled,
       bool timestampsInSnapshotsEnabled}) async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     await channel.invokeMethod('Firestore#settings', <String, dynamic>{
       'app': app.name,
       'persistenceEnabled': persistenceEnabled,

--- a/packages/cloud_firestore/lib/src/query.dart
+++ b/packages/cloud_firestore/lib/src/query.dart
@@ -53,6 +53,9 @@ class Query {
     StreamController<QuerySnapshot> controller; // ignore: close_sinks
     controller = StreamController<QuerySnapshot>.broadcast(
       onListen: () {
+        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
         _handle = Firestore.channel.invokeMethod(
           'Query#addSnapshotListener',
           <String, dynamic>{
@@ -67,6 +70,9 @@ class Query {
       },
       onCancel: () {
         _handle.then((int handle) async {
+          // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+          // https://github.com/flutter/flutter/issues/26431
+          // ignore: strong_mode_implicit_dynamic_method
           await Firestore.channel.invokeMethod(
             'Query#removeListener',
             <String, dynamic>{'handle': handle},
@@ -80,6 +86,9 @@ class Query {
 
   /// Fetch the documents for this query
   Future<QuerySnapshot> getDocuments() async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     final Map<dynamic, dynamic> data = await Firestore.channel.invokeMethod(
       'Query#getDocuments',
       <String, dynamic>{

--- a/packages/cloud_firestore/lib/src/transaction.dart
+++ b/packages/cloud_firestore/lib/src/transaction.dart
@@ -15,6 +15,9 @@ class Transaction {
 
   Future<DocumentSnapshot> get(DocumentReference documentReference) async {
     final dynamic result = await Firestore.channel
+        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
         .invokeMethod('Transaction#get', <String, dynamic>{
       'app': _firestore.app.name,
       'transactionId': _transactionId,
@@ -30,6 +33,9 @@ class Transaction {
 
   Future<void> delete(DocumentReference documentReference) async {
     return Firestore.channel
+        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
         .invokeMethod('Transaction#delete', <String, dynamic>{
       'app': _firestore.app.name,
       'transactionId': _transactionId,
@@ -40,6 +46,9 @@ class Transaction {
   Future<void> update(
       DocumentReference documentReference, Map<String, dynamic> data) async {
     return Firestore.channel
+        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
         .invokeMethod('Transaction#update', <String, dynamic>{
       'app': _firestore.app.name,
       'transactionId': _transactionId,
@@ -50,6 +59,9 @@ class Transaction {
 
   Future<void> set(
       DocumentReference documentReference, Map<String, dynamic> data) async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return Firestore.channel.invokeMethod('Transaction#set', <String, dynamic>{
       'app': _firestore.app.name,
       'transactionId': _transactionId,

--- a/packages/cloud_firestore/lib/src/write_batch.dart
+++ b/packages/cloud_firestore/lib/src/write_batch.dart
@@ -12,6 +12,9 @@ part of cloud_firestore;
 /// nor can it be committed again.
 class WriteBatch {
   WriteBatch._(this._firestore)
+      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+      // https://github.com/flutter/flutter/issues/26431
+      // ignore: strong_mode_implicit_dynamic_method
       : _handle = Firestore.channel.invokeMethod(
             'WriteBatch#create', <String, dynamic>{'app': _firestore.app.name});
 
@@ -29,6 +32,9 @@ class WriteBatch {
     if (!_committed) {
       _committed = true;
       await Future.wait<dynamic>(_actions);
+      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+      // https://github.com/flutter/flutter/issues/26431
+      // ignore: strong_mode_implicit_dynamic_method
       await Firestore.channel.invokeMethod(
           'WriteBatch#commit', <String, dynamic>{'handle': await _handle});
     } else {
@@ -41,6 +47,9 @@ class WriteBatch {
     if (!_committed) {
       _handle.then((dynamic handle) {
         _actions.add(
+          // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+          // https://github.com/flutter/flutter/issues/26431
+          // ignore: strong_mode_implicit_dynamic_method
           Firestore.channel.invokeMethod(
             'WriteBatch#delete',
             <String, dynamic>{
@@ -68,6 +77,9 @@ class WriteBatch {
     if (!_committed) {
       _handle.then((dynamic handle) {
         _actions.add(
+          // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+          // https://github.com/flutter/flutter/issues/26431
+          // ignore: strong_mode_implicit_dynamic_method
           Firestore.channel.invokeMethod(
             'WriteBatch#setData',
             <String, dynamic>{
@@ -93,6 +105,9 @@ class WriteBatch {
     if (!_committed) {
       _handle.then((dynamic handle) {
         _actions.add(
+          // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+          // https://github.com/flutter/flutter/issues/26431
+          // ignore: strong_mode_implicit_dynamic_method
           Firestore.channel.invokeMethod(
             'WriteBatch#updateData',
             <String, dynamic>{

--- a/packages/cloud_functions/lib/cloud_functions.dart
+++ b/packages/cloud_functions/lib/cloud_functions.dart
@@ -34,6 +34,9 @@ class CloudFunctions {
       {@required String functionName, Map<String, dynamic> parameters}) async {
     try {
       final dynamic response =
+          // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+          // https://github.com/flutter/flutter/issues/26431
+          // ignore: strong_mode_implicit_dynamic_method
           await channel.invokeMethod('CloudFunctions#call', <String, dynamic>{
         'functionName': functionName,
         'parameters': parameters,

--- a/packages/connectivity/lib/connectivity.dart
+++ b/packages/connectivity/lib/connectivity.dart
@@ -39,6 +39,9 @@ class Connectivity {
   ///
   /// Instead listen for connectivity changes via [onConnectivityChanged] stream.
   Future<ConnectivityResult> checkConnectivity() async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     final String result = await _methodChannel.invokeMethod('check');
     return _parseConnectivityResult(result);
   }
@@ -50,6 +53,9 @@ class Connectivity {
   /// From android 8.0 onwards the GPS must be ON (high accuracy)
   /// in order to be able to obtain the SSID.
   Future<String> getWifiName() async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     String wifiName = await _methodChannel.invokeMethod('wifiName');
     // as Android might return <unknown ssid>, uniforming result
     // our iOS implementation will return null

--- a/packages/device_info/lib/device_info.dart
+++ b/packages/device_info/lib/device_info.dart
@@ -22,6 +22,9 @@ class DeviceInfoPlugin {
   /// See: https://developer.android.com/reference/android/os/Build.html
   Future<AndroidDeviceInfo> get androidInfo async =>
       _cachedAndroidDeviceInfo ??= AndroidDeviceInfo._fromMap(
+          // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+          // https://github.com/flutter/flutter/issues/26431
+          // ignore: strong_mode_implicit_dynamic_method
           await channel.invokeMethod('getAndroidDeviceInfo'));
 
   /// This information does not change from call to call. Cache it.
@@ -31,6 +34,9 @@ class DeviceInfoPlugin {
   ///
   /// See: https://developer.apple.com/documentation/uikit/uidevice
   Future<IosDeviceInfo> get iosInfo async => _cachedIosDeviceInfo ??=
+      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+      // https://github.com/flutter/flutter/issues/26431
+      // ignore: strong_mode_implicit_dynamic_method
       IosDeviceInfo._fromMap(await channel.invokeMethod('getIosDeviceInfo'));
 }
 

--- a/packages/firebase_admob/lib/firebase_admob.dart
+++ b/packages/firebase_admob/lib/firebase_admob.dart
@@ -515,6 +515,9 @@ class FirebaseAdMob {
 }
 
 Future<bool> _invokeBooleanMethod(String method, [dynamic arguments]) async {
+  // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+  // https://github.com/flutter/flutter/issues/26431
+  // ignore: strong_mode_implicit_dynamic_method
   final bool result = await FirebaseAdMob.instance._channel.invokeMethod(
     method,
     arguments,

--- a/packages/firebase_analytics/lib/firebase_analytics.dart
+++ b/packages/firebase_analytics/lib/firebase_analytics.dart
@@ -55,6 +55,9 @@ class FirebaseAnalytics {
           'Prefix "$kReservedPrefix" is reserved and cannot be used.');
     }
 
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     await _channel.invokeMethod('logEvent', <String, dynamic>{
       'name': name,
       'parameters': parameters,
@@ -67,6 +70,9 @@ class FirebaseAnalytics {
   ///
   /// [1]: https://www.google.com/policies/privacy/
   Future<void> setUserId(String id) async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     await _channel.invokeMethod('setUserId', id);
   }
 
@@ -94,6 +100,9 @@ class FirebaseAnalytics {
       throw ArgumentError.notNull('screenName');
     }
 
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     await _channel.invokeMethod('setCurrentScreen', <String, String>{
       'screenName': screenName,
       'screenClassOverride': screenClassOverride,
@@ -128,6 +137,9 @@ class FirebaseAnalytics {
     if (name.startsWith('firebase_'))
       throw ArgumentError.value(name, 'name', '"firebase_" prefix is reserved');
 
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     await _channel.invokeMethod('setUserProperty', <String, String>{
       'name': name,
       'value': value,
@@ -787,6 +799,9 @@ class FirebaseAnalyticsAndroid {
       throw ArgumentError.notNull('enabled');
     }
 
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     await _channel.invokeMethod('setAnalyticsCollectionEnabled', enabled);
   }
 
@@ -798,6 +813,9 @@ class FirebaseAnalyticsAndroid {
       throw ArgumentError.notNull('milliseconds');
     }
 
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     await _channel.invokeMethod('setMinimumSessionDuration', milliseconds);
   }
 
@@ -809,6 +827,9 @@ class FirebaseAnalyticsAndroid {
       throw ArgumentError.notNull('milliseconds');
     }
 
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     await _channel.invokeMethod('setSessionTimeoutDuration', milliseconds);
   }
 }

--- a/packages/firebase_analytics/test/firebase_analytics_test.dart
+++ b/packages/firebase_analytics/test/firebase_analytics_test.dart
@@ -39,6 +39,9 @@ void main() {
       invokedMethod = null;
       arguments = null;
 
+      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+      // https://github.com/flutter/flutter/issues/26431
+      // ignore: strong_mode_implicit_dynamic_method
       when(mockChannel.invokeMethod(any, any))
           .thenAnswer((Invocation invocation) {
         invokedMethod = invocation.positionalArguments[0];
@@ -125,6 +128,9 @@ void main() {
       name = null;
       parameters = null;
 
+      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+      // https://github.com/flutter/flutter/issues/26431
+      // ignore: strong_mode_implicit_dynamic_method
       when(mockChannel.invokeMethod('logEvent', any))
           .thenAnswer((Invocation invocation) {
         final Map<String, dynamic> args = invocation.positionalArguments[1];
@@ -134,6 +140,9 @@ void main() {
         return Future<void>.value();
       });
 
+      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+      // https://github.com/flutter/flutter/issues/26431
+      // ignore: strong_mode_implicit_dynamic_method
       when(mockChannel.invokeMethod(argThat(isNot('logEvent')), any))
           .thenThrow(ArgumentError('Only logEvent invocations expected'));
 

--- a/packages/firebase_auth/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/lib/src/firebase_auth.dart
@@ -44,6 +44,9 @@ class FirebaseAuth {
 
     StreamController<FirebaseUser> controller;
     controller = StreamController<FirebaseUser>.broadcast(onListen: () {
+      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+      // https://github.com/flutter/flutter/issues/26431
+      // ignore: strong_mode_implicit_dynamic_method
       _handle = channel.invokeMethod('startListeningAuthState',
           <String, String>{"app": app.name}).then<int>((dynamic v) => v);
       _handle.then((int handle) {
@@ -51,6 +54,9 @@ class FirebaseAuth {
       });
     }, onCancel: () {
       _handle.then((int handle) async {
+        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
         await channel.invokeMethod("stopListeningAuthState",
             <String, dynamic>{"id": handle, "app": app.name});
         _authStateChangedControllers.remove(handle);
@@ -73,6 +79,9 @@ class FirebaseAuth {
   ///   • `ERROR_OPERATION_NOT_ALLOWED` - Indicates that Anonymous accounts are not enabled.
   Future<FirebaseUser> signInAnonymously() async {
     final Map<dynamic, dynamic> data = await channel
+        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
         .invokeMethod('signInAnonymously', <String, String>{"app": app.name});
     final FirebaseUser currentUser = FirebaseUser._(data, app);
     return currentUser;
@@ -93,6 +102,9 @@ class FirebaseAuth {
   }) async {
     assert(email != null);
     assert(password != null);
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     final Map<dynamic, dynamic> data = await channel.invokeMethod(
       'createUserWithEmailAndPassword',
       <String, String>{'email': email, 'password': password, 'app': app.name},
@@ -114,6 +126,9 @@ class FirebaseAuth {
     @required String email,
   }) async {
     assert(email != null);
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     final List<dynamic> providers = await channel.invokeMethod(
       'fetchSignInMethodsForEmail',
       <String, String>{'email': email, 'app': app.name},
@@ -132,6 +147,9 @@ class FirebaseAuth {
     @required String email,
   }) async {
     assert(email != null);
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return await channel.invokeMethod(
       'sendPasswordResetEmail',
       <String, String>{'email': email, 'app': app.name},
@@ -187,6 +205,9 @@ class FirebaseAuth {
   ///   • `ERROR_OPERATION_NOT_ALLOWED` - Indicates that Google accounts are not enabled.
   Future<FirebaseUser> signInWithCredential(AuthCredential credential) async {
     assert(credential != null);
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     final Map<dynamic, dynamic> data = await channel.invokeMethod(
       'signInWithCredential',
       <String, dynamic>{
@@ -267,6 +288,9 @@ class FirebaseAuth {
       'app': app.name,
     };
 
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     await channel.invokeMethod('verifyPhoneNumber', params);
   }
 
@@ -290,6 +314,9 @@ class FirebaseAuth {
   ///     Ensure your app's SHA1 is correct in the Firebase console.
   Future<FirebaseUser> signInWithCustomToken({@required String token}) async {
     assert(token != null);
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     final Map<dynamic, dynamic> data = await channel.invokeMethod(
       'signInWithCustomToken',
       <String, String>{'token': token, 'app': app.name},
@@ -304,12 +331,18 @@ class FirebaseAuth {
   /// the [onAuthStateChanged] stream.
   Future<void> signOut() async {
     return await channel
+        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
         .invokeMethod("signOut", <String, String>{'app': app.name});
   }
 
   /// Returns the currently signed-in [FirebaseUser] or [null] if there is none.
   Future<FirebaseUser> currentUser() async {
     final Map<dynamic, dynamic> data = await channel
+        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
         .invokeMethod("currentUser", <String, String>{'app': app.name});
     final FirebaseUser currentUser =
         data == null ? null : FirebaseUser._(data, app);
@@ -332,6 +365,9 @@ class FirebaseAuth {
   ///   • `ERROR_OPERATION_NOT_ALLOWED` - Indicates that this type of account is not enabled.
   Future<FirebaseUser> linkWithCredential(AuthCredential credential) async {
     assert(credential != null);
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     final Map<dynamic, dynamic> data = await channel.invokeMethod(
       'linkWithCredential',
       <String, dynamic>{
@@ -349,6 +385,9 @@ class FirebaseAuth {
   /// code should follow the conventions defined by the IETF in BCP47.
   Future<void> setLanguageCode(String language) async {
     assert(language != null);
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     await FirebaseAuth.channel.invokeMethod('setLanguageCode', <String, String>{
       'language': language,
       'app': app.name,

--- a/packages/firebase_auth/lib/src/firebase_user.dart
+++ b/packages/firebase_auth/lib/src/firebase_user.dart
@@ -35,6 +35,9 @@ class FirebaseUser extends UserInfo {
   /// Completes with an error if the user is signed out.
   Future<String> getIdToken({bool refresh = false}) async {
     return await FirebaseAuth.channel
+        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
         .invokeMethod('getIdToken', <String, dynamic>{
       'refresh': refresh,
       'app': _app.name,
@@ -43,6 +46,9 @@ class FirebaseUser extends UserInfo {
 
   /// Initiates email verification for the user.
   Future<void> sendEmailVerification() async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     await FirebaseAuth.channel.invokeMethod(
         'sendEmailVerification', <String, String>{'app': _app.name});
   }
@@ -51,12 +57,18 @@ class FirebaseUser extends UserInfo {
   /// attached providers, display name, and so on).
   Future<void> reload() async {
     await FirebaseAuth.channel
+        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
         .invokeMethod('reload', <String, String>{'app': _app.name});
   }
 
   /// Deletes the user record from your Firebase project's database.
   Future<void> delete() async {
     await FirebaseAuth.channel
+        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
         .invokeMethod('delete', <String, String>{'app': _app.name});
   }
 
@@ -78,6 +90,9 @@ class FirebaseUser extends UserInfo {
   ///   • `ERROR_OPERATION_NOT_ALLOWED` - Indicates that Email & Password accounts are not enabled.
   Future<void> updateEmail(String email) async {
     assert(email != null);
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return await FirebaseAuth.channel.invokeMethod(
       'updateEmail',
       <String, String>{'email': email, 'app': _app.name},
@@ -100,6 +115,9 @@ class FirebaseUser extends UserInfo {
   ///   • `ERROR_OPERATION_NOT_ALLOWED` - Indicates that Email & Password accounts are not enabled.
   Future<void> updatePassword(String password) async {
     assert(password != null);
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return await FirebaseAuth.channel.invokeMethod(
       'updatePassword',
       <String, String>{'password': password, 'app': _app.name},
@@ -115,6 +133,9 @@ class FirebaseUser extends UserInfo {
     assert(userUpdateInfo != null);
     final Map<String, String> data = userUpdateInfo._updateData;
     data['app'] = _app.name;
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return await FirebaseAuth.channel.invokeMethod(
       'updateProfile',
       data,
@@ -140,6 +161,9 @@ class FirebaseUser extends UserInfo {
   Future<FirebaseUser> reauthenticateWithCredential(
       AuthCredential credential) async {
     assert(credential != null);
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     await FirebaseAuth.channel.invokeMethod(
       'reauthenticateWithCredential',
       <String, dynamic>{
@@ -166,6 +190,9 @@ class FirebaseUser extends UserInfo {
   ///   • `ERROR_REQUIRES_RECENT_LOGIN` - If the user's last sign-in time does not meet the security threshold. Use reauthenticate methods to resolve.
   Future<void> unlinkFromProvider(String provider) async {
     assert(provider != null);
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return await FirebaseAuth.channel.invokeMethod(
       'unlinkFromProvider',
       <String, String>{'provider': provider, 'app': _app.name},

--- a/packages/firebase_core/lib/src/firebase_app.dart
+++ b/packages/firebase_core/lib/src/firebase_app.dart
@@ -24,6 +24,9 @@ class FirebaseApp {
   /// This getter is asynchronous because apps can also be configured by native
   /// code.
   Future<FirebaseOptions> get options async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     final Map<dynamic, dynamic> app = await channel.invokeMethod(
       'FirebaseApp#appNamed',
       name,
@@ -35,6 +38,9 @@ class FirebaseApp {
   /// Returns a previously created FirebaseApp instance with the given name,
   /// or null if no such app exists.
   static Future<FirebaseApp> appNamed(String name) async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     final Map<dynamic, dynamic> app = await channel.invokeMethod(
       'FirebaseApp#appNamed',
       name,
@@ -66,6 +72,9 @@ class FirebaseApp {
       assert(await existingApp.options == options);
       return existingApp;
     }
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     await channel.invokeMethod(
       'FirebaseApp#configure',
       <String, dynamic>{'name': name, 'options': options.asMap},
@@ -76,6 +85,9 @@ class FirebaseApp {
   /// Returns a list of all extant FirebaseApp instances, or null if there are
   /// no FirebaseApp instances.
   static Future<List<FirebaseApp>> allApps() async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     final List<dynamic> result = await channel.invokeMethod(
       'FirebaseApp#allApps',
     );

--- a/packages/firebase_database/lib/src/database_reference.dart
+++ b/packages/firebase_database/lib/src/database_reference.dart
@@ -70,6 +70,9 @@ class DatabaseReference extends Query {
   /// Passing null for the new value means all data at this location or any
   /// child location will be deleted.
   Future<void> set(dynamic value, {dynamic priority}) {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return _database._channel.invokeMethod(
       'DatabaseReference#set',
       <String, dynamic>{
@@ -84,6 +87,9 @@ class DatabaseReference extends Query {
 
   /// Update the node with the `value`
   Future<void> update(Map<String, dynamic> value) {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return _database._channel.invokeMethod(
       'DatabaseReference#update',
       <String, dynamic>{
@@ -120,6 +126,9 @@ class DatabaseReference extends Query {
   /// floating-point numbers. Keys are always stored as strings and are treated
   /// as numbers only when they can be parsed as a 32-bit integer.
   Future<void> setPriority(dynamic priority) async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return _database._channel.invokeMethod(
       'DatabaseReference#setPriority',
       <String, dynamic>{
@@ -171,6 +180,9 @@ class DatabaseReference extends Query {
     }
 
     _database._channel
+        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
         .invokeMethod('DatabaseReference#runTransaction', <String, dynamic>{
       'app': _database.app?.name,
       'databaseURL': _database.databaseURL,

--- a/packages/firebase_database/lib/src/firebase_database.dart
+++ b/packages/firebase_database/lib/src/firebase_database.dart
@@ -88,6 +88,9 @@ class FirebaseDatabase {
   /// thus be available again when the app is restarted (even when there is no
   /// network connectivity at that time).
   Future<bool> setPersistenceEnabled(bool enabled) async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     final bool result = await _channel.invokeMethod(
       'FirebaseDatabase#setPersistenceEnabled',
       <String, dynamic>{
@@ -117,6 +120,9 @@ class FirebaseDatabase {
   /// on disk may temporarily exceed it at times. Cache sizes smaller than 1 MB
   /// or greater than 100 MB are not supported.
   Future<bool> setPersistenceCacheSizeBytes(int cacheSize) async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     final bool result = await _channel.invokeMethod(
       'FirebaseDatabase#setPersistenceCacheSizeBytes',
       <String, dynamic>{
@@ -131,6 +137,9 @@ class FirebaseDatabase {
   /// Resumes our connection to the Firebase Database backend after a previous
   /// [goOffline] call.
   Future<void> goOnline() {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return _channel.invokeMethod(
       'FirebaseDatabase#goOnline',
       <String, dynamic>{
@@ -143,6 +152,9 @@ class FirebaseDatabase {
   /// Shuts down our connection to the Firebase Database backend until
   /// [goOnline] is called.
   Future<void> goOffline() {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return _channel.invokeMethod(
       'FirebaseDatabase#goOffline',
       <String, dynamic>{
@@ -163,6 +175,9 @@ class FirebaseDatabase {
   /// affected event listeners, and the client will not (re-)send them to the
   /// Firebase Database backend.
   Future<void> purgeOutstandingWrites() {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return _channel.invokeMethod(
       'FirebaseDatabase#purgeOutstandingWrites',
       <String, dynamic>{

--- a/packages/firebase_database/lib/src/on_disconnect.dart
+++ b/packages/firebase_database/lib/src/on_disconnect.dart
@@ -8,6 +8,9 @@ class OnDisconnect {
   final String path;
 
   Future<void> set(dynamic value, {dynamic priority}) {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return _database._channel.invokeMethod(
       'OnDisconnect#set',
       <String, dynamic>{
@@ -23,6 +26,9 @@ class OnDisconnect {
   Future<void> remove() => set(null);
 
   Future<void> cancel() {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return _database._channel.invokeMethod(
       'OnDisconnect#cancel',
       <String, dynamic>{
@@ -34,6 +40,9 @@ class OnDisconnect {
   }
 
   Future<void> update(Map<String, dynamic> value) {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return _database._channel.invokeMethod(
       'OnDisconnect#update',
       <String, dynamic>{

--- a/packages/firebase_database/lib/src/query.dart
+++ b/packages/firebase_database/lib/src/query.dart
@@ -47,6 +47,9 @@ class Query {
     StreamController<Event> controller; // ignore: close_sinks
     controller = StreamController<Event>.broadcast(
       onListen: () {
+        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
         _handle = _database._channel.invokeMethod(
           'Query#observe',
           <String, dynamic>{
@@ -63,6 +66,9 @@ class Query {
       },
       onCancel: () {
         _handle.then((int handle) async {
+          // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+          // https://github.com/flutter/flutter/issues/26431
+          // ignore: strong_mode_implicit_dynamic_method
           await _database._channel.invokeMethod(
             'Query#removeObserver',
             <String, dynamic>{
@@ -206,6 +212,9 @@ class Query {
   /// attached for that location. Additionally, while a location is kept synced,
   /// it will not be evicted from the persistent disk cache.
   Future<void> keepSynced(bool value) {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return _database._channel.invokeMethod(
       'Query#keepSynced',
       <String, dynamic>{

--- a/packages/firebase_dynamic_links/lib/src/dynamic_link_parameters.dart
+++ b/packages/firebase_dynamic_links/lib/src/dynamic_link_parameters.dart
@@ -66,6 +66,9 @@ class DynamicLinkParameters {
   static Future<ShortDynamicLink> shortenUrl(Uri url,
       [DynamicLinkParametersOptions options]) async {
     final Map<dynamic, dynamic> reply = await FirebaseDynamicLinks.channel
+        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
         .invokeMethod('DynamicLinkParameters#shortenUrl', <String, dynamic>{
       'url': url.toString(),
       'dynamicLinkParametersOptions': options?._data,
@@ -89,6 +92,9 @@ class DynamicLinkParameters {
   /// Generate a long Dynamic Link URL.
   Future<Uri> buildUrl() async {
     final String url = await FirebaseDynamicLinks.channel
+        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
         .invokeMethod('DynamicLinkParameters#buildUrl', _data);
     return Uri.parse(url);
   }
@@ -96,6 +102,9 @@ class DynamicLinkParameters {
   /// Generate a short Dynamic Link.
   Future<ShortDynamicLink> buildShortLink() async {
     final Map<dynamic, dynamic> reply = await FirebaseDynamicLinks.channel
+        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
         .invokeMethod('DynamicLinkParameters#buildShortLink', _data);
     return _parseShortLink(reply);
   }

--- a/packages/firebase_dynamic_links/lib/src/firebase_dynamic_links.dart
+++ b/packages/firebase_dynamic_links/lib/src/firebase_dynamic_links.dart
@@ -24,6 +24,9 @@ class FirebaseDynamicLinks {
   /// the first attempt.
   Future<PendingDynamicLinkData> retrieveDynamicLink() async {
     final Map<dynamic, dynamic> linkData =
+        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
         await channel.invokeMethod('FirebaseDynamicLinks#retrieveDynamicLink');
 
     if (linkData == null) return null;

--- a/packages/firebase_messaging/lib/firebase_messaging.dart
+++ b/packages/firebase_messaging/lib/firebase_messaging.dart
@@ -42,6 +42,9 @@ class FirebaseMessaging {
     if (!_platform.isIOS) {
       return;
     }
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     _channel.invokeMethod(
         'requestNotificationPermissions', iosSettings.toMap());
   }
@@ -66,6 +69,9 @@ class FirebaseMessaging {
     _onLaunch = onLaunch;
     _onResume = onResume;
     _channel.setMethodCallHandler(_handleMethod);
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     _channel.invokeMethod('configure');
   }
 
@@ -79,6 +85,9 @@ class FirebaseMessaging {
 
   /// Returns the FCM token.
   Future<String> getToken() async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return await _channel.invokeMethod('getToken');
   }
 
@@ -87,11 +96,17 @@ class FirebaseMessaging {
   /// [topic] must match the following regular expression:
   /// "[a-zA-Z0-9-_.~%]{1,900}".
   void subscribeToTopic(String topic) {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     _channel.invokeMethod('subscribeToTopic', topic);
   }
 
   /// Unsubscribe from topic in background.
   void unsubscribeFromTopic(String topic) {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     _channel.invokeMethod('unsubscribeFromTopic', topic);
   }
 
@@ -101,16 +116,25 @@ class FirebaseMessaging {
   ///
   /// returns true if the operations executed successfully and false if an error ocurred
   Future<bool> deleteInstanceID() async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return await _channel.invokeMethod('deleteInstanceID');
   }
 
   /// Determine whether FCM auto-initialization is enabled or disabled.
   Future<bool> autoInitEnabled() async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return await _channel.invokeMethod('autoInitEnabled');
   }
 
   /// Enable or disable auto-initialization of Firebase Cloud Messaging.
   Future<void> setAutoInitEnabled(bool enabled) async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     await _channel.invokeMethod('setAutoInitEnabled', enabled);
   }
 

--- a/packages/firebase_messaging/test/firebase_messaging_test.dart
+++ b/packages/firebase_messaging/test/firebase_messaging_test.dart
@@ -22,6 +22,9 @@ void main() {
 
   test('requestNotificationPermissions on ios with default permissions', () {
     firebaseMessaging.requestNotificationPermissions();
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     verify(mockChannel.invokeMethod('requestNotificationPermissions',
         <String, bool>{'sound': true, 'badge': true, 'alert': true}));
   });
@@ -29,6 +32,9 @@ void main() {
   test('requestNotificationPermissions on ios with custom permissions', () {
     firebaseMessaging.requestNotificationPermissions(
         const IosNotificationSettings(sound: false));
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     verify(mockChannel.invokeMethod('requestNotificationPermissions',
         <String, bool>{'sound': false, 'badge': true, 'alert': true}));
   });
@@ -52,6 +58,9 @@ void main() {
   test('configure', () {
     firebaseMessaging.configure();
     verify(mockChannel.setMethodCallHandler(any));
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     verify(mockChannel.invokeMethod('configure'));
   });
 
@@ -125,26 +134,41 @@ void main() {
 
   test('subscribe to topic', () {
     firebaseMessaging.subscribeToTopic(myTopic);
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     verify(mockChannel.invokeMethod('subscribeToTopic', myTopic));
   });
 
   test('unsubscribe from topic', () {
     firebaseMessaging.unsubscribeFromTopic(myTopic);
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     verify(mockChannel.invokeMethod('unsubscribeFromTopic', myTopic));
   });
 
   test('getToken', () {
     firebaseMessaging.getToken();
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     verify(mockChannel.invokeMethod('getToken'));
   });
 
   test('deleteInstanceID', () {
     firebaseMessaging.deleteInstanceID();
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     verify(mockChannel.invokeMethod('deleteInstanceID'));
   });
 
   test('autoInitEnabled', () {
     firebaseMessaging.autoInitEnabled();
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     verify(mockChannel.invokeMethod('autoInitEnabled'));
   });
 
@@ -155,6 +179,9 @@ void main() {
     firebaseMessaging.setAutoInitEnabled(true);
 
     // assert we called the method with enabled = true
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     verify(mockChannel.invokeMethod('setAutoInitEnabled', true));
 
     // assert that enabled = false was not yet called
@@ -163,6 +190,9 @@ void main() {
     firebaseMessaging.setAutoInitEnabled(false);
 
     // assert call with enabled = false was properly done
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     verify(mockChannel.invokeMethod('setAutoInitEnabled', false));
   });
 }

--- a/packages/firebase_ml_vision/lib/src/barcode_detector.dart
+++ b/packages/firebase_ml_vision/lib/src/barcode_detector.dart
@@ -186,6 +186,9 @@ class BarcodeDetector extends FirebaseVisionDetector {
   /// The barcode scanning is performed asynchronously.
   @override
   Future<List<Barcode>> detectInImage(FirebaseVisionImage visionImage) async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     final List<dynamic> reply = await FirebaseVision.channel.invokeMethod(
       'BarcodeDetector#detectInImage',
       <String, dynamic>{

--- a/packages/firebase_ml_vision/lib/src/face_detector.dart
+++ b/packages/firebase_ml_vision/lib/src/face_detector.dart
@@ -41,6 +41,9 @@ class FaceDetector extends FirebaseVisionDetector {
   /// Detects faces in the input image.
   @override
   Future<List<Face>> detectInImage(FirebaseVisionImage visionImage) async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     final List<dynamic> reply = await FirebaseVision.channel.invokeMethod(
       'FaceDetector#detectInImage',
       <String, dynamic>{

--- a/packages/firebase_ml_vision/lib/src/label_detector.dart
+++ b/packages/firebase_ml_vision/lib/src/label_detector.dart
@@ -31,6 +31,9 @@ class LabelDetector extends FirebaseVisionDetector {
   /// Performed asynchronously.
   @override
   Future<List<Label>> detectInImage(FirebaseVisionImage visionImage) async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     final List<dynamic> reply = await FirebaseVision.channel.invokeMethod(
       'LabelDetector#detectInImage',
       <String, dynamic>{
@@ -76,6 +79,9 @@ class CloudLabelDetector extends FirebaseVisionDetector {
   /// Performed asynchronously.
   @override
   Future<List<Label>> detectInImage(FirebaseVisionImage visionImage) async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     final List<dynamic> reply = await FirebaseVision.channel.invokeMethod(
       'CloudLabelDetector#detectInImage',
       <String, dynamic>{

--- a/packages/firebase_ml_vision/lib/src/text_recognizer.dart
+++ b/packages/firebase_ml_vision/lib/src/text_recognizer.dart
@@ -19,6 +19,9 @@ class TextRecognizer implements FirebaseVisionDetector {
   /// The OCR is performed asynchronously.
   Future<VisionText> processImage(FirebaseVisionImage visionImage) async {
     final Map<dynamic, dynamic> reply =
+        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
         await FirebaseVision.channel.invokeMethod(
       'TextRecognizer#processImage',
       <String, dynamic>{

--- a/packages/firebase_performance/lib/src/firebase_performance.dart
+++ b/packages/firebase_performance/lib/src/firebase_performance.dart
@@ -30,6 +30,9 @@ class FirebasePerformance {
   /// does not reflect whether instrumentation is enabled/disabled.
   Future<bool> isPerformanceCollectionEnabled() async {
     final bool isEnabled = await channel
+        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
         .invokeMethod('FirebasePerformance#isPerformanceCollectionEnabled');
     return isEnabled;
   }
@@ -39,6 +42,9 @@ class FirebasePerformance {
   /// This setting is persisted and applied on future invocations of your
   /// application. By default, performance monitoring is enabled.
   Future<void> setPerformanceCollectionEnabled(bool enable) async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     await channel.invokeMethod(
         'FirebasePerformance#setPerformanceCollectionEnabled', enable);
   }

--- a/packages/firebase_performance/lib/src/http_metric.dart
+++ b/packages/firebase_performance/lib/src/http_metric.dart
@@ -48,6 +48,9 @@ class HttpMetric extends PerformanceAttributes {
 
     _hasStarted = true;
     return FirebasePerformance.channel
+        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
         .invokeMethod('HttpMetric#start', <String, dynamic>{
       'handle': _handle,
       'url': _url,
@@ -76,6 +79,9 @@ class HttpMetric extends PerformanceAttributes {
     };
 
     _hasStopped = true;
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return FirebasePerformance.channel.invokeMethod('HttpMetric#stop', data);
   }
 

--- a/packages/firebase_performance/lib/src/trace.dart
+++ b/packages/firebase_performance/lib/src/trace.dart
@@ -48,6 +48,9 @@ class Trace extends PerformanceAttributes {
 
     _hasStarted = true;
     return FirebasePerformance.channel
+        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
         .invokeMethod('Trace#start', <String, dynamic>{
       'handle': _handle,
       'name': _name,
@@ -73,6 +76,9 @@ class Trace extends PerformanceAttributes {
     };
 
     _hasStopped = true;
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return FirebasePerformance.channel.invokeMethod('Trace#stop', data);
   }
 

--- a/packages/firebase_remote_config/lib/src/remote_config.dart
+++ b/packages/firebase_remote_config/lib/src/remote_config.dart
@@ -36,6 +36,9 @@ class RemoteConfig extends ChangeNotifier {
 
   static void _getRemoteConfigInstance() async {
     final Map<dynamic, dynamic> properties =
+        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
         await channel.invokeMethod('RemoteConfig#instance');
 
     final RemoteConfig instance = RemoteConfig();
@@ -99,6 +102,9 @@ class RemoteConfig extends ChangeNotifier {
   Future<void> setConfigSettings(
       RemoteConfigSettings remoteConfigSettings) async {
     await channel
+        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
         .invokeMethod('RemoteConfig#setConfigSettings', <String, dynamic>{
       'debugMode': remoteConfigSettings.debugMode,
     });
@@ -113,6 +119,9 @@ class RemoteConfig extends ChangeNotifier {
   /// Expiration must be defined in seconds.
   Future<void> fetch({Duration expiration = const Duration(hours: 12)}) async {
     try {
+      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+      // https://github.com/flutter/flutter/issues/26431
+      // ignore: strong_mode_implicit_dynamic_method
       final Map<dynamic, dynamic> properties = await channel.invokeMethod(
           'RemoteConfig#fetch',
           <dynamic, dynamic>{'expiration': expiration.inSeconds});
@@ -138,6 +147,9 @@ class RemoteConfig extends ChangeNotifier {
   /// from the currently activated config, it contains false otherwise.
   Future<bool> activateFetched() async {
     final Map<dynamic, dynamic> properties =
+        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
         await channel.invokeMethod('RemoteConfig#activate');
     final Map<dynamic, dynamic> rawParameters = properties['parameters'];
     final bool newConfig = properties['newConfig'];
@@ -164,6 +176,9 @@ class RemoteConfig extends ChangeNotifier {
         _parameters[key] = remoteConfigValue;
       }
     });
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     await channel.invokeMethod(
         'RemoteConfig#setDefaults', <String, dynamic>{'defaults': defaults});
   }

--- a/packages/firebase_storage/lib/src/firebase_storage.dart
+++ b/packages/firebase_storage/lib/src/firebase_storage.dart
@@ -58,6 +58,9 @@ class FirebaseStorage {
   StorageReference ref() => StorageReference._(const <String>[], this);
 
   Future<int> getMaxDownloadRetryTimeMillis() async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return await channel.invokeMethod(
         "FirebaseStorage#getMaxDownloadRetryTime", <String, dynamic>{
       'app': app?.name,
@@ -66,6 +69,9 @@ class FirebaseStorage {
   }
 
   Future<int> getMaxUploadRetryTimeMillis() async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return await channel.invokeMethod(
         "FirebaseStorage#getMaxUploadRetryTime", <String, dynamic>{
       'app': app?.name,
@@ -74,6 +80,9 @@ class FirebaseStorage {
   }
 
   Future<int> getMaxOperationRetryTimeMillis() async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return await channel.invokeMethod(
         "FirebaseStorage#getMaxOperationRetryTime", <String, dynamic>{
       'app': app?.name,
@@ -82,6 +91,9 @@ class FirebaseStorage {
   }
 
   Future<void> setMaxDownloadRetryTimeMillis(int time) {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return channel.invokeMethod(
         "FirebaseStorage#setMaxDownloadRetryTime", <String, dynamic>{
       'app': app?.name,
@@ -91,6 +103,9 @@ class FirebaseStorage {
   }
 
   Future<void> setMaxUploadRetryTimeMillis(int time) {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return channel.invokeMethod(
         "FirebaseStorage#setMaxUploadRetryTime", <String, dynamic>{
       'app': app?.name,
@@ -100,6 +115,9 @@ class FirebaseStorage {
   }
 
   Future<void> setMaxOperationRetryTimeMillis(int time) {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return channel.invokeMethod(
         "FirebaseStorage#setMaxOperationRetryTime", <String, dynamic>{
       'app': app?.name,
@@ -118,6 +136,9 @@ class StorageFileDownloadTask {
   final File _file;
 
   Future<void> _start() async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     final int totalByteCount = await FirebaseStorage.channel.invokeMethod(
       "StorageReference#writeToFile",
       <String, dynamic>{

--- a/packages/firebase_storage/lib/src/storage_reference.dart
+++ b/packages/firebase_storage/lib/src/storage_reference.dart
@@ -77,6 +77,9 @@ class StorageReference {
   /// Returns the Google Cloud Storage bucket that holds this object.
   Future<String> getBucket() async {
     return await FirebaseStorage.channel
+        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
         .invokeMethod("StorageReference#getBucket", <String, String>{
       'app': _firebaseStorage.app?.name,
       'bucket': _firebaseStorage.storageBucket,
@@ -88,6 +91,9 @@ class StorageReference {
   /// Storage bucket.
   Future<String> getPath() async {
     return await FirebaseStorage.channel
+        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
         .invokeMethod("StorageReference#getPath", <String, String>{
       'app': _firebaseStorage.app?.name,
       'bucket': _firebaseStorage.storageBucket,
@@ -98,6 +104,9 @@ class StorageReference {
   /// Returns the short name of this object.
   Future<String> getName() async {
     return await FirebaseStorage.channel
+        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
         .invokeMethod("StorageReference#getName", <String, String>{
       'app': _firebaseStorage.app?.name,
       'bucket': _firebaseStorage.storageBucket,
@@ -108,6 +117,9 @@ class StorageReference {
   /// Asynchronously downloads the object at the StorageReference to a list in memory.
   /// A list of the provided max size will be allocated.
   Future<Uint8List> getData(int maxSize) async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return await FirebaseStorage.channel.invokeMethod(
       "StorageReference#getData",
       <String, dynamic>{
@@ -133,6 +145,9 @@ class StorageReference {
   /// developer in the Firebase Console if desired.
   Future<dynamic> getDownloadURL() async {
     return await FirebaseStorage.channel
+        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
         .invokeMethod("StorageReference#getDownloadUrl", <String, String>{
       'app': _firebaseStorage.app?.name,
       'bucket': _firebaseStorage.storageBucket,
@@ -142,6 +157,9 @@ class StorageReference {
 
   Future<void> delete() {
     return FirebaseStorage.channel
+        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
         .invokeMethod("StorageReference#delete", <String, String>{
       'app': _firebaseStorage.app?.name,
       'bucket': _firebaseStorage.storageBucket,
@@ -152,6 +170,9 @@ class StorageReference {
   /// Retrieves metadata associated with an object at this [StorageReference].
   Future<StorageMetadata> getMetadata() async {
     return StorageMetadata._fromMap(await FirebaseStorage.channel
+        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
         .invokeMethod("StorageReference#getMetadata", <String, String>{
       'app': _firebaseStorage.app?.name,
       'bucket': _firebaseStorage.storageBucket,
@@ -168,6 +189,9 @@ class StorageReference {
   /// by passing the empty string.
   Future<StorageMetadata> updateMetadata(StorageMetadata metadata) async {
     return StorageMetadata._fromMap(await FirebaseStorage.channel
+        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
         .invokeMethod("StorageReference#updateMetadata", <String, dynamic>{
       'app': _firebaseStorage.app?.name,
       'bucket': _firebaseStorage.storageBucket,

--- a/packages/firebase_storage/lib/src/upload_task.dart
+++ b/packages/firebase_storage/lib/src/upload_task.dart
@@ -89,6 +89,9 @@ abstract class StorageUploadTask {
   }
 
   /// Pause the upload
+  // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+  // https://github.com/flutter/flutter/issues/26431
+  // ignore: strong_mode_implicit_dynamic_method
   void pause() => FirebaseStorage.channel.invokeMethod(
         'UploadTask#pause',
         <String, dynamic>{
@@ -99,6 +102,9 @@ abstract class StorageUploadTask {
       );
 
   /// Resume the upload
+  // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+  // https://github.com/flutter/flutter/issues/26431
+  // ignore: strong_mode_implicit_dynamic_method
   void resume() => FirebaseStorage.channel.invokeMethod(
         'UploadTask#resume',
         <String, dynamic>{
@@ -109,6 +115,9 @@ abstract class StorageUploadTask {
       );
 
   /// Cancel the upload
+  // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+  // https://github.com/flutter/flutter/issues/26431
+  // ignore: strong_mode_implicit_dynamic_method
   void cancel() => FirebaseStorage.channel.invokeMethod(
         'UploadTask#cancel',
         <String, dynamic>{
@@ -128,6 +137,9 @@ class _StorageFileUploadTask extends StorageUploadTask {
 
   @override
   Future<dynamic> _platformStart() {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return FirebaseStorage.channel.invokeMethod(
       'StorageReference#putFile',
       <String, dynamic>{
@@ -151,6 +163,9 @@ class _StorageDataUploadTask extends StorageUploadTask {
 
   @override
   Future<dynamic> _platformStart() {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return FirebaseStorage.channel.invokeMethod(
       'StorageReference#putData',
       <String, dynamic>{

--- a/packages/google_maps_flutter/lib/src/controller.dart
+++ b/packages/google_maps_flutter/lib/src/controller.dart
@@ -31,6 +31,9 @@ class GoogleMapController extends ChangeNotifier {
     assert(id != null);
     final MethodChannel channel =
         MethodChannel('plugins.flutter.io/google_maps_$id');
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     await channel.invokeMethod('map#waitForMap');
     return GoogleMapController._(id, channel, initialCameraPosition);
   }
@@ -103,6 +106,9 @@ class GoogleMapController extends ChangeNotifier {
   /// The returned [Future] completes after listeners have been notified.
   Future<void> _updateMapOptions(Map<String, dynamic> optionsUpdate) async {
     assert(optionsUpdate != null);
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     final dynamic json = await _channel.invokeMethod(
       'map#update',
       <String, dynamic>{
@@ -118,6 +124,9 @@ class GoogleMapController extends ChangeNotifier {
   /// The returned [Future] completes after the change has been started on the
   /// platform side.
   Future<void> animateCamera(CameraUpdate cameraUpdate) async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     await _channel.invokeMethod('camera#animate', <String, dynamic>{
       'cameraUpdate': cameraUpdate._toJson(),
     });
@@ -128,6 +137,9 @@ class GoogleMapController extends ChangeNotifier {
   /// The returned [Future] completes after the change has been made on the
   /// platform side.
   Future<void> moveCamera(CameraUpdate cameraUpdate) async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     await _channel.invokeMethod('camera#move', <String, dynamic>{
       'cameraUpdate': cameraUpdate._toJson(),
     });
@@ -143,6 +155,9 @@ class GoogleMapController extends ChangeNotifier {
   Future<Marker> addMarker(MarkerOptions options) async {
     final MarkerOptions effectiveOptions =
         MarkerOptions.defaultOptions.copyWith(options);
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     final String markerId = await _channel.invokeMethod(
       'marker#add',
       <String, dynamic>{
@@ -166,6 +181,9 @@ class GoogleMapController extends ChangeNotifier {
     assert(marker != null);
     assert(_markers[marker._id] == marker);
     assert(changes != null);
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     await _channel.invokeMethod('marker#update', <String, dynamic>{
       'marker': marker._id,
       'options': changes._toJson(),
@@ -209,6 +227,9 @@ class GoogleMapController extends ChangeNotifier {
   /// The returned [Future] completes once the marker has been removed from
   /// [_markers].
   Future<void> _removeMarker(String id) async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     await _channel.invokeMethod('marker#remove', <String, dynamic>{
       'marker': id,
     });

--- a/packages/google_sign_in/lib/google_sign_in.dart
+++ b/packages/google_sign_in/lib/google_sign_in.dart
@@ -79,6 +79,9 @@ class GoogleSignInAccount implements GoogleIdentity {
     }
 
     final Map<dynamic, dynamic> response =
+        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
         await GoogleSignIn.channel.invokeMethod(
       'getTokens',
       <String, dynamic>{
@@ -108,6 +111,9 @@ class GoogleSignInAccount implements GoogleIdentity {
   /// this method and grab `authHeaders` once again.
   Future<void> clearAuthCache() async {
     final String token = (await authentication).accessToken;
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     await GoogleSignIn.channel.invokeMethod(
       'clearAuthCache',
       <String, dynamic>{'token': token},
@@ -214,6 +220,9 @@ class GoogleSignIn {
   Future<GoogleSignInAccount> _callMethod(String method) async {
     await _ensureInitialized();
 
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     final Map<dynamic, dynamic> response = await channel.invokeMethod(method);
     return _setCurrentUser(response != null && response.isNotEmpty
         ? GoogleSignInAccount._(this, response)
@@ -230,6 +239,9 @@ class GoogleSignIn {
 
   Future<void> _ensureInitialized() {
     if (_initialization == null) {
+      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+      // https://github.com/flutter/flutter/issues/26431
+      // ignore: strong_mode_implicit_dynamic_method
       _initialization = channel.invokeMethod('init', <String, dynamic>{
         'signInOption': (signInOption ?? SignInOption.standard).toString(),
         'scopes': scopes ?? <String>[],
@@ -306,6 +318,9 @@ class GoogleSignIn {
   /// Returns a future that resolves to whether a user is currently signed in.
   Future<bool> isSignedIn() async {
     await _ensureInitialized();
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     final bool result = await channel.invokeMethod('isSignedIn');
     return result;
   }

--- a/packages/image_picker/lib/image_picker.dart
+++ b/packages/image_picker/lib/image_picker.dart
@@ -44,6 +44,9 @@ class ImagePicker {
       throw ArgumentError.value(maxHeight, 'maxHeight cannot be negative');
     }
 
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     final String path = await _channel.invokeMethod(
       'pickImage',
       <String, dynamic>{
@@ -61,6 +64,9 @@ class ImagePicker {
   }) async {
     assert(source != null);
 
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     final String path = await _channel.invokeMethod(
       'pickVideo',
       <String, dynamic>{

--- a/packages/in_app_purchase/lib/in_app_purchase.dart
+++ b/packages/in_app_purchase/lib/in_app_purchase.dart
@@ -6,6 +6,9 @@ class InAppPurchase {
   static const MethodChannel _channel = MethodChannel('in_app_purchase');
 
   static Future<String> get platformVersion async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     final String version = await _channel.invokeMethod('getPlatformVersion');
     return version;
   }

--- a/packages/local_auth/lib/local_auth.dart
+++ b/packages/local_auth/lib/local_auth.dart
@@ -72,6 +72,9 @@ class LocalAuthentication {
               'operating systems.',
           details: 'Your operating system is ${Platform.operatingSystem}');
     }
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return await _channel.invokeMethod('authenticateWithBiometrics', args);
   }
 
@@ -79,6 +82,9 @@ class LocalAuthentication {
   ///
   /// Returns a [Future] bool true or false:
   Future<bool> get canCheckBiometrics async =>
+      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+      // https://github.com/flutter/flutter/issues/26431
+      // ignore: strong_mode_implicit_dynamic_method
       (await _channel.invokeMethod('getAvailableBiometrics')).isNotEmpty;
 
   /// Returns a list of enrolled biometrics
@@ -89,6 +95,9 @@ class LocalAuthentication {
   /// - BiometricType.iris (not yet implemented)
   Future<List<BiometricType>> getAvailableBiometrics() async {
     final List<String> result =
+        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
         (await _channel.invokeMethod('getAvailableBiometrics')).cast<String>();
     final List<BiometricType> biometrics = <BiometricType>[];
     result.forEach((String value) {

--- a/packages/location_background/lib/location_background_plugin.dart
+++ b/packages/location_background/lib/location_background_plugin.dart
@@ -118,6 +118,9 @@ class LocationBackgroundPlugin {
         PluginUtilities.getCallbackHandle(_backgroundCallbackDispatcher);
     assert(handle != null, 'Unable to lookup callback.');
     _channel
+        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
         .invokeMethod(_kStartHeadlessService, <dynamic>[handle.toRawHandle()]);
   }
 
@@ -144,6 +147,9 @@ class LocationBackgroundPlugin {
       throw ArgumentError.notNull('callback');
     }
     final CallbackHandle handle = PluginUtilities.getCallbackHandle(callback);
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return _channel.invokeMethod(_kMonitorLocationChanges, <dynamic>[
       handle.toRawHandle(),
       pauseLocationUpdatesAutomatically,
@@ -154,5 +160,8 @@ class LocationBackgroundPlugin {
 
   /// Stop all location updates.
   Future<void> cancelLocationUpdates() =>
+      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+      // https://github.com/flutter/flutter/issues/26431
+      // ignore: strong_mode_implicit_dynamic_method
       _channel.invokeMethod(_kCancelLocationUpdates);
 }

--- a/packages/package_info/lib/package_info.dart
+++ b/packages/package_info/lib/package_info.dart
@@ -32,6 +32,9 @@ class PackageInfo {
     if (_fromPlatform == null) {
       final Completer<PackageInfo> completer = Completer<PackageInfo>();
 
+      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+      // https://github.com/flutter/flutter/issues/26431
+      // ignore: strong_mode_implicit_dynamic_method
       _kChannel.invokeMethod('getAll').then((dynamic result) {
         final Map<dynamic, dynamic> map = result;
 

--- a/packages/path_provider/lib/path_provider.dart
+++ b/packages/path_provider/lib/path_provider.dart
@@ -21,6 +21,9 @@ const MethodChannel _channel =
 ///
 /// On Android, this uses the `getCacheDir` API on the context.
 Future<Directory> getTemporaryDirectory() async {
+  // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+  // https://github.com/flutter/flutter/issues/26431
+  // ignore: strong_mode_implicit_dynamic_method
   final String path = await _channel.invokeMethod('getTemporaryDirectory');
   if (path == null) {
     return null;
@@ -37,6 +40,9 @@ Future<Directory> getTemporaryDirectory() async {
 /// On Android, this returns the AppData directory.
 Future<Directory> getApplicationDocumentsDirectory() async {
   final String path =
+      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+      // https://github.com/flutter/flutter/issues/26431
+      // ignore: strong_mode_implicit_dynamic_method
       await _channel.invokeMethod('getApplicationDocumentsDirectory');
   if (path == null) {
     return null;
@@ -55,6 +61,9 @@ Future<Directory> getApplicationDocumentsDirectory() async {
 Future<Directory> getExternalStorageDirectory() async {
   if (Platform.isIOS)
     throw UnsupportedError("Functionality not available on iOS");
+  // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+  // https://github.com/flutter/flutter/issues/26431
+  // ignore: strong_mode_implicit_dynamic_method
   final String path = await _channel.invokeMethod('getStorageDirectory');
   if (path == null) {
     return null;

--- a/packages/quick_actions/lib/quick_actions.dart
+++ b/packages/quick_actions/lib/quick_actions.dart
@@ -52,11 +52,17 @@ class QuickActions {
   Future<void> setShortcutItems(List<ShortcutItem> items) async {
     final List<Map<String, String>> itemsList =
         items.map(_serializeItem).toList();
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     await _kChannel.invokeMethod('setShortcutItems', itemsList);
   }
 
   /// Removes all [ShortcutItem]s registered for the app.
   Future<void> clearShortcutItems() =>
+      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+      // https://github.com/flutter/flutter/issues/26431
+      // ignore: strong_mode_implicit_dynamic_method
       _kChannel.invokeMethod('clearShortcutItems');
 
   Map<String, String> _serializeItem(ShortcutItem item) {

--- a/packages/share/lib/share.dart
+++ b/packages/share/lib/share.dart
@@ -41,6 +41,9 @@ class Share {
       params['originHeight'] = sharePositionOrigin.height;
     }
 
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return channel.invokeMethod('share', params);
   }
 }

--- a/packages/share/test/share_test.dart
+++ b/packages/share/test/share_test.dart
@@ -17,6 +17,9 @@ void main() {
     mockChannel = MockMethodChannel();
     // Re-pipe to mockito for easier verifies.
     Share.channel.setMockMethodCallHandler((MethodCall call) async {
+      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+      // https://github.com/flutter/flutter/issues/26431
+      // ignore: strong_mode_implicit_dynamic_method
       mockChannel.invokeMethod(call.method, call.arguments);
     });
   });
@@ -42,6 +45,9 @@ void main() {
       'some text to share',
       sharePositionOrigin: Rect.fromLTWH(1.0, 2.0, 3.0, 4.0),
     );
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     verify(mockChannel.invokeMethod('share', <String, dynamic>{
       'text': 'some text to share',
       'originX': 1.0,

--- a/packages/shared_preferences/lib/shared_preferences.dart
+++ b/packages/shared_preferences/lib/shared_preferences.dart
@@ -22,6 +22,9 @@ class SharedPreferences {
   static Future<SharedPreferences> getInstance() async {
     if (_instance == null) {
       final Map<Object, Object> fromSystem =
+          // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+          // https://github.com/flutter/flutter/issues/26431
+          // ignore: strong_mode_implicit_dynamic_method
           await _kChannel.invokeMethod('getAll');
       assert(fromSystem != null);
       // Strip the flutter. prefix from the returned preferences.
@@ -118,12 +121,18 @@ class SharedPreferences {
     if (value == null) {
       _preferenceCache.remove(key);
       return _kChannel
+          // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+          // https://github.com/flutter/flutter/issues/26431
+          // ignore: strong_mode_implicit_dynamic_method
           .invokeMethod('remove', params)
           .then<bool>((dynamic result) => result);
     } else {
       _preferenceCache[key] = value;
       params['value'] = value;
       return _kChannel
+          // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+          // https://github.com/flutter/flutter/issues/26431
+          // ignore: strong_mode_implicit_dynamic_method
           .invokeMethod('set$valueType', params)
           .then<bool>((dynamic result) => result);
     }
@@ -132,11 +141,17 @@ class SharedPreferences {
   /// Always returns true.
   /// On iOS, synchronize is marked deprecated. On Android, we commit every set.
   @deprecated
+  // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+  // https://github.com/flutter/flutter/issues/26431
+  // ignore: strong_mode_implicit_dynamic_method
   Future<bool> commit() async => await _kChannel.invokeMethod('commit');
 
   /// Completes with true once the user preferences for the app has been cleared.
   Future<bool> clear() async {
     _preferenceCache.clear();
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return await _kChannel.invokeMethod('clear');
   }
 

--- a/packages/shared_preferences/test/shared_preferences_test.dart
+++ b/packages/shared_preferences/test/shared_preferences_test.dart
@@ -136,8 +136,14 @@ void main() {
     });
 
     test('mocking', () async {
+      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+      // https://github.com/flutter/flutter/issues/26431
+      // ignore: strong_mode_implicit_dynamic_method
       expect(await channel.invokeMethod('getAll'), kTestValues);
       SharedPreferences.setMockInitialValues(kTestValues2);
+      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+      // https://github.com/flutter/flutter/issues/26431
+      // ignore: strong_mode_implicit_dynamic_method
       expect(await channel.invokeMethod('getAll'), kTestValues2);
     });
   });

--- a/packages/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/lib/url_launcher.dart
@@ -64,6 +64,9 @@ Future<void> launch(
         ? SystemUiOverlayStyle.dark
         : SystemUiOverlayStyle.light);
   }
+  // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+  // https://github.com/flutter/flutter/issues/26431
+  // ignore: strong_mode_implicit_dynamic_method
   return _channel.invokeMethod(
     'launch',
     <String, Object>{
@@ -86,6 +89,9 @@ Future<bool> canLaunch(String urlString) async {
   if (urlString == null) {
     return false;
   }
+  // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+  // https://github.com/flutter/flutter/issues/26431
+  // ignore: strong_mode_implicit_dynamic_method
   return await _channel.invokeMethod(
     'canLaunch',
     <String, Object>{'url': urlString},
@@ -100,5 +106,8 @@ Future<bool> canLaunch(String urlString) async {
 /// `true`, this call will not do anything either, simply because there is no
 /// WebView available to be closed.
 Future<void> closeWebView() async {
+  // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+  // https://github.com/flutter/flutter/issues/26431
+  // ignore: strong_mode_implicit_dynamic_method
   return await _channel.invokeMethod('closeWebView');
 }

--- a/packages/video_player/lib/video_player.dart
+++ b/packages/video_player/lib/video_player.dart
@@ -12,6 +12,9 @@ import 'package:meta/meta.dart';
 final MethodChannel _channel = const MethodChannel('flutter.io/videoPlayer')
   // This will clear all open videos on the platform when a full restart is
   // performed.
+  // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+  // https://github.com/flutter/flutter/issues/26431
+  // ignore: strong_mode_implicit_dynamic_method
   ..invokeMethod('init');
 
 class DurationRange {
@@ -205,6 +208,9 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
       case DataSourceType.file:
         dataSourceDescription = <String, dynamic>{'uri': dataSource};
     }
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     final Map<dynamic, dynamic> response = await _channel.invokeMethod(
       'create',
       dataSourceDescription,
@@ -278,6 +284,9 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
         _isDisposed = true;
         _timer?.cancel();
         await _eventSubscription?.cancel();
+        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
         await _channel.invokeMethod(
           'dispose',
           <String, dynamic>{'textureId': _textureId},
@@ -308,6 +317,9 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
     if (!value.initialized || _isDisposed) {
       return;
     }
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     _channel.invokeMethod(
       'setLooping',
       <String, dynamic>{'textureId': _textureId, 'looping': value.isLooping},
@@ -319,6 +331,9 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
       return;
     }
     if (value.isPlaying) {
+      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+      // https://github.com/flutter/flutter/issues/26431
+      // ignore: strong_mode_implicit_dynamic_method
       await _channel.invokeMethod(
         'play',
         <String, dynamic>{'textureId': _textureId},
@@ -338,6 +353,9 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
       );
     } else {
       _timer?.cancel();
+      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+      // https://github.com/flutter/flutter/issues/26431
+      // ignore: strong_mode_implicit_dynamic_method
       await _channel.invokeMethod(
         'pause',
         <String, dynamic>{'textureId': _textureId},
@@ -349,6 +367,9 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
     if (!value.initialized || _isDisposed) {
       return;
     }
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     await _channel.invokeMethod(
       'setVolume',
       <String, dynamic>{'textureId': _textureId, 'volume': value.volume},
@@ -361,6 +382,9 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
       return null;
     }
     return Duration(
+      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+      // https://github.com/flutter/flutter/issues/26431
+      // ignore: strong_mode_implicit_dynamic_method
       milliseconds: await _channel.invokeMethod(
         'position',
         <String, dynamic>{'textureId': _textureId},
@@ -377,6 +401,9 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
     } else if (moment < const Duration()) {
       moment = const Duration();
     }
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     await _channel.invokeMethod('seekTo', <String, dynamic>{
       'textureId': _textureId,
       'location': moment.inMilliseconds,

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -194,6 +194,9 @@ class WebViewController {
   Future<void> loadUrl(String url) async {
     assert(url != null);
     _validateUrlString(url);
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return _channel.invokeMethod('loadUrl', url);
   }
 
@@ -205,6 +208,9 @@ class WebViewController {
   /// words, by the time this future completes, the WebView may be displaying a
   /// different URL).
   Future<String> currentUrl() async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     final String url = await _channel.invokeMethod('currentUrl');
     return url;
   }
@@ -214,6 +220,9 @@ class WebViewController {
   /// Note that this operation is asynchronous, and it is possible that the "canGoBack" state has
   /// changed by the time the future completed.
   Future<bool> canGoBack() async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     final bool canGoBack = await _channel.invokeMethod("canGoBack");
     return canGoBack;
   }
@@ -223,6 +232,9 @@ class WebViewController {
   /// Note that this operation is asynchronous, and it is possible that the "canGoForward" state has
   /// changed by the time the future completed.
   Future<bool> canGoForward() async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     final bool canGoForward = await _channel.invokeMethod("canGoForward");
     return canGoForward;
   }
@@ -231,6 +243,9 @@ class WebViewController {
   ///
   /// If there is no back history item this is a no-op.
   Future<void> goBack() async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return _channel.invokeMethod("goBack");
   }
 
@@ -238,11 +253,17 @@ class WebViewController {
   ///
   /// If there is no forward history item this is a no-op.
   Future<void> goForward() async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return _channel.invokeMethod("goForward");
   }
 
   /// Reloads the current URL.
   Future<void> reload() async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return _channel.invokeMethod("reload");
   }
 
@@ -252,6 +273,9 @@ class WebViewController {
       return null;
     }
     _settings = setting;
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     return _channel.invokeMethod('updateSettings', updateMap);
   }
 
@@ -275,6 +299,9 @@ class WebViewController {
     if (javascriptString == null) {
       throw ArgumentError('The argument javascriptString must not be null. ');
     }
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
     final String result =
         await _channel.invokeMethod('evaluateJavascript', javascriptString);
     return result;


### PR DESCRIPTION
flutter/flutter#26303 added a template argument to `invokeMethod`, which triggers the `strong_mode_implicit_dynamic_method` analyzer warning in many call sites in the plugins repo.

We should add the type parameter to all these call sites, but we can only do that after bumping the Flutter dependency constraint which we will only do once the `invokeMethod` change makes it to the stable release.

For now we're suppressing the warning in all call sites (we're not disabling the lint wholesale as we still want it for the rest of the code)

See: flutter/flutter#26431