### PR TITLE
Iap make payment objc

### DIFF
--- a/packages/in_app_purchase/example/ios/in_app_purchase_pluginTests/InAppPurchasePluginTest.m
+++ b/packages/in_app_purchase/example/ios/in_app_purchase_pluginTests/InAppPurchasePluginTest.m
@@ -101,7 +101,7 @@
                                           @"productID" : @"123",
                                           @"quantity" : @(1),
                                           @"simulatesAskToBuyInSandBox" : @YES,
-                                          @"usePaymentObject": @YES
+                                          @"usePaymentObject" : @YES
                                         }];
   SKPaymentQueueStub* queue = [SKPaymentQueueStub new];
   queue.testState = SKPaymentTransactionStateFailed;
@@ -138,7 +138,7 @@
                                           @"productID" : @"123",
                                           @"quantity" : @(1),
                                           @"simulatesAskToBuyInSandBox" : @YES,
-                                          @"usePaymentObject": @YES
+                                          @"usePaymentObject" : @YES
                                         }];
   SKPaymentQueueStub* queue = [SKPaymentQueueStub new];
   queue.testState = SKPaymentTransactionStatePurchased;

--- a/packages/in_app_purchase/example/ios/in_app_purchase_pluginTests/InAppPurchasePluginTest.m
+++ b/packages/in_app_purchase/example/ios/in_app_purchase_pluginTests/InAppPurchasePluginTest.m
@@ -3,18 +3,20 @@
 // found in the LICENSE file.
 
 #import <XCTest/XCTest.h>
+#import "FIAPaymentQueueHandler.h"
 #import "InAppPurchasePlugin.h"
 #import "Stubs.h"
 
 @interface InAppPurchasePluginTest : XCTestCase
 
+@property(strong, nonatomic) InAppPurchasePlugin* plugin;
+
 @end
 
 @implementation InAppPurchasePluginTest
