### PR TITLE
[cloud_firestore] fix NoSuchMethodError regression and add test

### DIFF
--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.9.7
 
-* Fixes an iOS regression in getDocuments introduced in 0.9.6.
+* Fixes a NoSuchMethodError when using getDocuments on iOS (introduced in 0.9.6).
 * Adds a driver test for getDocuments.
 
 ## 0.9.6

--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.9.7
+
+* Fixes an iOS regression in getDocuments introduced in 0.9.6.
+* Adds a driver test for getDocuments.
+
 ## 0.9.6
 
 * On iOS, update null checking to match the recommended pattern usage in the Firebase documentation.

--- a/packages/cloud_firestore/example/pubspec.yaml
+++ b/packages/cloud_firestore/example/pubspec.yaml
@@ -8,5 +8,10 @@ dependencies:
     path: ../
   firebase_core: "^0.3.0"
 
+dev_dependencies:
+  flutter_driver:
+    sdk: flutter
+  test: any
+
 flutter:
   uses-material-design: true

--- a/packages/cloud_firestore/example/test_driver/cloud_firestore.dart
+++ b/packages/cloud_firestore/example/test_driver/cloud_firestore.dart
@@ -30,6 +30,5 @@ void main() {
       final QuerySnapshot snapshot = await reference.getDocuments();
       expect(snapshot.documents.length, isNonZero);
     });
-
   });
 }

--- a/packages/cloud_firestore/example/test_driver/cloud_firestore.dart
+++ b/packages/cloud_firestore/example/test_driver/cloud_firestore.dart
@@ -27,7 +27,7 @@ void main() {
 
     test('getDocuments', () async {
       final CollectionReference reference = firestore.collection('messages');
-      QuerySnapshot snapshot = await reference.getDocuments();
+      final QuerySnapshot snapshot = await reference.getDocuments();
       expect(snapshot.documents.length, isNonZero);
     });
 

--- a/packages/cloud_firestore/example/test_driver/cloud_firestore.dart
+++ b/packages/cloud_firestore/example/test_driver/cloud_firestore.dart
@@ -1,0 +1,35 @@
+import 'dart:async';
+import 'package:flutter_driver/driver_extension.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_core/firebase_core.dart';
+
+void main() {
+  final Completer<String> completer = Completer<String>();
+  enableFlutterDriverExtension(handler: (_) => completer.future);
+  tearDownAll(() => completer.complete(null));
+
+  group('$Firestore', () {
+    Firestore firestore;
+
+    setUp(() async {
+      final FirebaseApp app = await FirebaseApp.configure(
+        name: 'test',
+        options: const FirebaseOptions(
+          googleAppID: '1:79601577497:ios:5f2bcc6ba8cecddd',
+          gcmSenderID: '79601577497',
+          apiKey: 'AIzaSyArgmRGfB5kiQT6CunAOmKRVKEsxKmy6YI-G72PVU',
+          projectID: 'flutter-firestore',
+        ),
+      );
+      firestore = Firestore(app: app);
+    });
+
+    test('getDocuments', () async {
+      final CollectionReference reference = firestore.collection('messages');
+      QuerySnapshot snapshot = await reference.getDocuments();
+      expect(snapshot.documents.length, isNonZero);
+    });
+
+  });
+}

--- a/packages/cloud_firestore/example/test_driver/cloud_firestore_test.dart
+++ b/packages/cloud_firestore/example/test_driver/cloud_firestore_test.dart
@@ -1,0 +1,10 @@
+import 'package:flutter_driver/flutter_driver.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('CloudFirestore driver test', () async {
+    final FlutterDriver driver = await FlutterDriver.connect();
+    await driver.requestData(null, timeout: const Duration(minutes: 1));
+    driver.close();
+  });
+}

--- a/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
+++ b/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
@@ -450,7 +450,7 @@ const UInt8 TIMESTAMP = 136;
     }
     [query getDocumentsWithCompletion:^(FIRQuerySnapshot *_Nullable snapshot,
                                         NSError *_Nullable error) {
-      if (snapshot != nil) {
+      if (snapshot == nil) {
         result(getFlutterError(error));
         return;
       }

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_firestore
-version: 0.9.6
+version: 0.9.7
 
 flutter:
   plugin:

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -21,6 +21,9 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  flutter_driver:
+    sdk: flutter
+  test: any
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"


### PR DESCRIPTION
Fixes a `NoSuchMethodError` in getDocuments(), introduced in #1339

Adds a simple driver test for the fix.

Fixes flutter/flutter#29423