### PR TITLE
Remove left over conflict marker

### DIFF
--- a/packages/firebase_messaging/CHANGELOG.md
+++ b/packages/firebase_messaging/CHANGELOG.md
@@ -36,7 +36,6 @@
   requires any Android apps using this plugin to [also
   migrate](https://developer.android.com/jetpack/androidx/migrate) if they're
   using the original support library.
->>>>>>> origin/master
 
 ## 2.1.0
 


### PR DESCRIPTION
Remove a leftover conflict marker from https://github.com/flutter/plugins/commit/c96eb1bf358a3d6e3cf7847bb921c114168210c1