### PR TITLE
Introduce CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,17 @@
+packages/cloud_firestore/* @collinjackson @kroikie
+packages/firebase_auth/* @collinjackson @kroikie
+packages/firebase_messaging/* @collinjackson @kroikie
+packages/camera/* @bparrishMines 
+packages/firebase_admob/* @amirh
+packages/firebase_ml_vision/* @bparrishMines
+packages/image_picker/* @cyanglaz
+packages/android_alarm_manager/* @bkonyi
+packages/google_maps_flutter/* @amirh
+packages/google_sign_in/* @cyanglaz
+packages/firebase_database/* @collinjackson @kroikie
+packages/firebase_storage/* @collinjackson @kroikie
+packages/package_info/* @cyanglaz
+packages/firebase_analytics/* @collinjackson @kroikie
+packages/connectivity/* @cyanglaz
+packages/webview_flutter/* @amirh
+

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,6 @@
+# Below is a list of Flutter team members who are suggested reviewers
+# for contributions to plugins in this repository.
+
 packages/cloud_firestore/* @collinjackson @kroikie
 packages/firebase_auth/* @collinjackson @kroikie
 packages/firebase_messaging/* @collinjackson @kroikie

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,16 +1,20 @@
 # Below is a list of Flutter team members who are suggested reviewers
 # for contributions to plugins in this repository.
+#
+# These names are just suggestions. It is fine to have your changes
+# reviewed by someone else.
 
 packages/cloud_firestore/* @collinjackson @kroikie
 packages/firebase_auth/* @collinjackson @kroikie
 packages/firebase_messaging/* @collinjackson @kroikie
-packages/camera/* @bparrishMines 
+packages/camera/* @bparrishMines @mklim
 packages/firebase_admob/* @amirh
 packages/firebase_ml_vision/* @bparrishMines
 packages/image_picker/* @cyanglaz
 packages/android_alarm_manager/* @bkonyi
 packages/google_maps_flutter/* @amirh
-packages/google_sign_in/* @cyanglaz
+packages/google_sign_in/* @cyanglaz @mehmetf
+packages/in_app_purchase/* @mklim
 packages/firebase_database/* @collinjackson @kroikie
 packages/firebase_storage/* @collinjackson @kroikie
 packages/package_info/* @cyanglaz


### PR DESCRIPTION
See https://github.blog/2017-07-06-introducing-code-owners/

The idea here is to identify a default reviewer for pull requests automatically.

We don't have the protected branch feature on. That's an option to consider in the future, but I think it's relatively common to do a push of all first-party plugins without getting CODEOWNERS signoff.