### PR TITLE
[image_picker] only delete original image captured from camera if scaled

### DIFF
--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
@@ -395,7 +395,12 @@ public class ImagePickerDelegate
           new OnPathReadyListener() {
             @Override
             public void onPathReady(String path) {
-              handleImageResult(path);
+              String finalImagePath = handleImageResult(path);
+
+              //delete original file if scaled
+              if (!finalImagePath.equals(path)) {
+                new File(path).delete();
+              }
             }
           });
       return;
@@ -422,7 +427,7 @@ public class ImagePickerDelegate
     finishWithSuccess(null);
   }
 
-  private void handleImageResult(String path) {
+  private String handleImageResult(String path) {
     if (pendingResult != null) {
       Double maxWidth = methodCall.argument("maxWidth");
       Double maxHeight = methodCall.argument("maxHeight");
@@ -430,10 +435,7 @@ public class ImagePickerDelegate
       String finalImagePath = imageResizer.resizeImageIfNeeded(path, maxWidth, maxHeight);
       finishWithSuccess(finalImagePath);
 
-      //delete original file if scaled
-      if (!finalImagePath.equals(path)) {
-        new File(path).delete();
-      }
+      return finalImagePath;
     } else {
       throw new IllegalStateException("Received image from picker that was not requested");
     }


### PR DESCRIPTION
This should fix https://github.com/flutter/flutter/issues/29664.