### PR TITLE
Add support for map marker bitmap created “fromFile”

### DIFF
--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/Convert.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/Convert.java
@@ -37,6 +37,8 @@ class Convert {
           return BitmapDescriptorFactory.fromAsset(
               FlutterMain.getLookupKeyForAsset(toString(data.get(1)), toString(data.get(2))));
         }
+      case "fromFile":
+        return BitmapDescriptorFactory.fromPath(toString(data.get(1)));
       default:
         throw new IllegalArgumentException("Cannot interpret " + o + " as BitmapDescriptor");
     }

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapController.m
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapController.m
@@ -423,6 +423,10 @@ static void interpretMarkerOptions(id json, id<FLTGoogleMapMarkerOptionsSink> si
         image = [UIImage imageNamed:[registrar lookupKeyForAsset:iconData[1]
                                                      fromPackage:iconData[2]]];
       }
+    } else if ([iconData[0] isEqualToString:@"fromFile"]) {
+        NSData* data = [NSData dataWithContentsOfFile:iconData[1]];
+        CGFloat scale = [UIScreen mainScreen].scale;
+        image = [UIImage imageWithData:data scale:scale];
     }
     [sink setIcon:image];
   }

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapController.m
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapController.m
@@ -424,9 +424,9 @@ static void interpretMarkerOptions(id json, id<FLTGoogleMapMarkerOptionsSink> si
                                                      fromPackage:iconData[2]]];
       }
     } else if ([iconData[0] isEqualToString:@"fromFile"]) {
-        NSData* data = [NSData dataWithContentsOfFile:iconData[1]];
-        CGFloat scale = [UIScreen mainScreen].scale;
-        image = [UIImage imageWithData:data scale:scale];
+      NSData* data = [NSData dataWithContentsOfFile:iconData[1]];
+      CGFloat scale = [UIScreen mainScreen].scale;
+      image = [UIImage imageWithData:data scale:scale];
     }
     [sink setIcon:image];
   }

--- a/packages/google_maps_flutter/lib/src/bitmap.dart
+++ b/packages/google_maps_flutter/lib/src/bitmap.dart
@@ -43,6 +43,10 @@ class BitmapDescriptor {
     }
   }
 
+  static BitmapDescriptor fromFile(String fileName) {
+    return BitmapDescriptor._(<dynamic>['fromFile', fileName]);
+  }
+
   final dynamic _json;
 
   dynamic _toJson() => _json;


### PR DESCRIPTION
Support for creating markers using “defaultMarker” or “fromAsset” is already supported. With “fromFile” support for adding local image files is added.