### PR TITLE
[image_picker] android studio suggests to not use android.media.ExifInterface

### DIFF
--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ExifDataCopier.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ExifDataCopier.java
@@ -4,7 +4,7 @@
 
 package io.flutter.plugins.imagepicker;
 
-import android.media.ExifInterface;
+import androidx.exifinterface.media.ExifInterface;
 import android.util.Log;
 import java.util.Arrays;
 import java.util.List;


### PR DESCRIPTION
android studio suggests not using android.media.ExifInterface and using android.support.media.ExifInterface , however , migrating to androidX results to it becoming  androidx.exifinterface.media.ExifInterface ,it also needs adding 
// implementation 'androidx.exifinterface:exifinterface:1.0.0' 
// implementation 'androidx.legacy:legacy-support-v4:1.0.0'
to the dependencies