### PR TITLE
Added additional sample rates for sensor events

### DIFF
--- a/packages/sensors/README.md
+++ b/packages/sensors/README.md
@@ -20,4 +20,8 @@ accelerometerEvents.listen((AccelerometerEvent event) {
 gyroscopeEvents.listen((GyroscopeEvent event) {
  // Do something with the event.
 });
+
+// Optionally, specify the sample rate before listening.
+// .low equals 15 events per second, .medium 50, and .high 100 (iOS) and 120 (Android).
+setSensorsSampleRate(SampleRate.medium);
 ```

--- a/packages/sensors/android/src/main/java/io/flutter/plugins/sensors/SensorsPlugin.java
+++ b/packages/sensors/android/src/main/java/io/flutter/plugins/sensors/SensorsPlugin.java
@@ -50,7 +50,7 @@ public class SensorsPlugin implements EventChannel.StreamHandler {
   @Override
   public void onListen(Object arguments, EventChannel.EventSink events) {
     sensorEventListener = createSensorEventListener(events);
-    sensorManager.registerListener(sensorEventListener, sensor, sensorManager.SENSOR_DELAY_NORMAL);
+    sensorManager.registerListener(sensorEventListener, sensor, parseSampleRateArgument(arguments));
   }
 
   @Override
@@ -72,5 +72,16 @@ public class SensorsPlugin implements EventChannel.StreamHandler {
         events.success(sensorValues);
       }
     };
+  }
+
+  private int parseSampleRateArgument(Object arguments) {
+    switch(arguments.toString()) {
+      case "medium":
+        return sensorManager.SENSOR_DELAY_GAME;
+      case "high":
+        return sensorManager.SENSOR_DELAY_FASTEST;
+      default:
+        return sensorManager.SENSOR_DELAY_NORMAL;
+    }
   }
 }

--- a/packages/sensors/android/src/main/java/io/flutter/plugins/sensors/SensorsPlugin.java
+++ b/packages/sensors/android/src/main/java/io/flutter/plugins/sensors/SensorsPlugin.java
@@ -75,7 +75,7 @@ public class SensorsPlugin implements EventChannel.StreamHandler {
   }
 
   private int parseSampleRateArgument(Object arguments) {
-    switch(arguments.toString()) {
+    switch (arguments.toString()) {
       case "medium":
         return sensorManager.SENSOR_DELAY_GAME;
       case "high":

--- a/packages/sensors/example/lib/snake.dart
+++ b/packages/sensors/example/lib/snake.dart
@@ -70,6 +70,7 @@ class SnakeState extends State<Snake> {
   @override
   void initState() {
     super.initState();
+    setSensorsSampleRate(SampleRate.medium);
     accelerometerEvents.listen((AccelerometerEvent event) {
       setState(() {
         acceleration = event;

--- a/packages/sensors/ios/Classes/SensorsPlugin.h
+++ b/packages/sensors/ios/Classes/SensorsPlugin.h
@@ -15,3 +15,5 @@
 
 @interface FLTGyroscopeStreamHandler : NSObject <FlutterStreamHandler>
 @end
+
+float _parseSampleRateArgument(id arguments);

--- a/packages/sensors/ios/Classes/SensorsPlugin.m
+++ b/packages/sensors/ios/Classes/SensorsPlugin.m
@@ -120,10 +120,10 @@ float _parseSampleRateArgument(id arguments) {
   NSString* argument = (NSString*)arguments;
 
   if ([arguments isEqualToString:@"medium"]) {
-      return (float)1 / 50;
+    return (float)1 / 50;
   } else if ([arguments isEqualToString:@"high"]) {
-      return (float)1 / 100;
+    return (float)1 / 100;
   } else {
-      return (float)1 / 15;
+    return (float)1 / 15;
   }
 }

--- a/packages/sensors/ios/Classes/SensorsPlugin.m
+++ b/packages/sensors/ios/Classes/SensorsPlugin.m
@@ -52,6 +52,7 @@ static void sendTriplet(Float64 x, Float64 y, Float64 z, FlutterEventSink sink) 
 
 - (FlutterError*)onListenWithArguments:(id)arguments eventSink:(FlutterEventSink)eventSink {
   _initMotionManager();
+  _motionManager.accelerometerUpdateInterval = _parseSampleRateArgument(arguments);
   [_motionManager
       startAccelerometerUpdatesToQueue:[[NSOperationQueue alloc] init]
                            withHandler:^(CMAccelerometerData* accelerometerData, NSError* error) {
@@ -75,6 +76,7 @@ static void sendTriplet(Float64 x, Float64 y, Float64 z, FlutterEventSink sink) 
 
 - (FlutterError*)onListenWithArguments:(id)arguments eventSink:(FlutterEventSink)eventSink {
   _initMotionManager();
+  _motionManager.deviceMotionUpdateInterval = _parseSampleRateArgument(arguments);
   [_motionManager
       startDeviceMotionUpdatesToQueue:[[NSOperationQueue alloc] init]
                           withHandler:^(CMDeviceMotion* data, NSError* error) {
@@ -97,6 +99,7 @@ static void sendTriplet(Float64 x, Float64 y, Float64 z, FlutterEventSink sink) 
 
 - (FlutterError*)onListenWithArguments:(id)arguments eventSink:(FlutterEventSink)eventSink {
   _initMotionManager();
+  _motionManager.gyroUpdateInterval = _parseSampleRateArgument(arguments);
   [_motionManager
       startGyroUpdatesToQueue:[[NSOperationQueue alloc] init]
                   withHandler:^(CMGyroData* gyroData, NSError* error) {
@@ -112,3 +115,15 @@ static void sendTriplet(Float64 x, Float64 y, Float64 z, FlutterEventSink sink) 
 }
 
 @end
+
+float _parseSampleRateArgument(id arguments) {
+  NSString *argument = (NSString *) arguments;
+
+  if ([arguments isEqualToString:@"medium"]) {
+      return (float) 1/50;
+  } else if ([arguments isEqualToString:@"high"]) {
+      return (float) 1/100;
+  } else {
+      return (float) 1/15;
+  }
+}

--- a/packages/sensors/ios/Classes/SensorsPlugin.m
+++ b/packages/sensors/ios/Classes/SensorsPlugin.m
@@ -117,13 +117,13 @@ static void sendTriplet(Float64 x, Float64 y, Float64 z, FlutterEventSink sink) 
 @end
 
 float _parseSampleRateArgument(id arguments) {
-  NSString *argument = (NSString *) arguments;
+  NSString* argument = (NSString*)arguments;
 
   if ([arguments isEqualToString:@"medium"]) {
-      return (float) 1/50;
+      return (float)1 / 50;
   } else if ([arguments isEqualToString:@"high"]) {
-      return (float) 1/100;
+      return (float)1 / 100;
   } else {
-      return (float) 1/15;
+      return (float)1 / 15;
   }
 }

--- a/packages/sensors/lib/models/sample_rate_enum.dart
+++ b/packages/sensors/lib/models/sample_rate_enum.dart
@@ -1,0 +1,16 @@
+part of sensors;
+
+enum SampleRate {
+  /// Android: Maps to the sample rate of SensorManager.SENSOR_DELAY_NORMAL (15 events per second).
+  /// iOS: Maps to a update interval of 1/15 (15 events per second).
+  /// Constitutes the default value.
+  low,
+
+  /// Android: Maps to the sample rate of SensorManager.SENSOR_DELAY_GAME (50 events per second).
+  /// iOS: Maps to a update interval of 1/50 (50 events per second).
+  medium,
+
+  /// Android: Maps to the sample rate of SensorManager.SENSOR_DELAY_FASTEST (120 events per second).
+  /// iOS: Maps to the maximum update interval of 1/100 (100 events per second).
+  high
+}

--- a/packages/sensors/lib/sensors.dart
+++ b/packages/sensors/lib/sensors.dart
@@ -1,5 +1,10 @@
+library sensors;
+
 import 'dart:async';
 import 'package:flutter/services.dart';
+
+part 'models/sample_rate_enum.dart';
+part 'utils/codec.dart';
 
 const EventChannel _accelerometerEventChannel =
     EventChannel('plugins.flutter.io/sensors/accelerometer');
@@ -74,11 +79,17 @@ Stream<AccelerometerEvent> _accelerometerEvents;
 Stream<GyroscopeEvent> _gyroscopeEvents;
 Stream<UserAccelerometerEvent> _userAccelerometerEvents;
 
+SampleRate _sampleRate;
+
+void setSensorsSampleRate(SampleRate sampleRate) {
+  _sampleRate = sampleRate;
+}
+
 /// A broadcast stream of events from the device accelerometer.
 Stream<AccelerometerEvent> get accelerometerEvents {
   if (_accelerometerEvents == null) {
     _accelerometerEvents = _accelerometerEventChannel
-        .receiveBroadcastStream()
+        .receiveBroadcastStream(Codec.encodeSensorsSampleRate(_sampleRate))
         .map(
             (dynamic event) => _listToAccelerometerEvent(event.cast<double>()));
   }
@@ -89,7 +100,7 @@ Stream<AccelerometerEvent> get accelerometerEvents {
 Stream<GyroscopeEvent> get gyroscopeEvents {
   if (_gyroscopeEvents == null) {
     _gyroscopeEvents = _gyroscopeEventChannel
-        .receiveBroadcastStream()
+        .receiveBroadcastStream(Codec.encodeSensorsSampleRate(_sampleRate))
         .map((dynamic event) => _listToGyroscopeEvent(event.cast<double>()));
   }
   return _gyroscopeEvents;
@@ -99,7 +110,7 @@ Stream<GyroscopeEvent> get gyroscopeEvents {
 Stream<UserAccelerometerEvent> get userAccelerometerEvents {
   if (_userAccelerometerEvents == null) {
     _userAccelerometerEvents = _userAccelerometerEventChannel
-        .receiveBroadcastStream()
+        .receiveBroadcastStream(Codec.encodeSensorsSampleRate(_sampleRate))
         .map((dynamic event) =>
             _listToUserAccelerometerEvent(event.cast<double>()));
   }

--- a/packages/sensors/lib/utils/codec.dart
+++ b/packages/sensors/lib/utils/codec.dart
@@ -1,0 +1,7 @@
+part of sensors;
+
+class Codec {
+  static String encodeSensorsSampleRate(SampleRate sampleRate) {
+    return sampleRate.toString().split('.').last;
+  }
+}

--- a/packages/sensors/test/sensors_test.dart
+++ b/packages/sensors/test/sensors_test.dart
@@ -35,6 +35,7 @@ void main() {
       }
     });
 
+    setSensorsSampleRate(SampleRate.medium);
     final AccelerometerEvent event = await accelerometerEvents.first;
     expect(event.x, 1.0);
     expect(event.y, 2.0);


### PR DESCRIPTION
### Three options for all three sensor events:
**SampleRate.low** results in 15 sensor events per second on both platforms.
**SampleRate.medium** results in 50 sensors events per second on both platforms.
**SampleRate.high** results in 100 sensors events per second on iOS and 120 on Android.

A sample rate is set before the listening with, e.g., **setSensorsSampleRate(SampleRate.medium);**.