### PR TITLE
[cloud_firestore] ios ceck for nil snapshot in cloud_firestore error handling instead of checking for non-nil error

### DIFF
--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.9.6
+
+* On iOS, update null checking to match the recommended pattern usage in the Firebase documentation.
+* Fixes a case where snapshot errors might result in plugin crash.
+
 ## 0.9.5+2
 
 * Fixing PlatformException(Error 0, null, null) which happened when a successful operation was performed.

--- a/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
+++ b/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
@@ -390,7 +390,7 @@ const UInt8 TIMESTAMP = 136;
     FIRDocumentReference *document = getDocumentReference(call.arguments);
     [document getDocumentWithCompletion:^(FIRDocumentSnapshot *_Nullable snapshot,
                                           NSError *_Nullable error) {
-      if (error) {
+      if (snapshot == nil) {
         result(getFlutterError(error));
       } else {
         result(@{
@@ -411,7 +411,7 @@ const UInt8 TIMESTAMP = 136;
     }
     id<FIRListenerRegistration> listener = [query
         addSnapshotListener:^(FIRQuerySnapshot *_Nullable snapshot, NSError *_Nullable error) {
-          if (error) {
+          if (snapshot == nil) {
             result(getFlutterError(error));
             return;
           }
@@ -426,7 +426,7 @@ const UInt8 TIMESTAMP = 136;
     FIRDocumentReference *document = getDocumentReference(call.arguments);
     id<FIRListenerRegistration> listener =
         [document addSnapshotListener:^(FIRDocumentSnapshot *snapshot, NSError *_Nullable error) {
-          if (error) {
+          if (snapshot == nil) {
             result(getFlutterError(error));
             return;
           }
@@ -450,7 +450,10 @@ const UInt8 TIMESTAMP = 136;
     }
     [query getDocumentsWithCompletion:^(FIRQuerySnapshot *_Nullable snapshot,
                                         NSError *_Nullable error) {
-      if (error) result(getFlutterError(error));
+      if (snapshot != nil) {
+        result(getFlutterError(error));
+        return;
+      }
       result(parseQuerySnapshot(snapshot));
     }];
   } else if ([@"Query#removeListener" isEqualToString:call.method]) {

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_firestore
-version: 0.9.5+2
+version: 0.9.5+3
 
 flutter:
   plugin:

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_firestore
-version: 0.9.5+3
+version: 0.9.6
 
 flutter:
   plugin:


### PR DESCRIPTION
Fixes flutter/flutter#15837

iOS only

In addition to making our iOS plugin usage of the API match the [docs](https://firebase.google.com/docs/firestore/query-data/listen), this also fixes a case where we were returning from method call twice in an error case.

on Android we check if the error is not null per the example code.
