### PR TITLE
[image_picker] Fixed a crash that would occur when called in quick succession on Android

### DIFF
--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.0+1
+
+* Fix a crash when user calls the plugin in quick succession on Android.
+
 ## 0.5.0
 
 * **Breaking change**. Migrate from the deprecated original Android Support

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
@@ -226,7 +226,8 @@ public class ImagePickerDelegate
     boolean canTakePhotos = intentResolver.resolveActivity(intent);
 
     if (!canTakePhotos) {
-      finishPendingResultWithError("no_available_camera", "No cameras available for taking pictures.");
+      finishPendingResultWithError(
+          "no_available_camera", "No cameras available for taking pictures.");
       return;
     }
 
@@ -282,7 +283,8 @@ public class ImagePickerDelegate
     boolean canTakePhotos = intentResolver.resolveActivity(intent);
 
     if (!canTakePhotos) {
-      finishPendingResultWithError("no_available_camera", "No cameras available for taking pictures.");
+      finishPendingResultWithError(
+          "no_available_camera", "No cameras available for taking pictures.");
       return;
     }
 

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
@@ -483,7 +483,7 @@ public class ImagePickerDelegate
   }
 
   private void finishWithAlreadyActiveError(MethodChannel.Result result) {
-    result.error("already_active", "Image picker is already active.", null);
+    result.error("already_active", "Image picker is already active", null);
   }
 
   private void finishWithError(String errorCode, String errorMessage) {

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
@@ -482,13 +482,13 @@ public class ImagePickerDelegate
     clearMethodCallAndResult();
   }
 
+  private void finishWithAlreadyActiveError(MethodChannel.Result result) {
+    result.error("already_active", "Image picker is already active.", null);
+  }
+
   private void finishWithError(String errorCode, String errorMessage) {
     pendingResult.error(errorCode, errorMessage, null);
     clearMethodCallAndResult();
-  }
-
-  private void finishWithAlreadyActiveError(MethodChannel.Result result) {
-    result.error("already_active", "Image picker is already active.", null);
   }
 
   private void clearMethodCallAndResult() {

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
@@ -186,7 +186,7 @@ public class ImagePickerDelegate
 
   public void chooseVideoFromGallery(MethodCall methodCall, MethodChannel.Result result) {
     if (!setPendingMethodCallAndResult(methodCall, result)) {
-      finishWithAlreadyActiveError();
+      finishWithAlreadyActiveError(result);
       return;
     }
 
@@ -208,7 +208,7 @@ public class ImagePickerDelegate
 
   public void takeVideoWithCamera(MethodCall methodCall, MethodChannel.Result result) {
     if (!setPendingMethodCallAndResult(methodCall, result)) {
-      finishWithAlreadyActiveError();
+      finishWithAlreadyActiveError(result);
       return;
     }
 
@@ -226,7 +226,7 @@ public class ImagePickerDelegate
     boolean canTakePhotos = intentResolver.resolveActivity(intent);
 
     if (!canTakePhotos) {
-      finishWithError("no_available_camera", "No cameras available for taking pictures.");
+      finishPendingResultWithError("no_available_camera", "No cameras available for taking pictures.");
       return;
     }
 
@@ -242,7 +242,7 @@ public class ImagePickerDelegate
 
   public void chooseImageFromGallery(MethodCall methodCall, MethodChannel.Result result) {
     if (!setPendingMethodCallAndResult(methodCall, result)) {
-      finishWithAlreadyActiveError();
+      finishWithAlreadyActiveError(result);
       return;
     }
 
@@ -264,7 +264,7 @@ public class ImagePickerDelegate
 
   public void takeImageWithCamera(MethodCall methodCall, MethodChannel.Result result) {
     if (!setPendingMethodCallAndResult(methodCall, result)) {
-      finishWithAlreadyActiveError();
+      finishWithAlreadyActiveError(result);
       return;
     }
 
@@ -282,7 +282,7 @@ public class ImagePickerDelegate
     boolean canTakePhotos = intentResolver.resolveActivity(intent);
 
     if (!canTakePhotos) {
-      finishWithError("no_available_camera", "No cameras available for taking pictures.");
+      finishPendingResultWithError("no_available_camera", "No cameras available for taking pictures.");
       return;
     }
 
@@ -362,7 +362,7 @@ public class ImagePickerDelegate
     }
 
     if (!permissionGranted) {
-      finishWithSuccess(null);
+      finishPendingResultWithSuccess(null);
     }
 
     return true;
@@ -398,7 +398,7 @@ public class ImagePickerDelegate
     }
 
     // User cancelled choosing a picture.
-    finishWithSuccess(null);
+    finishPendingResultWithSuccess(null);
   }
 
   private void handleChooseVideoResult(int resultCode, Intent data) {
@@ -409,7 +409,7 @@ public class ImagePickerDelegate
     }
 
     // User cancelled choosing a picture.
-    finishWithSuccess(null);
+    finishPendingResultWithSuccess(null);
   }
 
   private void handleCaptureImageResult(int resultCode) {
@@ -426,7 +426,7 @@ public class ImagePickerDelegate
     }
 
     // User cancelled taking a picture.
-    finishWithSuccess(null);
+    finishPendingResultWithSuccess(null);
   }
 
   private void handleCaptureVideoResult(int resultCode) {
@@ -443,7 +443,7 @@ public class ImagePickerDelegate
     }
 
     // User cancelled taking a picture.
