### PR TITLE
Remove the method channel's reference to webview/maps on dispose.

### DIFF
--- a/packages/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0+3
+
+* Fixed a memory leak on Android - the map was not properly disposed.
+
 ## 0.2.0+2
 
 * Log a more detailed warning at build time about the previous AndroidX

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
@@ -289,6 +289,7 @@ final class GoogleMapController
       return;
     }
     disposed = true;
+    methodChannel.setMethodCallHandler(null);
     mapView.onDestroy();
     registrar.activity().getApplication().unregisterActivityLifecycleCallbacks(this);
   }

--- a/packages/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter
-version: 0.2.0+2
+version: 0.2.0+3
 
 dependencies:
   flutter:

--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.3+1
+
+* Fixed a memory leak on Android - the WebView was not properly disposed.
+
 ## 0.3.3
 
 * Add clearCache method to WebView controller.

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -201,5 +201,7 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
   }
 
   @Override
-  public void dispose() {}
+  public void dispose() {
+      methodChannel.setMethodCallHandler(null);
+  }
 }

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -202,6 +202,6 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
 
   @Override
   public void dispose() {
-      methodChannel.setMethodCallHandler(null);
+    methodChannel.setMethodCallHandler(null);
   }
 }

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
-version: 0.3.3
+version: 0.3.3+1
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/webview_flutter
 


### PR DESCRIPTION
The reference from the method channel to the webview/maps instance was never cleared on Android, which leaked memory as even after disposing the platform view the view was not released.

https://github.com/flutter/flutter/issues/24145