### PR TITLE
A few additional Androix dependencies

### DIFF
--- a/packages/cloud_firestore/android/build.gradle
+++ b/packages/cloud_firestore/android/build.gradle
@@ -35,5 +35,6 @@ android {
     }
     dependencies {
         api 'com.google.firebase:firebase-firestore:17.1.1'
+        implementation 'androidx.annotation:annotation:1.0.0'
     }
 }

--- a/packages/cloud_functions/android/build.gradle
+++ b/packages/cloud_functions/android/build.gradle
@@ -33,5 +33,6 @@ android {
     }
     dependencies {
         api 'com.google.firebase:firebase-functions:16.1.1'
+        implementation 'androidx.annotation:annotation:1.0.0'
     }
 }

--- a/packages/firebase_dynamic_links/android/build.gradle
+++ b/packages/firebase_dynamic_links/android/build.gradle
@@ -33,5 +33,6 @@ android {
     }
     dependencies {
         api 'com.google.firebase:firebase-dynamic-links:16.1.2'
+        implementation 'androidx.annotation:annotation:1.0.0'
     }
 }

--- a/packages/firebase_messaging/android/build.gradle
+++ b/packages/firebase_messaging/android/build.gradle
@@ -33,5 +33,7 @@ android {
     }
     dependencies {
         api 'com.google.firebase:firebase-messaging:17.3.3'
+        implementation 'androidx.annotation:annotation:1.0.0'
+        implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
     }
 }

--- a/packages/firebase_ml_vision/android/build.gradle
+++ b/packages/firebase_ml_vision/android/build.gradle
@@ -35,5 +35,6 @@ android {
         api 'com.android.support:support-v4:27.1.1'
         api 'com.google.firebase:firebase-ml-vision:17.0.1'
         api 'com.google.firebase:firebase-ml-vision-image-label-model:16.2.0'
+        implementation 'androidx.annotation:annotation:1.0.0'
     }
 }

--- a/packages/firebase_remote_config/android/build.gradle
+++ b/packages/firebase_remote_config/android/build.gradle
@@ -33,5 +33,6 @@ android {
     }
     dependencies {
         api 'com.google.firebase:firebase-config:16.0.1'
+        implementation 'androidx.annotation:annotation:1.0.0'
     }
 }

--- a/packages/firebase_storage/android/build.gradle
+++ b/packages/firebase_storage/android/build.gradle
@@ -41,5 +41,6 @@ android {
     }
     dependencies {
         api 'com.google.firebase:firebase-storage:16.0.3'
+        implementation 'androidx.annotation:annotation:1.0.0'
     }
 }


### PR DESCRIPTION
Apparently some dependencies like android.support.annotation were implicitly available, but that doesn't seem to be true anymore with AndroidX.

Tracked in flutter/flutter#23995.
Related to https://github.com/flutter/plugins/pull/1115