### PR TITLE
[cloud_firestore,firebase_database,firebase_storage] handling error nil on getFlutterError

### DIFF
--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.6
+
+* Fixing PlatformException(Error 0, null, null) which happened when a successful operation was performed.
+
 ## 0.9.5+1
 
 * Log messages about automatic configuration of the default app are now less confusing.

--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.9.6
+## 0.9.5+2
 
 * Fixing PlatformException(Error 0, null, null) which happened when a successful operation was performed.
 

--- a/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
+++ b/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
@@ -7,7 +7,9 @@
 #import <Firebase/Firebase.h>
 
 static FlutterError *getFlutterError(NSError *error) {
-  return [FlutterError errorWithCode:[NSString stringWithFormat:@"Error %d", (int)error.code]
+  if (error == nil) return nil;
+
+  return [FlutterError errorWithCode:[NSString stringWithFormat:@"Error %ld", error.code]
                              message:error.domain
                              details:error.localizedDescription];
 }

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_firestore
-version: 0.9.6
+version: 0.9.5+2
 
 flutter:
   plugin:

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_firestore
-version: 0.9.5+1
+version: 0.9.6
 
 flutter:
   plugin:

--- a/packages/firebase_database/CHANGELOG.md
+++ b/packages/firebase_database/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.2
+
+* Fixing DatabaseReference.set unhandled exception which happened when a successful operation was performed.
+
 ## 2.0.1+2
 
 * Log messages about automatic configuration of the default app are now less confusing.

--- a/packages/firebase_database/CHANGELOG.md
+++ b/packages/firebase_database/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.2
+## 2.0.1+3
 
 * Fixing DatabaseReference.set unhandled exception which happened when a successful operation was performed.
 

--- a/packages/firebase_database/ios/Classes/FirebaseDatabasePlugin.m
+++ b/packages/firebase_database/ios/Classes/FirebaseDatabasePlugin.m
@@ -7,7 +7,9 @@
 #import <Firebase/Firebase.h>
 
 static FlutterError *getFlutterError(NSError *error) {
-  return [FlutterError errorWithCode:[NSString stringWithFormat:@"Error %d", (int)error.code]
+  if (error == nil) return nil;
+
+  return [FlutterError errorWithCode:[NSString stringWithFormat:@"Error %ld", error.code]
                              message:error.domain
                              details:error.localizedDescription];
 }

--- a/packages/firebase_database/pubspec.yaml
+++ b/packages/firebase_database/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Database, a cloud-hosted NoSQL database
   with realtime data syncing across Android and iOS clients, and offline access.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_database
-version: 2.0.1+1
+version: 2.0.2
 
 flutter:
   plugin:

--- a/packages/firebase_database/pubspec.yaml
+++ b/packages/firebase_database/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Database, a cloud-hosted NoSQL database
   with realtime data syncing across Android and iOS clients, and offline access.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_database
-version: 2.0.2
+version: 2.0.1+3
 
 flutter:
   plugin:

--- a/packages/firebase_storage/CHANGELOG.md
+++ b/packages/firebase_storage/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.1.1
+## 2.1.0+1
 
 * Reverting error.code casting/formatting to what it was until version 2.0.1.
 

--- a/packages/firebase_storage/CHANGELOG.md
+++ b/packages/firebase_storage/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.1
+
+* Reverting error.code casting/formatting to what it was until version 2.0.1.
+
 ## 2.1.0
 
 * Added support for getReferenceFromUrl.

--- a/packages/firebase_storage/ios/Classes/FirebaseStoragePlugin.m
+++ b/packages/firebase_storage/ios/Classes/FirebaseStoragePlugin.m
@@ -7,7 +7,7 @@
 #import <Firebase/Firebase.h>
 
 static FlutterError *getFlutterError(NSError *error) {
-  return [FlutterError errorWithCode:[NSString stringWithFormat:@"Error %d", (int)error.code]
+  return [FlutterError errorWithCode:[NSString stringWithFormat:@"Error %ld", (long)error.code]
                              message:error.domain
                              details:error.localizedDescription];
 }

--- a/packages/firebase_storage/pubspec.yaml
+++ b/packages/firebase_storage/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Cloud Storage, a powerful, simple, and
   cost-effective object storage service for Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_storage
-version: 2.1.0
+version: 2.1.1
 
 flutter:
   plugin:

--- a/packages/firebase_storage/pubspec.yaml
+++ b/packages/firebase_storage/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Cloud Storage, a powerful, simple, and
   cost-effective object storage service for Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_storage
-version: 2.1.1
+version: 2.1.0+1
 
 flutter:
   plugin:


### PR DESCRIPTION
When `getFlutterError` was introduced, some plugins started to throw exceptions for successful operations. I originally faced that with `firebase_database`, but I can see the same happened to `cloud_firestore`.

As you can see in the code, either the caller would have to be changed to check for `error == nil` before calling it, or we can do it inside `getFlutterError` and keep the plugin original code.

I checked the other plugins, and apparently they don't need the same change as they already do the check or use the `getFlutterError` differently.

Some of the formatting of the error code was slightly changed and I restored it to what it was, please let me know if that's ok or if that change was intentional.

intends to
 fix flutter/flutter#28344
 fix flutter/flutter#28065
 fix flutter/flutter#28103

cc @collinjackson @kroikie @cyanglaz