### PR TITLE
[camera] Fix crash android camera plugin when camera is closed

### DIFF
--- a/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
+++ b/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
@@ -181,6 +181,8 @@ public class CameraPlugin implements MethodCallHandler {
           result.success(cameras);
         } catch (CameraAccessException e) {
           result.error("cameraAccess", e.getMessage(), null);
+        } catch (Exception e) {
+          result.error("exception", e.getMessage(), null);
         }
         break;
       case "initialize":
@@ -220,6 +222,8 @@ public class CameraPlugin implements MethodCallHandler {
             result.success(null);
           } catch (CameraAccessException e) {
             result.error("CameraAccess", e.getMessage(), null);
+          }catch (Exception e) {
+            result.error("exception", e.getMessage(), null);
           }
           break;
         }
@@ -230,6 +234,8 @@ public class CameraPlugin implements MethodCallHandler {
             result.success(null);
           } catch (CameraAccessException e) {
             result.error("CameraAccess", e.getMessage(), null);
+          }catch (Exception e) {
+            result.error("exception", e.getMessage(), null);
           }
           break;
         }
@@ -363,6 +369,8 @@ public class CameraPlugin implements MethodCallHandler {
         result.error("CameraAccess", e.getMessage(), null);
       } catch (IllegalArgumentException e) {
         result.error("IllegalArgumentException", e.getMessage(), null);
+      }catch (Exception e) {
+        result.error("Exception", e.getMessage(), null);
       }
     }
 
@@ -500,6 +508,11 @@ public class CameraPlugin implements MethodCallHandler {
                     cameraDevice.close();
                     Camera.this.cameraDevice = null;
                     return;
+                  }catch (Exception e) {
+                    if (result != null) result.error("exception", e.getMessage(), null);
+                    cameraDevice.close();
+                    Camera.this.cameraDevice = null;
+                    return;
                   }
 
                   if (result != null) {
@@ -559,6 +572,8 @@ public class CameraPlugin implements MethodCallHandler {
               null);
         } catch (CameraAccessException e) {
           if (result != null) result.error("cameraAccess", e.getMessage(), null);
+        }catch (Exception e) {
+          if (result != null) result.error("exception", e.getMessage(), null);
         }
       }
     }
@@ -628,6 +643,8 @@ public class CameraPlugin implements MethodCallHandler {
             null);
       } catch (CameraAccessException e) {
         result.error("cameraAccess", e.getMessage(), null);
+      }catch (Exception e) {
+        result.error("exception", e.getMessage(), null);
       }
     }
 
@@ -683,6 +700,15 @@ public class CameraPlugin implements MethodCallHandler {
                 } catch (CameraAccessException e) {
                   result.error("cameraAccess", e.getMessage(), null);
                 }
+                catch (IllegalArgumentException e) {
+                  result.error("illegalArgumentException", e.getMessage(), null);
+                }
+                catch (IllegalStateException e) {
+                  result.error("illegalStateException", e.getMessage(), null);
+                }
+                catch (Exception e) {
+                  result.error("exception", e.getMessage(), null);
+                }
               }
 
               @Override
@@ -692,6 +718,8 @@ public class CameraPlugin implements MethodCallHandler {
             },
             null);
       } catch (CameraAccessException | IOException e) {
+        result.error("videoRecordingFailed", e.getMessage(), null);
+      }catch (Exception e) {
         result.error("videoRecordingFailed", e.getMessage(), null);
       }
     }
@@ -709,6 +737,8 @@ public class CameraPlugin implements MethodCallHandler {
         startPreview();
         result.success(null);
       } catch (CameraAccessException | IllegalStateException e) {
+        result.error("videoRecordingFailed", e.getMessage(), null);
+      } catch (Exception e) {
         result.error("videoRecordingFailed", e.getMessage(), null);
       }
     }
@@ -745,6 +775,15 @@ public class CameraPlugin implements MethodCallHandler {
                 cameraCaptureSession.setRepeatingRequest(captureRequestBuilder.build(), null, null);
               } catch (CameraAccessException e) {
                 sendErrorEvent(e.getMessage());
+              }
+              catch (IllegalArgumentException e) {
+                sendErrorEvent("illegalArgumentException: " + e.getMessage());
+              }
+              catch (IllegalStateException e) {
+                sendErrorEvent("illegalStateException: " + e.getMessage());
+              }
+              catch (Exception e) {
+                sendErrorEvent("exception: " + e.getMessage());
               }
             }
 
@@ -790,6 +829,15 @@ public class CameraPlugin implements MethodCallHandler {
                 cameraCaptureSession.setRepeatingRequest(captureRequestBuilder.build(), null, null);
               } catch (CameraAccessException e) {
                 sendErrorEvent(e.getMessage());
+              }
+              catch (IllegalArgumentException e) {
+                sendErrorEvent("illegalArgumentException: " + e.getMessage());
+              }
+              catch (IllegalStateException e) {
+                sendErrorEvent("illegalStateException: " + e.getMessage());
+              }
+              catch (Exception e) {
+                sendErrorEvent("exception: " + e.getMessage());
               }
             }
 

