### PR TITLE
[image_picker] Improvements for image_picker plugin.

### DIFF
--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
@@ -450,8 +450,9 @@ public class ImagePickerDelegate
     if (pendingResult != null) {
       Double maxWidth = methodCall.argument("maxWidth");
       Double maxHeight = methodCall.argument("maxHeight");
+      boolean crop = methodCall.argument("crop");
 
-      String finalImagePath = imageResizer.resizeImageIfNeeded(path, maxWidth, maxHeight);
+      String finalImagePath = imageResizer.resizeImageIfNeeded(path, maxWidth, maxHeight, crop);
       finishWithSuccess(finalImagePath);
     } else {
       throw new IllegalStateException("Received image from picker that was not requested");

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImageResizer.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImageResizer.java
@@ -8,9 +8,6 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
 import android.graphics.Paint;
-import android.graphics.RectF;
-import android.media.ThumbnailUtils;
-import android.util.Size;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImageResizer.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImageResizer.java
@@ -8,7 +8,6 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
 import android.graphics.Paint;
-
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -27,7 +26,14 @@ class ImageResizer {
     public final double drawWidth;
     public final double drawHeight;
 
-    SizeInfo(int width, int height, double scale, double drawX, double drawY, double drawWidth, double drawHeight) {
+    SizeInfo(
+        int width,
+        int height,
+        double scale,
+        double drawX,
+        double drawY,
+        double drawWidth,
+        double drawHeight) {
       this.width = width;
       this.height = height;
       this.scale = scale;
@@ -66,7 +72,8 @@ class ImageResizer {
     }
   }
 
-  public static SizeInfo computeSizeInfo(int originalWidth, int originalHeight, Double maxWidth, Double maxHeight, boolean crop) {
+  public static SizeInfo computeSizeInfo(
+      int originalWidth, int originalHeight, Double maxWidth, Double maxHeight, boolean crop) {
     boolean hasMaxWidth = maxWidth != null;
     boolean hasMaxHeight = maxHeight != null;
 
@@ -103,30 +110,33 @@ class ImageResizer {
     double drawX = (width - drawWidth) / 2;
     double drawY = (height - drawHeight) / 2;
 
-    return new SizeInfo((int)width, (int)height, scale, drawX, drawY, drawWidth, drawHeight);
+    return new SizeInfo((int) width, (int) height, scale, drawX, drawY, drawWidth, drawHeight);
   }
 
-  private File resizedImage(String path, Double maxWidth, Double maxHeight, boolean crop) throws IOException {
+  private File resizedImage(String path, Double maxWidth, Double maxHeight, boolean crop)
+      throws IOException {
     Bitmap bmp = BitmapFactory.decodeFile(path);
-    final SizeInfo info = computeSizeInfo(bmp.getWidth(), bmp.getHeight(), maxWidth, maxHeight, crop);
+    final SizeInfo info =
+        computeSizeInfo(bmp.getWidth(), bmp.getHeight(), maxWidth, maxHeight, crop);
 
     int sampleSize = 1;
-    while (sampleSize * 2 < 1/info.scale) {
+    while (sampleSize * 2 < 1 / info.scale) {
       sampleSize *= 2;
     }
 
     Bitmap.Config config = bmp.getConfig();
     if (config == null) {
-        config = Bitmap.Config.ARGB_8888;
+      config = Bitmap.Config.ARGB_8888;
     }
 
     Paint paint = new Paint(Paint.FILTER_BITMAP_FLAG);
 
     // First step - scale in range [0.5; 1)
     {
-      Bitmap scaledBmp = Bitmap.createBitmap(info.width * sampleSize, info.height * sampleSize, config);
+      Bitmap scaledBmp =
+          Bitmap.createBitmap(info.width * sampleSize, info.height * sampleSize, config);
       Canvas canvas = new Canvas(scaledBmp);
-      canvas.translate((float)(info.drawX * sampleSize), (float)(info.drawY * sampleSize));
+      canvas.translate((float) (info.drawX * sampleSize), (float) (info.drawY * sampleSize));
       float scale = (float) (info.scale * sampleSize);
       canvas.scale(scale, scale);
       canvas.drawBitmap(bmp, 0, 0, paint);
@@ -138,7 +148,8 @@ class ImageResizer {
     while (sampleSize > 1) {
       sampleSize /= 2;
 
-      Bitmap scaledBmp = Bitmap.createBitmap(info.width * sampleSize, info.height * sampleSize, config);
+      Bitmap scaledBmp =
+          Bitmap.createBitmap(info.width * sampleSize, info.height * sampleSize, config);
       Canvas canvas = new Canvas(scaledBmp);
       canvas.scale(0.5f, 0.5f);
       canvas.drawBitmap(bmp, 0, 0, paint);

--- a/packages/image_picker/example/android/app/src/test/java/io/flutter/plugins/imagepicker/ImagePickerDelegateTest.java
+++ b/packages/image_picker/example/android/app/src/test/java/io/flutter/plugins/imagepicker/ImagePickerDelegateTest.java
@@ -60,12 +60,12 @@ public class ImagePickerDelegateTest {
     when(mockFileUtils.getPathFromUri(any(Context.class), any(Uri.class)))
         .thenReturn("pathFromUri");
 
-    when(mockImageResizer.resizeImageIfNeeded("pathFromUri", null, null))
+    when(mockImageResizer.resizeImageIfNeeded("pathFromUri", null, null, false))
         .thenReturn("originalPath");
-    when(mockImageResizer.resizeImageIfNeeded("pathFromUri", WIDTH, HEIGHT))
+    when(mockImageResizer.resizeImageIfNeeded("pathFromUri", WIDTH, HEIGHT, false))
         .thenReturn("scaledPath");
-    when(mockImageResizer.resizeImageIfNeeded("pathFromUri", WIDTH, null)).thenReturn("scaledPath");
-    when(mockImageResizer.resizeImageIfNeeded("pathFromUri", null, HEIGHT))
+    when(mockImageResizer.resizeImageIfNeeded("pathFromUri", WIDTH, null, false)).thenReturn("scaledPath");
+    when(mockImageResizer.resizeImageIfNeeded("pathFromUri", null, HEIGHT, false))
         .thenReturn("scaledPath");
 
     mockFileUriResolver = new MockFileUriResolver();
@@ -271,6 +271,7 @@ public class ImagePickerDelegateTest {
   @Test
   public void
       onActivityResult_WhenImagePickedFromGallery_AndNoResizeNeeded_FinishesWithImagePath() {
+    when(mockMethodCall.argument("crop")).thenReturn(false);
     ImagePickerDelegate delegate = createDelegateWithPendingResultAndMethodCall();
 
     delegate.onActivityResult(
@@ -284,6 +285,7 @@ public class ImagePickerDelegateTest {
   public void
       onActivityResult_WhenImagePickedFromGallery_AndResizeNeeded_FinishesWithScaledImagePath() {
     when(mockMethodCall.argument("maxWidth")).thenReturn(WIDTH);
+    when(mockMethodCall.argument("crop")).thenReturn(false);
 
     ImagePickerDelegate delegate = createDelegateWithPendingResultAndMethodCall();
     delegate.onActivityResult(
@@ -297,6 +299,7 @@ public class ImagePickerDelegateTest {
   public void
       onActivityResult_WhenVideoPickedFromGallery_AndResizeParametersSupplied_FinishesWithFilePath() {
     when(mockMethodCall.argument("maxWidth")).thenReturn(WIDTH);
+    when(mockMethodCall.argument("crop")).thenReturn(false);
 
     ImagePickerDelegate delegate = createDelegateWithPendingResultAndMethodCall();
     delegate.onActivityResult(
@@ -319,6 +322,7 @@ public class ImagePickerDelegateTest {
 
   @Test
   public void onActivityResult_WhenImageTakenWithCamera_AndNoResizeNeeded_FinishesWithImagePath() {
+    when(mockMethodCall.argument("crop")).thenReturn(false);
     ImagePickerDelegate delegate = createDelegateWithPendingResultAndMethodCall();
 
     delegate.onActivityResult(
@@ -332,6 +336,7 @@ public class ImagePickerDelegateTest {
   public void
       onActivityResult_WhenImageTakenWithCamera_AndResizeNeeded_FinishesWithScaledImagePath() {
     when(mockMethodCall.argument("maxWidth")).thenReturn(WIDTH);
+    when(mockMethodCall.argument("crop")).thenReturn(false);
 
     ImagePickerDelegate delegate = createDelegateWithPendingResultAndMethodCall();
     delegate.onActivityResult(
@@ -345,6 +350,7 @@ public class ImagePickerDelegateTest {
   public void
       onActivityResult_WhenVideoTakenWithCamera_AndResizeParametersSupplied_FinishesWithFilePath() {
     when(mockMethodCall.argument("maxWidth")).thenReturn(WIDTH);
+    when(mockMethodCall.argument("crop")).thenReturn(false);
 
     ImagePickerDelegate delegate = createDelegateWithPendingResultAndMethodCall();
     delegate.onActivityResult(

--- a/packages/image_picker/example/android/app/src/test/java/io/flutter/plugins/imagepicker/ImagePickerDelegateTest.java
+++ b/packages/image_picker/example/android/app/src/test/java/io/flutter/plugins/imagepicker/ImagePickerDelegateTest.java
@@ -64,7 +64,8 @@ public class ImagePickerDelegateTest {
         .thenReturn("originalPath");
     when(mockImageResizer.resizeImageIfNeeded("pathFromUri", WIDTH, HEIGHT, false))
         .thenReturn("scaledPath");
-    when(mockImageResizer.resizeImageIfNeeded("pathFromUri", WIDTH, null, false)).thenReturn("scaledPath");
+    when(mockImageResizer.resizeImageIfNeeded("pathFromUri", WIDTH, null, false))
+        .thenReturn("scaledPath");
     when(mockImageResizer.resizeImageIfNeeded("pathFromUri", null, HEIGHT, false))
         .thenReturn("scaledPath");
 

--- a/packages/image_picker/example/android/app/src/test/java/io/flutter/plugins/imagepicker/ImageResizerTest.java
+++ b/packages/image_picker/example/android/app/src/test/java/io/flutter/plugins/imagepicker/ImageResizerTest.java
@@ -1,0 +1,200 @@
+package io.flutter.plugins.imagepicker;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class ImageResizerTest {
+
+  private void doCheck(
+      int originalWidth, int originalHeight,
+      Double maxWidth, Double maxHeight, boolean crop,
+      int expectedWidth, int expectedHeight,
+      double expectedScale,
+      double expectedDrawX, double expectedDrawY,
+      double expectedDrawWidth, double expectedDrawHeight
+  ) {
+    ImageResizer.SizeInfo info = ImageResizer.computeSizeInfo(originalWidth, originalHeight, maxWidth, maxHeight, crop);
+    assertEquals(expectedWidth, info.width);
+    assertEquals(expectedHeight, info.height);
+    assertEquals(expectedScale, info.scale, 0);
+    assertEquals(expectedDrawX, info.drawX, 0);
+    assertEquals(expectedDrawY, info.drawY, 0);
+    assertEquals(expectedDrawWidth, info.drawWidth, 0);
+    assertEquals(expectedDrawHeight, info.drawHeight, 0);
+  }
+
+  private void check(
+      int originalWidth, int originalHeight,
+      Double maxWidth, Double maxHeight, boolean crop,
+      int expectedWidth, int expectedHeight,
+      double expectedScale,
+      double expectedDrawX, double expectedDrawY,
+      double expectedDrawWidth, double expectedDrawHeight
+  ) {
+    doCheck(
+        originalWidth, originalHeight, maxWidth, maxHeight, crop,
+        expectedWidth, expectedHeight, expectedScale,
+        expectedDrawX, expectedDrawY, expectedDrawWidth, expectedDrawHeight
+    );
+    doCheck(
+        originalHeight, originalWidth, maxHeight, maxWidth, crop,
+        expectedHeight, expectedWidth, expectedScale,
+        expectedDrawY, expectedDrawX, expectedDrawHeight, expectedDrawWidth
+    );
+  }
+
+  private void check(
+      int originalWidth, int originalHeight,
+      Double maxWidth, Double maxHeight,
+      int expectedWidth, int expectedHeight,
+      double expectedScale,
+      double expectedDrawX, double expectedDrawY,
+      double expectedDrawWidth, double expectedDrawHeight
+  ) {
+    check(
+        originalWidth, originalHeight, maxWidth, maxHeight, false,
+        expectedWidth, expectedHeight, expectedScale,
+        expectedDrawX, expectedDrawY, expectedDrawWidth, expectedDrawHeight
+    );
+    check(
+        originalWidth, originalHeight, maxWidth, maxHeight, true,
+        expectedWidth, expectedHeight, expectedScale,
+        expectedDrawX, expectedDrawY, expectedDrawWidth, expectedDrawHeight
+    );
+  }
+
+  @Test
+  public void testEmpty() {
+    check(
+        0, 0, null, null,
+        0, 0, 1,
+        0, 0, 0, 0
+    );
+    check(
+        50, 0, null, null,
+        50, 0, 1,
+        0, 0, 50, 0
+    );
+    check(
+        0, 0, 50.0, null,
+        0, 0, 1,
+        0, 0, 0, 0
+    );
+    check(
+        100, 0, 50.0, null,
+        50, 0, 0.5,
+        0, 0, 50, 0
+    );
+  }
+
+  @Test
+  public void testNoLimits() {
+    check(
+        200, 300, null, null,
+        200, 300, 1,
+        0, 0, 200, 300
+    );
+  }
+
+  @Test
+  public void testOnlyWidth() {
+    check(
+        200, 300, 220.0, null,
+        200, 300, 1,
+        0, 0, 200, 300
+    );
+    check(
+        200, 300, 200.0, null,
+        200, 300, 1,
+        0, 0, 200, 300
+    );
+    check(
+        200, 300, 100.0, null,
+        100, 150, 0.5,
+        0, 0, 100, 150
+    );
+  }
+
+  @Test
+  public void testOnlyHeight() {
+    check(
+        200, 300, null, 320.0,
+        200, 300, 1,
+        0, 0, 200, 300
+    );
+    check(
+        200, 300, null, 300.0,
+        200, 300, 1,
+        0, 0, 200, 300
+    );
+    check(
+        200, 300, null, 100.0,
+        67, 100, 1.0 / 3.0,
+        0, 0, 67, 100
+    );
+  }
+
+  @Test
+  public void testLoose() {
+    check(
+        200, 300, 220.0, 320.0,
+        200, 300, 1,
+        0, 0, 200, 300
+    );
+    check(
+        200, 300, 200.0, 320.0,
+        200, 300, 1,
+        0, 0, 200, 300
+    );
+    check(
+        200, 300, 220.0, 300.0,
+        200, 300, 1,
+        0, 0, 200, 300
+    );
+    check(
+        200, 300, 200.0, 300.0,
+        200, 300, 1,
+        0, 0, 200, 300
+    );
+  }
+
+  @Test
+  public void testFit() {
+    check(
+        200, 300, 200.0, 250.0, false,
+        167, 250, 5.0 / 6.0,
+        0, 0, 167, 250
+    );
+    check(
+        200, 300, 100.0, 250.0, false,
+        100, 150, 0.5,
+        0, 0, 100, 150
+    );
+    check(
+        200, 300, 150.0, 100.0, false,
+        67, 100, 1.0 / 3.0,
+        0, 0, 67, 100
+    );
+  }
+
+  @Test
+  public void testCrop() {
+    check(
+        200, 300, 200.0, 250.0, true,
+        200, 250, 1,
+        0, -25, 200, 300
+    );
+    check(
+        200, 300, 100.0, 250.0, true,
+        100, 250, 5.0 / 6.0,
+        -33.5, 0, 167, 250
+    );
+    check(
+        200, 300, 150.0, 100.0, true,
+        150, 100, 3.0 / 4.0,
+        0, -62.5, 150, 225
+    );
+  }
+}
+

--- a/packages/image_picker/example/android/app/src/test/java/io/flutter/plugins/imagepicker/ImageResizerTest.java
+++ b/packages/image_picker/example/android/app/src/test/java/io/flutter/plugins/imagepicker/ImageResizerTest.java
@@ -7,14 +7,20 @@ import org.junit.Test;
 public class ImageResizerTest {
 
   private void doCheck(
-      int originalWidth, int originalHeight,
-      Double maxWidth, Double maxHeight, boolean crop,
-      int expectedWidth, int expectedHeight,
+      int originalWidth,
+      int originalHeight,
+      Double maxWidth,
+      Double maxHeight,
+      boolean crop,
+      int expectedWidth,
+      int expectedHeight,
       double expectedScale,
-      double expectedDrawX, double expectedDrawY,
-      double expectedDrawWidth, double expectedDrawHeight
-  ) {
-    ImageResizer.SizeInfo info = ImageResizer.computeSizeInfo(originalWidth, originalHeight, maxWidth, maxHeight, crop);
+      double expectedDrawX,
+      double expectedDrawY,
+      double expectedDrawWidth,
+      double expectedDrawHeight) {
+    ImageResizer.SizeInfo info =
+        ImageResizer.computeSizeInfo(originalWidth, originalHeight, maxWidth, maxHeight, crop);
     assertEquals(expectedWidth, info.width);
     assertEquals(expectedHeight, info.height);
     assertEquals(expectedScale, info.scale, 0);
@@ -25,176 +31,132 @@ public class ImageResizerTest {
   }
 
   private void check(
-      int originalWidth, int originalHeight,
-      Double maxWidth, Double maxHeight, boolean crop,
-      int expectedWidth, int expectedHeight,
+      int originalWidth,
+      int originalHeight,
+      Double maxWidth,
+      Double maxHeight,
+      boolean crop,
+      int expectedWidth,
+      int expectedHeight,
       double expectedScale,
-      double expectedDrawX, double expectedDrawY,
-      double expectedDrawWidth, double expectedDrawHeight
-  ) {
+      double expectedDrawX,
+      double expectedDrawY,
+      double expectedDrawWidth,
+      double expectedDrawHeight) {
     doCheck(
-        originalWidth, originalHeight, maxWidth, maxHeight, crop,
-        expectedWidth, expectedHeight, expectedScale,
-        expectedDrawX, expectedDrawY, expectedDrawWidth, expectedDrawHeight
-    );
+        originalWidth,
+        originalHeight,
+        maxWidth,
+        maxHeight,
+        crop,
+        expectedWidth,
+        expectedHeight,
+        expectedScale,
+        expectedDrawX,
+        expectedDrawY,
+        expectedDrawWidth,
+        expectedDrawHeight);
     doCheck(
-        originalHeight, originalWidth, maxHeight, maxWidth, crop,
-        expectedHeight, expectedWidth, expectedScale,
-        expectedDrawY, expectedDrawX, expectedDrawHeight, expectedDrawWidth
-    );
+        originalHeight,
+        originalWidth,
+        maxHeight,
+        maxWidth,
+        crop,
+        expectedHeight,
+        expectedWidth,
+        expectedScale,
+        expectedDrawY,
+        expectedDrawX,
+        expectedDrawHeight,
+        expectedDrawWidth);
   }
 
   private void check(
-      int originalWidth, int originalHeight,
-      Double maxWidth, Double maxHeight,
-      int expectedWidth, int expectedHeight,
+      int originalWidth,
+      int originalHeight,
+      Double maxWidth,
+      Double maxHeight,
+      int expectedWidth,
+      int expectedHeight,
       double expectedScale,
-      double expectedDrawX, double expectedDrawY,
-      double expectedDrawWidth, double expectedDrawHeight
-  ) {
+      double expectedDrawX,
+      double expectedDrawY,
+      double expectedDrawWidth,
+      double expectedDrawHeight) {
     check(
-        originalWidth, originalHeight, maxWidth, maxHeight, false,
-        expectedWidth, expectedHeight, expectedScale,
-        expectedDrawX, expectedDrawY, expectedDrawWidth, expectedDrawHeight
-    );
+        originalWidth,
+        originalHeight,
+        maxWidth,
+        maxHeight,
+        false,
+        expectedWidth,
+        expectedHeight,
+        expectedScale,
+        expectedDrawX,
+        expectedDrawY,
+        expectedDrawWidth,
+        expectedDrawHeight);
     check(
-        originalWidth, originalHeight, maxWidth, maxHeight, true,
-        expectedWidth, expectedHeight, expectedScale,
-        expectedDrawX, expectedDrawY, expectedDrawWidth, expectedDrawHeight
-    );
+        originalWidth,
+        originalHeight,
+        maxWidth,
+        maxHeight,
+        true,
+        expectedWidth,
+        expectedHeight,
+        expectedScale,
+        expectedDrawX,
+        expectedDrawY,
+        expectedDrawWidth,
+        expectedDrawHeight);
   }
 
   @Test
   public void testEmpty() {
-    check(
-        0, 0, null, null,
-        0, 0, 1,
-        0, 0, 0, 0
-    );
-    check(
-        50, 0, null, null,
-        50, 0, 1,
-        0, 0, 50, 0
-    );
-    check(
-        0, 0, 50.0, null,
-        0, 0, 1,
-        0, 0, 0, 0
-    );
-    check(
-        100, 0, 50.0, null,
-        50, 0, 0.5,
-        0, 0, 50, 0
-    );
+    check(0, 0, null, null, 0, 0, 1, 0, 0, 0, 0);
+    check(50, 0, null, null, 50, 0, 1, 0, 0, 50, 0);
+    check(0, 0, 50.0, null, 0, 0, 1, 0, 0, 0, 0);
+    check(100, 0, 50.0, null, 50, 0, 0.5, 0, 0, 50, 0);
   }
 
   @Test
   public void testNoLimits() {
-    check(
-        200, 300, null, null,
-        200, 300, 1,
-        0, 0, 200, 300
-    );
+    check(200, 300, null, null, 200, 300, 1, 0, 0, 200, 300);
   }
 
   @Test
   public void testOnlyWidth() {
-    check(
-        200, 300, 220.0, null,
-        200, 300, 1,
-        0, 0, 200, 300
-    );
-    check(
-        200, 300, 200.0, null,
-        200, 300, 1,
-        0, 0, 200, 300
-    );
-    check(
-        200, 300, 100.0, null,
-        100, 150, 0.5,
-        0, 0, 100, 150
-    );
+    check(200, 300, 220.0, null, 200, 300, 1, 0, 0, 200, 300);
+    check(200, 300, 200.0, null, 200, 300, 1, 0, 0, 200, 300);
+    check(200, 300, 100.0, null, 100, 150, 0.5, 0, 0, 100, 150);
   }
 
   @Test
   public void testOnlyHeight() {
-    check(
-        200, 300, null, 320.0,
-        200, 300, 1,
-        0, 0, 200, 300
-    );
-    check(
-        200, 300, null, 300.0,
-        200, 300, 1,
-        0, 0, 200, 300
-    );
-    check(
-        200, 300, null, 100.0,
-        67, 100, 1.0 / 3.0,
-        0, 0, 67, 100
-    );
+    check(200, 300, null, 320.0, 200, 300, 1, 0, 0, 200, 300);
+    check(200, 300, null, 300.0, 200, 300, 1, 0, 0, 200, 300);
+    check(200, 300, null, 100.0, 67, 100, 1.0 / 3.0, 0, 0, 67, 100);
   }
 
   @Test
   public void testLoose() {
-    check(
-        200, 300, 220.0, 320.0,
-        200, 300, 1,
-        0, 0, 200, 300
-    );
-    check(
-        200, 300, 200.0, 320.0,
-        200, 300, 1,
-        0, 0, 200, 300
-    );
-    check(
-        200, 300, 220.0, 300.0,
-        200, 300, 1,
-        0, 0, 200, 300
-    );
-    check(
-        200, 300, 200.0, 300.0,
-        200, 300, 1,
-        0, 0, 200, 300
-    );
+    check(200, 300, 220.0, 320.0, 200, 300, 1, 0, 0, 200, 300);
+    check(200, 300, 200.0, 320.0, 200, 300, 1, 0, 0, 200, 300);
+    check(200, 300, 220.0, 300.0, 200, 300, 1, 0, 0, 200, 300);
+    check(200, 300, 200.0, 300.0, 200, 300, 1, 0, 0, 200, 300);
   }
 
   @Test
   public void testFit() {
-    check(
-        200, 300, 200.0, 250.0, false,
-        167, 250, 5.0 / 6.0,
-        0, 0, 167, 250
-    );
-    check(
-        200, 300, 100.0, 250.0, false,
-        100, 150, 0.5,
-        0, 0, 100, 150
-    );
-    check(
-        200, 300, 150.0, 100.0, false,
-        67, 100, 1.0 / 3.0,
-        0, 0, 67, 100
-    );
+    check(200, 300, 200.0, 250.0, false, 167, 250, 5.0 / 6.0, 0, 0, 167, 250);
+    check(200, 300, 100.0, 250.0, false, 100, 150, 0.5, 0, 0, 100, 150);
+    check(200, 300, 150.0, 100.0, false, 67, 100, 1.0 / 3.0, 0, 0, 67, 100);
   }
 
   @Test
   public void testCrop() {
-    check(
-        200, 300, 200.0, 250.0, true,
-        200, 250, 1,
-        0, -25, 200, 300
-    );
-    check(
-        200, 300, 100.0, 250.0, true,
-        100, 250, 5.0 / 6.0,
-        -33.5, 0, 167, 250
-    );
-    check(
-        200, 300, 150.0, 100.0, true,
-        150, 100, 3.0 / 4.0,
-        0, -62.5, 150, 225
-    );
+    check(200, 300, 200.0, 250.0, true, 200, 250, 1, 0, -25, 200, 300);
+    check(200, 300, 100.0, 250.0, true, 100, 250, 5.0 / 6.0, -33.5, 0, 167, 250);
+    check(200, 300, 150.0, 100.0, true, 150, 100, 3.0 / 4.0, 0, -62.5, 150, 225);
   }
 }
-

--- a/packages/image_picker/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/image_picker/example/ios/Runner.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		3B80C3941E831B6300D905FE /* App.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B80C3931E831B6300D905FE /* App.framework */; };
 		3B80C3951E831B6300D905FE /* App.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3B80C3931E831B6300D905FE /* App.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		4AD9E6732216F54200EEDDA7 /* ImagePickerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4AD9E6722216F54200EEDDA7 /* ImagePickerTests.m */; };
 		5C9513011EC38BD300040975 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C9513001EC38BD300040975 /* GeneratedPluginRegistrant.m */; };
 		9705A1C61CF904A100538489 /* Flutter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9740EEBA1CF902C7004384FC /* Flutter.framework */; };
 		9705A1C71CF904A300538489 /* Flutter.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9740EEBA1CF902C7004384FC /* Flutter.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -23,6 +24,16 @@
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		F4F7A436CCA4BF276270A3AE /* libPods-Runner.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EC32F6993F4529982D9519F1 /* libPods-Runner.a */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		4AD9E66D2216F50600EEDDA7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 97C146E61CF9000F007C117D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 97C146ED1CF9000F007C117D;
+			remoteInfo = Runner;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
 		9705A1C41CF9048500538489 /* Embed Frameworks */ = {
@@ -43,6 +54,9 @@
 		2D5378251FAA1A9400D5DBA9 /* flutter_assets */ = {isa = PBXFileReference; lastKnownFileType = folder; name = flutter_assets; path = Flutter/flutter_assets; sourceTree = SOURCE_ROOT; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		3B80C3931E831B6300D905FE /* App.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = App.framework; path = Flutter/App.framework; sourceTree = "<group>"; };
+		4AD9E6682216F50600EEDDA7 /* image_picker_pluginTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = image_picker_pluginTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		4AD9E66C2216F50600EEDDA7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4AD9E6722216F54200EEDDA7 /* ImagePickerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ImagePickerTests.m; sourceTree = "<group>"; };
 		5C9512FF1EC38BD300040975 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		5C9513001EC38BD300040975 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
@@ -61,6 +75,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		4AD9E6652216F50600EEDDA7 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		97C146EB1CF9000F007C117D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -74,6 +95,16 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		4AD9E6692216F50600EEDDA7 /* image_picker_pluginTests */ = {
+			isa = PBXGroup;
+			children = (
+				4AD9E6722216F54200EEDDA7 /* ImagePickerTests.m */,
+				4AD9E66C2216F50600EEDDA7 /* Info.plist */,
+			);
+			name = image_picker_pluginTests;
+			path = ../../ios/Tests;
+			sourceTree = "<group>";
+		};
 		840012C8B5EDBCF56B0E4AC1 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -100,6 +131,7 @@
 			children = (
 				9740EEB11CF90186004384FC /* Flutter */,
 				97C146F01CF9000F007C117D /* Runner */,
+				4AD9E6692216F50600EEDDA7 /* image_picker_pluginTests */,
 				97C146EF1CF9000F007C117D /* Products */,
 				840012C8B5EDBCF56B0E4AC1 /* Pods */,
 				CF3B75C9A7D2FA2A4C99F110 /* Frameworks */,
@@ -110,6 +142,7 @@
 			isa = PBXGroup;
 			children = (
 				97C146EE1CF9000F007C117D /* Runner.app */,
+				4AD9E6682216F50600EEDDA7 /* image_picker_pluginTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -149,6 +182,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		4AD9E6672216F50600EEDDA7 /* image_picker_pluginTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4AD9E6712216F50600EEDDA7 /* Build configuration list for PBXNativeTarget "image_picker_pluginTests" */;
+			buildPhases = (
+				4AD9E6642216F50600EEDDA7 /* Sources */,
+				4AD9E6652216F50600EEDDA7 /* Frameworks */,
+				4AD9E6662216F50600EEDDA7 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				4AD9E66E2216F50600EEDDA7 /* PBXTargetDependency */,
+			);
+			name = image_picker_pluginTests;
+			productName = image_picker_pluginTests;
+			productReference = 4AD9E6682216F50600EEDDA7 /* image_picker_pluginTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		97C146ED1CF9000F007C117D /* Runner */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
@@ -160,7 +211,6 @@
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				95BB15E9E1769C0D146AA592 /* [CP] Embed Pods Frameworks */,
-				532EA9D341340B1DCD08293D /* [CP] Copy Pods Resources */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 			);
 			buildRules = (
@@ -178,9 +228,15 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				DefaultBuildSystemTypeForWorkspace = Original;
 				LastUpgradeCheck = 0830;
 				ORGANIZATIONNAME = "The Chromium Authors";
 				TargetAttributes = {
+					4AD9E6672216F50600EEDDA7 = {
+						CreatedOnToolsVersion = 10.1;
+						ProvisioningStyle = Automatic;
+						TestTargetID = 97C146ED1CF9000F007C117D;
+					};
 					97C146ED1CF9000F007C117D = {
 						CreatedOnToolsVersion = 7.3.1;
 						DevelopmentTeam = 9FK3425VTA;
@@ -206,11 +262,19 @@
 			projectRoot = "";
 			targets = (
 				97C146ED1CF9000F007C117D /* Runner */,
+				4AD9E6672216F50600EEDDA7 /* image_picker_pluginTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		4AD9E6662216F50600EEDDA7 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		97C146EC1CF9000F007C117D /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -242,21 +306,6 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" thin";
 		};
-		532EA9D341340B1DCD08293D /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		95BB15E9E1769C0D146AA592 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -264,7 +313,7 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
-				"${PODS_ROOT}/.symlinks/flutter/ios/Flutter.framework",
+				"${PODS_ROOT}/../.symlinks/flutter/ios/Flutter.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
@@ -310,6 +359,14 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		4AD9E6642216F50600EEDDA7 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4AD9E6732216F54200EEDDA7 /* ImagePickerTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		97C146EA1CF9000F007C117D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -321,6 +378,14 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		4AD9E66E2216F50600EEDDA7 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 97C146ED1CF9000F007C117D /* Runner */;
+			targetProxy = 4AD9E66D2216F50600EEDDA7 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		97C146FA1CF9000F007C117D /* Main.storyboard */ = {
@@ -342,6 +407,69 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		4AD9E66F2216F50600EEDDA7 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = ../../ios/Tests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.image-picker-pluginTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/Runner";
+			};
+			name = Debug;
+		};
+		4AD9E6702216F50600EEDDA7 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = ../../ios/Tests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.image-picker-pluginTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/Runner";
+			};
+			name = Release;
+		};
 		97C147031CF9000F007C117D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
@@ -479,6 +607,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		4AD9E6712216F50600EEDDA7 /* Build configuration list for PBXNativeTarget "image_picker_pluginTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4AD9E66F2216F50600EEDDA7 /* Debug */,
+				4AD9E6702216F50600EEDDA7 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		97C146E91CF9000F007C117D /* Build configuration list for PBXProject "Runner" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/packages/image_picker/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/packages/image_picker/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -28,6 +28,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4AD9E6672216F50600EEDDA7"
+               BuildableName = "image_picker_pluginTests.xctest"
+               BlueprintName = "image_picker_pluginTests"
+               ReferencedContainer = "container:Runner.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/packages/image_picker/example/ios/Runner.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/packages/image_picker/example/ios/Runner.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildSystemType</key>
+	<string>Original</string>
+</dict>
+</plist>

--- a/packages/image_picker/ios/Classes/ImagePickerPlugin.h
+++ b/packages/image_picker/ios/Classes/ImagePickerPlugin.h
@@ -5,4 +5,11 @@
 #import <Flutter/Flutter.h>
 
 @interface FLTImagePickerPlugin : NSObject <FlutterPlugin>
+
++ (void)getSize:(CGSize*)size drawRect:(CGRect*)drawRect
+   originalSize:(CGSize)originalSize
+       maxWidth:(NSNumber*)maxWidth
+      maxHeight:(NSNumber*)maxHeight
+           crop:(BOOL)crop;
+
 @end

--- a/packages/image_picker/ios/Classes/ImagePickerPlugin.h
+++ b/packages/image_picker/ios/Classes/ImagePickerPlugin.h
@@ -6,10 +6,11 @@
 
 @interface FLTImagePickerPlugin : NSObject <FlutterPlugin>
 
-+ (void)getSize:(CGSize*)size drawRect:(CGRect*)drawRect
-   originalSize:(CGSize)originalSize
-       maxWidth:(NSNumber*)maxWidth
-      maxHeight:(NSNumber*)maxHeight
-           crop:(BOOL)crop;
++ (void)getSize:(CGSize*)size
+        drawRect:(CGRect*)drawRect
+    originalSize:(CGSize)originalSize
+        maxWidth:(NSNumber*)maxWidth
+       maxHeight:(NSNumber*)maxHeight
+            crop:(BOOL)crop;
 
 @end

--- a/packages/image_picker/ios/Classes/ImagePickerPlugin.m
+++ b/packages/image_picker/ios/Classes/ImagePickerPlugin.m
@@ -211,7 +211,7 @@ static const int SOURCE_GALLERY = 1;
                     crop:(BOOL)crop {
   double originalWidth = image.size.width * image.scale;
   double originalHeight = image.size.height * image.scale;
-  
+
   CGSize size;
   CGRect drawRect;
   [FLTImagePickerPlugin getSize:&size
@@ -220,7 +220,7 @@ static const int SOURCE_GALLERY = 1;
                        maxWidth:maxWidth
                       maxHeight:maxHeight
                            crop:crop];
-    
+
   UIGraphicsBeginImageContextWithOptions(size, NO, 1.0);
   [image drawInRect:drawRect];
 
@@ -230,11 +230,12 @@ static const int SOURCE_GALLERY = 1;
   return scaledImage;
 }
 
-+ (void)getSize:(CGSize*)size drawRect:(CGRect*)drawRect
-   originalSize:(CGSize)originalSize
-       maxWidth:(NSNumber*)maxWidth
-      maxHeight:(NSNumber*)maxHeight
-           crop:(BOOL)crop {
++ (void)getSize:(CGSize *)size
+        drawRect:(CGRect *)drawRect
+    originalSize:(CGSize)originalSize
+        maxWidth:(NSNumber *)maxWidth
+       maxHeight:(NSNumber *)maxHeight
+            crop:(BOOL)crop {
   bool hasMaxWidth = maxWidth != nil && maxWidth != (id)[NSNull null];
   bool hasMaxHeight = maxHeight != nil && maxHeight != (id)[NSNull null];
 
@@ -243,21 +244,21 @@ static const int SOURCE_GALLERY = 1;
 
   double scale;
   if (hasMaxWidth) {
-      if (hasMaxHeight) {
-          if (crop) {
-              scale = MAX(widthScale, heightScale);
-          } else {
-              scale = MIN(widthScale, heightScale);
-          }
+    if (hasMaxHeight) {
+      if (crop) {
+        scale = MAX(widthScale, heightScale);
       } else {
-          scale = widthScale;
+        scale = MIN(widthScale, heightScale);
       }
+    } else {
+      scale = widthScale;
+    }
   } else {
-      if (hasMaxHeight) {
-          scale = heightScale;
-      } else {
-          scale = 1.0;
-      }
+    if (hasMaxHeight) {
+      scale = heightScale;
+    } else {
+      scale = 1.0;
+    }
   }
 
   scale = MIN(scale, 1.0);
@@ -270,11 +271,11 @@ static const int SOURCE_GALLERY = 1;
 
   double drawX = (width - drawWidth) / 2;
   double drawY = (height - drawHeight) / 2;
-  
+
   if (size) {
     *size = CGSizeMake(width, height);
   }
-  
+
   if (drawRect) {
     *drawRect = CGRectMake(drawX, drawY, drawWidth, drawHeight);
   }

--- a/packages/image_picker/ios/Tests/ImagePickerTests.m
+++ b/packages/image_picker/ios/Tests/ImagePickerTests.m
@@ -1,0 +1,214 @@
+#import "ImagePickerPlugin.h"
+#import <XCTest/XCTest.h>
+
+@interface ImagePickerTests : XCTestCase @end
+
+static CGSize SwappedSize(CGSize size) {
+  return CGSizeMake(size.height, size.width);
+}
+
+static CGRect SwappedRect(CGRect rect) {
+  return CGRectMake(rect.origin.y, rect.origin.x, rect.size.height, rect.size.width);
+}
+
+@implementation ImagePickerTests
+
+- (void)doCheckOriginalSize:(CGSize)originalSize
+                   maxWidth:(NSNumber*)maxWidth
+                  maxHeight:(NSNumber*)maxHeight
+                       crop:(BOOL)crop
+                       size:(CGSize)expectedSize
+                   drawRect:(CGRect)expectedDrawRect
+{
+  {
+    CGSize size;
+    CGRect drawRect;
+    [FLTImagePickerPlugin getSize:&size
+                         drawRect:&drawRect
+                     originalSize:originalSize
+                         maxWidth:maxWidth
+                        maxHeight:maxHeight
+                             crop:crop];
+    XCTAssertEqual(size.width, expectedSize.width);
+    XCTAssertEqual(size.height, expectedSize.height);
+    XCTAssertEqual(drawRect.origin.x, expectedDrawRect.origin.x);
+    XCTAssertEqual(drawRect.origin.y, expectedDrawRect.origin.y);
+    XCTAssertEqual(drawRect.size.width, expectedDrawRect.size.width);
+    XCTAssertEqual(drawRect.size.height, expectedDrawRect.size.height);
+  }
+}
+
+- (void)checkOriginalSize:(CGSize)originalSize
+                 maxWidth:(NSNumber*)maxWidth
+                maxHeight:(NSNumber*)maxHeight
+                     crop:(BOOL)crop
+                     size:(CGSize)expectedSize
+                 drawRect:(CGRect)expectedDrawRect
+{
+  [self doCheckOriginalSize:originalSize
+                   maxWidth:maxWidth
+                  maxHeight:maxHeight
+                       crop:crop
+                       size:expectedSize
+                   drawRect:expectedDrawRect];
+  
+  [self doCheckOriginalSize:SwappedSize(originalSize)
+                   maxWidth:maxHeight
+                  maxHeight:maxWidth
+                       crop:crop
+                       size:SwappedSize(expectedSize)
+                   drawRect:SwappedRect(expectedDrawRect)];
+}
+
+- (void)checkOriginalSize:(CGSize)originalSize
+                 maxWidth:(NSNumber*)maxWidth
+                maxHeight:(NSNumber*)maxHeight
+                     size:(CGSize)expectedSize
+                 drawRect:(CGRect)expectedDrawRect {
+  [self checkOriginalSize:originalSize
+                 maxWidth:maxWidth
+                maxHeight:maxHeight
+                     crop:NO
+                     size:expectedSize
+                 drawRect:expectedDrawRect];
+  [self checkOriginalSize:originalSize
+                 maxWidth:maxWidth
+                maxHeight:maxHeight
+                     crop:YES
+                     size:expectedSize
+                 drawRect:expectedDrawRect];
+}
+
+- (void)testEmpty {
+  [self checkOriginalSize:CGSizeMake(0, 0)
+                 maxWidth:nil
+                maxHeight:nil
+                     size:CGSizeMake(0, 0)
+                 drawRect:CGRectMake(0, 0, 0, 0)];
+  [self checkOriginalSize:CGSizeMake(50, 0)
+                 maxWidth:nil
+                maxHeight:nil
+                     size:CGSizeMake(50, 0)
+                 drawRect:CGRectMake(0, 0, 50, 0)];
+  [self checkOriginalSize:CGSizeMake(0, 0)
+                 maxWidth:@50
+                maxHeight:nil
+                     size:CGSizeMake(0, 0)
+                 drawRect:CGRectMake(0, 0, 0, 0)];
+  [self checkOriginalSize:CGSizeMake(100, 0)
+                 maxWidth:@50
+                maxHeight:nil
+                     size:CGSizeMake(50, 0)
+                 drawRect:CGRectMake(0, 0, 50, 0)];
+}
+
+- (void)testNoLimits {
+  [self checkOriginalSize:CGSizeMake(200, 300)
+                 maxWidth:nil
+                maxHeight:nil
+                     size:CGSizeMake(200, 300)
+                 drawRect:CGRectMake(0, 0, 200, 300)];
+}
+
+- (void)testOnlyWidth {
+  [self checkOriginalSize:CGSizeMake(200, 300)
+                 maxWidth:@220
+                maxHeight:nil
+                     size:CGSizeMake(200, 300)
+                 drawRect:CGRectMake(0, 0, 200, 300)];
+  [self checkOriginalSize:CGSizeMake(200, 300)
+                 maxWidth:@200
+                maxHeight:nil
+                     size:CGSizeMake(200, 300)
+                 drawRect:CGRectMake(0, 0, 200, 300)];
+  [self checkOriginalSize:CGSizeMake(200, 300)
+                 maxWidth:@100
+                maxHeight:nil
+                     size:CGSizeMake(100, 150)
+                 drawRect:CGRectMake(0, 0, 100, 150)];
+}
+
+- (void)testOnlyHeight {
+  [self checkOriginalSize:CGSizeMake(200, 300)
+                 maxWidth:nil
+                maxHeight:@320
+                     size:CGSizeMake(200, 300)
+                 drawRect:CGRectMake(0, 0, 200, 300)];
+  [self checkOriginalSize:CGSizeMake(200, 300)
+                 maxWidth:nil
+                maxHeight:@300
+                     size:CGSizeMake(200, 300)
+                 drawRect:CGRectMake(0, 0, 200, 300)];
+  [self checkOriginalSize:CGSizeMake(200, 300)
+                 maxWidth:nil
+                maxHeight:@100
+                     size:CGSizeMake(67, 100)
+                 drawRect:CGRectMake(0, 0, 67, 100)];
+}
+
+- (void)testLoose {
+  [self checkOriginalSize:CGSizeMake(200, 300)
+                 maxWidth:@220
+                maxHeight:@320
+                     size:CGSizeMake(200, 300)
+                 drawRect:CGRectMake(0, 0, 200, 300)];
+  [self checkOriginalSize:CGSizeMake(200, 300)
+                 maxWidth:@200
+                maxHeight:@320
+                     size:CGSizeMake(200, 300)
+                 drawRect:CGRectMake(0, 0, 200, 300)];
+  [self checkOriginalSize:CGSizeMake(200, 300)
+                 maxWidth:@220
+                maxHeight:@300
+                     size:CGSizeMake(200, 300)
+                 drawRect:CGRectMake(0, 0, 200, 300)];
+  [self checkOriginalSize:CGSizeMake(200, 300)
+                 maxWidth:@200
+                maxHeight:@300
+                     size:CGSizeMake(200, 300)
+                 drawRect:CGRectMake(0, 0, 200, 300)];
+}
+
+- (void)testFit {
+  [self checkOriginalSize:CGSizeMake(200, 300)
+                 maxWidth:@200
+                maxHeight:@250
+                     crop:NO
+                     size:CGSizeMake(167, 250)
+                 drawRect:CGRectMake(0, 0, 167, 250)];
+  [self checkOriginalSize:CGSizeMake(200, 300)
+                 maxWidth:@100
+                maxHeight:@250
+                     crop:NO
+                     size:CGSizeMake(100, 150)
+                 drawRect:CGRectMake(0, 0, 100, 150)];
+  [self checkOriginalSize:CGSizeMake(200, 300)
+                 maxWidth:@150
+                maxHeight:@100
+                     crop:NO
+                     size:CGSizeMake(67, 100)
+                 drawRect:CGRectMake(0, 0, 67, 100)];
+}
+
+- (void)testCrop {
+  [self checkOriginalSize:CGSizeMake(200, 300)
+                 maxWidth:@200
+                maxHeight:@250
+                     crop:YES
+                     size:CGSizeMake(200, 250)
+                 drawRect:CGRectMake(0, -25, 200, 300)];
+  [self checkOriginalSize:CGSizeMake(200, 300)
+                 maxWidth:@100
+                maxHeight:@250
+                     crop:YES
+                     size:CGSizeMake(100, 250)
+                 drawRect:CGRectMake(-33.5, 0, 167, 250)];
+  [self checkOriginalSize:CGSizeMake(200, 300)
+                 maxWidth:@150
+                maxHeight:@100
+                     crop:YES
+                     size:CGSizeMake(150, 100)
+                 drawRect:CGRectMake(0, -62.5, 150, 225)];
+}
+
+@end

--- a/packages/image_picker/ios/Tests/ImagePickerTests.m
+++ b/packages/image_picker/ios/Tests/ImagePickerTests.m
@@ -1,11 +1,10 @@
-#import "ImagePickerPlugin.h"
 #import <XCTest/XCTest.h>
+#import "ImagePickerPlugin.h"
 
-@interface ImagePickerTests : XCTestCase @end
+@interface ImagePickerTests : XCTestCase
+@end
 
-static CGSize SwappedSize(CGSize size) {
-  return CGSizeMake(size.height, size.width);
-}
+static CGSize SwappedSize(CGSize size) { return CGSizeMake(size.height, size.width); }
 
 static CGRect SwappedRect(CGRect rect) {
   return CGRectMake(rect.origin.y, rect.origin.x, rect.size.height, rect.size.width);
@@ -18,8 +17,7 @@ static CGRect SwappedRect(CGRect rect) {
                   maxHeight:(NSNumber*)maxHeight
                        crop:(BOOL)crop
                        size:(CGSize)expectedSize
-                   drawRect:(CGRect)expectedDrawRect
-{
+                   drawRect:(CGRect)expectedDrawRect {
   {
     CGSize size;
     CGRect drawRect;
@@ -43,15 +41,14 @@ static CGRect SwappedRect(CGRect rect) {
                 maxHeight:(NSNumber*)maxHeight
                      crop:(BOOL)crop
                      size:(CGSize)expectedSize
-                 drawRect:(CGRect)expectedDrawRect
-{
+                 drawRect:(CGRect)expectedDrawRect {
   [self doCheckOriginalSize:originalSize
                    maxWidth:maxWidth
                   maxHeight:maxHeight
                        crop:crop
                        size:expectedSize
                    drawRect:expectedDrawRect];
-  
+
   [self doCheckOriginalSize:SwappedSize(originalSize)
                    maxWidth:maxHeight
                   maxHeight:maxWidth

--- a/packages/image_picker/ios/Tests/Info.plist
+++ b/packages/image_picker/ios/Tests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/packages/image_picker/ios/image_picker.podspec
+++ b/packages/image_picker/ios/image_picker.podspec
@@ -15,4 +15,8 @@ Flutter plugin that shows an image picker.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
+
+  s.test_spec 'Tests' do |test_spec|
+    test_spec.source_files = 'Tests/*.{h,m}'
+  end
 end

--- a/packages/image_picker/lib/image_picker.dart
+++ b/packages/image_picker/lib/image_picker.dart
@@ -29,19 +29,26 @@ class ImagePicker {
   /// If specified, the image will be at most [maxWidth] wide and
   /// [maxHeight] tall. Otherwise the image will be returned at it's
   /// original width and height.
+  ///
+  /// If [crop] is false, then image will be downscaled until both dimensions
+  /// satisfy the limits. If [crop] is true, then image will be downscaled
+  /// until any of dimensions satisfies the limits and another one will be
+  /// cropped.
   static Future<File> pickImage({
     @required ImageSource source,
     double maxWidth,
     double maxHeight,
+    bool crop = false,
   }) async {
     assert(source != null);
+    assert(crop != null);
 
-    if (maxWidth != null && maxWidth < 0) {
-      throw ArgumentError.value(maxWidth, 'maxWidth cannot be negative');
+    if (maxWidth != null && maxWidth <= 0) {
+      throw ArgumentError.value(maxWidth, 'maxWidth must be positive');
     }
 
-    if (maxHeight != null && maxHeight < 0) {
-      throw ArgumentError.value(maxHeight, 'maxHeight cannot be negative');
+    if (maxHeight != null && maxHeight <= 0) {
+      throw ArgumentError.value(maxHeight, 'maxHeight must be positive');
     }
 
     // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
@@ -53,6 +60,7 @@ class ImagePicker {
         'source': source.index,
         'maxWidth': maxWidth,
         'maxHeight': maxHeight,
+        'crop': crop
       },
     );
 

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -4,8 +4,9 @@ description: Flutter plugin for selecting images from the Android and iOS image
 authors:
   - Flutter Team <flutter-dev@googlegroups.com>
   - Rhodes Davis Jr. <rody.davis.jr@gmail.com>
+  - Mykola Pokhylets <pohilets@gmail.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.5.0+3
+version: 0.6.0
 
 flutter:
   plugin:

--- a/packages/image_picker/test/image_picker_test.dart
+++ b/packages/image_picker/test/image_picker_test.dart
@@ -34,11 +34,13 @@ void main() {
               'source': 0,
               'maxWidth': null,
               'maxHeight': null,
+              'crop': false,
             }),
             isMethodCall('pickImage', arguments: <String, dynamic>{
               'source': 1,
               'maxWidth': null,
               'maxHeight': null,
+              'crop': false,
             }),
           ],
         );
@@ -67,21 +69,48 @@ void main() {
               'source': 0,
               'maxWidth': null,
               'maxHeight': null,
+              'crop': false,
             }),
             isMethodCall('pickImage', arguments: <String, dynamic>{
               'source': 0,
               'maxWidth': 10.0,
               'maxHeight': null,
+              'crop': false,
             }),
             isMethodCall('pickImage', arguments: <String, dynamic>{
               'source': 0,
               'maxWidth': null,
               'maxHeight': 10.0,
+              'crop': false,
             }),
             isMethodCall('pickImage', arguments: <String, dynamic>{
               'source': 0,
               'maxWidth': 10.0,
               'maxHeight': 20.0,
+              'crop': false,
+            }),
+          ],
+        );
+      });
+
+      test('passes the crop argument correctly', () async {
+        await ImagePicker.pickImage(source: ImageSource.camera, crop: true);
+        await ImagePicker.pickImage(source: ImageSource.camera, crop: false);
+
+        expect(
+          log,
+          <Matcher>[
+            isMethodCall('pickImage', arguments: <String, dynamic>{
+              'source': 0,
+              'maxWidth': null,
+              'maxHeight': null,
+              'crop': true,
+            }),
+            isMethodCall('pickImage', arguments: <String, dynamic>{
+              'source': 0,
+              'maxWidth': null,
+              'maxHeight': null,
+              'crop': false,
             }),
           ],
         );
@@ -95,6 +124,18 @@ void main() {
 
         expect(
           ImagePicker.pickImage(source: ImageSource.camera, maxHeight: -1.0),
+          throwsArgumentError,
+        );
+      });
+
+      test('does not accept a zero width or height argument', () {
+        expect(
+          ImagePicker.pickImage(source: ImageSource.camera, maxWidth: 0.0),
+          throwsArgumentError,
+        );
+
+        expect(
+          ImagePicker.pickImage(source: ImageSource.camera, maxHeight: 0.0),
           throwsArgumentError,
         );
       });


### PR DESCRIPTION
* Added 'crop' parameter.
* Fixed size computation for non-square dimensions (trying to fit 400x300 into 250x200 was producing 267x200 instead of 250x188). Added unit-tests for this.
* Improve downscaling quality on Android by using progressive downscaling.

I wasn't able to find much docs/examples on how to structure unit tests for native code, so for iOS I've created a target in the example app. Suggestions for better solution are welcomed.