### PR TITLE
Fix biometrics check error below ios11.

### DIFF
--- a/packages/local_auth/ios/Classes/LocalAuthPlugin.m
+++ b/packages/local_auth/ios/Classes/LocalAuthPlugin.m
@@ -78,6 +78,9 @@
           [biometrics addObject:@"fingerprint"];
         }
       }
+      else {
+          [biometrics addObject:@"fingerprint"];
+      }
     }
   } else if (authError.code == LAErrorTouchIDNotEnrolled) {
     [biometrics addObject:@"undefined"];

--- a/packages/local_auth/ios/Classes/LocalAuthPlugin.m
+++ b/packages/local_auth/ios/Classes/LocalAuthPlugin.m
@@ -77,9 +77,8 @@
         } else if (context.biometryType == LABiometryTypeTouchID) {
           [biometrics addObject:@"fingerprint"];
         }
-      }
-      else {
-          [biometrics addObject:@"fingerprint"];
+      } else {
+        [biometrics addObject:@"fingerprint"];
       }
     }
   } else if (authError.code == LAErrorTouchIDNotEnrolled) {


### PR DESCRIPTION
Now in local_auth, the biometrics logic under ios11 is not working, fix it.
This would fix: https://github.com/flutter/flutter/issues/27366
https://github.com/flutter/flutter/issues/25635