### PR TITLE
[google_maps_flutter] The FloatingActionButton requires an icon

### DIFF
--- a/packages/google_maps_flutter/README.md
+++ b/packages/google_maps_flutter/README.md
@@ -139,6 +139,7 @@ class MapSampleState extends State<MapSample> {
       floatingActionButton: FloatingActionButton.extended(
         onPressed: _goToTheLake,
         label: Text('To the lake!'),
+        icon: Icon(Icons.directions_boat),
       ),
     );
   }


### PR DESCRIPTION
The sample code doesn't work.  It needs an icon specified for the FloatingActionButton.