-InAppPurchasePlugin* plugin;
 
 - (void)setUp {
-  plugin = [[InAppPurchasePluginStub alloc] init];
+  self.plugin = [[InAppPurchasePluginStub alloc] init];
 }
 
 - (void)tearDown {
@@ -25,7 +27,7 @@ InAppPurchasePlugin* plugin;
       [self expectationWithDescription:@"expect result to be not implemented"];
   FlutterMethodCall* call = [FlutterMethodCall methodCallWithMethodName:@"invalid" arguments:NULL];
   __block id result;
-  [plugin handleMethodCall:call
+  [self.plugin handleMethodCall:call
                     result:^(id r) {
                       [expectation fulfill];
                       result = r;
@@ -40,7 +42,7 @@ InAppPurchasePlugin* plugin;
       [FlutterMethodCall methodCallWithMethodName:@"-[SKPaymentQueue canMakePayments:]"
                                         arguments:NULL];
   __block id result;
-  [plugin handleMethodCall:call
+  [self.plugin handleMethodCall:call
                     result:^(id r) {
                       [expectation fulfill];
                       result = r;
@@ -56,7 +58,7 @@ InAppPurchasePlugin* plugin;
       methodCallWithMethodName:@"-[InAppPurchasePlugin startProductRequest:result:]"
                      arguments:@[ @"123" ]];
   __block id result;
-  [plugin handleMethodCall:call
+  [self.plugin handleMethodCall:call
                     result:^(id r) {
                       [expectation fulfill];
                       result = r;
@@ -66,6 +68,80 @@ InAppPurchasePlugin* plugin;
   NSArray* resultArray = [result objectForKey:@"products"];
   XCTAssertEqual(resultArray.count, 1);
   XCTAssertTrue([resultArray.firstObject[@"productIdentifier"] isEqualToString:@"123"]);
+}
+
+- (void)testAddPaymentFailure {
+    XCTestExpectation* expectation =
+    [self expectationWithDescription:@"result should return failed state"];
+    FlutterMethodCall* call =
+    [FlutterMethodCall methodCallWithMethodName:@"-[InAppPurchasePlugin addPayment:result:]"
+                                      arguments:@{
+                                                  @"productID" : @"123",
+                                                  @"quantity" : @(1),
+                                                  @"simulatesAskToBuyInSandBox" : @YES
+                                                  }];
+    SKPaymentQueueStub* queue = [SKPaymentQueueStub new];
+    queue.testState = SKPaymentTransactionStateFailed;
+    __block SKPaymentTransaction* transactionForUpdateBlock;
+    self.plugin.paymentQueueHandler = [[FIAPaymentQueueHandler alloc] initWithQueue:queue
+                                                                transactionsUpdated:^(NSArray<SKPaymentTransaction*>* _Nonnull transactions) {
+                                                                    SKPaymentTransaction* transaction = transactions[0];
+                                                                    if (transaction.transactionState == SKPaymentTransactionStateFailed) {
+                                                                        transactionForUpdateBlock = transaction;
+                                                                        [expectation fulfill];
+                                                                    }
+                                                                }
+                                                                 transactionRemoved:nil
+                                                           restoreTransactionFailed:nil
+                                               restoreCompletedTransactionsFinished:nil
+                                                              shouldAddStorePayment:^BOOL(SKPayment* _Nonnull payment, SKProduct* _Nonnull product) {
+                                                                  return YES;
+                                                              }
+                                                                   updatedDownloads:nil];
+    [queue addTransactionObserver:self.plugin.paymentQueueHandler];
+    self.plugin.paymentQueueHandler.testing = YES;
+    [self.plugin handleMethodCall:call
+                           result:^(id r){
+                           }];
+    [self waitForExpectations:@[ expectation ] timeout:5];
+    XCTAssertEqual(transactionForUpdateBlock.transactionState, SKPaymentTransactionStateFailed);
+}
+
+- (void)testAddPaymentSuccessWithMockQueue {
+    XCTestExpectation* expectation =
+    [self expectationWithDescription:@"result should return success state"];
+    FlutterMethodCall* call =
+    [FlutterMethodCall methodCallWithMethodName:@"-[InAppPurchasePlugin addPayment:result:]"
+                                      arguments:@{
+                                                  @"productID" : @"123",
+                                                  @"quantity" : @(1),
+                                                  @"simulatesAskToBuyInSandBox" : @YES
+                                                  }];
+    SKPaymentQueueStub* queue = [SKPaymentQueueStub new];
+    queue.testState = SKPaymentTransactionStatePurchased;
+    __block SKPaymentTransaction* transactionForUpdateBlock;
+    self.plugin.paymentQueueHandler = [[FIAPaymentQueueHandler alloc] initWithQueue:queue
+                                                                transactionsUpdated:^(NSArray<SKPaymentTransaction*>* _Nonnull transactions) {
+                                                                    SKPaymentTransaction* transaction = transactions[0];
+                                                                    if (transaction.transactionState == SKPaymentTransactionStatePurchased) {
+                                                                        transactionForUpdateBlock = transaction;
+                                                                        [expectation fulfill];
+                                                                    }
+                                                                }
+                                                                 transactionRemoved:nil
+                                                           restoreTransactionFailed:nil
+                                               restoreCompletedTransactionsFinished:nil
+                                                              shouldAddStorePayment:^BOOL(SKPayment* _Nonnull payment, SKProduct* _Nonnull product) {
+                                                                  return YES;
+                                                              }
+                                                                   updatedDownloads:nil];
+    [queue addTransactionObserver:self.plugin.paymentQueueHandler];
+    self.plugin.paymentQueueHandler.testing = YES;
+    [self.plugin handleMethodCall:call
+                           result:^(id r){
+                           }];
+    [self waitForExpectations:@[ expectation ] timeout:5];
+    XCTAssertEqual(transactionForUpdateBlock.transactionState, SKPaymentTransactionStatePurchased);
 }
 
 @end

--- a/packages/in_app_purchase/example/ios/in_app_purchase_pluginTests/InAppPurchasePluginTest.m
+++ b/packages/in_app_purchase/example/ios/in_app_purchase_pluginTests/InAppPurchasePluginTest.m
@@ -28,10 +28,10 @@
   FlutterMethodCall* call = [FlutterMethodCall methodCallWithMethodName:@"invalid" arguments:NULL];
   __block id result;
   [self.plugin handleMethodCall:call
-                    result:^(id r) {
-                      [expectation fulfill];
-                      result = r;
-                    }];
+                         result:^(id r) {
+                           [expectation fulfill];
+                           result = r;
+                         }];
   [self waitForExpectations:@[ expectation ] timeout:5];
   XCTAssertEqual(result, FlutterMethodNotImplemented);
 }
@@ -43,10 +43,10 @@
                                         arguments:NULL];
   __block id result;
   [self.plugin handleMethodCall:call
-                    result:^(id r) {
-                      [expectation fulfill];
-                      result = r;
-                    }];
+                         result:^(id r) {
+                           [expectation fulfill];
+                           result = r;
+                         }];
   [self waitForExpectations:@[ expectation ] timeout:5];
   XCTAssertEqual(result, [NSNumber numberWithBool:YES]);
 }
@@ -59,10 +59,10 @@
                      arguments:@[ @"123" ]];
   __block id result;
   [self.plugin handleMethodCall:call
-                    result:^(id r) {
-                      [expectation fulfill];
-                      result = r;
-                    }];
+                         result:^(id r) {
+                           [expectation fulfill];
+                           result = r;
+                         }];
   [self waitForExpectations:@[ expectation ] timeout:5];
   XCTAssert([result isKindOfClass:[NSDictionary class]]);
   NSArray* resultArray = [result objectForKey:@"products"];
@@ -71,99 +71,99 @@
 }
 
 - (void)testCreatePaymentWithProduct {
-    XCTestExpectation* expectation =
-    [self expectationWithDescription:@"must return a payment"];
-    FlutterMethodCall* call = [FlutterMethodCall
-                               methodCallWithMethodName:@"-[InAppPurchasePlugin startProductRequest:result:]"
-                               arguments:@[ @"123" ]];
-    FlutterMethodCall* createPaymentCall = [FlutterMethodCall
-                               methodCallWithMethodName:@"-[InAppPurchasePlugin createPaymentWithProductID:result:]"
-                               arguments:@"123"];
-    __block NSDictionary *result;
-    __weak typeof(self) weakSelf = self;
-    [self.plugin handleMethodCall:call
-                           result:^(id queryResult) {
-                               [weakSelf.plugin handleMethodCall:createPaymentCall result:^(id  _Nullable r) {
-                                   result = r;
-                                   [expectation fulfill];
-                               }];
-                           }];
-    [self waitForExpectations:@[ expectation ] timeout:5];
-    XCTAssertTrue([result[@"productIdentifier"] isEqualToString:@"123"]);
+  XCTestExpectation* expectation = [self expectationWithDescription:@"must return a payment"];
+  FlutterMethodCall* call = [FlutterMethodCall
+      methodCallWithMethodName:@"-[InAppPurchasePlugin startProductRequest:result:]"
+                     arguments:@[ @"123" ]];
+  FlutterMethodCall* createPaymentCall = [FlutterMethodCall
+      methodCallWithMethodName:@"-[InAppPurchasePlugin createPaymentWithProductID:result:]"
+                     arguments:@"123"];
+  __block NSDictionary* result;
+  __weak typeof(self) weakSelf = self;
+  [self.plugin handleMethodCall:call
+                         result:^(id queryResult) {
+                           [weakSelf.plugin handleMethodCall:createPaymentCall
+                                                      result:^(id _Nullable r) {
+                                                        result = r;
+                                                        [expectation fulfill];
+                                                      }];
+                         }];
+  [self waitForExpectations:@[ expectation ] timeout:5];
+  XCTAssertTrue([result[@"productIdentifier"] isEqualToString:@"123"]);
 }
 
 - (void)testAddPaymentFailure {
-    XCTestExpectation* expectation =
-    [self expectationWithDescription:@"result should return failed state"];
-    FlutterMethodCall* call =
-    [FlutterMethodCall methodCallWithMethodName:@"-[InAppPurchasePlugin addPayment:result:]"
-                                      arguments:@{
-                                                  @"productID" : @"123",
-                                                  @"quantity" : @(1),
-                                                  @"simulatesAskToBuyInSandBox" : @YES
-                                                  }];
-    SKPaymentQueueStub* queue = [SKPaymentQueueStub new];
-    queue.testState = SKPaymentTransactionStateFailed;
-    __block SKPaymentTransaction* transactionForUpdateBlock;
-    self.plugin.paymentQueueHandler = [[FIAPaymentQueueHandler alloc] initWithQueue:queue
-                                                                transactionsUpdated:^(NSArray<SKPaymentTransaction*>* _Nonnull transactions) {
-                                                                    SKPaymentTransaction* transaction = transactions[0];
-                                                                    if (transaction.transactionState == SKPaymentTransactionStateFailed) {
-                                                                        transactionForUpdateBlock = transaction;
-                                                                        [expectation fulfill];
-                                                                    }
-                                                                }
-                                                                 transactionRemoved:nil
-                                                           restoreTransactionFailed:nil
-                                               restoreCompletedTransactionsFinished:nil
-                                                              shouldAddStorePayment:^BOOL(SKPayment* _Nonnull payment, SKProduct* _Nonnull product) {
-                                                                  return YES;
-                                                              }
-                                                                   updatedDownloads:nil];
-    [queue addTransactionObserver:self.plugin.paymentQueueHandler];
-    self.plugin.paymentQueueHandler.testing = YES;
-    [self.plugin handleMethodCall:call
-                           result:^(id r){
-                           }];
-    [self waitForExpectations:@[ expectation ] timeout:5];
-    XCTAssertEqual(transactionForUpdateBlock.transactionState, SKPaymentTransactionStateFailed);
+  XCTestExpectation* expectation =
+      [self expectationWithDescription:@"result should return failed state"];
+  FlutterMethodCall* call =
+      [FlutterMethodCall methodCallWithMethodName:@"-[InAppPurchasePlugin addPayment:result:]"
+                                        arguments:@{
+                                          @"productID" : @"123",
+                                          @"quantity" : @(1),
+                                          @"simulatesAskToBuyInSandBox" : @YES
+                                        }];
+  SKPaymentQueueStub* queue = [SKPaymentQueueStub new];
+  queue.testState = SKPaymentTransactionStateFailed;
+  __block SKPaymentTransaction* transactionForUpdateBlock;
+  self.plugin.paymentQueueHandler = [[FIAPaymentQueueHandler alloc] initWithQueue:queue
+      transactionsUpdated:^(NSArray<SKPaymentTransaction*>* _Nonnull transactions) {
+        SKPaymentTransaction* transaction = transactions[0];
+        if (transaction.transactionState == SKPaymentTransactionStateFailed) {
+          transactionForUpdateBlock = transaction;
+          [expectation fulfill];
+        }
+      }
+      transactionRemoved:nil
+      restoreTransactionFailed:nil
+      restoreCompletedTransactionsFinished:nil
+      shouldAddStorePayment:^BOOL(SKPayment* _Nonnull payment, SKProduct* _Nonnull product) {
+        return YES;
+      }
+      updatedDownloads:nil];
+  [queue addTransactionObserver:self.plugin.paymentQueueHandler];
+  self.plugin.paymentQueueHandler.testing = YES;
+  [self.plugin handleMethodCall:call
+                         result:^(id r){
+                         }];
+  [self waitForExpectations:@[ expectation ] timeout:5];
+  XCTAssertEqual(transactionForUpdateBlock.transactionState, SKPaymentTransactionStateFailed);
 }
 
 - (void)testAddPaymentSuccessWithMockQueue {
-    XCTestExpectation* expectation =
-    [self expectationWithDescription:@"result should return success state"];
-    FlutterMethodCall* call =
-    [FlutterMethodCall methodCallWithMethodName:@"-[InAppPurchasePlugin addPayment:result:]"
-                                      arguments:@{
-                                                  @"productID" : @"123",
-                                                  @"quantity" : @(1),
-                                                  @"simulatesAskToBuyInSandBox" : @YES
-                                                  }];
-    SKPaymentQueueStub* queue = [SKPaymentQueueStub new];
-    queue.testState = SKPaymentTransactionStatePurchased;
-    __block SKPaymentTransaction* transactionForUpdateBlock;
-    self.plugin.paymentQueueHandler = [[FIAPaymentQueueHandler alloc] initWithQueue:queue
-                                                                transactionsUpdated:^(NSArray<SKPaymentTransaction*>* _Nonnull transactions) {
-                                                                    SKPaymentTransaction* transaction = transactions[0];
-                                                                    if (transaction.transactionState == SKPaymentTransactionStatePurchased) {
-                                                                        transactionForUpdateBlock = transaction;
-                                                                        [expectation fulfill];
-                                                                    }
-                                                                }
-                                                                 transactionRemoved:nil
-                                                           restoreTransactionFailed:nil
-                                               restoreCompletedTransactionsFinished:nil
-                                                              shouldAddStorePayment:^BOOL(SKPayment* _Nonnull payment, SKProduct* _Nonnull product) {
-                                                                  return YES;
-                                                              }
-                                                                   updatedDownloads:nil];
-    [queue addTransactionObserver:self.plugin.paymentQueueHandler];
-    self.plugin.paymentQueueHandler.testing = YES;
-    [self.plugin handleMethodCall:call
-                           result:^(id r){
-                           }];
-    [self waitForExpectations:@[ expectation ] timeout:5];
-    XCTAssertEqual(transactionForUpdateBlock.transactionState, SKPaymentTransactionStatePurchased);
+  XCTestExpectation* expectation =
+      [self expectationWithDescription:@"result should return success state"];
+  FlutterMethodCall* call =
+      [FlutterMethodCall methodCallWithMethodName:@"-[InAppPurchasePlugin addPayment:result:]"
+                                        arguments:@{
+                                          @"productID" : @"123",
+                                          @"quantity" : @(1),
+                                          @"simulatesAskToBuyInSandBox" : @YES
+                                        }];
+  SKPaymentQueueStub* queue = [SKPaymentQueueStub new];
+  queue.testState = SKPaymentTransactionStatePurchased;
+  __block SKPaymentTransaction* transactionForUpdateBlock;
+  self.plugin.paymentQueueHandler = [[FIAPaymentQueueHandler alloc] initWithQueue:queue
+      transactionsUpdated:^(NSArray<SKPaymentTransaction*>* _Nonnull transactions) {
+        SKPaymentTransaction* transaction = transactions[0];
+        if (transaction.transactionState == SKPaymentTransactionStatePurchased) {
+          transactionForUpdateBlock = transaction;
+          [expectation fulfill];
+        }
+      }
+      transactionRemoved:nil
+      restoreTransactionFailed:nil
+      restoreCompletedTransactionsFinished:nil
+      shouldAddStorePayment:^BOOL(SKPayment* _Nonnull payment, SKProduct* _Nonnull product) {
+        return YES;
+      }
+      updatedDownloads:nil];
+  [queue addTransactionObserver:self.plugin.paymentQueueHandler];
+  self.plugin.paymentQueueHandler.testing = YES;
+  [self.plugin handleMethodCall:call
+                         result:^(id r){
+                         }];
+  [self waitForExpectations:@[ expectation ] timeout:5];
+  XCTAssertEqual(transactionForUpdateBlock.transactionState, SKPaymentTransactionStatePurchased);
 }
 
 @end

--- a/packages/in_app_purchase/example/ios/in_app_purchase_pluginTests/InAppPurchasePluginTest.m
+++ b/packages/in_app_purchase/example/ios/in_app_purchase_pluginTests/InAppPurchasePluginTest.m
@@ -70,6 +70,28 @@
   XCTAssertTrue([resultArray.firstObject[@"productIdentifier"] isEqualToString:@"123"]);
 }
 
+- (void)testCreatePaymentWithProduct {
+    XCTestExpectation* expectation =
+    [self expectationWithDescription:@"must return a payment"];
+    FlutterMethodCall* call = [FlutterMethodCall
+                               methodCallWithMethodName:@"-[InAppPurchasePlugin startProductRequest:result:]"
+                               arguments:@[ @"123" ]];
+    FlutterMethodCall* createPaymentCall = [FlutterMethodCall
+                               methodCallWithMethodName:@"-[InAppPurchasePlugin createPaymentWithProductID:result:]"
+                               arguments:@"123"];
+    __block NSDictionary *result;
+    __weak typeof(self) weakSelf = self;
+    [self.plugin handleMethodCall:call
+                           result:^(id queryResult) {
+                               [weakSelf.plugin handleMethodCall:createPaymentCall result:^(id  _Nullable r) {
+                                   result = r;
+                                   [expectation fulfill];
+                               }];
+                           }];
+    [self waitForExpectations:@[ expectation ] timeout:5];
+    XCTAssertTrue([result[@"productIdentifier"] isEqualToString:@"123"]);
+}
+
 - (void)testAddPaymentFailure {
     XCTestExpectation* expectation =
     [self expectationWithDescription:@"result should return failed state"];

--- a/packages/in_app_purchase/example/ios/in_app_purchase_pluginTests/InAppPurchasePluginTest.m
+++ b/packages/in_app_purchase/example/ios/in_app_purchase_pluginTests/InAppPurchasePluginTest.m
@@ -100,7 +100,8 @@
                                         arguments:@{
                                           @"productID" : @"123",
                                           @"quantity" : @(1),
-                                          @"simulatesAskToBuyInSandBox" : @YES
+                                          @"simulatesAskToBuyInSandBox" : @YES,
+                                          @"usePaymentObject": @YES
                                         }];
   SKPaymentQueueStub* queue = [SKPaymentQueueStub new];
   queue.testState = SKPaymentTransactionStateFailed;
