### PR TITLE
[firebase_auth] Add a driver test

### DIFF
--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.1+5
+
+* Added a driver test.
+
 ## 0.8.1+4
 
 * Update README.

--- a/packages/firebase_auth/example/pubspec.yaml
+++ b/packages/firebase_auth/example/pubspec.yaml
@@ -10,5 +10,10 @@ dependencies:
   google_sign_in: ^4.0.0
   firebase_core: ^0.3.0
 
+dev_dependencies:
+  flutter_driver:
+    sdk: flutter
+  test: any
+
 flutter:
   uses-material-design: true

--- a/packages/firebase_auth/example/test/firebase_auth.dart
+++ b/packages/firebase_auth/example/test/firebase_auth.dart
@@ -13,8 +13,10 @@ void main() {
   tearDownAll(() => completer.complete(null));
 
   group('$FirebaseAuth', () {
+    final FirebaseAuth auth = FirebaseAuth.instance;
+
     test('signInAnonymously', () async {
-      final FirebaseUser user = await FirebaseAuth.instance.signInAnonymously();
+      final FirebaseUser user = await auth.signInAnonymously();
       expect(user.uid, isNotNull);
       expect(user.isAnonymous, isTrue);
     });

--- a/packages/firebase_auth/example/test/firebase_auth.dart
+++ b/packages/firebase_auth/example/test/firebase_auth.dart
@@ -1,0 +1,22 @@
+// Copyright 2019, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'package:flutter_driver/driver_extension.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+void main() {
+  final Completer<String> completer = Completer<String>();
+  enableFlutterDriverExtension(handler: (_) => completer.future);
+  tearDownAll(() => completer.complete(null));
+
+  group('$FirebaseAuth', () {
+    test('signInAnonymously', () async {
+      final FirebaseUser user = await FirebaseAuth.instance.signInAnonymously();
+      expect(user.uid, isNotNull);
+      expect(user.isAnonymous, isTrue);
+    });
+  });
+}

--- a/packages/firebase_auth/example/test/firebase_auth_test.dart
+++ b/packages/firebase_auth/example/test/firebase_auth_test.dart
@@ -1,0 +1,16 @@
+// Copyright 2019, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../lib/main.dart';
+
+void main() {
+  testWidgets('FirebaseAuth example widget test',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(MyApp());
+    await tester.tap(find.text('Test registration'));
+    expect(find.text('Test sign in anonymously'), findsOneWidget);
+  });
+}

--- a/packages/firebase_auth/example/test/firebase_auth_test.dart
+++ b/packages/firebase_auth/example/test/firebase_auth_test.dart
@@ -11,6 +11,7 @@ void main() {
       (WidgetTester tester) async {
     await tester.pumpWidget(MyApp());
     await tester.tap(find.text('Test registration'));
-    expect(find.text('Test sign in anonymously'), findsOneWidget);
+    await tester.pumpAndSettle();
+    expect(find.text('Registration'), findsOneWidget);
   });
 }

--- a/packages/firebase_auth/example/test/firebase_auth_test.dart
+++ b/packages/firebase_auth/example/test/firebase_auth_test.dart
@@ -7,8 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 import '../lib/main.dart';
 
 void main() {
-  testWidgets('FirebaseAuth example widget test',
-      (WidgetTester tester) async {
+  testWidgets('FirebaseAuth example widget test', (WidgetTester tester) async {
     await tester.pumpWidget(MyApp());
     await tester.tap(find.text('Test registration'));
     await tester.pumpAndSettle();

--- a/packages/firebase_auth/example/test_driver/firebase_auth_test.dart
+++ b/packages/firebase_auth/example/test_driver/firebase_auth_test.dart
@@ -1,0 +1,11 @@
+// Copyright 2019, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:flutter_driver/flutter_driver.dart';
+
+Future<void> main() async {
+  final FlutterDriver driver = await FlutterDriver.connect();
+  await driver.requestData(null, timeout: const Duration(minutes: 1));
+  driver.close();
+}

--- a/packages/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Firebase Auth, enabling Android and iOS
   like Google, Facebook and Twitter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_auth
-version: "0.8.1+4"
+version: "0.8.1+5"
 
 flutter:
   plugin:
@@ -23,6 +23,8 @@ dev_dependencies:
   google_sign_in: ^3.0.4
   test: ^1.3.0
   flutter_test:
+    sdk: flutter
+  flutter_driver:
     sdk: flutter
 
 environment:


### PR DESCRIPTION
This checks in an E2E plugin test and widget test for firebase_auth so that we can add regression tests for improvements that we make.