### PR TITLE
Update FirebaseAuthPlugin.java

### DIFF
--- a/packages/firebase_auth/android/src/main/java/io/flutter/plugins/firebaseauth/FirebaseAuthPlugin.java
+++ b/packages/firebase_auth/android/src/main/java/io/flutter/plugins/firebaseauth/FirebaseAuthPlugin.java
@@ -383,12 +383,12 @@ public class FirebaseAuthPlugin implements MethodCallHandler {
           break;
         }
       case PhoneAuthProvider.PROVIDER_ID:
-      {
-        String accessToken = data.get("verificationId");
-        String smsCode = data.get("smsCode");
-        credential = PhoneAuthProvider.getCredential(accessToken, smsCode);
-        break;
-      }
+        {
+          String accessToken = data.get("verificationId");
+          String smsCode = data.get("smsCode");
+          credential = PhoneAuthProvider.getCredential(accessToken, smsCode);
+          break;
+        }
       default:
         {
           credential = null;

--- a/packages/firebase_auth/android/src/main/java/io/flutter/plugins/firebaseauth/FirebaseAuthPlugin.java
+++ b/packages/firebase_auth/android/src/main/java/io/flutter/plugins/firebaseauth/FirebaseAuthPlugin.java
@@ -382,6 +382,13 @@ public class FirebaseAuthPlugin implements MethodCallHandler {
           credential = GithubAuthProvider.getCredential(token);
           break;
         }
+      case PhoneAuthProvider.PROVIDER_ID:
+      {
+        String accessToken = data.get("verificationId");
+        String smsCode = data.get("smsCode");
+        credential = PhoneAuthProvider.getCredential(accessToken, smsCode);
+        break;
+      }
       default:
         {
           credential = null;


### PR DESCRIPTION
A lot of people have problem with the getCredential(...) method, because there is no switch case for PhoneAuthProvider, making it impossible to get the credentials for phone authentication. This few lines fix the nullPointer exception problem for phone authentication