### PR TITLE
Skip Gradle's static permission check for the Maps MyLocation feature.

### DIFF
--- a/packages/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0+5
+
+* Skip the Gradle Android permissions lint for MyLocation (https://github.com/flutter/flutter/issues/28339)
+
 ## 0.2.0+4
 
 * Fixed a crash when the plugin is registered by a background FlutterView.

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
@@ -416,6 +416,11 @@ final class GoogleMapController
 
   private void updateMyLocationEnabled() {
     if (hasLocationPermission()) {
+      // The plugin doesn't add the location permission by default so that apps that don't need
+      // the feature won't require the permission.
+      // Gradle is doing a static check for missing permission and in some configurations will
+      // fail the build if the permission is missing. The following disables the Gradle lint.
+      //noinspection ResourceType
       googleMap.setMyLocationEnabled(myLocationEnabled);
     } else {
       // TODO(amirh): Make the options update fail.

--- a/packages/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter
-version: 0.2.0+4
+version: 0.2.0+5
 
 dependencies:
   flutter:


### PR DESCRIPTION
Only applications that use the MyLocation feature needs to add the
location permission to the Android manifest, but in some configurations
Gradle fails the build if the permission is not included.

Fixes https://github.com/flutter/flutter/issues/28339