### PR TITLE
[firebase_core] fixing crash on iOS due to app name not found

### DIFF
--- a/packages/firebase_core/CHANGELOG.md
+++ b/packages/firebase_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.2
+
+* Fixed crash on iOS related to `getDictionaryFromFIRApp`.
+
 ## 0.3.1
 
 * Remove an assertion that can interfere with hot-restart.

--- a/packages/firebase_core/ios/Classes/FirebaseCorePlugin.m
+++ b/packages/firebase_core/ios/Classes/FirebaseCorePlugin.m
@@ -73,7 +73,12 @@ static NSDictionary *getDictionaryFromFIRApp(FIRApp *app) {
   } else if ([@"FirebaseApp#appNamed" isEqualToString:call.method]) {
     NSString *name = call.arguments;
     FIRApp *app = [FIRApp appNamed:name];
-    result(getDictionaryFromFIRApp(app));
+    if (app == nil) {
+      NSLog(@"No app found with name '%@'", name);
+      result(nil);
+    } else {
+      result(getDictionaryFromFIRApp(app));
+    }
   } else {
     result(FlutterMethodNotImplemented);
   }

--- a/packages/firebase_core/pubspec.yaml
+++ b/packages/firebase_core/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Core, enabling connecting to multiple
   Firebase apps.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_core
-version: 0.3.1
+version: 0.3.2
 
 flutter:
   plugin:


### PR DESCRIPTION
I'm not sure wether it is crashing for everybody, but for the cases on which the app is not found with given name (like mine), it won't crash anymore, it just logs and continues (as it used to).

Example of the app log after this PR.

```
Configuring the default Firebase app...
Configured the default Firebase app __FIRAPP_DEFAULT.
5.4.1 - [Firebase/Core][I-COR000004] App with name __FIRAPP_DEFAULT does not exist.
5.4.1 - [Firebase/Analytics][I-ACS023007] Firebase Analytics v.50001000 started
5.4.1 - [Firebase/Analytics][I-ACS023008] To enable debug logging set the following application argument: -FIRAnalyticsDebugEnabled (see http://goo.gl/RfcP7r)
No app found with name 'exampleapp'
5.4.1 - [Firebase/Core][I-COR000004] App with name exampleapp does not exist.
```

Log using current `firebase_core` version (`0.3.1`):

```
Configuring the default Firebase app...
Configured the default Firebase app __FIRAPP_DEFAULT.
5.4.1 - [Firebase/Core][I-COR000004] App with name __FIRAPP_DEFAULT does not exist.
5.4.1 - [Firebase/Analytics][I-ACS023007] Firebase Analytics v.50001000 started
5.4.1 - [Firebase/Analytics][I-ACS023008] To enable debug logging set the following application argument: -FIRAnalyticsDebugEnabled (see http://goo.gl/RfcP7r)
5.4.1 - [Firebase/Core][I-COR000004] App with name exampleapp does not exist.
*** First throw call stack:
(
	0   CoreFoundation                      0x0000000105f161bb __exceptionPreprocess + 331
	1   libobjc.A.dylib                     0x00000001054b4735 objc_exception_throw + 48
	2   CoreFoundation                      0x0000000105e624ec _CFThrowFormattedException + 194
	3   CoreFoundation                      0x0000000105f85541 -[__NSPlaceholderDictionary initWithObjects:forKeys:count:] + 321
	4   CoreFoundation                      0x0000000105f11c9b +[NSDictionary dictionaryWithObjects:forKeys:count:] + 59
	5   Runner                              0x000000010218a2e9 getDictionaryFromFIRApp + 217
	6   Runner                              0x000000010218a131 -[FLTFirebaseCorePlugin handleMethodCall:result:] + 4225
	7   Flutter                             0x00000001033ad4ba __45-[Flutt<…>
```

intends to
  fix flutter/flutter#28248
  fix flutter/flutter#28199
  fix flutter/flutter#28328
  fix flutter/flutter#28068