### PR TITLE
Update android_alarm_manager with instructions on setting WAKE_LOCK permissions

### DIFF
--- a/packages/android_alarm_manager/CHANGELOG.md
+++ b/packages/android_alarm_manager/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.1+3
+
+* Update README.md to include instructions for setting the WAKE_LOCK permission.
+* Updated example application to use the WAKE_LOCK permission.
+
 ## 0.4.1+2
 
 * Include a missing API dependency.

--- a/packages/android_alarm_manager/README.md
+++ b/packages/android_alarm_manager/README.md
@@ -12,6 +12,7 @@ After importing this plugin to your project as usual, add the following to your
 
 ```xml
 <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+<uses-permission android:name="android.permission.WAKE_LOCK"/>
 ```
 
 Next, within the `<application></application>` tags, add:

--- a/packages/android_alarm_manager/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/android_alarm_manager/example/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
     package="io.flutter.plugins.androidalarmmanagerexample">
 
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+    <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.INTERNET"/>
 
     <application

--- a/packages/android_alarm_manager/pubspec.yaml
+++ b/packages/android_alarm_manager/pubspec.yaml
@@ -1,7 +1,7 @@
 name: android_alarm_manager
 description: Flutter plugin for accessing the Android AlarmManager service, and
   running Dart code in the background when alarms fire.
-version: 0.4.1+2
+version: 0.4.1+3
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/android_alarm_manager
 


### PR DESCRIPTION
The WAKE_LOCK permission is required by the [JobIntentService](https://developer.android.com/reference/android/support/v4/app/JobIntentService) on pre-O versions. Without this permission, a `java.lang.SecurityException` is thrown. 

Fixes documentation issue which arose from flutter/flutter#27921 