### PR TITLE
Fix cloud firestore platform error 0

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,3 +23,4 @@ Diego Velásquez <diego.velasquez.lopez@gmail.com>
 Hajime Nakamura <nkmrhj@gmail.com>
 Tuyển Vũ Xuân <netsoft1985@gmail.com>
 Sarthak Verma <sarthak@artiosys.com>
+Tom Alabaster <tomalabasteruk@gmail.com>

--- a/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
+++ b/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
@@ -11,8 +11,8 @@ static FlutterError *getFlutterError(NSError *error) {
     return nil;
   } else {
     return [FlutterError errorWithCode:[NSString stringWithFormat:@"Error %d", (int)error.code]
-                                   message:error.domain
-                                   details:error.localizedDescription];
+                               message:error.domain
+                               details:error.localizedDescription];
   }
 }
 

--- a/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
+++ b/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
@@ -7,9 +7,13 @@
 #import <Firebase/Firebase.h>
 
 static FlutterError *getFlutterError(NSError *error) {
-  return [FlutterError errorWithCode:[NSString stringWithFormat:@"Error %d", (int)error.code]
-                             message:error.domain
-                             details:error.localizedDescription];
+  if (error == nil) {
+    return nil;
+  } else {
+    return [FlutterError errorWithCode:[NSString stringWithFormat:@"Error %d", (int)error.code]
+                                   message:error.domain
+                                   details:error.localizedDescription];
+  }
 }
 
 FIRFirestore *getFirestore(NSDictionary *arguments) {

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_firestore
-version: 0.9.5+1
+version: 0.9.5+2
 
 flutter:
   plugin:


### PR DESCRIPTION
The changes in this [PR](https://github.com/flutter/plugins/pull/1226/files) has caused `cloud_firestore` to throw PlatformExceptions incorrectly. The `getFlutterError` method never returns `null` as if the `error` argument is `null`, the string formatting puts 0 in the `errorWithCode` parameter causing a `FlutterError` to always return.