### PR TITLE
Added support for persisting alarms across reboots

### DIFF
--- a/packages/android_alarm_manager/CHANGELOG.md
+++ b/packages/android_alarm_manager/CHANGELOG.md
@@ -1,3 +1,27 @@
+## 0.4.1
+* Added support for setting alarms which persist across reboots.
+  * Both `AndroidAlarmManager.oneShot` and `AndroidAlarmManager.periodic` have
+    an optional `rescheduleOnReboot` parameter which specifies whether the new
+    alarm should be rescheduled to run after a reboot (default: false). If set
+    to false, the alarm will not survive a device reboot.
+  * Requires AndroidManifest.xml to be updated to include the following
+    entries:
+
+    ```xml
+    <!--Within the application tag body-->
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+
+    <!--Within the manifest tag body-->
+    <receiver
+        android:name="io.flutter.plugins.androidalarmmanager.RebootBroadcastReceiver"
+        android:enabled="false">
+        <intent-filter>
+            <action android:name="android.intent.action.BOOT_COMPLETED"></action>
+        </intent-filter>
+    </receiver>
+
+    ```
+
 ## 0.4.0
 * **Breaking change**. Migrated the underlying AlarmService to utilize a
   BroadcastReceiver with a JobIntentService instead of a Service to handle

--- a/packages/android_alarm_manager/README.md
+++ b/packages/android_alarm_manager/README.md
@@ -8,7 +8,13 @@ Dart code in the background when alarms fire.
 ## Getting Started
 
 After importing this plugin to your project as usual, add the following to your
-`AndroidManifest.xml`:
+`AndroidManifest.xml` within the `<manifest></manifest>` tags:
+
+```xml
+<uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+```
+
+Next, within the `<application></application>` tags, add:
 
 ```xml
 <service
@@ -18,6 +24,14 @@ After importing this plugin to your project as usual, add the following to your
 <receiver
     android:name="io.flutter.plugins.androidalarmmanager.AlarmBroadcastReceiver"
     android:exported="false"/>
+<receiver
+    android:name="io.flutter.plugins.androidalarmmanager.RebootBroadcastReceiver"
+    android:enabled="false">
+    <intent-filter>
+        <action android:name="android.intent.action.BOOT_COMPLETED"></action>
+    </intent-filter>
+</receiver>
+
 ```
 
 Then in Dart code add:

--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AlarmService.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AlarmService.java
@@ -110,8 +110,7 @@ public class AlarmService extends JobIntentService {
   }
 
   public static void setCallbackDispatcher(Context context, long callbackHandle) {
-    SharedPreferences p =
-        context.getSharedPreferences(SHARED_PREFERENCES_KEY, 0);
+    SharedPreferences p = context.getSharedPreferences(SHARED_PREFERENCES_KEY, 0);
     p.edit().putLong(CALLBACK_HANDLE_KEY, callbackHandle).apply();
   }
 

--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AlarmService.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AlarmService.java
@@ -110,7 +110,8 @@ public class AlarmService extends JobIntentService {
   }
 
   public static void setCallbackDispatcher(Context context, long callbackHandle) {
-    SharedPreferences p = context.getSharedPreferences(SHARED_PREFERENCES_KEY, 0);
+    SharedPreferences p =
+        context.getSharedPreferences(SHARED_PREFERENCES_KEY, 0);
     p.edit().putLong(CALLBACK_HANDLE_KEY, callbackHandle).apply();
   }
 

--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AndroidAlarmManagerPlugin.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AndroidAlarmManagerPlugin.java
@@ -81,8 +81,10 @@ public class AndroidAlarmManagerPlugin implements MethodCallHandler, ViewDestroy
     boolean exact = arguments.getBoolean(1);
     boolean wakeup = arguments.getBoolean(2);
     long startMillis = arguments.getLong(3);
