### PR TITLE
[IAP] Clean up Dart unit tests

### DIFF
--- a/packages/in_app_purchase/lib/src/billing_client_wrappers/billing_client_wrapper.dart
+++ b/packages/in_app_purchase/lib/src/billing_client_wrappers/billing_client_wrapper.dart
@@ -19,7 +19,7 @@ class BillingClient {
   BillingClient() {
     _channel.setMethodCallHandler(_callHandler);
   }
-  MethodChannel _channel = Channel.instance;
+  final MethodChannel _channel = channel;
 
   // Occasionally methods in the native layer require a Dart callback to be
   // triggered in response to a Java callback. For example,

--- a/packages/in_app_purchase/lib/src/billing_client_wrappers/billing_client_wrapper.dart
+++ b/packages/in_app_purchase/lib/src/billing_client_wrappers/billing_client_wrapper.dart
@@ -17,9 +17,8 @@ import '../channel.dart';
 /// converted to futures where appropriate.
 class BillingClient {
   BillingClient() {
-    _channel.setMethodCallHandler(_callHandler);
+    channel.setMethodCallHandler(_callHandler);
   }
-  final MethodChannel _channel = channel;
 
   // Occasionally methods in the native layer require a Dart callback to be
   // triggered in response to a Java callback. For example,
@@ -35,7 +34,7 @@ class BillingClient {
   /// [`BillingClient#isReady()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.html#isReady())
   /// to get the ready status of the BillingClient instance.
   Future<bool> isReady() async =>
-      await _channel.invokeMethod('BillingClient#isReady()');
+      await channel.invokeMethod('BillingClient#isReady()');
 
   /// Calls
   /// [`BillingClient#startConnection(BillingClientStateListener)`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.html#startconnection)
@@ -54,7 +53,7 @@ class BillingClient {
       'OnBillingServiceDisconnected': onBillingServiceDisconnected,
     };
     _callbacks.add(callbacks);
-    return BillingResponse._(await _channel.invokeMethod(
+    return BillingResponse._(await channel.invokeMethod(
         "BillingClient#startConnection(BillingClientStateListener)",
         <String, dynamic>{'handle': _callbacks.length - 1}));
   }
@@ -67,7 +66,7 @@ class BillingClient {
   ///
   /// This triggers the destruction of the `BillingClient` instance in Java.
   Future<void> endConnection() async {
-    return _channel.invokeMethod("BillingClient#endConnection()", null);
+    return channel.invokeMethod("BillingClient#endConnection()", null);
   }
 
   Future<void> _callHandler(MethodCall call) async {

--- a/packages/in_app_purchase/lib/src/channel.dart
+++ b/packages/in_app_purchase/lib/src/channel.dart
@@ -1,16 +1,4 @@
 import 'package:flutter/services.dart';
-import 'package:meta/meta.dart';
 
 const MethodChannel channel =
     MethodChannel('plugins.flutter.io/in_app_purchase');
-
-class Channel {
-  static MethodChannel _channel =
-      const MethodChannel('plugins.flutter.io/in_app_purchase');
-  static MethodChannel _override;
-
-  static MethodChannel get instance => _override ?? _channel;
-
-  @visibleForTesting
-  static set override(MethodChannel override) => _override = override;
-}

--- a/packages/in_app_purchase/lib/src/store_kit_wrappers/sk_payment_queue_wrapper.dart
+++ b/packages/in_app_purchase/lib/src/store_kit_wrappers/sk_payment_queue_wrapper.dart
@@ -5,7 +5,7 @@ import '../channel.dart';
 
 /// A wrapper around [`SKPaymentQueue`](https://developer.apple.com/documentation/storekit/skpaymentqueue?language=objc).
 class SKPaymentQueueWrapper {
-  static MethodChannel _channel = Channel.instance;
+  static MethodChannel _channel = channel;
 
   /// Calls [`-[SKPaymentQueue canMakePayments:]`](https://developer.apple.com/documentation/storekit/skpaymentqueue/1506139-canmakepayments?language=objc).
   static Future<bool> canMakePayments() async =>

--- a/packages/in_app_purchase/lib/src/store_kit_wrappers/sk_payment_queue_wrapper.dart
+++ b/packages/in_app_purchase/lib/src/store_kit_wrappers/sk_payment_queue_wrapper.dart
@@ -1,13 +1,10 @@
 import 'dart:async';
-import 'package:flutter/services.dart';
 
 import '../channel.dart';
 
 /// A wrapper around [`SKPaymentQueue`](https://developer.apple.com/documentation/storekit/skpaymentqueue?language=objc).
 class SKPaymentQueueWrapper {
-  static MethodChannel _channel = channel;
-
   /// Calls [`-[SKPaymentQueue canMakePayments:]`](https://developer.apple.com/documentation/storekit/skpaymentqueue/1506139-canmakepayments?language=objc).
   static Future<bool> canMakePayments() async =>
-      await _channel.invokeMethod('-[SKPaymentQueue canMakePayments:]');
+      await channel.invokeMethod('-[SKPaymentQueue canMakePayments:]');
 }

--- a/packages/in_app_purchase/test/billing_client_wrappers/billing_client_wrapper_test.dart
+++ b/packages/in_app_purchase/test/billing_client_wrappers/billing_client_wrapper_test.dart
@@ -3,35 +3,34 @@ import 'package:flutter/services.dart';
 
 import 'package:in_app_purchase/billing_client_wrappers.dart';
 import 'package:in_app_purchase/src/channel.dart';
-import '../fake_in_app_purchase_platform.dart';
+import '../stub_in_app_purchase_platform.dart';
 
 void main() {
-  final FakeInAppPurchasePlatform fakePlatform = FakeInAppPurchasePlatform();
+  final StubInAppPurchasePlatform stubPlatform = StubInAppPurchasePlatform();
   BillingClient billingClient;
-
   setUpAll(() =>
-      channel.setMockMethodCallHandler(fakePlatform.fakeMethodCallHandler));
+      channel.setMockMethodCallHandler(stubPlatform.fakeMethodCallHandler));
 
   setUp(() {
     billingClient = BillingClient();
-    fakePlatform.reset();
+    stubPlatform.reset();
   });
 
   group('isReady', () {
     test('true', () async {
-      fakePlatform.addResponse(name: 'BillingClient#isReady()', value: true);
+      stubPlatform.addResponse(name: 'BillingClient#isReady()', value: true);
       expect(await billingClient.isReady(), isTrue);
     });
 
     test('false', () async {
-      fakePlatform.addResponse(name: 'BillingClient#isReady()', value: false);
+      stubPlatform.addResponse(name: 'BillingClient#isReady()', value: false);
       expect(await billingClient.isReady(), isFalse);
     });
   });
 
   group('startConnection', () {
     test('returns BillingResponse', () async {
-      fakePlatform.addResponse(
+      stubPlatform.addResponse(
           name: 'BillingClient#startConnection(BillingClientStateListener)',
           value: int.parse(BillingResponse.OK.toString()));
       expect(
@@ -43,19 +42,19 @@ void main() {
     test('passes handle to onBillingServiceDisconnected', () async {
       final String methodName =
           'BillingClient#startConnection(BillingClientStateListener)';
-      fakePlatform.addResponse(
+      stubPlatform.addResponse(
           name: methodName, value: int.parse(BillingResponse.OK.toString()));
       await billingClient.startConnection(onBillingServiceDisconnected: () {});
-      final MethodCall call = fakePlatform.previousCallMatching(methodName);
+      final MethodCall call = stubPlatform.previousCallMatching(methodName);
       expect(call.arguments, equals(<dynamic, dynamic>{'handle': 0}));
     });
   });
 
   test('endConnection', () async {
     final String endConnectionName = 'BillingClient#endConnection()';
-    expect(fakePlatform.countPreviousCalls(endConnectionName), equals(0));
-    fakePlatform.addResponse(name: endConnectionName, value: null);
+    expect(stubPlatform.countPreviousCalls(endConnectionName), equals(0));
+    stubPlatform.addResponse(name: endConnectionName, value: null);
     await billingClient.endConnection();
-    expect(fakePlatform.countPreviousCalls(endConnectionName), equals(1));
+    expect(stubPlatform.countPreviousCalls(endConnectionName), equals(1));
   });
 }

--- a/packages/in_app_purchase/test/billing_client_wrappers/billing_client_wrapper_test.dart
+++ b/packages/in_app_purchase/test/billing_client_wrappers/billing_client_wrapper_test.dart
@@ -3,41 +3,35 @@ import 'package:flutter/services.dart';
 
 import 'package:in_app_purchase/billing_client_wrappers.dart';
 import 'package:in_app_purchase/src/channel.dart';
-import '../fake_platform_views_controller.dart';
+import '../fake_in_app_purchase_platform.dart';
 
 void main() {
-  final FakePlatformViewsController fakePlatformViewsController =
-      FakePlatformViewsController();
+  final FakeInAppPurchasePlatform fakePlatform = FakeInAppPurchasePlatform();
   BillingClient billingClient;
 
-  setUpAll(() {
-    Channel.override = SystemChannels.platform_views;
-    SystemChannels.platform_views.setMockMethodCallHandler(
-        fakePlatformViewsController.fakePlatformViewsMethodHandler);
-  });
+  setUpAll(() =>
+      channel.setMockMethodCallHandler(fakePlatform.fakeMethodCallHandler));
 
   setUp(() {
     billingClient = BillingClient();
-    fakePlatformViewsController.reset();
+    fakePlatform.reset();
   });
 
   group('isReady', () {
     test('true', () async {
-      fakePlatformViewsController.addCall(
-          name: 'BillingClient#isReady()', value: true);
+      fakePlatform.addResponse(name: 'BillingClient#isReady()', value: true);
       expect(await billingClient.isReady(), isTrue);
     });
 
     test('false', () async {
-      fakePlatformViewsController.addCall(
-          name: 'BillingClient#isReady()', value: false);
+      fakePlatform.addResponse(name: 'BillingClient#isReady()', value: false);
       expect(await billingClient.isReady(), isFalse);
     });
   });
 
   group('startConnection', () {
     test('returns BillingResponse', () async {
-      fakePlatformViewsController.addCall(
+      fakePlatform.addResponse(
           name: 'BillingClient#startConnection(BillingClientStateListener)',
           value: int.parse(BillingResponse.OK.toString()));
       expect(
@@ -49,22 +43,19 @@ void main() {
     test('passes handle to onBillingServiceDisconnected', () async {
       final String methodName =
           'BillingClient#startConnection(BillingClientStateListener)';
-      fakePlatformViewsController.addCall(
+      fakePlatform.addResponse(
           name: methodName, value: int.parse(BillingResponse.OK.toString()));
       await billingClient.startConnection(onBillingServiceDisconnected: () {});
-      final MethodCall call =
-          fakePlatformViewsController.previousCallMatching(methodName);
+      final MethodCall call = fakePlatform.previousCallMatching(methodName);
       expect(call.arguments, equals(<dynamic, dynamic>{'handle': 0}));
     });
   });
 
   test('endConnection', () async {
     final String endConnectionName = 'BillingClient#endConnection()';
-    expect(fakePlatformViewsController.countPreviousCalls(endConnectionName),
-        equals(0));
-    fakePlatformViewsController.addCall(name: endConnectionName, value: null);
+    expect(fakePlatform.countPreviousCalls(endConnectionName), equals(0));
+    fakePlatform.addResponse(name: endConnectionName, value: null);
     await billingClient.endConnection();
-    expect(fakePlatformViewsController.countPreviousCalls(endConnectionName),
-        equals(1));
+    expect(fakePlatform.countPreviousCalls(endConnectionName), equals(1));
   });
 }

--- a/packages/in_app_purchase/test/fake_in_app_purchase_platform.dart
+++ b/packages/in_app_purchase/test/fake_in_app_purchase_platform.dart
@@ -1,9 +1,10 @@
 import 'dart:async';
 import 'package:flutter/services.dart';
 
-class FakePlatformViewsController {
+class FakeInAppPurchasePlatform {
   Map<String, dynamic> _expectedCalls = <String, dynamic>{};
-  void addCall({String name, dynamic value}) => _expectedCalls[name] = value;
+  void addResponse({String name, dynamic value}) =>
+      _expectedCalls[name] = value;
 
   List<MethodCall> _previousCalls = <MethodCall>[];
   List<MethodCall> get previousCalls => _previousCalls;
@@ -17,7 +18,7 @@ class FakePlatformViewsController {
     _previousCalls.clear();
   }
 
-  Future<dynamic> fakePlatformViewsMethodHandler(MethodCall call) {
+  Future<dynamic> fakeMethodCallHandler(MethodCall call) {
     _previousCalls.add(call);
     if (_expectedCalls.containsKey(call.method)) {
       return Future<dynamic>.sync(() => _expectedCalls[call.method]);

--- a/packages/in_app_purchase/test/in_app_purchase_connection/app_store_connection_test.dart
+++ b/packages/in_app_purchase/test/in_app_purchase_connection/app_store_connection_test.dart
@@ -2,23 +2,23 @@ import 'package:test/test.dart';
 
 import 'package:in_app_purchase/src/channel.dart';
 import 'package:in_app_purchase/src/in_app_purchase_connection/app_store_connection.dart';
-import '../fake_in_app_purchase_platform.dart';
+import '../stub_in_app_purchase_platform.dart';
 
 void main() {
-  final FakeInAppPurchasePlatform fakePlatform = FakeInAppPurchasePlatform();
+  final StubInAppPurchasePlatform stubPlatform = StubInAppPurchasePlatform();
 
   setUpAll(() =>
-      channel.setMockMethodCallHandler(fakePlatform.fakeMethodCallHandler));
+      channel.setMockMethodCallHandler(stubPlatform.fakeMethodCallHandler));
 
   group('isAvailable', () {
     test('true', () async {
-      fakePlatform.addResponse(
+      stubPlatform.addResponse(
           name: '-[SKPaymentQueue canMakePayments:]', value: true);
       expect(await AppStoreConnection.instance.isAvailable(), isTrue);
     });
 
     test('false', () async {
-      fakePlatform.addResponse(
+      stubPlatform.addResponse(
           name: '-[SKPaymentQueue canMakePayments:]', value: false);
       expect(await AppStoreConnection.instance.isAvailable(), isFalse);
     });

--- a/packages/in_app_purchase/test/in_app_purchase_connection/app_store_connection_test.dart
+++ b/packages/in_app_purchase/test/in_app_purchase_connection/app_store_connection_test.dart
@@ -1,28 +1,24 @@
 import 'package:test/test.dart';
-import 'package:flutter/services.dart';
 
 import 'package:in_app_purchase/src/channel.dart';
 import 'package:in_app_purchase/src/in_app_purchase_connection/app_store_connection.dart';
-import '../fake_platform_views_controller.dart';
+import '../fake_in_app_purchase_platform.dart';
 
 void main() {
-  final FakePlatformViewsController controller = FakePlatformViewsController();
+  final FakeInAppPurchasePlatform fakePlatform = FakeInAppPurchasePlatform();
 
-  setUpAll(() {
-    Channel.override = SystemChannels.platform_views;
-    SystemChannels.platform_views
-        .setMockMethodCallHandler(controller.fakePlatformViewsMethodHandler);
-  });
+  setUpAll(() =>
+      channel.setMockMethodCallHandler(fakePlatform.fakeMethodCallHandler));
 
   group('isAvailable', () {
     test('true', () async {
-      controller.addCall(
+      fakePlatform.addResponse(
           name: '-[SKPaymentQueue canMakePayments:]', value: true);
       expect(await AppStoreConnection.instance.isAvailable(), isTrue);
     });
 
     test('false', () async {
-      controller.addCall(
+      fakePlatform.addResponse(
           name: '-[SKPaymentQueue canMakePayments:]', value: false);
       expect(await AppStoreConnection.instance.isAvailable(), isFalse);
     });

--- a/packages/in_app_purchase/test/in_app_purchase_connection/google_play_connection_test.dart
+++ b/packages/in_app_purchase/test/in_app_purchase_connection/google_play_connection_test.dart
@@ -4,58 +4,58 @@ import 'package:flutter/widgets.dart';
 import 'package:in_app_purchase/billing_client_wrappers.dart';
 import 'package:in_app_purchase/src/in_app_purchase_connection/google_play_connection.dart';
 import 'package:in_app_purchase/src/channel.dart';
-import '../fake_in_app_purchase_platform.dart';
+import '../stub_in_app_purchase_platform.dart';
 
 void main() {
-  final FakeInAppPurchasePlatform fakePlatform = FakeInAppPurchasePlatform();
+  final StubInAppPurchasePlatform stubPlatform = StubInAppPurchasePlatform();
   GooglePlayConnection connection;
   const String startConnectionCall =
       'BillingClient#startConnection(BillingClientStateListener)';
   const String endConnectionCall = 'BillingClient#endConnection()';
 
   setUpAll(() =>
-      channel.setMockMethodCallHandler(fakePlatform.fakeMethodCallHandler));
+      channel.setMockMethodCallHandler(stubPlatform.fakeMethodCallHandler));
 
   setUp(() {
     WidgetsFlutterBinding.ensureInitialized();
-    fakePlatform.addResponse(
+    stubPlatform.addResponse(
         name: startConnectionCall,
         value: int.parse(BillingResponse.OK.toString()));
-    fakePlatform.addResponse(name: endConnectionCall, value: null);
+    stubPlatform.addResponse(name: endConnectionCall, value: null);
     connection = GooglePlayConnection.instance;
   });
 
   tearDown(() {
-    fakePlatform.reset();
+    stubPlatform.reset();
     GooglePlayConnection.reset();
   });
 
   group('connection management', () {
     test('connects on initialization', () {
-      expect(fakePlatform.countPreviousCalls(startConnectionCall), equals(1));
+      expect(stubPlatform.countPreviousCalls(startConnectionCall), equals(1));
     });
 
     test('disconnects on app pause', () {
-      expect(fakePlatform.countPreviousCalls(endConnectionCall), equals(0));
+      expect(stubPlatform.countPreviousCalls(endConnectionCall), equals(0));
       connection.didChangeAppLifecycleState(AppLifecycleState.paused);
-      expect(fakePlatform.countPreviousCalls(endConnectionCall), equals(1));
+      expect(stubPlatform.countPreviousCalls(endConnectionCall), equals(1));
     });
 
     test('reconnects on app resume', () {
-      expect(fakePlatform.countPreviousCalls(startConnectionCall), equals(1));
+      expect(stubPlatform.countPreviousCalls(startConnectionCall), equals(1));
       connection.didChangeAppLifecycleState(AppLifecycleState.resumed);
-      expect(fakePlatform.countPreviousCalls(startConnectionCall), equals(2));
+      expect(stubPlatform.countPreviousCalls(startConnectionCall), equals(2));
     });
   });
 
   group('isAvailable', () {
     test('true', () async {
-      fakePlatform.addResponse(name: 'BillingClient#isReady()', value: true);
+      stubPlatform.addResponse(name: 'BillingClient#isReady()', value: true);
       expect(await connection.isAvailable(), isTrue);
     });
 
     test('false', () async {
-      fakePlatform.addResponse(name: 'BillingClient#isReady()', value: false);
+      stubPlatform.addResponse(name: 'BillingClient#isReady()', value: false);
       expect(await connection.isAvailable(), isFalse);
     });
   });

--- a/packages/in_app_purchase/test/in_app_purchase_connection/google_play_connection_test.dart
+++ b/packages/in_app_purchase/test/in_app_purchase_connection/google_play_connection_test.dart
@@ -1,65 +1,61 @@
 import 'package:test/test.dart';
-import 'package:flutter/services.dart';
 
 import 'package:flutter/widgets.dart';
 import 'package:in_app_purchase/billing_client_wrappers.dart';
 import 'package:in_app_purchase/src/in_app_purchase_connection/google_play_connection.dart';
 import 'package:in_app_purchase/src/channel.dart';
-import '../fake_platform_views_controller.dart';
+import '../fake_in_app_purchase_platform.dart';
 
 void main() {
-  final FakePlatformViewsController controller = FakePlatformViewsController();
+  final FakeInAppPurchasePlatform fakePlatform = FakeInAppPurchasePlatform();
   GooglePlayConnection connection;
   const String startConnectionCall =
       'BillingClient#startConnection(BillingClientStateListener)';
   const String endConnectionCall = 'BillingClient#endConnection()';
 
-  setUpAll(() {
-    Channel.override = SystemChannels.platform_views;
-    SystemChannels.platform_views
-        .setMockMethodCallHandler(controller.fakePlatformViewsMethodHandler);
-  });
+  setUpAll(() =>
+      channel.setMockMethodCallHandler(fakePlatform.fakeMethodCallHandler));
 
   setUp(() {
     WidgetsFlutterBinding.ensureInitialized();
-    controller.addCall(
+    fakePlatform.addResponse(
         name: startConnectionCall,
         value: int.parse(BillingResponse.OK.toString()));
-    controller.addCall(name: endConnectionCall, value: null);
+    fakePlatform.addResponse(name: endConnectionCall, value: null);
     connection = GooglePlayConnection.instance;
   });
 
   tearDown(() {
-    controller.reset();
+    fakePlatform.reset();
     GooglePlayConnection.reset();
   });
 
   group('connection management', () {
     test('connects on initialization', () {
-      expect(controller.countPreviousCalls(startConnectionCall), equals(1));
+      expect(fakePlatform.countPreviousCalls(startConnectionCall), equals(1));
     });
 
     test('disconnects on app pause', () {
-      expect(controller.countPreviousCalls(endConnectionCall), equals(0));
+      expect(fakePlatform.countPreviousCalls(endConnectionCall), equals(0));
       connection.didChangeAppLifecycleState(AppLifecycleState.paused);
-      expect(controller.countPreviousCalls(endConnectionCall), equals(1));
+      expect(fakePlatform.countPreviousCalls(endConnectionCall), equals(1));
     });
 
     test('reconnects on app resume', () {
-      expect(controller.countPreviousCalls(startConnectionCall), equals(1));
+      expect(fakePlatform.countPreviousCalls(startConnectionCall), equals(1));
       connection.didChangeAppLifecycleState(AppLifecycleState.resumed);
-      expect(controller.countPreviousCalls(startConnectionCall), equals(2));
+      expect(fakePlatform.countPreviousCalls(startConnectionCall), equals(2));
     });
   });
 
   group('isAvailable', () {
     test('true', () async {
-      controller.addCall(name: 'BillingClient#isReady()', value: true);
+      fakePlatform.addResponse(name: 'BillingClient#isReady()', value: true);
       expect(await connection.isAvailable(), isTrue);
     });
 
     test('false', () async {
-      controller.addCall(name: 'BillingClient#isReady()', value: false);
+      fakePlatform.addResponse(name: 'BillingClient#isReady()', value: false);
       expect(await connection.isAvailable(), isFalse);
     });
   });

--- a/packages/in_app_purchase/test/store_kit_wrappers/sk_payment_queue_wrapper_test.dart
+++ b/packages/in_app_purchase/test/store_kit_wrappers/sk_payment_queue_wrapper_test.dart
@@ -2,23 +2,23 @@ import 'package:test/test.dart';
 
 import 'package:in_app_purchase/store_kit_wrappers.dart';
 import 'package:in_app_purchase/src/channel.dart';
-import '../fake_in_app_purchase_platform.dart';
+import '../stub_in_app_purchase_platform.dart';
 
 void main() {
-  final FakeInAppPurchasePlatform fakePlatform = FakeInAppPurchasePlatform();
+  final StubInAppPurchasePlatform stubPlatform = StubInAppPurchasePlatform();
 
   setUpAll(() =>
-      channel.setMockMethodCallHandler(fakePlatform.fakeMethodCallHandler));
+      channel.setMockMethodCallHandler(stubPlatform.fakeMethodCallHandler));
 
   group('canMakePayments', () {
     test('YES', () async {
-      fakePlatform.addResponse(
+      stubPlatform.addResponse(
           name: '-[SKPaymentQueue canMakePayments:]', value: true);
       expect(await SKPaymentQueueWrapper.canMakePayments(), isTrue);
     });
 
     test('NO', () async {
-      fakePlatform.addResponse(
+      stubPlatform.addResponse(
           name: '-[SKPaymentQueue canMakePayments:]', value: false);
       expect(await SKPaymentQueueWrapper.canMakePayments(), isFalse);
     });

--- a/packages/in_app_purchase/test/store_kit_wrappers/sk_payment_queue_wrapper_test.dart
+++ b/packages/in_app_purchase/test/store_kit_wrappers/sk_payment_queue_wrapper_test.dart
@@ -1,29 +1,24 @@
-import 'package:flutter/services.dart';
 import 'package:test/test.dart';
 
 import 'package:in_app_purchase/store_kit_wrappers.dart';
 import 'package:in_app_purchase/src/channel.dart';
-import '../fake_platform_views_controller.dart';
+import '../fake_in_app_purchase_platform.dart';
 
 void main() {
-  final FakePlatformViewsController fakePlatformViewsController =
-      FakePlatformViewsController();
+  final FakeInAppPurchasePlatform fakePlatform = FakeInAppPurchasePlatform();
 
-  setUpAll(() {
-    Channel.override = SystemChannels.platform_views;
-    SystemChannels.platform_views.setMockMethodCallHandler(
-        fakePlatformViewsController.fakePlatformViewsMethodHandler);
-  });
+  setUpAll(() =>
+      channel.setMockMethodCallHandler(fakePlatform.fakeMethodCallHandler));
 
   group('canMakePayments', () {
     test('YES', () async {
-      fakePlatformViewsController.addCall(
+      fakePlatform.addResponse(
           name: '-[SKPaymentQueue canMakePayments:]', value: true);
       expect(await SKPaymentQueueWrapper.canMakePayments(), isTrue);
     });
 
     test('NO', () async {
-      fakePlatformViewsController.addCall(
+      fakePlatform.addResponse(
           name: '-[SKPaymentQueue canMakePayments:]', value: false);
       expect(await SKPaymentQueueWrapper.canMakePayments(), isFalse);
     });

--- a/packages/in_app_purchase/test/stub_in_app_purchase_platform.dart
+++ b/packages/in_app_purchase/test/stub_in_app_purchase_platform.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'package:flutter/services.dart';
 
-class FakeInAppPurchasePlatform {
+class StubInAppPurchasePlatform {
   Map<String, dynamic> _expectedCalls = <String, dynamic>{};
   void addResponse({String name, dynamic value}) =>
       _expectedCalls[name] = value;


### PR DESCRIPTION
Rename `PlatformViewsController` to `StubInAppPurchasePlatform` to more
accurately describe what it's stubbing. Remove the overcomplicated
`Channel` class and just set a mock handler on the `const MethodChannel`
used by the entire plugin itself.