### PR TITLE
Don't register the Maps and Camera plugin for background FlutterViews.

### DIFF
--- a/packages/camera/CHANGELOG.md
+++ b/packages/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0+3
+
+* Fixed a crash when the plugin is registered by a background FlutterView.
+
 ## 0.4.0+2
 
 * Fix orientation of captured photos when camera is used for the first time on Android.

--- a/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
+++ b/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
@@ -137,6 +137,11 @@ public class CameraPlugin implements MethodCallHandler {
   }
 
   public static void registerWith(Registrar registrar) {
+    if (registrar.activity() == null) {
+      // When a background flutter view tries to register the plugin, the registrar has no activity.
+      // We stop the registration process as this plugin is foreground only.
+      return;
+    }
     final MethodChannel channel =
         new MethodChannel(registrar.messenger(), "plugins.flutter.io/camera");
 

--- a/packages/camera/pubspec.yaml
+++ b/packages/camera/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera
 description: A Flutter plugin for getting information about and controlling the
   camera on Android and iOS. Supports previewing the camera feed, capturing images, capturing video,
   and streaming image buffers to dart.
-version: 0.4.0+2
+version: 0.4.0+3
 authors:
   - Flutter Team <flutter-dev@googlegroups.com>
   - Luigi Agosti <luigi@tengio.com>

--- a/packages/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0+4
+
+* Fixed a crash when the plugin is registered by a background FlutterView.
+
 ## 0.2.0+3
 
 * Fixed a memory leak on Android - the map was not properly disposed.

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapsPlugin.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapsPlugin.java
@@ -27,6 +27,11 @@ public class GoogleMapsPlugin implements Application.ActivityLifecycleCallbacks 
   private final int registrarActivityHashCode;
 
   public static void registerWith(Registrar registrar) {
+    if (registrar.activity() == null) {
+      // When a background flutter view tries to register the plugin, the registrar has no activity.
+      // We stop the registration process as this plugin is foreground only.
+      return;
+    }
     final GoogleMapsPlugin plugin = new GoogleMapsPlugin(registrar);
     registrar.activity().getApplication().registerActivityLifecycleCallbacks(plugin);
     registrar

--- a/packages/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter
-version: 0.2.0+3
+version: 0.2.0+4
 
 dependencies:
   flutter:


### PR DESCRIPTION
Background FlutterViews do not have an activity, the Maps and Camera
plugins are foreground only and assumed and activity is available which
can result in a crash when the plugin is registered by a background
FlutterView.

We workaround by just not registering the plugins if there is no
activity.

Similar to https://github.com/flutter/plugins/pull/1125