### PR TITLE
Fix a crash when selecting downloaded images on certain devices

### DIFF
--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.4.13
+## 0.4.13
 
 * Fix a crash when selecting downloaded images from image picker on certain devices.
 

--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.4.13
+## 0.4.12+1
 
 * Fix a crash when selecting downloaded images from image picker on certain devices.
 

--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.13
+
+* Fix a crash when selecting downloaded images from image picker on certain devices.
+
 ## 0.4.12
 
 * Fix a crash when user tap the image mutiple times.

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
@@ -20,7 +20,6 @@
 package io.flutter.plugins.imagepicker;
 
 import android.annotation.SuppressLint;
-import android.content.ContentUris;
 import android.content.Context;
 import android.database.Cursor;
 import android.net.Uri;
@@ -63,10 +62,7 @@ class FileUtils {
 
         if (!TextUtils.isEmpty(id)) {
           try {
-            final Uri contentUri =
-                ContentUris.withAppendedId(
-                    Uri.parse("content://downloads/public_downloads"), Long.valueOf(id));
-            return getDataColumn(context, contentUri, null, null);
+            return getDataColumn(context, uri, null, null);
           } catch (NumberFormatException e) {
             return null;
           }

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
@@ -20,6 +20,7 @@
 package io.flutter.plugins.imagepicker;
 
 import android.annotation.SuppressLint;
+import android.content.ContentUris;
 import android.content.Context;
 import android.database.Cursor;
 import android.net.Uri;
@@ -62,7 +63,10 @@ class FileUtils {
 
         if (!TextUtils.isEmpty(id)) {
           try {
-            return getDataColumn(context, uri, null, null);
+            final Uri contentUri =
+                ContentUris.withAppendedId(
+                    Uri.parse(Environment.DIRECTORY_DOWNLOADS), Long.valueOf(id));
+            return getDataColumn(context, contentUri, null, null);
           } catch (NumberFormatException e) {
             return null;
           }

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -5,7 +5,7 @@ authors:
   - Flutter Team <flutter-dev@googlegroups.com>
   - Rhodes Davis Jr. <rody.davis.jr@gmail.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.4.13
+version: 0.4.12+1
 
 flutter:
   plugin:

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -5,7 +5,7 @@ authors:
   - Flutter Team <flutter-dev@googlegroups.com>
   - Rhodes Davis Jr. <rody.davis.jr@gmail.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.4.12
+version: 0.4.13
 
 flutter:
   plugin:


### PR DESCRIPTION
Some devices use different path for downloaded images. Those devices will crash when trying the access the public_download URI. 
Directly use default downloaded image URI instead of hard coding the string fixes the crash.
https://github.com/flutter/flutter/issues/21863