--- a/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
+++ b/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
@@ -222,7 +222,7 @@ public class CameraPlugin implements MethodCallHandler {
             result.success(null);
           } catch (CameraAccessException e) {
             result.error("CameraAccess", e.getMessage(), null);
-          }catch (Exception e) {
+          } catch (Exception e) {
             result.error("exception", e.getMessage(), null);
           }
           break;
@@ -234,7 +234,7 @@ public class CameraPlugin implements MethodCallHandler {
             result.success(null);
           } catch (CameraAccessException e) {
             result.error("CameraAccess", e.getMessage(), null);
-          }catch (Exception e) {
+          } catch (Exception e) {
             result.error("exception", e.getMessage(), null);
           }
           break;
@@ -369,7 +369,7 @@ public class CameraPlugin implements MethodCallHandler {
         result.error("CameraAccess", e.getMessage(), null);
       } catch (IllegalArgumentException e) {
         result.error("IllegalArgumentException", e.getMessage(), null);
-      }catch (Exception e) {
+      } catch (Exception e) {
         result.error("Exception", e.getMessage(), null);
       }
     }
@@ -508,7 +508,7 @@ public class CameraPlugin implements MethodCallHandler {
                     cameraDevice.close();
                     Camera.this.cameraDevice = null;
                     return;
-                  }catch (Exception e) {
+                  } catch (Exception e) {
                     if (result != null) result.error("exception", e.getMessage(), null);
                     cameraDevice.close();
                     Camera.this.cameraDevice = null;
@@ -572,7 +572,7 @@ public class CameraPlugin implements MethodCallHandler {
               null);
         } catch (CameraAccessException e) {
           if (result != null) result.error("cameraAccess", e.getMessage(), null);
-        }catch (Exception e) {
+        } catch (Exception e) {
           if (result != null) result.error("exception", e.getMessage(), null);
         }
       }
@@ -643,7 +643,7 @@ public class CameraPlugin implements MethodCallHandler {
             null);
       } catch (CameraAccessException e) {
         result.error("cameraAccess", e.getMessage(), null);
-      }catch (Exception e) {
+      } catch (Exception e) {
         result.error("exception", e.getMessage(), null);
       }
     }
@@ -719,7 +719,7 @@ public class CameraPlugin implements MethodCallHandler {
             null);
       } catch (CameraAccessException | IOException e) {
         result.error("videoRecordingFailed", e.getMessage(), null);
-      }catch (Exception e) {
+      } catch (Exception e) {
         result.error("videoRecordingFailed", e.getMessage(), null);
       }
     }

--- a/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
+++ b/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
@@ -699,14 +699,11 @@ public class CameraPlugin implements MethodCallHandler {
                   result.success(null);
                 } catch (CameraAccessException e) {
                   result.error("cameraAccess", e.getMessage(), null);
-                }
-                catch (IllegalArgumentException e) {
+                } catch (IllegalArgumentException e) {
                   result.error("illegalArgumentException", e.getMessage(), null);
-                }
-                catch (IllegalStateException e) {
+                } catch (IllegalStateException e) {
                   result.error("illegalStateException", e.getMessage(), null);
-                }
-                catch (Exception e) {
+                } catch (Exception e) {
                   result.error("exception", e.getMessage(), null);
                 }
               }
@@ -775,14 +772,11 @@ public class CameraPlugin implements MethodCallHandler {
                 cameraCaptureSession.setRepeatingRequest(captureRequestBuilder.build(), null, null);
               } catch (CameraAccessException e) {
                 sendErrorEvent(e.getMessage());
-              }
-              catch (IllegalArgumentException e) {
+              } catch (IllegalArgumentException e) {
                 sendErrorEvent("illegalArgumentException: " + e.getMessage());
-              }
-              catch (IllegalStateException e) {
+              } catch (IllegalStateException e) {
                 sendErrorEvent("illegalStateException: " + e.getMessage());
-              }
-              catch (Exception e) {
+              } catch (Exception e) {
                 sendErrorEvent("exception: " + e.getMessage());
               }
             }
@@ -829,14 +823,11 @@ public class CameraPlugin implements MethodCallHandler {
                 cameraCaptureSession.setRepeatingRequest(captureRequestBuilder.build(), null, null);
               } catch (CameraAccessException e) {
                 sendErrorEvent(e.getMessage());
-              }
-              catch (IllegalArgumentException e) {
+              } catch (IllegalArgumentException e) {
                 sendErrorEvent("illegalArgumentException: " + e.getMessage());
-              }
-              catch (IllegalStateException e) {
+              } catch (IllegalStateException e) {
                 sendErrorEvent("illegalStateException: " + e.getMessage());
-              }
-              catch (Exception e) {
+              } catch (Exception e) {
                 sendErrorEvent("exception: " + e.getMessage());
               }
             }


### PR DESCRIPTION
the camera plugin catch only `CameraAccessException` type, but it must catch all exception type.

Fix android application crash #27736

error log:
java.lang.IllegalStateException: Session has been closed; further changes are illegal.
E/AndroidRuntime(22426): 	at android.hardware.camera2.impl.CameraCaptureSessionImpl.checkNotClosed(CameraCaptureSessionImpl.java:672)
E/AndroidRuntime(22426): 	at android.hardware.camera2.impl.CameraCaptureSessionImpl.setRepeatingRequest(CameraCaptureSessionImpl.java:235)