### PR TITLE
[url_launcher] fixing close webview method on iOS

### DIFF
--- a/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
+++ b/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
@@ -146,10 +146,7 @@ API_AVAILABLE(ios(9.0))
   self.currentSession = [[FLTUrlLaunchSession alloc] initWithUrl:url withFlutterResult:result];
   __weak typeof(self) weakSelf = self;
   [self.viewController presentViewController:self.currentSession.safari
-                                    animated:YES
-                                  completion:^void() {
-                                    weakSelf.currentSession = nil;
-                                  }];
+                                    animated:YES];
 }
 
 - (void)closeWebViewWithResult:(FlutterResult)result API_AVAILABLE(ios(9.0)) {

--- a/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
+++ b/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
@@ -146,7 +146,7 @@ API_AVAILABLE(ios(9.0))
   self.currentSession = [[FLTUrlLaunchSession alloc] initWithUrl:url withFlutterResult:result];
   [self.viewController presentViewController:self.currentSession.safari
                                     animated:YES
-                                  completion:^void() {
+                                  completion:^void(){
                                   }];
 }
 

--- a/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
+++ b/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
@@ -144,9 +144,10 @@ API_AVAILABLE(ios(9.0))
 - (void)launchURLInVC:(NSString *)urlString result:(FlutterResult)result API_AVAILABLE(ios(9.0)) {
   NSURL *url = [NSURL URLWithString:urlString];
   self.currentSession = [[FLTUrlLaunchSession alloc] initWithUrl:url withFlutterResult:result];
-  __weak typeof(self) weakSelf = self;
   [self.viewController presentViewController:self.currentSession.safari
-                                    animated:YES];
+                                    animated:YES
+                                  completion:^void() {
+                                  }];
 }
 
 - (void)closeWebViewWithResult:(FlutterResult)result API_AVAILABLE(ios(9.0)) {


### PR DESCRIPTION
currentSession was being set to nil when the webview loaded on iOS, preventing it to be closed via code.