### PR TITLE
Set GoogleAppMeasurement dependency version

### DIFF
--- a/packages/firebase_ml_vision/CHANGELOG.md
+++ b/packages/firebase_ml_vision/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.0+1
+
+* Fixes `FIRAnalyticsVersionMismatch` compilation error on iOS. Please run `pod update` in directory
+  containing `Podfile`.
+
 ## 0.5.0
 
 * **Breaking Change** Change `Rectangle<int>` to `Rect` in Text/Face/Barcode results.

--- a/packages/firebase_ml_vision/ios/firebase_ml_vision.podspec
+++ b/packages/firebase_ml_vision/ios/firebase_ml_vision.podspec
@@ -22,6 +22,7 @@ An SDK that brings Google's machine learning expertise to Android and iOS apps i
   s.dependency 'Firebase/MLVisionFaceModel'
   s.dependency 'Firebase/MLVisionLabelModel'
   s.dependency 'Firebase/MLVisionTextModel'
+  s.dependency 'GoogleAppMeasurement', '~> 5.3.0'
   s.ios.deployment_target = '8.0'
   s.static_framework = true
 end

--- a/packages/firebase_ml_vision/pubspec.yaml
+++ b/packages/firebase_ml_vision/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_ml_vision
 description: Flutter plugin for Firebase machine learning vision services.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_ml_vision
-version: 0.5.0
+version: 0.5.0+1
 
 dependencies:
   flutter:


### PR DESCRIPTION
When using `firebase_ml_vision` plugin, you would receive this error after running `pod update`:
```
*** Terminating app due to uncaught exception 'FIRAnalyticsVersionMismatch', reason:
 'Google Analytics for Firebase version (50300000) does not match with Google App Measurement 
(50500000) version. Please update.'
```

We solve this by setting the compatible `GoogleAppMeasurement` version in plugin podspec.

Fixes https://github.com/flutter/flutter/issues/23259