### PR TITLE
[webview_flutter] propagate more events back to flutter, allow customization of UserAgent, basic auth

### DIFF
--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -4,8 +4,6 @@ import android.content.Context;
 import android.view.View;
 import android.webkit.WebStorage;
 import android.webkit.WebView;
-import android.webkit.WebViewDatabase;
-
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -4,6 +4,8 @@ import android.content.Context;
 import android.view.View;
 import android.webkit.WebStorage;
 import android.webkit.WebView;
+import android.webkit.WebViewDatabase;
+
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
@@ -28,6 +30,7 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
     methodChannel.setMethodCallHandler(this);
 
     applySettings((Map<String, Object>) params.get("settings"));
+    webView.setWebViewClient(new FlutterWebViewClient(methodChannel));
 
     if (params.containsKey(JS_CHANNEL_NAMES_FIELD)) {
       registerJavaScriptChannelNames((List<String>) params.get(JS_CHANNEL_NAMES_FIELD));
@@ -173,6 +176,12 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
       switch (key) {
         case "jsMode":
           updateJsMode((Integer) settings.get(key));
+          break;
+        case "userAgent":
+          Object agent = settings.get(key);
+          if (agent != null) {
+            webView.getSettings().setUserAgentString(agent.toString());
+          }
           break;
         default:
           throw new IllegalArgumentException("Unknown WebView setting: " + key);

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewClient.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewClient.java
@@ -1,0 +1,74 @@
+package io.flutter.plugins.webviewflutter;
+
+import android.util.Log;
+import android.webkit.HttpAuthHandler;
+import android.webkit.WebResourceError;
+import android.webkit.WebResourceRequest;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.flutter.plugin.common.MethodChannel;
+
+public class FlutterWebViewClient extends WebViewClient {
+
+    private final static String TAG = "FlutterWebViewClient";
+
+    private final MethodChannel methodChannel;
+
+    public FlutterWebViewClient(MethodChannel methodChannel) {
+        this.methodChannel = methodChannel;
+    }
+
+    @Override
+    public void onLoadResource(WebView view, String url) {
+        Log.d(TAG, "onLoadResource: loading " + url);
+    }
+
+    @Override
+    public void onReceivedError(WebView view, WebResourceRequest request, WebResourceError error) {
+        super.onReceivedError(view, request, error);
+        Log.d(TAG, "onReceivedError: received error." + error);
+    }
+
+    @Override
+    public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
+        Log.d(TAG, "shouldOverrideUrlLoading: " + request);
+        return super.shouldOverrideUrlLoading(view, request);
+    }
+
+    @Override
+    public void onReceivedHttpAuthRequest(WebView view, final HttpAuthHandler handler, String host, String realm) {
+        HashMap<String, String> arguments = new HashMap<>();
+        arguments.put("host", host);
+        arguments.put("realm", realm);
+        methodChannel.invokeMethod("onReceivedHttpAuthRequest", arguments, new MethodChannel.Result() {
+            @Override
+            public void success(Object o) {
+                if (o instanceof Map) {
+                    Map<?, ?> map = (Map<?, ?>) o;
+                    Object username = map.get("username");
+                    Object password = map.get("password");
+                    if (username != null && password != null) {
+                        handler.proceed(username.toString(), password.toString());
+                        return;
+                    }
+                }
+                handler.cancel();
+            }
+
+            @Override
+            public void error(String s, String s1, Object o) {
+                handler.cancel();
+            }
+
+            @Override
+            public void notImplemented() {
+                handler.cancel();
+            }
+        });
+
+    }
+}

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewClient.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewClient.java
@@ -8,19 +8,15 @@ import android.webkit.WebResourceError;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
-
+import io.flutter.plugin.common.MethodChannel;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import io.flutter.plugin.common.MethodChannel;
-
-/**
- * WebViewClient implementation for forwarding notifications to flutter channel.
- */
+/** WebViewClient implementation for forwarding notifications to flutter channel. */
 public class FlutterWebViewClient extends WebViewClient {
 
-  private final static String TAG = "FlutterWebViewClient";
+  private static final String TAG = "FlutterWebViewClient";
 
   private final MethodChannel methodChannel;
 
@@ -53,35 +49,38 @@ public class FlutterWebViewClient extends WebViewClient {
   }
 
   @Override
-  public void onReceivedHttpAuthRequest(WebView view, final HttpAuthHandler handler, String host, String realm) {
+  public void onReceivedHttpAuthRequest(
+      WebView view, final HttpAuthHandler handler, String host, String realm) {
     HashMap<String, String> arguments = new HashMap<>();
     arguments.put("host", host);
     arguments.put("realm", realm);
-    methodChannel.invokeMethod("onReceivedHttpAuthRequest", arguments, new MethodChannel.Result() {
-      @Override
-      public void success(Object o) {
-        if (o instanceof Map) {
-          Map<?, ?> map = (Map<?, ?>) o;
-          Object username = map.get("username");
-          Object password = map.get("password");
-          if (username != null && password != null) {
-            handler.proceed(username.toString(), password.toString());
-            return;
+    methodChannel.invokeMethod(
+        "onReceivedHttpAuthRequest",
+        arguments,
+        new MethodChannel.Result() {
+          @Override
+          public void success(Object o) {
+            if (o instanceof Map) {
+              Map<?, ?> map = (Map<?, ?>) o;
+              Object username = map.get("username");
+              Object password = map.get("password");
+              if (username != null && password != null) {
+                handler.proceed(username.toString(), password.toString());
+                return;
+              }
+            }
+            handler.cancel();
           }
-        }
-        handler.cancel();
-      }
 
-      @Override
-      public void error(String s, String s1, Object o) {
-        handler.cancel();
-      }
+          @Override
+          public void error(String s, String s1, Object o) {
+            handler.cancel();
+          }
 
-      @Override
-      public void notImplemented() {
-        handler.cancel();
-      }
-    });
-
+          @Override
+          public void notImplemented() {
+            handler.cancel();
+          }
+        });
   }
 }

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewClient.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewClient.java
@@ -1,5 +1,7 @@
 package io.flutter.plugins.webviewflutter;
 
+import android.graphics.Bitmap;
+import android.os.Build;
 import android.util.Log;
 import android.webkit.HttpAuthHandler;
 import android.webkit.WebResourceError;
@@ -7,6 +9,7 @@ import android.webkit.WebResourceRequest;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,9 +31,30 @@ public class FlutterWebViewClient extends WebViewClient {
     }
 
     @Override
+    public void onPageFinished(WebView view, String url) {
+        super.onPageFinished(view, url);
+        Log.d(TAG, "onPageFinished: " + url);
+        this.methodChannel.invokeMethod("onPageFinished", Collections.singletonMap("url", url));
+    }
+
+    @Override
+    public void onPageStarted(WebView view, String url, Bitmap favicon) {
+        super.onPageStarted(view, url, favicon);
+        this.methodChannel.invokeMethod("onPageStarted", Collections.singletonMap("url", url));
+    }
+
+    @Override
     public void onReceivedError(WebView view, WebResourceRequest request, WebResourceError error) {
         super.onReceivedError(view, request, error);
         Log.d(TAG, "onReceivedError: received error." + error);
+        Map<String, String> map = new HashMap<>();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            map.put("url", request.getUrl().toString());
+            map.put("description", error.getDescription().toString());
+        } else {
+            map.put("description", error.toString());
+        }
+        this.methodChannel.invokeMethod("onReceivedError", map);
     }
 
     @Override

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewClient.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewClient.java
@@ -15,84 +15,73 @@ import java.util.Map;
 
 import io.flutter.plugin.common.MethodChannel;
 
+/**
+ * WebViewClient implementation for forwarding notifications to flutter channel.
+ */
 public class FlutterWebViewClient extends WebViewClient {
 
-    private final static String TAG = "FlutterWebViewClient";
+  private final static String TAG = "FlutterWebViewClient";
 
-    private final MethodChannel methodChannel;
+  private final MethodChannel methodChannel;
 
-    public FlutterWebViewClient(MethodChannel methodChannel) {
-        this.methodChannel = methodChannel;
+  FlutterWebViewClient(MethodChannel methodChannel) {
+    this.methodChannel = methodChannel;
+  }
+
+  @Override
+  public void onPageFinished(WebView view, String url) {
+    Log.d(TAG, "onPageFinished: " + url);
+    this.methodChannel.invokeMethod("onPageFinished", Collections.singletonMap("url", url));
+  }
+
+  @Override
+  public void onPageStarted(WebView view, String url, Bitmap favicon) {
+    this.methodChannel.invokeMethod("onPageStarted", Collections.singletonMap("url", url));
+  }
+
+  @Override
+  public void onReceivedError(WebView view, WebResourceRequest request, WebResourceError error) {
+    Log.d(TAG, "onReceivedError: received error." + error);
+    Map<String, String> map = new HashMap<>();
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      map.put("url", request.getUrl().toString());
+      map.put("description", error.getDescription().toString());
+    } else {
+      map.put("description", error.toString());
     }
+    this.methodChannel.invokeMethod("onReceivedError", map);
+  }
 
-    @Override
-    public void onLoadResource(WebView view, String url) {
-        Log.d(TAG, "onLoadResource: loading " + url);
-    }
-
-    @Override
-    public void onPageFinished(WebView view, String url) {
-        super.onPageFinished(view, url);
-        Log.d(TAG, "onPageFinished: " + url);
-        this.methodChannel.invokeMethod("onPageFinished", Collections.singletonMap("url", url));
-    }
-
-    @Override
-    public void onPageStarted(WebView view, String url, Bitmap favicon) {
-        super.onPageStarted(view, url, favicon);
-        this.methodChannel.invokeMethod("onPageStarted", Collections.singletonMap("url", url));
-    }
-
-    @Override
-    public void onReceivedError(WebView view, WebResourceRequest request, WebResourceError error) {
-        super.onReceivedError(view, request, error);
-        Log.d(TAG, "onReceivedError: received error." + error);
-        Map<String, String> map = new HashMap<>();
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            map.put("url", request.getUrl().toString());
-            map.put("description", error.getDescription().toString());
-        } else {
-            map.put("description", error.toString());
+  @Override
+  public void onReceivedHttpAuthRequest(WebView view, final HttpAuthHandler handler, String host, String realm) {
+    HashMap<String, String> arguments = new HashMap<>();
+    arguments.put("host", host);
+    arguments.put("realm", realm);
+    methodChannel.invokeMethod("onReceivedHttpAuthRequest", arguments, new MethodChannel.Result() {
+      @Override
+      public void success(Object o) {
+        if (o instanceof Map) {
+          Map<?, ?> map = (Map<?, ?>) o;
+          Object username = map.get("username");
+          Object password = map.get("password");
+          if (username != null && password != null) {
+            handler.proceed(username.toString(), password.toString());
+            return;
+          }
         }
-        this.methodChannel.invokeMethod("onReceivedError", map);
-    }
+        handler.cancel();
+      }
 
-    @Override
-    public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
-        Log.d(TAG, "shouldOverrideUrlLoading: " + request);
-        return super.shouldOverrideUrlLoading(view, request);
-    }
+      @Override
+      public void error(String s, String s1, Object o) {
+        handler.cancel();
+      }
 
-    @Override
-    public void onReceivedHttpAuthRequest(WebView view, final HttpAuthHandler handler, String host, String realm) {
-        HashMap<String, String> arguments = new HashMap<>();
-        arguments.put("host", host);
-        arguments.put("realm", realm);
-        methodChannel.invokeMethod("onReceivedHttpAuthRequest", arguments, new MethodChannel.Result() {
-            @Override
-            public void success(Object o) {
-                if (o instanceof Map) {
-                    Map<?, ?> map = (Map<?, ?>) o;
-                    Object username = map.get("username");
-                    Object password = map.get("password");
-                    if (username != null && password != null) {
-                        handler.proceed(username.toString(), password.toString());
-                        return;
-                    }
-                }
-                handler.cancel();
-            }
+      @Override
+      public void notImplemented() {
+        handler.cancel();
+      }
+    });
 
-            @Override
-            public void error(String s, String s1, Object o) {
-                handler.cancel();
-            }
-
-            @Override
-            public void notImplemented() {
-                handler.cancel();
-            }
-        });
-
-    }
+  }
 }

--- a/packages/webview_flutter/ios/Classes/FlutterWebView.h
+++ b/packages/webview_flutter/ios/Classes/FlutterWebView.h
@@ -7,7 +7,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface FLTWebViewController : NSObject <FlutterPlatformView>
+@interface FLTWebViewController : NSObject <FlutterPlatformView, WKNavigationDelegate>
 
 - (instancetype)initWithFrame:(CGRect)frame
                viewIdentifier:(int64_t)viewId

--- a/packages/webview_flutter/ios/Classes/FlutterWebView.m
+++ b/packages/webview_flutter/ios/Classes/FlutterWebView.m
@@ -288,38 +288,55 @@
 
 #pragma mark WKNavigationDelegate
 
-- (void)webView:(WKWebView *)webView didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *_Nullable))completionHandler {
-  NSURLProtectionSpace *ps = challenge.protectionSpace;
-  [_channel invokeMethod:@"onReceivedHttpAuthRequest"
-               arguments:@{@"host": ps.host, @"realm": ps.realm ? ps.realm : @""}
-                  result:^(id _Nullable result) {
-                      if (result && [result isKindOfClass:[NSDictionary class]]) {
-                        id username = result[@"username"];
-                        id password = result[@"password"];
-                        if (username && password) {
-                          completionHandler(
-                                  NSURLSessionAuthChallengeUseCredential,
-                                  [NSURLCredential credentialWithUser:username password:password persistence:NSURLCredentialPersistenceForSession]);
-                          return;
-                        }
-                      }
-                      completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
-                  }];
+- (void)webView:(WKWebView*)webView
+    didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge*)challenge
+                    completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition,
+                                                NSURLCredential* _Nullable))completionHandler {
+  NSURLProtectionSpace* ps = challenge.protectionSpace;
+  [_channel
+      invokeMethod:@"onReceivedHttpAuthRequest"
+         arguments:@{@"host" : ps.host, @"realm" : ps.realm ? ps.realm : @""}
+            result:^(id _Nullable result) {
+              if (result && [result isKindOfClass:[NSDictionary class]]) {
+                id username = result[@"username"];
+                id password = result[@"password"];
+                if (username && password) {
+                  completionHandler(
+                      NSURLSessionAuthChallengeUseCredential,
+                      [NSURLCredential credentialWithUser:username
+                                                 password:password
+                                              persistence:NSURLCredentialPersistenceForSession]);
+                  return;
+                }
+              }
+              completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
+            }];
 }
 
