### PR TITLE
Add missing imports to README.md image_picker code example

### DIFF
--- a/packages/image_picker/README.md
+++ b/packages/image_picker/README.md
@@ -26,7 +26,10 @@ No configuration required - the plugin should work out of the box.
 ### Example
 
 ``` dart
+import 'dart:io';
+import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
+
 
 class MyHomePage extends StatefulWidget {
   @override


### PR DESCRIPTION
Add missing imports to README.md image_picker code example

`dart:io` for `File` type. 
`package:flutter/material.dart` for `StatefulWidget`

```
import 'dart:io';
import 'package:flutter/material.dart';
```