### PR TITLE
[sensors] Specify sample rate for sensor events

### DIFF
--- a/packages/sensors/CHANGELOG.md
+++ b/packages/sensors/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.6
+
+* Added option to specify sample rate.
+
 ## 0.3.5
 
 * Added missing test package dependency.

--- a/packages/sensors/README.md
+++ b/packages/sensors/README.md
@@ -20,4 +20,8 @@ accelerometerEvents.listen((AccelerometerEvent event) {
 gyroscopeEvents.listen((GyroscopeEvent event) {
  // Do something with the event.
 });
+
+// Optionally, specify the sample rate in Hz (events per second) before listening.
+// Note that for Android this is only a hint to the system. Events may be received faster or slower.
+setSensorsSampleRate(50);
 ```

--- a/packages/sensors/android/src/main/java/io/flutter/plugins/sensors/SensorsPlugin.java
+++ b/packages/sensors/android/src/main/java/io/flutter/plugins/sensors/SensorsPlugin.java
@@ -50,7 +50,7 @@ public class SensorsPlugin implements EventChannel.StreamHandler {
   @Override
   public void onListen(Object arguments, EventChannel.EventSink events) {
     sensorEventListener = createSensorEventListener(events);
-    sensorManager.registerListener(sensorEventListener, sensor, sensorManager.SENSOR_DELAY_NORMAL);
+    sensorManager.registerListener(sensorEventListener, sensor, (int) (1000000 / (int) arguments));
   }
 
   @Override

--- a/packages/sensors/ios/Classes/SensorsPlugin.m
+++ b/packages/sensors/ios/Classes/SensorsPlugin.m
@@ -52,6 +52,7 @@ static void sendTriplet(Float64 x, Float64 y, Float64 z, FlutterEventSink sink) 
 
 - (FlutterError*)onListenWithArguments:(id)arguments eventSink:(FlutterEventSink)eventSink {
   _initMotionManager();
+  _motionManager.accelerometerUpdateInterval = (float)1 / [arguments integerValue];
   [_motionManager
       startAccelerometerUpdatesToQueue:[[NSOperationQueue alloc] init]
                            withHandler:^(CMAccelerometerData* accelerometerData, NSError* error) {
@@ -75,6 +76,7 @@ static void sendTriplet(Float64 x, Float64 y, Float64 z, FlutterEventSink sink) 
 
 - (FlutterError*)onListenWithArguments:(id)arguments eventSink:(FlutterEventSink)eventSink {
   _initMotionManager();
+  _motionManager.deviceMotionUpdateInterval = (float)1 / [arguments integerValue];
   [_motionManager
       startDeviceMotionUpdatesToQueue:[[NSOperationQueue alloc] init]
                           withHandler:^(CMDeviceMotion* data, NSError* error) {
@@ -97,6 +99,7 @@ static void sendTriplet(Float64 x, Float64 y, Float64 z, FlutterEventSink sink) 
 
 - (FlutterError*)onListenWithArguments:(id)arguments eventSink:(FlutterEventSink)eventSink {
   _initMotionManager();
+  _motionManager.gyroUpdateInterval = (float)1 / [arguments integerValue];
   [_motionManager
       startGyroUpdatesToQueue:[[NSOperationQueue alloc] init]
                   withHandler:^(CMGyroData* gyroData, NSError* error) {

--- a/packages/sensors/lib/sensors.dart
+++ b/packages/sensors/lib/sensors.dart
@@ -74,11 +74,19 @@ Stream<AccelerometerEvent> _accelerometerEvents;
 Stream<GyroscopeEvent> _gyroscopeEvents;
 Stream<UserAccelerometerEvent> _userAccelerometerEvents;
 
+final int _sampleRateDefault = 15;
+int _sampleRate;
+
+/// Set the specified sample rate if it is greater than zero.
+void setSensorsSampleRate(int sampleRate) {
+  _sampleRate = (sampleRate > 0) ? sampleRate : _sampleRate;
+}
+
 /// A broadcast stream of events from the device accelerometer.
 Stream<AccelerometerEvent> get accelerometerEvents {
   if (_accelerometerEvents == null) {
     _accelerometerEvents = _accelerometerEventChannel
-        .receiveBroadcastStream()
+        .receiveBroadcastStream(_sampleRate ?? _sampleRateDefault)
         .map(
             (dynamic event) => _listToAccelerometerEvent(event.cast<double>()));
   }
@@ -89,7 +97,7 @@ Stream<AccelerometerEvent> get accelerometerEvents {
 Stream<GyroscopeEvent> get gyroscopeEvents {
   if (_gyroscopeEvents == null) {
     _gyroscopeEvents = _gyroscopeEventChannel
-        .receiveBroadcastStream()
+        .receiveBroadcastStream(_sampleRate ?? _sampleRateDefault)
         .map((dynamic event) => _listToGyroscopeEvent(event.cast<double>()));
   }
   return _gyroscopeEvents;
@@ -99,7 +107,7 @@ Stream<GyroscopeEvent> get gyroscopeEvents {
 Stream<UserAccelerometerEvent> get userAccelerometerEvents {
   if (_userAccelerometerEvents == null) {
     _userAccelerometerEvents = _userAccelerometerEventChannel
-        .receiveBroadcastStream()
+        .receiveBroadcastStream(_sampleRate ?? _sampleRateDefault)
         .map((dynamic event) =>
             _listToUserAccelerometerEvent(event.cast<double>()));
   }

--- a/packages/sensors/pubspec.yaml
+++ b/packages/sensors/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for accessing the Android and iOS accelerometer and
   gyroscope sensors.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/sensors
-version: 0.3.5
+version: 0.3.6
 
 flutter:
   plugin:

--- a/packages/sensors/test/sensors_test.dart
+++ b/packages/sensors/test/sensors_test.dart
@@ -35,6 +35,7 @@ void main() {
       }
     });
 
+    setSensorsSampleRate(50);
     final AccelerometerEvent event = await accelerometerEvents.first;
     expect(event.x, 1.0);
     expect(event.y, 2.0);


### PR DESCRIPTION
> Related issue: https://github.com/flutter/flutter/issues/25971

I reopen this PR because this feature should be regarded critical (as mentioned by @motiongestures in the closed PR: https://github.com/flutter/plugins/pull/1081). Without the ability to specify the sample rate for the accelerometer and gyroscope sensor, the sensors plugin has very limited utility. Furthermore, the current implementation results in ~15 events per second on Android and 100 events per second on iOS which is an unreasonable gap. The added changes on Java- and Objective-C side are very minimal and if there is no testing for the native code so far, I do not think it is rational to postpone this feature due to the missing test harness.

A sample rate is set in Hz (sensor events per second) before the listening with, e.g., `setSensorsSampleRate(50);`. If no sample rate is set, the default value is 15.