### PR TITLE
Add WebView JavaScript channels (Dart side).

### DIFF
--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.1
+
+* Added JavaScript channels to facilitate message passing from JavaScript code running inside
+  the WebView to the Flutter app's Dart code.
+
 ## 0.3.0
 
 * **Breaking change**. Migrate from the deprecated original Android Support

--- a/packages/webview_flutter/example/lib/main.dart
+++ b/packages/webview_flutter/example/lib/main.dart
@@ -23,15 +23,32 @@ class WebViewExample extends StatelessWidget {
           SampleMenu(_controller.future),
         ],
       ),
-      body: WebView(
-        initialUrl: 'https://flutter.io',
-        javascriptMode: JavascriptMode.unrestricted,
-        onWebViewCreated: (WebViewController webViewController) {
-          _controller.complete(webViewController);
-        },
-      ),
+      // We're using a Builder here so we have a context that is below the Scaffold
+      // to allow calling Scaffold.maketoast
+      body: Builder(builder: (BuildContext context) {
+        return WebView(
+          initialUrl: 'https://flutter.io',
+          javascriptMode: JavascriptMode.unrestricted,
+          onWebViewCreated: (WebViewController webViewController) {
+            _controller.complete(webViewController);
+          },
+          javascriptChannels: <JavascriptChannel>[
+            _toasterJavascriptChannel(context),
+          ].toSet(),
+        );
+      }),
       floatingActionButton: favoriteButton(),
     );
