### PR TITLE
[cloud_functions]Add SocketTimeoutException for Cloud Functions

### DIFF
--- a/packages/cloud_functions/android/src/main/java/io/flutter/plugins/firebase/cloudfunctions/cloudfunctions/CloudFunctionsPlugin.java
+++ b/packages/cloud_functions/android/src/main/java/io/flutter/plugins/firebase/cloudfunctions/cloudfunctions/CloudFunctionsPlugin.java
@@ -16,6 +16,7 @@ import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
+import java.net.SocketTimeoutException;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/packages/cloud_functions/android/src/main/java/io/flutter/plugins/firebase/cloudfunctions/cloudfunctions/CloudFunctionsPlugin.java
+++ b/packages/cloud_functions/android/src/main/java/io/flutter/plugins/firebase/cloudfunctions/cloudfunctions/CloudFunctionsPlugin.java
@@ -55,7 +55,18 @@ public class CloudFunctionsPlugin implements MethodCallHandler {
                             "functionsError",
                             "Cloud function failed with exception.",
                             exceptionMap);
-                      } else {
+                      } else if (task.getException() instanceof SocketTimeoutException) {
+                        SocketTimeoutException exception =
+                        (SocketTimeoutException) task.getException();
+                        Map < String, Object > exceptionMap = new HashMap < > ();
+                        exceptionMap.put("code", FirebaseFunctionsException.Code.DEADLINE_EXCEEDED.name());
+                        exceptionMap.put("message", exception.getMessage());
+                        exceptionMap.put("details", "SocketTimeoutException");
+                        result.error(
+                          "functionsError",
+                          "Cloud function failed with exception.",
+                          exceptionMap);
+                        }else {
                         Exception exception = task.getException();
                         result.error(null, exception.getMessage(), null);
                       }

--- a/packages/cloud_functions/ios/Classes/CloudFunctionsPlugin.m
+++ b/packages/cloud_functions/ios/Classes/CloudFunctionsPlugin.m
@@ -4,11 +4,11 @@
 
 #import "CloudFunctionsPlugin.h"
 
-#import "FIRFunctions+Internal.h"
 #import "Firebase/Firebase.h"
 
 @interface CloudFunctionsPlugin ()
 @property(nonatomic, retain) FlutterMethodChannel *_channel;
+@property(strong, nonatomic) FIRFunctions *functions;
 @end
 
 @implementation CloudFunctionsPlugin
@@ -35,36 +35,33 @@
   if ([@"CloudFunctions#call" isEqualToString:call.method]) {
     NSString *functionName = call.arguments[@"functionName"];
     NSObject *parameters = call.arguments[@"parameters"];
-    [[FIRFunctions functions]
-        callFunction:functionName
-          withObject:parameters
-          completion:^(FIRHTTPSCallableResult *callableResult, NSError *error) {
-            if (error) {
+      [[_functions HTTPSCallableWithName:functionName] callWithObject:parameters completion:^(FIRHTTPSCallableResult * _Nullable callRresult, NSError * _Nullable error) {
+          if (error) {
               FlutterError *flutterError;
               if (error.domain == FIRFunctionsErrorDomain) {
-                NSDictionary *details = [NSMutableDictionary dictionary];
-                [details setValue:[self mapFunctionsErrorCodes:error.code] forKey:@"code"];
-                if (error.localizedDescription != nil) {
-                  [details setValue:error.localizedDescription forKey:@"message"];
-                }
-                if (error.userInfo[FIRFunctionsErrorDetailsKey] != nil) {
-                  [details setValue:error.userInfo[FIRFunctionsErrorDetailsKey] forKey:@"details"];
-                }
-
-                flutterError =
-                    [FlutterError errorWithCode:@"functionsError"
-                                        message:@"Firebase function failed with exception."
-                                        details:details];
+                  NSDictionary *details = [NSMutableDictionary dictionary];
+                  [details setValue:[self mapFunctionsErrorCodes:error.code] forKey:@"code"];
+                  if (error.localizedDescription != nil) {
+                      [details setValue:error.localizedDescription forKey:@"message"];
+                  }
+                  if (error.userInfo[FIRFunctionsErrorDetailsKey] != nil) {
+                      [details setValue:error.userInfo[FIRFunctionsErrorDetailsKey] forKey:@"details"];
+                  }
+                  
+                  flutterError =
+                  [FlutterError errorWithCode:@"functionsError"
+                                      message:@"Firebase function failed with exception."
+                                      details:details];
               } else {
-                flutterError = [FlutterError errorWithCode:nil
-                                                   message:error.localizedDescription
-                                                   details:nil];
+                  flutterError = [FlutterError errorWithCode:nil
+                                                     message:error.localizedDescription
+                                                     details:nil];
               }
               result(flutterError);
-            } else {
-              result(callableResult.data);
-            }
-          }];
+          } else {
+              result(callRresult.data);
+          }
+      }];
   } else {
     result(FlutterMethodNotImplemented);
   }


### PR DESCRIPTION
On android, usually much sooner than firebase timeout, socket timeout exception occurs. This is not handled properly and invalid format envelope exception is thrown. Exception is not handled and whole call is interrupted as non handled dart exception.

pulyaevskiy/firebase-functions-interop#43
flutter/flutter#24997