@@ -136,7 +137,8 @@
                                         arguments:@{
                                           @"productID" : @"123",
                                           @"quantity" : @(1),
-                                          @"simulatesAskToBuyInSandBox" : @YES
+                                          @"simulatesAskToBuyInSandBox" : @YES,
+                                          @"usePaymentObject": @YES
                                         }];
   SKPaymentQueueStub* queue = [SKPaymentQueueStub new];
   queue.testState = SKPaymentTransactionStatePurchased;

--- a/packages/in_app_purchase/example/ios/in_app_purchase_pluginTests/InAppPurchasePluginTest.m
+++ b/packages/in_app_purchase/example/ios/in_app_purchase_pluginTests/InAppPurchasePluginTest.m
@@ -121,7 +121,6 @@
       }
       updatedDownloads:nil];
   [queue addTransactionObserver:self.plugin.paymentQueueHandler];
-  self.plugin.paymentQueueHandler.testing = YES;
   [self.plugin handleMethodCall:call
                          result:^(id r){
                          }];
@@ -158,7 +157,6 @@
       }
       updatedDownloads:nil];
   [queue addTransactionObserver:self.plugin.paymentQueueHandler];
-  self.plugin.paymentQueueHandler.testing = YES;
   [self.plugin handleMethodCall:call
                          result:^(id r){
                          }];

--- a/packages/in_app_purchase/example/ios/in_app_purchase_pluginTests/PaymentQueueTest.m
+++ b/packages/in_app_purchase/example/ios/in_app_purchase_pluginTests/PaymentQueueTest.m
@@ -1,0 +1,186 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <XCTest/XCTest.h>
+#import "FIAPaymentQueueHandler.h"
+#import "Stubs.h"
+
+@interface PaymentQueueTest : XCTestCase
+
+@property(strong, nonatomic) NSDictionary *periodMap;
+@property(strong, nonatomic) NSDictionary *discountMap;
+@property(strong, nonatomic) NSDictionary *productMap;
+@property(strong, nonatomic) NSDictionary *productResponseMap;
+
+@end
+
+@implementation PaymentQueueTest
+
+- (void)setUp {
+  self.periodMap = @{@"numberOfUnits" : @(0), @"unit" : @(0)};
+  self.discountMap = @{
+    @"price" : @1.0,
+    @"currencyCode" : @"USD",
+    @"numberOfPeriods" : @1,
+    @"subscriptionPeriod" : self.periodMap,
+    @"paymentMode" : @1
+  };
+  self.productMap = @{
+    @"price" : @1.0,
+    @"currencyCode" : @"USD",
+    @"productIdentifier" : @"123",
+    @"localizedTitle" : @"title",
+    @"localizedDescription" : @"des",
+    @"downloadable" : @YES,
+    @"downloadContentLengths" : @1,
+    @"downloadContentVersion" : [NSNull null],  // not mockable
+    @"subscriptionPeriod" : self.periodMap,
+    @"introductoryPrice" : self.discountMap,
+    @"subscriptionGroupIdentifier" : @"com.group"
+  };
+  self.productResponseMap =
+      @{@"products" : @[ self.productMap ], @"invalidProductIdentifiers" : [NSNull null]};
+}
+
+- (void)testTransactionPurchased {
+  XCTestExpectation *expectation =
+      [self expectationWithDescription:@"expect to get purchased transcation."];
+  SKPaymentQueueStub *queue = [[SKPaymentQueueStub alloc] init];
+  queue.testState = SKPaymentTransactionStatePurchased;
+  __block SKPaymentTransactionStub *tran;
+  FIAPaymentQueueHandler *handler = [[FIAPaymentQueueHandler alloc] initWithQueue:queue
+      transactionsUpdated:^(NSArray<SKPaymentTransaction *> *_Nonnull transactions) {
+        SKPaymentTransaction *transaction = transactions[0];
+        tran = (SKPaymentTransactionStub *)transaction;
+        [expectation fulfill];
+      }
+      transactionRemoved:nil
+      restoreTransactionFailed:nil
+      restoreCompletedTransactionsFinished:nil
+      shouldAddStorePayment:^BOOL(SKPayment *_Nonnull payment, SKProduct *_Nonnull product) {
+        return YES;
+      }
+      updatedDownloads:nil];
+  handler.testing = YES;
+  [queue addTransactionObserver:handler];
+  SKPayment *payment =
+      [SKPayment paymentWithProduct:[[SKProductStub alloc] initWithMap:self.productResponseMap]];
+  [handler addPayment:payment];
+  [self waitForExpectations:@[ expectation ] timeout:5];
+  XCTAssertEqual(tran.transactionState, SKPaymentTransactionStatePurchased);
+}
+
+- (void)testTransactionFailed {
+  XCTestExpectation *expectation =
+      [self expectationWithDescription:@"expect to get failed transcation."];
+  SKPaymentQueueStub *queue = [[SKPaymentQueueStub alloc] init];
+  queue.testState = SKPaymentTransactionStateFailed;
+  __block SKPaymentTransactionStub *tran;
+  FIAPaymentQueueHandler *handler = [[FIAPaymentQueueHandler alloc] initWithQueue:queue
+      transactionsUpdated:^(NSArray<SKPaymentTransaction *> *_Nonnull transactions) {
+        SKPaymentTransaction *transaction = transactions[0];
+        tran = (SKPaymentTransactionStub *)transaction;
+        [expectation fulfill];
+      }
+      transactionRemoved:nil
+      restoreTransactionFailed:nil
+      restoreCompletedTransactionsFinished:nil
+      shouldAddStorePayment:^BOOL(SKPayment *_Nonnull payment, SKProduct *_Nonnull product) {
+        return YES;
+      }
+      updatedDownloads:nil];
+  handler.testing = YES;
+  [queue addTransactionObserver:handler];
+  SKPayment *payment =
+      [SKPayment paymentWithProduct:[[SKProductStub alloc] initWithMap:self.productResponseMap]];
+  [handler addPayment:payment];
+  [self waitForExpectations:@[ expectation ] timeout:5];
+  XCTAssertEqual(tran.transactionState, SKPaymentTransactionStateFailed);
+}
+
+- (void)testTransactionRestored {
+  XCTestExpectation *expectation =
+      [self expectationWithDescription:@"expect to get restored transcation."];
+  SKPaymentQueueStub *queue = [[SKPaymentQueueStub alloc] init];
+  queue.testState = SKPaymentTransactionStateRestored;
+  __block SKPaymentTransactionStub *tran;
+  FIAPaymentQueueHandler *handler = [[FIAPaymentQueueHandler alloc] initWithQueue:queue
+      transactionsUpdated:^(NSArray<SKPaymentTransaction *> *_Nonnull transactions) {
+        SKPaymentTransaction *transaction = transactions[0];
+        tran = (SKPaymentTransactionStub *)transaction;
+        [expectation fulfill];
+      }
+      transactionRemoved:nil
+      restoreTransactionFailed:nil
+      restoreCompletedTransactionsFinished:nil
+      shouldAddStorePayment:^BOOL(SKPayment *_Nonnull payment, SKProduct *_Nonnull product) {
+        return YES;
+      }
+      updatedDownloads:nil];
+  handler.testing = YES;
+  [queue addTransactionObserver:handler];
+  SKPayment *payment =
+      [SKPayment paymentWithProduct:[[SKProductStub alloc] initWithMap:self.productResponseMap]];
+  [handler addPayment:payment];
+  [self waitForExpectations:@[ expectation ] timeout:5];
+  XCTAssertEqual(tran.transactionState, SKPaymentTransactionStateRestored);
+}
+
+- (void)testTransactionPurchasing {
+  XCTestExpectation *expectation =
+      [self expectationWithDescription:@"expect to get purchasing transcation."];
+  SKPaymentQueueStub *queue = [[SKPaymentQueueStub alloc] init];
+  queue.testState = SKPaymentTransactionStatePurchasing;
+  __block SKPaymentTransactionStub *tran;
+  FIAPaymentQueueHandler *handler = [[FIAPaymentQueueHandler alloc] initWithQueue:queue
+      transactionsUpdated:^(NSArray<SKPaymentTransaction *> *_Nonnull transactions) {
+        SKPaymentTransaction *transaction = transactions[0];
+        tran = (SKPaymentTransactionStub *)transaction;
+        [expectation fulfill];
+      }
+      transactionRemoved:nil
+      restoreTransactionFailed:nil
+      restoreCompletedTransactionsFinished:nil
+      shouldAddStorePayment:^BOOL(SKPayment *_Nonnull payment, SKProduct *_Nonnull product) {
+        return YES;
+      }
+      updatedDownloads:nil];
+  handler.testing = YES;
+  [queue addTransactionObserver:handler];
+  SKPayment *payment =
+      [SKPayment paymentWithProduct:[[SKProductStub alloc] initWithMap:self.productResponseMap]];
+  [handler addPayment:payment];
+  [self waitForExpectations:@[ expectation ] timeout:5];
+  XCTAssertEqual(tran.transactionState, SKPaymentTransactionStatePurchasing);
+}
+
+- (void)testTransactionDeferred {
+  XCTestExpectation *expectation =
+      [self expectationWithDescription:@"expect to get deffered transcation."];
+  SKPaymentQueueStub *queue = [[SKPaymentQueueStub alloc] init];
+  queue.testState = SKPaymentTransactionStateDeferred;
+  __block SKPaymentTransactionStub *tran;
+  FIAPaymentQueueHandler *handler = [[FIAPaymentQueueHandler alloc] initWithQueue:queue
+      transactionsUpdated:^(NSArray<SKPaymentTransaction *> *_Nonnull transactions) {
+        SKPaymentTransaction *transaction = transactions[0];
+        tran = (SKPaymentTransactionStub *)transaction;
+        [expectation fulfill];
+      }
+      transactionRemoved:nil
+      restoreTransactionFailed:nil
+      restoreCompletedTransactionsFinished:nil
+      shouldAddStorePayment:^BOOL(SKPayment *_Nonnull payment, SKProduct *_Nonnull product) {
+        return YES;
+      }
+      updatedDownloads:nil];
+  handler.testing = YES;
+  [queue addTransactionObserver:handler];
+  SKPayment *payment =
+      [SKPayment paymentWithProduct:[[SKProductStub alloc] initWithMap:self.productResponseMap]];
+  [handler addPayment:payment];
+  [self waitForExpectations:@[ expectation ] timeout:5];
+  XCTAssertEqual(tran.transactionState, SKPaymentTransactionStateDeferred);
+}
+
+@end