+  }
+
+  JavascriptChannel _toasterJavascriptChannel(BuildContext context) {
+    return JavascriptChannel(
+        name: 'Toaster',
+        onMessageReceived: (JavascriptMessage message) {
+          Scaffold.of(context).showSnackBar(
+            SnackBar(content: Text(message.message)),
+          );
+        });
   }
 
   Widget favoriteButton() {
@@ -44,7 +61,7 @@ class WebViewExample extends StatelessWidget {
               onPressed: () async {
                 final String url = await controller.data.currentUrl();
                 Scaffold.of(context).showSnackBar(
-                  SnackBar(content: Text("Favorited $url")),
+                  SnackBar(content: Text('Favorited $url')),
                 );
               },
               child: const Icon(Icons.favorite),
@@ -56,7 +73,7 @@ class WebViewExample extends StatelessWidget {
 }
 
 enum MenuOptions {
-  evaluateJavascript,
+  showUserAgent,
   toast,
 }
 
@@ -73,8 +90,8 @@ class SampleMenu extends StatelessWidget {
         return PopupMenuButton<MenuOptions>(
           onSelected: (MenuOptions value) {
             switch (value) {
-              case MenuOptions.evaluateJavascript:
-                _onEvaluateJavascript(controller.data, context);
+              case MenuOptions.showUserAgent:
+                _onShowUserAgent(controller.data, context);
                 break;
               case MenuOptions.toast:
                 Scaffold.of(context).showSnackBar(
@@ -87,8 +104,8 @@ class SampleMenu extends StatelessWidget {
           },
           itemBuilder: (BuildContext context) => <PopupMenuItem<MenuOptions>>[
                 PopupMenuItem<MenuOptions>(
-                  value: MenuOptions.evaluateJavascript,
-                  child: const Text('Evaluate JavaScript'),
+                  value: MenuOptions.showUserAgent,
+                  child: const Text('Show user agent'),
                   enabled: controller.hasData,
                 ),
                 const PopupMenuItem<MenuOptions>(
@@ -101,15 +118,12 @@ class SampleMenu extends StatelessWidget {
     );
   }
 
-  void _onEvaluateJavascript(
+  void _onShowUserAgent(
       WebViewController controller, BuildContext context) async {
-    final String result = await controller
-        .evaluateJavascript("document.body.style.backgroundColor = 'red'");
-    Scaffold.of(context).showSnackBar(
-      SnackBar(
-        content: Text('JavaScript evaluated, the result is: $result'),
-      ),
-    );
+    // Send a message with the user agent string to the Toaster JavaScript channel we registered
+    // with the WebView.
+    controller.evaluateJavascript(
+        'Toaster.postMessage("User Agent: " + navigator.userAgent);');
   }
 }
 

--- a/packages/webview_flutter/example/lib/main.dart
+++ b/packages/webview_flutter/example/lib/main.dart
@@ -24,7 +24,7 @@ class WebViewExample extends StatelessWidget {
         ],
       ),
       // We're using a Builder here so we have a context that is below the Scaffold
-      // to allow calling Scaffold.maketoast
+      // to allow calling Scaffold.of(context) so we can show a snackbar.
       body: Builder(builder: (BuildContext context) {
         return WebView(
           initialUrl: 'https://flutter.io',

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -19,8 +19,19 @@ enum JavascriptMode {
   unrestricted,
 }
 
+/// A message that was sent by JavaScript code running in a [WebView].
+class JavascriptMessage {
+  /// Constructs a JavaScript message object.
+  ///
+  /// The `message` parameter must not be null.
+  const JavascriptMessage(this.message) : assert(message != null);
+
+  /// The contents of the message that was sent by the JavaScript code.
+  final String message;
+}
+
 /// Callback type for handling messages sent from Javascript running in a web view.
-typedef void JavascriptMessageHandler(String message);
+typedef void JavascriptMessageHandler(JavascriptMessage message);
 
 final RegExp _validChannelNames = RegExp('^[a-zA-Z_][a-zA-Z0-9]*\$');
 
@@ -43,6 +54,8 @@ class JavascriptChannel {
   ///
   /// The name must start with a letter or underscore(_), followed by any combination of those
   /// characters plus digits.
+  ///
+  /// Note that any JavaScript existing `window` property with this name will be overriden.
   ///
   /// See also [WebView.javascriptChannels] for more details on the channel registration mechanism.
   final String name;
@@ -292,7 +305,7 @@ class WebViewController {
       case 'javascriptChannelMessage':
         final String channel = call.arguments['channel'];
         final String message = call.arguments['message'];
-        _javascriptChannels[channel].onMessageReceived(message);
+        _javascriptChannels[channel].onMessageReceived(JavascriptMessage(message));
         break;
     }
   }

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -123,6 +123,8 @@ class WebView extends StatefulWidget {
   ///
   /// To asynchronously invoke the message handler which will print the message to standard output.
   ///
+  /// Adding a new JavaScript channel only takes affect after the next page is loaded.
+  ///
   /// Set values must not be null. A [JavascriptChannel.name] cannot be the same for multiple
   /// channels in the list.
   ///

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -305,7 +305,8 @@ class WebViewController {
       case 'javascriptChannelMessage':
         final String channel = call.arguments['channel'];
         final String message = call.arguments['message'];
-        _javascriptChannels[channel].onMessageReceived(JavascriptMessage(message));
+        _javascriptChannels[channel]
+            .onMessageReceived(JavascriptMessage(message));
         break;
     }
   }

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -429,10 +429,10 @@ class WebViewController {
   }
 
   void _updateJavascriptChannelsFromSet(Set<JavascriptChannel> channels) {
+    _javascriptChannels.clear();
     if (channels == null) {
       return;
     }
-    _javascriptChannels.clear();
     for (JavascriptChannel channel in channels) {
       _javascriptChannels[channel.name] = channel;
     }

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -115,7 +115,8 @@ class WebView extends StatefulWidget {
 }
 
 class _WebViewState extends State<WebView> {
-  final Completer<WebViewController> _controller = Completer<WebViewController>();
+  final Completer<WebViewController> _controller =
+      Completer<WebViewController>();
 
   _WebSettings _settings;
 
@@ -152,7 +153,8 @@ class _WebViewState extends State<WebView> {
         creationParamsCodec: const StandardMessageCodec(),
       );
     }
-    return Text('$defaultTargetPlatform is not yet supported by the webview_flutter plugin');
+    return Text(
+        '$defaultTargetPlatform is not yet supported by the webview_flutter plugin');
   }
 
   @override
@@ -188,10 +190,12 @@ class _WebViewState extends State<WebView> {
   }
 
   void _assertJavascriptChannelNamesAreUnique() {
-    if (widget.javascriptChannels == null || widget.javascriptChannels.isEmpty) {
+    if (widget.javascriptChannels == null ||
+        widget.javascriptChannels.isEmpty) {
       return;
     }
-    assert(_extractChannelNames(widget.javascriptChannels).length == widget.javascriptChannels.length);
+    assert(_extractChannelNames(widget.javascriptChannels).length ==
+        widget.javascriptChannels.length);
   }
 }
 
@@ -203,13 +207,15 @@ Set<String> _extractChannelNames(Set<JavascriptChannel> channels) {
 }
 
 class _CreationParams {
-  _CreationParams({this.initialUrl, this.settings, this.javascriptChannelNames});
+  _CreationParams(
+      {this.initialUrl, this.settings, this.javascriptChannelNames});
 
   static _CreationParams fromWidget(WebView widget) {
     return _CreationParams(
       initialUrl: widget.initialUrl,
       settings: _WebSettings.fromWidget(widget),
-      javascriptChannelNames: _extractChannelNames(widget.javascriptChannels).toList(),
+      javascriptChannelNames:
+          _extractChannelNames(widget.javascriptChannels).toList(),
     );
   }
 
@@ -260,7 +266,8 @@ class _WebSettings {
 /// A [WebViewController] instance can be obtained by setting the [WebView.onWebViewCreated]
 /// callback for a [WebView] widget.
 class WebViewController {
-  WebViewController._(int id, this._settings, Set<JavascriptChannel> javascriptChannels)
+  WebViewController._(
+      int id, this._settings, Set<JavascriptChannel> javascriptChannels)
       : _channel = MethodChannel('plugins.flutter.io/webview_$id') {
     _updateJavascriptChannelsFromSet(javascriptChannels);
     _channel.setMethodCallHandler(_onMethodCall);
@@ -271,10 +278,11 @@ class WebViewController {
   _WebSettings _settings;
 
   // Maps a channel name to a channel.
-  Map<String, JavascriptChannel> _javascriptChannels = <String, JavascriptChannel> {};
+  Map<String, JavascriptChannel> _javascriptChannels =
+      <String, JavascriptChannel>{};
 
   Future<void> _onMethodCall(MethodCall call) async {
-    switch(call.method) {
+    switch (call.method) {
       case 'javascriptChannelMessage':
         final String channel = call.arguments['channel'];
         final String message = call.arguments['message'];
@@ -376,16 +384,20 @@ class WebViewController {
     return _channel.invokeMethod('updateSettings', updateMap);
   }
 
-  Future<void> _updateJavascriptChannels(Set<JavascriptChannel> newChannels) async {
+  Future<void> _updateJavascriptChannels(
+      Set<JavascriptChannel> newChannels) async {
     final Set<String> currentChannels = _javascriptChannels.keys.toSet();
     final Set<String> newChannelNames = _extractChannelNames(newChannels);
-    final Set<String> channelsToAdd = newChannelNames.difference(currentChannels);
-    final Set<String> channelsToRemove = currentChannels.difference(newChannelNames);
+    final Set<String> channelsToAdd =
+        newChannelNames.difference(currentChannels);
+    final Set<String> channelsToRemove =
+        currentChannels.difference(newChannelNames);
     if (channelsToRemove.isNotEmpty) {
       // TODO(amirh): remove this when the invokeMethod update makes it to stable Flutter.
       // https://github.com/flutter/flutter/issues/26431
       // ignore: strong_mode_implicit_dynamic_method
-      _channel.invokeMethod('removeJavascriptChannels', channelsToRemove.toList());
+      _channel.invokeMethod(
+          'removeJavascriptChannels', channelsToRemove.toList());
     }
     if (channelsToAdd.isNotEmpty) {
       // TODO(amirh): remove this when the invokeMethod update makes it to stable Flutter.

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -22,6 +22,8 @@ enum JavascriptMode {
 /// Callback type for handling messages sent from Javascript running in a web view.
 typedef void JavascriptMessageHandler(String message);
 
+final RegExp _validChannelNames = RegExp('^[a-zA-Z_][a-zA-Z0-9]*\$');
+
 /// A named channel for receiving messaged from JavaScript code running inside a web view.
 class JavascriptChannel {
   /// Constructs a Javascript channel.
@@ -30,13 +32,17 @@ class JavascriptChannel {
   JavascriptChannel({
     @required this.name,
     @required this.onMessageReceived,
-  });
+  })  : assert(name != null),
+        assert(onMessageReceived != null),
+        assert(_validChannelNames.hasMatch(name));
 
   /// The channel's name.
   ///
-  ///
   /// Passing this channel object as part of a [WebView.javascriptChannels] adds a channel object to
   /// the Javascript window object's property named `name`.
+  ///
+  /// The name must start with a letter or underscore(_), followed by any combination of those
+  /// characters plus digits.
   ///
   /// See also [WebView.javascriptChannels] for more details on the channel registration mechanism.
   final String name;

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
-version: 0.3.0
+version: 0.3.1
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/webview_flutter
 

--- a/packages/webview_flutter/test/webview_flutter_test.dart
+++ b/packages/webview_flutter/test/webview_flutter_test.dart
@@ -9,6 +9,8 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
+typedef void VoidCallback();
+
 void main() {
   final _FakePlatformViewsController fakePlatformViewsController =
       _FakePlatformViewsController();
@@ -370,6 +372,22 @@ void main() {
 
     expect(platformWebView.javascriptChannelNames,
         unorderedEquals(<String>['Tts', 'Alarm']));
+  });
+
+  test('Only valid JavaScript channel names are allowed', () {
+    final JavascriptMessageHandler noOp = (String msg) {};
+    JavascriptChannel(name: 'Tts1', onMessageReceived: noOp);
+    JavascriptChannel(name: '_Alarm', onMessageReceived: noOp);
+
+    VoidCallback createChannel(String name) {
+      return () {
+        JavascriptChannel(name: name, onMessageReceived: noOp);
+      };
+    }
+
+    expect(createChannel('1Alarm'), throwsAssertionError);
+    expect(createChannel('foo.bar'), throwsAssertionError);
+    expect(createChannel(''), throwsAssertionError);
   });
 
   testWidgets('Unique JavaScript channel names are required',

--- a/packages/webview_flutter/test/webview_flutter_test.dart
+++ b/packages/webview_flutter/test/webview_flutter_test.dart
@@ -442,6 +442,42 @@ void main() {
         unorderedEquals(<String>['Tts', 'Alarm2', 'Alarm3']));
   });
 
+  testWidgets('Remove all JavaScript channels and then add', (WidgetTester tester) async {
+    // This covers a specific bug we had where after updating javascriptChannels to null,
+    // updating it again with a subset of the previously registered channels fails as the
+    // widget's cache of current channel wasn't properly updated when updating javascriptChannels to
+    // null.
+    await tester.pumpWidget(
+      WebView(
+        initialUrl: 'https://youtube.com',
+        javascriptChannels: <JavascriptChannel>[
+          JavascriptChannel(name: 'Tts', onMessageReceived: (JavascriptMessage msg) {}),
+        ].toSet(),
+      ),
+    );
+
+    await tester.pumpWidget(
+      const WebView(
+        initialUrl: 'https://youtube.com',
+      ),
+    );
+
+    await tester.pumpWidget(
+      WebView(
+        initialUrl: 'https://youtube.com',
+        javascriptChannels: <JavascriptChannel>[
+          JavascriptChannel(name: 'Tts', onMessageReceived: (JavascriptMessage msg) {}),
+        ].toSet(),
+      ),
+    );
+
+    final FakePlatformWebView platformWebView =
+        fakePlatformViewsController.lastCreatedView;
+
+    expect(platformWebView.javascriptChannelNames,
+        unorderedEquals(<String>['Tts']));
+  });
+
   testWidgets('JavaScript channel messages', (WidgetTester tester) async {
     final List<String> ttsMessagesReceived = <String>[];
     final List<String> alarmMessagesReceived = <String>[];
@@ -474,6 +510,7 @@ void main() {
 
     expect(ttsMessagesReceived, <String>['Hello', 'World']);
   });
+
 }
 
 class FakePlatformWebView {

--- a/packages/webview_flutter/test/webview_flutter_test.dart
+++ b/packages/webview_flutter/test/webview_flutter_test.dart
@@ -361,8 +361,10 @@ void main() {
       WebView(
         initialUrl: 'https://youtube.com',
         javascriptChannels: <JavascriptChannel>[
-          JavascriptChannel(name: 'Tts', onMessageReceived: (JavascriptMessage msg) {}),
-          JavascriptChannel(name: 'Alarm', onMessageReceived: (JavascriptMessage msg) {}),
+          JavascriptChannel(
+              name: 'Tts', onMessageReceived: (JavascriptMessage msg) {}),
+          JavascriptChannel(
+              name: 'Alarm', onMessageReceived: (JavascriptMessage msg) {}),
         ].toSet(),
       ),
     );
@@ -396,8 +398,10 @@ void main() {
       WebView(
         initialUrl: 'https://youtube.com',
         javascriptChannels: <JavascriptChannel>[
-          JavascriptChannel(name: 'Alarm', onMessageReceived: (JavascriptMessage msg) {}),
-          JavascriptChannel(name: 'Alarm', onMessageReceived: (JavascriptMessage msg) {}),
+          JavascriptChannel(
+              name: 'Alarm', onMessageReceived: (JavascriptMessage msg) {}),
+          JavascriptChannel(
+              name: 'Alarm', onMessageReceived: (JavascriptMessage msg) {}),
         ].toSet(),
       ),
     );
@@ -409,8 +413,10 @@ void main() {
       WebView(
         initialUrl: 'https://youtube.com',
         javascriptChannels: <JavascriptChannel>[
-          JavascriptChannel(name: 'Tts', onMessageReceived: (JavascriptMessage msg) {}),
-          JavascriptChannel(name: 'Alarm', onMessageReceived: (JavascriptMessage msg) {}),
+          JavascriptChannel(
+              name: 'Tts', onMessageReceived: (JavascriptMessage msg) {}),
+          JavascriptChannel(
+              name: 'Alarm', onMessageReceived: (JavascriptMessage msg) {}),
         ].toSet(),
       ),
     );
@@ -419,9 +425,12 @@ void main() {
       WebView(
         initialUrl: 'https://youtube.com',
         javascriptChannels: <JavascriptChannel>[
-          JavascriptChannel(name: 'Tts', onMessageReceived: (JavascriptMessage msg) {}),
-          JavascriptChannel(name: 'Alarm2', onMessageReceived: (JavascriptMessage msg) {}),
-          JavascriptChannel(name: 'Alarm3', onMessageReceived: (JavascriptMessage msg) {}),
+          JavascriptChannel(
+              name: 'Tts', onMessageReceived: (JavascriptMessage msg) {}),
+          JavascriptChannel(
+              name: 'Alarm2', onMessageReceived: (JavascriptMessage msg) {}),
+          JavascriptChannel(
+              name: 'Alarm3', onMessageReceived: (JavascriptMessage msg) {}),
         ].toSet(),
       ),
     );

--- a/packages/webview_flutter/test/webview_flutter_test.dart
+++ b/packages/webview_flutter/test/webview_flutter_test.dart
@@ -10,11 +10,12 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
 void main() {
-  final _FakePlatformViewsController fakePlatformViewsController = _FakePlatformViewsController();
+  final _FakePlatformViewsController fakePlatformViewsController =
+      _FakePlatformViewsController();
 
   setUpAll(() {
-    SystemChannels.platform_views
-        .setMockMethodCallHandler(fakePlatformViewsController.fakePlatformViewsMethodHandler);
+    SystemChannels.platform_views.setMockMethodCallHandler(
+        fakePlatformViewsController.fakePlatformViewsMethodHandler);
   });
 
   setUp(() {
@@ -45,7 +46,8 @@ void main() {
       javascriptMode: JavascriptMode.unrestricted,
     ));
 
-    final FakePlatformWebView platformWebView = fakePlatformViewsController.lastCreatedView;
+    final FakePlatformWebView platformWebView =
+        fakePlatformViewsController.lastCreatedView;
 
     expect(platformWebView.javascriptMode, JavascriptMode.unrestricted);
 
@@ -97,7 +99,8 @@ void main() {
     expect(await controller.currentUrl(), isNull);
   });
 
-  testWidgets("Can't go back before loading a page", (WidgetTester tester) async {
+  testWidgets("Can't go back before loading a page",
+      (WidgetTester tester) async {
     WebViewController controller;
     await tester.pumpWidget(
       WebView(
@@ -150,7 +153,8 @@ void main() {
     expect(canGoBackSecondPageLoaded, true);
   });
 
-  testWidgets("Can't go forward before loading a page", (WidgetTester tester) async {
+  testWidgets("Can't go forward before loading a page",
+      (WidgetTester tester) async {
     WebViewController controller;
     await tester.pumpWidget(
       WebView(
@@ -292,7 +296,8 @@ void main() {
       ),
     );
 
-    final FakePlatformWebView platformWebView = fakePlatformViewsController.lastCreatedView;
+    final FakePlatformWebView platformWebView =
+        fakePlatformViewsController.lastCreatedView;
 
     expect(platformWebView.currentUrl, 'https://flutter.io');
     expect(platformWebView.amountOfReloadsOnCurrentUrl, 0);
@@ -318,7 +323,8 @@ void main() {
         },
       ),
     );
-    expect(await controller.evaluateJavascript("fake js string"), "fake js string",
+    expect(
+        await controller.evaluateJavascript("fake js string"), "fake js string",
         reason: 'should get the argument');
     expect(
       () => controller.evaluateJavascript(null),
@@ -326,7 +332,8 @@ void main() {
     );
   });
 
-  testWidgets('evaluate Javascript with JavascriptMode disabled', (WidgetTester tester) async {
+  testWidgets('evaluate Javascript with JavascriptMode disabled',
+      (WidgetTester tester) async {
     WebViewController controller;
     await tester.pumpWidget(
       WebView(
@@ -358,12 +365,15 @@ void main() {
       ),
     );
 
-    final FakePlatformWebView platformWebView = fakePlatformViewsController.lastCreatedView;
+    final FakePlatformWebView platformWebView =
+        fakePlatformViewsController.lastCreatedView;
 
-    expect(platformWebView.javascriptChannelNames, unorderedEquals(<String>['Tts', 'Alarm']));
+    expect(platformWebView.javascriptChannelNames,
+        unorderedEquals(<String>['Tts', 'Alarm']));
   });
 
-  testWidgets('Unique JavaScript channel names are required', (WidgetTester tester) async {
+  testWidgets('Unique JavaScript channel names are required',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       WebView(
         initialUrl: 'https://youtube.com',
@@ -398,9 +408,11 @@ void main() {
       ),
     );
 
-    final FakePlatformWebView platformWebView = fakePlatformViewsController.lastCreatedView;
+    final FakePlatformWebView platformWebView =
+        fakePlatformViewsController.lastCreatedView;
 
-    expect(platformWebView.javascriptChannelNames, unorderedEquals(<String>['Tts', 'Alarm2', 'Alarm3']));
+    expect(platformWebView.javascriptChannelNames,
+        unorderedEquals(<String>['Tts', 'Alarm2', 'Alarm3']));
   });
 
   testWidgets('JavaScript channel messages', (WidgetTester tester) async {
@@ -410,13 +422,22 @@ void main() {
       WebView(
         initialUrl: 'https://youtube.com',
         javascriptChannels: <JavascriptChannel>[
-          JavascriptChannel(name: 'Tts', onMessageReceived: (String msg) {ttsMessagesReceived.add(msg); }),
-          JavascriptChannel(name: 'Alarm', onMessageReceived: (String msg) {alarmMessagesReceived.add(msg); }),
+          JavascriptChannel(
+              name: 'Tts',
+              onMessageReceived: (String msg) {
+                ttsMessagesReceived.add(msg);
+              }),
+          JavascriptChannel(
+              name: 'Alarm',
+              onMessageReceived: (String msg) {
+                alarmMessagesReceived.add(msg);
+              }),
         ].toSet(),
       ),
     );
 
-    final FakePlatformWebView platformWebView = fakePlatformViewsController.lastCreatedView;
+    final FakePlatformWebView platformWebView =
+        fakePlatformViewsController.lastCreatedView;
 
     expect(ttsMessagesReceived, isEmpty);
     expect(alarmMessagesReceived, isEmpty);
@@ -439,9 +460,11 @@ class FakePlatformWebView {
       javascriptMode = JavascriptMode.values[params['settings']['jsMode']];
     }
     if (params.containsKey('javascriptChannelNames')) {
-      javascriptChannelNames = List<String>.from(params['javascriptChannelNames']);
+      javascriptChannelNames =
+          List<String>.from(params['javascriptChannelNames']);
     }
-    channel = MethodChannel('plugins.flutter.io/webview_$id', const StandardMethodCodec());
+    channel = MethodChannel(
+        'plugins.flutter.io/webview_$id', const StandardMethodCodec());
     channel.setMockMethodCallHandler(onMethodCall);
   }
 
@@ -499,7 +522,8 @@ class FakePlatformWebView {
         break;
       case 'removeJavascriptChannels':
         final List<String> channelNames = List<String>.from(call.arguments);
-        javascriptChannelNames.removeWhere((String channel) => channelNames.contains(channel));
+        javascriptChannelNames
+            .removeWhere((String channel) => channelNames.contains(channel));
         break;
     }
     return Future<void>.sync(() {});
@@ -507,12 +531,14 @@ class FakePlatformWebView {
 
   void fakeJavascriptPostMessage(String jsChannel, String message) {
     final StandardMethodCodec codec = const StandardMethodCodec();
-    final Map<String, dynamic> arguments = <String, dynamic> {
+    final Map<String, dynamic> arguments = <String, dynamic>{
       'channel': jsChannel,
       'message': message
     };
-    final ByteData data = codec.encodeMethodCall(MethodCall('javascriptChannelMessage', arguments));
-    BinaryMessages.handlePlatformMessage(channel.name, data, (ByteData data) {});
+    final ByteData data = codec
+        .encodeMethodCall(MethodCall('javascriptChannelMessage', arguments));
+    BinaryMessages.handlePlatformMessage(
+        channel.name, data, (ByteData data) {});
   }
 }
 

--- a/packages/webview_flutter/test/webview_flutter_test.dart
+++ b/packages/webview_flutter/test/webview_flutter_test.dart
@@ -361,8 +361,8 @@ void main() {
       WebView(
         initialUrl: 'https://youtube.com',
         javascriptChannels: <JavascriptChannel>[
-          JavascriptChannel(name: 'Tts', onMessageReceived: (String msg) {}),
-          JavascriptChannel(name: 'Alarm', onMessageReceived: (String msg) {}),
+          JavascriptChannel(name: 'Tts', onMessageReceived: (JavascriptMessage msg) {}),
+          JavascriptChannel(name: 'Alarm', onMessageReceived: (JavascriptMessage msg) {}),
         ].toSet(),
       ),
     );
@@ -375,7 +375,7 @@ void main() {
   });
 
   test('Only valid JavaScript channel names are allowed', () {
-    final JavascriptMessageHandler noOp = (String msg) {};
+    final JavascriptMessageHandler noOp = (JavascriptMessage msg) {};
     JavascriptChannel(name: 'Tts1', onMessageReceived: noOp);
     JavascriptChannel(name: '_Alarm', onMessageReceived: noOp);
 
@@ -396,8 +396,8 @@ void main() {
       WebView(
         initialUrl: 'https://youtube.com',
         javascriptChannels: <JavascriptChannel>[
-          JavascriptChannel(name: 'Alarm', onMessageReceived: (String msg) {}),
-          JavascriptChannel(name: 'Alarm', onMessageReceived: (String msg) {}),
+          JavascriptChannel(name: 'Alarm', onMessageReceived: (JavascriptMessage msg) {}),
+          JavascriptChannel(name: 'Alarm', onMessageReceived: (JavascriptMessage msg) {}),
         ].toSet(),
       ),
     );
@@ -409,8 +409,8 @@ void main() {
       WebView(
         initialUrl: 'https://youtube.com',
         javascriptChannels: <JavascriptChannel>[
-          JavascriptChannel(name: 'Tts', onMessageReceived: (String msg) {}),
-          JavascriptChannel(name: 'Alarm', onMessageReceived: (String msg) {}),
+          JavascriptChannel(name: 'Tts', onMessageReceived: (JavascriptMessage msg) {}),
+          JavascriptChannel(name: 'Alarm', onMessageReceived: (JavascriptMessage msg) {}),
         ].toSet(),
       ),
     );
@@ -419,9 +419,9 @@ void main() {
       WebView(
         initialUrl: 'https://youtube.com',
         javascriptChannels: <JavascriptChannel>[
-          JavascriptChannel(name: 'Tts', onMessageReceived: (String msg) {}),
-          JavascriptChannel(name: 'Alarm2', onMessageReceived: (String msg) {}),
-          JavascriptChannel(name: 'Alarm3', onMessageReceived: (String msg) {}),
+          JavascriptChannel(name: 'Tts', onMessageReceived: (JavascriptMessage msg) {}),
+          JavascriptChannel(name: 'Alarm2', onMessageReceived: (JavascriptMessage msg) {}),
+          JavascriptChannel(name: 'Alarm3', onMessageReceived: (JavascriptMessage msg) {}),
         ].toSet(),
       ),
     );
@@ -442,13 +442,13 @@ void main() {
         javascriptChannels: <JavascriptChannel>[
           JavascriptChannel(
               name: 'Tts',
-              onMessageReceived: (String msg) {
-                ttsMessagesReceived.add(msg);
+              onMessageReceived: (JavascriptMessage msg) {
+                ttsMessagesReceived.add(msg.message);
               }),
           JavascriptChannel(
               name: 'Alarm',
-              onMessageReceived: (String msg) {
-                alarmMessagesReceived.add(msg);
+              onMessageReceived: (JavascriptMessage msg) {
+                alarmMessagesReceived.add(msg.message);
               }),
         ].toSet(),
       ),

--- a/packages/webview_flutter/test/webview_flutter_test.dart
+++ b/packages/webview_flutter/test/webview_flutter_test.dart
@@ -442,7 +442,8 @@ void main() {
         unorderedEquals(<String>['Tts', 'Alarm2', 'Alarm3']));
   });
 
-  testWidgets('Remove all JavaScript channels and then add', (WidgetTester tester) async {
+  testWidgets('Remove all JavaScript channels and then add',
+      (WidgetTester tester) async {
     // This covers a specific bug we had where after updating javascriptChannels to null,
     // updating it again with a subset of the previously registered channels fails as the
     // widget's cache of current channel wasn't properly updated when updating javascriptChannels to
@@ -451,7 +452,8 @@ void main() {
       WebView(
         initialUrl: 'https://youtube.com',
         javascriptChannels: <JavascriptChannel>[
-          JavascriptChannel(name: 'Tts', onMessageReceived: (JavascriptMessage msg) {}),
+          JavascriptChannel(
+              name: 'Tts', onMessageReceived: (JavascriptMessage msg) {}),
         ].toSet(),
       ),
     );
@@ -466,7 +468,8 @@ void main() {
       WebView(
         initialUrl: 'https://youtube.com',
         javascriptChannels: <JavascriptChannel>[
-          JavascriptChannel(name: 'Tts', onMessageReceived: (JavascriptMessage msg) {}),
+          JavascriptChannel(
+              name: 'Tts', onMessageReceived: (JavascriptMessage msg) {}),
         ].toSet(),
       ),
     );
@@ -510,7 +513,6 @@ void main() {
 
     expect(ttsMessagesReceived, <String>['Hello', 'World']);
   });
-
 }
 
 class FakePlatformWebView {


### PR DESCRIPTION
Allows JavaScript code running in the WebView to send messages that will be received by the Flutter app's Dart code.

To keep the PRs smaller this does not include the platform side implementations which will be sent in following PRs.

Right now there are no return values on the JavaScript side, we could think of returning a JavaScript promise (or a promise equivalent) in the future, but as a first step I start without it (`evaluateJavascript` can be used to pass messages in the other direction so this shouldn't be a blocking limitation).
I believe that if we end up adding a return value on the JavaScript side this could be done without making a breaking change.

### Sample usage
Dart:
```dart
WebView(
  javascriptChannels: <JavascriptChannel>[
    JavascriptChannel(name: 'Print', onMessageReceived: (String msg) {print(msg); }),
  ].toSet(),
),
```

JavaScript (running inside the WebView):
```javascript
Print.postMessage('Hello!');
```


Fixes: https://github.com/flutter/flutter/issues/24837