### PR TITLE
[image_picker] adding exifinterface android x dependency

### DIFF
--- a/packages/image_picker/android/build.gradle
+++ b/packages/image_picker/android/build.gradle
@@ -37,5 +37,6 @@ android {
 }
 
 dependencies {
+    implementation 'androidx.exifinterface:exifinterface:1.0.0'
     api 'androidx.legacy:legacy-support-v4:1.0.0'
 }


### PR DESCRIPTION
android studio suggests not using android.media.ExifInterface and using android.support.media.ExifInterface , however , migrating to androidX results to it becoming  androidx.exifinterface.media.ExifInterface ,it also needs adding 
// implementation 'androidx.exifinterface:exifinterface:1.0.0' 
// implementation 'androidx.legacy:legacy-support-v4:1.0.0'
to the dependencies