### PR TITLE
Expose exception on the signIn method in Google sign in.

### DIFF
--- a/packages/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 4.0.0+1
 
-* Added better error message for iOS when the app is missing necessary URL schemes.
+* Added a better error message for iOS when the app is missing necessary URL schemes.
 
 ## 4.0.0
 

--- a/packages/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.0+1
+
+* Added better error message for iOS when the app is missing necessary URL schemes.
+
 ## 4.0.0
 
 * **Breaking change**. Migrate from the deprecated original Android Support

--- a/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
+++ b/packages/google_sign_in/ios/Classes/GoogleSignInPlugin.m
@@ -96,7 +96,12 @@ static NSString *const kErrorReasonSignInFailed = @"sign_in_failed";
     result(@([[GIDSignIn sharedInstance] hasAuthInKeychain]));
   } else if ([call.method isEqualToString:@"signIn"]) {
     if ([self setAccountRequest:result]) {
-      [[GIDSignIn sharedInstance] signIn];
+      @try {
+        [[GIDSignIn sharedInstance] signIn];
+      } @catch (NSException *e) {
+        result([FlutterError errorWithCode:@"google_sign_in" message:e.reason details:e.name]);
+        [e raise];
+      }
     }
   } else if ([call.method isEqualToString:@"getTokens"]) {
     GIDGoogleUser *currentUser = [GIDSignIn sharedInstance].currentUser;

--- a/packages/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_sign_in
-version: 4.0.0
+version: 4.0.0+1
 
 flutter:
   plugin:


### PR DESCRIPTION
Fix https://github.com/flutter/flutter/issues/12734
When users are setting up the google sign in plugin, if for some reason, the `<key>CFBundleURLTypes</key>` is not properly set, we do not provide a clear enough error message to make their debugging life happier. 

We would still like to crash the app since the crash would be a good reminder for the users to set up any necessary properties to use this plugin, and the users should not ship the product without fixing the issue that causes the exception. 

After this fix, the error message will be shown as 

```
flutter: PlatformException(google_sign_in, Your app is missing support for the following URL schemes: com.googleusercontent.apps.479882132969-9i9aqik3jfjd7qhci1nqf0bm2g71rm1u, NSInvalidArgumentException)
*** First throw call stack:
(
        0   CoreFoundation                      0x000000011332a1bb __exceptionPreprocess + 331
        1   libobjc.A.dylib                     0x00000001128c8735 objc_exception_throw + 48
        2   CoreFoundation                      0x000000011332a015 +[NSException raise:format:] + 197
        3   Runner                              0x000000010fa9652d -[GIDSignIn signInWithOptions:] + 242
        4   Runner                              0x000000010fa92b22 -[GIDSignIn signIn] + 64
        5   Runner                              0x000000010fa8aeeb -[FLTGoogleSignInPlugin handleMethodCall:result:] + 2251
        6   Flutter                             0x00000001105bffba __45-[FlutterMethodChannel setMethodCallHandler:]_block_invoke + 115
        7   Flutter                             0x00000001105dcc9c _ZNK5shel<…>
Lost connection to device.
```