### PR TITLE
Update play-services-maps from 15.+ to 16.1.0

### DIFF
--- a/packages/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0+3
+
+* Update Android play-services-maps to 16.1.0
+
 ## 0.3.0+2
 
 * Address an issue on iOS where icons were not loading.

--- a/packages/google_maps_flutter/android/build.gradle
+++ b/packages/google_maps_flutter/android/build.gradle
@@ -46,6 +46,6 @@ android {
     }
 
     dependencies {
-        implementation 'com.google.android.gms:play-services-maps:15.+'
+        implementation 'com.google.android.gms:play-services-maps:16.1.0'
     }
 }

--- a/packages/google_maps_flutter/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/google_maps_flutter/example/android/app/src/main/AndroidManifest.xml
@@ -8,7 +8,6 @@
         android:name="io.flutter.app.FlutterApplication"
         android:label="google_maps_flutter_example"
         android:icon="@mipmap/ic_launcher">
-      <uses-library android:name="org.apache.http.legacy" android:required="false"/>
       <meta-data
             android:name="com.google.android.gms.version"
             android:value="@integer/google_play_services_version" />

--- a/packages/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter
-version: 0.3.0+2
+version: 0.3.0+3
 
 dependencies:
   flutter:


### PR DESCRIPTION
Addresses https://developers.google.com/maps/documentation/android-sdk/config#specify_requirement_for_apache_http_legacy_library
Also removed the need to legacy override in manifest