### PR TITLE
[IAP] Add Java call for launchBillingFlow

### DIFF
--- a/packages/in_app_purchase/android/build.gradle
+++ b/packages/in_app_purchase/android/build.gradle
@@ -35,7 +35,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 16

--- a/packages/in_app_purchase/android/src/main/java/io/flutter/plugins/inapppurchase/InAppPurchasePlugin.java
+++ b/packages/in_app_purchase/android/src/main/java/io/flutter/plugins/inapppurchase/InAppPurchasePlugin.java
@@ -6,11 +6,13 @@ package io.flutter.plugins.inapppurchase;
 
 import static io.flutter.plugins.inapppurchase.Translator.fromSkuDetailsList;
 
+import android.app.Activity;
 import android.content.Context;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import com.android.billingclient.api.BillingClient;
 import com.android.billingclient.api.BillingClientStateListener;
+import com.android.billingclient.api.BillingFlowParams;
 import com.android.billingclient.api.Purchase;
 import com.android.billingclient.api.PurchasesUpdatedListener;
 import com.android.billingclient.api.SkuDetails;
@@ -29,36 +31,60 @@ import java.util.Map;
 /** Wraps a {@link BillingClient} instance and responds to Dart calls for it. */
 public class InAppPurchasePlugin implements MethodCallHandler {
   private @Nullable BillingClient billingClient;
+  private final Activity activity;
   private final Context context;
   private final MethodChannel channel;
+
+  @VisibleForTesting
+  static final class MethodNames {
+    static final String IS_READY = "BillingClient#isReady()";
+    static final String START_CONNECTION =
+        "BillingClient#startConnection(BillingClientStateListener)";
+    static final String END_CONNECTION = "BillingClient#endConnection()";
+    static final String ON_DISCONNECT = "BillingClientStateListener#onBillingServiceDisconnected()";
+    static final String QUERY_SKU_DETAILS =
+        "BillingClient#querySkuDetailsAsync(SkuDetailsParams, SkuDetailsResponseListener)";
+    static final String LAUNCH_BILLING_FLOW =
+        "BillingClient#launchBillingFlow(Activity, BillingFlowParams)";
+
+    private MethodNames() {};
+  }
+
+  private HashMap<String, SkuDetails> cachedSkus = new HashMap<>();
 
   /** Plugin registration. */
   public static void registerWith(Registrar registrar) {
     final MethodChannel channel =
         new MethodChannel(registrar.messenger(), "plugins.flutter.io/in_app_purchase");
-    channel.setMethodCallHandler(new InAppPurchasePlugin(registrar.context(), channel));
+    channel.setMethodCallHandler(
+        new InAppPurchasePlugin(registrar.context(), registrar.activity(), channel));
   }
 
-  public InAppPurchasePlugin(Context context, MethodChannel channel) {
+  public InAppPurchasePlugin(Context context, Activity activity, MethodChannel channel) {
     this.context = context;
+    this.activity = activity;
     this.channel = channel;
   }
 
   @Override
   public void onMethodCall(MethodCall call, Result result) {
     switch (call.method) {
-      case "BillingClient#isReady()":
+      case MethodNames.IS_READY:
         isReady(result);
         break;
-      case "BillingClient#startConnection(BillingClientStateListener)":
+      case MethodNames.START_CONNECTION:
         startConnection((int) call.argument("handle"), result);
         break;
-      case "BillingClient#endConnection()":
+      case MethodNames.END_CONNECTION:
         endConnection(result);
         break;
-      case "BillingClient#querySkuDetailsAsync(SkuDetailsParams, SkuDetailsResponseListener)":
+      case MethodNames.QUERY_SKU_DETAILS:
         querySkuDetailsAsync(
             (String) call.argument("skuType"), (List<String>) call.argument("skusList"), result);
+        break;
+      case MethodNames.LAUNCH_BILLING_FLOW:
+        launchBillingFlow(
+            (String) call.argument("sku"), (String) call.argument("accountId"), result);
         break;
       default:
         result.notImplemented();
@@ -66,10 +92,11 @@ public class InAppPurchasePlugin implements MethodCallHandler {
   }
 
   @VisibleForTesting
-  /*package*/ InAppPurchasePlugin(BillingClient billingClient, MethodChannel channel) {
+  /*package*/ InAppPurchasePlugin(@Nullable BillingClient billingClient, MethodChannel channel) {
     this.billingClient = billingClient;
     this.channel = channel;
     this.context = null;
+    this.activity = null;
   }
 
   private void startConnection(final int handle, final Result result) {
@@ -89,8 +116,7 @@ public class InAppPurchasePlugin implements MethodCallHandler {
           public void onBillingServiceDisconnected() {
             final Map<String, Object> arguments = new HashMap<>();
             arguments.put("handle", handle);
-            channel.invokeMethod(
-                "BillingClientStateListener#onBillingServiceDisconnected()", arguments);
+            channel.invokeMethod(MethodNames.ON_DISCONNECT, arguments);
           }
         });
   }
@@ -124,12 +150,41 @@ public class InAppPurchasePlugin implements MethodCallHandler {
         new SkuDetailsResponseListener() {
           public void onSkuDetailsResponse(
               int responseCode, @Nullable List<SkuDetails> skuDetailsList) {
+            updateCachedSkus(skuDetailsList);
             final Map<String, Object> skuDetailsResponse = new HashMap<>();
             skuDetailsResponse.put("responseCode", responseCode);
             skuDetailsResponse.put("skuDetailsList", fromSkuDetailsList(skuDetailsList));
             result.success(skuDetailsResponse);
           }
         });
+  }
+
+  private void launchBillingFlow(String sku, @Nullable String accountId, Result result) {
+    if (billingClientError(result)) {
+      return;
+    }
+
+    SkuDetails skuDetails = cachedSkus.get(sku);
+    if (skuDetails == null) {
+      result.error(
+          "NOT_FOUND",
+          "Details for sku " + sku + " are not available. Has this ID already been fetched?",
+          null);
+      return;
+    }
+
+    BillingFlowParams.Builder paramsBuilder =
+        BillingFlowParams.newBuilder().setSkuDetails(skuDetails);
+    if (accountId != null && !accountId.isEmpty()) {
+      paramsBuilder.setAccountId(accountId);
+    }
+    result.success(billingClient.launchBillingFlow(activity, paramsBuilder.build()));
+  }
+
+  private void updateCachedSkus(List<SkuDetails> skuDetailsList) {
+    for (SkuDetails skuDetails : skuDetailsList) {
+      cachedSkus.put(skuDetails.getSku(), skuDetails);
+    }
   }
 
   private boolean billingClientError(Result result) {

--- a/packages/in_app_purchase/lib/src/billing_client_wrappers/sku_details_wrapper.g.dart
+++ b/packages/in_app_purchase/lib/src/billing_client_wrappers/sku_details_wrapper.g.dart
@@ -20,46 +20,15 @@ SkuDetailsWrapper _$SkuDetailsWrapperFromJson(Map json) {
       sku: json['sku'] as String,
       subscriptionPeriod: json['subscriptionPeriod'] as String,
       title: json['title'] as String,
-      type: _$enumDecode(_$SkuTypeEnumMap, json['type']),
+      type: const SkuTypeConverter().fromJson(json['type'] as String),
       isRewarded: json['isRewarded'] as bool);
 }
 
-T _$enumDecode<T>(Map<T, dynamic> enumValues, dynamic source) {
-  if (source == null) {
-    throw ArgumentError('A value must be provided. Supported values: '
-        '${enumValues.values.join(', ')}');
-  }
-  return enumValues.entries
-      .singleWhere((e) => e.value == source,
-          orElse: () => throw ArgumentError(
-              '`$source` is not one of the supported values: '
-              '${enumValues.values.join(', ')}'))
-      .key;
-}
-
-const _$SkuTypeEnumMap = <SkuType, dynamic>{
-  SkuType.inapp: 'inapp',
-  SkuType.subs: 'subs'
-};
-
 SkuDetailsResponseWrapper _$SkuDetailsResponseWrapperFromJson(Map json) {
   return SkuDetailsResponseWrapper(
-      responseCode:
-          _$enumDecode(_$BillingResponseEnumMap, json['responseCode']),
+      responseCode: const BillingResponseConverter()
+          .fromJson(json['responseCode'] as int),
       skuDetailsList: (json['skuDetailsList'] as List)
           .map((e) => SkuDetailsWrapper.fromJson(e as Map))
           .toList());
 }
-
-const _$BillingResponseEnumMap = <BillingResponse, dynamic>{
-  BillingResponse.featureNotSupported: -2,
-  BillingResponse.ok: 0,
-  BillingResponse.userCanceled: 1,
-  BillingResponse.serviceUnavailable: 2,
-  BillingResponse.billingUnavailable: 3,
-  BillingResponse.itemUnavailable: 4,
-  BillingResponse.developerError: 5,
-  BillingResponse.error: 6,
-  BillingResponse.itemAlreadyOwned: 7,
-  BillingResponse.itemNotOwned: 8
-};


### PR DESCRIPTION
The call requires passing in a fully constructed `SkuDetail`. We could
fetch it again at runtime here, but for now I'm opting for caching
fetched SkuDetails and requiring them to be fetched before this call
instead to mirror how the iOS side is working.

flutter/flutter#26327