### PR TITLE
Flutterfire apps no longer show a confusing log message about configuring default app

### DIFF
--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.1
+
+* No longer shows a confusing log message about configuring default app
+
 ## 0.9.0+1
 
 * Log a more detailed warning at build time about the previous AndroidX

--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 0.9.1
+## 0.9.0+2
 
-* No longer shows a confusing log message about configuring default app
+* Log messages about automatic configuration of the default app are now less confusing.
 
 ## 0.9.0+1
 

--- a/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
+++ b/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
@@ -278,6 +278,7 @@ const UInt8 TIMESTAMP = 136;
   self = [super init];
   if (self) {
     if (![FIRApp appNamed:@"__FIRAPP_DEFAULT"]) {
+      NSLog(@"Configuring the default Firebase app...");
       [FIRApp configure];
     }
     _listeners = [NSMutableDictionary<NSNumber *, id<FIRListenerRegistration>> dictionary];

--- a/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
+++ b/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
@@ -274,6 +274,7 @@ const UInt8 TIMESTAMP = 136;
     if (![FIRApp appNamed:@"__FIRAPP_DEFAULT"]) {
       NSLog(@"Configuring the default Firebase app...");
       [FIRApp configure];
+      NSLog(@"Configured the default Firebase app %@.", [FIRApp defaultApp].name);
     }
     _listeners = [NSMutableDictionary<NSNumber *, id<FIRListenerRegistration>> dictionary];
     _batches = [NSMutableDictionary<NSNumber *, FIRWriteBatch *> dictionary];

--- a/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
+++ b/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
@@ -277,7 +277,7 @@ const UInt8 TIMESTAMP = 136;
 - (instancetype)init {
   self = [super init];
   if (self) {
-    if (![FIRApp defaultApp]) {
+    if (![FIRApp appNamed:@"__FIRAPP_DEFAULT"]) {
       [FIRApp configure];
     }
     _listeners = [NSMutableDictionary<NSNumber *, id<FIRListenerRegistration>> dictionary];

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_firestore
-version: 0.9.1
+version: 0.9.0+1
 
 flutter:
   plugin:

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_firestore
-version: 0.9.0+1
+version: 0.9.1
 
 flutter:
   plugin:

--- a/packages/cloud_functions/CHANGELOG.md
+++ b/packages/cloud_functions/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1
+
+* No longer shows a confusing log message about configuring default app
+
 ## 0.1.0+1
 
 * Log a more detailed warning at build time about the previous AndroidX

--- a/packages/cloud_functions/CHANGELOG.md
+++ b/packages/cloud_functions/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 0.1.1
+## 0.1.0+2
 
-* No longer shows a confusing log message about configuring default app
+* Log messages about automatic configuration of the default app are now less confusing.
 
 ## 0.1.0+1
 

--- a/packages/cloud_functions/ios/Classes/CloudFunctionsPlugin.m
+++ b/packages/cloud_functions/ios/Classes/CloudFunctionsPlugin.m
@@ -25,6 +25,7 @@
   self = [super init];
   if (self) {
     if (![FIRApp appNamed:@"__FIRAPP_DEFAULT"]) {
+      NSLog(@"Configuring the default Firebase app...");
       [FIRApp configure];
     }
   }

--- a/packages/cloud_functions/ios/Classes/CloudFunctionsPlugin.m
+++ b/packages/cloud_functions/ios/Classes/CloudFunctionsPlugin.m
@@ -27,6 +27,7 @@
     if (![FIRApp appNamed:@"__FIRAPP_DEFAULT"]) {
       NSLog(@"Configuring the default Firebase app...");
       [FIRApp configure];
+      NSLog(@"Configured the default Firebase app %@.", [FIRApp defaultApp].name);
     }
   }
   return self;

--- a/packages/cloud_functions/ios/Classes/CloudFunctionsPlugin.m
+++ b/packages/cloud_functions/ios/Classes/CloudFunctionsPlugin.m
@@ -24,7 +24,7 @@
 - (instancetype)init {
   self = [super init];
   if (self) {
-    if (![FIRApp defaultApp]) {
+    if (![FIRApp appNamed:@"__FIRAPP_DEFAULT"]) {
       [FIRApp configure];
     }
   }

--- a/packages/cloud_functions/pubspec.yaml
+++ b/packages/cloud_functions/pubspec.yaml
@@ -1,7 +1,6 @@
 name: cloud_functions
 description: Flutter plugin for Cloud Functions.
 version: 0.1.1+1
->>>>>>> 2db554ebf8b52ac904941ef2888ac22dfd6b29a6
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_functions
 

--- a/packages/cloud_functions/pubspec.yaml
+++ b/packages/cloud_functions/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cloud_functions
 description: Flutter plugin for Cloud Functions.
-version: 0.1.0+1
+version: 0.1.0+2
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_functions
 

--- a/packages/cloud_functions/pubspec.yaml
+++ b/packages/cloud_functions/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cloud_functions
 description: Flutter plugin for Cloud Functions.
-version: 0.1.1
+version: 0.1.0+1
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_functions
 

--- a/packages/cloud_functions/pubspec.yaml
+++ b/packages/cloud_functions/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cloud_functions
 description: Flutter plugin for Cloud Functions.
-version: 0.1.0+1
+version: 0.1.1
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_functions
 

--- a/packages/firebase_admob/CHANGELOG.md
+++ b/packages/firebase_admob/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.1
+
+* No longer shows a confusing log message about configuring default app
+
 ## 0.8.0+1
 
 * Log a more detailed warning at build time about the previous AndroidX

--- a/packages/firebase_admob/CHANGELOG.md
+++ b/packages/firebase_admob/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 0.8.1
+## 0.8.0+2
 
-* No longer shows a confusing log message about configuring default app
+* Log messages about automatic configuration of the default app are now less confusing.
 
 ## 0.8.0+1
 

--- a/packages/firebase_admob/ios/Classes/FirebaseAdMobPlugin.m
+++ b/packages/firebase_admob/ios/Classes/FirebaseAdMobPlugin.m
@@ -31,6 +31,7 @@
   if (self && ![FIRApp appNamed:@"__FIRAPP_DEFAULT"]) {
     NSLog(@"Configuring the default Firebase app...");
     [FIRApp configure];
+    NSLog(@"Configured the default Firebase app %@.", [FIRApp defaultApp].name);
   }
   return self;
 }

--- a/packages/firebase_admob/ios/Classes/FirebaseAdMobPlugin.m
+++ b/packages/firebase_admob/ios/Classes/FirebaseAdMobPlugin.m
@@ -41,6 +41,7 @@
 - (instancetype)init {
   self = [super init];
   if (self && ![FIRApp appNamed:@"__FIRAPP_DEFAULT"]) {
+    NSLog(@"Configuring the default Firebase app...");
     [FIRApp configure];
   }
   return self;

--- a/packages/firebase_admob/ios/Classes/FirebaseAdMobPlugin.m
+++ b/packages/firebase_admob/ios/Classes/FirebaseAdMobPlugin.m
@@ -40,8 +40,7 @@
 
 - (instancetype)init {
   self = [super init];
-  if (self && ![FIRApp defaultApp]) {
-    FLTLogWarning(@"[FIRApp configure]");
+  if (self && ![FIRApp appNamed:@"__FIRAPP_DEFAULT"]) {
     [FIRApp configure];
   }
   return self;

--- a/packages/firebase_admob/pubspec.yaml
+++ b/packages/firebase_admob/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_admob
 description: Firebase AdMob plugin for Flutter applications.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_admob
-version: 0.8.0+1
+version: 0.8.1
 
 flutter:
   plugin:

--- a/packages/firebase_admob/pubspec.yaml
+++ b/packages/firebase_admob/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_admob
 description: Firebase AdMob plugin for Flutter applications.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_admob
-version: 0.8.1
+version: 0.8.0+2
 
 flutter:
   plugin:

--- a/packages/firebase_analytics/CHANGELOG.md
+++ b/packages/firebase_analytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.2
+
+* No longer shows a confusing log message about configuring default app
+
 ## 2.0.1
 
 * Log a more detailed warning at build time about the previous AndroidX

--- a/packages/firebase_analytics/CHANGELOG.md
+++ b/packages/firebase_analytics/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 2.0.2
+## 2.0.1+1
 
-* No longer shows a confusing log message about configuring default app
+* Log messages about automatic configuration of the default app are now less confusing.
 
 ## 2.0.1
 

--- a/packages/firebase_analytics/ios/Classes/FirebaseAnalyticsPlugin.m
+++ b/packages/firebase_analytics/ios/Classes/FirebaseAnalyticsPlugin.m
@@ -20,7 +20,7 @@
 - (instancetype)init {
   self = [super init];
   if (self) {
-    if (![FIRApp defaultApp]) {
+    if (![FIRApp appNamed:@"__FIRAPP_DEFAULT"]) {
       [FIRApp configure];
     }
   }

--- a/packages/firebase_analytics/ios/Classes/FirebaseAnalyticsPlugin.m
+++ b/packages/firebase_analytics/ios/Classes/FirebaseAnalyticsPlugin.m
@@ -23,6 +23,7 @@
     if (![FIRApp appNamed:@"__FIRAPP_DEFAULT"]) {
       NSLog(@"Configuring the default Firebase app...");
       [FIRApp configure];
+      NSLog(@"Configured the default Firebase app %@.", [FIRApp defaultApp].name);
     }
   }
   return self;

--- a/packages/firebase_analytics/ios/Classes/FirebaseAnalyticsPlugin.m
+++ b/packages/firebase_analytics/ios/Classes/FirebaseAnalyticsPlugin.m
@@ -21,6 +21,7 @@
   self = [super init];
   if (self) {
     if (![FIRApp appNamed:@"__FIRAPP_DEFAULT"]) {
+      NSLog(@"Configuring the default Firebase app...");
       [FIRApp configure];
     }
   }

--- a/packages/firebase_analytics/pubspec.yaml
+++ b/packages/firebase_analytics/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Analytics for Firebase, an app measuremen
   solution that provides insight on app usage and user engagement on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_analytics
-version: 2.0.1
+version: 2.0.2
 
 flutter:
   plugin:

--- a/packages/firebase_analytics/pubspec.yaml
+++ b/packages/firebase_analytics/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Analytics for Firebase, an app measuremen
   solution that provides insight on app usage and user engagement on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_analytics
-version: 2.0.2
+version: 2.0.1+1
 
 flutter:
   plugin:

--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.2
+
+* No longer shows a confusing log message about configuring default app
+
 ## 0.8.1
 
 * Fixes Firebase auth phone sign-in for Android.

--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 0.8.2
+## 0.8.1+1
 
-* No longer shows a confusing log message about configuring default app
+* Log messages about automatic configuration of the default app are now less confusing.
 
 ## 0.8.1
 

--- a/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
+++ b/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
@@ -51,6 +51,7 @@ int nextHandle = 0;
     if (![FIRApp appNamed:@"__FIRAPP_DEFAULT"]) {
       NSLog(@"Configuring the default Firebase app...");
       [FIRApp configure];
+      NSLog(@"Configured the default Firebase app %@.", [FIRApp defaultApp].name);
     }
   }
   return self;

--- a/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
+++ b/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
@@ -55,6 +55,7 @@ int nextHandle = 0;
   self = [super init];
   if (self) {
     if (![FIRApp appNamed:@"__FIRAPP_DEFAULT"]) {
+      NSLog(@"Configuring the default Firebase app...");
       [FIRApp configure];
     }
   }

--- a/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
+++ b/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
@@ -54,7 +54,7 @@ int nextHandle = 0;
 - (instancetype)init {
   self = [super init];
   if (self) {
-    if (![FIRApp defaultApp]) {
+    if (![FIRApp appNamed:@"__FIRAPP_DEFAULT"]) {
       [FIRApp configure];
     }
   }

--- a/packages/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Firebase Auth, enabling Android and iOS
   like Google, Facebook and Twitter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_auth
-version: "0.8.2"
+version: "0.8.1+1"
 
 flutter:
   plugin:

--- a/packages/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Firebase Auth, enabling Android and iOS
   like Google, Facebook and Twitter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_auth
-version: "0.8.1"
+version: "0.8.2"
 
 flutter:
   plugin:

--- a/packages/firebase_database/CHANGELOG.md
+++ b/packages/firebase_database/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.2
+
+* No longer shows a confusing log message about configuring default app
+
 ## 2.0.1
 
 * Log a more detailed warning at build time about the previous AndroidX

--- a/packages/firebase_database/CHANGELOG.md
+++ b/packages/firebase_database/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 2.0.2
+## 2.0.1+1
 
-* No longer shows a confusing log message about configuring default app
+* Log messages about automatic configuration of the default app are now less confusing.
 
 ## 2.0.1
 

--- a/packages/firebase_database/CHANGELOG.md
+++ b/packages/firebase_database/CHANGELOG.md
@@ -1,10 +1,10 @@
+## 2.0.1+2
+
+* Log messages about automatic configuration of the default app are now less confusing.
+
 ## 2.0.1+1
 
-<<<<<<< HEAD
-* Log messages about automatic configuration of the default app are now less confusing.
-=======
 * Remove categories.
->>>>>>> 3b9a34192561a45ed175492ab10d6e0ef90f4c95
 
 ## 2.0.1
 

--- a/packages/firebase_database/ios/Classes/FirebaseDatabasePlugin.m
+++ b/packages/firebase_database/ios/Classes/FirebaseDatabasePlugin.m
@@ -150,7 +150,7 @@ id roundDoubles(id value) {
 - (instancetype)init {
   self = [super init];
   if (self) {
-    if (![FIRApp defaultApp]) {
+    if (![FIRApp appNamed:@"__FIRAPP_DEFAULT"]) {
       [FIRApp configure];
     }
     self.updatedSnapshots = [NSMutableDictionary new];

--- a/packages/firebase_database/ios/Classes/FirebaseDatabasePlugin.m
+++ b/packages/firebase_database/ios/Classes/FirebaseDatabasePlugin.m
@@ -151,6 +151,7 @@ id roundDoubles(id value) {
   self = [super init];
   if (self) {
     if (![FIRApp appNamed:@"__FIRAPP_DEFAULT"]) {
+      NSLog(@"Configuring the default Firebase app...");
       [FIRApp configure];
     }
     self.updatedSnapshots = [NSMutableDictionary new];

--- a/packages/firebase_database/ios/Classes/FirebaseDatabasePlugin.m
+++ b/packages/firebase_database/ios/Classes/FirebaseDatabasePlugin.m
@@ -147,6 +147,7 @@ id roundDoubles(id value) {
     if (![FIRApp appNamed:@"__FIRAPP_DEFAULT"]) {
       NSLog(@"Configuring the default Firebase app...");
       [FIRApp configure];
+      NSLog(@"Configured the default Firebase app %@.", [FIRApp defaultApp].name);
     }
     self.updatedSnapshots = [NSMutableDictionary new];
   }

--- a/packages/firebase_database/pubspec.yaml
+++ b/packages/firebase_database/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Database, a cloud-hosted NoSQL database
   with realtime data syncing across Android and iOS clients, and offline access.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_database
-version: 2.0.1
+version: 2.0.2
 
 flutter:
   plugin:

--- a/packages/firebase_database/pubspec.yaml
+++ b/packages/firebase_database/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Database, a cloud-hosted NoSQL database
   with realtime data syncing across Android and iOS clients, and offline access.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_database
-version: 2.0.2
+version: 2.0.1+1
 
 flutter:
   plugin:

--- a/packages/firebase_dynamic_links/CHANGELOG.md
+++ b/packages/firebase_dynamic_links/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1
+
+* No longer shows a confusing log message about configuring default app
+
 ## 0.2.0+1
 
 * Log a more detailed warning at build time about the previous AndroidX

--- a/packages/firebase_dynamic_links/CHANGELOG.md
+++ b/packages/firebase_dynamic_links/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 0.2.1
+## 0.2.0+2
 
-* No longer shows a confusing log message about configuring default app
+* Log messages about automatic configuration of the default app are now less confusing.
 
 ## 0.2.0+1
 

--- a/packages/firebase_dynamic_links/ios/Classes/FirebaseDynamicLinksPlugin.m
+++ b/packages/firebase_dynamic_links/ios/Classes/FirebaseDynamicLinksPlugin.m
@@ -28,6 +28,7 @@ static FlutterError *getFlutterError(NSError *error) {
     if (![FIRApp appNamed:@"__FIRAPP_DEFAULT"]) {
       NSLog(@"Configuring the default Firebase app...");
       [FIRApp configure];
+      NSLog(@"Configured the default Firebase app %@.", [FIRApp defaultApp].name);
     }
   }
   return self;

--- a/packages/firebase_dynamic_links/ios/Classes/FirebaseDynamicLinksPlugin.m
+++ b/packages/firebase_dynamic_links/ios/Classes/FirebaseDynamicLinksPlugin.m
@@ -32,6 +32,7 @@
   self = [super init];
   if (self) {
     if (![FIRApp appNamed:@"__FIRAPP_DEFAULT"]) {
+      NSLog(@"Configuring the default Firebase app...");
       [FIRApp configure];
     }
   }

--- a/packages/firebase_dynamic_links/ios/Classes/FirebaseDynamicLinksPlugin.m
+++ b/packages/firebase_dynamic_links/ios/Classes/FirebaseDynamicLinksPlugin.m
@@ -31,7 +31,7 @@
 - (instancetype)init {
   self = [super init];
   if (self) {
-    if (![FIRApp defaultApp]) {
+    if (![FIRApp appNamed:@"__FIRAPP_DEFAULT"]) {
       [FIRApp configure];
     }
   }

--- a/packages/firebase_dynamic_links/pubspec.yaml
+++ b/packages/firebase_dynamic_links/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_dynamic_links
 description: Flutter plugin for Google Dynamic Links for Firebase, an app solution for creating
   and handling links across multiple platforms.
-version: 0.2.1
+version: 0.2.0+1
 
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_dynamic_links

--- a/packages/firebase_dynamic_links/pubspec.yaml
+++ b/packages/firebase_dynamic_links/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_dynamic_links
 description: Flutter plugin for Google Dynamic Links for Firebase, an app solution for creating
   and handling links across multiple platforms.
-version: 0.2.0+1
+version: 0.2.1
 
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_dynamic_links

--- a/packages/firebase_messaging/CHANGELOG.md
+++ b/packages/firebase_messaging/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 3.0.2
+## 3.0.1+1
 
-* No longer shows a confusing log message about configuring default app
+* Log messages about automatic configuration of the default app are now less confusing.
 
 ## 3.0.1
 

--- a/packages/firebase_messaging/CHANGELOG.md
+++ b/packages/firebase_messaging/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.2
+
+* No longer shows a confusing log message about configuring default app
+
 ## 3.0.1
 
 * Log a more detailed warning at build time about the previous AndroidX

--- a/packages/firebase_messaging/ios/Classes/FirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/ios/Classes/FirebaseMessagingPlugin.m
@@ -33,7 +33,7 @@
   if (self) {
     _channel = channel;
     _resumingFromBackground = NO;
-    if (![FIRApp defaultApp]) {
+    if (![FIRApp appNamed:@"__FIRAPP_DEFAULT"]) {
       [FIRApp configure];
     }
     [FIRMessaging messaging].delegate = self;

--- a/packages/firebase_messaging/ios/Classes/FirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/ios/Classes/FirebaseMessagingPlugin.m
@@ -34,6 +34,7 @@
     _channel = channel;
     _resumingFromBackground = NO;
     if (![FIRApp appNamed:@"__FIRAPP_DEFAULT"]) {
+      NSLog(@"Configuring the default Firebase app...");
       [FIRApp configure];
     }
     [FIRMessaging messaging].delegate = self;

--- a/packages/firebase_messaging/ios/Classes/FirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/ios/Classes/FirebaseMessagingPlugin.m
@@ -36,6 +36,7 @@
     if (![FIRApp appNamed:@"__FIRAPP_DEFAULT"]) {
       NSLog(@"Configuring the default Firebase app...");
       [FIRApp configure];
+      NSLog(@"Configured the default Firebase app %@.", [FIRApp defaultApp].name);
     }
     [FIRMessaging messaging].delegate = self;
   }

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Cloud Messaging, a cross-platform
   messaging solution that lets you reliably deliver messages on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_messaging
-version: 3.0.2
+version: 3.0.1+1
 
 flutter:
   plugin:

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Cloud Messaging, a cross-platform
   messaging solution that lets you reliably deliver messages on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_messaging
-version: 3.0.1
+version: 3.0.2
 
 flutter:
   plugin:

--- a/packages/firebase_ml_vision/CHANGELOG.md
+++ b/packages/firebase_ml_vision/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1
+
+* No longer shows a confusing log message about configuring default app
+
 ## 0.4.0+1
 
 * Log a more detailed warning at build time about the previous AndroidX

--- a/packages/firebase_ml_vision/CHANGELOG.md
+++ b/packages/firebase_ml_vision/CHANGELOG.md
@@ -25,7 +25,6 @@
 
 * Fixes `FIRAnalyticsVersionMismatch` compilation error on iOS. Please run `pod update` in directory
   containing `Podfile`.
->>>>>>> 3b9a34192561a45ed175492ab10d6e0ef90f4c95
 
 ## 0.5.0
 

--- a/packages/firebase_ml_vision/ios/Classes/FirebaseMlVisionPlugin.m
+++ b/packages/firebase_ml_vision/ios/Classes/FirebaseMlVisionPlugin.m
@@ -25,6 +25,7 @@ static FlutterError *getFlutterError(NSError *error) {
     if (![FIRApp appNamed:@"__FIRAPP_DEFAULT"]) {
       NSLog(@"Configuring the default Firebase app...");
       [FIRApp configure];
+      NSLog(@"Configured the default Firebase app %@.", [FIRApp defaultApp].name);
     }
   }
   return self;

--- a/packages/firebase_ml_vision/ios/Classes/FirebaseMlVisionPlugin.m
+++ b/packages/firebase_ml_vision/ios/Classes/FirebaseMlVisionPlugin.m
@@ -29,6 +29,7 @@
   self = [super init];
   if (self) {
     if (![FIRApp appNamed:@"__FIRAPP_DEFAULT"]) {
+      NSLog(@"Configuring the default Firebase app...");
       [FIRApp configure];
     }
   }

--- a/packages/firebase_ml_vision/ios/Classes/FirebaseMlVisionPlugin.m
+++ b/packages/firebase_ml_vision/ios/Classes/FirebaseMlVisionPlugin.m
@@ -28,7 +28,7 @@
 - (instancetype)init {
   self = [super init];
   if (self) {
-    if (![FIRApp defaultApp]) {
+    if (![FIRApp appNamed:@"__FIRAPP_DEFAULT"]) {
       [FIRApp configure];
     }
   }

--- a/packages/firebase_ml_vision/pubspec.yaml
+++ b/packages/firebase_ml_vision/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_ml_vision
 description: Flutter plugin for Firebase machine learning vision services.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_ml_vision
-version: 0.4.0+1
+version: 0.4.1
 
 dependencies:
   flutter:

--- a/packages/firebase_performance/CHANGELOG.md
+++ b/packages/firebase_performance/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1
+
+* No longer shows a confusing log message about configuring default app
+
 ## 0.1.0+1
 
 * Log a more detailed warning at build time about the previous AndroidX

--- a/packages/firebase_performance/CHANGELOG.md
+++ b/packages/firebase_performance/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 * Log messages about automatic configuration of the default app are now less confusing.
 
- longer shows a confusing log message about configuring default app
-
 ## 0.1.0+2
 
 * Fixed bug where `Traces` and `HttpMetrics` weren't being passed to Firebase on iOS.

--- a/packages/firebase_performance/ios/Classes/FirebasePerformancePlugin.m
+++ b/packages/firebase_performance/ios/Classes/FirebasePerformancePlugin.m
@@ -26,6 +26,7 @@
     if (![FIRApp appNamed:@"__FIRAPP_DEFAULT"]) {
       NSLog(@"Configuring the default Firebase app...");
       [FIRApp configure];
+      NSLog(@"Configured the default Firebase app %@.", [FIRApp defaultApp].name);
     }
 
     _traces = [[NSMutableDictionary alloc] init];

--- a/packages/firebase_performance/ios/Classes/FirebasePerformancePlugin.m
+++ b/packages/firebase_performance/ios/Classes/FirebasePerformancePlugin.m
@@ -23,7 +23,7 @@
 - (instancetype)init {
   self = [super init];
   if (self) {
-    if (![FIRApp defaultApp]) {
+    if (![FIRApp appNamed:@"__FIRAPP_DEFAULT"]) {
       [FIRApp configure];
       _traces = [[NSMutableDictionary alloc] init];
     }

--- a/packages/firebase_performance/ios/Classes/FirebasePerformancePlugin.m
+++ b/packages/firebase_performance/ios/Classes/FirebasePerformancePlugin.m
@@ -24,6 +24,7 @@
   self = [super init];
   if (self) {
     if (![FIRApp appNamed:@"__FIRAPP_DEFAULT"]) {
+      NSLog(@"Configuring the default Firebase app...");
       [FIRApp configure];
       _traces = [[NSMutableDictionary alloc] init];
     }

--- a/packages/firebase_performance/pubspec.yaml
+++ b/packages/firebase_performance/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Google Performance Monitoring for Firebase, an a
   iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_performance
-version: 0.1.0+1
+version: 0.1.1
 
 dependencies:
   flutter:

--- a/packages/firebase_remote_config/CHANGELOG.md
+++ b/packages/firebase_remote_config/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1
+
+* No longer shows a confusing log message about configuring default app
+
 ## 0.1.0+1
 
 * Log a more detailed warning at build time about the previous AndroidX

--- a/packages/firebase_remote_config/CHANGELOG.md
+++ b/packages/firebase_remote_config/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 0.1.1
+## 0.1.0+2
 
-* No longer shows a confusing log message about configuring default app
+* Log messages about automatic configuration of the default app are now less confusing.
 
 ## 0.1.0+1
 

--- a/packages/firebase_remote_config/ios/Classes/FirebaseRemoteConfigPlugin.m
+++ b/packages/firebase_remote_config/ios/Classes/FirebaseRemoteConfigPlugin.m
@@ -22,6 +22,7 @@
     if (![FIRApp appNamed:@"__FIRAPP_DEFAULT"]) {
       NSLog(@"Configuring the default Firebase app...");
       [FIRApp configure];
+      NSLog(@"Configured the default Firebase app %@.", [FIRApp defaultApp].name);
     }
   }
   return self;

--- a/packages/firebase_remote_config/ios/Classes/FirebaseRemoteConfigPlugin.m
+++ b/packages/firebase_remote_config/ios/Classes/FirebaseRemoteConfigPlugin.m
@@ -20,6 +20,7 @@
   self = [super init];
   if (self) {
     if (![FIRApp appNamed:@"__FIRAPP_DEFAULT"]) {
+      NSLog(@"Configuring the default Firebase app...");
       [FIRApp configure];
     }
   }

--- a/packages/firebase_remote_config/ios/Classes/FirebaseRemoteConfigPlugin.m
+++ b/packages/firebase_remote_config/ios/Classes/FirebaseRemoteConfigPlugin.m
@@ -19,7 +19,7 @@
 - (instancetype)init {
   self = [super init];
   if (self) {
-    if (![FIRApp defaultApp]) {
+    if (![FIRApp appNamed:@"__FIRAPP_DEFAULT"]) {
       [FIRApp configure];
     }
   }

--- a/packages/firebase_remote_config/pubspec.yaml
+++ b/packages/firebase_remote_config/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Remote Config. Update your application 
   re-releasing.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_remote_config
-version: 0.1.1
+version: 0.1.0+2
 
 dependencies:
   flutter:

--- a/packages/firebase_remote_config/pubspec.yaml
+++ b/packages/firebase_remote_config/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Remote Config. Update your application 
   re-releasing.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_remote_config
-version: 0.1.0+1
+version: 0.1.1
 
 dependencies:
   flutter:

--- a/packages/firebase_storage/CHANGELOG.md
+++ b/packages/firebase_storage/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.2
+
+* No longer shows a confusing log message about configuring default app
+
 ## 2.0.1
 
 * Log a more detailed warning at build time about the previous AndroidX

--- a/packages/firebase_storage/CHANGELOG.md
+++ b/packages/firebase_storage/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 2.0.2
+## 2.0.1+1
 
-* No longer shows a confusing log message about configuring default app
+* Log messages about automatic configuration of the default app are now less confusing.
 
 ## 2.0.1
 

--- a/packages/firebase_storage/ios/Classes/FirebaseStoragePlugin.m
+++ b/packages/firebase_storage/ios/Classes/FirebaseStoragePlugin.m
@@ -39,6 +39,7 @@ static FlutterError *getFlutterError(NSError *error) {
     if (![FIRApp appNamed:@"__FIRAPP_DEFAULT"]) {
       NSLog(@"Configuring the default Firebase app...");
       [FIRApp configure];
+      NSLog(@"Configured the default Firebase app %@.", [FIRApp defaultApp].name);
     }
     _storageMap = [[NSMutableDictionary alloc] init];
     _uploadTasks = [NSMutableDictionary<NSNumber *, FIRStorageUploadTask *> dictionary];

--- a/packages/firebase_storage/ios/Classes/FirebaseStoragePlugin.m
+++ b/packages/firebase_storage/ios/Classes/FirebaseStoragePlugin.m
@@ -43,6 +43,7 @@
   self = [super init];
   if (self) {
     if (![FIRApp appNamed:@"__FIRAPP_DEFAULT"]) {
+      NSLog(@"Configuring the default Firebase app...");
       [FIRApp configure];
     }
     _storageMap = [[NSMutableDictionary alloc] init];

--- a/packages/firebase_storage/ios/Classes/FirebaseStoragePlugin.m
+++ b/packages/firebase_storage/ios/Classes/FirebaseStoragePlugin.m
@@ -42,7 +42,7 @@
 - (instancetype)init {
   self = [super init];
   if (self) {
-    if (![FIRApp defaultApp]) {
+    if (![FIRApp appNamed:@"__FIRAPP_DEFAULT"]) {
       [FIRApp configure];
     }
     _storageMap = [[NSMutableDictionary alloc] init];

--- a/packages/firebase_storage/pubspec.yaml
+++ b/packages/firebase_storage/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Cloud Storage, a powerful, simple, and
   cost-effective object storage service for Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_storage
-version: 2.0.1
+version: 2.0.2
 
 flutter:
   plugin:

--- a/packages/firebase_storage/pubspec.yaml
+++ b/packages/firebase_storage/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Cloud Storage, a powerful, simple, and
   cost-effective object storage service for Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_storage
-version: 2.0.2
+version: 2.0.1+1
 
 flutter:
   plugin:


### PR DESCRIPTION
Fixes flutter/flutter#16534

Note that this doesn't completely fix the issue, it just changes the error message from the previous, really confusing:

```
"4.8.1 - [Firebase/Core][I-COR000003] The default Firebase app has not yet been configured.
Add `[FIRApp configure];` (`FirebaseApp.configure()` in Swift) to your application
initialization.
```

New log message:

```
[Firebase/Core][I-COR000004] App with name __FIRAPP_DEFAULT does not exist.
```