### PR TITLE
[cloud_firestore] Update firebase-firestore to 18.2.0

### DIFF
--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,4 +1,5 @@
-## 0.9.7+3
+## 0.9.8
+
 * Bump Android dependencies to latest.
 
 ## 0.9.7+2

--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.9.7+3
+* Bump Android dependencies to latest.
+
 ## 0.9.7+2
 
 * Bump the minimum Flutter version to 1.2.0.

--- a/packages/cloud_firestore/android/build.gradle
+++ b/packages/cloud_firestore/android/build.gradle
@@ -47,7 +47,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        api 'com.google.firebase:firebase-firestore:17.1.1'
+        api 'com.google.firebase:firebase-firestore:18.2.0'
         implementation 'androidx.annotation:annotation:1.0.0'
     }
 }

--- a/packages/cloud_firestore/android/build.gradle
+++ b/packages/cloud_firestore/android/build.gradle
@@ -42,7 +42,6 @@ android {
     defaultConfig {
         minSdkVersion 16
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        multiDexEnabled true
     }
     lintOptions {
         disable 'InvalidPackage'

--- a/packages/cloud_firestore/android/build.gradle
+++ b/packages/cloud_firestore/android/build.gradle
@@ -42,6 +42,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        multiDexEnabled true
     }
     lintOptions {
         disable 'InvalidPackage'

--- a/packages/cloud_firestore/example/android/app/build.gradle
+++ b/packages/cloud_firestore/example/android/app/build.gradle
@@ -38,6 +38,7 @@ android {
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        multiDexEnabled true
     }
 
     buildTypes {

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_firestore
-version: 0.9.7+3
+version: 0.9.8
 
 flutter:
   plugin:

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_firestore
-version: 0.9.7+2
+version: 0.9.7+3
 
 flutter:
   plugin:


### PR DESCRIPTION
Update `firebase-firestore` dependency to `18.2.0`. Previously, using `setData` method on `DocumentReference` would result in a crash.

Resolves https://github.com/flutter/flutter/issues/28082