### PR TITLE
[IAP] Fetch SkuDetails from Google Play

### DIFF
--- a/packages/in_app_purchase/android/src/main/java/io/flutter/plugins/inapppurchase/Translator.java
+++ b/packages/in_app_purchase/android/src/main/java/io/flutter/plugins/inapppurchase/Translator.java
@@ -1,0 +1,47 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package io.flutter.plugins.inapppurchase;
+
+import android.support.annotation.Nullable;
+import com.android.billingclient.api.SkuDetails;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+/** Handles serialization of {@link com.android.billingclient.api.BillingClient} related objects. */
+/*package*/ class Translator {
+  static HashMap<String, Object> fromSkuDetail(SkuDetails detail) {
+    HashMap<String, Object> info = new HashMap<>();
+    info.put("title", detail.getTitle());
+    info.put("description", detail.getDescription());
+    info.put("freeTrialPeriod", detail.getFreeTrialPeriod());
+    info.put("introductoryPrice", detail.getIntroductoryPrice());
+    info.put("introductoryPriceAmountMicros", detail.getIntroductoryPriceAmountMicros());
+    info.put("introductoryPriceCycles", detail.getIntroductoryPriceCycles());
+    info.put("introductoryPricePeriod", detail.getIntroductoryPricePeriod());
+    info.put("price", detail.getPrice());
+    info.put("priceAmountMicros", detail.getPriceAmountMicros());
+    info.put("priceCurrencyCode", detail.getPriceCurrencyCode());
+    info.put("sku", detail.getSku());
+    info.put("type", detail.getType());
+    info.put("isRewarded", detail.isRewarded());
+    info.put("subscriptionPeriod", detail.getSubscriptionPeriod());
+    return info;
+  }
+
+  static List<HashMap<String, Object>> fromSkuDetailsList(
+      @Nullable List<SkuDetails> skuDetailsList) {
+    if (skuDetailsList == null) {
+      return Collections.emptyList();
+    }
+
+    ArrayList<HashMap<String, Object>> output = new ArrayList<>();
+    for (SkuDetails detail : skuDetailsList) {
+      output.add(fromSkuDetail(detail));
+    }
+    return output;
+  }
+}

--- a/packages/in_app_purchase/example/android/app/build.gradle
+++ b/packages/in_app_purchase/example/android/app/build.gradle
@@ -111,6 +111,7 @@ dependencies {
     implementation 'com.android.billingclient:billing:1.2'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.17.0'
+    testImplementation 'org.json:json:20180813'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 }

--- a/packages/in_app_purchase/example/android/app/src/test/java/io/flutter/plugins/inapppurchase/TranslatorTest.java
+++ b/packages/in_app_purchase/example/android/app/src/test/java/io/flutter/plugins/inapppurchase/TranslatorTest.java
@@ -1,0 +1,67 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package io.flutter.plugins.inapppurchase;
+
+import static org.junit.Assert.assertEquals;
+
+import com.android.billingclient.api.SkuDetails;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.json.JSONException;
+import org.junit.Test;
+
+public class TranslatorTest {
+  private static final String SKU_DETAIL_EXAMPLE_JSON =
+      "{\"productId\":\"example\",\"type\":\"inapp\",\"price\":\"$0.99\",\"price_amount_micros\":990000,\"price_currency_code\":\"USD\",\"title\":\"Example title\",\"description\":\"Example description.\"}";
+
+  @Test
+  public void fromSkuDetail() throws JSONException {
+    final SkuDetails expected = new SkuDetails(SKU_DETAIL_EXAMPLE_JSON);
+
+    Map<String, Object> serialized = Translator.fromSkuDetail(expected);
+
+    assertSerialized(expected, serialized);
+  }
+
+  @Test
+  public void fromSkuDetailsList() throws JSONException {
+    final String SKU_DETAIL_EXAMPLE_2_JSON =
+        "{\"productId\":\"example2\",\"type\":\"inapp\",\"price\":\"$0.99\",\"price_amount_micros\":990000,\"price_currency_code\":\"USD\",\"title\":\"Example title\",\"description\":\"Example description.\"}";
+    final List<SkuDetails> expected =
+        Arrays.asList(
+            new SkuDetails(SKU_DETAIL_EXAMPLE_JSON), new SkuDetails(SKU_DETAIL_EXAMPLE_2_JSON));
+
+    final List<HashMap<String, Object>> serialized = Translator.fromSkuDetailsList(expected);
+
+    assertEquals(expected.size(), serialized.size());
+    assertSerialized(expected.get(0), serialized.get(0));
+    assertSerialized(expected.get(1), serialized.get(1));
+  }
+
+  @Test
+  public void fromSkuDetailsList_null() {
+    assertEquals(0, Translator.fromSkuDetailsList(null).size());
+  }
+
+  private void assertSerialized(SkuDetails expected, Map<String, Object> serialized) {
+    assertEquals(expected.getDescription(), serialized.get("description"));
+    assertEquals(expected.getFreeTrialPeriod(), serialized.get("freeTrialPeriod"));
+    assertEquals(expected.getIntroductoryPrice(), serialized.get("introductoryPrice"));
+    assertEquals(
+        expected.getIntroductoryPriceAmountMicros(),
+        serialized.get("introductoryPriceAmountMicros"));
+    assertEquals(expected.getIntroductoryPriceCycles(), serialized.get("introductoryPriceCycles"));
+    assertEquals(expected.getIntroductoryPricePeriod(), serialized.get("introductoryPricePeriod"));
+    assertEquals(expected.getPrice(), serialized.get("price"));
+    assertEquals(expected.getPriceAmountMicros(), serialized.get("priceAmountMicros"));
+    assertEquals(expected.getPriceCurrencyCode(), serialized.get("priceCurrencyCode"));
+    assertEquals(expected.getSku(), serialized.get("sku"));
+    assertEquals(expected.getSubscriptionPeriod(), serialized.get("subscriptionPeriod"));
+    assertEquals(expected.getTitle(), serialized.get("title"));
+    assertEquals(expected.getType(), serialized.get("type"));
+  }
+}

