### PR TITLE
[firebase_dynamic_links] sometimes got error NSPOSIXErrorDomain Code=53 in ios

### DIFF
--- a/packages/firebase_dynamic_links/CHANGELOG.md
+++ b/packages/firebase_dynamic_links/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1
+
+* Throw `PlatformException` if there is an error retrieving dynamic link.
+
 ## 0.2.0+4
 
 * Fix crash when receiving `ShortDynamicLink` warnings.

--- a/packages/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebasedynamiclinks/FirebaseDynamicLinksPlugin.java
+++ b/packages/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebasedynamiclinks/FirebaseDynamicLinksPlugin.java
@@ -3,6 +3,7 @@ package io.flutter.plugins.firebasedynamiclinks;
 import android.net.Uri;
 import androidx.annotation.NonNull;
 import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.dynamiclinks.DynamicLink;
 import com.google.firebase.dynamiclinks.FirebaseDynamicLinks;
@@ -83,6 +84,13 @@ public class FirebaseDynamicLinksPlugin implements MethodCallHandler {
                   }
                 }
                 result.success(null);
+              }
+            })
+        .addOnFailureListener(
+            new OnFailureListener() {
+              @Override
+              public void onFailure(@NonNull Exception e) {
+                result.error(e.getClass().getSimpleName(), e.getMessage(), null);
               }
             });
   }

--- a/packages/firebase_dynamic_links/pubspec.yaml
+++ b/packages/firebase_dynamic_links/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_dynamic_links
 description: Flutter plugin for Google Dynamic Links for Firebase, an app solution for creating
   and handling links across multiple platforms.
-version: 0.2.0+4
+version: 0.2.1
 
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_dynamic_links


### PR DESCRIPTION
As in link, there is a case of nil at the completion of handleUniversalLink.
https://github.com/firebase/firebase-ios-sdk/issues/2303

Also, even if  sleep,  cause an error, so fixed it to tell
it to the dart side.

https://github.com/flutter/flutter/issues/27810