### PR TITLE
[WIP] Re-enable Android emulator builds using Cirrus

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -6,6 +6,6 @@ RUN yes | sdkmanager \
     "build-tools;27.0.3" \
     "extras;google;m2repository" \
     "extras;android;m2repository" \
-    "system-images;android-21;default;armeabi-v7a"
+    "system-images;android-21;google_apis;armeabi-v7a"
 
 RUN yes | sdkmanager --licenses

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -28,7 +28,7 @@ task:
           PLUGIN_SHARDING: "--shardIndex 0 --shardCount 2"
           PLUGIN_SHARDING: "--shardIndex 1 --shardCount 2"
       create_device_script:
-        echo no | avdmanager -v create avd -n test -k "system-images;android-21;default;armeabi-v7a"
+        echo no | avdmanager -v create avd -n test -k "system-images;android-21;google_apis;armeabi-v7a"
       start_emulator_background_script:
       - $ANDROID_HOME/emulator/emulator -avd test -no-audio -no-window
       wait_for_emulator_script: adb wait-for-device
@@ -45,9 +45,7 @@ task:
         - export CIRRUS_COMMIT_MESSAGE=""
         - ./script/incremental_build.sh build-examples --apk
         - ./script/incremental_build.sh java-test  # must come after apk build
-        # TODO(jackson): Re-enable once Android emulators support Firebase
-        # https://github.com/flutter/flutter/issues/29571
-        # - ./script/incremental_build.sh drive-examples
+        - ./script/incremental_build.sh drive-examples
         - export CIRRUS_CHANGE_MESSAGE=`cat /tmp/cirrus_change_message.txt`
         - export CIRRUS_COMMIT_MESSAGE=`cat /tmp/cirrus_commit_message.txt`
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -25,8 +25,10 @@ task:
     - name: build-apks+java-test+drive-examples
       env:
         matrix:
-          PLUGIN_SHARDING: "--shardIndex 0 --shardCount 2"
-          PLUGIN_SHARDING: "--shardIndex 1 --shardCount 2"
+          PLUGIN_SHARDING: "--shardIndex 0 --shardCount 4"
+          PLUGIN_SHARDING: "--shardIndex 1 --shardCount 4"
+          PLUGIN_SHARDING: "--shardIndex 2 --shardCount 4"
+          PLUGIN_SHARDING: "--shardIndex 3 --shardCount 4"
       create_device_script:
         echo no | avdmanager -v create avd -n test -k "system-images;android-21;google_apis;armeabi-v7a"
       start_emulator_background_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -32,7 +32,7 @@ task:
       create_device_script:
         echo no | avdmanager -v create avd -n test -k "system-images;android-21;google_apis;armeabi-v7a"
       start_emulator_background_script:
-      - $ANDROID_HOME/emulator/emulator -avd test -no-audio -no-window
+      - $ANDROID_HOME/emulator/emulator -avd test -no-audio -no-window -wipe-data
       wait_for_emulator_script: adb wait-for-device
       script:
         # Unsetting CIRRUS_CHANGE_MESSAGE and CIRRUS_COMMIT_MESSAGE as they

--- a/packages/firebase_auth/example/test/firebase_auth.dart
+++ b/packages/firebase_auth/example/test/firebase_auth.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'package:flutter/services.dart';
 import 'package:flutter_driver/driver_extension.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:firebase_auth/firebase_auth.dart';
@@ -15,10 +16,30 @@ void main() {
   group('$FirebaseAuth', () {
     final FirebaseAuth auth = FirebaseAuth.instance;
 
-    test('signInAnonymously', () async {
+    test('anonymous auth', () async {
       final FirebaseUser user = await auth.signInAnonymously();
       expect(user.uid, isNotNull);
       expect(user.isAnonymous, isTrue);
+    });
+
+    test('email auth', () async {
+      final String email = 'test@example.com';
+      final String password = 'pa55word';
+      FirebaseUser user;
+      try {
+        user = await auth.signInWithEmailAndPassword(
+          email: email,
+          password: password,
+        );
+      } on PlatformException catch(e) {
+        expect(e.code, 'ERROR_USER_NOT_FOUND');
+        user = await auth.createUserWithEmailAndPassword(
+          email: email,
+          password: password,
+        );
+      }
+      expect(user.uid, isNotNull);
+      expect(user.isAnonymous, isFalse);
     });
   });
 }


### PR DESCRIPTION
Adds Google APIs support.

Adds more test coverage of plugins that rely on Google APIs.

Wipes emulators and adds shards.

Fixes flutter/flutter#29571