### PR TITLE
Bugfix documents: webview_flutter JavascriptChannel, Example is not updated.

### DIFF
--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -112,7 +112,7 @@ class WebView extends StatefulWidget {
   /// For example for the following JavascriptChannel:
   ///
   /// ```dart
-  /// JavascriptChannel(name: 'Print', onMessageReceived: (String message) { print(message); });
+  /// JavascriptChannel(name: 'Print', onMessageReceived: (JavascriptMessage message) { print(message); });
   /// ```
   ///
   /// JavaScript code can call:


### PR DESCRIPTION
I copy `JavascriptChannel` from the document, but it has an error.
I hope to update the document.