### PR TITLE
[webview_flutter] fix link navigation for android webview

### DIFF
--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.view.View;
 import android.webkit.WebStorage;
 import android.webkit.WebView;
+import android.webkit.WebViewClient;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
@@ -21,6 +22,14 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
   @SuppressWarnings("unchecked")
   FlutterWebView(Context context, BinaryMessenger messenger, int id, Map<String, Object> params) {
     webView = new WebView(context);
+    webView.setWebViewClient(
+        new WebViewClient() {
+          @Override
+          public boolean shouldOverrideUrlLoading(WebView view, String url) {
+            view.loadUrl(url);
+            return false;
+          }
+        });
     // Allow local storage.
     webView.getSettings().setDomStorageEnabled(true);
 


### PR DESCRIPTION
Orignally in Android, link navigation within flutter webview plugin will ask user to open with another application.

![image](https://user-images.githubusercontent.com/526674/52847470-3bf71b80-3147-11e9-87ff-33065acf8953.png)

This PR tries to solve this issue.