### PR TITLE
[in_app_purchase] Java API for querying purchases

### DIFF
--- a/packages/in_app_purchase/android/src/main/java/io/flutter/plugins/inapppurchase/Translator.java
+++ b/packages/in_app_purchase/android/src/main/java/io/flutter/plugins/inapppurchase/Translator.java
@@ -5,6 +5,8 @@
 package io.flutter.plugins.inapppurchase;
 
 import androidx.annotation.Nullable;
+import com.android.billingclient.api.Purchase;
+import com.android.billingclient.api.Purchase.PurchasesResult;
 import com.android.billingclient.api.SkuDetails;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -43,5 +45,36 @@ import java.util.List;
       output.add(fromSkuDetail(detail));
     }
     return output;
+  }
+
+  static HashMap<String, Object> fromPurchase(Purchase purchase) {
+    HashMap<String, Object> info = new HashMap<>();
+    info.put("orderId", purchase.getOrderId());
+    info.put("packageName", purchase.getPackageName());
+    info.put("purchaseTime", purchase.getPurchaseTime());
+    info.put("purchaseToken", purchase.getPurchaseToken());
+    info.put("signature", purchase.getSignature());
+    info.put("sku", purchase.getSku());
+    info.put("isAutoRenewing", purchase.isAutoRenewing());
+    return info;
+  }
+
+  static List<HashMap<String, Object>> fromPurchasesList(@Nullable List<Purchase> purchases) {
+    if (purchases == null) {
+      return Collections.emptyList();
+    }
+
+    List<HashMap<String, Object>> serialized = new ArrayList<>();
+    for (Purchase purchase : purchases) {
+      serialized.add(fromPurchase(purchase));
+    }
+    return serialized;
+  }
+
+  static HashMap<String, Object> fromPurchasesResult(PurchasesResult purchasesResult) {
+    HashMap<String, Object> info = new HashMap<>();
+    info.put("responseCode", purchasesResult.getResponseCode());
+    info.put("purchasesList", fromPurchasesList(purchasesResult.getPurchasesList()));
+    return info;
   }
 }

