### PR TITLE
android_alarm_manager background execution bug fixes

### DIFF
--- a/packages/android_alarm_manager/CHANGELOG.md
+++ b/packages/android_alarm_manager/CHANGELOG.md
@@ -1,3 +1,26 @@
+## 0.4.0
+* **Breaking change**. Migrated the underlying AlarmService to utilize a
+  BroadcastReceiver with a JobIntentService instead of a Service to handle
+  processing of alarms. This requires AndroidManifest.xml to be updated to
+  include the following entries:
+
+  ```xml
+        <service
+            android:name="io.flutter.plugins.androidalarmmanager.AlarmService"
+            android:permission="android.permission.BIND_JOB_SERVICE"
+            android:exported="false"/>
+        <receiver
+            android:name="io.flutter.plugins.androidalarmmanager.AlarmBroadcastReceiver"
+            android:exported="false"/>
+  ```
+
+* Fixed issue where background service was not starting due to background
+  execution restrictions on Android 8+ (see [issue
+  #26846](https://github.com/flutter/flutter/issues/26846)).
+* Fixed issue where alarm events were ignored when the background isolate was
+  still initializing. Alarm events are now queued if the background isolate has
+  not completed initializing and are processed once initialization is complete.
+
 ## 0.3.0
 
 * **Breaking change**. Migrate from the deprecated original Android Support

--- a/packages/android_alarm_manager/README.md
+++ b/packages/android_alarm_manager/README.md
@@ -13,6 +13,10 @@ After importing this plugin to your project as usual, add the following to your
 ```xml
 <service
     android:name="io.flutter.plugins.androidalarmmanager.AlarmService"
+    android:permission="android.permission.BIND_JOB_SERVICE"
+    android:exported="false"/>
+<receiver
+    android:name="io.flutter.plugins.androidalarmmanager.AlarmBroadcastReceiver"
     android:exported="false"/>
 ```
 

--- a/packages/android_alarm_manager/android/build.gradle
+++ b/packages/android_alarm_manager/android/build.gradle
@@ -32,3 +32,7 @@ android {
         disable 'InvalidPackage'
     }
 }
+
+dependencies {
+    implementation 'androidx.appcompat:appcompat:1.0.0'
+}

--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AlarmBroadcastReceiver.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AlarmBroadcastReceiver.java
@@ -4,12 +4,9 @@
 
 package io.flutter.plugins.androidalarmmanager;
 
-import android.app.AlarmManager;
-import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.util.Log;
 
 public class AlarmBroadcastReceiver extends BroadcastReceiver {
   @Override

--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AlarmBroadcastReceiver.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AlarmBroadcastReceiver.java
@@ -1,0 +1,19 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.plugins.androidalarmmanager;
+
+import android.app.AlarmManager;
+import android.app.PendingIntent;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+
+public class AlarmBroadcastReceiver extends BroadcastReceiver {
+  @Override
+  public void onReceive(Context context, Intent intent) {
+    AlarmService.enqueueAlarmProcessing(context, intent);
+  }
+}

--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AlarmService.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AlarmService.java
@@ -6,11 +6,9 @@ package io.flutter.plugins.androidalarmmanager;
 
 import android.app.AlarmManager;
 import android.app.PendingIntent;
-import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.os.IBinder;
 import android.util.Log;
 import androidx.core.app.JobIntentService;
 import io.flutter.plugin.common.MethodChannel;
@@ -19,21 +17,18 @@ import io.flutter.view.FlutterCallbackInformation;
 import io.flutter.view.FlutterMain;
 import io.flutter.view.FlutterNativeView;
 import io.flutter.view.FlutterRunArguments;
-import java.util.Iterator;
-import java.util.List;
-import java.util.LinkedList;
 import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class AlarmService extends JobIntentService {
   public static final String TAG = "AlarmService";
-  private static final String SHARED_PREFERENCES_KEY =
-      "io.flutter.android_alarm_manager_plugin";
-  private static final String CALLBACK_HANDLE_KEY =
-      "callback_handle";
+  private static final String SHARED_PREFERENCES_KEY = "io.flutter.android_alarm_manager_plugin";
+  private static final String CALLBACK_HANDLE_KEY = "callback_handle";
   private static AtomicBoolean sStarted = new AtomicBoolean(false);
-  private static List<Intent> sAlarmQueue =
-      Collections.synchronizedList(new LinkedList<Intent>());
+  private static List<Intent> sAlarmQueue = Collections.synchronizedList(new LinkedList<Intent>());
   private static FlutterNativeView sBackgroundFlutterView;
   private static MethodChannel sBackgroundChannel;
   private static PluginRegistrantCallback sPluginRegistrantCallback;
@@ -114,8 +109,7 @@ public class AlarmService extends JobIntentService {
   }
 
   public static void setCallbackDispatcher(Context context, long callbackHandle) {
-    SharedPreferences p =
-        context.getSharedPreferences(SHARED_PREFERENCES_KEY, 0);
+    SharedPreferences p = context.getSharedPreferences(SHARED_PREFERENCES_KEY, 0);
     p.edit().putLong(CALLBACK_HANDLE_KEY, callbackHandle).apply();
   }
 
@@ -136,7 +130,7 @@ public class AlarmService extends JobIntentService {
   protected void onHandleWork(Intent intent) {
     // If we're in the middle of processing queued alarms, block until they're
     // done before processing new alarms.
-    synchronized(sAlarmQueue) {
+    synchronized (sAlarmQueue) {
       if (!sStarted.get()) {
         Log.i(TAG, "AlarmService has not yet started.");
         sAlarmQueue.add(intent);

--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AlarmService.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AlarmService.java
@@ -9,27 +9,70 @@ import android.app.PendingIntent;
 import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.IBinder;
 import android.util.Log;
+import androidx.core.app.JobIntentService;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.PluginRegistry.PluginRegistrantCallback;
 import io.flutter.view.FlutterCallbackInformation;
 import io.flutter.view.FlutterMain;
 import io.flutter.view.FlutterNativeView;
 import io.flutter.view.FlutterRunArguments;
+import java.util.Iterator;
+import java.util.List;
+import java.util.LinkedList;
+import java.util.Collections;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public class AlarmService extends Service {
+public class AlarmService extends JobIntentService {
   public static final String TAG = "AlarmService";
+  private static final String SHARED_PREFERENCES_KEY =
+      "io.flutter.android_alarm_manager_plugin";
+  private static final String CALLBACK_HANDLE_KEY =
+      "callback_handle";
   private static AtomicBoolean sStarted = new AtomicBoolean(false);
+  private static List<Intent> sAlarmQueue =
+      Collections.synchronizedList(new LinkedList<Intent>());
   private static FlutterNativeView sBackgroundFlutterView;
   private static MethodChannel sBackgroundChannel;
   private static PluginRegistrantCallback sPluginRegistrantCallback;
 
   private String mAppBundlePath;
 
+  @Override
+  public void onCreate() {
+    super.onCreate();
+    Context context = getApplicationContext();
+    FlutterMain.ensureInitializationComplete(context, null);
+    mAppBundlePath = FlutterMain.findAppBundlePath(context);
+    if (!sStarted.get()) {
+      SharedPreferences p = context.getSharedPreferences(SHARED_PREFERENCES_KEY, 0);
+      long callbackHandle = p.getLong(CALLBACK_HANDLE_KEY, 0);
+      startAlarmService(context, callbackHandle);
+    }
+  }
+
+  // Schedule the alarm to be handled by the AlarmService.
+  public static void enqueueAlarmProcessing(Context context, Intent alarmContext) {
+    enqueueWork(context, AlarmService.class, 1984, alarmContext);
+  }
+
+  // Called once the Dart isolate (sBackgroundFlutterView) has finished
+  // initializing. Processes all alarm events that came in while the isolate
+  // was starting.
   public static void onInitialized() {
+    Log.i(TAG, "AlarmService started!");
     sStarted.set(true);
+    synchronized (sAlarmQueue) {
+      // Handle all the alarm events received before the Dart isolate was fully
+      // initialized and clear the queue.
+      Iterator<Intent> i = sAlarmQueue.iterator();
+      while (i.hasNext()) {
+        invokeCallbackDispatcher(i.next());
+      }
+      sAlarmQueue.clear();
+    }
   }
 
   // Here we start the AlarmService. This method does a few things:
@@ -70,6 +113,96 @@ public class AlarmService extends Service {
     sBackgroundChannel = channel;
   }
 
+  public static void setCallbackDispatcher(Context context, long callbackHandle) {
+    SharedPreferences p =
+        context.getSharedPreferences(SHARED_PREFERENCES_KEY, 0);
+    p.edit().putLong(CALLBACK_HANDLE_KEY, callbackHandle).apply();
+  }
+
+  public static boolean setBackgroundFlutterView(FlutterNativeView view) {
+    if (sBackgroundFlutterView != null && sBackgroundFlutterView != view) {
+      Log.i(TAG, "setBackgroundFlutterView tried to overwrite an existing FlutterNativeView");
+      return false;
+    }
+    sBackgroundFlutterView = view;
+    return true;
+  }
+
+  public static void setPluginRegistrant(PluginRegistrantCallback callback) {
+    sPluginRegistrantCallback = callback;
+  }
+
+  @Override
+  protected void onHandleWork(Intent intent) {
+    // If we're in the middle of processing queued alarms, block until they're
+    // done before processing new alarms.
+    synchronized(sAlarmQueue) {
+      if (!sStarted.get()) {
+        Log.i(TAG, "AlarmService has not yet started.");
+        sAlarmQueue.add(intent);
+        return;
+      }
+    }
+    invokeCallbackDispatcher(intent);
+  }
+
+  // This is where we handle alarm events before sending them to our callback
+  // dispatcher in Dart.
+  private static void invokeCallbackDispatcher(Intent intent) {
+    // Grab the handle for the callback associated with this alarm. Pay close
+    // attention to the type of the callback handle as storing this value in a
+    // variable of the wrong size will cause the callback lookup to fail.
+    long callbackHandle = intent.getLongExtra("callbackHandle", 0);
+    if (sBackgroundChannel == null) {
+      Log.e(
+          TAG,
+          "setBackgroundChannel was not called before alarms were scheduled." + " Bailing out.");
+      return;
+    }
+    // Handle the alarm event in Dart. Note that for this plugin, we don't
+    // care about the method name as we simply lookup and invoke the callback
+    // provided.
+    sBackgroundChannel.invokeMethod("", new Object[] {callbackHandle});
+  }
+
+  private static void scheduleAlarm(
+      Context context,
+      int requestCode,
+      boolean repeating,
+      boolean exact,
+      boolean wakeup,
+      long startMillis,
+      long intervalMillis,
+      long callbackHandle) {
+    // Create an Intent for the alarm and set the desired Dart callback handle.
+    Intent alarm = new Intent(context, AlarmBroadcastReceiver.class);
+    alarm.putExtra("callbackHandle", callbackHandle);
+    PendingIntent pendingIntent =
+        PendingIntent.getBroadcast(context, requestCode, alarm, PendingIntent.FLAG_UPDATE_CURRENT);
+
+    // Use the appropriate clock.
+    int clock = AlarmManager.RTC;
+    if (wakeup) {
+      clock = AlarmManager.RTC_WAKEUP;
+    }
+
+    // Schedule the alarm.
+    AlarmManager manager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+    if (exact) {
+      if (repeating) {
+        manager.setRepeating(clock, startMillis, intervalMillis, pendingIntent);
+      } else {
+        manager.setExact(clock, startMillis, pendingIntent);
+      }
+    } else {
+      if (repeating) {
+        manager.setInexactRepeating(clock, startMillis, intervalMillis, pendingIntent);
+      } else {
+        manager.set(clock, startMillis, pendingIntent);
+      }
+    }
+  }
+
   public static void setOneShot(
       Context context,
       int requestCode,
@@ -102,104 +235,14 @@ public class AlarmService extends Service {
   }
 
   public static void cancel(Context context, int requestCode) {
-    Intent alarm = new Intent(context, AlarmService.class);
+    Intent alarm = new Intent(context, AlarmBroadcastReceiver.class);
     PendingIntent existingIntent =
-        PendingIntent.getService(context, requestCode, alarm, PendingIntent.FLAG_NO_CREATE);
+        PendingIntent.getBroadcast(context, requestCode, alarm, PendingIntent.FLAG_NO_CREATE);
     if (existingIntent == null) {
-      Log.i(TAG, "cancel: service not found");
+      Log.i(TAG, "cancel: broadcast receiver not found");
       return;
     }
     AlarmManager manager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
     manager.cancel(existingIntent);
-  }
-
-  public static boolean setBackgroundFlutterView(FlutterNativeView view) {
-    if (sBackgroundFlutterView != null && sBackgroundFlutterView != view) {
-      Log.i(TAG, "setBackgroundFlutterView tried to overwrite an existing FlutterNativeView");
-      return false;
-    }
-    sBackgroundFlutterView = view;
-    return true;
-  }
-
-  public static void setPluginRegistrant(PluginRegistrantCallback callback) {
-    sPluginRegistrantCallback = callback;
-  }
-
-  @Override
-  public void onCreate() {
-    super.onCreate();
-    Context context = getApplicationContext();
-    FlutterMain.ensureInitializationComplete(context, null);
-    mAppBundlePath = FlutterMain.findAppBundlePath(context);
-  }
-
-  // This is where we handle alarm events before sending them to our callback
-  // dispatcher in Dart.
-  @Override
-  public int onStartCommand(Intent intent, int flags, int startId) {
-    if (!sStarted.get()) {
-      Log.i(TAG, "AlarmService has not yet started.");
-      // TODO(bkonyi): queue up alarm events.
-      return START_NOT_STICKY;
-    }
-    // Grab the handle for the callback associated with this alarm. Pay close
-    // attention to the type of the callback handle as storing this value in a
-    // variable of the wrong size will cause the callback lookup to fail.
-    long callbackHandle = intent.getLongExtra("callbackHandle", 0);
-    if (sBackgroundChannel == null) {
-      Log.e(
-          TAG,
-          "setBackgroundChannel was not called before alarms were scheduled." + " Bailing out.");
-      return START_NOT_STICKY;
-    }
-    // Handle the alarm event in Dart. Note that for this plugin, we don't
-    // care about the method name as we simply lookup and invoke the callback
-    // provided.
-    sBackgroundChannel.invokeMethod("", new Object[] {callbackHandle});
-    return START_NOT_STICKY;
-  }
-
-  @Override
-  public IBinder onBind(Intent intent) {
-    return null;
-  }
-
-  private static void scheduleAlarm(
-      Context context,
-      int requestCode,
-      boolean repeating,
-      boolean exact,
-      boolean wakeup,
-      long startMillis,
-      long intervalMillis,
-      long callbackHandle) {
-    // Create an Intent for the alarm and set the desired Dart callback handle.
-    Intent alarm = new Intent(context, AlarmService.class);
-    alarm.putExtra("callbackHandle", callbackHandle);
-    PendingIntent pendingIntent =
-        PendingIntent.getService(context, requestCode, alarm, PendingIntent.FLAG_UPDATE_CURRENT);
-
-    // Use the appropriate clock.
-    int clock = AlarmManager.RTC;
-    if (wakeup) {
-      clock = AlarmManager.RTC_WAKEUP;
-    }
-
-    // Schedule the alarm.
-    AlarmManager manager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
-    if (exact) {
-      if (repeating) {
-        manager.setRepeating(clock, startMillis, intervalMillis, pendingIntent);
-      } else {
-        manager.setExact(clock, startMillis, pendingIntent);
-      }
-    } else {
-      if (repeating) {
-        manager.setInexactRepeating(clock, startMillis, intervalMillis, pendingIntent);
-      } else {
-        manager.set(clock, startMillis, pendingIntent);
-      }
-    }
   }
 }

--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AlarmService.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AlarmService.java
@@ -27,6 +27,7 @@ public class AlarmService extends JobIntentService {
   public static final String TAG = "AlarmService";
   private static final String SHARED_PREFERENCES_KEY = "io.flutter.android_alarm_manager_plugin";
   private static final String CALLBACK_HANDLE_KEY = "callback_handle";
+  private static final int JOB_ID = 1984; // Random job ID.
   private static AtomicBoolean sStarted = new AtomicBoolean(false);
   private static List<Intent> sAlarmQueue = Collections.synchronizedList(new LinkedList<Intent>());
   private static FlutterNativeView sBackgroundFlutterView;
@@ -50,7 +51,7 @@ public class AlarmService extends JobIntentService {
 
   // Schedule the alarm to be handled by the AlarmService.
   public static void enqueueAlarmProcessing(Context context, Intent alarmContext) {
-    enqueueWork(context, AlarmService.class, 1984, alarmContext);
+    enqueueWork(context, AlarmService.class, JOB_ID, alarmContext);
   }
 
   // Called once the Dart isolate (sBackgroundFlutterView) has finished

--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AndroidAlarmManagerPlugin.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AndroidAlarmManagerPlugin.java
@@ -72,6 +72,7 @@ public class AndroidAlarmManagerPlugin implements MethodCallHandler, ViewDestroy
 
   private void startService(JSONArray arguments) throws JSONException {
     long callbackHandle = arguments.getLong(0);
+    AlarmService.setCallbackDispatcher(mContext, callbackHandle);
     AlarmService.startAlarmService(mContext, callbackHandle);
   }
 

--- a/packages/android_alarm_manager/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/android_alarm_manager/example/android/app/src/main/AndroidManifest.xml
@@ -24,6 +24,10 @@
         </activity>
         <service
             android:name="io.flutter.plugins.androidalarmmanager.AlarmService"
+            android:permission="android.permission.BIND_JOB_SERVICE"
+            android:exported="false"/>
+        <receiver
+            android:name="io.flutter.plugins.androidalarmmanager.AlarmBroadcastReceiver"
             android:exported="false"/>
     </application>
 </manifest>

--- a/packages/android_alarm_manager/example/pubspec.yaml
+++ b/packages/android_alarm_manager/example/pubspec.yaml
@@ -7,7 +7,7 @@ dependencies:
   android_alarm_manager:
     path: ../
   firebase_auth: "^0.8.0+1"
-  google_sign_in: ^3.3.0
+  google_sign_in: "^4.0.0"
 
 dev_dependencies:
   flutter_test:

--- a/packages/android_alarm_manager/pubspec.yaml
+++ b/packages/android_alarm_manager/pubspec.yaml
@@ -1,7 +1,7 @@
 name: android_alarm_manager
 description: Flutter plugin for accessing the Android AlarmManager service, and
   running Dart code in the background when alarms fire.
-version: 0.3.0
+version: 0.4.0
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/android_alarm_manager
 


### PR DESCRIPTION
* Updated android_alarm_manager to fix issues with "background start not
allowed" when attempting to start AlarmService while backgrounded.
  * Switched to using a combination of BroadcastReceiver and
  JobIntentService from using a Service (launching a Service from an
  alarm Intent causes the "Background start not allowed" on Android 8+)

* Alarm events received before the AlarmService isolate is finished
initializing are now queued and processed once the isolate is
initialized.

* Updated CHANGELOG.md and README.md with new setup steps.

* Bumped version to 0.4.0.

Fixes flutter/flutter#26846.