### PR TITLE
[IAP] Generate boilerplate serializers

### DIFF
--- a/packages/in_app_purchase/README.md
+++ b/packages/in_app_purchase/README.md
@@ -15,7 +15,15 @@ Play and the App Store require developers to configure an app with in-app items
 for purchase to call their in-app-purchase APIs. You can check out the [example
 app](example/README.md) for an example on configuring both.
 
-## Design
+## Development
+
+This plugin uses
+[json_serializable](https://pub.dartlang.org/packages/json_serializable) for the
+many data structs passed between the underlying platform layers and Dart. After
+editing any of the serialized data structs, rebuild the serializers by running
+`flutter packages pub run build_runner run`.
+
+### Design
 
 The API surface is stacked into 2 main layers.
 

--- a/packages/in_app_purchase/analysis_options.yaml
+++ b/packages/in_app_purchase/analysis_options.yaml
@@ -1,0 +1,3 @@
+analyzer:
+  exclude:
+    - lib/**/*.g.dart # Ignore generated files

--- a/packages/in_app_purchase/build.yaml
+++ b/packages/in_app_purchase/build.yaml
@@ -1,0 +1,8 @@
+targets:
+  $default:
+    builders:
+      json_serializable:
+        options:
+          any_map: true
+          create_to_json: false
+          nullable: false

--- a/packages/in_app_purchase/lib/src/billing_client_wrappers/billing_client_wrapper.dart
+++ b/packages/in_app_purchase/lib/src/billing_client_wrappers/billing_client_wrapper.dart
@@ -115,11 +115,12 @@ class BillingClient {
 /// to call back on `BillingClient` disconnect.
 typedef void OnBillingServiceDisconnected();
 
-/// Wraps
-/// [`BillingClient.BillingResponse`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.BillingResponse),
-/// possible status codes.
+/// Possible `BillingClient` response statuses.
 ///
-/// See the `BillingResponse` docs for an explanation of the different constants.
+/// Wraps
+/// [`BillingClient.BillingResponse`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.BillingResponse).
+/// See the `BillingResponse` docs for more explanation of the different
+/// constants.
 enum BillingResponse {
   // WARNING: Changes to this class need to be reflected in our generated code.
   // Run `flutter packages pub run build_runner watch` to rebuild and watch for

--- a/packages/in_app_purchase/lib/src/billing_client_wrappers/billing_client_wrapper.dart
+++ b/packages/in_app_purchase/lib/src/billing_client_wrappers/billing_client_wrapper.dart
@@ -5,8 +5,10 @@
 import 'dart:async';
 import 'package:flutter/services.dart';
 import 'package:flutter/foundation.dart';
+import 'package:json_annotation/json_annotation.dart';
 import '../channel.dart';
 import 'sku_details_wrapper.dart';
+import 'enum_converters.dart';
 
 /// This class can be used directly instead of [InAppPurchaseConnection] to call
 /// Play-specific billing APIs.
@@ -58,7 +60,7 @@ class BillingClient {
       'OnBillingServiceDisconnected': onBillingServiceDisconnected,
     };
     _callbacks.add(callbacks);
-    return BillingResponse._(await channel.invokeMethod(
+    return BillingResponseConverter().fromJson(await channel.invokeMethod(
         "BillingClient#startConnection(BillingClientStateListener)",
         <String, dynamic>{'handle': _callbacks.length - 1}));
   }
@@ -118,28 +120,39 @@ typedef void OnBillingServiceDisconnected();
 /// possible status codes.
 ///
 /// See the `BillingResponse` docs for an explanation of the different constants.
-class BillingResponse {
-  const BillingResponse._(this._code);
-  static BillingResponse fromInt(int code) => BillingResponse._(code);
-  final int _code;
-  @override
-  String toString() => _code.toString();
-  @override
-  int get hashCode => _code.hashCode;
-  @override
-  bool operator ==(dynamic other) =>
-      other is BillingResponse && other._code == _code;
+enum BillingResponse {
+  // WARNING: Changes to this class need to be reflected in our generated code.
+  // Run `flutter packages pub run build_runner watch` to rebuild and watch for
+  // further changes.
+  @JsonValue(-2)
+  featureNotSupported,
 
-  static const BillingResponse FEATURE_NOT_SUPPORTED = BillingResponse._(-2);
-  static const BillingResponse OK = BillingResponse._(0);
-  static const BillingResponse USER_CANCELED = BillingResponse._(1);
-  static const BillingResponse SERVICE_UNAVAILABLE = BillingResponse._(2);
-  static const BillingResponse BILLING_UNAVAILABLE = BillingResponse._(3);
-  static const BillingResponse ITEM_UNAVAILABLE = BillingResponse._(4);
-  static const BillingResponse DEVELOPER_ERROR = BillingResponse._(5);
-  static const BillingResponse ERROR = BillingResponse._(6);
-  static const BillingResponse ITEM_ALREADY_OWNED = BillingResponse._(7);
-  static const BillingResponse ITEM_NOT_OWNED = BillingResponse._(8);
+  @JsonValue(0)
+  ok,
+
+  @JsonValue(1)
+  userCanceled,
+
+  @JsonValue(2)
+  serviceUnavailable,
+
+  @JsonValue(3)
+  billingUnavailable,
+
+  @JsonValue(4)
+  itemUnavailable,
+
+  @JsonValue(5)
+  developerError,
+
+  @JsonValue(6)
+  error,
+
+  @JsonValue(7)
+  itemAlreadyOwned,
+
+  @JsonValue(8)
+  itemNotOwned,
 }
 
 /// Enum representing potential [SkuDetailsWrapper.type]s.
@@ -147,27 +160,16 @@ class BillingResponse {
 /// Wraps
 /// [`BillingClient.SkuType`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.SkuType)
 /// See the linked documentation for an explanation of the different constants.
-class SkuType {
-  const SkuType._(this._type);
-  static SkuType fromString(String type) {
-    final SkuType skuType = SkuType._(type);
-    if (skuType != INAPP && skuType != SUBS) {
-      return null;
-    }
-    return skuType;
-  }
-
-  final String _type;
-  @override
-  String toString() => _type;
-  @override
-  int get hashCode => _type.hashCode;
-  @override
-  bool operator ==(dynamic other) => other is SkuType && other._type == _type;
+enum SkuType {
+  // WARNING: Changes to this class need to be reflected in our generated code.
+  // Run `flutter packages pub run build_runner watch` to rebuild and watch for
+  // further changes.
 
   /// A one time product. Acquired in a single transaction.
-  static const SkuType INAPP = SkuType._("inapp");
+  @JsonValue('inapp')
+  inapp,
 
   /// A product requiring a recurring charge over time.
-  static const SkuType SUBS = SkuType._("subs");
+  @JsonValue('subs')
+  subs,
 }

--- a/packages/in_app_purchase/lib/src/billing_client_wrappers/billing_client_wrapper.dart
+++ b/packages/in_app_purchase/lib/src/billing_client_wrappers/billing_client_wrapper.dart
@@ -89,7 +89,7 @@ class BillingClient {
       'skuType': skuType.toString(),
       'skusList': skusList
     };
-    return SkuDetailsResponseWrapper.fromMap(await channel.invokeMapMethod<
+    return SkuDetailsResponseWrapper.fromJson(await channel.invokeMapMethod<
             String, dynamic>(
         'BillingClient#querySkuDetailsAsync(SkuDetailsParams, SkuDetailsResponseListener)',
         arguments));

--- a/packages/in_app_purchase/lib/src/billing_client_wrappers/enum_converters.dart
+++ b/packages/in_app_purchase/lib/src/billing_client_wrappers/enum_converters.dart
@@ -1,0 +1,41 @@
+import 'package:in_app_purchase/billing_client_wrappers.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'enum_converters.g.dart';
+
+/// Serializer for [BillingResponse].
+///
+/// Use these in `@JsonSerializable()` classes by annotating them with
+/// `@BillingResponseConverter()`.
+class BillingResponseConverter implements JsonConverter<BillingResponse, int> {
+  const BillingResponseConverter();
+
+  @override
+  BillingResponse fromJson(int json) => _$enumDecode<BillingResponse>(
+      _$BillingResponseEnumMap.cast<BillingResponse, dynamic>(), json);
+
+  @override
+  int toJson(BillingResponse object) => _$BillingResponseEnumMap[object];
+}
+
+/// Serializer for [SkuType].
+///
+/// Use these in `@JsonSerializable()` classes by annotating them with
+/// `@SkuTypeConverter()`.
+class SkuTypeConverter implements JsonConverter<SkuType, String> {
+  const SkuTypeConverter();
+
+  @override
+  SkuType fromJson(String json) =>
+      _$enumDecode<SkuType>(_$SkuTypeEnumMap.cast<SkuType, dynamic>(), json);
+
+  @override
+  String toJson(SkuType object) => _$SkuTypeEnumMap[object];
+}
+
+// Define a class so we generate serializer helper methods for the enums
+@JsonSerializable()
+class _SerializedEnums {
+  BillingResponse response;
+  SkuType type;
+}

--- a/packages/in_app_purchase/lib/src/billing_client_wrappers/enum_converters.g.dart
+++ b/packages/in_app_purchase/lib/src/billing_client_wrappers/enum_converters.g.dart
@@ -1,0 +1,44 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'enum_converters.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_SerializedEnums _$_SerializedEnumsFromJson(Map json) {
+  return _SerializedEnums()
+    ..response = _$enumDecode(_$BillingResponseEnumMap, json['response'])
+    ..type = _$enumDecode(_$SkuTypeEnumMap, json['type']);
+}
+
+T _$enumDecode<T>(Map<T, dynamic> enumValues, dynamic source) {
+  if (source == null) {
+    throw ArgumentError('A value must be provided. Supported values: '
+        '${enumValues.values.join(', ')}');
+  }
+  return enumValues.entries
+      .singleWhere((e) => e.value == source,
+          orElse: () => throw ArgumentError(
+              '`$source` is not one of the supported values: '
+              '${enumValues.values.join(', ')}'))
+      .key;
+}
+
+const _$BillingResponseEnumMap = <BillingResponse, dynamic>{
+  BillingResponse.featureNotSupported: -2,
+  BillingResponse.ok: 0,
+  BillingResponse.userCanceled: 1,
+  BillingResponse.serviceUnavailable: 2,
+  BillingResponse.billingUnavailable: 3,
+  BillingResponse.itemUnavailable: 4,
+  BillingResponse.developerError: 5,
+  BillingResponse.error: 6,
+  BillingResponse.itemAlreadyOwned: 7,
+  BillingResponse.itemNotOwned: 8
+};
+
+const _$SkuTypeEnumMap = <SkuType, dynamic>{
+  SkuType.inapp: 'inapp',
+  SkuType.subs: 'subs'
+};

--- a/packages/in_app_purchase/lib/src/billing_client_wrappers/sku_details_wrapper.dart
+++ b/packages/in_app_purchase/lib/src/billing_client_wrappers/sku_details_wrapper.dart
@@ -4,11 +4,18 @@
 
 import 'dart:ui' show hashValues;
 import 'package:flutter/foundation.dart';
+import 'package:json_annotation/json_annotation.dart';
 import 'billing_client_wrapper.dart';
+
+// WARNING: Changes to `@JsonSerializable` classes need to be reflected in the
+// below generated file. Run `flutter packages pub run build_runner watch` to
+// rebuild and watch for further changes.
+part 'sku_details_wrapper.g.dart';
 
 /// Dart wrapper around [`com.android.billingclient.api.SkuDetails`](https://developer.android.com/reference/com/android/billingclient/api/SkuDetails).
 ///
 /// Contains the details of an available product in Google Play Billing.
+@JsonSerializable()
 class SkuDetailsWrapper {
   @visibleForTesting
   SkuDetailsWrapper({
@@ -33,21 +40,8 @@ class SkuDetailsWrapper {
   /// The map needs to have named string keys with values matching the names and
   /// types of all of the members on this class.
   @visibleForTesting
-  SkuDetailsWrapper.fromMap(Map<dynamic, dynamic> map)
-      : description = map['description'],
-        freeTrialPeriod = map['freeTrialPeriod'],
-        introductoryPrice = map['introductoryPrice'],
-        introductoryPriceMicros = map['introductoryPriceMicros'],
-        introductoryPriceCycles = map['introductoryPriceCycles'],
-        introductoryPricePeriod = map['introductoryPricePeriod'],
-        price = map['price'],
-        priceAmountMicros = map['priceAmountMicros'],
-        priceCurrencyCode = map['priceCurrencyCode'],
-        sku = map['sku'],
-        subscriptionPeriod = map['subscriptionPeriod'],
-        title = map['title'],
-        type = SkuType.fromString(map['type']),
-        isRewarded = map['isRewarded'];
+  factory SkuDetailsWrapper.fromJson(Map map) =>
+      _$SkuDetailsWrapperFromJson(map);
 
   final String description;
 
@@ -83,6 +77,7 @@ class SkuDetailsWrapper {
   final String title;
 
   /// The [SkuType] of the product.
+  @JsonKey(fromJson: SkuType.fromString)
   final SkuType type;
 
   /// False if the product is paid.
@@ -133,6 +128,7 @@ class SkuDetailsWrapper {
 /// Translation of [`com.android.billingclient.api.SkuDetailsResponseListener`](https://developer.android.com/reference/com/android/billingclient/api/SkuDetailsResponseListener.html).
 ///
 /// Returned by [BillingClient.querySkuDetails].
+@JsonSerializable()
 class SkuDetailsResponseWrapper {
   @visibleForTesting
   SkuDetailsResponseWrapper({@required this.responseCode, this.skuDetailsList});
@@ -141,15 +137,11 @@ class SkuDetailsResponseWrapper {
   ///
   /// The map needs to have named string keys with values matching the names and
   /// types of all of the members on this class.
-  SkuDetailsResponseWrapper.fromMap(Map<dynamic, dynamic> map)
-      : responseCode = BillingResponse.fromInt(map['responseCode']),
-        skuDetailsList =
-            List.castFrom<dynamic, Map<dynamic, dynamic>>(map['skuDetailsList'])
-                .map((Map<dynamic, dynamic> entry) =>
-                    SkuDetailsWrapper.fromMap(entry))
-                .toList();
+  factory SkuDetailsResponseWrapper.fromJson(Map<String, dynamic> map) =>
+      _$SkuDetailsResponseWrapperFromJson(map);
 
   /// The final status of the [BillingClient.querySkuDetails] call.
+  @JsonKey(fromJson: BillingResponse.fromInt)
   final BillingResponse responseCode;
 
   /// A list of [SkuDetailsWrapper] matching the query to [BillingClient.querySkuDetails].

--- a/packages/in_app_purchase/lib/src/billing_client_wrappers/sku_details_wrapper.dart
+++ b/packages/in_app_purchase/lib/src/billing_client_wrappers/sku_details_wrapper.dart
@@ -6,6 +6,7 @@ import 'dart:ui' show hashValues;
 import 'package:flutter/foundation.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'billing_client_wrapper.dart';
+import 'enum_converters.dart';
 
 // WARNING: Changes to `@JsonSerializable` classes need to be reflected in the
 // below generated file. Run `flutter packages pub run build_runner watch` to
@@ -16,6 +17,7 @@ part 'sku_details_wrapper.g.dart';
 ///
 /// Contains the details of an available product in Google Play Billing.
 @JsonSerializable()
+@SkuTypeConverter()
 class SkuDetailsWrapper {
   @visibleForTesting
   SkuDetailsWrapper({
@@ -48,7 +50,7 @@ class SkuDetailsWrapper {
   /// Trial period in ISO 8601 format.
   final String freeTrialPeriod;
 
-  /// Introductory price, only applies to [SkuType.SUBS]. Formatted ("$0.99").
+  /// Introductory price, only applies to [SkuType.subs]. Formatted ("$0.99").
   final String introductoryPrice;
 
   /// [introductoryPrice] in micro-units 990000
@@ -72,12 +74,11 @@ class SkuDetailsWrapper {
   /// The product ID in Google Play Console.
   final String sku;
 
-  /// Applies to [SkuType.SUBS], formatted in ISO 8601.
+  /// Applies to [SkuType.subs], formatted in ISO 8601.
   final String subscriptionPeriod;
   final String title;
 
   /// The [SkuType] of the product.
-  @JsonKey(fromJson: SkuType.fromString)
   final SkuType type;
 
   /// False if the product is paid.
@@ -129,6 +130,7 @@ class SkuDetailsWrapper {
 ///
 /// Returned by [BillingClient.querySkuDetails].
 @JsonSerializable()
+@BillingResponseConverter()
 class SkuDetailsResponseWrapper {
   @visibleForTesting
   SkuDetailsResponseWrapper({@required this.responseCode, this.skuDetailsList});
@@ -141,9 +143,23 @@ class SkuDetailsResponseWrapper {
       _$SkuDetailsResponseWrapperFromJson(map);
 
   /// The final status of the [BillingClient.querySkuDetails] call.
-  @JsonKey(fromJson: BillingResponse.fromInt)
   final BillingResponse responseCode;
 
   /// A list of [SkuDetailsWrapper] matching the query to [BillingClient.querySkuDetails].
   final List<SkuDetailsWrapper> skuDetailsList;
+
+  @override
+  bool operator ==(dynamic other) {
+    if (other.runtimeType != runtimeType) {
+      return false;
+    }
+
+    final SkuDetailsResponseWrapper typedOther = other;
+    return typedOther is SkuDetailsResponseWrapper &&
+        typedOther.responseCode == responseCode &&
+        typedOther.skuDetailsList == skuDetailsList;
+  }
+
+  @override
+  int get hashCode => hashValues(responseCode, skuDetailsList);
 }

--- a/packages/in_app_purchase/lib/src/billing_client_wrappers/sku_details_wrapper.g.dart
+++ b/packages/in_app_purchase/lib/src/billing_client_wrappers/sku_details_wrapper.g.dart
@@ -20,13 +20,14 @@ SkuDetailsWrapper _$SkuDetailsWrapperFromJson(Map json) {
       sku: json['sku'] as String,
       subscriptionPeriod: json['subscriptionPeriod'] as String,
       title: json['title'] as String,
-      type: SkuType.fromString(json['type'] as String),
+      type: const SkuTypeConverter().fromJson(json['type'] as String),
       isRewarded: json['isRewarded'] as bool);
 }
 
 SkuDetailsResponseWrapper _$SkuDetailsResponseWrapperFromJson(Map json) {
   return SkuDetailsResponseWrapper(
-      responseCode: BillingResponse.fromInt(json['responseCode'] as int),
+      responseCode: const BillingResponseConverter()
+          .fromJson(json['responseCode'] as int),
       skuDetailsList: (json['skuDetailsList'] as List)
           .map((e) => SkuDetailsWrapper.fromJson(e as Map))
           .toList());

--- a/packages/in_app_purchase/lib/src/billing_client_wrappers/sku_details_wrapper.g.dart
+++ b/packages/in_app_purchase/lib/src/billing_client_wrappers/sku_details_wrapper.g.dart
@@ -1,0 +1,33 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'sku_details_wrapper.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+SkuDetailsWrapper _$SkuDetailsWrapperFromJson(Map json) {
+  return SkuDetailsWrapper(
+      description: json['description'] as String,
+      freeTrialPeriod: json['freeTrialPeriod'] as String,
+      introductoryPrice: json['introductoryPrice'] as String,
+      introductoryPriceMicros: json['introductoryPriceMicros'] as String,
+      introductoryPriceCycles: json['introductoryPriceCycles'] as String,
+      introductoryPricePeriod: json['introductoryPricePeriod'] as String,
+      price: json['price'] as String,
+      priceAmountMicros: json['priceAmountMicros'] as int,
+      priceCurrencyCode: json['priceCurrencyCode'] as String,
+      sku: json['sku'] as String,
+      subscriptionPeriod: json['subscriptionPeriod'] as String,
+      title: json['title'] as String,
+      type: SkuType.fromString(json['type'] as String),
+      isRewarded: json['isRewarded'] as bool);
+}
+
+SkuDetailsResponseWrapper _$SkuDetailsResponseWrapperFromJson(Map json) {
+  return SkuDetailsResponseWrapper(
+      responseCode: BillingResponse.fromInt(json['responseCode'] as int),
+      skuDetailsList: (json['skuDetailsList'] as List)
+          .map((e) => SkuDetailsWrapper.fromJson(e as Map))
+          .toList());
+}

--- a/packages/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/pubspec.yaml
@@ -5,19 +5,22 @@ homepage: https://github.com/flutter/plugins/tree/master/packages/in_app_purchas
 version: 0.0.2
 
 dependencies:
+  async: ^2.0.8
   flutter:
     sdk: flutter
-  async: ^2.0.8
+  json_annotation: ^2.0.0
   meta: ^1.1.6
 
 dev_dependencies:
+  build_runner: ^1.0.0
+  json_serializable: ^2.0.0
   flutter_test:
     sdk: flutter
-  test: 1.5.1
   flutter_driver:
     sdk: flutter
   in_app_purchase_example:
     path: example/
+  test: 1.5.1
 
 flutter:
   plugin:

--- a/packages/in_app_purchase/test/billing_client_wrappers/billing_client_wrapper_test.dart
+++ b/packages/in_app_purchase/test/billing_client_wrappers/billing_client_wrapper_test.dart
@@ -6,6 +6,7 @@ import 'package:test/test.dart';
 import 'package:flutter/services.dart';
 
 import 'package:in_app_purchase/billing_client_wrappers.dart';
+import 'package:in_app_purchase/src/billing_client_wrappers/enum_converters.dart';
 import 'package:in_app_purchase/src/channel.dart';
 import '../stub_in_app_purchase_platform.dart';
 import 'sku_details_wrapper_test.dart';
@@ -37,18 +38,19 @@ void main() {
     test('returns BillingResponse', () async {
       stubPlatform.addResponse(
           name: 'BillingClient#startConnection(BillingClientStateListener)',
-          value: int.parse(BillingResponse.OK.toString()));
+          value: BillingResponseConverter().toJson(BillingResponse.ok));
       expect(
           await billingClient.startConnection(
               onBillingServiceDisconnected: () {}),
-          equals(BillingResponse.OK));
+          equals(BillingResponse.ok));
     });
 
     test('passes handle to onBillingServiceDisconnected', () async {
       final String methodName =
           'BillingClient#startConnection(BillingClientStateListener)';
       stubPlatform.addResponse(
-          name: methodName, value: int.parse(BillingResponse.OK.toString()));
+          name: methodName,
+          value: BillingResponseConverter().toJson(BillingResponse.ok));
       await billingClient.startConnection(onBillingServiceDisconnected: () {});
       final MethodCall call = stubPlatform.previousCallMatching(methodName);
       expect(call.arguments, equals(<dynamic, dynamic>{'handle': 0}));
@@ -68,30 +70,30 @@ void main() {
         'BillingClient#querySkuDetailsAsync(SkuDetailsParams, SkuDetailsResponseListener)';
 
     test('handles empty skuDetails', () async {
-      final BillingResponse responseCode = BillingResponse.DEVELOPER_ERROR;
+      final BillingResponse responseCode = BillingResponse.developerError;
       stubPlatform.addResponse(name: queryMethodName, value: <dynamic, dynamic>{
-        'responseCode': int.parse(responseCode.toString()),
+        'responseCode': BillingResponseConverter().toJson(responseCode),
         'skuDetailsList': <Map<String, dynamic>>[]
       });
 
       final SkuDetailsResponseWrapper response = await billingClient
           .querySkuDetails(
-              skuType: SkuType.INAPP, skusList: <String>['invalid']);
+              skuType: SkuType.inapp, skusList: <String>['invalid']);
 
       expect(response.responseCode, equals(responseCode));
       expect(response.skuDetailsList, isEmpty);
     });
 
     test('returns SkuDetailsResponseWrapper', () async {
-      final BillingResponse responseCode = BillingResponse.OK;
+      final BillingResponse responseCode = BillingResponse.ok;
       stubPlatform.addResponse(name: queryMethodName, value: <String, dynamic>{
-        'responseCode': int.parse(responseCode.toString()),
+        'responseCode': BillingResponseConverter().toJson(responseCode),
         'skuDetailsList': <Map<String, dynamic>>[buildSkuMap(dummyWrapper)]
       });
 
       final SkuDetailsResponseWrapper response = await billingClient
           .querySkuDetails(
-              skuType: SkuType.INAPP, skusList: <String>['invalid']);
+              skuType: SkuType.inapp, skusList: <String>['invalid']);
 
       expect(response.responseCode, equals(responseCode));
       expect(response.skuDetailsList, contains(dummyWrapper));

--- a/packages/in_app_purchase/test/billing_client_wrappers/sku_details_wrapper_test.dart
+++ b/packages/in_app_purchase/test/billing_client_wrappers/sku_details_wrapper_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:test/test.dart';
 import 'package:in_app_purchase/billing_client_wrappers.dart';
+import 'package:in_app_purchase/src/billing_client_wrappers/enum_converters.dart';
 
 final SkuDetailsWrapper dummyWrapper = SkuDetailsWrapper(
   description: 'description',
@@ -18,7 +19,7 @@ final SkuDetailsWrapper dummyWrapper = SkuDetailsWrapper(
   sku: 'sku',
   subscriptionPeriod: 'subscriptionPeriod',
   title: 'title',
-  type: SkuType.INAPP,
+  type: SkuType.inapp,
   isRewarded: true,
 );
 
@@ -35,7 +36,7 @@ void main() {
 
   group('SkuDetailsResponseWrapper', () {
     test('parsed from map', () {
-      final BillingResponse responseCode = BillingResponse.OK;
+      final BillingResponse responseCode = BillingResponse.ok;
       final List<SkuDetailsWrapper> skusDetails = <SkuDetailsWrapper>[
         dummyWrapper,
         dummyWrapper
@@ -45,7 +46,7 @@ void main() {
 
       final SkuDetailsResponseWrapper parsed =
           SkuDetailsResponseWrapper.fromJson(<String, dynamic>{
-        'responseCode': int.parse(responseCode.toString()),
+        'responseCode': BillingResponseConverter().toJson(responseCode),
         'skuDetailsList': <Map<String, dynamic>>[
           buildSkuMap(dummyWrapper),
           buildSkuMap(dummyWrapper)
@@ -57,14 +58,14 @@ void main() {
     });
 
     test('handles empty list of skuDetails', () {
-      final BillingResponse responseCode = BillingResponse.ERROR;
+      final BillingResponse responseCode = BillingResponse.error;
       final List<SkuDetailsWrapper> skusDetails = <SkuDetailsWrapper>[];
       final SkuDetailsResponseWrapper expected = SkuDetailsResponseWrapper(
           responseCode: responseCode, skuDetailsList: skusDetails);
 
       final SkuDetailsResponseWrapper parsed =
           SkuDetailsResponseWrapper.fromJson(<String, dynamic>{
-        'responseCode': int.parse(responseCode.toString()),
+        'responseCode': BillingResponseConverter().toJson(responseCode),
         'skuDetailsList': <Map<String, dynamic>>[]
       });
 
@@ -74,20 +75,21 @@ void main() {
   });
 }
 
-Map<String, dynamic> buildSkuMap(SkuDetailsWrapper original) =>
-    <String, dynamic>{
-      'description': original.description,
-      'freeTrialPeriod': original.freeTrialPeriod,
-      'introductoryPrice': original.introductoryPrice,
-      'introductoryPriceMicros': original.introductoryPriceMicros,
-      'introductoryPriceCycles': original.introductoryPriceCycles,
-      'introductoryPricePeriod': original.introductoryPricePeriod,
-      'price': original.price,
-      'priceAmountMicros': original.priceAmountMicros,
-      'priceCurrencyCode': original.priceCurrencyCode,
-      'sku': original.sku,
-      'subscriptionPeriod': original.subscriptionPeriod,
-      'title': original.title,
-      'type': original.type.toString(),
-      'isRewarded': original.isRewarded,
-    };
+Map<String, dynamic> buildSkuMap(SkuDetailsWrapper original) {
+  return <String, dynamic>{
+    'description': original.description,
+    'freeTrialPeriod': original.freeTrialPeriod,
+    'introductoryPrice': original.introductoryPrice,
+    'introductoryPriceMicros': original.introductoryPriceMicros,
+    'introductoryPriceCycles': original.introductoryPriceCycles,
+    'introductoryPricePeriod': original.introductoryPricePeriod,
+    'price': original.price,
+    'priceAmountMicros': original.priceAmountMicros,
+    'priceCurrencyCode': original.priceCurrencyCode,
+    'sku': original.sku,
+    'subscriptionPeriod': original.subscriptionPeriod,
+    'title': original.title,
+    'type': original.type.toString().substring(8),
+    'isRewarded': original.isRewarded,
+  };
+}

--- a/packages/in_app_purchase/test/billing_client_wrappers/sku_details_wrapper_test.dart
+++ b/packages/in_app_purchase/test/billing_client_wrappers/sku_details_wrapper_test.dart
@@ -27,7 +27,7 @@ void main() {
     test('converts from map', () {
       final SkuDetailsWrapper expected = dummyWrapper;
       final SkuDetailsWrapper parsed =
-          SkuDetailsWrapper.fromMap(buildSkuMap(expected));
+          SkuDetailsWrapper.fromJson(buildSkuMap(expected));
 
       expect(parsed, equals(expected));
     });
@@ -44,7 +44,7 @@ void main() {
           responseCode: responseCode, skuDetailsList: skusDetails);
 
       final SkuDetailsResponseWrapper parsed =
-          SkuDetailsResponseWrapper.fromMap(<String, dynamic>{
+          SkuDetailsResponseWrapper.fromJson(<String, dynamic>{
         'responseCode': int.parse(responseCode.toString()),
         'skuDetailsList': <Map<String, dynamic>>[
           buildSkuMap(dummyWrapper),
@@ -63,7 +63,7 @@ void main() {
           responseCode: responseCode, skuDetailsList: skusDetails);
 
       final SkuDetailsResponseWrapper parsed =
-          SkuDetailsResponseWrapper.fromMap(<String, dynamic>{
+          SkuDetailsResponseWrapper.fromJson(<String, dynamic>{
         'responseCode': int.parse(responseCode.toString()),
         'skuDetailsList': <Map<String, dynamic>>[]
       });

--- a/packages/in_app_purchase/test/in_app_purchase_connection/google_play_connection_test.dart
+++ b/packages/in_app_purchase/test/in_app_purchase_connection/google_play_connection_test.dart
@@ -6,6 +6,7 @@ import 'package:test/test.dart';
 
 import 'package:flutter/widgets.dart';
 import 'package:in_app_purchase/billing_client_wrappers.dart';
+import 'package:in_app_purchase/src/billing_client_wrappers/enum_converters.dart';
 import 'package:in_app_purchase/src/in_app_purchase_connection/google_play_connection.dart';
 import 'package:in_app_purchase/src/channel.dart';
 import '../stub_in_app_purchase_platform.dart';
@@ -24,7 +25,7 @@ void main() {
     WidgetsFlutterBinding.ensureInitialized();
     stubPlatform.addResponse(
         name: startConnectionCall,
-        value: int.parse(BillingResponse.OK.toString()));
+        value: BillingResponseConverter().toJson(BillingResponse.ok));
     stubPlatform.addResponse(name: endConnectionCall, value: null);
     connection = GooglePlayConnection.instance;
   });


### PR DESCRIPTION
Brings in `json_serializable` as a build step to generate the Dart
platform channel parsing boilerplate. This dependency is still very
experimental and may be abandoned if the extra build step ends up being
a maitenance burden greater than maintaining the boilerplate. At this
point I expect it to be worth the trouble given the sheer amount of data
classes and deserialization that's going to happen in this plugin.

Also converts `SkuType` and `BillingResponse` to enums.