### PR TITLE
[package_info] calling new method for BuildNumber in new android versions

### DIFF
--- a/packages/package_info/CHANGELOG.md
+++ b/packages/package_info/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.4.1
+## 0.4.0+2
 
 * Android: Using new method for BuildNumber in new android versions
 

--- a/packages/package_info/CHANGELOG.md
+++ b/packages/package_info/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1
+
+* Android: Using new method for BuildNumber in new android versions
+
 ## 0.4.0+1
 
 * Log a more detailed warning at build time about the previous AndroidX

--- a/packages/package_info/android/src/main/java/io/flutter/plugins/packageinfo/PackageInfoPlugin.java
+++ b/packages/package_info/android/src/main/java/io/flutter/plugins/packageinfo/PackageInfoPlugin.java
@@ -7,6 +7,7 @@ package io.flutter.plugins.packageinfo;
 import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.os.Build;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
@@ -14,7 +15,6 @@ import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
 import java.util.HashMap;
 import java.util.Map;
-import android.os.Build;
 
 /** PackageInfoPlugin */
 public class PackageInfoPlugin implements MethodCallHandler {

--- a/packages/package_info/android/src/main/java/io/flutter/plugins/packageinfo/PackageInfoPlugin.java
+++ b/packages/package_info/android/src/main/java/io/flutter/plugins/packageinfo/PackageInfoPlugin.java
@@ -14,6 +14,7 @@ import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
 import java.util.HashMap;
 import java.util.Map;
+import android.os.Build;
 
 /** PackageInfoPlugin */
 public class PackageInfoPlugin implements MethodCallHandler {
@@ -42,7 +43,7 @@ public class PackageInfoPlugin implements MethodCallHandler {
         map.put("appName", info.applicationInfo.loadLabel(pm).toString());
         map.put("packageName", context.getPackageName());
         map.put("version", info.versionName);
-        map.put("buildNumber", String.valueOf(info.versionCode));
+        map.put("buildNumber", String.valueOf(getLongVersionCode(info)));
 
         result.success(map);
       } else {
@@ -51,5 +52,13 @@ public class PackageInfoPlugin implements MethodCallHandler {
     } catch (PackageManager.NameNotFoundException ex) {
       result.error("Name not found", ex.getMessage(), null);
     }
+  }
+
+  private static long getLongVersionCode(PackageInfo info) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+      return info.getLongVersionCode();
+    }
+    //noinspection deprecation
+    return info.versionCode;
   }
 }

--- a/packages/package_info/pubspec.yaml
+++ b/packages/package_info/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for querying information about the application
   package, such as CFBundleVersion on iOS or versionCode on Android.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/package_info
-version: 0.4.1
+version: 0.4.0+2
 
 flutter:
   plugin:

--- a/packages/package_info/pubspec.yaml
+++ b/packages/package_info/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for querying information about the application
   package, such as CFBundleVersion on iOS or versionCode on Android.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/package_info
-version: 0.4.0+1
+version: 0.4.1
 
 flutter:
   plugin:


### PR DESCRIPTION
fixed https://github.com/flutter/flutter/issues/28155