### PR TITLE
[camera] Added a check for pictureImageReader != null

### DIFF
--- a/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
+++ b/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
@@ -720,7 +720,10 @@ public class CameraPlugin implements MethodCallHandler {
       Surface previewSurface = new Surface(surfaceTexture);
       surfaces.add(previewSurface);
       captureRequestBuilder.addTarget(previewSurface);
-
+      if (pictureImageReader == null) {
+        sendErrorEvent("Failed to configure the camera for preview.");
+        return;
+      }
       surfaces.add(pictureImageReader.getSurface());
 
       cameraDevice.createCaptureSession(


### PR DESCRIPTION
Fixed an error `Attempt to invoke virtual method 'android.view.Surface android.media.ImageReader.getSurface()' on a null object reference`

This is the bug report:
https://github.com/flutter/flutter/issues/19595