### PR TITLE
[firebase_storage] Fix putFile method's Content-Type auto-detection for iOS

### DIFF
--- a/packages/firebase_storage/CHANGELOG.md
+++ b/packages/firebase_storage/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.1.2
+## 2.1.1+2
 
 * On iOS, use `putFile` instead of `putData` appropriately to detect `Content-Type`.
 

--- a/packages/firebase_storage/CHANGELOG.md
+++ b/packages/firebase_storage/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.2
+
+* On iOS, use `putFile` instead of `putData` appropriately to detect `Content-Type`.
+
 ## 2.1.1+1
 
 * On iOS, gracefully handle the case of uploading a nonexistent file without crashing.

--- a/packages/firebase_storage/example/test_driver/firebase_storage.dart
+++ b/packages/firebase_storage/example/test_driver/firebase_storage.dart
@@ -44,6 +44,7 @@ void main() {
       final String url = await ref.getDownloadURL();
       final http.Response downloadData = await http.get(url);
       expect(downloadData.body, kTestString);
+      expect(downloadData.headers['content-type'], 'text/plain');
       final File tempFile = File('${systemTempDir.path}/tmp$uuid.txt');
       if (tempFile.existsSync()) {
         await tempFile.delete();

--- a/packages/firebase_storage/ios/Classes/FirebaseStoragePlugin.m
+++ b/packages/firebase_storage/ios/Classes/FirebaseStoragePlugin.m
@@ -180,22 +180,35 @@ static FlutterError *getFlutterError(NSError *error) {
 }
 
 - (void)putFile:(FlutterMethodCall *)call result:(FlutterResult)result {
-  NSData *data = [NSData dataWithContentsOfFile:call.arguments[@"filename"]];
+  NSURL *fileUrl = [NSURL fileURLWithPath:call.arguments[@"filename"]];
+  [self
+      putHandler:^(FIRStorageReference *fileRef, FIRStorageMetadata *metadata) {
+        return [fileRef putFile:fileUrl metadata:metadata];
+      }
+            call:call
+          result:result];
+}
+
+- (void)putData:(FlutterMethodCall *)call result:(FlutterResult)result {
+  NSData *data = [(FlutterStandardTypedData *)call.arguments[@"data"] data];
   if (data == nil) {
     result([FlutterError errorWithCode:@"storage_error"
                                message:@"Failed to read file"
                                details:nil]);
     return;
   }
-  [self put:data call:call result:result];
+  [self
+      putHandler:^(FIRStorageReference *fileRef, FIRStorageMetadata *metadata) {
+        return [fileRef putData:data metadata:metadata];
+      }
+            call:call
+          result:result];
 }
 
-- (void)putData:(FlutterMethodCall *)call result:(FlutterResult)result {
-  NSData *data = [(FlutterStandardTypedData *)call.arguments[@"data"] data];
-  [self put:data call:call result:result];
-}
-
-- (void)put:(NSData *)data call:(FlutterMethodCall *)call result:(FlutterResult)result {
+- (void)putHandler:(FIRStorageUploadTask * (^)(FIRStorageReference *fileRef,
+                                               FIRStorageMetadata *metadata))putHandler
+              call:(FlutterMethodCall *)call
+            result:(FlutterResult)result {
   NSString *path = call.arguments[@"path"];
   NSDictionary *metadataDictionary = call.arguments[@"metadata"];
   FIRStorageMetadata *metadata;
@@ -203,7 +216,7 @@ static FlutterError *getFlutterError(NSError *error) {
     metadata = [self buildMetadataFromDictionary:metadataDictionary];
   }
   FIRStorageReference *fileRef = [storage.reference child:path];
-  FIRStorageUploadTask *uploadTask = [fileRef putData:data metadata:metadata];
+  FIRStorageUploadTask *uploadTask = putHandler(fileRef, metadata);
   NSNumber *handle = [NSNumber numberWithInt:_nextUploadHandle++];
   [uploadTask observeStatus:FIRStorageTaskStatusSuccess
                     handler:^(FIRStorageTaskSnapshot *snapshot) {

--- a/packages/firebase_storage/pubspec.yaml
+++ b/packages/firebase_storage/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Cloud Storage, a powerful, simple, and
   cost-effective object storage service for Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_storage
-version: 2.1.1+1
+version: 2.1.2
 
 flutter:
   plugin:

--- a/packages/firebase_storage/pubspec.yaml
+++ b/packages/firebase_storage/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Cloud Storage, a powerful, simple, and
   cost-effective object storage service for Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_storage
-version: 2.1.2
+version: 2.1.1+2
 
 flutter:
   plugin:


### PR DESCRIPTION
- `putFile` should use `putFile` iOS SDK method correctly
- `putFile` should auto-detect Content-Type automatically by file extension if not specified

I tested at this sample on **iOS**:
https://github.com/flutter/plugins/blob/master/packages/firebase_storage/example/lib/main.dart.

This uses `putFile` here:
https://github.com/flutter/plugins/blob/04d6f52e3b09193462a18a38a7249da92b901ba5/packages/firebase_storage/example/lib/main.dart#L66

## Before this pull request

Uploaded file:
https://firebasestorage.googleapis.com/v0/b/flutter-firebase-plugins.appspot.com/o/text%2Ffoob3d87700-3260-11e9-d838-d7a1f7b2a3d4.txt

`contentType` is `application/octet-stream`, but this is unintended value because `putFile` should auto-detect `contentType` as written this document.

> The putFile: method automatically infers the content type from the NSURL filename extension, but you can override the auto-detected type by specifying contentType in the metadata. If you do not provide a contentType and Cloud Storage cannot infer a default from the file extension, Cloud Storage uses application/octet-stream.
> https://firebase.google.com/docs/storage/ios/upload-files#add_file_metadata

In this case, the file's extension is `txt`, so `contentType` should be `plain/text`.

### After this pull request

Uploaded file:
https://firebasestorage.googleapis.com/v0/b/flutter-firebase-plugins.appspot.com/o/text%2Ffoo09aa2e30-3260-11e9-efe1-e3ed438ea03f.txt

`contentType` is `plain/text`, which is intended value.