### PR TITLE
Fix bug where HttpMetric/Trace dictionaries weren't being initialized on iOS

### DIFF
--- a/packages/firebase_performance/CHANGELOG.md
+++ b/packages/firebase_performance/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0+2
+
+* Fixed bug where `Traces` and `HttpMetrics` weren't being passed to Firebase on iOS.
+
 ## 0.1.0+1
 
 * Log a more detailed warning at build time about the previous AndroidX

--- a/packages/firebase_performance/ios/Classes/FirebasePerformancePlugin.m
+++ b/packages/firebase_performance/ios/Classes/FirebasePerformancePlugin.m
@@ -25,8 +25,10 @@
   if (self) {
     if (![FIRApp defaultApp]) {
       [FIRApp configure];
-      _traces = [[NSMutableDictionary alloc] init];
     }
+
+    _traces = [[NSMutableDictionary alloc] init];
+    _httpMetrics = [[NSMutableDictionary alloc] init];
   }
 
   return self;

--- a/packages/firebase_performance/pubspec.yaml
+++ b/packages/firebase_performance/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Google Performance Monitoring for Firebase, an a
   iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_performance
-version: 0.1.0+1
+version: 0.1.0+2
 
 dependencies:
   flutter:


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/24518