### PR TITLE
Use string to save double for shared_preference(Android).

### DIFF
--- a/packages/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.1
+
+* Use String to save double in Android.
+
 ## 0.5.0
 
 * **Breaking change**. Migrate from the deprecated original Android Support

--- a/packages/shared_preferences/android/src/main/java/io/flutter/plugins/sharedpreferences/SharedPreferencesPlugin.java
+++ b/packages/shared_preferences/android/src/main/java/io/flutter/plugins/sharedpreferences/SharedPreferencesPlugin.java
@@ -32,7 +32,7 @@ public class SharedPreferencesPlugin implements MethodCallHandler {
   // Fun fact: The following is a base64 encoding of the string "This is the prefix for a list."
   private static final String LIST_IDENTIFIER = "VGhpcyBpcyB0aGUgcHJlZml4IGZvciBhIGxpc3Qu";
   private static final String BIG_INTEGER_PREFIX = "VGhpcyBpcyB0aGUgcHJlZml4IGZvciBCaWdJbnRlZ2Vy";
-  private static final String DOUBLE_PREFIX = "VGhpcyBpcyB0aGUgcHJlZml4IGZvciBTeCcXmYaGwHtE";
+  private static final String DOUBLE_PREFIX = "VGhpcyBpcyB0aGUgcHJlZml4IGZvciBEb3VibGUu";
 
   private final android.content.SharedPreferences preferences;
 

--- a/packages/shared_preferences/android/src/main/java/io/flutter/plugins/sharedpreferences/SharedPreferencesPlugin.java
+++ b/packages/shared_preferences/android/src/main/java/io/flutter/plugins/sharedpreferences/SharedPreferencesPlugin.java
@@ -32,6 +32,7 @@ public class SharedPreferencesPlugin implements MethodCallHandler {
   // Fun fact: The following is a base64 encoding of the string "This is the prefix for a list."
   private static final String LIST_IDENTIFIER = "VGhpcyBpcyB0aGUgcHJlZml4IGZvciBhIGxpc3Qu";
   private static final String BIG_INTEGER_PREFIX = "VGhpcyBpcyB0aGUgcHJlZml4IGZvciBCaWdJbnRlZ2Vy";
+  private static final String DOUBLE_PREFIX = "VGhpcyBpcyB0aGUgcHJlZml4IGZvciBTeCcXmYaGwHtE";
 
   private final android.content.SharedPreferences preferences;
 
@@ -88,6 +89,9 @@ public class SharedPreferencesPlugin implements MethodCallHandler {
           } else if (stringValue.startsWith(BIG_INTEGER_PREFIX)) {
             String encoded = stringValue.substring(BIG_INTEGER_PREFIX.length());
             value = new BigInteger(encoded, Character.MAX_RADIX);
+          } else if (stringValue.startsWith(DOUBLE_PREFIX)) {
+            String doubleStr = stringValue.substring(DOUBLE_PREFIX.length());
+            value = Double.valueOf(doubleStr);
           }
         } else if (value instanceof Set) {
           // This only happens for previous usage of setStringSet. The app expects a list.
@@ -122,8 +126,9 @@ public class SharedPreferencesPlugin implements MethodCallHandler {
           status = preferences.edit().putBoolean(key, (boolean) call.argument("value")).commit();
           break;
         case "setDouble":
-          float floatValue = ((Number) call.argument("value")).floatValue();
-          status = preferences.edit().putFloat(key, floatValue).commit();
+          double doubleValue = ((Number) call.argument("value")).doubleValue();
+          String doubleValueStr = Double.toString(doubleValue);
+          status = preferences.edit().putString(key, DOUBLE_PREFIX + doubleValueStr).commit();
           break;
         case "setInt":
           Number number = call.argument("value");

--- a/packages/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for reading and writing simple key-value pairs.
   Wraps NSUserDefaults on iOS and SharedPreferences on Android.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/shared_preferences
-version: 0.5.0
+version: 0.5.1
 
 flutter:
   plugin:


### PR DESCRIPTION
Use string to save double for shared_preference instead of converting it to float.
This will fix: https://github.com/flutter/flutter/issues/27222