### PR TITLE
[firebase_ml_vision] Update version of GoogleAppMeasurement dependency

### DIFF
--- a/packages/firebase_ml_vision/ios/firebase_ml_vision.podspec
+++ b/packages/firebase_ml_vision/ios/firebase_ml_vision.podspec
@@ -18,7 +18,7 @@ An SDK that brings Google's machine learning expertise to Android and iOS apps i
   s.dependency 'Flutter'
   s.dependency 'Firebase/Core'
   s.dependency 'Firebase/MLVision'
-  s.dependency 'GoogleAppMeasurement', '~> 5.3.0'
+  s.dependency 'GoogleAppMeasurement', '~> 5.7.0'
   s.ios.deployment_target = '8.0'
   s.static_framework = true
 end


### PR DESCRIPTION
* Fixes conflict with firebase_analytics https://github.com/flutter/flutter/issues/28054

It seems the version of `GoogleAppMeasurement` listed for `firebase_ml_vision` doesn't play nice with the one required by `firebase_analytics`

Error received before this change:

```
[!] CocoaPods could not find compatible versions for pod "Firebase/Core":
  In Podfile:
    firebase_analytics (from `.symlinks/plugins/firebase_analytics/ios`) was resolved to 0.0.1, which depends on
      Firebase/Core

Specs satisfying the `Firebase/Core` dependency were found, but they required a higher minimum deployment target.
CocoaPods could not find compatible versions for pod "GoogleAppMeasurement":
  In Podfile:
    firebase_analytics (from `.symlinks/plugins/firebase_analytics/ios`) was resolved to 0.0.1, which depends on
      Firebase/Core was resolved to 5.18.0, which depends on
        FirebaseAnalytics (= 5.7.0) was resolved to 5.7.0, which depends on
          GoogleAppMeasurement (= 5.7.0)

    firebase_ml_vision (from `.symlinks/plugins/firebase_ml_vision/ios`) was resolved to 0.1.1, which depends on
      GoogleAppMeasurement (~> 5.3.0)
```

After making this change locally in `.symlinks/plugins/firebase_ml_vision/ios` `pod install` works without a hitch.