--- a/packages/in_app_purchase/example/ios/in_app_purchase_pluginTests/Stubs.h
+++ b/packages/in_app_purchase/example/ios/in_app_purchase_pluginTests/Stubs.h
@@ -32,8 +32,13 @@ NS_ASSUME_NONNULL_BEGIN
 @interface InAppPurchasePluginStub : InAppPurchasePlugin
 @end
 
+@interface SKPaymentQueueStub : SKPaymentQueue
+@property(assign, nonatomic) SKPaymentTransactionState testState;
+@end
+
 @interface SKPaymentTransactionStub : SKPaymentTransaction
 - (instancetype)initWithMap:(NSDictionary *)map;
+- (instancetype)initWithState:(SKPaymentTransactionState)state;
 @end
 
 @interface SKDownloadStub : SKDownload

--- a/packages/in_app_purchase/example/ios/in_app_purchase_pluginTests/Stubs.m
+++ b/packages/in_app_purchase/example/ios/in_app_purchase_pluginTests/Stubs.m
@@ -186,6 +186,7 @@
 - (instancetype)initWithState:(SKPaymentTransactionState)state {
     self = [super init];
     if (self) {
+        [self setValue:@"fakeID" forKey:@"transactionIdentifier"];
         [self setValue:@(state) forKey:@"transactionState"];
     }
     return self;

--- a/packages/in_app_purchase/example/ios/in_app_purchase_pluginTests/Stubs.m
+++ b/packages/in_app_purchase/example/ios/in_app_purchase_pluginTests/Stubs.m
@@ -130,6 +130,26 @@
 
 @end
 
+@interface SKPaymentQueueStub ()
+
+@property(strong, nonatomic) id<SKPaymentTransactionObserver> observer;
+
+@end
+
+@implementation SKPaymentQueueStub
+
+- (void)addTransactionObserver:(id<SKPaymentTransactionObserver>)observer {
+    self.observer = observer;
+}
+
+- (void)addPayment:(SKPayment *)payment {
+    SKPaymentTransactionStub *transaction =
+    [[SKPaymentTransactionStub alloc] initWithState:self.testState];
+    [self.observer paymentQueue:self updatedTransactions:@[ transaction ]];
+}
+
+@end
+
 @implementation SKPaymentTransactionStub
 
 - (instancetype)initWithID:(NSString *)identifier {
@@ -161,6 +181,14 @@
     [self setValue:downloads forKey:@"downloads"];
   }
   return self;
+}
+
+- (instancetype)initWithState:(SKPaymentTransactionState)state {
+    self = [super init];
+    if (self) {
+        [self setValue:@(state) forKey:@"transactionState"];
+    }
+    return self;
 }
 
 @end

--- a/packages/in_app_purchase/example/ios/in_app_purchase_pluginTests/Stubs.m
+++ b/packages/in_app_purchase/example/ios/in_app_purchase_pluginTests/Stubs.m
@@ -139,13 +139,13 @@
 @implementation SKPaymentQueueStub
 
 - (void)addTransactionObserver:(id<SKPaymentTransactionObserver>)observer {
-    self.observer = observer;
+  self.observer = observer;
 }
 
 - (void)addPayment:(SKPayment *)payment {
-    SKPaymentTransactionStub *transaction =
-    [[SKPaymentTransactionStub alloc] initWithState:self.testState];
-    [self.observer paymentQueue:self updatedTransactions:@[ transaction ]];
+  SKPaymentTransactionStub *transaction =
+      [[SKPaymentTransactionStub alloc] initWithState:self.testState];
+  [self.observer paymentQueue:self updatedTransactions:@[ transaction ]];
 }
 
 @end
@@ -184,12 +184,12 @@
 }
 
 - (instancetype)initWithState:(SKPaymentTransactionState)state {
-    self = [super init];
-    if (self) {
-        [self setValue:@"fakeID" forKey:@"transactionIdentifier"];
-        [self setValue:@(state) forKey:@"transactionState"];
-    }
-    return self;
+  self = [super init];
+  if (self) {
+    [self setValue:@"fakeID" forKey:@"transactionIdentifier"];
+    [self setValue:@(state) forKey:@"transactionState"];
+  }
+  return self;
 }
 
 @end

--- a/packages/in_app_purchase/ios/Classes/FIAPaymentQueueHandler.h
+++ b/packages/in_app_purchase/ios/Classes/FIAPaymentQueueHandler.h
@@ -29,6 +29,7 @@ typedef void (^UpdatedDownloads)(NSArray<SKDownload *> *downloads);
                    shouldAddStorePayment:(nullable ShouldAddStorePayment)shouldAddStorePayment
                         updatedDownloads:(nullable UpdatedDownloads)updatedDownloads;
 - (void)addPayment:(SKPayment *)payment;
+// Can throw exceptions, should always used in a @try block.
 - (void)finishTransaction:(SKPaymentTransaction *)transaction;
 
 // Enable testing.

--- a/packages/in_app_purchase/ios/Classes/FIAPaymentQueueHandler.h
+++ b/packages/in_app_purchase/ios/Classes/FIAPaymentQueueHandler.h
@@ -18,6 +18,8 @@ typedef void (^UpdatedDownloads)(NSArray<SKDownload *> *downloads);
 
 @interface FIAPaymentQueueHandler : NSObject <SKPaymentTransactionObserver>
 
+@property (copy, nonatomic, readonly) NSDictionary *transactions;
+
 - (instancetype)initWithQueue:(nonnull SKPaymentQueue *)queue
                      transactionsUpdated:(nullable TransactionsUpdated)transactionsUpdated
                       transactionRemoved:(nullable TransactionsRemoved)transactionsRemoved
@@ -27,6 +29,7 @@ typedef void (^UpdatedDownloads)(NSArray<SKDownload *> *downloads);
                    shouldAddStorePayment:(nullable ShouldAddStorePayment)shouldAddStorePayment
                         updatedDownloads:(nullable UpdatedDownloads)updatedDownloads;
 - (void)addPayment:(SKPayment *)payment;
+- (void)finishTransaction:(SKPaymentTransaction *)transaction;
 
 // Enable testing.
 

--- a/packages/in_app_purchase/ios/Classes/FIAPaymentQueueHandler.h
+++ b/packages/in_app_purchase/ios/Classes/FIAPaymentQueueHandler.h
@@ -1,0 +1,41 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <Foundation/Foundation.h>
+#import <StoreKit/StoreKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+extern NSString *const TestingProductID;
+
+typedef void (^TransactionsUpdated)(NSArray<SKPaymentTransaction *> *transactions);
+typedef void (^TransactionsRemoved)(NSArray<SKPaymentTransaction *> *transactions);
+typedef void (^RestoreTransactionFailed)(NSError *error);
+typedef void (^RestoreCompletedTransactionsFinished)(void);
+typedef BOOL (^ShouldAddStorePayment)(SKPayment *payment, SKProduct *product);
+typedef void (^UpdatedDownloads)(NSArray<SKDownload *> *downloads);
+
+@interface FIAPaymentQueueHandler : NSObject <SKPaymentTransactionObserver>
+
+- (instancetype)initWithQueue:(nonnull SKPaymentQueue *)queue
+                     transactionsUpdated:(nullable TransactionsUpdated)transactionsUpdated
+                      transactionRemoved:(nullable TransactionsRemoved)transactionsRemoved
+                restoreTransactionFailed:(nullable RestoreTransactionFailed)restoreTransactionFailed
+    restoreCompletedTransactionsFinished:
+        (nullable RestoreCompletedTransactionsFinished)restoreCompletedTransactionsFinished
+                   shouldAddStorePayment:(nullable ShouldAddStorePayment)shouldAddStorePayment
+                        updatedDownloads:(nullable UpdatedDownloads)updatedDownloads;
+- (void)addPayment:(SKPayment *)payment;
+
+// Enable testing.
+
+// Because payment object in transaction is not KVC, we cannot mock the payment object in the
+// transaction. So there is no easay way to create stubs and test the handler.
+// When set to true, we always this a constant TestingProductID as product ID
+// when storing and accessing the completion block from self.completionMap
+@property(assign, nonatomic) BOOL testing;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/in_app_purchase/ios/Classes/FIAPaymentQueueHandler.h
+++ b/packages/in_app_purchase/ios/Classes/FIAPaymentQueueHandler.h
@@ -18,7 +18,7 @@ typedef void (^UpdatedDownloads)(NSArray<SKDownload *> *downloads);
 
 @interface FIAPaymentQueueHandler : NSObject <SKPaymentTransactionObserver>
 
-@property (copy, nonatomic, readonly) NSDictionary *transactions;
+@property(copy, nonatomic, readonly) NSDictionary *transactions;
 
 - (instancetype)initWithQueue:(nonnull SKPaymentQueue *)queue
                      transactionsUpdated:(nullable TransactionsUpdated)transactionsUpdated

--- a/packages/in_app_purchase/ios/Classes/FIAPaymentQueueHandler.h
+++ b/packages/in_app_purchase/ios/Classes/FIAPaymentQueueHandler.h
@@ -7,8 +7,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-extern NSString *const TestingProductID;
-
 typedef void (^TransactionsUpdated)(NSArray<SKPaymentTransaction *> *transactions);
 typedef void (^TransactionsRemoved)(NSArray<SKPaymentTransaction *> *transactions);
 typedef void (^RestoreTransactionFailed)(NSError *error);
@@ -29,16 +27,8 @@ typedef void (^UpdatedDownloads)(NSArray<SKDownload *> *downloads);
                    shouldAddStorePayment:(nullable ShouldAddStorePayment)shouldAddStorePayment
                         updatedDownloads:(nullable UpdatedDownloads)updatedDownloads;
 - (void)addPayment:(SKPayment *)payment;
-// Can throw exceptions, should always used in a @try block.
+// Can throw exceptions if the transaction type is purchasing, should always used in a @try block.
 - (void)finishTransaction:(SKPaymentTransaction *)transaction;
-
-// Enable testing.
-
-// Because payment object in transaction is not KVC, we cannot mock the payment object in the
-// transaction. So there is no easay way to create stubs and test the handler.
-// When set to true, we always this a constant TestingProductID as product ID
-// when storing and accessing the completion block from self.completionMap
-@property(assign, nonatomic) BOOL testing;
 
 @end
 

