### PR TITLE
[firebase_performance] Fix incorrect setting of Trace & HttpMetric attributes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,3 +23,5 @@ Diego Velásquez <diego.velasquez.lopez@gmail.com>
 Hajime Nakamura <nkmrhj@gmail.com>
 Tuyển Vũ Xuân <netsoft1985@gmail.com>
 Sarthak Verma <sarthak@artiosys.com>
+Mike Diarmid <mike@invertase.io>
+Invertase <oss@invertase.io>

--- a/packages/firebase_performance/ios/Classes/FirebasePerformancePlugin.m
+++ b/packages/firebase_performance/ios/Classes/FirebasePerformancePlugin.m
@@ -77,7 +77,7 @@
 
   NSDictionary *attributes = call.arguments[@"attributes"];
   [attributes enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSString *value, BOOL *stop) {
-    [trace setValue:key forAttribute:value];
+    [trace setValue:value forAttribute:key];
   }];
 
   [trace stop];
@@ -149,7 +149,7 @@
 
   NSDictionary *attributes = call.arguments[@"attributes"];
   [attributes enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSString *value, BOOL *stop) {
-    [metric setValue:key forAttribute:value];
+    [metric setValue:value forAttribute:key];
   }];
 
   [metric stop];


### PR DESCRIPTION
### Description

The args for trace and metric attributes are the wrong way around, attribute value is where the key should be and vice-versa. This PR swaps them around for both.

#### iOS `FIRPerformanceAttributable` definition

![image](https://user-images.githubusercontent.com/5347038/53298317-037ccf00-3824-11e9-9fd1-0b1cb3ddc264.png)


### Changelog

- Fixed a bug where attributes for `Traces` and `HttpMetrics` were incorrectly using the attribute value as the attributes' name.
