### PR TITLE
[cloud_functions]fixed error introduced by #1210

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,3 +25,4 @@ Tuyển Vũ Xuân <netsoft1985@gmail.com>
 Sarthak Verma <sarthak@artiosys.com>
 Mike Diarmid <mike@invertase.io>
 Invertase <oss@invertase.io>
+Rishab Nayak <rishab@bu.edu>

--- a/packages/cloud_functions/lib/cloud_functions.dart
+++ b/packages/cloud_functions/lib/cloud_functions.dart
@@ -22,7 +22,7 @@ class CloudFunctionsException implements Exception {
 class CloudFunctions {
   CloudFunctions({FirebaseApp app, String region})
       : _app = app ?? FirebaseApp.instance,
-        _region = region;
+        _region = region ?? "us-central1";
 
   @visibleForTesting
   static const MethodChannel channel = MethodChannel('cloud_functions');

--- a/packages/cloud_functions/test/cloud_functions_test.dart
+++ b/packages/cloud_functions/test/cloud_functions_test.dart
@@ -41,7 +41,7 @@ void main() {
             'CloudFunctions#call',
             arguments: <String, dynamic>{
               'app': '[DEFAULT]',
-              'region': null ?? 'us-central1',
+              'region': 'us-central1',
               'functionName': 'baz',
               'parameters': null,
             },

--- a/packages/cloud_functions/test/cloud_functions_test.dart
+++ b/packages/cloud_functions/test/cloud_functions_test.dart
@@ -41,7 +41,7 @@ void main() {
             'CloudFunctions#call',
             arguments: <String, dynamic>{
               'app': '[DEFAULT]',
-              'region': null,
+              'region': null ?? 'us-central1',
               'functionName': 'baz',
               'parameters': null,
             },


### PR DESCRIPTION
Fixes [flutter/flutter#28578](https://github.com/flutter/flutter/issues/28578), which was an artifact introduced by #1210 which tried to fix [flutter/flutter#27888](https://github.com/flutter/flutter/issues/27888) and [flutter/flutter#24333](https://github.com/flutter/flutter/issues/24333).

This issue is most likely caused by #1210 as this commit is correlated with the version roll to 0.1.1, which is confirmed by [git blame](https://github.com/flutter/plugins/blame/f2b1e696eb1391fa734090faaac66b46057a0d38/packages/cloud_functions/lib/cloud_functions.dart#L25).

Thanks to @aytunch for confirming that the build works with ```cloud_functions: 0.1.0+1```

Performs a null check on the variable, reverting it to the default ```us-central1``` if not found.