### PR TITLE
[firebase_performance] remove deprecated trace counter API usage

### DIFF
--- a/packages/firebase_performance/CHANGELOG.md
+++ b/packages/firebase_performance/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.0+4
+
+* Remove deprecated methods for iOS.
+* Fix bug where `Trace` attributes were not set correctly.
+
 ## 0.1.0+3
 
 * Log messages about automatic configuration of the default app are now less confusing.

--- a/packages/firebase_performance/ios/Classes/FirebasePerformancePlugin.m
+++ b/packages/firebase_performance/ios/Classes/FirebasePerformancePlugin.m
@@ -72,7 +72,7 @@
 
   NSDictionary *counters = call.arguments[@"counters"];
   [counters enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSNumber *value, BOOL *stop) {
-    [trace setIntValue:(int64_t) value forMetric:key];
+    [trace setIntValue:(int64_t)value forMetric:key];
   }];
 
   NSDictionary *attributes = call.arguments[@"attributes"];

--- a/packages/firebase_performance/ios/Classes/FirebasePerformancePlugin.m
+++ b/packages/firebase_performance/ios/Classes/FirebasePerformancePlugin.m
@@ -72,7 +72,7 @@
 
   NSDictionary *counters = call.arguments[@"counters"];
   [counters enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSNumber *value, BOOL *stop) {
-    [trace setIntValue:(int64_t)value forMetric:key];
+    [trace setIntValue:[value longLongValue] forMetric:key];
   }];
 
   NSDictionary *attributes = call.arguments[@"attributes"];

--- a/packages/firebase_performance/ios/Classes/FirebasePerformancePlugin.m
+++ b/packages/firebase_performance/ios/Classes/FirebasePerformancePlugin.m
@@ -72,7 +72,7 @@
 
   NSDictionary *counters = call.arguments[@"counters"];
   [counters enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSNumber *value, BOOL *stop) {
-    [trace incrementCounterNamed:key by:[value integerValue]];
+    [trace setIntValue:(int64_t) value forMetric:key];
   }];
 
   NSDictionary *attributes = call.arguments[@"attributes"];

--- a/packages/firebase_performance/pubspec.yaml
+++ b/packages/firebase_performance/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Google Performance Monitoring for Firebase, an a
   iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_performance
-version: 0.1.0+3
+version: 0.1.0+4
 
 dependencies:
   flutter:


### PR DESCRIPTION
### Description

(My `AUTHORS` file change is on another PR: https://github.com/flutter/plugins/pull/1277)

The Trace API `incrementCounterNamed` has been deprecated for some time (since Firebase iOS SDK v5.0.0 - May 2018, we're now on 5.17.0). This PR switches to using the replacement metrics API; specifically `setIntValue` (not increment as formerly used - as we're only setting the value once).

Ideally the `firebase_performance.podspec` for Performance should be specifying a version of the Pod to use; but as none of the other Firebase packages do this I can't change this one without causing duplication build issues. The same applies if a newer version of the Firebase iOS SDK is released with breaking changes; as none of the podspecs are version locked they will always install the latest version.

**Example:**
```diff
- s.dependency 'Firebase/Core'
+ s.dependency 'Firebase/Core', '~> 5.15.0'
- s.dependency 'Firebase/Performance'
+ s.dependency 'Firebase/Performance', '~> 5.15.0'
```

I can send a seperate PR up to apply a minimum version to all the Firebase packages podspecs, please let me know. 🙃 This is what we do on [`invertase/react-native-firebase`](https://github.com/invertase/react-native-firebase).

#### **DEPRECATED** `FIRTrace` -> `incrementCounterNamed` definition:

![image](https://user-images.githubusercontent.com/5347038/53298529-4e4c1600-3827-11e9-81dc-93d89b334913.png)

#### **REPLACEMENT** `FIRTrace` -> `incrementMetric` definition:

![image](https://user-images.githubusercontent.com/5347038/53298533-5efc8c00-3827-11e9-8a11-7857ba88cf2e.png)

### Changelog

- Replaced deprecated API usage of Trace counters with the replacement `Metrics` API.
- Minimum supported Firebase iOS SDK is now v5.0.0
