### PR TITLE
[firebase_auth] update example app and README

### DIFF
--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## 0.8.1+2
 
 * Update README.
+* Update the example app. The example app now have two separate pages includes a `Registration` page and a `SignIn/SignOut` page. The SignIn methods included in the `SignIn/SignOut` page are:
+    * `Google authentication`
+    * `Email&Password authentication`
+    * `Phone authentication`
+    * `Anonymously Sign in`
 
 ## 0.8.1+1
 

--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,6 +1,10 @@
+## 0.8.1+2
+
+* Update README.
+
 ## 0.8.1+1
 
-* Updates README.
+* Remove categories.
 
 ## 0.8.1
 

--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,11 +1,7 @@
 ## 0.8.1+2
 
 * Update README.
-* Update the example app. The example app now have two separate pages includes a `Registration` page and a `SignIn/SignOut` page. The SignIn methods included in the `SignIn/SignOut` page are:
-    * `Google authentication`
-    * `Email&Password authentication`
-    * `Phone authentication`
-    * `Anonymously Sign in`
+* Update the example app with separate pages for registration and sign-in.
 
 ## 0.8.1+1
 

--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.1+1
+
+* Updates README.
+
 ## 0.8.1
 
 * Fixes Firebase auth phone sign-in for Android.

--- a/packages/firebase_auth/README.md
+++ b/packages/firebase_auth/README.md
@@ -95,12 +95,12 @@ final FirebaseUser user = await _auth.createUserWithEmailAndPassword(
 ### Supported Firebase authentication methods
 
 * `Google authentication`
-
 * `Email&Password authentication`
-
 * `Phone authentication`
-
 * `Anonymously Sign in`
+* `Github authentication`
+* `Facebook authentication`
+* `Twitter authentication`
 
 ### Phone Auth
 

--- a/packages/firebase_auth/README.md
+++ b/packages/firebase_auth/README.md
@@ -83,10 +83,29 @@ _handleSignIn()
     .catchError((e) => print(e));
 ```
 
+### Register a user
+
+You can now register a new user using firebase_auth, e.g.
+```dart
+final FirebaseUser user = await _auth.createUserWithEmailAndPassword(
+      email: 'an email',
+      password: 'a password',
+    );
+```
+
+### Supported firebase authentication methods.
+
+Supported authentication methods includes `Google authentication`, `Email&Password authentication`, `Phone authentication` and `Anonymously Sign in`.
+
 ### Phone Auth
 
 You can use Firebase Authentication to sign in a user by sending an SMS message to
 the user's phone. The user signs in using a one-time code contained in the SMS message.
+
+### After authentication
+
+After a successful authentication, you should get a FirebaseUser object. You can use this object to check if the email is verified, to update email, to send verification email and etc. See [Documentation](https://pub.dartlang.org/documentation/firebase_auth/latest/firebase_auth/FirebaseUser-class.html) for more details on the FirebaseUser Object.
+
 
 #### iOS setup
 

--- a/packages/firebase_auth/README.md
+++ b/packages/firebase_auth/README.md
@@ -10,7 +10,7 @@ For Flutter plugins for other Firebase products, see [FlutterFire.md](https://gi
 ## Usage
 
 ### Configure the Google sign-in plugin
-The Google Sign-in plugin is required to use the firebase_auth plugin. Follow the [Google sign-in plugin installation instructions](https://pub.dartlang.org/packages/google_sign_in#pub-pkg-tab-installing).
+The Google Sign-in plugin is required to use the Firebase_auth plugin. Follow the [Google sign-in plugin installation instructions](https://pub.dartlang.org/packages/google_sign_in#pub-pkg-tab-installing).
 
 ### Import the firebase_auth plugin
 To use the firebase_auth plugin, follow the [plugin installation instructions](https://pub.dartlang.org/packages/firebase_auth#pub-pkg-tab-installing).
@@ -85,7 +85,6 @@ _handleSignIn()
 
 ### Register a user
 
-You can now register a new user using firebase_auth, e.g.
 ```dart
 final FirebaseUser user = await _auth.createUserWithEmailAndPassword(
       email: 'an email',
@@ -93,9 +92,15 @@ final FirebaseUser user = await _auth.createUserWithEmailAndPassword(
     );
 ```
 
-### Supported firebase authentication methods.
+### Supported Firebase authentication methods
 
-Supported authentication methods includes `Google authentication`, `Email&Password authentication`, `Phone authentication` and `Anonymously Sign in`.
+* `Google authentication`
+
+* `Email&Password authentication`
+
+* `Phone authentication`
+
+* `Anonymously Sign in`
 
 ### Phone Auth
 
@@ -104,7 +109,7 @@ the user's phone. The user signs in using a one-time code contained in the SMS m
 
 ### After authentication
 
-After a successful authentication, you should get a FirebaseUser object. You can use this object to check if the email is verified, to update email, to send verification email and etc. See [Documentation](https://pub.dartlang.org/documentation/firebase_auth/latest/firebase_auth/FirebaseUser-class.html) for more details on the FirebaseUser Object.
+After a successful authentication, you will receive a `FirebaseUser` object. You can use this object to check if the email is verified, to update email, to send verification email and etc. See [Documentation](https://pub.dartlang.org/documentation/firebase_auth/latest/firebase_auth/FirebaseUser-class.html) for more details on the `FirebaseUser` Object.
 
 
 #### iOS setup

--- a/packages/firebase_auth/README.md
+++ b/packages/firebase_auth/README.md
@@ -109,7 +109,7 @@ the user's phone. The user signs in using a one-time code contained in the SMS m
 
 ### After authentication
 
-After a successful authentication, you will receive a `FirebaseUser` object. You can use this object to check if the email is verified, to update email, to send verification email and so on. See the [FirebaseUser](https://pub.dartlang.org/documentation/firebase_auth/latest/firebase_auth/FirebaseUser-class.html) API documentation for more details on the `FirebaseUser` Object.
+After a successful authentication, you will receive a `FirebaseUser` object. You can use this object to check if the email is verified, to update email, to send verification email and so on. See the [FirebaseUser](https://pub.dartlang.org/documentation/firebase_auth/latest/firebase_auth/FirebaseUser-class.html) API documentation for more details on the `FirebaseUser` object.
 
 
 #### iOS setup

--- a/packages/firebase_auth/README.md
+++ b/packages/firebase_auth/README.md
@@ -10,7 +10,7 @@ For Flutter plugins for other Firebase products, see [FlutterFire.md](https://gi
 ## Usage
 
 ### Configure the Google sign-in plugin
-The Google Sign-in plugin is required to use the Firebase_auth plugin. Follow the [Google sign-in plugin installation instructions](https://pub.dartlang.org/packages/google_sign_in#pub-pkg-tab-installing).
+The Google Sign-in plugin is required to use the firebase_auth plugin. Follow the [Google sign-in plugin installation instructions](https://pub.dartlang.org/packages/google_sign_in#pub-pkg-tab-installing).
 
 ### Import the firebase_auth plugin
 To use the firebase_auth plugin, follow the [plugin installation instructions](https://pub.dartlang.org/packages/firebase_auth#pub-pkg-tab-installing).
@@ -94,13 +94,13 @@ final FirebaseUser user = await _auth.createUserWithEmailAndPassword(
 
 ### Supported Firebase authentication methods
 
-* `Google authentication`
-* `Email&Password authentication`
-* `Phone authentication`
-* `Anonymously Sign in`
-* `Github authentication`
-* `Facebook authentication`
-* `Twitter authentication`
+* Google
+* Email and Password
+* Phone
+* Anonymously
+* GitHub
+* Facebook
+* Twitter
 
 ### Phone Auth
 
@@ -109,7 +109,7 @@ the user's phone. The user signs in using a one-time code contained in the SMS m
 
 ### After authentication
 
-After a successful authentication, you will receive a `FirebaseUser` object. You can use this object to check if the email is verified, to update email, to send verification email and etc. See [Documentation](https://pub.dartlang.org/documentation/firebase_auth/latest/firebase_auth/FirebaseUser-class.html) for more details on the `FirebaseUser` Object.
+After a successful authentication, you will receive a `FirebaseUser` object. You can use this object to check if the email is verified, to update email, to send verification email and so on. See the [FirebaseUser](https://pub.dartlang.org/documentation/firebase_auth/latest/firebase_auth/FirebaseUser-class.html) API documentation for more details on the `FirebaseUser` Object.
 
 
 #### iOS setup

--- a/packages/firebase_auth/example/lib/main.dart
+++ b/packages/firebase_auth/example/lib/main.dart
@@ -51,8 +51,8 @@ class _MyHomePageState extends State<MyHomePage> {
           ),
           Container(
             child: RaisedButton(
-              child: const Text('Test signin/signout'),
-              onPressed: () => _pushPage(context, SigninPage()),
+              child: const Text('Test SignIn/SignOut'),
+              onPressed: () => _pushPage(context, SignInPage()),
             ),
             padding: const EdgeInsets.all(16),
             alignment: Alignment.center,

--- a/packages/firebase_auth/example/lib/main.dart
+++ b/packages/firebase_auth/example/lib/main.dart
@@ -2,15 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:google_sign_in/google_sign_in.dart';
-
-final FirebaseAuth _auth = FirebaseAuth.instance;
-final GoogleSignIn _googleSignIn = GoogleSignIn();
+import './register_page.dart';
+import './signin_page.dart';
 
 void main() {
   runApp(MyApp());
@@ -36,108 +31,7 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  Future<String> _message = Future<String>.value('');
-  TextEditingController _smsCodeController = TextEditingController();
-  String verificationId;
-  final String testSmsCode = '888888';
-  final String testPhoneNumber = '+1 408-555-6969';
-
-  Future<String> _testSignInAnonymously() async {
-    final FirebaseUser user = await _auth.signInAnonymously();
-    assert(user != null);
-    assert(user.isAnonymous);
-    assert(!user.isEmailVerified);
-    assert(await user.getIdToken() != null);
-    if (Platform.isIOS) {
-      // Anonymous auth doesn't show up as a provider on iOS
-      assert(user.providerData.isEmpty);
-    } else if (Platform.isAndroid) {
-      // Anonymous auth does show up as a provider on Android
-      assert(user.providerData.length == 1);
-      assert(user.providerData[0].providerId == 'firebase');
-      assert(user.providerData[0].uid != null);
-      assert(user.providerData[0].displayName == null);
-      assert(user.providerData[0].photoUrl == null);
-      assert(user.providerData[0].email == null);
-    }
-
-    final FirebaseUser currentUser = await _auth.currentUser();
-    assert(user.uid == currentUser.uid);
-
-    return 'signInAnonymously succeeded: $user';
-  }
-
-  Future<String> _testSignInWithGoogle() async {
-    final GoogleSignInAccount googleUser = await _googleSignIn.signIn();
-    final GoogleSignInAuthentication googleAuth =
-        await googleUser.authentication;
-    final AuthCredential credential = GoogleAuthProvider.getCredential(
-      accessToken: googleAuth.accessToken,
-      idToken: googleAuth.idToken,
-    );
-    final FirebaseUser user = await _auth.signInWithCredential(credential);
-    assert(user.email != null);
-    assert(user.displayName != null);
-    assert(!user.isAnonymous);
-    assert(await user.getIdToken() != null);
-
-    final FirebaseUser currentUser = await _auth.currentUser();
-    assert(user.uid == currentUser.uid);
-
-    return 'signInWithGoogle succeeded: $user';
-  }
-
-  Future<void> _testVerifyPhoneNumber() async {
-    final PhoneVerificationCompleted verificationCompleted =
-        (FirebaseUser user) {
-      setState(() {
-        _message =
-            Future<String>.value('signInWithPhoneNumber auto succeeded: $user');
-      });
-    };
-
-    final PhoneVerificationFailed verificationFailed =
-        (AuthException authException) {
-      setState(() {
-        _message = Future<String>.value(
-            'Phone number verification failed. Code: ${authException.code}. Message: ${authException.message}');
-      });
-    };
-
-    final PhoneCodeSent codeSent =
-        (String verificationId, [int forceResendingToken]) async {
-      this.verificationId = verificationId;
-      _smsCodeController.text = testSmsCode;
-    };
-
-    final PhoneCodeAutoRetrievalTimeout codeAutoRetrievalTimeout =
-        (String verificationId) {
-      this.verificationId = verificationId;
-      _smsCodeController.text = testSmsCode;
-    };
-
-    await _auth.verifyPhoneNumber(
-        phoneNumber: testPhoneNumber,
-        timeout: const Duration(seconds: 5),
-        verificationCompleted: verificationCompleted,
-        verificationFailed: verificationFailed,
-        codeSent: codeSent,
-        codeAutoRetrievalTimeout: codeAutoRetrievalTimeout);
-  }
-
-  Future<String> _testSignInWithPhoneNumber(String smsCode) async {
-    final AuthCredential credential = PhoneAuthProvider.getCredential(
-      verificationId: verificationId,
-      smsCode: smsCode,
-    );
-    final FirebaseUser user = await _auth.signInWithCredential(credential);
-    final FirebaseUser currentUser = await _auth.currentUser();
-    assert(user.uid == currentUser.uid);
-
-    _smsCodeController.text = '';
-    return 'signInWithPhoneNumber succeeded: $user';
-  }
-
+  FirebaseUser user;
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -147,58 +41,30 @@ class _MyHomePageState extends State<MyHomePage> {
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
-          MaterialButton(
-              child: const Text('Test signInAnonymously'),
-              onPressed: () {
-                setState(() {
-                  _message = _testSignInAnonymously();
-                });
-              }),
-          MaterialButton(
-              child: const Text('Test signInWithGoogle'),
-              onPressed: () {
-                setState(() {
-                  _message = _testSignInWithGoogle();
-                });
-              }),
-          MaterialButton(
-              child: const Text('Test verifyPhoneNumber'),
-              onPressed: () {
-                _testVerifyPhoneNumber();
-              }),
           Container(
-            margin: const EdgeInsets.only(
-              top: 8.0,
-              bottom: 8.0,
-              left: 16.0,
-              right: 16.0,
+            child: RaisedButton(
+              child: const Text('Test registration'),
+              onPressed: () => _pushPage(context, RegisterPage()),
             ),
-            child: TextField(
-              controller: _smsCodeController,
-              decoration: const InputDecoration(
-                hintText: 'SMS Code',
-              ),
-            ),
+            padding: const EdgeInsets.all(16),
+            alignment: Alignment.center,
           ),
-          MaterialButton(
-              child: const Text('Test signInWithPhoneNumber'),
-              onPressed: () {
-                if (_smsCodeController.text != null) {
-                  setState(() {
-                    _message =
-                        _testSignInWithPhoneNumber(_smsCodeController.text);
-                  });
-                }
-              }),
-          FutureBuilder<String>(
-              future: _message,
-              builder: (_, AsyncSnapshot<String> snapshot) {
-                return Text(snapshot.data ?? '',
-                    style:
-                        const TextStyle(color: Color.fromARGB(255, 0, 155, 0)));
-              }),
+          Container(
+            child: RaisedButton(
+              child: const Text('Test signin/signout'),
+              onPressed: () => _pushPage(context, SigninPage()),
+            ),
+            padding: const EdgeInsets.all(16),
+            alignment: Alignment.center,
+          ),
         ],
       ),
+    );
+  }
+
+  void _pushPage(BuildContext context, Widget page) {
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(builder: (_) => page),
     );
   }
 }

--- a/packages/firebase_auth/example/lib/register_page.dart
+++ b/packages/firebase_auth/example/lib/register_page.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+final FirebaseAuth _auth = FirebaseAuth.instance;
+
+class RegisterPage extends StatefulWidget {
+  final String title = 'Registration';
+  @override
+  State<StatefulWidget> createState() => RegisterPageState();
+}
+
+class RegisterPageState extends State<RegisterPage> {
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+  bool _success;
+  String _userEmail;
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.title),
+      ),
+      body: Form(
+        key: _formKey,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            TextFormField(
+              controller: _emailController,
+              decoration: InputDecoration(labelText: 'Email'),
+              validator: (String value) {
+                if (value.isEmpty) {
+                  return 'Please enter some text';
+                }
+              },
+            ),
+            TextFormField(
+              controller: _passwordController,
+              decoration: InputDecoration(labelText: 'Password'),
+              validator: (String value) {
+                if (value.isEmpty) {
+                  return 'Please enter some text';
+                }
+              },
+            ),
+            Container(
+              padding: const EdgeInsets.symmetric(vertical: 16.0),
+              alignment: Alignment.center,
+              child: RaisedButton(
+                onPressed: () async {
+                  if (_formKey.currentState.validate()) {
+                    _register();
+                  }
+                },
+                child: const Text('Submit'),
+              ),
+            ),
+            Container(
+              alignment: Alignment.center,
+              child: Text(_success == null
+                  ? ''
+                  : (_success
+                      ? 'Successfully registered ' + _userEmail
+                      : 'Registration failed')),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    // Clean up the controller when the Widget is disposed
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  // Example code for registration.
+  void _register() async {
+    final FirebaseUser user = await _auth.createUserWithEmailAndPassword(
+      email: _emailController.text,
+      password: _passwordController.text,
+    );
+    if (user != null) {
+      setState(() {
+        _success = true;
+        _userEmail = user.email;
+      });
+    } else {
+      _success = false;
+    }
+  }
+}

--- a/packages/firebase_auth/example/lib/signin_page.dart
+++ b/packages/firebase_auth/example/lib/signin_page.dart
@@ -6,13 +6,13 @@ import 'package:google_sign_in/google_sign_in.dart';
 final FirebaseAuth _auth = FirebaseAuth.instance;
 final GoogleSignIn _googleSignIn = GoogleSignIn();
 
-class SigninPage extends StatefulWidget {
+class SignInPage extends StatefulWidget {
   final String title = 'Registration';
   @override
-  State<StatefulWidget> createState() => SigninPageState();
+  State<StatefulWidget> createState() => SignInPageState();
 }
 
-class SigninPageState extends State<SigninPage> {
+class SignInPageState extends State<SignInPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -169,7 +169,7 @@ class _AnonymouslySigninSectionState extends State<_AnonymouslySigninSection> {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
         Container(
-          child: const Text('Test sign Anonymously'),
+          child: const Text('Test sign in anonymously'),
           padding: const EdgeInsets.all(16),
           alignment: Alignment.center,
         ),
@@ -180,7 +180,7 @@ class _AnonymouslySigninSectionState extends State<_AnonymouslySigninSection> {
             onPressed: () async {
               _signInAnonymously();
             },
-            child: const Text('Sign in Anonymously'),
+            child: const Text('Sign in anonymously'),
           ),
         ),
         Container(
@@ -245,7 +245,7 @@ class _GoogleSigninSectionState extends State<_GoogleSigninSection> {
     return Column(
       children: <Widget>[
         Container(
-          child: const Text('Test sign with Google'),
+          child: const Text('Test sign in with Google'),
           padding: const EdgeInsets.all(16),
           alignment: Alignment.center,
         ),
@@ -324,7 +324,7 @@ class _PhoneSignInSectionState extends State<_PhoneSignInSection> {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
         Container(
-          child: const Text('Test sign with Phone number'),
+          child: const Text('Test sign in with phone number'),
           padding: const EdgeInsets.all(16),
           alignment: Alignment.center,
         ),
@@ -345,12 +345,12 @@ class _PhoneSignInSectionState extends State<_PhoneSignInSection> {
             onPressed: () async {
               _verifyPhoneNumber();
             },
-            child: const Text('Veity phone number'),
+            child: const Text('Verify phone number'),
           ),
         ),
         TextField(
           controller: _smsController,
-          decoration: InputDecoration(labelText: 'verification code'),
+          decoration: InputDecoration(labelText: 'Verification code'),
         ),
         Container(
           padding: const EdgeInsets.symmetric(vertical: 16.0),
@@ -359,7 +359,7 @@ class _PhoneSignInSectionState extends State<_PhoneSignInSection> {
             onPressed: () async {
               _signInWithPhoneNumber();
             },
-            child: const Text('Sign in with Phone number'),
+            child: const Text('Sign in with phone number'),
           ),
         ),
         Container(

--- a/packages/firebase_auth/example/lib/signin_page.dart
+++ b/packages/firebase_auth/example/lib/signin_page.dart
@@ -24,7 +24,7 @@ class SigninPageState extends State<SigninPage> {
               child: const Text('Sign out'),
               textColor: Theme.of(context).buttonColor,
               onPressed: () async {
-                FirebaseUser user = await _auth.currentUser();
+                final FirebaseUser user = await _auth.currentUser();
                 if (user == null) {
                   Scaffold.of(context).showSnackBar(SnackBar(
                     content: const Text('No one has signed in.'),
@@ -304,10 +304,10 @@ class _GoogleSigninSectionState extends State<_GoogleSigninSection> {
 }
 
 class _PhoneSignInSection extends StatefulWidget {
-  final ScaffoldState _scaffold;
 
   _PhoneSignInSection(this._scaffold);
 
+  final ScaffoldState _scaffold;
   @override
   State<StatefulWidget> createState() => _PhoneSignInSectionState();
 }

--- a/packages/firebase_auth/example/lib/signin_page.dart
+++ b/packages/firebase_auth/example/lib/signin_page.dart
@@ -46,8 +46,8 @@ class SignInPageState extends State<SignInPage> {
           scrollDirection: Axis.vertical,
           children: <Widget>[
             _EmailPasswordForm(),
-            _AnonymouslySigninSection(),
-            _GoogleSigninSection(),
+            _AnonymouslySignInSection(),
+            _GoogleSignInSection(),
             _PhoneSignInSection(Scaffold.of(context)),
           ],
         );
@@ -155,12 +155,12 @@ class _EmailPasswordFormState extends State<_EmailPasswordForm> {
   }
 }
 
-class _AnonymouslySigninSection extends StatefulWidget {
+class _AnonymouslySignInSection extends StatefulWidget {
   @override
-  State<StatefulWidget> createState() => _AnonymouslySigninSectionState();
+  State<StatefulWidget> createState() => _AnonymouslySignInSectionState();
 }
 
-class _AnonymouslySigninSectionState extends State<_AnonymouslySigninSection> {
+class _AnonymouslySignInSectionState extends State<_AnonymouslySignInSection> {
   bool _success;
   String _userID;
   @override
@@ -232,12 +232,12 @@ class _AnonymouslySigninSectionState extends State<_AnonymouslySigninSection> {
   }
 }
 
-class _GoogleSigninSection extends StatefulWidget {
+class _GoogleSignInSection extends StatefulWidget {
   @override
-  State<StatefulWidget> createState() => _GoogleSigninSectionState();
+  State<StatefulWidget> createState() => _GoogleSignInSectionState();
 }
 
-class _GoogleSigninSectionState extends State<_GoogleSigninSection> {
+class _GoogleSignInSectionState extends State<_GoogleSignInSection> {
   bool _success;
   String _userID;
   @override

--- a/packages/firebase_auth/example/lib/signin_page.dart
+++ b/packages/firebase_auth/example/lib/signin_page.dart
@@ -304,7 +304,6 @@ class _GoogleSigninSectionState extends State<_GoogleSigninSection> {
 }
 
 class _PhoneSignInSection extends StatefulWidget {
-
   _PhoneSignInSection(this._scaffold);
 
   final ScaffoldState _scaffold;

--- a/packages/firebase_auth/example/lib/signin_page.dart
+++ b/packages/firebase_auth/example/lib/signin_page.dart
@@ -1,0 +1,438 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+
+final FirebaseAuth _auth = FirebaseAuth.instance;
+final GoogleSignIn _googleSignIn = GoogleSignIn();
+
+class SigninPage extends StatefulWidget {
+  final String title = 'Registration';
+  @override
+  State<StatefulWidget> createState() => SigninPageState();
+}
+
+class SigninPageState extends State<SigninPage> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.title),
+        actions: <Widget>[
+          Builder(builder: (BuildContext context) {
+            return FlatButton(
+              child: const Text('Sign out'),
+              textColor: Theme.of(context).buttonColor,
+              onPressed: () async {
+                FirebaseUser user = await _auth.currentUser();
+                if (user == null) {
+                  Scaffold.of(context).showSnackBar(SnackBar(
+                    content: const Text('No one has signed in.'),
+                  ));
+                  return;
+                }
+                _signOut();
+                final String uid = user.uid;
+                Scaffold.of(context).showSnackBar(SnackBar(
+                  content: Text(uid + ' has successfully signed out.'),
+                ));
+              },
+            );
+          })
+        ],
+      ),
+      body: Builder(builder: (BuildContext context) {
+        return ListView(
+          scrollDirection: Axis.vertical,
+          children: <Widget>[
+            _EmailPasswordForm(),
+            _AnonymouslySigninSection(),
+            _GoogleSigninSection(),
+            _PhoneSignInSection(Scaffold.of(context)),
+          ],
+        );
+      }),
+    );
+  }
+
+  // Example code for sign out.
+  void _signOut() async {
+    await _auth.signOut();
+  }
+}
+
+class _EmailPasswordForm extends StatefulWidget {
+  @override
+  State<StatefulWidget> createState() => _EmailPasswordFormState();
+}
+
+class _EmailPasswordFormState extends State<_EmailPasswordForm> {
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+  bool _success;
+  String _userEmail;
+  @override
+  Widget build(BuildContext context) {
+    return Form(
+      key: _formKey,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Container(
+            child: const Text('Test sign in with email and password'),
+            padding: const EdgeInsets.all(16),
+            alignment: Alignment.center,
+          ),
+          TextFormField(
+            controller: _emailController,
+            decoration: InputDecoration(labelText: 'Email'),
+            validator: (String value) {
+              if (value.isEmpty) {
+                return 'Please enter some text';
+              }
+            },
+          ),
+          TextFormField(
+            controller: _passwordController,
+            decoration: InputDecoration(labelText: 'Password'),
+            validator: (String value) {
+              if (value.isEmpty) {
+                return 'Please enter some text';
+              }
+            },
+          ),
+          Container(
+            padding: const EdgeInsets.symmetric(vertical: 16.0),
+            alignment: Alignment.center,
+            child: RaisedButton(
+              onPressed: () async {
+                if (_formKey.currentState.validate()) {
+                  _signInWithEmailAndPassword();
+                }
+              },
+              child: const Text('Submit'),
+            ),
+          ),
+          Container(
+            alignment: Alignment.center,
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Text(
+              _success == null
+                  ? ''
+                  : (_success
+                      ? 'Successfully signed in ' + _userEmail
+                      : 'Sign in failed'),
+              style: TextStyle(color: Colors.red),
+            ),
+          )
+        ],
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  // Example code of how to sign in with email and password.
+  void _signInWithEmailAndPassword() async {
+    final FirebaseUser user = await _auth.signInWithEmailAndPassword(
+      email: _emailController.text,
+      password: _passwordController.text,
+    );
+    if (user != null) {
+      setState(() {
+        _success = true;
+        _userEmail = user.email;
+      });
+    } else {
+      _success = false;
+    }
+  }
+}
+
+class _AnonymouslySigninSection extends StatefulWidget {
+  @override
+  State<StatefulWidget> createState() => _AnonymouslySigninSectionState();
+}
+
+class _AnonymouslySigninSectionState extends State<_AnonymouslySigninSection> {
+  bool _success;
+  String _userID;
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Container(
+          child: const Text('Test sign Anonymously'),
+          padding: const EdgeInsets.all(16),
+          alignment: Alignment.center,
+        ),
+        Container(
+          padding: const EdgeInsets.symmetric(vertical: 16.0),
+          alignment: Alignment.center,
+          child: RaisedButton(
+            onPressed: () async {
+              _signInAnonymously();
+            },
+            child: const Text('Sign in Anonymously'),
+          ),
+        ),
+        Container(
+          alignment: Alignment.center,
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Text(
+            _success == null
+                ? ''
+                : (_success
+                    ? 'Successfully signed in, uid: ' + _userID
+                    : 'Sign in failed'),
+            style: TextStyle(color: Colors.red),
+          ),
+        )
+      ],
+    );
+  }
+
+  // Example code of how to sign in anonymously.
+  void _signInAnonymously() async {
+    final FirebaseUser user = await _auth.signInAnonymously();
+    assert(user != null);
+    assert(user.isAnonymous);
+    assert(!user.isEmailVerified);
+    assert(await user.getIdToken() != null);
+    if (Platform.isIOS) {
+      // Anonymous auth doesn't show up as a provider on iOS
+      assert(user.providerData.isEmpty);
+    } else if (Platform.isAndroid) {
+      // Anonymous auth does show up as a provider on Android
+      assert(user.providerData.length == 1);
+      assert(user.providerData[0].providerId == 'firebase');
+      assert(user.providerData[0].uid != null);
+      assert(user.providerData[0].displayName == null);
+      assert(user.providerData[0].photoUrl == null);
+      assert(user.providerData[0].email == null);
+    }
+
+    final FirebaseUser currentUser = await _auth.currentUser();
+    assert(user.uid == currentUser.uid);
+    setState(() {
+      if (user != null) {
+        _success = true;
+        _userID = user.uid;
+      } else {
+        _success = false;
+      }
+    });
+  }
+}
+
+class _GoogleSigninSection extends StatefulWidget {
+  @override
+  State<StatefulWidget> createState() => _GoogleSigninSectionState();
+}
+
+class _GoogleSigninSectionState extends State<_GoogleSigninSection> {
+  bool _success;
+  String _userID;
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: <Widget>[
+        Container(
+          child: const Text('Test sign with Google'),
+          padding: const EdgeInsets.all(16),
+          alignment: Alignment.center,
+        ),
+        Container(
+          padding: const EdgeInsets.symmetric(vertical: 16.0),
+          alignment: Alignment.center,
+          child: RaisedButton(
+            onPressed: () async {
+              _signInWithGoogle();
+            },
+            child: const Text('Sign in with Google'),
+          ),
+        ),
+        Container(
+          alignment: Alignment.center,
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Text(
+            _success == null
+                ? ''
+                : (_success
+                    ? 'Successfully signed in, uid: ' + _userID
+                    : 'Sign in failed'),
+            style: TextStyle(color: Colors.red),
+          ),
+        )
+      ],
+    );
+  }
+
+  // Example code of how to sign in with google.
+  void _signInWithGoogle() async {
+    final GoogleSignInAccount googleUser = await _googleSignIn.signIn();
+    final GoogleSignInAuthentication googleAuth =
+        await googleUser.authentication;
+    final AuthCredential credential = GoogleAuthProvider.getCredential(
+      accessToken: googleAuth.accessToken,
+      idToken: googleAuth.idToken,
+    );
+    final FirebaseUser user = await _auth.signInWithCredential(credential);
+    assert(user.email != null);
+    assert(user.displayName != null);
+    assert(!user.isAnonymous);
+    assert(await user.getIdToken() != null);
+
+    final FirebaseUser currentUser = await _auth.currentUser();
+    assert(user.uid == currentUser.uid);
+    setState(() {
+      if (user != null) {
+        _success = true;
+        _userID = user.uid;
+      } else {
+        _success = false;
+      }
+    });
+  }
+}
+
+class _PhoneSignInSection extends StatefulWidget {
+  final ScaffoldState _scaffold;
+
+  _PhoneSignInSection(this._scaffold);
+
+  @override
+  State<StatefulWidget> createState() => _PhoneSignInSectionState();
+}
+
+class _PhoneSignInSectionState extends State<_PhoneSignInSection> {
+  final TextEditingController _phoneNumberController = TextEditingController();
+  final TextEditingController _smsController = TextEditingController();
+
+  String _message = '';
+  String _verificationId;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Container(
+          child: const Text('Test sign with Phone number'),
+          padding: const EdgeInsets.all(16),
+          alignment: Alignment.center,
+        ),
+        TextFormField(
+          controller: _phoneNumberController,
+          decoration:
+              InputDecoration(labelText: 'Phone number (+x xxx-xxx-xxxx)'),
+          validator: (String value) {
+            if (value.isEmpty) {
+              return 'Phone number (+x xxx-xxx-xxxx)';
+            }
+          },
+        ),
+        Container(
+          padding: const EdgeInsets.symmetric(vertical: 16.0),
+          alignment: Alignment.center,
+          child: RaisedButton(
+            onPressed: () async {
+              _verifyPhoneNumber();
+            },
+            child: const Text('Veity phone number'),
+          ),
+        ),
+        TextField(
+          controller: _smsController,
+          decoration: InputDecoration(labelText: 'verification code'),
+        ),
+        Container(
+          padding: const EdgeInsets.symmetric(vertical: 16.0),
+          alignment: Alignment.center,
+          child: RaisedButton(
+            onPressed: () async {
+              _signInWithPhoneNumber();
+            },
+            child: const Text('Sign in with Phone number'),
+          ),
+        ),
+        Container(
+          alignment: Alignment.center,
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Text(
+            _message,
+            style: TextStyle(color: Colors.red),
+          ),
+        )
+      ],
+    );
+  }
+
+  // Exmaple code of how to veify phone number
+  void _verifyPhoneNumber() async {
+    setState(() {
+      _message = '';
+    });
+    final PhoneVerificationCompleted verificationCompleted =
+        (FirebaseUser user) {
+      setState(() {
+        _message = 'signInWithPhoneNumber auto succeeded: $user';
+      });
+    };
+
+    final PhoneVerificationFailed verificationFailed =
+        (AuthException authException) {
+      setState(() {
+        _message =
+            'Phone number verification failed. Code: ${authException.code}. Message: ${authException.message}';
+      });
+    };
+
+    final PhoneCodeSent codeSent =
+        (String verificationId, [int forceResendingToken]) async {
+      widget._scaffold.showSnackBar(SnackBar(
+        content:
+            const Text('Please check your phone for the verification code.'),
+      ));
+      _verificationId = verificationId;
+    };
+
+    final PhoneCodeAutoRetrievalTimeout codeAutoRetrievalTimeout =
+        (String verificationId) {
+      _verificationId = verificationId;
+    };
+
+    await _auth.verifyPhoneNumber(
+        phoneNumber: _phoneNumberController.text,
+        timeout: const Duration(seconds: 5),
+        verificationCompleted: verificationCompleted,
+        verificationFailed: verificationFailed,
+        codeSent: codeSent,
+        codeAutoRetrievalTimeout: codeAutoRetrievalTimeout);
+  }
+
+  // Example code of how to sign in with phone.
+  void _signInWithPhoneNumber() async {
+    final AuthCredential credential = PhoneAuthProvider.getCredential(
+      verificationId: _verificationId,
+      smsCode: _smsController.text,
+    );
+    final FirebaseUser user = await _auth.signInWithCredential(credential);
+    final FirebaseUser currentUser = await _auth.currentUser();
+    assert(user.uid == currentUser.uid);
+    setState(() {
+      if (user != null) {
+        _message = 'Successfully signed in, uid: ' + user.uid;
+      } else {
+        _message = 'Sign in failed';
+      }
+    });
+  }
+}

--- a/packages/firebase_auth/example/lib/signin_page.dart
+++ b/packages/firebase_auth/example/lib/signin_page.dart
@@ -49,6 +49,7 @@ class SignInPageState extends State<SignInPage> {
             _AnonymouslySignInSection(),
             _GoogleSignInSection(),
             _PhoneSignInSection(Scaffold.of(context)),
+            _OtherProvidersSignInSection(),
           ],
         );
       }),
@@ -431,6 +432,199 @@ class _PhoneSignInSectionState extends State<_PhoneSignInSection> {
         _message = 'Successfully signed in, uid: ' + user.uid;
       } else {
         _message = 'Sign in failed';
+      }
+    });
+  }
+}
+
+class _OtherProvidersSignInSection extends StatefulWidget {
+  _OtherProvidersSignInSection();
+
+  @override
+  State<StatefulWidget> createState() => _OtherProvidersSignInSectionState();
+}
+
+class _OtherProvidersSignInSectionState
+    extends State<_OtherProvidersSignInSection> {
+  final TextEditingController _tokenController = TextEditingController();
+  final TextEditingController _tokenSecretController = TextEditingController();
+
+  String _message = '';
+  int _selection = 0;
+  bool _showAuthSecretTextField = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Container(
+          child: const Text(
+              'Test other providers authentication. (We do not provide an API to obtain the token for below providers. Please use a third party service to obtain token for below providers.)'),
+          padding: const EdgeInsets.all(16),
+          alignment: Alignment.center,
+        ),
+        Container(
+          padding: const EdgeInsets.symmetric(vertical: 16.0),
+          alignment: Alignment.center,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              Radio<int>(
+                value: 0,
+                groupValue: _selection,
+                onChanged: _handleRadioButtonSelected,
+              ),
+              Text(
+                'Github',
+                style: TextStyle(fontSize: 16.0),
+              ),
+              Radio<int>(
+                value: 1,
+                groupValue: _selection,
+                onChanged: _handleRadioButtonSelected,
+              ),
+              Text(
+                'Facebook',
+                style: TextStyle(
+                  fontSize: 16.0,
+                ),
+              ),
+              Radio<int>(
+                value: 2,
+                groupValue: _selection,
+                onChanged: _handleRadioButtonSelected,
+              ),
+              Text(
+                'Twitter',
+                style: TextStyle(fontSize: 16.0),
+              ),
+            ],
+          ),
+        ),
+        TextField(
+          controller: _tokenController,
+          decoration: InputDecoration(labelText: 'Enter provider\'s token'),
+        ),
+        Container(
+          child: _showAuthSecretTextField
+              ? TextField(
+                  controller: _tokenSecretController,
+                  decoration: InputDecoration(
+                      labelText: 'Enter provider\'s authTokenSecret'),
+                )
+              : null,
+        ),
+        Container(
+          padding: const EdgeInsets.symmetric(vertical: 16.0),
+          alignment: Alignment.center,
+          child: RaisedButton(
+            onPressed: () async {
+              _signInWithOtherProvider();
+            },
+            child: const Text('Sign in'),
+          ),
+        ),
+        Container(
+          alignment: Alignment.center,
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Text(
+            _message,
+            style: TextStyle(color: Colors.red),
+          ),
+        )
+      ],
+    );
+  }
+
+  void _handleRadioButtonSelected(int value) {
+    setState(() {
+      _selection = value;
+      if (_selection == 2) {
+        _showAuthSecretTextField = true;
+      } else {
+        _showAuthSecretTextField = false;
+      }
+    });
+  }
+
+  void _signInWithOtherProvider() {
+    switch (_selection) {
+      case 0:
+        _signInWithGithub();
+        break;
+      case 1:
+        _signInWithFacebook();
+        break;
+      case 2:
+        _signInWithTwitter();
+        break;
+      default:
+    }
+  }
+
+  // Example code of how to sign in with Github.
+  void _signInWithGithub() async {
+    final AuthCredential credential = GithubAuthProvider.getCredential(
+      token: _tokenController.text,
+    );
+    final FirebaseUser user = await _auth.signInWithCredential(credential);
+    assert(user.email != null);
+    assert(user.displayName != null);
+    assert(!user.isAnonymous);
+    assert(await user.getIdToken() != null);
+
+    final FirebaseUser currentUser = await _auth.currentUser();
+    assert(user.uid == currentUser.uid);
+    setState(() {
+      if (user != null) {
+        _message = 'Successfully signed in with Github. ' + user.uid;
+      } else {
+        _message = 'Failed to sign in with Github. ';
+      }
+    });
+  }
+
+  // Example code of how to sign in with Facebook.
+  void _signInWithFacebook() async {
+    final AuthCredential credential = FacebookAuthProvider.getCredential(
+      accessToken: _tokenController.text,
+    );
+    final FirebaseUser user = await _auth.signInWithCredential(credential);
+    assert(user.email != null);
+    assert(user.displayName != null);
+    assert(!user.isAnonymous);
+    assert(await user.getIdToken() != null);
+
+    final FirebaseUser currentUser = await _auth.currentUser();
+    assert(user.uid == currentUser.uid);
+    setState(() {
+      if (user != null) {
+        _message = 'Successfully signed in with Facebook. ' + user.uid;
+      } else {
+        _message = 'Failed to sign in with Facebook. ';
+      }
+    });
+  }
+
+  // Example code of how to sign in with Twitter.
+  void _signInWithTwitter() async {
+    final AuthCredential credential = TwitterAuthProvider.getCredential(
+        authToken: _tokenController.text,
+        authTokenSecret: _tokenSecretController.text);
+    final FirebaseUser user = await _auth.signInWithCredential(credential);
+    assert(user.email != null);
+    assert(user.displayName != null);
+    assert(!user.isAnonymous);
+    assert(await user.getIdToken() != null);
+
+    final FirebaseUser currentUser = await _auth.currentUser();
+    assert(user.uid == currentUser.uid);
+    setState(() {
+      if (user != null) {
+        _message = 'Successfully signed in with Twitter. ' + user.uid;
+      } else {
+        _message = 'Failed to sign in with Twitter. ';
       }
     });
   }

--- a/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
+++ b/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
@@ -6,19 +6,13 @@
 
 #import "Firebase/Firebase.h"
 
-@interface NSError (FIRAuthErrorCode)
-@property(readonly, nonatomic) NSString *firAuthErrorCode;
-@end
-
-@implementation NSError (FIRAuthErrorCode)
-- (NSString *)firAuthErrorCode {
-  NSString *code = [self userInfo][FIRAuthErrorNameKey];
+static NSString *getFlutterErrorCode(NSError *error) {
+  NSString *code = [error userInfo][FIRAuthErrorNameKey];
   if (code != nil) {
     return code;
   }
-  return [NSString stringWithFormat:@"ERROR_%d", (int)self.code];
+  return [NSString stringWithFormat:@"ERROR_%d", (int)error.code];
 }
-@end
 
 NSDictionary *toDictionary(id<FIRUserInfo> userInfo) {
   return @{
@@ -299,7 +293,7 @@ int nextHandle = 0;
 
 - (void)sendResult:(FlutterResult)result forObject:(NSObject *)object error:(NSError *)error {
   if (error != nil) {
-    result([FlutterError errorWithCode:error.firAuthErrorCode
+    result([FlutterError errorWithCode:getFlutterErrorCode(error)
                                message:error.localizedDescription
                                details:nil]);
   } else if (object == nil) {

--- a/packages/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Firebase Auth, enabling Android and iOS
   like Google, Facebook and Twitter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_auth
-version: "0.8.1"
+version: "0.8.1+2"
 
 flutter:
   plugin:


### PR DESCRIPTION
This is an improvement of the documentation and the example for [flutter/flutter#16217](https://github.com/flutter/flutter/issues/16217)

Added a registration flow and a sign in with email&password flow in the example app.
Separated the example app into 2 parts: registration and SignIn/SignOut.
Updated README, added a list of supported authentication methods and an example of registration.