### PR TITLE
[camera] change mediaRecorder.setVideoEncodingBitRate for better video quality

### DIFF
--- a/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
+++ b/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
@@ -464,7 +464,7 @@ public class CameraPlugin implements MethodCallHandler {
       mediaRecorder.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4);
       mediaRecorder.setAudioEncoder(MediaRecorder.AudioEncoder.AAC);
       mediaRecorder.setVideoEncoder(MediaRecorder.VideoEncoder.H264);
-      mediaRecorder.setVideoEncodingBitRate(1024 * 1000);
+      mediaRecorder.setVideoEncodingBitRate(3000000);
       mediaRecorder.setAudioSamplingRate(16000);
       mediaRecorder.setVideoFrameRate(27);
       mediaRecorder.setVideoSize(videoSize.getWidth(), videoSize.getHeight());


### PR DESCRIPTION
closes https://github.com/flutter/flutter/issues/26959

## Description

Changing `mediaRecorder.setVideoEncodingBitRate` from `1024 * 1000` to `3000000` for better quality.
