### PR TITLE
Mark some packages as unpublishable

### DIFF
--- a/packages/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/pubspec.yaml
@@ -3,6 +3,7 @@ description: A Flutter plugin for in-app purchases.
 author:  Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/in_app_purchase
 version: 0.0.2
+publish_to: none # Not ready to be uploaded
 
 dependencies:
   async: ^2.0.8

--- a/packages/location_background/pubspec.yaml
+++ b/packages/location_background/pubspec.yaml
@@ -3,6 +3,7 @@ description: A new flutter plugin project.
 author:  Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/location_background
 version: 0.1.0+1
+publish_to: none
 
 dependencies:
   flutter:

--- a/script/check_publish.sh
+++ b/script/check_publish.sh
@@ -15,7 +15,9 @@ function check_publish() {
   for package_name in "$@"; do
     local dir="$REPO_DIR/packages/$package_name"
     echo "Checking that $package_name can be published."
-    if (cd "$dir" && pub publish --dry-run > /dev/null); then
+    if [[ $(cd "$dir" && cat pubspec.yaml | grep -E "^publish_to: none") ]]; then
+      echo "Package $package_name is marked as unpublishable. Skipping."
+    elif (cd "$dir" && pub publish --dry-run > /dev/null); then
       echo "Package $package_name is able to be published."
     else
       error "Unable to publish $package_name"


### PR DESCRIPTION
Skip publish checks on `publish_to: none` packages so that CI doesn't
fail with this change.

Related to flutter/flutter#27258
Works around dart-lang/pub#2004