--- a/packages/in_app_purchase/lib/billing_client_wrappers.dart
+++ b/packages/in_app_purchase/lib/billing_client_wrappers.dart
@@ -3,3 +3,4 @@
 // found in the LICENSE file.
 
 export 'src/billing_client_wrappers/billing_client_wrapper.dart';
+export 'src/billing_client_wrappers/sku_details_wrapper.dart';

--- a/packages/in_app_purchase/lib/src/billing_client_wrappers/billing_client_wrapper.dart
+++ b/packages/in_app_purchase/lib/src/billing_client_wrappers/billing_client_wrapper.dart
@@ -74,11 +74,14 @@ class BillingClient {
     return channel.invokeMethod("BillingClient#endConnection()", null);
   }
 
-  /// Calls through to `BillingClient#querySkuDetailsAsync(SkuDetailsParams params, SkuDetailsResponseListener listener)`
+  /// Returns a list of [SkuDetailsWrapper]s that have [SkuDetailsWrapper.sku]
+  /// in [skusList], and [SkuDetailsWrapper.type] matching [skuType].
   ///
-  /// Instead of taking a callback parameter, it returns the async output in the
-  /// form of a future. It also takes the values of `SkuDetailsParams` as direct
-  /// arguments instead of requiring it constructed and passed in as a class.
+  /// Calls through to `BillingClient#querySkuDetailsAsync(SkuDetailsParams
+  /// params, SkuDetailsResponseListener listener)` Instead of taking a callback
+  /// parameter, it returns a Future [SkuDetailsResponseWrapper]. It also takes
+  /// the values of `SkuDetailsParams` as direct arguments instead of requiring
+  /// it constructed and passed in as a class.
   Future<SkuDetailsResponseWrapper> querySkuDetails(
       {@required SkuType skuType, @required List<String> skusList}) async {
     final Map<String, dynamic> arguments = <String, dynamic>{
@@ -114,6 +117,7 @@ typedef void OnBillingServiceDisconnected();
 /// See the `BillingResponse` docs for an explanation of the different constants.
 class BillingResponse {
   const BillingResponse._(this._code);
+  static BillingResponse fromInt(int code) => BillingResponse._(code);
   final int _code;
   @override
   String toString() => _code.toString();
@@ -135,8 +139,10 @@ class BillingResponse {
   static const BillingResponse ITEM_NOT_OWNED = BillingResponse._(8);
 }
 
-/// Enum representing [`BillingClient.SkuType`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.SkuType)
+/// Enum representing potential [SkuDetailsWrapper.type]s.
 ///
+/// Wraps
+/// [`BillingClient.SkuType`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.SkuType)
 /// See the linked documentation for an explanation of the different constants.
 class SkuType {
   const SkuType._(this._type);
@@ -156,6 +162,9 @@ class SkuType {
   @override
   bool operator ==(dynamic other) => other is SkuType && other._type == _type;
 
+  /// A one time product. Acquired in a single transaction.
   static const SkuType INAPP = SkuType._("inapp");
+
+  /// A product requiring a recurring charge over time.
   static const SkuType SUBS = SkuType._("subs");
 }

--- a/packages/in_app_purchase/lib/src/billing_client_wrappers/billing_client_wrapper.dart
+++ b/packages/in_app_purchase/lib/src/billing_client_wrappers/billing_client_wrapper.dart
@@ -75,13 +75,14 @@ class BillingClient {
   }
 
   /// Returns a list of [SkuDetailsWrapper]s that have [SkuDetailsWrapper.sku]
-  /// in [skusList], and [SkuDetailsWrapper.type] matching [skuType].
+  /// in `skusList`, and [SkuDetailsWrapper.type] matching `skuType`.
   ///
-  /// Calls through to `BillingClient#querySkuDetailsAsync(SkuDetailsParams
-  /// params, SkuDetailsResponseListener listener)` Instead of taking a callback
-  /// parameter, it returns a Future [SkuDetailsResponseWrapper]. It also takes
-  /// the values of `SkuDetailsParams` as direct arguments instead of requiring
-  /// it constructed and passed in as a class.
+  /// Calls through to [`BillingClient#querySkuDetailsAsync(SkuDetailsParams,
+  /// SkuDetailsResponseListener)`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#querySkuDetailsAsync(com.android.billingclient.api.SkuDetailsParams,%20com.android.billingclient.api.SkuDetailsResponseListener))
+  /// Instead of taking a callback parameter, it returns a Future
+  /// [SkuDetailsResponseWrapper]. It also takes the values of
+  /// `SkuDetailsParams` as direct arguments instead of requiring it constructed
+  /// and passed in as a class.
   Future<SkuDetailsResponseWrapper> querySkuDetails(
       {@required SkuType skuType, @required List<String> skusList}) async {
     final Map<String, dynamic> arguments = <String, dynamic>{
@@ -105,6 +106,8 @@ class BillingClient {
   }
 }
 
+/// Callback triggered when the [BillingClientWrapper] is disconnected.
+///
 /// Wraps
 /// [`com.android.billingclient.api.BillingClientStateListener.onServiceDisconnected()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClientStateListener.html#onBillingServiceDisconnected())
 /// to call back on `BillingClient` disconnect.

--- a/packages/in_app_purchase/lib/src/billing_client_wrappers/sku_details_wrapper.dart
+++ b/packages/in_app_purchase/lib/src/billing_client_wrappers/sku_details_wrapper.dart
@@ -1,0 +1,114 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'billing_client_wrapper.dart';
+
+/// Dart wrapper around [`com.android.billingclient.api.SkuDetails`](https://developer.android.com/reference/com/android/billingclient/api/SkuDetails).
+class SkuDetailsWrapper {
+  SkuDetailsWrapper({
+    @required this.description,
+    @required this.freeTrialPeriod,
+    @required this.introductoryPrice,
+    @required this.introductoryPriceMicros,
+    @required this.introductoryPriceCycles,
+    @required this.introductoryPricePeriod,
+    @required this.price,
+    @required this.priceAmountMicros,
+    @required this.priceCurrencyCode,
+    @required this.sku,
+    @required this.subscriptionPeriod,
+    @required this.title,
+    @required this.type,
+    @required this.isRewarded,
+  });
+
+  /// Constructs an instance of this from a key value map of data.
+  ///
+  /// The map needs to have named string keys with values matching the names and
+  /// types of all of the members on this class.
+  static SkuDetailsWrapper fromMap(Map<String, dynamic> map) =>
+      SkuDetailsWrapper(
+          description: map['description'],
+          freeTrialPeriod: map['freeTrialPeriod'],
+          introductoryPrice: map['introductoryPrice'],
+          introductoryPriceMicros: map['introductoryPriceMicros'],
+          introductoryPriceCycles: map['introductoryPriceCycles'],
+          introductoryPricePeriod: map['introductoryPricePeriod'],
+          price: map['price'],
+          priceAmountMicros: map['priceAmountMicros'],
+          priceCurrencyCode: map['priceCurrencyCode'],
+          sku: map['sku'],
+          subscriptionPeriod: map['subscriptionPeriod'],
+          title: map['title'],
+          type: SkuType.fromString(map['type']),
+          isRewarded: map['isRewarded']);
+
+  final String description;
+  final String freeTrialPeriod;
+  final String introductoryPrice;
+  final String introductoryPriceMicros;
+  final String introductoryPriceCycles;
+  final String introductoryPricePeriod;
+  final String price;
+  final int priceAmountMicros;
+  final String priceCurrencyCode;
+  final String sku;
+  final String subscriptionPeriod;
+  final String title;
+  final SkuType type;
+  final bool isRewarded;
+
+  @override
+  bool operator ==(dynamic other) =>
+      other is SkuDetailsWrapper &&
+      other.description == description &&
+      other.freeTrialPeriod == freeTrialPeriod &&
+      other.introductoryPrice == introductoryPrice &&
+      other.introductoryPriceMicros == introductoryPriceMicros &&
+      other.introductoryPriceCycles == introductoryPriceCycles &&
+      other.introductoryPricePeriod == introductoryPricePeriod &&
+      other.price == price &&
+      other.priceAmountMicros == priceAmountMicros &&
+      other.sku == sku &&
+      other.subscriptionPeriod == subscriptionPeriod &&
+      other.title == title &&
+      other.type == type &&
+      other.isRewarded == isRewarded;
+
+  @override
+  int get hashCode =>
+      description.hashCode +
+      freeTrialPeriod.hashCode +
+      introductoryPrice.hashCode +
+      introductoryPriceMicros.hashCode +
+      introductoryPriceCycles.hashCode +
+      introductoryPricePeriod.hashCode +
+      price.hashCode +
+      priceAmountMicros.hashCode +
+      sku.hashCode +
+      subscriptionPeriod.hashCode +
+      title.hashCode +
+      type.hashCode +
+      isRewarded.hashCode;
+}
+
+/// Translation of [`com.android.billingclient.api.SkuDetailsResponseListener`](https://developer.android.com/reference/com/android/billingclient/api/SkuDetailsResponseListener.html).
+///
+/// Returned as a datatype in a future instead of existing as a callback.
+class SkuDetailsResponseWrapper {
+  SkuDetailsResponseWrapper({@required this.responseCode, this.skuDetailsList});
+  static SkuDetailsResponseWrapper fromMap(Map<String, dynamic> map) {
+    final List<SkuDetailsWrapper> skuDetailsList = List.castFrom<dynamic,
+            Map<dynamic, dynamic>>(map['skuDetailsList'])
+        .map((Map<dynamic, dynamic> uncast) => uncast.cast<String, dynamic>())
+        .map((Map<String, dynamic> entry) => SkuDetailsWrapper.fromMap(entry))
+        .toList();
+    return SkuDetailsResponseWrapper(
+        responseCode: map['responseCode'], skuDetailsList: skuDetailsList);
+  }
+
+  final int responseCode;
+  final List<SkuDetailsWrapper> skuDetailsList;
+}

--- a/packages/in_app_purchase/lib/src/billing_client_wrappers/sku_details_wrapper.dart
+++ b/packages/in_app_purchase/lib/src/billing_client_wrappers/sku_details_wrapper.dart
@@ -10,6 +10,7 @@ import 'billing_client_wrapper.dart';
 ///
 /// Contains the details of an available product in Google Play Billing.
 class SkuDetailsWrapper {
+  @visibleForTesting
   SkuDetailsWrapper({
     @required this.description,
     @required this.freeTrialPeriod,
@@ -31,23 +32,22 @@ class SkuDetailsWrapper {
   ///
   /// The map needs to have named string keys with values matching the names and
   /// types of all of the members on this class.
-  static SkuDetailsWrapper fromMap(Map<dynamic, dynamic> map) {
-    return SkuDetailsWrapper(
-        description: map['description'],
-        freeTrialPeriod: map['freeTrialPeriod'],
-        introductoryPrice: map['introductoryPrice'],
-        introductoryPriceMicros: map['introductoryPriceMicros'],
-        introductoryPriceCycles: map['introductoryPriceCycles'],
-        introductoryPricePeriod: map['introductoryPricePeriod'],
-        price: map['price'],
-        priceAmountMicros: map['priceAmountMicros'],
-        priceCurrencyCode: map['priceCurrencyCode'],
-        sku: map['sku'],
-        subscriptionPeriod: map['subscriptionPeriod'],
-        title: map['title'],
-        type: SkuType.fromString(map['type']),
-        isRewarded: map['isRewarded']);
-  }
+  @visibleForTesting
+  SkuDetailsWrapper.fromMap(Map<dynamic, dynamic> map)
+      : description = map['description'],
+        freeTrialPeriod = map['freeTrialPeriod'],
+        introductoryPrice = map['introductoryPrice'],
+        introductoryPriceMicros = map['introductoryPriceMicros'],
+        introductoryPriceCycles = map['introductoryPriceCycles'],
+        introductoryPricePeriod = map['introductoryPricePeriod'],
+        price = map['price'],
+        priceAmountMicros = map['priceAmountMicros'],
+        priceCurrencyCode = map['priceCurrencyCode'],
+        sku = map['sku'],
+        subscriptionPeriod = map['subscriptionPeriod'],
+        title = map['title'],
+        type = SkuType.fromString(map['type']),
+        isRewarded = map['isRewarded'];
 
   final String description;
 
@@ -134,16 +134,20 @@ class SkuDetailsWrapper {
 ///
 /// Returned by [BillingClient.querySkuDetails].
 class SkuDetailsResponseWrapper {
+  @visibleForTesting
   SkuDetailsResponseWrapper({@required this.responseCode, this.skuDetailsList});
-  static SkuDetailsResponseWrapper fromMap(Map<dynamic, dynamic> map) {
-    final List<SkuDetailsWrapper> skuDetailsList = List.castFrom<dynamic,
-            Map<dynamic, dynamic>>(map['skuDetailsList'])
-        .map((Map<dynamic, dynamic> entry) => SkuDetailsWrapper.fromMap(entry))
-        .toList();
-    return SkuDetailsResponseWrapper(
-        responseCode: BillingResponse.fromInt(map['responseCode']),
-        skuDetailsList: skuDetailsList);
-  }
+
+  /// Constructs an instance of this from a key value map of data.
+  ///
+  /// The map needs to have named string keys with values matching the names and
+  /// types of all of the members on this class.
+  SkuDetailsResponseWrapper.fromMap(Map<dynamic, dynamic> map)
+      : responseCode = BillingResponse.fromInt(map['responseCode']),
+        skuDetailsList =
+            List.castFrom<dynamic, Map<dynamic, dynamic>>(map['skuDetailsList'])
+                .map((Map<dynamic, dynamic> entry) =>
+                    SkuDetailsWrapper.fromMap(entry))
+                .toList();
 
   /// The final status of the [BillingClient.querySkuDetails] call.
   final BillingResponse responseCode;

--- a/packages/in_app_purchase/lib/src/billing_client_wrappers/sku_details_wrapper.dart
+++ b/packages/in_app_purchase/lib/src/billing_client_wrappers/sku_details_wrapper.dart
@@ -2,10 +2,13 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+import 'dart:ui' show hashValues;
 import 'package:flutter/foundation.dart';
 import 'billing_client_wrapper.dart';
 
 /// Dart wrapper around [`com.android.billingclient.api.SkuDetails`](https://developer.android.com/reference/com/android/billingclient/api/SkuDetails).
+///
+/// Contains the details of an available product in Google Play Billing.
 class SkuDetailsWrapper {
   SkuDetailsWrapper({
     @required this.description,
@@ -28,87 +31,123 @@ class SkuDetailsWrapper {
   ///
   /// The map needs to have named string keys with values matching the names and
   /// types of all of the members on this class.
-  static SkuDetailsWrapper fromMap(Map<String, dynamic> map) =>
-      SkuDetailsWrapper(
-          description: map['description'],
-          freeTrialPeriod: map['freeTrialPeriod'],
-          introductoryPrice: map['introductoryPrice'],
-          introductoryPriceMicros: map['introductoryPriceMicros'],
-          introductoryPriceCycles: map['introductoryPriceCycles'],
-          introductoryPricePeriod: map['introductoryPricePeriod'],
-          price: map['price'],
-          priceAmountMicros: map['priceAmountMicros'],
-          priceCurrencyCode: map['priceCurrencyCode'],
-          sku: map['sku'],
-          subscriptionPeriod: map['subscriptionPeriod'],
-          title: map['title'],
-          type: SkuType.fromString(map['type']),
-          isRewarded: map['isRewarded']);
+  static SkuDetailsWrapper fromMap(Map<dynamic, dynamic> map) {
+    return SkuDetailsWrapper(
+        description: map['description'],
+        freeTrialPeriod: map['freeTrialPeriod'],
+        introductoryPrice: map['introductoryPrice'],
+        introductoryPriceMicros: map['introductoryPriceMicros'],
+        introductoryPriceCycles: map['introductoryPriceCycles'],
+        introductoryPricePeriod: map['introductoryPricePeriod'],
+        price: map['price'],
+        priceAmountMicros: map['priceAmountMicros'],
+        priceCurrencyCode: map['priceCurrencyCode'],
+        sku: map['sku'],
+        subscriptionPeriod: map['subscriptionPeriod'],
+        title: map['title'],
+        type: SkuType.fromString(map['type']),
+        isRewarded: map['isRewarded']);
+  }
 
   final String description;
+
+  /// Trial period in ISO 8601 format.
   final String freeTrialPeriod;
+
+  /// Introductory price, only applies to [SkuType.SUBS]. Formatted ("$0.99").
   final String introductoryPrice;
+
+  /// [introductoryPrice] in micro-units 990000
   final String introductoryPriceMicros;
+
+  /// The number of billing perios that [introductoryPrice] is valid for ("2").
   final String introductoryPriceCycles;
+
+  /// The billing period of [introductoryPrice], in ISO 8601 format.
   final String introductoryPricePeriod;
+
+  /// Formatted with currency symbol ("$0.99").
   final String price;
+
+  /// [price] in micro-units ("990000").
   final int priceAmountMicros;
+
+  /// [price] ISO 4217 currency code.
   final String priceCurrencyCode;
+
+  /// The product ID in Google Play Console.
   final String sku;
+
+  /// Applies to [SkuType.SUBS], formatted in ISO 8601.
   final String subscriptionPeriod;
   final String title;
+
+  /// The [SkuType] of the product.
   final SkuType type;
+
+  /// False if the product is paid.
   final bool isRewarded;
 
   @override
-  bool operator ==(dynamic other) =>
-      other is SkuDetailsWrapper &&
-      other.description == description &&
-      other.freeTrialPeriod == freeTrialPeriod &&
-      other.introductoryPrice == introductoryPrice &&
-      other.introductoryPriceMicros == introductoryPriceMicros &&
-      other.introductoryPriceCycles == introductoryPriceCycles &&
-      other.introductoryPricePeriod == introductoryPricePeriod &&
-      other.price == price &&
-      other.priceAmountMicros == priceAmountMicros &&
-      other.sku == sku &&
-      other.subscriptionPeriod == subscriptionPeriod &&
-      other.title == title &&
-      other.type == type &&
-      other.isRewarded == isRewarded;
+  bool operator ==(dynamic other) {
+    if (other.runtimeType != runtimeType) {
+      return false;
+    }
+
+    final SkuDetailsWrapper typedOther = other;
+    return typedOther is SkuDetailsWrapper &&
+        typedOther.description == description &&
+        typedOther.freeTrialPeriod == freeTrialPeriod &&
+        typedOther.introductoryPrice == introductoryPrice &&
+        typedOther.introductoryPriceMicros == introductoryPriceMicros &&
+        typedOther.introductoryPriceCycles == introductoryPriceCycles &&
+        typedOther.introductoryPricePeriod == introductoryPricePeriod &&
+        typedOther.price == price &&
+        typedOther.priceAmountMicros == priceAmountMicros &&
+        typedOther.sku == sku &&
+        typedOther.subscriptionPeriod == subscriptionPeriod &&
+        typedOther.title == title &&
+        typedOther.type == type &&
+        typedOther.isRewarded == isRewarded;
+  }
 
   @override
-  int get hashCode =>
-      description.hashCode +
-      freeTrialPeriod.hashCode +
-      introductoryPrice.hashCode +
-      introductoryPriceMicros.hashCode +
-      introductoryPriceCycles.hashCode +
-      introductoryPricePeriod.hashCode +
-      price.hashCode +
-      priceAmountMicros.hashCode +
-      sku.hashCode +
-      subscriptionPeriod.hashCode +
-      title.hashCode +
-      type.hashCode +
-      isRewarded.hashCode;
+  int get hashCode {
+    return hashValues(
+        description.hashCode,
+        freeTrialPeriod.hashCode,
+        introductoryPrice.hashCode,
+        introductoryPriceMicros.hashCode,
+        introductoryPriceCycles.hashCode,
+        introductoryPricePeriod.hashCode,
+        price.hashCode,
+        priceAmountMicros.hashCode,
+        sku.hashCode,
+        subscriptionPeriod.hashCode,
+        title.hashCode,
+        type.hashCode,
+        isRewarded.hashCode);
+  }
 }
 
 /// Translation of [`com.android.billingclient.api.SkuDetailsResponseListener`](https://developer.android.com/reference/com/android/billingclient/api/SkuDetailsResponseListener.html).
 ///
-/// Returned as a datatype in a future instead of existing as a callback.
+/// Returned by [BillingClient.querySkuDetails].
 class SkuDetailsResponseWrapper {
   SkuDetailsResponseWrapper({@required this.responseCode, this.skuDetailsList});
-  static SkuDetailsResponseWrapper fromMap(Map<String, dynamic> map) {
+  static SkuDetailsResponseWrapper fromMap(Map<dynamic, dynamic> map) {
     final List<SkuDetailsWrapper> skuDetailsList = List.castFrom<dynamic,
             Map<dynamic, dynamic>>(map['skuDetailsList'])
-        .map((Map<dynamic, dynamic> uncast) => uncast.cast<String, dynamic>())
-        .map((Map<String, dynamic> entry) => SkuDetailsWrapper.fromMap(entry))
+        .map((Map<dynamic, dynamic> entry) => SkuDetailsWrapper.fromMap(entry))
         .toList();
     return SkuDetailsResponseWrapper(
-        responseCode: map['responseCode'], skuDetailsList: skuDetailsList);
+        responseCode: BillingResponse.fromInt(map['responseCode']),
+        skuDetailsList: skuDetailsList);
   }
 
-  final int responseCode;
+  /// The final status of the [BillingClient.querySkuDetails] call.
+  final BillingResponse responseCode;
+
+  /// A list of [SkuDetailsWrapper] matching the query to [BillingClient.querySkuDetails].
   final List<SkuDetailsWrapper> skuDetailsList;
 }

--- a/packages/in_app_purchase/test/billing_client_wrappers/billing_client_wrapper_test.dart
+++ b/packages/in_app_purchase/test/billing_client_wrappers/billing_client_wrapper_test.dart
@@ -68,9 +68,9 @@ void main() {
         'BillingClient#querySkuDetailsAsync(SkuDetailsParams, SkuDetailsResponseListener)';
 
     test('handles empty skuDetails', () async {
-      final int responseCode = 500;
+      final BillingResponse responseCode = BillingResponse.DEVELOPER_ERROR;
       stubPlatform.addResponse(name: queryMethodName, value: <dynamic, dynamic>{
-        'responseCode': responseCode,
+        'responseCode': int.parse(responseCode.toString()),
         'skuDetailsList': <Map<String, dynamic>>[]
       });
 
@@ -78,14 +78,14 @@ void main() {
           .querySkuDetails(
               skuType: SkuType.INAPP, skusList: <String>['invalid']);
 
-      expect(response.responseCode, equals(500));
+      expect(response.responseCode, equals(responseCode));
       expect(response.skuDetailsList, isEmpty);
     });
 
     test('returns SkuDetailsResponseWrapper', () async {
-      final int responseCode = 200;
-      stubPlatform.addResponse(name: queryMethodName, value: <dynamic, dynamic>{
-        'responseCode': responseCode,
+      final BillingResponse responseCode = BillingResponse.OK;
+      stubPlatform.addResponse(name: queryMethodName, value: <String, dynamic>{
+        'responseCode': int.parse(responseCode.toString()),
         'skuDetailsList': <Map<String, dynamic>>[buildSkuMap(dummyWrapper)]
       });
 

--- a/packages/in_app_purchase/test/billing_client_wrappers/billing_client_wrapper_test.dart
+++ b/packages/in_app_purchase/test/billing_client_wrappers/billing_client_wrapper_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter/services.dart';
 import 'package:in_app_purchase/billing_client_wrappers.dart';
 import 'package:in_app_purchase/src/channel.dart';
 import '../stub_in_app_purchase_platform.dart';
+import 'sku_details_wrapper_test.dart';
 
 void main() {
   final StubInAppPurchasePlatform stubPlatform = StubInAppPurchasePlatform();
@@ -60,5 +61,40 @@ void main() {
     stubPlatform.addResponse(name: endConnectionName, value: null);
     await billingClient.endConnection();
     expect(stubPlatform.countPreviousCalls(endConnectionName), equals(1));
+  });
+
+  group('querySkuDetails', () {
+    final String queryMethodName =
+        'BillingClient#querySkuDetailsAsync(SkuDetailsParams, SkuDetailsResponseListener)';
+
+    test('handles empty skuDetails', () async {
+      final int responseCode = 500;
+      stubPlatform.addResponse(name: queryMethodName, value: <dynamic, dynamic>{
+        'responseCode': responseCode,
+        'skuDetailsList': <Map<String, dynamic>>[]
+      });
+
+      final SkuDetailsResponseWrapper response = await billingClient
+          .querySkuDetails(
+              skuType: SkuType.INAPP, skusList: <String>['invalid']);
+
+      expect(response.responseCode, equals(500));
+      expect(response.skuDetailsList, isEmpty);
+    });
+
+    test('returns SkuDetailsResponseWrapper', () async {
+      final int responseCode = 200;
+      stubPlatform.addResponse(name: queryMethodName, value: <dynamic, dynamic>{
+        'responseCode': responseCode,
+        'skuDetailsList': <Map<String, dynamic>>[buildSkuMap(dummyWrapper)]
+      });
+
+      final SkuDetailsResponseWrapper response = await billingClient
+          .querySkuDetails(
+              skuType: SkuType.INAPP, skusList: <String>['invalid']);
+
+      expect(response.responseCode, equals(responseCode));
+      expect(response.skuDetailsList, contains(dummyWrapper));
+    });
   });
 }

--- a/packages/in_app_purchase/test/billing_client_wrappers/sku_details_wrapper_test.dart
+++ b/packages/in_app_purchase/test/billing_client_wrappers/sku_details_wrapper_test.dart
@@ -35,7 +35,7 @@ void main() {
 
   group('SkuDetailsResponseWrapper', () {
     test('parsed from map', () {
-      final int responseCode = 200;
+      final BillingResponse responseCode = BillingResponse.OK;
       final List<SkuDetailsWrapper> skusDetails = <SkuDetailsWrapper>[
         dummyWrapper,
         dummyWrapper
@@ -45,7 +45,7 @@ void main() {
 
       final SkuDetailsResponseWrapper parsed =
           SkuDetailsResponseWrapper.fromMap(<String, dynamic>{
-        'responseCode': responseCode,
+        'responseCode': int.parse(responseCode.toString()),
         'skuDetailsList': <Map<String, dynamic>>[
           buildSkuMap(dummyWrapper),
           buildSkuMap(dummyWrapper)
@@ -57,14 +57,14 @@ void main() {
     });
 
     test('handles empty list of skuDetails', () {
-      final int responseCode = 500;
+      final BillingResponse responseCode = BillingResponse.ERROR;
       final List<SkuDetailsWrapper> skusDetails = <SkuDetailsWrapper>[];
       final SkuDetailsResponseWrapper expected = SkuDetailsResponseWrapper(
           responseCode: responseCode, skuDetailsList: skusDetails);
 
       final SkuDetailsResponseWrapper parsed =
           SkuDetailsResponseWrapper.fromMap(<String, dynamic>{
-        'responseCode': responseCode,
+        'responseCode': int.parse(responseCode.toString()),
         'skuDetailsList': <Map<String, dynamic>>[]
       });
 

--- a/packages/in_app_purchase/test/billing_client_wrappers/sku_details_wrapper_test.dart
+++ b/packages/in_app_purchase/test/billing_client_wrappers/sku_details_wrapper_test.dart
@@ -1,0 +1,93 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+import 'package:in_app_purchase/billing_client_wrappers.dart';
+
+final SkuDetailsWrapper dummyWrapper = SkuDetailsWrapper(
+  description: 'description',
+  freeTrialPeriod: 'freeTrialPeriod',
+  introductoryPrice: 'introductoryPrice',
+  introductoryPriceMicros: 'introductoryPriceMicros',
+  introductoryPriceCycles: 'introductoryPriceCycles',
+  introductoryPricePeriod: 'introductoryPricePeriod',
+  price: 'price',
+  priceAmountMicros: 1000,
+  priceCurrencyCode: 'priceCurrencyCode',
+  sku: 'sku',
+  subscriptionPeriod: 'subscriptionPeriod',
+  title: 'title',
+  type: SkuType.INAPP,
+  isRewarded: true,
+);
+
+void main() {
+  group('SkuDetailsWrapper', () {
+    test('converts from map', () {
+      final SkuDetailsWrapper expected = dummyWrapper;
+      final SkuDetailsWrapper parsed =
+          SkuDetailsWrapper.fromMap(buildSkuMap(expected));
+
+      expect(parsed, equals(expected));
+    });
+  });
+
+  group('SkuDetailsResponseWrapper', () {
+    test('parsed from map', () {
+      final int responseCode = 200;
+      final List<SkuDetailsWrapper> skusDetails = <SkuDetailsWrapper>[
+        dummyWrapper,
+        dummyWrapper
+      ];
+      final SkuDetailsResponseWrapper expected = SkuDetailsResponseWrapper(
+          responseCode: responseCode, skuDetailsList: skusDetails);
+
+      final SkuDetailsResponseWrapper parsed =
+          SkuDetailsResponseWrapper.fromMap(<String, dynamic>{
+        'responseCode': responseCode,
+        'skuDetailsList': <Map<String, dynamic>>[
+          buildSkuMap(dummyWrapper),
+          buildSkuMap(dummyWrapper)
+        ]
+      });
+
+      expect(parsed.responseCode, equals(expected.responseCode));
+      expect(parsed.skuDetailsList, containsAll(expected.skuDetailsList));
+    });
+
+    test('handles empty list of skuDetails', () {
+      final int responseCode = 500;
+      final List<SkuDetailsWrapper> skusDetails = <SkuDetailsWrapper>[];
+      final SkuDetailsResponseWrapper expected = SkuDetailsResponseWrapper(
+          responseCode: responseCode, skuDetailsList: skusDetails);
+
+      final SkuDetailsResponseWrapper parsed =
+          SkuDetailsResponseWrapper.fromMap(<String, dynamic>{
+        'responseCode': responseCode,
+        'skuDetailsList': <Map<String, dynamic>>[]
+      });
+
+      expect(parsed.responseCode, equals(expected.responseCode));
+      expect(parsed.skuDetailsList, containsAll(expected.skuDetailsList));
+    });
+  });
+}
+
+Map<String, dynamic> buildSkuMap(SkuDetailsWrapper original) =>
+    <String, dynamic>{
+      'description': original.description,
+      'freeTrialPeriod': original.freeTrialPeriod,
+      'introductoryPrice': original.introductoryPrice,
+      'introductoryPriceMicros': original.introductoryPriceMicros,
+      'introductoryPriceCycles': original.introductoryPriceCycles,
+      'introductoryPricePeriod': original.introductoryPricePeriod,
+      'price': original.price,
+      'priceAmountMicros': original.priceAmountMicros,
+      'priceCurrencyCode': original.priceCurrencyCode,
+      'sku': original.sku,
+      'subscriptionPeriod': original.subscriptionPeriod,
+      'title': original.title,
+      'type': original.type.toString(),
+      'isRewarded': original.isRewarded,
+    };


### PR DESCRIPTION
Adds the `queryProductsAsync` API and associated classes to
`billing_client_wrappers/`.

Brings in `json_serializable` as a build step to generate the Dart
platform channel parsing boilerplate. This dependency is still very
experimental and may be abandoned if the extra build step ends up being
a maitenance burden greater than maintaining the boilerplate. At this
point I expect it to be worth the trouble given the sheer amount of data
classes and deserialization that's going to happen in this plugin.

flutter/flutter#26325