--- a/packages/in_app_purchase/example/android/app/build.gradle
+++ b/packages/in_app_purchase/example/android/app/build.gradle
@@ -27,6 +27,8 @@ project.ext {
     KEYSTORE_STORE_PASSWORD = keystoreProperties['storePassword']
     KEYSTORE_KEY_ALIAS = keystoreProperties['keyAlias']
     KEYSTORE_KEY_PASSWORD = keystoreProperties['keyPassword']
+    VERSION_CODE = 1
+    VERSION_NAME = "0.0.1"
 }
 
 if (project.APP_ID == "io.flutter.plugins.inapppurchaseexample.DEFAULT_DO_NOT_USE") {
@@ -44,16 +46,6 @@ if (!configured) {
 def flutterRoot = localProperties.getProperty('flutter.sdk')
 if (flutterRoot == null) {
     throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
-}
-
-def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
-if (flutterVersionCode == null) {
-    flutterVersionCode = '1'
-}
-
-def flutterVersionName = localProperties.getProperty('flutter.versionName')
-if (flutterVersionName == null) {
-    flutterVersionName = '1.0'
 }
 
 apply plugin: 'com.android.application'
@@ -79,8 +71,8 @@ android {
         applicationId project.APP_ID
         minSdkVersion 16
         targetSdkVersion 28
-        versionCode flutterVersionCode.toInteger()
-        versionName flutterVersionName
+        versionCode project.VERSION_CODE
+        versionName project.VERSION_NAME
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/packages/in_app_purchase/example/android/app/src/test/java/io/flutter/plugins/inapppurchase/TranslatorTest.java
+++ b/packages/in_app_purchase/example/android/app/src/test/java/io/flutter/plugins/inapppurchase/TranslatorTest.java
@@ -5,9 +5,15 @@
 package io.flutter.plugins.inapppurchase;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.android.billingclient.api.BillingClient.BillingResponse;
+import com.android.billingclient.api.Purchase;
+import com.android.billingclient.api.Purchase.PurchasesResult;
 import com.android.billingclient.api.SkuDetails;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -17,6 +23,8 @@ import org.junit.Test;
 public class TranslatorTest {
   private static final String SKU_DETAIL_EXAMPLE_JSON =
       "{\"productId\":\"example\",\"type\":\"inapp\",\"price\":\"$0.99\",\"price_amount_micros\":990000,\"price_currency_code\":\"USD\",\"title\":\"Example title\",\"description\":\"Example description.\"}";
+  private static final String PURCHASE_EXAMPLE_JSON =
+      "{\"orderId\":\"foo\",\"packageName\":\"bar\",\"productId\":\"consumable\",\"purchaseTime\":11111111,\"purchaseState\":0,\"purchaseToken\":\"baz\"}";
 
   @Test
   public void fromSkuDetail() throws JSONException {
@@ -44,7 +52,68 @@ public class TranslatorTest {
 
   @Test
   public void fromSkuDetailsList_null() {
-    assertEquals(0, Translator.fromSkuDetailsList(null).size());
+    assertEquals(Collections.emptyList(), Translator.fromSkuDetailsList(null));
+  }
+
+  @Test
+  public void fromPurchase() throws JSONException {
+    final Purchase expected = new Purchase(PURCHASE_EXAMPLE_JSON, "signature");
+
+    assertSerialized(expected, Translator.fromPurchase(expected));
+  }
+
+  @Test
+  public void fromPurchasesList() throws JSONException {
+    final String purchase2Json =
+        "{\"orderId\":\"foo2\",\"packageName\":\"bar\",\"productId\":\"consumable\",\"purchaseTime\":11111111,\"purchaseState\":0,\"purchaseToken\":\"baz\"}";
+    final String signature = "signature";
+    final List<Purchase> expected =
+        Arrays.asList(
+            new Purchase(PURCHASE_EXAMPLE_JSON, signature), new Purchase(purchase2Json, signature));
+
+    final List<HashMap<String, Object>> serialized = Translator.fromPurchasesList(expected);
+
+    assertEquals(expected.size(), serialized.size());
+    assertSerialized(expected.get(0), serialized.get(0));
+    assertSerialized(expected.get(1), serialized.get(1));
+  }
+
+  @Test
+  public void fromPurchasesList_null() {
+    assertEquals(Collections.emptyList(), Translator.fromPurchasesList(null));
+  }
+
+  @Test
+  public void fromPurchasesResult() throws JSONException {
+    PurchasesResult result = mock(PurchasesResult.class);
+    final String purchase2Json =
+        "{\"orderId\":\"foo2\",\"packageName\":\"bar\",\"productId\":\"consumable\",\"purchaseTime\":11111111,\"purchaseState\":0,\"purchaseToken\":\"baz\"}";
+    final String signature = "signature";
+    final List<Purchase> expectedPurchases =
+        Arrays.asList(
+            new Purchase(PURCHASE_EXAMPLE_JSON, signature), new Purchase(purchase2Json, signature));
+    when(result.getPurchasesList()).thenReturn(expectedPurchases);
+    when(result.getResponseCode()).thenReturn(BillingResponse.OK);
+
+    final HashMap<String, Object> serialized = Translator.fromPurchasesResult(result);
+
+    assertEquals(BillingResponse.OK, serialized.get("responseCode"));
+    List<Map<String, Object>> serializedPurchases =
+        (List<Map<String, Object>>) serialized.get("purchasesList");
+    assertEquals(expectedPurchases.size(), serializedPurchases.size());
+    assertSerialized(expectedPurchases.get(0), serializedPurchases.get(0));
+    assertSerialized(expectedPurchases.get(1), serializedPurchases.get(1));
+  }
+
+  @Test
+  public void fromPurchasesResult_null() throws JSONException {
+    PurchasesResult result = mock(PurchasesResult.class);
+    when(result.getResponseCode()).thenReturn(BillingResponse.ERROR);
+
+    final HashMap<String, Object> serialized = Translator.fromPurchasesResult(result);
+
+    assertEquals(BillingResponse.ERROR, serialized.get("responseCode"));
+    assertEquals(Collections.emptyList(), serialized.get("purchasesList"));
   }
 
   private void assertSerialized(SkuDetails expected, Map<String, Object> serialized) {
@@ -63,5 +132,14 @@ public class TranslatorTest {
     assertEquals(expected.getSubscriptionPeriod(), serialized.get("subscriptionPeriod"));
     assertEquals(expected.getTitle(), serialized.get("title"));
     assertEquals(expected.getType(), serialized.get("type"));
+  }
+
+  private void assertSerialized(Purchase expected, Map<String, Object> serialized) {
+    assertEquals(expected.getOrderId(), serialized.get("orderId"));
+    assertEquals(expected.getPackageName(), serialized.get("packageName"));
+    assertEquals(expected.getPurchaseTime(), serialized.get("purchaseTime"));
+    assertEquals(expected.getPurchaseToken(), serialized.get("purchaseToken"));
+    assertEquals(expected.getSignature(), serialized.get("signature"));
+    assertEquals(expected.getSku(), serialized.get("sku"));
   }
 }


### PR DESCRIPTION
Actually responds in the onPurchasesUpdated() handler automatically
called when purchase updates are received.

Exposes BillingClient#queryPurchases, which is meant to be used to get
recently purchased items from the on disk Play cache.

Also exposes BillingClient#queryPurchaseHistoryAsync, which returns the
most recent purchase of the user for each SKU of the given type.

This patch also contains some updates to the Gradle script so that the
example app version is set independently of the Flutter SDK version.