### PR TITLE
[firebase_analytics] Add resetAnalyticsData method

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,3 +25,4 @@ Tuyển Vũ Xuân <netsoft1985@gmail.com>
 Sarthak Verma <sarthak@artiosys.com>
 Mike Diarmid <mike@invertase.io>
 Invertase <oss@invertase.io>
+Elliot Hesp <elliot@invertase.io>

--- a/packages/firebase_analytics/CHANGELOG.md
+++ b/packages/firebase_analytics/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.2
+## 2.0.3
 
 * Add resetAnalyticsData method
 

--- a/packages/firebase_analytics/CHANGELOG.md
+++ b/packages/firebase_analytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.2
+
+* Add resetAnalyticsData method
+
 ## 2.0.2+1
 
 * Log messages about automatic configuration of the default app are now less confusing.

--- a/packages/firebase_analytics/android/src/main/java/io/flutter/plugins/firebaseanalytics/FirebaseAnalyticsPlugin.java
+++ b/packages/firebase_analytics/android/src/main/java/io/flutter/plugins/firebaseanalytics/FirebaseAnalyticsPlugin.java
@@ -56,6 +56,9 @@ public class FirebaseAnalyticsPlugin implements MethodCallHandler {
       case "setUserProperty":
         handleSetUserProperty(call, result);
         break;
+      case "resetAnalyticsData":
+        handleResetAnalyticsData(call, result);
+        break;
       default:
         result.notImplemented();
         break;
@@ -120,6 +123,11 @@ public class FirebaseAnalyticsPlugin implements MethodCallHandler {
     final String value = (String) arguments.get("value");
 
     firebaseAnalytics.setUserProperty(name, value);
+    result.success(null);
+  }
+
+  private void handleResetAnalyticsData(MethodCall call, Result result) {
+    firebaseAnalytics.resetAnalyticsData();
     result.success(null);
   }
 

--- a/packages/firebase_analytics/ios/Classes/FirebaseAnalyticsPlugin.m
+++ b/packages/firebase_analytics/ios/Classes/FirebaseAnalyticsPlugin.m
@@ -59,6 +59,9 @@
     NSNumber *enabled = [NSNumber numberWithBool:call.arguments];
     [[FIRAnalyticsConfiguration sharedInstance] setAnalyticsCollectionEnabled:[enabled boolValue]];
     result(nil);
+  } else if ([@"resetAnalyticsData" isEqualToString:call.method]) {
+    [FIRAnalytics resetAnalyticsData];
+    result(nil);
   } else {
     result(FlutterMethodNotImplemented);
   }

--- a/packages/firebase_analytics/lib/firebase_analytics.dart
+++ b/packages/firebase_analytics/lib/firebase_analytics.dart
@@ -162,10 +162,10 @@ class FirebaseAnalytics {
 
   /// Clears all analytics data for this app from the device and resets the app instance id.
   Future<void> resetAnalyticsData() async {
-     // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-     // https://github.com/flutter/flutter/issues/26431
-     // ignore: strong_mode_implicit_dynamic_method
-     await _channel.invokeMethod('resetAnalyticsData');
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
+    await _channel.invokeMethod('resetAnalyticsData');
   }
 
   /// Logs the standard `add_payment_info` event.

--- a/packages/firebase_analytics/lib/firebase_analytics.dart
+++ b/packages/firebase_analytics/lib/firebase_analytics.dart
@@ -162,6 +162,9 @@ class FirebaseAnalytics {
 
   /// Clears all analytics data for this app from the device and resets the app instance id.
   Future<void> resetAnalyticsData() async {
+     // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+     // https://github.com/flutter/flutter/issues/26431
+     // ignore: strong_mode_implicit_dynamic_method
      await _channel.invokeMethod('resetAnalyticsData');
   }
 

--- a/packages/firebase_analytics/lib/firebase_analytics.dart
+++ b/packages/firebase_analytics/lib/firebase_analytics.dart
@@ -160,6 +160,11 @@ class FirebaseAnalytics {
     });
   }
 
+  /// Clears all analytics data for this app from the device and resets the app instance id.
+  Future<void> resetAnalyticsData() {
+     await _channel.invokeMethod('resetAnalyticsData');
+  }
+
   /// Logs the standard `add_payment_info` event.
   ///
   /// This event signifies that a user has submitted their payment information

--- a/packages/firebase_analytics/lib/firebase_analytics.dart
+++ b/packages/firebase_analytics/lib/firebase_analytics.dart
@@ -161,7 +161,7 @@ class FirebaseAnalytics {
   }
 
   /// Clears all analytics data for this app from the device and resets the app instance id.
-  Future<void> resetAnalyticsData() {
+  Future<void> resetAnalyticsData() async {
      await _channel.invokeMethod('resetAnalyticsData');
   }
 

--- a/packages/firebase_analytics/pubspec.yaml
+++ b/packages/firebase_analytics/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Analytics for Firebase, an app measuremen
   solution that provides insight on app usage and user engagement on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_analytics
-version: 2.0.2+1
+version: 2.0.3
 
 flutter:
   plugin:

--- a/packages/firebase_analytics/test/firebase_analytics_test.dart
+++ b/packages/firebase_analytics/test/firebase_analytics_test.dart
@@ -114,6 +114,11 @@ void main() {
       expect(invokedMethod, 'setSessionTimeoutDuration');
       expect(arguments, 234);
     });
+
+    test('resetAnalyticsData', () async {
+      await analytics.resetAnalyticsData();
+      expect(invokedMethod, 'resetAnalyticsData');
+    });
   });
 
   group('$FirebaseAnalytics analytics events', () {


### PR DESCRIPTION
This PR adds support for the missing resetAnalyticsData method to the firebase_analytics package.

https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.html#resetAnalyticsData()