### PR TITLE
[cloud_functions] Specify version for CocoaPod and handle null regions gracefully

### DIFF
--- a/packages/cloud_functions/CHANGELOG.md
+++ b/packages/cloud_functions/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Specifying a version for Cloud Functions CocoaPod dependency to prevent build errors on iOS.
 * Fix on iOS when using a null region.
+* Upgrade the firebase_core dependency of the example app.
 
 ## 0.1.1+1
 

--- a/packages/cloud_functions/CHANGELOG.md
+++ b/packages/cloud_functions/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2
+
+* Fix crash on iOS when using a null region
+
 ## 0.1.1+1
 
 * Log messages about automatic configuration of the default app are now less confusing.

--- a/packages/cloud_functions/CHANGELOG.md
+++ b/packages/cloud_functions/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.1.2
 
-* Fix crash on iOS when using a null region
+* Specifying a version for Cloud Functions CocoaPod dependency to prevent build errors on iOS.
+* Fix on iOS when using a null region.
 
 ## 0.1.1+1
 

--- a/packages/cloud_functions/example/pubspec.yaml
+++ b/packages/cloud_functions/example/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   cupertino_icons: ^0.1.2
   cloud_functions:
     path: ..
-  firebase_core: 0.3.0
+  firebase_core: ^0.3.1
 
 dev_dependencies:
   flutter_test:

--- a/packages/cloud_functions/ios/Classes/CloudFunctionsPlugin.m
+++ b/packages/cloud_functions/ios/Classes/CloudFunctionsPlugin.m
@@ -41,7 +41,7 @@
     NSString *region = call.arguments[@"region"];
     FIRApp *app = [FIRApp appNamed:appName];
     FIRFunctions *functions;
-    if (region != nil) {
+    if (region != nil && region != (id)[NSNull null]) {
       functions = [FIRFunctions functionsForApp:app region:region];
     } else {
       functions = [FIRFunctions functionsForApp:app];

--- a/packages/cloud_functions/ios/Classes/CloudFunctionsPlugin.m
+++ b/packages/cloud_functions/ios/Classes/CloudFunctionsPlugin.m
@@ -48,35 +48,35 @@
     }
     FIRHTTPSCallable *function = [functions HTTPSCallableWithName:functionName];
     [function callWithObject:parameters
-                     completion:^(FIRHTTPSCallableResult *callableResult, NSError *error) {
-                   if (error) {
-                     FlutterError *flutterError;
-                     if (error.domain == FIRFunctionsErrorDomain) {
-                       NSDictionary *details = [NSMutableDictionary dictionary];
-                       [details setValue:[self mapFunctionsErrorCodes:error.code] forKey:@"code"];
-                       if (error.localizedDescription != nil) {
-                         [details setValue:error.localizedDescription forKey:@"message"];
-                       }
-                       if (error.userInfo[FIRFunctionsErrorDetailsKey] != nil) {
-                         [details setValue:error.userInfo[FIRFunctionsErrorDetailsKey]
-                                    forKey:@"details"];
-                       }
+                  completion:^(FIRHTTPSCallableResult *callableResult, NSError *error) {
+                    if (error) {
+                      FlutterError *flutterError;
+                      if (error.domain == FIRFunctionsErrorDomain) {
+                        NSDictionary *details = [NSMutableDictionary dictionary];
+                        [details setValue:[self mapFunctionsErrorCodes:error.code] forKey:@"code"];
+                        if (error.localizedDescription != nil) {
+                          [details setValue:error.localizedDescription forKey:@"message"];
+                        }
+                        if (error.userInfo[FIRFunctionsErrorDetailsKey] != nil) {
+                          [details setValue:error.userInfo[FIRFunctionsErrorDetailsKey]
+                                     forKey:@"details"];
+                        }
 
-                       flutterError =
-                           [FlutterError errorWithCode:@"functionsError"
-                                               message:@"Firebase function failed with exception."
-                                               details:details];
-                     } else {
-                       flutterError = [FlutterError
-                           errorWithCode:[NSString stringWithFormat:@"%ld", error.code]
-                                 message:error.localizedDescription
-                                 details:nil];
-                     }
-                     result(flutterError);
-                   } else {
-                     result(callableResult.data);
-                   }
-                 }];
+                        flutterError =
+                            [FlutterError errorWithCode:@"functionsError"
+                                                message:@"Firebase function failed with exception."
+                                                details:details];
+                      } else {
+                        flutterError = [FlutterError
+                            errorWithCode:[NSString stringWithFormat:@"%ld", error.code]
+                                  message:error.localizedDescription
+                                  details:nil];
+                      }
+                      result(flutterError);
+                    } else {
+                      result(callableResult.data);
+                    }
+                  }];
   } else {
     result(FlutterMethodNotImplemented);
   }

--- a/packages/cloud_functions/ios/Classes/CloudFunctionsPlugin.m
+++ b/packages/cloud_functions/ios/Classes/CloudFunctionsPlugin.m
@@ -46,9 +46,9 @@
     } else {
       functions = [FIRFunctions functionsForApp:app];
     }
-    [functions callFunction:functionName
-                 withObject:parameters
-                 completion:^(FIRHTTPSCallableResult *callableResult, NSError *error) {
+    FIRHTTPSCallable *function = [functions HTTPSCallableWithName:functionName];
+    [function callWithObject:parameters
+                     completion:^(FIRHTTPSCallableResult *callableResult, NSError *error) {
                    if (error) {
                      FlutterError *flutterError;
                      if (error.domain == FIRFunctionsErrorDomain) {

--- a/packages/cloud_functions/ios/cloud_functions.podspec
+++ b/packages/cloud_functions/ios/cloud_functions.podspec
@@ -17,7 +17,7 @@ A new flutter plugin project.
   s.ios.deployment_target = '8.0'
   s.dependency 'Flutter'
   s.dependency 'Firebase/Core'
-  s.dependency 'Firebase/Functions'
+  s.dependency 'Firebase/Functions', '~> 5.18'
   s.static_framework = true
 end
 

--- a/packages/cloud_functions/pubspec.yaml
+++ b/packages/cloud_functions/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cloud_functions
 description: Flutter plugin for Cloud Functions.
-version: 0.1.1+1
+version: 0.1.2
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_functions
 


### PR DESCRIPTION
Recently Cloud Functions changed their API in a breaking fashion, which caused build errors for some users. Also fixes a regression in the new region handling that didn't handle the default case gracefully.

Fixes flutter/flutter#28433
Fixes flutter/flutter#28578

I verified manually that the iOS app works properly.