### PR TITLE
Include Android SDK 27 in the docker image and accept licenses

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,0 +1,8 @@
+
+FROM cirrusci/flutter:latest
+
+RUN yes | sdkmanager \
+    "platforms;android-27" \
+    "build-tools;27.0.3" \
+    "extras;google;m2repository" \
+    "extras;android;m2repository"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 task:
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
   container:
-    image: cirrusci/flutter:latest
+    dockerfile: .ci/Dockerfile
     cpu: 4
     memory: 8G
   upgrade_script:


### PR DESCRIPTION
This was ripped off #1091.
CI was failing on multiple packages when trying to build apks with:
```
A problem occurred evaluating root project 'android'.
> A problem occurred configuring project ':app'.
   > Failed to install the following Android SDK packages as some licences have not been accepted.
        platforms;android-27 Android SDK Platform 27
     To build this project, accept the SDK license agreements and install the missing components using the Android Studio SDK Manager.
     Alternatively, to transfer the license agreements from one workstation to another, see http://d.android.com/r/studio-ui/export-licenses.html
     Using Android SDK: /opt/android-sdk-linux
```

This tweaks the docker file to also install Android SDK 27 accept licenses for it, which fixes the CI failure.

The patch was authored by @dnfield I just split part of it out of #1091.