--- a/packages/in_app_purchase/ios/Classes/FIAPaymentQueueHandler.m
+++ b/packages/in_app_purchase/ios/Classes/FIAPaymentQueueHandler.m
@@ -17,7 +17,7 @@ NSString *const TestingProductID = @"testing";
 @property(nullable, copy, nonatomic) ShouldAddStorePayment shouldAddStorePayment;
 @property(nullable, copy, nonatomic) UpdatedDownloads updatedDownloads;
 
-@property (strong, nonatomic) NSMutableDictionary *transactionsSetter;
+@property(strong, nonatomic) NSMutableDictionary *transactionsSetter;
 
 @end
 
@@ -54,12 +54,13 @@ NSString *const TestingProductID = @"testing";
 }
 
 - (void)finishTransaction:(SKPaymentTransaction *)transaction {
-    @try {
-        [self.queue finishTransaction:transaction];
-    } @catch (NSException *e) {
-        // finish transaction will throw exception if the transaction type is purchasing. Raise the exception so the InAppPurchasePlugin will get notified.
-        [e raise];
-    }
+  @try {
+    [self.queue finishTransaction:transaction];
+  } @catch (NSException *e) {
+    // finish transaction will throw exception if the transaction type is purchasing. Raise the
+    // exception so the InAppPurchasePlugin will get notified.
+    [e raise];
+  }
 }
 
 #pragma mark - observing
@@ -67,9 +68,9 @@ NSString *const TestingProductID = @"testing";
 // state of transactions and finish as appropriate.
 - (void)paymentQueue:(SKPaymentQueue *)queue
     updatedTransactions:(NSArray<SKPaymentTransaction *> *)transactions {
-    for (SKPaymentTransaction *transaction in transactions) {
-        [self.transactionsSetter setObject:transaction forKey:transaction.transactionIdentifier];
-    }
+  for (SKPaymentTransaction *transaction in transactions) {
+    [self.transactionsSetter setObject:transaction forKey:transaction.transactionIdentifier];
+  }
   // notify dart through callbacks.
   if (self.transactionsUpdated) {
     self.transactionsUpdated(transactions);
@@ -121,7 +122,7 @@ NSString *const TestingProductID = @"testing";
 #pragma mark - getter
 
 - (NSDictionary *)transactions {
-    return self.transactionsSetter;
+  return self.transactionsSetter;
 }
 
 @end

--- a/packages/in_app_purchase/ios/Classes/FIAPaymentQueueHandler.m
+++ b/packages/in_app_purchase/ios/Classes/FIAPaymentQueueHandler.m
@@ -1,0 +1,120 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "FIAPaymentQueueHandler.h"
+
+NSString *const TestingProductID = @"testing";
+
+@interface FIAPaymentQueueHandler ()
+
+@property(strong, nonatomic) SKPaymentQueue *queue;
+@property(nullable, copy, nonatomic) TransactionsUpdated transactionsUpdated;
+@property(nullable, copy, nonatomic) TransactionsRemoved transactionsRemoved;
+@property(nullable, copy, nonatomic) RestoreTransactionFailed restoreTransactionFailed;
+@property(nullable, copy, nonatomic)
+    RestoreCompletedTransactionsFinished paymentQueueRestoreCompletedTransactionsFinished;
+@property(nullable, copy, nonatomic) ShouldAddStorePayment shouldAddStorePayment;
+@property(nullable, copy, nonatomic) UpdatedDownloads updatedDownloads;
+
+@end
+
+@implementation FIAPaymentQueueHandler
+
+- (instancetype)initWithQueue:(nonnull SKPaymentQueue *)queue
+                     transactionsUpdated:(nullable TransactionsUpdated)transactionsUpdated
+                      transactionRemoved:(nullable TransactionsRemoved)transactionsRemoved
+                restoreTransactionFailed:(nullable RestoreTransactionFailed)restoreTransactionFailed
+    restoreCompletedTransactionsFinished:
+        (nullable RestoreCompletedTransactionsFinished)restoreCompletedTransactionsFinished
+                   shouldAddStorePayment:(nullable ShouldAddStorePayment)shouldAddStorePayment
+                        updatedDownloads:(nullable UpdatedDownloads)updatedDownloads {
+  self = [super init];
+  if (self) {
+    self.queue = queue;
+    self.transactionsUpdated = transactionsUpdated;
+    self.transactionsRemoved = transactionsRemoved;
+    self.restoreTransactionFailed = restoreTransactionFailed;
+    self.paymentQueueRestoreCompletedTransactionsFinished = restoreCompletedTransactionsFinished;
+    self.shouldAddStorePayment = shouldAddStorePayment;
+    self.updatedDownloads = updatedDownloads;
+  }
+  return self;
+}
+
+- (void)addPayment:(SKPayment *)payment {
+  NSString *productID = payment.productIdentifier;
+  if (self.testing) {
+    productID = TestingProductID;
+  }
+  [self.queue addPayment:payment];
+}
+
+#pragma mark - observing
+// Sent when the transaction array has changed (additions or state changes).  Client should check
+// state of transactions and finish as appropriate.
+- (void)paymentQueue:(SKPaymentQueue *)queue
+    updatedTransactions:(NSArray<SKPaymentTransaction *> *)transactions {
+  // notify dart through callbacks.
+  if (self.transactionsUpdated) {
+    self.transactionsUpdated(transactions);
+  }
+  for (SKPaymentTransaction *transaction in transactions) {
+    switch (transaction.transactionState) {
+        // The following three states indicates that the transaction has been complete.
+        // We mark the transaction to be finished and send the signal back to dart.
+      case SKPaymentTransactionStatePurchased:
+      case SKPaymentTransactionStateFailed:
+      case SKPaymentTransactionStateRestored:
+        // mark finished transaction as finished as required by OBJC api.
+        [queue finishTransaction:transaction];
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+// Sent when transactions are removed from the queue (via finishTransaction:).
+- (void)paymentQueue:(SKPaymentQueue *)queue
+    removedTransactions:(NSArray<SKPaymentTransaction *> *)transactions {
+  if (self.transactionsRemoved) {
+    self.transactionsRemoved(transactions);
+  }
+}
+
+// Sent when an error is encountered while adding transactions from the user's purchase history back
+// to the queue.
+- (void)paymentQueue:(SKPaymentQueue *)queue
+    restoreCompletedTransactionsFailedWithError:(NSError *)error {
+  if (self.restoreTransactionFailed) {
+    self.restoreTransactionFailed(error);
+  }
+}
+
+// Sent when all transactions from the user's purchase history have successfully been added back to
+// the queue.
+- (void)paymentQueueRestoreCompletedTransactionsFinished:(SKPaymentQueue *)queue {
+  if (self.paymentQueueRestoreCompletedTransactionsFinished) {
+    self.paymentQueueRestoreCompletedTransactionsFinished();
+  }
+}
+
+// Sent when the download state has changed.
+- (void)paymentQueue:(SKPaymentQueue *)queue updatedDownloads:(NSArray<SKDownload *> *)downloads {
+  if (self.updatedDownloads) {
+    self.updatedDownloads(downloads);
+  }
+}
+
+// Sent when a user initiates an IAP buy from the App Store
+- (BOOL)paymentQueue:(SKPaymentQueue *)queue
+    shouldAddStorePayment:(SKPayment *)payment
+               forProduct:(SKProduct *)product {
+  if (self.shouldAddStorePayment) {
+    return (self.shouldAddStorePayment(payment, product));
+  }
+  return YES;
+}
+
+@end

--- a/packages/in_app_purchase/ios/Classes/FIAPaymentQueueHandler.m
+++ b/packages/in_app_purchase/ios/Classes/FIAPaymentQueueHandler.m
@@ -57,6 +57,7 @@ NSString *const TestingProductID = @"testing";
     @try {
         [self.queue finishTransaction:transaction];
     } @catch (NSException *e) {
+        // finish transaction will throw exception if the transaction type is purchasing. Raise the exception so the InAppPurchasePlugin will get notified.
         [e raise];
     }
 }

--- a/packages/in_app_purchase/ios/Classes/FIAPaymentQueueHandler.m
+++ b/packages/in_app_purchase/ios/Classes/FIAPaymentQueueHandler.m
@@ -4,8 +4,6 @@
 
 #import "FIAPaymentQueueHandler.h"
 
-NSString *const TestingProductID = @"testing";
-
 @interface FIAPaymentQueueHandler ()
 
 @property(strong, nonatomic) SKPaymentQueue *queue;
@@ -46,21 +44,11 @@ NSString *const TestingProductID = @"testing";
 }
 
 - (void)addPayment:(SKPayment *)payment {
-  NSString *productID = payment.productIdentifier;
-  if (self.testing) {
-    productID = TestingProductID;
-  }
   [self.queue addPayment:payment];
 }
 
 - (void)finishTransaction:(SKPaymentTransaction *)transaction {
-  @try {
     [self.queue finishTransaction:transaction];
-  } @catch (NSException *e) {
-    // finish transaction will throw exception if the transaction type is purchasing. Raise the
-    // exception so the InAppPurchasePlugin will get notified.
-    [e raise];
-  }
 }
 
 #pragma mark - observing

--- a/packages/in_app_purchase/ios/Classes/FIAPaymentQueueHandler.m
+++ b/packages/in_app_purchase/ios/Classes/FIAPaymentQueueHandler.m
@@ -66,32 +66,32 @@
 // Sent when transactions are removed from the queue (via finishTransaction:).
 - (void)paymentQueue:(SKPaymentQueue *)queue
     removedTransactions:(NSArray<SKPaymentTransaction *> *)transactions {
-    self.transactionsRemoved(transactions);
+  self.transactionsRemoved(transactions);
 }
 
 // Sent when an error is encountered while adding transactions from the user's purchase history back
 // to the queue.
 - (void)paymentQueue:(SKPaymentQueue *)queue
     restoreCompletedTransactionsFailedWithError:(NSError *)error {
-    self.restoreTransactionFailed(error);
+  self.restoreTransactionFailed(error);
 }
 
 // Sent when all transactions from the user's purchase history have successfully been added back to
 // the queue.
 - (void)paymentQueueRestoreCompletedTransactionsFinished:(SKPaymentQueue *)queue {
-    self.paymentQueueRestoreCompletedTransactionsFinished();
+  self.paymentQueueRestoreCompletedTransactionsFinished();
 }
 
 // Sent when the download state has changed.
 - (void)paymentQueue:(SKPaymentQueue *)queue updatedDownloads:(NSArray<SKDownload *> *)downloads {
-    self.updatedDownloads(downloads);
+  self.updatedDownloads(downloads);
 }
 
 // Sent when a user initiates an IAP buy from the App Store
 - (BOOL)paymentQueue:(SKPaymentQueue *)queue
     shouldAddStorePayment:(SKPayment *)payment
                forProduct:(SKProduct *)product {
-    return (self.shouldAddStorePayment(payment, product));
+  return (self.shouldAddStorePayment(payment, product));
 }
 
 #pragma mark - getter

--- a/packages/in_app_purchase/ios/Classes/FIAPaymentQueueHandler.m
+++ b/packages/in_app_purchase/ios/Classes/FIAPaymentQueueHandler.m
@@ -48,7 +48,7 @@
 }
 
 - (void)finishTransaction:(SKPaymentTransaction *)transaction {
-    [self.queue finishTransaction:transaction];
+  [self.queue finishTransaction:transaction];
 }
 
 #pragma mark - observing

--- a/packages/in_app_purchase/ios/Classes/FIAPaymentQueueHandler.m
+++ b/packages/in_app_purchase/ios/Classes/FIAPaymentQueueHandler.m
@@ -60,51 +60,38 @@
     [self.transactionsSetter setObject:transaction forKey:transaction.transactionIdentifier];
   }
   // notify dart through callbacks.
-  if (self.transactionsUpdated) {
-    self.transactionsUpdated(transactions);
-  }
+  self.transactionsUpdated(transactions);
 }
 
 // Sent when transactions are removed from the queue (via finishTransaction:).
 - (void)paymentQueue:(SKPaymentQueue *)queue
     removedTransactions:(NSArray<SKPaymentTransaction *> *)transactions {
-  if (self.transactionsRemoved) {
     self.transactionsRemoved(transactions);
-  }
 }
 
 // Sent when an error is encountered while adding transactions from the user's purchase history back
 // to the queue.
 - (void)paymentQueue:(SKPaymentQueue *)queue
     restoreCompletedTransactionsFailedWithError:(NSError *)error {
-  if (self.restoreTransactionFailed) {
     self.restoreTransactionFailed(error);
-  }
 }
 
 // Sent when all transactions from the user's purchase history have successfully been added back to
 // the queue.
 - (void)paymentQueueRestoreCompletedTransactionsFinished:(SKPaymentQueue *)queue {
-  if (self.paymentQueueRestoreCompletedTransactionsFinished) {
     self.paymentQueueRestoreCompletedTransactionsFinished();
-  }
 }
 
 // Sent when the download state has changed.
 - (void)paymentQueue:(SKPaymentQueue *)queue updatedDownloads:(NSArray<SKDownload *> *)downloads {
-  if (self.updatedDownloads) {
     self.updatedDownloads(downloads);
-  }
 }
 
 // Sent when a user initiates an IAP buy from the App Store
 - (BOOL)paymentQueue:(SKPaymentQueue *)queue
     shouldAddStorePayment:(SKPayment *)payment
                forProduct:(SKProduct *)product {
-  if (self.shouldAddStorePayment) {
     return (self.shouldAddStorePayment(payment, product));
-  }
-  return YES;
 }
 
 #pragma mark - getter

