### PR TITLE
Corrected CameraPosition

### DIFF
--- a/packages/google_maps_flutter/example/lib/place_marker.dart
+++ b/packages/google_maps_flutter/example/lib/place_marker.dart
@@ -175,9 +175,11 @@ class PlaceMarkerBodyState extends State<PlaceMarkerBody> {
             height: 200.0,
             child: GoogleMap(
               onMapCreated: _onMapCreated,
-              initialCameraPosition: const CameraPosition(
+              options: GoogleMapOptions(
+                cameraPosition: const CameraPosition(
                 target: LatLng(-33.852, 151.211),
                 zoom: 11.0,
+                ),
               ),
             ),
           ),


### PR DESCRIPTION
initialCameraPosition no longer exists, no inside GoogleMapsOptions under cameraPosition.