### PR TITLE
[webview_flutter] Enable geolocation on Android

### DIFF
--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -8,6 +8,9 @@ import android.annotation.TargetApi;
 import android.content.Context;
 import android.os.Build;
 import android.view.View;
+import android.webkit.GeolocationPermissions;
+import android.webkit.WebChromeClient;
+import android.webkit.WebSettings;
 import android.webkit.WebStorage;
 import android.webkit.WebView;
 import io.flutter.plugin.common.BinaryMessenger;
@@ -42,6 +45,8 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
     }
 
     webView.setWebViewClient(flutterWebViewClient);
+
+    enableGeolocation();
 
     if (params.containsKey("initialUrl")) {
       String url = (String) params.get("initialUrl");
@@ -217,5 +222,15 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
   @Override
   public void dispose() {
     methodChannel.setMethodCallHandler(null);
+  }
+
+  private void enableGeolocation() {
+    webView.getSettings().setGeolocationEnabled(true);
+    webView.setWebChromeClient(new WebChromeClient() {
+        @Override
+        public void onGeolocationPermissionsShowPrompt(String origin, GeolocationPermissions.Callback callback) {
+            callback.invoke(origin, true, false);
+        }
+    });
   }
 }

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -231,7 +231,7 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
           public void onGeolocationPermissionsShowPrompt(
               String origin, GeolocationPermissions.Callback callback) {
             callback.invoke(origin, true, false);
-        }
-      });
+          }
+        });
   }
 }

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -10,7 +10,6 @@ import android.os.Build;
 import android.view.View;
 import android.webkit.GeolocationPermissions;
 import android.webkit.WebChromeClient;
-import android.webkit.WebSettings;
 import android.webkit.WebStorage;
 import android.webkit.WebView;
 import io.flutter.plugin.common.BinaryMessenger;
@@ -226,11 +225,13 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
 
   private void enableGeolocation() {
     webView.getSettings().setGeolocationEnabled(true);
-    webView.setWebChromeClient(new WebChromeClient() {
-        @Override
-        public void onGeolocationPermissionsShowPrompt(String origin, GeolocationPermissions.Callback callback) {
+    webView.setWebChromeClient(
+        new WebChromeClient() {
+          @Override
+          public void onGeolocationPermissionsShowPrompt(
+              String origin, GeolocationPermissions.Callback callback) {
             callback.invoke(origin, true, false);
         }
-    });
+      });
   }
 }


### PR DESCRIPTION
Quick hack for enabling geolocation on Android. Native app still needs to ask for required geo permissions. Temporary solution for requesting permissions without further modifications to the webview_flutter plugin:

pubspec.yml:
```
dependencies:
  geolocator: ^3.0.0
```

Somewhere in app's code before creating WebView:

`Geolocator().getLastKnownPosition(desiredAccuracy: LocationAccuracy.high);`