--- a/packages/in_app_purchase/ios/Classes/InAppPurchasePlugin.h
+++ b/packages/in_app_purchase/ios/Classes/InAppPurchasePlugin.h
@@ -3,6 +3,10 @@
 // found in the LICENSE file.
 
 #import <Flutter/Flutter.h>
+@class FIAPaymentQueueHandler;
 
 @interface InAppPurchasePlugin : NSObject <FlutterPlugin>
+
+@property(strong, nonatomic) FIAPaymentQueueHandler *paymentQueueHandler;
+
 @end

--- a/packages/in_app_purchase/ios/Classes/InAppPurchasePlugin.m
+++ b/packages/in_app_purchase/ios/Classes/InAppPurchasePlugin.m
@@ -9,10 +9,10 @@
 #import "FIAPaymentQueueHandler.h"
 
 typedef enum : NSUInteger {
-    PaymentQueueCallbackTypeUpdate,
-    PaymentQueueCallbackTypeRemoved,
-    PaymentQueueCallbackTypeRestoreTransactionFailed,
-    PaymentQueueCallbackTypeRestoreCompletedTransactionsFinished,
+  PaymentQueueCallbackTypeUpdate,
+  PaymentQueueCallbackTypeRemoved,
+  PaymentQueueCallbackTypeRestoreTransactionFailed,
+  PaymentQueueCallbackTypeRestoreCompletedTransactionsFinished,
 } PaymentQueueCallbackType;
 
 @interface InAppPurchasePlugin ()
@@ -25,7 +25,8 @@ typedef enum : NSUInteger {
 // for purchase.
 @property(copy, nonatomic) NSMutableDictionary *productsCache;
 // Saved payment object used for resume payments;
-@property(copy, nonatomic) NSMutableDictionary *paymentsCache;;
+@property(copy, nonatomic) NSMutableDictionary *paymentsCache;
+;
 
 // Call back channel to dart used for when a listener function is triggered.
 @property(strong, nonatomic) FlutterMethodChannel *callbackChannel;
@@ -50,8 +51,9 @@ typedef enum : NSUInteger {
     [self canMakePayments:result];
   } else if ([@"-[InAppPurchasePlugin startProductRequest:result:]" isEqualToString:call.method]) {
     [self handleProductRequestMethodCall:call result:result];
-  } else if ([@"-[InAppPurchasePlugin createPaymentWithProductID:result:]" isEqualToString:call.method]) {
-      [self createPaymentWithProductID:call result:result];
+  } else if ([@"-[InAppPurchasePlugin createPaymentWithProductID:result:]"
+                 isEqualToString:call.method]) {
+    [self createPaymentWithProductID:call result:result];
   } else if ([@"-[InAppPurchasePlugin addPayment:result:]" isEqualToString:call.method]) {
     [self addPayment:call result:result];
   } else if ([@"-[InAppPurchasePlugin finishTransaction:result:]" isEqualToString:call.method]) {
@@ -62,35 +64,35 @@ typedef enum : NSUInteger {
 }
 
 - (instancetype)initWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
-    self = [self init];
-    self.registrar = registrar;
-    self.registry = [registrar textures];
-    self.messenger = [registrar messenger];
-    __weak typeof(self) weakSelf = self;
-    self.paymentQueueHandler =
-    [[FIAPaymentQueueHandler alloc] initWithQueue:[SKPaymentQueue defaultQueue]
-                              transactionsUpdated:^(NSArray<SKPaymentTransaction *> *_Nonnull transactions) {
-                                  [weakSelf handleTransactionsUpdated:transactions];
-                              }
-                               transactionRemoved:^(NSArray<SKPaymentTransaction *> *_Nonnull transactions) {
-                                   [weakSelf handleTransactionsRemoved:transactions];
-                               }
-                         restoreTransactionFailed:^(NSError *_Nonnull error) {
-                             [self handleTransactionRestoreFailed:error];
-                         }
-             restoreCompletedTransactionsFinished:^{
-                 [self restoreCompletedTransactionsFinished];
-             }
-                            shouldAddStorePayment:^BOOL(SKPayment *payment, SKProduct *product) {
-                                return [self shouldAddStorePayment:payment product:product];
-                            }
-                                 updatedDownloads:^void(NSArray<SKDownload *> *_Nonnull downloads) {
-                                     [self updatedDownloads:downloads];
-                                 }];
-    self.callbackChannel =
-    [FlutterMethodChannel methodChannelWithName:@"plugins.flutter.io/in_app_purchase_callback"
-                                binaryMessenger:[registrar messenger]];
-    return self;
+  self = [self init];
+  self.registrar = registrar;
+  self.registry = [registrar textures];
+  self.messenger = [registrar messenger];
+  __weak typeof(self) weakSelf = self;
+  self.paymentQueueHandler =
+      [[FIAPaymentQueueHandler alloc] initWithQueue:[SKPaymentQueue defaultQueue]
+          transactionsUpdated:^(NSArray<SKPaymentTransaction *> *_Nonnull transactions) {
+            [weakSelf handleTransactionsUpdated:transactions];
+          }
+          transactionRemoved:^(NSArray<SKPaymentTransaction *> *_Nonnull transactions) {
+            [weakSelf handleTransactionsRemoved:transactions];
+          }
+          restoreTransactionFailed:^(NSError *_Nonnull error) {
+            [self handleTransactionRestoreFailed:error];
+          }
+          restoreCompletedTransactionsFinished:^{
+            [self restoreCompletedTransactionsFinished];
+          }
+          shouldAddStorePayment:^BOOL(SKPayment *payment, SKProduct *product) {
+            return [self shouldAddStorePayment:payment product:product];
+          }
+          updatedDownloads:^void(NSArray<SKDownload *> *_Nonnull downloads) {
+            [self updatedDownloads:downloads];
+          }];
+  self.callbackChannel =
+      [FlutterMethodChannel methodChannelWithName:@"plugins.flutter.io/in_app_purchase_callback"
+                                  binaryMessenger:[registrar messenger]];
+  return self;
 }
 
 - (void)canMakePayments:(FlutterResult)result {
@@ -128,136 +130,146 @@ typedef enum : NSUInteger {
                                  details:call.arguments]);
       return;
     }
