### PR TITLE
[firebase_core][firebase_database]Add nil check for some static methods to avoid unwanted behaviors

### DIFF
--- a/packages/firebase_core/CHANGELOG.md
+++ b/packages/firebase_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1+1
+
+* Add nil check on static functions to prevent crashes or unwanted behaviors.
+
 ## 0.3.1
 
 * Remove an assertion that can interfere with hot-restart.

--- a/packages/firebase_core/ios/Classes/FirebaseCorePlugin.m
+++ b/packages/firebase_core/ios/Classes/FirebaseCorePlugin.m
@@ -7,6 +7,9 @@
 #import <Firebase/Firebase.h>
 
 static NSDictionary *getDictionaryFromFIROptions(FIROptions *options) {
+  if (!options) {
+    return nil;
+  }
   return @{
     @"googleAppID" : options.googleAppID ?: [NSNull null],
     @"bundleID" : options.bundleID ?: [NSNull null],
@@ -23,6 +26,9 @@ static NSDictionary *getDictionaryFromFIROptions(FIROptions *options) {
 }
 
 static NSDictionary *getDictionaryFromFIRApp(FIRApp *app) {
+  if (!app) {
+    return nil;
+  }
   return @{@"name" : app.name, @"options" : getDictionaryFromFIROptions(app.options)};
 }
 

--- a/packages/firebase_core/pubspec.yaml
+++ b/packages/firebase_core/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Core, enabling connecting to multiple
   Firebase apps.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_core
-version: 0.3.1
+version: 0.3.1+1
 
 flutter:
   plugin:

--- a/packages/firebase_database/CHANGELOG.md
+++ b/packages/firebase_database/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.2
+
+* Fix the issue that `getDictionaryFromError` always returns non nil result even when the parameter is nil.
+
 ## 2.0.1+3
 
 * Fixing DatabaseReference.set unhandled exception which happened when a successful operation was performed.

--- a/packages/firebase_database/ios/Classes/FirebaseDatabasePlugin.m
+++ b/packages/firebase_database/ios/Classes/FirebaseDatabasePlugin.m
@@ -15,6 +15,9 @@ static FlutterError *getFlutterError(NSError *error) {
 }
 
 static NSDictionary *getDictionaryFromError(NSError *error) {
+  if (!error) {
+    return nil;
+  }
   return @{
     @"code" : @(error.code),
     @"message" : error.domain ?: [NSNull null],

--- a/packages/firebase_database/pubspec.yaml
+++ b/packages/firebase_database/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Database, a cloud-hosted NoSQL database
   with realtime data syncing across Android and iOS clients, and offline access.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_database
-version: 2.0.1+3
+version: 2.0.2
 
 flutter:
   plugin:


### PR DESCRIPTION
After I removed categories in https://github.com/flutter/plugins/pull/1226, I missed the nil check. 
This PR is to add those nil checks to make the static method behave as the same as the category functions if the parameter is nil, this is a similar fix following up https://github.com/flutter/plugins/pull/1274