### PR TITLE
[in_app_purchase] Minor bugfixes and code cleanup

### DIFF
--- a/packages/in_app_purchase/android/src/main/java/io/flutter/plugins/inapppurchase/InAppPurchasePlugin.java
+++ b/packages/in_app_purchase/android/src/main/java/io/flutter/plugins/inapppurchase/InAppPurchasePlugin.java
@@ -51,9 +51,9 @@ public class InAppPurchasePlugin implements MethodCallHandler {
         "BillingClient#launchBillingFlow(Activity, BillingFlowParams)";
     static final String ON_PURCHASES_UPDATED =
         "PurchasesUpdatedListener#onPurchasesUpdated(int, List<Purchase>)";
-    static final String QUERY_PURCHASES = "queryPurchases(String)";
+    static final String QUERY_PURCHASES = "BillingClient#queryPurchases(String)";
     static final String QUERY_PURCHASE_HISTORY_ASYNC =
-        "queryPurchaseHistoryAsync(String, PurchaseHistoryResponseListener)";
+        "BillingClient#queryPurchaseHistoryAsync(String, PurchaseHistoryResponseListener)";
 
     private MethodNames() {};
   }
@@ -259,7 +259,7 @@ public class InAppPurchasePlugin implements MethodCallHandler {
     public void onPurchasesUpdated(int responseCode, @Nullable List<Purchase> purchases) {
       final Map<String, Object> callbackArgs = new HashMap<>();
       callbackArgs.put("responseCode", responseCode);
-      callbackArgs.put("purchases", fromPurchasesList(purchases));
+      callbackArgs.put("purchasesList", fromPurchasesList(purchases));
       channel.invokeMethod(MethodNames.ON_PURCHASES_UPDATED, callbackArgs);
     }
   }

--- a/packages/in_app_purchase/example/android/app/build.gradle
+++ b/packages/in_app_purchase/example/android/app/build.gradle
@@ -21,14 +21,16 @@ try {
 }
 
 project.ext {
-    // TODO(YOU): Set this to match your package ID in the Play Developer Console (see example/README.md).
-    APP_ID = "io.flutter.plugins.inapppurchaseexample.DEFAULT_DO_NOT_USE"
+    // TODO(YOU): Create release keys and a `keystore.properties` file. See
+    // `example/README.md` for more info and `keystore.example.properties` for an
+    // example.
+    APP_ID = configured ? keystoreProperties['appId'] : "io.flutter.plugins.inapppurchaseexample.DEFAULT_DO_NOT_USE"
     KEYSTORE_STORE_FILE = configured ? rootProject.file(keystoreProperties['storeFile']) : null
     KEYSTORE_STORE_PASSWORD = keystoreProperties['storePassword']
     KEYSTORE_KEY_ALIAS = keystoreProperties['keyAlias']
     KEYSTORE_KEY_PASSWORD = keystoreProperties['keyPassword']
-    VERSION_CODE = 1
-    VERSION_NAME = "0.0.1"
+    VERSION_CODE = configured ? keystoreProperties['versionCode'].toInteger() : 1
+    VERSION_NAME = configured ? keystoreProperties['versionName'] : "0.0.1"
 }
 
 if (project.APP_ID == "io.flutter.plugins.inapppurchaseexample.DEFAULT_DO_NOT_USE") {

--- a/packages/in_app_purchase/example/android/app/src/test/java/io/flutter/plugins/inapppurchase/InAppPurchasePluginTest.java
+++ b/packages/in_app_purchase/example/android/app/src/test/java/io/flutter/plugins/inapppurchase/InAppPurchasePluginTest.java
@@ -376,7 +376,7 @@ public class InAppPurchasePluginTest {
 
     HashMap<String, Object> resultData = resultCaptor.getValue();
     assertEquals(responseCode, resultData.get("responseCode"));
-    assertEquals(fromPurchasesList(purchasesList), resultData.get("purchases"));
+    assertEquals(fromPurchasesList(purchasesList), resultData.get("purchasesList"));
   }
 
   private void establishConnectedBillingClient(

--- a/packages/in_app_purchase/example/keystore.example.properties
+++ b/packages/in_app_purchase/example/keystore.example.properties
@@ -2,3 +2,6 @@ storePassword=???
 keyPassword=???
 keyAlias=???
 storeFile=???
+appId=io.flutter.plugins.inapppurchaseexample.DEFAULT_DO_NOT_USE
+versionCode=1
+versionName=0.0.1

--- a/packages/in_app_purchase/lib/src/billing_client_wrappers/enum_converters.g.dart
+++ b/packages/in_app_purchase/lib/src/billing_client_wrappers/enum_converters.g.dart
@@ -27,6 +27,7 @@ T _$enumDecode<T>(Map<T, dynamic> enumValues, dynamic source) {
 
 const _$BillingResponseEnumMap = <BillingResponse, dynamic>{
   BillingResponse.featureNotSupported: -2,
+  BillingResponse.serviceDisconnected: -1,
   BillingResponse.ok: 0,
   BillingResponse.userCanceled: 1,
   BillingResponse.serviceUnavailable: 2,


### PR DESCRIPTION
Some refactoring split out from a future patch on querying the purchase
history.

1. Moved all Android app-specific information to the keystore.properties
   file. I initially didn't put everything there because normally the
   keystore file only has signing information. But the app ID, verison
   name, and version code all do need to be potentially modified in the
   example to get it up and running. They're not inherently sensitive
   like the signing information is but it probably makes sense to keep
   them out of source control for the plugin repo too.
2. Fixed the MethodChannel argument naming for some of the new methods.
3. Added a missing `BillingResponse` code.
4. Changed the `BillingClient#_callbacks` to be a map of lists instead
   of a list of maps. The OnPurchasesUpdated() listener is a singleton
   and we never really have a good opportunity to pass down a `handle`.
   It makes more sense to me to store these by name. Also deleted the
   `remove` code since it would cause `handle` to be off for future
   entries.
5. Fixed a concurrency issue on Android in the example app, and tweaked
   the UI slightly.