### PR TITLE
fixing iOS closeWebview method

### DIFF
--- a/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
+++ b/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
@@ -146,10 +146,8 @@ API_AVAILABLE(ios(9.0))
   self.currentSession = [[FLTUrlLaunchSession alloc] initWithUrl:url withFlutterResult:result];
   __weak typeof(self) weakSelf = self;
   [self.viewController presentViewController:self.currentSession.safari
-                                    animated:YES
-                                  completion:^void() {
-                                    weakSelf.currentSession = nil;
-                                  }];
+                                    animated:YES completion:^{
+                                    }];
 }
 
 - (void)closeWebViewWithResult:(FlutterResult)result API_AVAILABLE(ios(9.0)) {


### PR DESCRIPTION
UrlLauncherPlugin.m was wrongly settting currentSession to nil when the page did the initial load, and that prevented the webview to closed via code.
