### PR TITLE
Exclude longPress from semantics

### DIFF
--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.4
+## 0.3.3+2
 
 * Exclude LongPress handler from semantics tree since it does nothing.
 

--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.4
+
+* Exclude LongPress handler from semantics tree since it does nothing.
+
 ## 0.3.3+1
 
 * Fixed a memory leak on Android - the WebView was not properly disposed.

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -153,6 +153,7 @@ class _WebViewState extends State<WebView> {
         // handles are not showing.
         // TODO(amirh): remove this when the issues above are fixed.
         onLongPress: () {},
+        excludeFromSemantics: true,
         child: AndroidView(
           viewType: 'plugins.flutter.io/webview',
           onPlatformViewCreated: _onPlatformViewCreated,

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
-version: 0.3.3+1
+version: 0.3.4
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/webview_flutter
 

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
-version: 0.3.4
+version: 0.3.3+2
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/webview_flutter
 


### PR DESCRIPTION
The longpress handler should not be exposed to the semantics tree since it doesn't do anything. It will just confuse screenreaders. 