### PR TITLE
[android_alarm_manager] add support for specifying startAt time for AlarmManager.periodic()

### DIFF
--- a/packages/android_alarm_manager/lib/android_alarm_manager.dart
+++ b/packages/android_alarm_manager/lib/android_alarm_manager.dart
@@ -137,6 +137,9 @@ class AndroidAlarmManager {
   /// The repeating timer is uniquely identified by `id`. Calling this function
   /// again with the same `id` will cancel and replace the existing timer.
   ///
+  /// If `startAt` is passed, the timer will first go off at that time and
+  /// subsequently run with period `duration`.
+  ///
   /// If `exact` is passed as `true`, the timer will be created with Android's
   /// `AlarmManager.setRepeating`. When `exact` is `false` (the default), the
   /// timer will be created with `AlarmManager.setInexactRepeating`.
@@ -151,12 +154,14 @@ class AndroidAlarmManager {
     Duration duration,
     int id,
     dynamic Function() callback, {
+    DateTime startAt,
     bool exact = false,
     bool wakeup = false,
   }) async {
     final int now = DateTime.now().millisecondsSinceEpoch;
     final int period = duration.inMilliseconds;
-    final int first = now + period;
+    final int first =
+        startAt != null ? startAt.millisecondsSinceEpoch : now + period;
     final CallbackHandle handle = PluginUtilities.getCallbackHandle(callback);
     if (handle == null) {
       return false;


### PR DESCRIPTION
Fixes [flutter/flutter#7115](https://github.com/flutter/flutter/issues/27115)