-- (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation {
-  [_channel invokeMethod:@"onPageFinished" arguments:@{@"url": _webView.URL.absoluteString}];
+- (void)webView:(WKWebView*)webView didFinishNavigation:(WKNavigation*)navigation {
+  [_channel invokeMethod:@"onPageFinished" arguments:@{@"url" : _webView.URL.absoluteString}];
 }
 
-- (void)webView:(WKWebView *)webView didFailNavigation:(WKNavigation *)navigation withError:(NSError *)error {
-  [_channel invokeMethod:@"onReceivedError" arguments:@{@"url": _webView.URL, @"description": [error localizedDescription]}];
+- (void)webView:(WKWebView*)webView
+    didFailNavigation:(WKNavigation*)navigation
+            withError:(NSError*)error {
+  [_channel invokeMethod:@"onReceivedError"
+               arguments:@{@"url" : _webView.URL, @"description" : [error localizedDescription]}];
 }
 
-- (void)webView:(WKWebView *)webView didFailProvisionalNavigation:(WKNavigation *)navigation withError:(NSError *)error {
-  [_channel invokeMethod:@"onReceivedError" arguments:@{@"url": _webView.URL, @"description": [error localizedDescription]}];
+- (void)webView:(WKWebView*)webView
+    didFailProvisionalNavigation:(WKNavigation*)navigation
+                       withError:(NSError*)error {
+  [_channel invokeMethod:@"onReceivedError"
+               arguments:@{
+                 @"url" : _webView.URL ?: [NSNull null],
+                 @"description" : [error localizedDescription]
+               }];
 }
 
-- (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler {
+- (void)webView:(WKWebView*)webView
+    decidePolicyForNavigationAction:(WKNavigationAction*)navigationAction
+                    decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler {
   decisionHandler(WKNavigationActionPolicyAllow);
 }
 

--- a/packages/webview_flutter/ios/Classes/FlutterWebView.m
+++ b/packages/webview_flutter/ios/Classes/FlutterWebView.m
@@ -231,10 +231,13 @@
       NSNumber* mode = settings[key];
       [self updateJsMode:mode];
     } else if ([key isEqualToString:@"userAgent"]) {
-      if (@available(iOS 9.0, *)) {
-        _webView.customUserAgent = settings[key];
-      } else {
-        NSLog(@"webview_flutter: prior to iOS 9.0, a custom userAgent is not supported.");
+      id userAgent = settings[key];
+      if (userAgent && ![userAgent isEqual:[NSNull null]]) {
+        if (@available(iOS 9.0, *)) {
+          _webView.customUserAgent = settings[key];
+        } else {
+          NSLog(@"webview_flutter: prior to iOS 9.0, a custom userAgent is not supported.");
+        }
       }
     } else {
       NSLog(@"webview_flutter: unknown setting key: %@", key);

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -262,13 +262,11 @@ class _CreationParams {
 }
 
 class _WebSettings {
-  _WebSettings({
-    this.javascriptMode,
-    this.userAgent
-  });
+  _WebSettings({this.javascriptMode, this.userAgent});
 
   static _WebSettings fromWidget(WebView widget) {
-    return _WebSettings(javascriptMode: widget.javascriptMode, userAgent: widget.userAgent);
+    return _WebSettings(
+        javascriptMode: widget.javascriptMode, userAgent: widget.userAgent);
   }
 
   final JavascriptMode javascriptMode;
@@ -291,40 +289,31 @@ class _WebSettings {
   }
 }
 
-/**
- * Simple credentials wrapper for authorization requests returned by [WebViewClient.onReceivedHttpAuthRequest].
- */
+/// Simple credentials wrapper for authorization requests returned by [WebViewClient.onReceivedHttpAuthRequest].
 class AuthInfo {
+  AuthInfo(this.username, this.password);
+
   final String username;
   final String password;
-
-  AuthInfo(this.username, this.password);
 }
 
 typedef Future<AuthInfo> AuthHandler(String host, String realm);
 
-/**
- * Generic error during loading page in [WebView] and passed to [WebViewClient.onReceivedError].
- */
+/// Generic error during loading page in [WebView] and passed to [WebViewClient.onReceivedError].
 class WebViewError {
+  WebViewError({this.url, this.description});
+
   /// URL of the page when the error happened. (might be null if unknown)
   final String url;
 
   /// Localized description of the error.
   final String description;
-
-  WebViewError({this.url, this.description});
 }
 
-/**
- * Allows listening for [WebView] events and customize behavior.
- */
+/// Allows listening for [WebView] events and customize behavior.
 class WebViewClient {
-
-  /**
-   * Called for authorization requests (basic authorization) Expected to return username/password,
-   * or null if it should cancel the request.
-   */
+  /// Called for authorization requests (basic authorization) Expected to return username/password,
+  /// or null if it should cancel the request.
   Future<AuthInfo> onReceivedHttpAuthRequest(String host, String realm) async {
     return null;
   }
@@ -372,8 +361,9 @@ class WebViewController {
       case 'onReceivedHttpAuthRequest':
         final String host = call.arguments['host'];
         final String realm = call.arguments['realm'];
-        final handled = await webViewClient.onReceivedHttpAuthRequest(host, realm);
-        return {
+        final AuthInfo handled =
+            await webViewClient.onReceivedHttpAuthRequest(host, realm);
+        return <String, String>{
           'username': handled.username,
           'password': handled.password,
         };

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -291,28 +291,51 @@ class _WebSettings {
   }
 }
 
+/**
+ * Simple credentials wrapper for authorization requests returned by [WebViewClient.onReceivedHttpAuthRequest].
+ */
 class AuthInfo {
   final String username;
   final String password;
 
   AuthInfo(this.username, this.password);
 }
+
 typedef Future<AuthInfo> AuthHandler(String host, String realm);
 
+/**
+ * Generic error during loading page in [WebView] and passed to [WebViewClient.onReceivedError].
+ */
 class WebViewError {
+  /// URL of the page when the error happened. (might be null if unknown)
   final String url;
+
+  /// Localized description of the error.
   final String description;
+
   WebViewError({this.url, this.description});
 }
 
+/**
+ * Allows listening for [WebView] events and customize behavior.
+ */
 class WebViewClient {
+
+  /**
+   * Called for authorization requests (basic authorization) Expected to return username/password,
+   * or null if it should cancel the request.
+   */
   Future<AuthInfo> onReceivedHttpAuthRequest(String host, String realm) async {
     return null;
   }
 
-  void onReceivedError(WebViewError) {}
+  /// Notification of an error while loading the current page.
+  void onReceivedError(WebViewError error) {}
 
+  /// Notification of the main page in the [WebView] finished loading.
   void onPageFinished(String url) {}
+
+  /// Notification when the main frame starts loading. (url might be null if unknown)
   void onPageStarted(String url) {}
 }
 


### PR DESCRIPTION
Hi,
I required a few customizations for the platform WebView and wondered if it might be useful for others:

* Customization of the User-Agent string (on iOS only since 9).
* Getting notifications for page loading, finished and error events.
* Handling authorization requests (for basic authorization)

let me know if this is something which makes sense to be contributed back.

thanks,
  Herbert