-    long callbackHandle = arguments.getLong(4);
-    AlarmService.setOneShot(mContext, requestCode, exact, wakeup, startMillis, callbackHandle);
+    boolean rescheduleOnReboot = arguments.getBoolean(4);
+    long callbackHandle = arguments.getLong(5);
+    AlarmService.setOneShot(
+        mContext, requestCode, exact, wakeup, startMillis, rescheduleOnReboot, callbackHandle);
   }
 
   private void periodic(JSONArray arguments) throws JSONException {
@@ -91,9 +93,17 @@ public class AndroidAlarmManagerPlugin implements MethodCallHandler, ViewDestroy
     boolean wakeup = arguments.getBoolean(2);
     long startMillis = arguments.getLong(3);
     long intervalMillis = arguments.getLong(4);
-    long callbackHandle = arguments.getLong(5);
+    boolean rescheduleOnReboot = arguments.getBoolean(5);
+    long callbackHandle = arguments.getLong(6);
     AlarmService.setPeriodic(
-        mContext, requestCode, exact, wakeup, startMillis, intervalMillis, callbackHandle);
+        mContext,
+        requestCode,
+        exact,
+        wakeup,
+        startMillis,
+        intervalMillis,
+        rescheduleOnReboot,
+        callbackHandle);
   }
 
   private void cancel(JSONArray arguments) throws JSONException {

--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/RebootBroadcastReceiver.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/RebootBroadcastReceiver.java
@@ -1,0 +1,36 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.plugins.androidalarmmanager;
+
+import android.content.BroadcastReceiver;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.util.Log;
+
+public class RebootBroadcastReceiver extends BroadcastReceiver {
+  @Override
+  public void onReceive(Context context, Intent intent) {
+    if (intent.getAction().equals("android.intent.action.BOOT_COMPLETED")) {
+      Log.i("AlarmService", "Rescheduling after boot!");
+      AlarmService.reschedulePersistentAlarms(context);
+    }
+  }
+
+  public static void enableRescheduleOnReboot(Context context) {
+    scheduleOnReboot(context, PackageManager.COMPONENT_ENABLED_STATE_ENABLED);
+  }
+
+  public static void disableRescheduleOnReboot(Context context) {
+    scheduleOnReboot(context, PackageManager.COMPONENT_ENABLED_STATE_DISABLED);
+  }
+
+  private static void scheduleOnReboot(Context context, int state) {
+    ComponentName receiver = new ComponentName(context, RebootBroadcastReceiver.class);
+    PackageManager pm = context.getPackageManager();
+    pm.setComponentEnabledSetting(receiver, state, PackageManager.DONT_KILL_APP);
+  }
+}

--- a/packages/android_alarm_manager/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/android_alarm_manager/example/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="io.flutter.plugins.androidalarmmanagerexample">
 
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.INTERNET"/>
 
     <application
@@ -29,5 +30,12 @@
         <receiver
             android:name="io.flutter.plugins.androidalarmmanager.AlarmBroadcastReceiver"
             android:exported="false"/>
+        <receiver
+            android:name="io.flutter.plugins.androidalarmmanager.RebootBroadcastReceiver"
+            android:enabled="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED"></action>
+            </intent-filter>
+        </receiver>
     </application>
 </manifest>

--- a/packages/android_alarm_manager/lib/android_alarm_manager.dart
+++ b/packages/android_alarm_manager/lib/android_alarm_manager.dart
@@ -97,6 +97,10 @@ class AndroidAlarmManager {
   /// alarm fires. If `wakeup` is false (the default), the device will not be
   /// woken up to service the alarm.
   ///
+  /// If `rescheduleOnReboot` is passed as `true`, the alarm will be persisted
+  /// across reboots. If `rescheduleOnReboot` is false (the default), the alarm
+  /// will not be rescheduled after a reboot and will not be executed.
+  ///
   /// Returns a [Future] that resolves to `true` on success and `false` on
   /// failure.
   static Future<bool> oneShot(
@@ -105,6 +109,7 @@ class AndroidAlarmManager {
     dynamic Function() callback, {
     bool exact = false,
     bool wakeup = false,
+    bool rescheduleOnReboot = false,
   }) async {
     final int now = DateTime.now().millisecondsSinceEpoch;
     final int first = now + delay.inMilliseconds;
@@ -120,6 +125,7 @@ class AndroidAlarmManager {
       exact,
       wakeup,
       first,
+      rescheduleOnReboot,
       handle.toRawHandle(),
     ]);
     return (r == null) ? false : r;
@@ -145,6 +151,10 @@ class AndroidAlarmManager {
   /// alarm fires. If `wakeup` is false (the default), the device will not be
   /// woken up to service the alarm.
   ///
+  /// If `rescheduleOnReboot` is passed as `true`, the alarm will be persisted
+  /// across reboots. If `rescheduleOnReboot` is false (the default), the alarm
+  /// will not be rescheduled after a reboot and will not be executed.
+  ///
   /// Returns a [Future] that resolves to `true` on success and `false` on
   /// failure.
   static Future<bool> periodic(
@@ -153,6 +163,7 @@ class AndroidAlarmManager {
     dynamic Function() callback, {
     bool exact = false,
     bool wakeup = false,
+    bool rescheduleOnReboot = false,
   }) async {
     final int now = DateTime.now().millisecondsSinceEpoch;
     final int period = duration.inMilliseconds;
@@ -164,8 +175,15 @@ class AndroidAlarmManager {
     // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
     // https://github.com/flutter/flutter/issues/26431
     // ignore: strong_mode_implicit_dynamic_method
-    final dynamic r = await _channel.invokeMethod('Alarm.periodic',
-        <dynamic>[id, exact, wakeup, first, period, handle.toRawHandle()]);
+    final dynamic r = await _channel.invokeMethod('Alarm.periodic', <dynamic>[
+      id,
+      exact,
+      wakeup,
+      first,
+      period,
+      rescheduleOnReboot,
+      handle.toRawHandle()
+    ]);
     return (r == null) ? false : r;
   }
 

--- a/packages/android_alarm_manager/pubspec.yaml
+++ b/packages/android_alarm_manager/pubspec.yaml
@@ -1,7 +1,7 @@
 name: android_alarm_manager
 description: Flutter plugin for accessing the Android AlarmManager service, and
   running Dart code in the background when alarms fire.
-version: 0.4.0
+version: 0.4.1
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/android_alarm_manager
 


### PR DESCRIPTION
Android doesn't automatically reschedule alarms after a reboot, so
alarms set using this plugin would have to be scheduled manually after
each reboot. With this change, alarms scheduled with the 'rescheduleOnReboot'
flag set to true will be rescheduled at boot.