### PR TITLE
Updated `launch` to use async and await, fixed the incorrect return value by `launch` method.

### DIFF
--- a/packages/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.2.0+2
+
+* Updated `launch` to use async and await, fixed the incorrect return value by `luanch` method.
+
 ## 4.2.0+1
 
 * Refactored the Java and Objective-C code. Replaced instance variables with properties in Objective-C.

--- a/packages/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 4.2.0+2
 
-* Updated `launch` to use async and await, fixed the incorrect return value by `luanch` method.
+* Updated `launch` to use async and await, fixed the incorrect return value by `launch` method.
 
 ## 4.2.0+1
 

--- a/packages/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/lib/url_launcher.dart
@@ -59,7 +59,7 @@ Future<bool> launch(
   bool enableJavaScript,
   bool universalLinksOnly,
   Brightness statusBarBrightness,
-}) {
+}) async {
   assert(urlString != null);
   final Uri url = Uri.parse(urlString.trimLeft());
   final bool isWebURL = url.scheme == 'http' || url.scheme == 'https';
@@ -82,7 +82,7 @@ Future<bool> launch(
   // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
   // https://github.com/flutter/flutter/issues/26431
   // ignore: strong_mode_implicit_dynamic_method
-  return _channel.invokeMethod(
+  final bool result = await _channel.invokeMethod(
     'launch',
     <String, Object>{
       'url': urlString,
@@ -91,12 +91,12 @@ Future<bool> launch(
       'enableJavaScript': enableJavaScript ?? false,
       'universalLinksOnly': universalLinksOnly ?? false,
     },
-  ).then((void _) {
-    if (statusBarBrightness != null) {
-      WidgetsBinding.instance.renderView.automaticSystemUiAdjustment =
-          previousAutomaticSystemUiAdjustment;
-    }
-  });
+  );
+  if (statusBarBrightness != null) {
+    WidgetsBinding.instance.renderView.automaticSystemUiAdjustment =
+        previousAutomaticSystemUiAdjustment;
+  }
+  return result;
 }
 
 /// Checks whether the specified URL can be handled by some app installed on the

--- a/packages/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for launching a URL on Android and iOS. Supports
   web, phone, SMS, and email schemes.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher
-version: 4.2.0+1
+version: 4.2.0+2
 
 flutter:
   plugin:


### PR DESCRIPTION
This is a fix for the comments https://github.com/flutter/flutter/issues/25991#issuecomment-457834526 and https://github.com/flutter/flutter/issues/25991#issuecomment-458002938 which mentioned that the `launch` api returns null instead of a boolean.   https://github.com/flutter/flutter/issues/25991