### PR TITLE
[google_maps_flutter] Update README.md

### DIFF
--- a/packages/google_maps_flutter/README.md
+++ b/packages/google_maps_flutter/README.md
@@ -122,6 +122,7 @@ class MapsDemoState extends State<MapsDemo> {
               height: 200.0,
               child: GoogleMap(
                 onMapCreated: _onMapCreated,
+                initialCameraPosition: CameraPosition(target: LatLng(52.4111068, 16.9408641)),
               ),
             ),
           ),


### PR DESCRIPTION
For `GoogleMap` constructor it is required to pass initialCameraPosition