-  for (SKProduct *product in response.products) {
+    for (SKProduct *product in response.products) {
       [self.productsCache setObject:product forKey:product.productIdentifier];
-  }
+    }
     result([FIAObjectTranslator getMapFromSKProductsResponse:response]);
     [weakSelf.requestHandlers removeObject:handler];
   }];
 }
 
 - (void)createPaymentWithProductID:(FlutterMethodCall *)call result:(FlutterResult)result {
-    if (![call.arguments isKindOfClass:[NSString class]]) {
-        result([FlutterError errorWithCode:@"storekit_invalide_argument"
-                                   message:@"Argument type of createPaymentWithProductID is not a string."
-                                   details:call.arguments]);
-        return;
-    }
-    NSString *productID = call.arguments;
-    SKProduct *product = [self.productsCache objectForKey:productID];
-    if (!product) {
-        result([FlutterError errorWithCode:@"storekit_product_not_found"
-                                   message:@"Cannot find the product. To create a payment of a product, you must query the product with SKProductRequestMaker.startProductRequest."
-                                   details:call.arguments]);
-        return;
-    }
-    SKPayment *payment = [SKPayment paymentWithProduct:product];
-    [self.paymentsCache setObject:payment forKey:productID];
-    result([FIAObjectTranslator getMapFromSKPayment:payment]);
+  if (![call.arguments isKindOfClass:[NSString class]]) {
+    result([FlutterError
+        errorWithCode:@"storekit_invalide_argument"
+              message:@"Argument type of createPaymentWithProductID is not a string."
+              details:call.arguments]);
+    return;
+  }
+  NSString *productID = call.arguments;
+  SKProduct *product = [self.productsCache objectForKey:productID];
+  if (!product) {
+    result([FlutterError
+        errorWithCode:@"storekit_product_not_found"
+              message:@"Cannot find the product. To create a payment of a product, you must query "
+                      @"the product with SKProductRequestMaker.startProductRequest."
+              details:call.arguments]);
+    return;
+  }
+  SKPayment *payment = [SKPayment paymentWithProduct:product];
+  [self.paymentsCache setObject:payment forKey:productID];
+  result([FIAObjectTranslator getMapFromSKPayment:payment]);
 }
 
 - (void)addPayment:(FlutterMethodCall *)call result:(FlutterResult)result {
-    if (![call.arguments isKindOfClass:[NSDictionary class]]) {
-        result([FlutterError errorWithCode:@"storekit_invalide_argument"
-                                   message:@"Argument type of addPayment is not a map"
-                                   details:call.arguments]);
-        return;
+  if (![call.arguments isKindOfClass:[NSDictionary class]]) {
+    result([FlutterError errorWithCode:@"storekit_invalide_argument"
+                               message:@"Argument type of addPayment is not a map"
+                               details:call.arguments]);
+    return;
+  }
+  NSDictionary *paymentMap = (NSDictionary *)call.arguments;
+  NSString *productID = [paymentMap objectForKey:@"productID"];
+  SKPayment *payment = [self.paymentsCache objectForKey:productID];
+  // User can use  payment object with mutable = true and add simulatesAskToBuyInSandBox = true to
+  // test the payment flow.
+  if (!payment || [paymentMap[@"mutable"] boolValue] == YES) {
+    SKMutablePayment *mutablePayment = [[SKMutablePayment alloc] init];
+    mutablePayment.productIdentifier = productID;
+    NSNumber *quantity = [paymentMap objectForKey:@"quantity"];
+    if (quantity) {
+      mutablePayment.quantity = quantity.integerValue;
     }
-    NSDictionary *paymentMap = (NSDictionary *)call.arguments;
-    NSString *productID = [paymentMap objectForKey:@"productID"];
-    SKPayment *payment = [self.paymentsCache objectForKey:productID];
-    // User can use  payment object with mutable = true and add simulatesAskToBuyInSandBox = true to test the payment flow.
-    if (!payment || [paymentMap[@"mutable"] boolValue] == YES) {
-        SKMutablePayment *mutablePayment = [[SKMutablePayment alloc] init];
-        mutablePayment.productIdentifier = productID;
-        NSNumber *quantity = [paymentMap objectForKey:@"quantity"];
-        if (quantity) {
-            mutablePayment.quantity = quantity.integerValue;
-        }
-        NSString *applicationUsername = [paymentMap objectForKey:@"applicationUsername"];
-        mutablePayment.applicationUsername = applicationUsername;
-        if (@available(iOS 8.3, *)) {
-            mutablePayment.simulatesAskToBuyInSandbox =
-            [[paymentMap objectForKey:@"simulatesAskToBuyInSandBox"] boolValue];
-        }
-        [self.paymentQueueHandler addPayment:payment];
-    } else {
-        [self.paymentQueueHandler addPayment:payment];
+    NSString *applicationUsername = [paymentMap objectForKey:@"applicationUsername"];
+    mutablePayment.applicationUsername = applicationUsername;
+    if (@available(iOS 8.3, *)) {
+      mutablePayment.simulatesAskToBuyInSandbox =
+          [[paymentMap objectForKey:@"simulatesAskToBuyInSandBox"] boolValue];
     }
+    [self.paymentQueueHandler addPayment:payment];
+  } else {
+    [self.paymentQueueHandler addPayment:payment];
+  }
 }
 
 - (void)finishTransaction:(FlutterMethodCall *)call result:(FlutterResult)result {
-    if (![call.arguments isKindOfClass:[NSString class]]) {
-        result([FlutterError errorWithCode:@"storekit_invalide_argument"
-                                   message:@"Argument type of finishTransaction is not a string."
-                                   details:call.arguments]);
-        return;
-    }
-    NSString *identifier = call.arguments;
-    SKPaymentTransaction *transaction = [self.paymentQueueHandler.transactions objectForKey:identifier];
-    if (!transaction) {
-        result([FlutterError errorWithCode:@"storekit_platform_invalid_transaction"
-                                   message:@"Invalid transaction ID is used."
-                                   details:call.arguments]);
-        return;
-    }
-    @try {
-        // finish transaction will throw exception if the transaction type is purchasing. Notify dart about this exception.
-        [self.paymentQueueHandler finishTransaction:transaction];
-    } @catch (NSException *e){
-        result([FlutterError errorWithCode:@"storekit_finish_transaction_exception"
-                                   message:e.name
-                                   details:e.description]);
-        return;
-    }
+  if (![call.arguments isKindOfClass:[NSString class]]) {
+    result([FlutterError errorWithCode:@"storekit_invalide_argument"
+                               message:@"Argument type of finishTransaction is not a string."
+                               details:call.arguments]);
+    return;
+  }
+  NSString *identifier = call.arguments;
+  SKPaymentTransaction *transaction =
+      [self.paymentQueueHandler.transactions objectForKey:identifier];
+  if (!transaction) {
+    result([FlutterError errorWithCode:@"storekit_platform_invalid_transaction"
+                               message:@"Invalid transaction ID is used."
+                               details:call.arguments]);
+    return;
+  }
+  @try {
+    // finish transaction will throw exception if the transaction type is purchasing. Notify dart
+    // about this exception.
+    [self.paymentQueueHandler finishTransaction:transaction];
+  } @catch (NSException *e) {
+    result([FlutterError errorWithCode:@"storekit_finish_transaction_exception"
+                               message:e.name
+                               details:e.description]);
+    return;
+  }
 }
 
 #pragma mark - delegates
 
 - (void)handleTransactionsUpdated:(NSArray<SKPaymentTransaction *> *)transactions {
-    NSMutableArray *maps = [NSMutableArray new];
-    for (SKPaymentTransaction *transcation in transactions) {
-        [maps addObject:[FIAObjectTranslator getMapFromSKPaymentTransaction:transcation]];
-    }
-    [self.callbackChannel invokeMethod:@"updatedTransaction" arguments:maps];
+  NSMutableArray *maps = [NSMutableArray new];
+  for (SKPaymentTransaction *transcation in transactions) {
+    [maps addObject:[FIAObjectTranslator getMapFromSKPaymentTransaction:transcation]];
+  }
+  [self.callbackChannel invokeMethod:@"updatedTransaction" arguments:maps];
 }
 
 - (void)handleTransactionsRemoved:(NSArray<SKPaymentTransaction *> *)transactions {
-    NSMutableArray *maps = [NSMutableArray new];
-    for (SKPaymentTransaction *transcation in transactions) {
-        [maps addObject:[FIAObjectTranslator getMapFromSKPaymentTransaction:transcation]];
-    }
-    [self.callbackChannel invokeMethod:@"removedTransaction" arguments:maps];
+  NSMutableArray *maps = [NSMutableArray new];
+  for (SKPaymentTransaction *transcation in transactions) {
+    [maps addObject:[FIAObjectTranslator getMapFromSKPaymentTransaction:transcation]];
+  }
+  [self.callbackChannel invokeMethod:@"removedTransaction" arguments:maps];
 }
 
 - (void)handleTransactionRestoreFailed:(NSError *)error {
-    FlutterError *fltError = [FlutterError errorWithCode:error.domain
-                                                 message:error.description
-                                                 details:error.description];
-    [self.callbackChannel invokeMethod:@"restoreCompletedTransactions" arguments:fltError];
+  FlutterError *fltError = [FlutterError errorWithCode:error.domain
+                                               message:error.description
+                                               details:error.description];
+  [self.callbackChannel invokeMethod:@"restoreCompletedTransactions" arguments:fltError];
 }
 
 - (void)restoreCompletedTransactionsFinished {
-    [self.callbackChannel invokeMethod:@"paymentQueueRestoreCompletedTransactionsFinished"
-                             arguments:nil];
+  [self.callbackChannel invokeMethod:@"paymentQueueRestoreCompletedTransactionsFinished"
+                           arguments:nil];
 }
 
 - (void)updatedDownloads:(NSArray<SKDownload *> *)downloads {
-    NSMutableArray *maps = [NSMutableArray new];
-    for (SKDownload *download in downloads) {
-        [maps addObject:[FIAObjectTranslator getMapFromSKDownload:download]];
-    }
-    [self.callbackChannel invokeMethod:@"updatedDownloads" arguments:maps];
+  NSMutableArray *maps = [NSMutableArray new];
+  for (SKDownload *download in downloads) {
+    [maps addObject:[FIAObjectTranslator getMapFromSKDownload:download]];
+  }
+  [self.callbackChannel invokeMethod:@"updatedDownloads" arguments:maps];
 }
 
 - (BOOL)shouldAddStorePayment:(SKPayment *)payment product:(SKProduct *)product {
-    // We alwasy return NO here. And we send the message to dart to process the payment; and we will have a incerpection method that deciding if the payment should be processed (implemented by the programmer).
-    [self.productsCache setObject:product forKey:product.productIdentifier];
-    [self.paymentsCache setObject:payment forKey:payment.productIdentifier];
-    [self.callbackChannel invokeMethod:@"shouldAddStorePayment" arguments:@{@"payment":[FIAObjectTranslator getMapFromSKPayment:payment],
-                                                                            @"proudt":[FIAObjectTranslator getMapFromSKProduct:product]
-                                                                            }];
-    return NO;
+  // We alwasy return NO here. And we send the message to dart to process the payment; and we will
+  // have a incerpection method that deciding if the payment should be processed (implemented by the
+  // programmer).
+  [self.productsCache setObject:product forKey:product.productIdentifier];
+  [self.paymentsCache setObject:payment forKey:payment.productIdentifier];
+  [self.callbackChannel invokeMethod:@"shouldAddStorePayment"
+                           arguments:@{
+                             @"payment" : [FIAObjectTranslator getMapFromSKPayment:payment],
+                             @"proudt" : [FIAObjectTranslator getMapFromSKProduct:product]
+                           }];
+  return NO;
 }
 
 #pragma mark - dependency injection (for unit testing)
@@ -276,17 +288,17 @@ typedef enum : NSUInteger {
 }
 
 - (NSMutableDictionary *)productsCache {
-    if (!_productsCache) {
-        _productsCache = [NSMutableDictionary new];
-    }
-    return _productsCache;
+  if (!_productsCache) {
+    _productsCache = [NSMutableDictionary new];
+  }
+  return _productsCache;
 }
 
 - (NSMutableDictionary *)paymentsCache {
-    if (!_paymentsCache) {
-        _paymentsCache = [NSMutableDictionary new];
-    }
-    return _paymentsCache;
+  if (!_paymentsCache) {
+    _paymentsCache = [NSMutableDictionary new];
+  }
+  return _paymentsCache;
 }
 
 @end

--- a/packages/in_app_purchase/ios/Classes/InAppPurchasePlugin.m
+++ b/packages/in_app_purchase/ios/Classes/InAppPurchasePlugin.m
@@ -202,9 +202,9 @@
       errorWithCode:@"storekit_invalid_payment_object"
             message:
                 @"You have requested a payment with an invalid payment object. A valid payment "
-                @"object should be one of the following. 1. Payment object that is automatically "
-                @"handled when the user starts an in-app purchase in the App Store; and you "
-                @"returned true to the `shouldAddStorePayment` method or manually request a "
+                @"object should be one of the following: 1. Payment object that is automatically "
+                @"handled when the user starts an in-app purchase in the App Store and you "
+                @"returned true to the `shouldAddStorePayment` method or manually requested a "
                 @"payment with the productID that is provided in the `shouldAddStorePayment` "
                 @"method. 2. A payment requested for a product that has been fetched. 3. A custom "
                 @"payment object. This is not an error for a payment failure."

--- a/packages/in_app_purchase/ios/Classes/InAppPurchasePlugin.m
+++ b/packages/in_app_purchase/ios/Classes/InAppPurchasePlugin.m
@@ -227,10 +227,11 @@ typedef enum : NSUInteger {
 }
 
 - (BOOL)shouldAddStorePayment:(SKPayment *)payment product:(SKProduct *)product {
-    // TODO(cyanglaz): getting the callback from dart so dart is able to override this callback.
-    // Currently the invokeMethod gets result asynchronously and dispatch_semaphore does not work
-    // with the invokeMethod api.
-    return YES;
+    // We alwasy return NO here. And we send the message to dart to process the payment; and we will have a incerpection method that deciding if the payment should be processed (implemented by the programmer).
+    [self.callbackChannel invokeMethod:@"shouldAddStorePayment" arguments:@{@"payment":[FIAObjectTranslator getMapFromSKPayment:payment],
+                                                                            @"proudt":[FIAObjectTranslator getMapFromSKProduct:product]
+                                                                            }];
+    return NO;
 }
 
 #pragma mark - dependency injection (for unit testing)

--- a/packages/in_app_purchase/ios/Classes/InAppPurchasePlugin.m
+++ b/packages/in_app_purchase/ios/Classes/InAppPurchasePlugin.m
@@ -178,6 +178,7 @@ typedef enum : NSUInteger {
         return;
     }
     @try {
+        // finish transaction will throw exception if the transaction type is purchasing. Notify dart about this exception.
         [self.paymentQueueHandler finishTransaction:transaction];
     } @catch (NSException *e){
         result([FlutterError errorWithCode:@"storekit_finish_transaction_exception"

--- a/packages/in_app_purchase/ios/Classes/InAppPurchasePlugin.m
+++ b/packages/in_app_purchase/ios/Classes/InAppPurchasePlugin.m
@@ -164,13 +164,13 @@
   NSDictionary *paymentMap = (NSDictionary *)call.arguments;
   NSString *productID = [paymentMap objectForKey:@"productID"];
   SKPayment *payment = [self.paymentsCache objectForKey:productID];
-  // User can use payment object with usePaymentObject = true and add simulatesAskToBuyInSandBox = true to
-  // test the payment flow.
+  // User can use payment object with usePaymentObject = true and add simulatesAskToBuyInSandBox =
+  // true to test the payment flow.
   if (!payment || [paymentMap[@"usePaymentObject"] boolValue] == YES) {
     SKMutablePayment *mutablePayment = [[SKMutablePayment alloc] init];
     mutablePayment.productIdentifier = productID;
     NSNumber *quantity = [paymentMap objectForKey:@"quantity"];
-    mutablePayment.quantity = quantity?quantity.integerValue:1;
+    mutablePayment.quantity = quantity ? quantity.integerValue : 1;
     NSString *applicationUsername = [paymentMap objectForKey:@"applicationUsername"];
     mutablePayment.applicationUsername = applicationUsername;
     if (@available(iOS 8.3, *)) {
@@ -181,7 +181,7 @@
   } else {
     [self.paymentQueueHandler addPayment:payment];
   }
-    result(nil);
+  result(nil);
 }
 
 - (void)finishTransaction:(FlutterMethodCall *)call result:(FlutterResult)result {

--- a/packages/in_app_purchase/ios/Classes/InAppPurchasePlugin.m
+++ b/packages/in_app_purchase/ios/Classes/InAppPurchasePlugin.m
@@ -139,6 +139,7 @@ typedef enum : NSUInteger {
     NSDictionary *paymentMap = (NSDictionary *)call.arguments;
     NSString *productID = [paymentMap objectForKey:@"productID"];
     SKProduct *product = [self.productsMap objectForKey:productID];
+    // User can use  payment object with mutable = true and add simulatesAskToBuyInSandBox = true to test the payment flow.
     if ([[paymentMap objectForKey:@"mutable"] boolValue]) {
         SKMutablePayment *payment = [[SKMutablePayment alloc] init];
         payment.productIdentifier = productID;

--- a/packages/in_app_purchase/ios/Classes/InAppPurchasePlugin.m
+++ b/packages/in_app_purchase/ios/Classes/InAppPurchasePlugin.m
@@ -267,7 +267,7 @@ typedef enum : NSUInteger {
   [self.callbackChannel invokeMethod:@"shouldAddStorePayment"
                            arguments:@{
                              @"payment" : [FIAObjectTranslator getMapFromSKPayment:payment],
-                             @"proudt" : [FIAObjectTranslator getMapFromSKProduct:product]
+                             @"product" : [FIAObjectTranslator getMapFromSKProduct:product]
                            }];
   return NO;
 }

--- a/packages/in_app_purchase/ios/Classes/InAppPurchasePlugin.m
+++ b/packages/in_app_purchase/ios/Classes/InAppPurchasePlugin.m
@@ -50,12 +50,12 @@ typedef enum : NSUInteger {
     [self canMakePayments:result];
   } else if ([@"-[InAppPurchasePlugin startProductRequest:result:]" isEqualToString:call.method]) {
     [self handleProductRequestMethodCall:call result:result];
+  } else if ([@"-[InAppPurchasePlugin createPaymentWithProductID:result:]" isEqualToString:call.method]) {
+      [self createPaymentWithProductID:call result:result];
   } else if ([@"-[InAppPurchasePlugin addPayment:result:]" isEqualToString:call.method]) {
     [self addPayment:call result:result];
   } else if ([@"-[InAppPurchasePlugin finishTransaction:result:]" isEqualToString:call.method]) {
     [self finishTransaction:call result:result];
-  } else if ([@"-[InAppPurchasePlugin createPaymentWithProductID:result:]" isEqualToString:call.method]) {
-    [self createPaymentWithProductID:call result:result];
   } else {
     result(FlutterMethodNotImplemented);
   }

--- a/packages/in_app_purchase/ios/Classes/InAppPurchasePlugin.m
+++ b/packages/in_app_purchase/ios/Classes/InAppPurchasePlugin.m
@@ -71,16 +71,16 @@
             [weakSelf handleTransactionsRemoved:transactions];
           }
           restoreTransactionFailed:^(NSError *_Nonnull error) {
-            [self handleTransactionRestoreFailed:error];
+            [weakSelf handleTransactionRestoreFailed:error];
           }
           restoreCompletedTransactionsFinished:^{
-            [self restoreCompletedTransactionsFinished];
+            [weakSelf restoreCompletedTransactionsFinished];
           }
           shouldAddStorePayment:^BOOL(SKPayment *payment, SKProduct *product) {
-            return [self shouldAddStorePayment:payment product:product];
+            return [weakSelf shouldAddStorePayment:payment product:product];
           }
           updatedDownloads:^void(NSArray<SKDownload *> *_Nonnull downloads) {
-            [self updatedDownloads:downloads];
+            [weakSelf updatedDownloads:downloads];
           }];
   self.callbackChannel =
       [FlutterMethodChannel methodChannelWithName:@"plugins.flutter.io/in_app_purchase_callback"

--- a/packages/in_app_purchase/ios/Classes/InAppPurchasePlugin.m
+++ b/packages/in_app_purchase/ios/Classes/InAppPurchasePlugin.m
@@ -8,13 +8,6 @@
 #import "FIAPRequestHandler.h"
 #import "FIAPaymentQueueHandler.h"
 
-typedef enum : NSUInteger {
-  PaymentQueueCallbackTypeUpdate,
-  PaymentQueueCallbackTypeRemoved,
-  PaymentQueueCallbackTypeRestoreTransactionFailed,
-  PaymentQueueCallbackTypeRestoreCompletedTransactionsFinished,
-} PaymentQueueCallbackType;
-
 @interface InAppPurchasePlugin ()
 
 // Holding strong references to FIAPRequestHandlers. Remove the handlers from the set after


### PR DESCRIPTION
The objective-c portion of add payment flow.

Since there is no dart code in this PR, it could be hard to trace what is going on. Included 2 purchase flows below to better explain.

A regular flow of a user to process a purchase will be as such:
1. User queries the products by `-[InAppPurchasePlugin startProductRequest:result:]`
2. User creates a payment object using productID which is found in the result of the 1st step.
3. User make a payment calling `-[InAppPurchasePlugin addPayment:result:]` using the payment object gotten from step 2.
4. `updatedTransaction` in dart waiting for the transaction to be at state of 'purchased'
5. User finish the transaction by calling `-[InAppPurchasePlugin finishTransaction:result:]` with the transaction gotten from step 4.

A app store purchase flow will be as such:
1. Customer triggered the purchase in the app store.
2. Programmer gets a notification in a callback named `shouldAddStorePayment` in dart.
3. If `shouldAddStorePayment` return true, the payment object will be automatically added to the queue using `-[InAppPurchasePlugin addPayment:result:]` (called by our plugin code, not the programmer)
4. Same as step 4 in the regular flow from this point.

https://github.com/flutter/flutter/issues/26328