### PR TITLE
[image_picker] update Uri Authority for GooglePhotos

### DIFF
--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.0+8
+
+* Fixed wrong GooglePhotos authority of image Uri
+
 ## 0.5.0+7
 * Fix a crash when selecting images from yandex.disk and dropbox.
 

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
@@ -187,6 +187,7 @@ class FileUtils {
   }
 
   private static boolean isGooglePhotosUri(Uri uri) {
-    return "com.google.android.apps.photos.content".equals(uri.getAuthority());
+    String authority = uri.getAuthority();
+    return authority != null && authority.startsWith("com.google.android.apps.photos.content");
   }
 }

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
@@ -187,7 +187,6 @@ class FileUtils {
   }
 
   private static boolean isGooglePhotosUri(Uri uri) {
-    String authority = uri.getAuthority();
-    return authority != null && authority.startsWith("com.google.android.apps.photos.content");
+    return "com.google.android.apps.photos.contentprovider".equals(uri.getAuthority());
   }
 }

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -5,7 +5,7 @@ authors:
   - Flutter Team <flutter-dev@googlegroups.com>
   - Rhodes Davis Jr. <rody.davis.jr@gmail.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.5.0+7
+version: 0.5.0+8
 
 flutter:
   plugin:


### PR DESCRIPTION
google photo version 4.10.0.233345822 on Android 9 return Uri with authority "com.google.android.apps.photos.contentprovider". for backward compatibility I changed equals to startsWith.