-    finishWithSuccess(null);
+    finishPendingResultWithSuccess(null);
   }
 
   private void handleImageResult(String path) {
@@ -452,7 +452,7 @@ public class ImagePickerDelegate
       Double maxHeight = methodCall.argument("maxHeight");
 
       String finalImagePath = imageResizer.resizeImageIfNeeded(path, maxWidth, maxHeight);
-      finishWithSuccess(finalImagePath);
+      finishPendingResultWithSuccess(finalImagePath);
     } else {
       throw new IllegalStateException("Received image from picker that was not requested");
     }
@@ -460,7 +460,7 @@ public class ImagePickerDelegate
 
   private void handleVideoResult(String path) {
     if (pendingResult != null) {
-      finishWithSuccess(path);
+      finishPendingResultWithSuccess(path);
     } else {
       throw new IllegalStateException("Received video from picker that was not requested");
     }
@@ -477,16 +477,16 @@ public class ImagePickerDelegate
     return true;
   }
 
-  private void finishWithSuccess(String imagePath) {
+  private void finishPendingResultWithSuccess(String imagePath) {
     pendingResult.success(imagePath);
     clearMethodCallAndResult();
   }
 
-  private void finishWithAlreadyActiveError() {
-    finishWithError("already_active", "Image picker is already active");
+  private void finishWithAlreadyActiveError(MethodChannel.Result result) {
+    result.error("already_active", "Image picker is already active", null);
   }
 
-  private void finishWithError(String errorCode, String errorMessage) {
+  private void finishPendingResultWithError(String errorCode, String errorMessage) {
     pendingResult.error(errorCode, errorMessage, null);
     clearMethodCallAndResult();
   }

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
@@ -226,8 +226,7 @@ public class ImagePickerDelegate
     boolean canTakePhotos = intentResolver.resolveActivity(intent);
 
     if (!canTakePhotos) {
-      finishPendingResultWithError(
-          "no_available_camera", "No cameras available for taking pictures.");
+      finishWithError("no_available_camera", "No cameras available for taking pictures.");
       return;
     }
 
@@ -283,8 +282,7 @@ public class ImagePickerDelegate
     boolean canTakePhotos = intentResolver.resolveActivity(intent);
 
     if (!canTakePhotos) {
-      finishPendingResultWithError(
-          "no_available_camera", "No cameras available for taking pictures.");
+      finishWithError("no_available_camera", "No cameras available for taking pictures.");
       return;
     }
 
@@ -364,7 +362,7 @@ public class ImagePickerDelegate
     }
 
     if (!permissionGranted) {
-      finishPendingResultWithSuccess(null);
+      finishWithSuccess(null);
     }
 
     return true;
@@ -400,7 +398,7 @@ public class ImagePickerDelegate
     }
 
     // User cancelled choosing a picture.
-    finishPendingResultWithSuccess(null);
+    finishWithSuccess(null);
   }
 
   private void handleChooseVideoResult(int resultCode, Intent data) {
@@ -411,7 +409,7 @@ public class ImagePickerDelegate
     }
 
     // User cancelled choosing a picture.
-    finishPendingResultWithSuccess(null);
+    finishWithSuccess(null);
   }
 
   private void handleCaptureImageResult(int resultCode) {
@@ -428,7 +426,7 @@ public class ImagePickerDelegate
     }
 
     // User cancelled taking a picture.
-    finishPendingResultWithSuccess(null);
+    finishWithSuccess(null);
   }
 
   private void handleCaptureVideoResult(int resultCode) {
@@ -445,7 +443,7 @@ public class ImagePickerDelegate
     }
 
     // User cancelled taking a picture.
-    finishPendingResultWithSuccess(null);
+    finishWithSuccess(null);
   }
 
   private void handleImageResult(String path) {
@@ -454,7 +452,7 @@ public class ImagePickerDelegate
       Double maxHeight = methodCall.argument("maxHeight");
 
       String finalImagePath = imageResizer.resizeImageIfNeeded(path, maxWidth, maxHeight);
-      finishPendingResultWithSuccess(finalImagePath);
+      finishWithSuccess(finalImagePath);
     } else {
       throw new IllegalStateException("Received image from picker that was not requested");
     }
@@ -462,7 +460,7 @@ public class ImagePickerDelegate
 
   private void handleVideoResult(String path) {
     if (pendingResult != null) {
-      finishPendingResultWithSuccess(path);
+      finishWithSuccess(path);
     } else {
       throw new IllegalStateException("Received video from picker that was not requested");
     }
@@ -479,18 +477,18 @@ public class ImagePickerDelegate
     return true;
   }
 
-  private void finishPendingResultWithSuccess(String imagePath) {
+  private void finishWithSuccess(String imagePath) {
     pendingResult.success(imagePath);
     clearMethodCallAndResult();
   }
 
-  private void finishWithAlreadyActiveError(MethodChannel.Result result) {
-    result.error("already_active", "Image picker is already active", null);
-  }
-
-  private void finishPendingResultWithError(String errorCode, String errorMessage) {
+  private void finishWithError(String errorCode, String errorMessage) {
     pendingResult.error(errorCode, errorMessage, null);
     clearMethodCallAndResult();
+  }
+
+  private void finishWithAlreadyActiveError(MethodChannel.Result result) {
+    result.error("already_active", "Image picker is already active.", null);
   }
 
   private void clearMethodCallAndResult() {

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -5,7 +5,7 @@ authors:
   - Flutter Team <flutter-dev@googlegroups.com>
   - Rhodes Davis Jr. <rody.davis.jr@gmail.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.5.0
+version: 0.5.0+1
 
 flutter:
   plugin:


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/19819

When the `image_picker` is called before another call is finished it should return an error with the `MethodResult` object that came with the last method call. But instead it uses the `MethodResult` object from the first method call. When finishing up the first method call, the `pendingResult` (`MethodResult` object of the first call) property will already be set to null.