### PR TITLE
[google_maps_flutter] initialCameraPosition required now

### DIFF
--- a/packages/google_maps_flutter/README.md
+++ b/packages/google_maps_flutter/README.md
@@ -103,6 +103,12 @@ class MapsDemoState extends State<MapsDemo> {
               height: 200.0,
               child: GoogleMap(
                 onMapCreated: _onMapCreated,
+                initialCameraPosition: CameraPosition(
+                   target: LatLng(
+                      0.00,
+                      0.00,
+                   ),
+                 ),
               ),
             ),
           ),


### PR DESCRIPTION
initialCameraPosition is now required else the app blows up.