### PR TITLE
Template type invokemethod

### DIFF
--- a/packages/android_alarm_manager/CHANGELOG.md
+++ b/packages/android_alarm_manager/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.1+4
+
+* Bump the minimum flutter version to 1.2.0.
+* Add Template type parameter to `invokeMethod` calls.
+
 ## 0.4.1+3
 
 * Update README.md to include instructions for setting the WAKE_LOCK permission.

--- a/packages/android_alarm_manager/lib/android_alarm_manager.dart
+++ b/packages/android_alarm_manager/lib/android_alarm_manager.dart
@@ -43,10 +43,7 @@ void _alarmManagerCallbackDispatcher() {
 
   // Once we've finished initializing, let the native portion of the plugin
   // know that it can start scheduling alarms.
-  // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-  // https://github.com/flutter/flutter/issues/26431
-  // ignore: strong_mode_implicit_dynamic_method
-  _channel.invokeMethod('AlarmService.initialized');
+  _channel.invokeMethod<void>('AlarmService.initialized');
 }
 
 /// A Flutter plugin for registering Dart callbacks with the Android
@@ -70,10 +67,7 @@ class AndroidAlarmManager {
       return false;
     }
     final dynamic r = await _channel
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        .invokeMethod('AlarmService.start', <dynamic>[handle.toRawHandle()]);
+        .invokeMethod<dynamic>('AlarmService.start', <dynamic>[handle.toRawHandle()]);
     return r ?? false;
   }
 
@@ -117,10 +111,7 @@ class AndroidAlarmManager {
     if (handle == null) {
       return false;
     }
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    final dynamic r = await _channel.invokeMethod('Alarm.oneShot', <dynamic>[
+    final dynamic r = await _channel.invokeMethod<dynamic>('Alarm.oneShot', <dynamic>[
       id,
       exact,
       wakeup,
@@ -172,10 +163,7 @@ class AndroidAlarmManager {
     if (handle == null) {
       return false;
     }
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    final dynamic r = await _channel.invokeMethod('Alarm.periodic', <dynamic>[
+    final dynamic r = await _channel.invokeMethod<dynamic>('Alarm.periodic', <dynamic>[
       id,
       exact,
       wakeup,
@@ -196,10 +184,7 @@ class AndroidAlarmManager {
   /// failure.
   static Future<bool> cancel(int id) async {
     final dynamic r =
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        await _channel.invokeMethod('Alarm.cancel', <dynamic>[id]);
+        await _channel.invokeMethod<dynamic>('Alarm.cancel', <dynamic>[id]);
     return (r == null) ? false : r;
   }
 }

--- a/packages/android_alarm_manager/lib/android_alarm_manager.dart
+++ b/packages/android_alarm_manager/lib/android_alarm_manager.dart
@@ -66,7 +66,8 @@ class AndroidAlarmManager {
     if (handle == null) {
       return false;
     }
-    return _channel.invokeMethod<bool>('AlarmService.start', <dynamic>[handle.toRawHandle()]);
+    final bool r = await _channel.invokeMethod<bool>('AlarmService.start', <dynamic>[handle.toRawHandle()]);
+    return r ?? false;
   }
 
   /// Schedules a one-shot timer to run `callback` after time `delay`.
@@ -109,7 +110,7 @@ class AndroidAlarmManager {
     if (handle == null) {
       return false;
     }
-   return _channel.invokeMethod<bool>('Alarm.oneShot', <dynamic>[
+   final bool r = await _channel.invokeMethod<bool>('Alarm.oneShot', <dynamic>[
       id,
       exact,
       wakeup,
@@ -181,8 +182,7 @@ class AndroidAlarmManager {
   /// Returns a [Future] that resolves to `true` on success and `false` on
   /// failure.
   static Future<bool> cancel(int id) async {
-    final dynamic r =
-        final bool r = await _channel.invokeMethod<bool>('Alarm.cancel', <dynamic>[id]);
+    final bool r = await _channel.invokeMethod<bool>('Alarm.cancel', <dynamic>[id]);
     return (r == null) ? false : r;
   }
 }

--- a/packages/android_alarm_manager/lib/android_alarm_manager.dart
+++ b/packages/android_alarm_manager/lib/android_alarm_manager.dart
@@ -66,9 +66,7 @@ class AndroidAlarmManager {
     if (handle == null) {
       return false;
     }
-    final dynamic r = await _channel
     return _channel.invokeMethod<bool>('AlarmService.start', <dynamic>[handle.toRawHandle()]);
-    return r ?? false;
   }
 
   /// Schedules a one-shot timer to run `callback` after time `delay`.

--- a/packages/android_alarm_manager/lib/android_alarm_manager.dart
+++ b/packages/android_alarm_manager/lib/android_alarm_manager.dart
@@ -162,7 +162,7 @@ class AndroidAlarmManager {
     if (handle == null) {
       return false;
     }
-    final dynamic r = await _channel.invokeMethod<dynamic>('Alarm.periodic', <dynamic>[
+    final bool r = await _channel.invokeMethod<bool>('Alarm.periodic', <dynamic>[
       id,
       exact,
       wakeup,

--- a/packages/android_alarm_manager/lib/android_alarm_manager.dart
+++ b/packages/android_alarm_manager/lib/android_alarm_manager.dart
@@ -66,7 +66,8 @@ class AndroidAlarmManager {
     if (handle == null) {
       return false;
     }
-    final bool r = await _channel.invokeMethod<bool>('AlarmService.start', <dynamic>[handle.toRawHandle()]);
+    final bool r = await _channel.invokeMethod<bool>(
+        'AlarmService.start', <dynamic>[handle.toRawHandle()]);
     return r ?? false;
   }
 
@@ -110,7 +111,7 @@ class AndroidAlarmManager {
     if (handle == null) {
       return false;
     }
-   final bool r = await _channel.invokeMethod<bool>('Alarm.oneShot', <dynamic>[
+    final bool r = await _channel.invokeMethod<bool>('Alarm.oneShot', <dynamic>[
       id,
       exact,
       wakeup,
@@ -162,7 +163,8 @@ class AndroidAlarmManager {
     if (handle == null) {
       return false;
     }
-    final bool r = await _channel.invokeMethod<bool>('Alarm.periodic', <dynamic>[
+    final bool r = await _channel.invokeMethod<bool>(
+        'Alarm.periodic', <dynamic>[
       id,
       exact,
       wakeup,
@@ -182,7 +184,8 @@ class AndroidAlarmManager {
   /// Returns a [Future] that resolves to `true` on success and `false` on
   /// failure.
   static Future<bool> cancel(int id) async {
-    final bool r = await _channel.invokeMethod<bool>('Alarm.cancel', <dynamic>[id]);
+    final bool r =
+        await _channel.invokeMethod<bool>('Alarm.cancel', <dynamic>[id]);
     return (r == null) ? false : r;
   }
 }

--- a/packages/android_alarm_manager/pubspec.yaml
+++ b/packages/android_alarm_manager/pubspec.yaml
@@ -1,7 +1,7 @@
 name: android_alarm_manager
 description: Flutter plugin for accessing the Android AlarmManager service, and
   running Dart code in the background when alarms fire.
-version: 0.4.1+3
+version: 0.4.1+4
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/android_alarm_manager
 

--- a/packages/android_alarm_manager/pubspec.yaml
+++ b/packages/android_alarm_manager/pubspec.yaml
@@ -20,4 +20,4 @@ flutter:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.1.4 <2.0.0"
+  flutter: ">=1.2.0 <2.0.0"

--- a/packages/android_intent/CHANGELOG.md
+++ b/packages/android_intent/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.0+2
+
+* Bump the minimum flutter version to 1.2.0.
+* Add Template type parameter to `invokeMethod` calls.
+
 ## 0.3.0+1
 
 * Log a more detailed warning at build time about the previous AndroidX

--- a/packages/android_intent/lib/android_intent.dart
+++ b/packages/android_intent/lib/android_intent.dart
@@ -57,9 +57,6 @@ class AndroidIntent {
     if (package != null) {
       args['package'] = package;
     }
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    await _channel.invokeMethod('launch', args);
+    await _channel.invokeMethod<void>('launch', args);
   }
 }

--- a/packages/android_intent/pubspec.yaml
+++ b/packages/android_intent/pubspec.yaml
@@ -2,7 +2,7 @@ name: android_intent
 description: Flutter plugin for launching Android Intents. Not supported on iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/android_intent
-version: 0.3.0+1
+version: 0.3.0+2
 
 flutter:
   plugin:

--- a/packages/android_intent/pubspec.yaml
+++ b/packages/android_intent/pubspec.yaml
@@ -18,4 +18,4 @@ dependencies:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.1.4 <2.0.0"
+  flutter: ">=1.2.0 <2.0.0"

--- a/packages/battery/CHANGELOG.md
+++ b/packages/battery/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.0+2
+
+* Bump the minimum flutter version to 1.2.0.
+* Add Template type parameter to `invokeMethod` calls.
+
 ## 0.3.0+1
 
 * Log a more detailed warning at build time about the previous AndroidX

--- a/packages/battery/lib/battery.dart
+++ b/packages/battery/lib/battery.dart
@@ -33,10 +33,7 @@ class Battery {
 
   /// Returns the current battery level in percent.
   Future<int> get batteryLevel => _methodChannel
-      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-      // https://github.com/flutter/flutter/issues/26431
-      // ignore: strong_mode_implicit_dynamic_method
-      .invokeMethod('getBatteryLevel')
+      .invokeMethod<int>('getBatteryLevel')
       .then<int>((dynamic result) => result);
 
   /// Fires whenever the battery state changes.

--- a/packages/battery/pubspec.yaml
+++ b/packages/battery/pubspec.yaml
@@ -25,4 +25,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.1.4 <2.0.0"
+  flutter: ">=1.2.0 <2.0.0"

--- a/packages/battery/pubspec.yaml
+++ b/packages/battery/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for accessing information about the battery state
   (full, charging, discharging) on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/battery
-version: 0.3.0+1
+version: 0.3.0+2
 
 flutter:
   plugin:

--- a/packages/battery/test/battery_test.dart
+++ b/packages/battery/test/battery_test.dart
@@ -22,10 +22,7 @@ void main() {
   });
 
   test('batteryLevel', () async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    when(methodChannel.invokeMethod('getBatteryLevel'))
+    when(methodChannel.invokeMethod<int>('getBatteryLevel'))
         .thenAnswer((Invocation invoke) => Future<int>.value(42));
     expect(await battery.batteryLevel, 42);
   });

--- a/packages/camera/CHANGELOG.md
+++ b/packages/camera/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.4.3+1
+
+* Bump the minimum flutter version to 1.2.0.
+* Add Template type parameter to `invokeMethod` calls.
+
+
 ## 0.4.3
 
 * Add capability to prepare the capture session for video recording on iOS.

--- a/packages/camera/lib/camera.dart
+++ b/packages/camera/lib/camera.dart
@@ -49,9 +49,9 @@ CameraLensDirection _parseCameraLensDirection(String string) {
 /// May throw a [CameraException].
 Future<List<CameraDescription>> availableCameras() async {
   try {
-    final List<dynamic> cameras =
-        await _channel.invokeListMethod<dynamic>('availableCameras');
-    return cameras.map((dynamic camera) {
+    final List<Map<String, dynamic>> cameras =
+        await _channel.invokeListMethod<Map<String, dynamic>>('availableCameras');
+    return cameras.map((Map<String, dynamic> camera) {
       return CameraDescription(
         name: camera['name'],
         lensDirection: _parseCameraLensDirection(camera['lensFacing']),
@@ -224,7 +224,7 @@ class CameraController extends ValueNotifier<CameraValue> {
     }
     try {
       _creatingCompleter = Completer<void>();
-      final Map<dynamic, dynamic> reply = await _channel.invokeMapMethod<String, dynamic>(
+      final Map<String, dynamic> reply = await _channel.invokeMapMethod<String, dynamic>(
         'initialize',
         <String, dynamic>{
           'cameraName': description.name,

--- a/packages/camera/lib/camera.dart
+++ b/packages/camera/lib/camera.dart
@@ -224,7 +224,7 @@ class CameraController extends ValueNotifier<CameraValue> {
     }
     try {
       _creatingCompleter = Completer<void>();
-      final Map<dynamic, dynamic> reply = await _channel.invokeMethod<Map<dynamic, dynamic>>(
+      final Map<dynamic, dynamic> reply = await _channel.invokeMapMethod<dynamic, dynamic>(
         'initialize',
         <String, dynamic>{
           'cameraName': description.name,

--- a/packages/camera/lib/camera.dart
+++ b/packages/camera/lib/camera.dart
@@ -50,7 +50,7 @@ CameraLensDirection _parseCameraLensDirection(String string) {
 Future<List<CameraDescription>> availableCameras() async {
   try {
     final List<dynamic> cameras =
-        await _channel.invokeMethod<List<dynamic>>('availableCameras');
+        await _channel.invokeListMethod<dynamic>('availableCameras');
     return cameras.map((dynamic camera) {
       return CameraDescription(
         name: camera['name'],
@@ -224,7 +224,7 @@ class CameraController extends ValueNotifier<CameraValue> {
     }
     try {
       _creatingCompleter = Completer<void>();
-      final Map<dynamic, dynamic> reply = await _channel.invokeMapMethod<dynamic, dynamic>(
+      final Map<dynamic, dynamic> reply = await _channel.invokeMapMethod<String, dynamic>(
         'initialize',
         <String, dynamic>{
           'cameraName': description.name,

--- a/packages/camera/lib/camera.dart
+++ b/packages/camera/lib/camera.dart
@@ -50,10 +50,7 @@ CameraLensDirection _parseCameraLensDirection(String string) {
 Future<List<CameraDescription>> availableCameras() async {
   try {
     final List<dynamic> cameras =
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        await _channel.invokeMethod('availableCameras');
+        await _channel.invokeMethod<List<dynamic>>('availableCameras');
     return cameras.map((dynamic camera) {
       return CameraDescription(
         name: camera['name'],
@@ -227,10 +224,7 @@ class CameraController extends ValueNotifier<CameraValue> {
     }
     try {
       _creatingCompleter = Completer<void>();
-      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-      // https://github.com/flutter/flutter/issues/26431
-      // ignore: strong_mode_implicit_dynamic_method
-      final Map<dynamic, dynamic> reply = await _channel.invokeMethod(
+      final Map<dynamic, dynamic> reply = await _channel.invokeMethod<Map<dynamic, dynamic>>(
         'initialize',
         <String, dynamic>{
           'cameraName': description.name,
@@ -268,10 +262,7 @@ class CameraController extends ValueNotifier<CameraValue> {
   ///
   /// Throws a [CameraException] if the prepare fails.
   Future<void> prepareForVideoRecording() async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    await _channel.invokeMethod('prepareForVideoRecording');
+    await _channel.invokeMethod<void>('prepareForVideoRecording');
   }
 
   /// Listen to events from the native plugins.
@@ -317,10 +308,7 @@ class CameraController extends ValueNotifier<CameraValue> {
     }
     try {
       value = value.copyWith(isTakingPicture: true);
-      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-      // https://github.com/flutter/flutter/issues/26431
-      // ignore: strong_mode_implicit_dynamic_method
-      await _channel.invokeMethod(
+      await _channel.invokeMethod<void>(
         'takePicture',
         <String, dynamic>{'textureId': _textureId, 'path': path},
       );
@@ -365,10 +353,7 @@ class CameraController extends ValueNotifier<CameraValue> {
     }
 
     try {
-      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-      // https://github.com/flutter/flutter/issues/26431
-      // ignore: strong_mode_implicit_dynamic_method
-      await _channel.invokeMethod('startImageStream');
+      await _channel.invokeMethod<void>('startImageStream');
       value = value.copyWith(isStreamingImages: true);
     } on PlatformException catch (e) {
       throw CameraException(e.code, e.message);
@@ -409,10 +394,7 @@ class CameraController extends ValueNotifier<CameraValue> {
 
     try {
       value = value.copyWith(isStreamingImages: false);
-      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-      // https://github.com/flutter/flutter/issues/26431
-      // ignore: strong_mode_implicit_dynamic_method
-      await _channel.invokeMethod('stopImageStream');
+      await _channel.invokeMethod<void>('stopImageStream');
     } on PlatformException catch (e) {
       throw CameraException(e.code, e.message);
     }
@@ -452,10 +434,7 @@ class CameraController extends ValueNotifier<CameraValue> {
     }
 
     try {
-      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-      // https://github.com/flutter/flutter/issues/26431
-      // ignore: strong_mode_implicit_dynamic_method
-      await _channel.invokeMethod(
+      await _channel.invokeMethod<void>(
         'startVideoRecording',
         <String, dynamic>{'textureId': _textureId, 'filePath': filePath},
       );
@@ -481,10 +460,7 @@ class CameraController extends ValueNotifier<CameraValue> {
     }
     try {
       value = value.copyWith(isRecordingVideo: false);
-      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-      // https://github.com/flutter/flutter/issues/26431
-      // ignore: strong_mode_implicit_dynamic_method
-      await _channel.invokeMethod(
+      await _channel.invokeMethod<void>(
         'stopVideoRecording',
         <String, dynamic>{'textureId': _textureId},
       );
@@ -503,10 +479,7 @@ class CameraController extends ValueNotifier<CameraValue> {
     super.dispose();
     if (_creatingCompleter != null) {
       await _creatingCompleter.future;
-      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-      // https://github.com/flutter/flutter/issues/26431
-      // ignore: strong_mode_implicit_dynamic_method
-      await _channel.invokeMethod(
+      await _channel.invokeMethod<void>(
         'dispose',
         <String, dynamic>{'textureId': _textureId},
       );

--- a/packages/camera/lib/camera.dart
+++ b/packages/camera/lib/camera.dart
@@ -49,8 +49,8 @@ CameraLensDirection _parseCameraLensDirection(String string) {
 /// May throw a [CameraException].
 Future<List<CameraDescription>> availableCameras() async {
   try {
-    final List<Map<String, dynamic>> cameras =
-        await _channel.invokeListMethod<Map<String, dynamic>>('availableCameras');
+    final List<Map<String, dynamic>> cameras = await _channel
+        .invokeListMethod<Map<String, dynamic>>('availableCameras');
     return cameras.map((Map<String, dynamic> camera) {
       return CameraDescription(
         name: camera['name'],
@@ -224,7 +224,8 @@ class CameraController extends ValueNotifier<CameraValue> {
     }
     try {
       _creatingCompleter = Completer<void>();
-      final Map<String, dynamic> reply = await _channel.invokeMapMethod<String, dynamic>(
+      final Map<String, dynamic> reply =
+          await _channel.invokeMapMethod<String, dynamic>(
         'initialize',
         <String, dynamic>{
           'cameraName': description.name,

--- a/packages/camera/pubspec.yaml
+++ b/packages/camera/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera
 description: A Flutter plugin for getting information about and controlling the
   camera on Android and iOS. Supports previewing the camera feed, capturing images, capturing video,
   and streaming image buffers to dart.
-version: 0.4.3
+version: 0.4.3+1
 authors:
   - Flutter Team <flutter-dev@googlegroups.com>
   - Luigi Agosti <luigi@tengio.com>

--- a/packages/camera/pubspec.yaml
+++ b/packages/camera/pubspec.yaml
@@ -27,4 +27,4 @@ flutter:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.1.4 <2.0.0"
+  flutter: ">=1.2.0 <2.0.0"

--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,7 +1,7 @@
-## 0.9.7
+## 0.9.6+1
 
-* Fixes a NoSuchMethodError when using getDocuments on iOS (introduced in 0.9.6).
-* Adds a driver test for getDocuments.
+* Bump the minimum flutter version to 1.2.0.
+* Add Template type parameter to `invokeMethod` calls.
 
 ## 0.9.6
 

--- a/packages/cloud_firestore/lib/src/document_reference.dart
+++ b/packages/cloud_firestore/lib/src/document_reference.dart
@@ -72,7 +72,7 @@ class DocumentReference {
   ///
   /// If no document exists, the read will return null.
   Future<DocumentSnapshot> get() async {
-    final Map<dynamic, dynamic> data = await Firestore.channel.invokeMethod<Map<dynamic, dynamic>>(
+    final Map<dynamic, dynamic> data = await Firestore.channel.invokeMapMethod<dynamic, dynamic>(
       'DocumentReference#get',
       <String, dynamic>{'app': firestore.app.name, 'path': path},
     );

--- a/packages/cloud_firestore/lib/src/document_reference.dart
+++ b/packages/cloud_firestore/lib/src/document_reference.dart
@@ -72,7 +72,7 @@ class DocumentReference {
   ///
   /// If no document exists, the read will return null.
   Future<DocumentSnapshot> get() async {
-    final Map<dynamic, dynamic> data = await Firestore.channel.invokeMapMethod<dynamic, dynamic>(
+    final Map<String, dynamic> data = await Firestore.channel.invokeMapMethod<String, dynamic>(
       'DocumentReference#get',
       <String, dynamic>{'app': firestore.app.name, 'path': path},
     );

--- a/packages/cloud_firestore/lib/src/document_reference.dart
+++ b/packages/cloud_firestore/lib/src/document_reference.dart
@@ -40,10 +40,7 @@ class DocumentReference {
   /// If [merge] is true, the provided data will be merged into an
   /// existing document instead of overwriting.
   Future<void> setData(Map<String, dynamic> data, {bool merge = false}) {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return Firestore.channel.invokeMethod(
+    return Firestore.channel.invokeMethod<void>(
       'DocumentReference#setData',
       <String, dynamic>{
         'app': firestore.app.name,
@@ -61,10 +58,7 @@ class DocumentReference {
   ///
   /// If no document exists yet, the update will fail.
   Future<void> updateData(Map<String, dynamic> data) {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return Firestore.channel.invokeMethod(
+    return Firestore.channel.invokeMethod<void>(
       'DocumentReference#updateData',
       <String, dynamic>{
         'app': firestore.app.name,
@@ -78,10 +72,7 @@ class DocumentReference {
   ///
   /// If no document exists, the read will return null.
   Future<DocumentSnapshot> get() async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    final Map<dynamic, dynamic> data = await Firestore.channel.invokeMethod(
+    final Map<dynamic, dynamic> data = await Firestore.channel.invokeMethod<Map<dynamic, dynamic>>(
       'DocumentReference#get',
       <String, dynamic>{'app': firestore.app.name, 'path': path},
     );
@@ -94,10 +85,7 @@ class DocumentReference {
 
   /// Deletes the document referred to by this [DocumentReference].
   Future<void> delete() {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return Firestore.channel.invokeMethod(
+    return Firestore.channel.invokeMethod<void>(
       'DocumentReference#delete',
       <String, dynamic>{'app': firestore.app.name, 'path': path},
     );
@@ -120,10 +108,7 @@ class DocumentReference {
     StreamController<DocumentSnapshot> controller; // ignore: close_sinks
     controller = StreamController<DocumentSnapshot>.broadcast(
       onListen: () {
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        _handle = Firestore.channel.invokeMethod(
+        _handle = Firestore.channel.invokeMethod<int>(
           'Query#addDocumentListener',
           <String, dynamic>{
             'app': firestore.app.name,
@@ -136,10 +121,7 @@ class DocumentReference {
       },
       onCancel: () {
         _handle.then((int handle) async {
-          // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-          // https://github.com/flutter/flutter/issues/26431
-          // ignore: strong_mode_implicit_dynamic_method
-          await Firestore.channel.invokeMethod(
+          await Firestore.channel.invokeMethod<void>(
             'Query#removeListener',
             <String, dynamic>{'handle': handle},
           );

--- a/packages/cloud_firestore/lib/src/document_reference.dart
+++ b/packages/cloud_firestore/lib/src/document_reference.dart
@@ -72,7 +72,8 @@ class DocumentReference {
   ///
   /// If no document exists, the read will return null.
   Future<DocumentSnapshot> get() async {
-    final Map<String, dynamic> data = await Firestore.channel.invokeMapMethod<String, dynamic>(
+    final Map<String, dynamic> data =
+        await Firestore.channel.invokeMapMethod<String, dynamic>(
       'DocumentReference#get',
       <String, dynamic>{'app': firestore.app.name, 'path': path},
     );

--- a/packages/cloud_firestore/lib/src/firestore.dart
+++ b/packages/cloud_firestore/lib/src/firestore.dart
@@ -111,10 +111,7 @@ class Firestore {
     final int transactionId = _transactionHandlerId++;
     _transactionHandlers[transactionId] = transactionHandler;
     final Map<dynamic, dynamic> result = await channel
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        .invokeMethod('Firestore#runTransaction', <String, dynamic>{
+        .invokeMethod<Map<dynamic, dynamic>>('Firestore#runTransaction', <String, dynamic>{
       'app': app.name,
       'transactionId': transactionId,
       'transactionTimeout': timeout.inMilliseconds
@@ -125,10 +122,7 @@ class Firestore {
   @deprecated
   Future<void> enablePersistence(bool enable) async {
     assert(enable != null);
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    await channel.invokeMethod('Firestore#enablePersistence', <String, dynamic>{
+    await channel.invokeMethod<void>('Firestore#enablePersistence', <String, dynamic>{
       'app': app.name,
       'enable': enable,
     });
@@ -139,10 +133,7 @@ class Firestore {
       String host,
       bool sslEnabled,
       bool timestampsInSnapshotsEnabled}) async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    await channel.invokeMethod('Firestore#settings', <String, dynamic>{
+    await channel.invokeMethod<void>('Firestore#settings', <String, dynamic>{
       'app': app.name,
       'persistenceEnabled': persistenceEnabled,
       'host': host,

--- a/packages/cloud_firestore/lib/src/firestore.dart
+++ b/packages/cloud_firestore/lib/src/firestore.dart
@@ -110,13 +110,13 @@ class Firestore {
         'Transaction timeout must be more than 0 milliseconds');
     final int transactionId = _transactionHandlerId++;
     _transactionHandlers[transactionId] = transactionHandler;
-    final Map<dynamic, dynamic> result = await channel
-        .invokeMethod<Map<dynamic, dynamic>>('Firestore#runTransaction', <String, dynamic>{
+    final Map<String, dynamic> result = await channel
+        .invokeMapMethod<String, dynamic>('Firestore#runTransaction', <String, dynamic>{
       'app': app.name,
       'transactionId': transactionId,
       'transactionTimeout': timeout.inMilliseconds
     });
-    return result?.cast<String, dynamic>() ?? <String, dynamic>{};
+    return result ?? <String, dynamic>{};
   }
 
   @deprecated

--- a/packages/cloud_firestore/lib/src/firestore.dart
+++ b/packages/cloud_firestore/lib/src/firestore.dart
@@ -111,7 +111,8 @@ class Firestore {
     final int transactionId = _transactionHandlerId++;
     _transactionHandlers[transactionId] = transactionHandler;
     final Map<String, dynamic> result = await channel
-        .invokeMapMethod<String, dynamic>('Firestore#runTransaction', <String, dynamic>{
+        .invokeMapMethod<String, dynamic>(
+            'Firestore#runTransaction', <String, dynamic>{
       'app': app.name,
       'transactionId': transactionId,
       'transactionTimeout': timeout.inMilliseconds
@@ -122,7 +123,8 @@ class Firestore {
   @deprecated
   Future<void> enablePersistence(bool enable) async {
     assert(enable != null);
-    await channel.invokeMethod<void>('Firestore#enablePersistence', <String, dynamic>{
+    await channel
+        .invokeMethod<void>('Firestore#enablePersistence', <String, dynamic>{
       'app': app.name,
       'enable': enable,
     });

--- a/packages/cloud_firestore/lib/src/query.dart
+++ b/packages/cloud_firestore/lib/src/query.dart
@@ -80,7 +80,7 @@ class Query {
 
   /// Fetch the documents for this query
   Future<QuerySnapshot> getDocuments() async {
-    final Map<dynamic, dynamic> data = await Firestore.channel.invokeMapMethod<dynamic, dynamic>(
+    final Map<String, dynamic> data = await Firestore.channel.invokeMapMethod<String, dynamic>(
       'Query#getDocuments',
       <String, dynamic>{
         'app': firestore.app.name,

--- a/packages/cloud_firestore/lib/src/query.dart
+++ b/packages/cloud_firestore/lib/src/query.dart
@@ -80,7 +80,7 @@ class Query {
 
   /// Fetch the documents for this query
   Future<QuerySnapshot> getDocuments() async {
-    final Map<dynamic, dynamic> data = await Firestore.channel.invokeMethod<Map<dynamic, dynamic>>(
+    final Map<dynamic, dynamic> data = await Firestore.channel.invokeMapMethod<dynamic, dynamic>(
       'Query#getDocuments',
       <String, dynamic>{
         'app': firestore.app.name,

--- a/packages/cloud_firestore/lib/src/query.dart
+++ b/packages/cloud_firestore/lib/src/query.dart
@@ -80,7 +80,8 @@ class Query {
 
   /// Fetch the documents for this query
   Future<QuerySnapshot> getDocuments() async {
-    final Map<String, dynamic> data = await Firestore.channel.invokeMapMethod<String, dynamic>(
+    final Map<String, dynamic> data =
+        await Firestore.channel.invokeMapMethod<String, dynamic>(
       'Query#getDocuments',
       <String, dynamic>{
         'app': firestore.app.name,

--- a/packages/cloud_firestore/lib/src/query.dart
+++ b/packages/cloud_firestore/lib/src/query.dart
@@ -53,10 +53,7 @@ class Query {
     StreamController<QuerySnapshot> controller; // ignore: close_sinks
     controller = StreamController<QuerySnapshot>.broadcast(
       onListen: () {
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        _handle = Firestore.channel.invokeMethod(
+        _handle = Firestore.channel.invokeMethod<int>(
           'Query#addSnapshotListener',
           <String, dynamic>{
             'app': firestore.app.name,
@@ -70,10 +67,7 @@ class Query {
       },
       onCancel: () {
         _handle.then((int handle) async {
-          // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-          // https://github.com/flutter/flutter/issues/26431
-          // ignore: strong_mode_implicit_dynamic_method
-          await Firestore.channel.invokeMethod(
+          await Firestore.channel.invokeMethod<void>(
             'Query#removeListener',
             <String, dynamic>{'handle': handle},
           );
@@ -86,10 +80,7 @@ class Query {
 
   /// Fetch the documents for this query
   Future<QuerySnapshot> getDocuments() async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    final Map<dynamic, dynamic> data = await Firestore.channel.invokeMethod(
+    final Map<dynamic, dynamic> data = await Firestore.channel.invokeMethod<Map<dynamic, dynamic>>(
       'Query#getDocuments',
       <String, dynamic>{
         'app': firestore.app.name,

--- a/packages/cloud_firestore/lib/src/transaction.dart
+++ b/packages/cloud_firestore/lib/src/transaction.dart
@@ -50,7 +50,8 @@ class Transaction {
 
   Future<void> set(
       DocumentReference documentReference, Map<String, dynamic> data) async {
-    return Firestore.channel.invokeMethod<void>('Transaction#set', <String, dynamic>{
+    return Firestore.channel
+        .invokeMethod<void>('Transaction#set', <String, dynamic>{
       'app': _firestore.app.name,
       'transactionId': _transactionId,
       'path': documentReference.path,

--- a/packages/cloud_firestore/lib/src/transaction.dart
+++ b/packages/cloud_firestore/lib/src/transaction.dart
@@ -14,8 +14,8 @@ class Transaction {
   Firestore _firestore;
 
   Future<DocumentSnapshot> get(DocumentReference documentReference) async {
-    final dynamic result = await Firestore.channel
-        .invokeMethod<dynamic>('Transaction#get', <String, dynamic>{
+    final Map<String, dynamic> result = await Firestore.channel
+        .invokeMapMethod<String, dynamic>('Transaction#get', <String, dynamic>{
       'app': _firestore.app.name,
       'transactionId': _transactionId,
       'path': documentReference.path,

--- a/packages/cloud_firestore/lib/src/transaction.dart
+++ b/packages/cloud_firestore/lib/src/transaction.dart
@@ -15,10 +15,7 @@ class Transaction {
 
   Future<DocumentSnapshot> get(DocumentReference documentReference) async {
     final dynamic result = await Firestore.channel
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        .invokeMethod('Transaction#get', <String, dynamic>{
+        .invokeMethod<dynamic>('Transaction#get', <String, dynamic>{
       'app': _firestore.app.name,
       'transactionId': _transactionId,
       'path': documentReference.path,
@@ -33,10 +30,7 @@ class Transaction {
 
   Future<void> delete(DocumentReference documentReference) async {
     return Firestore.channel
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        .invokeMethod('Transaction#delete', <String, dynamic>{
+        .invokeMethod<void>('Transaction#delete', <String, dynamic>{
       'app': _firestore.app.name,
       'transactionId': _transactionId,
       'path': documentReference.path,
@@ -46,10 +40,7 @@ class Transaction {
   Future<void> update(
       DocumentReference documentReference, Map<String, dynamic> data) async {
     return Firestore.channel
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        .invokeMethod('Transaction#update', <String, dynamic>{
+        .invokeMethod<void>('Transaction#update', <String, dynamic>{
       'app': _firestore.app.name,
       'transactionId': _transactionId,
       'path': documentReference.path,
@@ -59,10 +50,7 @@ class Transaction {
 
   Future<void> set(
       DocumentReference documentReference, Map<String, dynamic> data) async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return Firestore.channel.invokeMethod('Transaction#set', <String, dynamic>{
+    return Firestore.channel.invokeMethod<void>('Transaction#set', <String, dynamic>{
       'app': _firestore.app.name,
       'transactionId': _transactionId,
       'path': documentReference.path,

--- a/packages/cloud_firestore/lib/src/write_batch.dart
+++ b/packages/cloud_firestore/lib/src/write_batch.dart
@@ -12,10 +12,7 @@ part of cloud_firestore;
 /// nor can it be committed again.
 class WriteBatch {
   WriteBatch._(this._firestore)
-      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-      // https://github.com/flutter/flutter/issues/26431
-      // ignore: strong_mode_implicit_dynamic_method
-      : _handle = Firestore.channel.invokeMethod(
+      : _handle = Firestore.channel.invokeMethod<dynamic>(
             'WriteBatch#create', <String, dynamic>{'app': _firestore.app.name});
 
   final Firestore _firestore;
@@ -32,10 +29,7 @@ class WriteBatch {
     if (!_committed) {
       _committed = true;
       await Future.wait<dynamic>(_actions);
-      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-      // https://github.com/flutter/flutter/issues/26431
-      // ignore: strong_mode_implicit_dynamic_method
-      await Firestore.channel.invokeMethod(
+      await Firestore.channel.invokeMethod<void>(
           'WriteBatch#commit', <String, dynamic>{'handle': await _handle});
     } else {
       throw StateError("This batch has already been committed.");
@@ -47,10 +41,7 @@ class WriteBatch {
     if (!_committed) {
       _handle.then((dynamic handle) {
         _actions.add(
-          // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-          // https://github.com/flutter/flutter/issues/26431
-          // ignore: strong_mode_implicit_dynamic_method
-          Firestore.channel.invokeMethod(
+          Firestore.channel.invokeMethod<void>(
             'WriteBatch#delete',
             <String, dynamic>{
               'app': _firestore.app.name,
@@ -77,10 +68,7 @@ class WriteBatch {
     if (!_committed) {
       _handle.then((dynamic handle) {
         _actions.add(
-          // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-          // https://github.com/flutter/flutter/issues/26431
-          // ignore: strong_mode_implicit_dynamic_method
-          Firestore.channel.invokeMethod(
+          Firestore.channel.invokeMethod<void>(
             'WriteBatch#setData',
             <String, dynamic>{
               'app': _firestore.app.name,
@@ -105,10 +93,7 @@ class WriteBatch {
     if (!_committed) {
       _handle.then((dynamic handle) {
         _actions.add(
-          // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-          // https://github.com/flutter/flutter/issues/26431
-          // ignore: strong_mode_implicit_dynamic_method
-          Firestore.channel.invokeMethod(
+          Firestore.channel.invokeMethod<void>(
             'WriteBatch#updateData',
             <String, dynamic>{
               'app': _firestore.app.name,

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_firestore
-version: 0.9.7
+version: 0.9.7+1
 
 flutter:
   plugin:

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -27,4 +27,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.2.4 <2.0.0"
+  flutter: ">=1.2.0 <2.0.0"

--- a/packages/cloud_functions/CHANGELOG.md
+++ b/packages/cloud_functions/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.2+2
+
+* Bump the minimum flutter version to 1.2.0.
+* Add Template type parameter to `invokeMethod` calls.
+
 ## 0.1.2+1
 
 * Added a driver test.

--- a/packages/cloud_functions/lib/cloud_functions.dart
+++ b/packages/cloud_functions/lib/cloud_functions.dart
@@ -42,8 +42,8 @@ class CloudFunctions {
   Future<dynamic> call(
       {@required String functionName, Map<String, dynamic> parameters}) async {
     try {
-      final dynamic response =
-          await channel.invokeMethod<dynamic>('CloudFunctions#call', <String, dynamic>{
+      final dynamic response = await channel
+          .invokeMethod<dynamic>('CloudFunctions#call', <String, dynamic>{
         'app': _app.name,
         'region': _region,
         'functionName': functionName,

--- a/packages/cloud_functions/lib/cloud_functions.dart
+++ b/packages/cloud_functions/lib/cloud_functions.dart
@@ -43,10 +43,7 @@ class CloudFunctions {
       {@required String functionName, Map<String, dynamic> parameters}) async {
     try {
       final dynamic response =
-          // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-          // https://github.com/flutter/flutter/issues/26431
-          // ignore: strong_mode_implicit_dynamic_method
-          await channel.invokeMethod('CloudFunctions#call', <String, dynamic>{
+          await channel.invokeMethod<dynamic>('CloudFunctions#call', <String, dynamic>{
         'app': _app.name,
         'region': _region,
         'functionName': functionName,

--- a/packages/cloud_functions/pubspec.yaml
+++ b/packages/cloud_functions/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cloud_functions
 description: Flutter plugin for Cloud Functions.
-version: 0.1.2+1
+version: 0.1.2+2
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_functions
 

--- a/packages/cloud_functions/pubspec.yaml
+++ b/packages/cloud_functions/pubspec.yaml
@@ -24,4 +24,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.2.4 <2.0.0"
+  flutter: ">=1.2.0 <2.0.0"

--- a/packages/connectivity/CHANGELOG.md
+++ b/packages/connectivity/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.2+1
+
+* Bump the minimum flutter version to 1.2.0.
+* Add Template type parameter to `invokeMethod` calls.
+
 ## 0.4.2
 
 * Adding getWifiIP() to obtain current wifi network's IP.

--- a/packages/connectivity/README.md
+++ b/packages/connectivity/README.md
@@ -33,7 +33,7 @@ import 'package:connectivity/connectivity.dart';
 @override
 initState() {
   super.initState();
-  
+
   subscription = Connectivity().onConnectivityChanged.listen((ConnectivityResult result) {
     // Got a new connectivity status!
   })
@@ -43,7 +43,7 @@ initState() {
 @override
 dispose() {
   super.dispose();
-  
+
   subscription.cancel();
 }
 ```

--- a/packages/connectivity/lib/connectivity.dart
+++ b/packages/connectivity/lib/connectivity.dart
@@ -61,10 +61,7 @@ class Connectivity {
   ///
   /// Instead listen for connectivity changes via [onConnectivityChanged] stream.
   Future<ConnectivityResult> checkConnectivity() async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    final String result = await methodChannel.invokeMethod('check');
+    final String result = await methodChannel.invokeMethod<String>('check');
     return _parseConnectivityResult(result);
   }
 
@@ -75,10 +72,7 @@ class Connectivity {
   /// From android 8.0 onwards the GPS must be ON (high accuracy)
   /// in order to be able to obtain the SSID.
   Future<String> getWifiName() async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    String wifiName = await methodChannel.invokeMethod('wifiName');
+    String wifiName = await methodChannel.invokeMethod<String>('wifiName');
     // as Android might return <unknown ssid>, uniforming result
     // our iOS implementation will return null
     if (wifiName == '<unknown ssid>') wifiName = null;
@@ -87,7 +81,7 @@ class Connectivity {
 
   /// Obtains the IP address of the connected wifi network
   Future<String> getWifiIP() async {
-    return await methodChannel.invokeMethod('wifiIPAddress');
+    return await methodChannel.invokeMethod<String>('wifiIPAddress');
   }
 }
 

--- a/packages/connectivity/pubspec.yaml
+++ b/packages/connectivity/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for discovering the state of the network (WiFi &
   mobile/cellular) connectivity on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/connectivity
-version: 0.4.2
+version: 0.4.2+1
 
 flutter:
   plugin:

--- a/packages/connectivity/pubspec.yaml
+++ b/packages/connectivity/pubspec.yaml
@@ -22,4 +22,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.1.4 <2.0.0"
+  flutter: ">=1.2.0 <2.0.0"

--- a/packages/device_info/CHANGELOG.md
+++ b/packages/device_info/CHANGELOG.md
@@ -1,9 +1,9 @@
-## 0.4.0+1
+## 0.4.0+2
 
 * Bump the minimum flutter version to 1.2.0.
 * Add Template type parameter to `invokeMethod` calls.
 
-## 0.4.0
+## 0.4.0+1
 
 * Log a more detailed warning at build time about the previous AndroidX
   migration.

--- a/packages/device_info/CHANGELOG.md
+++ b/packages/device_info/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.0+1
+
+* Bump the minimum flutter version to 1.2.0.
+* Add Template type parameter to `invokeMethod` calls.
+
 ## 0.4.0
 
 * Log a more detailed warning at build time about the previous AndroidX

--- a/packages/device_info/lib/device_info.dart
+++ b/packages/device_info/lib/device_info.dart
@@ -21,8 +21,8 @@ class DeviceInfoPlugin {
   ///
   /// See: https://developer.android.com/reference/android/os/Build.html
   Future<AndroidDeviceInfo> get androidInfo async =>
-      _cachedAndroidDeviceInfo ??= AndroidDeviceInfo._fromMap(
-          await channel.invokeMapMethod<String, dynamic>('getAndroidDeviceInfo'));
+      _cachedAndroidDeviceInfo ??= AndroidDeviceInfo._fromMap(await channel
+          .invokeMapMethod<String, dynamic>('getAndroidDeviceInfo'));
 
   /// This information does not change from call to call. Cache it.
   IosDeviceInfo _cachedIosDeviceInfo;
@@ -30,8 +30,9 @@ class DeviceInfoPlugin {
   /// Information derived from `UIDevice`.
   ///
   /// See: https://developer.apple.com/documentation/uikit/uidevice
-  Future<IosDeviceInfo> get iosInfo async => _cachedIosDeviceInfo ??=
-      IosDeviceInfo._fromMap(await channel.invokeMapMethod<String, dynamic>('getIosDeviceInfo'));
+  Future<IosDeviceInfo> get iosInfo async =>
+      _cachedIosDeviceInfo ??= IosDeviceInfo._fromMap(
+          await channel.invokeMapMethod<String, dynamic>('getIosDeviceInfo'));
 }
 
 /// Information derived from `android.os.Build`.

--- a/packages/device_info/lib/device_info.dart
+++ b/packages/device_info/lib/device_info.dart
@@ -22,10 +22,7 @@ class DeviceInfoPlugin {
   /// See: https://developer.android.com/reference/android/os/Build.html
   Future<AndroidDeviceInfo> get androidInfo async =>
       _cachedAndroidDeviceInfo ??= AndroidDeviceInfo._fromMap(
-          // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-          // https://github.com/flutter/flutter/issues/26431
-          // ignore: strong_mode_implicit_dynamic_method
-          await channel.invokeMethod('getAndroidDeviceInfo'));
+          await channel.invokeMethod<dynamic>('getAndroidDeviceInfo'));
 
   /// This information does not change from call to call. Cache it.
   IosDeviceInfo _cachedIosDeviceInfo;
@@ -34,10 +31,7 @@ class DeviceInfoPlugin {
   ///
   /// See: https://developer.apple.com/documentation/uikit/uidevice
   Future<IosDeviceInfo> get iosInfo async => _cachedIosDeviceInfo ??=
-      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-      // https://github.com/flutter/flutter/issues/26431
-      // ignore: strong_mode_implicit_dynamic_method
-      IosDeviceInfo._fromMap(await channel.invokeMethod('getIosDeviceInfo'));
+      IosDeviceInfo._fromMap(await channel.invokeMethod<dynamic>('getIosDeviceInfo'));
 }
 
 /// Information derived from `android.os.Build`.

--- a/packages/device_info/lib/device_info.dart
+++ b/packages/device_info/lib/device_info.dart
@@ -22,7 +22,7 @@ class DeviceInfoPlugin {
   /// See: https://developer.android.com/reference/android/os/Build.html
   Future<AndroidDeviceInfo> get androidInfo async =>
       _cachedAndroidDeviceInfo ??= AndroidDeviceInfo._fromMap(
-          await channel.invokeMethod<dynamic>('getAndroidDeviceInfo'));
+          await channel.invokeMapMethod<String, dynamic>('getAndroidDeviceInfo'));
 
   /// This information does not change from call to call. Cache it.
   IosDeviceInfo _cachedIosDeviceInfo;
@@ -31,7 +31,7 @@ class DeviceInfoPlugin {
   ///
   /// See: https://developer.apple.com/documentation/uikit/uidevice
   Future<IosDeviceInfo> get iosInfo async => _cachedIosDeviceInfo ??=
-      IosDeviceInfo._fromMap(await channel.invokeMethod<dynamic>('getIosDeviceInfo'));
+      IosDeviceInfo._fromMap(await channel.invokeMapMethod<String, dynamic>('getIosDeviceInfo'));
 }
 
 /// Information derived from `android.os.Build`.
@@ -124,29 +124,28 @@ class AndroidDeviceInfo {
   final String androidId;
 
   /// Deserializes from the message received from [_kChannel].
-  static AndroidDeviceInfo _fromMap(dynamic message) {
-    final Map<dynamic, dynamic> map = message;
+  static AndroidDeviceInfo _fromMap(Map<String, dynamic> message) {
     return AndroidDeviceInfo._(
-      version: AndroidBuildVersion._fromMap(map['version']),
-      board: map['board'],
-      bootloader: map['bootloader'],
-      brand: map['brand'],
-      device: map['device'],
-      display: map['display'],
-      fingerprint: map['fingerprint'],
-      hardware: map['hardware'],
-      host: map['host'],
-      id: map['id'],
-      manufacturer: map['manufacturer'],
-      model: map['model'],
-      product: map['product'],
-      supported32BitAbis: _fromList(map['supported32BitAbis']),
-      supported64BitAbis: _fromList(map['supported64BitAbis']),
-      supportedAbis: _fromList(map['supportedAbis']),
-      tags: map['tags'],
-      type: map['type'],
-      isPhysicalDevice: map['isPhysicalDevice'],
-      androidId: map['androidId'],
+      version: AndroidBuildVersion._fromMap(message['version']),
+      board: message['board'],
+      bootloader: message['bootloader'],
+      brand: message['brand'],
+      device: message['device'],
+      display: message['display'],
+      fingerprint: message['fingerprint'],
+      hardware: message['hardware'],
+      host: message['host'],
+      id: message['id'],
+      manufacturer: message['manufacturer'],
+      model: message['model'],
+      product: message['product'],
+      supported32BitAbis: _fromList(message['supported32BitAbis']),
+      supported64BitAbis: _fromList(message['supported64BitAbis']),
+      supportedAbis: _fromList(message['supportedAbis']),
+      tags: message['tags'],
+      type: message['type'],
+      isPhysicalDevice: message['isPhysicalDevice'],
+      androidId: message['androidId'],
     );
   }
 
@@ -250,17 +249,16 @@ class IosDeviceInfo {
   final IosUtsname utsname;
 
   /// Deserializes from the map message received from [_kChannel].
-  static IosDeviceInfo _fromMap(dynamic message) {
-    final Map<dynamic, dynamic> map = message;
+  static IosDeviceInfo _fromMap(Map<String, dynamic> message) {
     return IosDeviceInfo._(
-      name: map['name'],
-      systemName: map['systemName'],
-      systemVersion: map['systemVersion'],
-      model: map['model'],
-      localizedModel: map['localizedModel'],
-      identifierForVendor: map['identifierForVendor'],
-      isPhysicalDevice: map['isPhysicalDevice'] == 'true',
-      utsname: IosUtsname._fromMap(map['utsname']),
+      name: message['name'],
+      systemName: message['systemName'],
+      systemVersion: message['systemVersion'],
+      model: message['model'],
+      localizedModel: message['localizedModel'],
+      identifierForVendor: message['identifierForVendor'],
+      isPhysicalDevice: message['isPhysicalDevice'] == 'true',
+      utsname: IosUtsname._fromMap(message['utsname']),
     );
   }
 }

--- a/packages/device_info/pubspec.yaml
+++ b/packages/device_info/pubspec.yaml
@@ -17,4 +17,4 @@ dependencies:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.1.4 <2.0.0"
+  flutter: ">=1.2.0 <2.0.0"

--- a/packages/device_info/pubspec.yaml
+++ b/packages/device_info/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin providing detailed information about the device
   (make, model, etc.), and Android or iOS version the app is running on.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/device_info
-version: 0.4.0+1
+version: 0.4.0+2
 
 flutter:
   plugin:

--- a/packages/firebase_admob/CHANGELOG.md
+++ b/packages/firebase_admob/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.8.0+4
+
+* Bump the minimum flutter version to 1.2.0.
+* Add Template type parameter to `invokeMethod` calls.
+
 ## 0.8.0+3
 
 * Log messages about automatic configuration of the default app are now less confusing.

--- a/packages/firebase_admob/lib/firebase_admob.dart
+++ b/packages/firebase_admob/lib/firebase_admob.dart
@@ -515,10 +515,7 @@ class FirebaseAdMob {
 }
 
 Future<bool> _invokeBooleanMethod(String method, [dynamic arguments]) async {
-  // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-  // https://github.com/flutter/flutter/issues/26431
-  // ignore: strong_mode_implicit_dynamic_method
-  final bool result = await FirebaseAdMob.instance._channel.invokeMethod(
+  final bool result = await FirebaseAdMob.instance._channel.invokeMethod<bool>(
     method,
     arguments,
   );

--- a/packages/firebase_admob/pubspec.yaml
+++ b/packages/firebase_admob/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_admob
 description: Firebase AdMob plugin for Flutter applications.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_admob
-version: 0.8.0+3
+version: 0.8.0+4
 
 flutter:
   plugin:

--- a/packages/firebase_admob/pubspec.yaml
+++ b/packages/firebase_admob/pubspec.yaml
@@ -24,4 +24,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.1.4 <2.0.0"
+  flutter: ">=1.2.0 <2.0.0"

--- a/packages/firebase_analytics/CHANGELOG.md
+++ b/packages/firebase_analytics/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.4
+
+* Bump the minimum flutter version to 1.2.0.
+* Add Template type parameter to `invokeMethod` calls.
+
 ## 2.0.3
 
 * Add resetAnalyticsData method

--- a/packages/firebase_analytics/lib/firebase_analytics.dart
+++ b/packages/firebase_analytics/lib/firebase_analytics.dart
@@ -55,10 +55,7 @@ class FirebaseAnalytics {
           'Prefix "$kReservedPrefix" is reserved and cannot be used.');
     }
 
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    await _channel.invokeMethod('logEvent', <String, dynamic>{
+    await _channel.invokeMethod<void>('logEvent', <String, dynamic>{
       'name': name,
       'parameters': parameters,
     });
@@ -72,10 +69,7 @@ class FirebaseAnalytics {
       throw ArgumentError.notNull('enabled');
     }
 
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    await _channel.invokeMethod('setAnalyticsCollectionEnabled', enabled);
+    await _channel.invokeMethod<void>('setAnalyticsCollectionEnabled', enabled);
   }
 
   /// Sets the user ID property.
@@ -84,10 +78,7 @@ class FirebaseAnalytics {
   ///
   /// [1]: https://www.google.com/policies/privacy/
   Future<void> setUserId(String id) async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    await _channel.invokeMethod('setUserId', id);
+    await _channel.invokeMethod<void>('setUserId', id);
   }
 
   /// Sets the current [screenName], which specifies the current visual context
@@ -114,10 +105,7 @@ class FirebaseAnalytics {
       throw ArgumentError.notNull('screenName');
     }
 
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    await _channel.invokeMethod('setCurrentScreen', <String, String>{
+    await _channel.invokeMethod<void>('setCurrentScreen', <String, String>{
       'screenName': screenName,
       'screenClassOverride': screenClassOverride,
     });
@@ -151,10 +139,7 @@ class FirebaseAnalytics {
     if (name.startsWith('firebase_'))
       throw ArgumentError.value(name, 'name', '"firebase_" prefix is reserved');
 
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    await _channel.invokeMethod('setUserProperty', <String, String>{
+    await _channel.invokeMethod<void>('setUserProperty', <String, String>{
       'name': name,
       'value': value,
     });
@@ -162,10 +147,7 @@ class FirebaseAnalytics {
 
   /// Clears all analytics data for this app from the device and resets the app instance id.
   Future<void> resetAnalyticsData() async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    await _channel.invokeMethod('resetAnalyticsData');
+    await _channel.invokeMethod<void>('resetAnalyticsData');
   }
 
   /// Logs the standard `add_payment_info` event.
@@ -823,10 +805,7 @@ class FirebaseAnalyticsAndroid {
       throw ArgumentError.notNull('enabled');
     }
 
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    await _channel.invokeMethod('setAnalyticsCollectionEnabled', enabled);
+    await _channel.invokeMethod<void>('setAnalyticsCollectionEnabled', enabled);
   }
 
   /// Sets the minimum engagement time required before starting a session.
@@ -837,10 +816,7 @@ class FirebaseAnalyticsAndroid {
       throw ArgumentError.notNull('milliseconds');
     }
 
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    await _channel.invokeMethod('setMinimumSessionDuration', milliseconds);
+    await _channel.invokeMethod<void>('setMinimumSessionDuration', milliseconds);
   }
 
   /// Sets the duration of inactivity that terminates the current session.
@@ -851,10 +827,7 @@ class FirebaseAnalyticsAndroid {
       throw ArgumentError.notNull('milliseconds');
     }
 
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    await _channel.invokeMethod('setSessionTimeoutDuration', milliseconds);
+    await _channel.invokeMethod<void>('setSessionTimeoutDuration', milliseconds);
   }
 }
 

--- a/packages/firebase_analytics/lib/firebase_analytics.dart
+++ b/packages/firebase_analytics/lib/firebase_analytics.dart
@@ -816,7 +816,8 @@ class FirebaseAnalyticsAndroid {
       throw ArgumentError.notNull('milliseconds');
     }
 
-    await _channel.invokeMethod<void>('setMinimumSessionDuration', milliseconds);
+    await _channel.invokeMethod<void>(
+        'setMinimumSessionDuration', milliseconds);
   }
 
   /// Sets the duration of inactivity that terminates the current session.
@@ -827,7 +828,8 @@ class FirebaseAnalyticsAndroid {
       throw ArgumentError.notNull('milliseconds');
     }
 
-    await _channel.invokeMethod<void>('setSessionTimeoutDuration', milliseconds);
+    await _channel.invokeMethod<void>(
+        'setSessionTimeoutDuration', milliseconds);
   }
 }
 

--- a/packages/firebase_analytics/pubspec.yaml
+++ b/packages/firebase_analytics/pubspec.yaml
@@ -25,4 +25,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.1.4 <2.0.0"
+  flutter: ">=1.2.0 <2.0.0"

--- a/packages/firebase_analytics/pubspec.yaml
+++ b/packages/firebase_analytics/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Analytics for Firebase, an app measuremen
   solution that provides insight on app usage and user engagement on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_analytics
-version: 2.0.3
+version: 2.0.4
 
 flutter:
   plugin:

--- a/packages/firebase_analytics/test/firebase_analytics_test.dart
+++ b/packages/firebase_analytics/test/firebase_analytics_test.dart
@@ -39,10 +39,7 @@ void main() {
       invokedMethod = null;
       arguments = null;
 
-      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-      // https://github.com/flutter/flutter/issues/26431
-      // ignore: strong_mode_implicit_dynamic_method
-      when(mockChannel.invokeMethod(any, any))
+      when(mockChannel.invokeMethod<dynamic>(any, any))
           .thenAnswer((Invocation invocation) {
         invokedMethod = invocation.positionalArguments[0];
         arguments = invocation.positionalArguments[1];
@@ -133,10 +130,7 @@ void main() {
       name = null;
       parameters = null;
 
-      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-      // https://github.com/flutter/flutter/issues/26431
-      // ignore: strong_mode_implicit_dynamic_method
-      when(mockChannel.invokeMethod('logEvent', any))
+      when(mockChannel.invokeMethod<dynamic>('logEvent', any))
           .thenAnswer((Invocation invocation) {
         final Map<String, dynamic> args = invocation.positionalArguments[1];
         name = args['name'];
@@ -145,10 +139,7 @@ void main() {
         return Future<void>.value();
       });
 
-      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-      // https://github.com/flutter/flutter/issues/26431
-      // ignore: strong_mode_implicit_dynamic_method
-      when(mockChannel.invokeMethod(argThat(isNot('logEvent')), any))
+      when(mockChannel.invokeMethod<dynamic>(argThat(isNot('logEvent')), any))
           .thenThrow(ArgumentError('Only logEvent invocations expected'));
 
       analytics = FirebaseAnalytics.private(mockChannel);

--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.8.1+6
+
+* Bump the minimum flutter version to 1.2.0.
+* Add Template type parameter to `invokeMethod` calls.
+
 ## 0.8.1+5
 
 * Added a driver test.

--- a/packages/firebase_auth/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/lib/src/firebase_auth.dart
@@ -73,7 +73,7 @@ class FirebaseAuth {
   ///   • `ERROR_OPERATION_NOT_ALLOWED` - Indicates that Anonymous accounts are not enabled.
   Future<FirebaseUser> signInAnonymously() async {
     final Map<dynamic, dynamic> data = await channel
-        .invokeMethod<Map<dynamic, dynamic>>('signInAnonymously', <String, String>{"app": app.name});
+        .invokeMapMethod<dynamic, dynamic>('signInAnonymously', <String, String>{"app": app.name});
     final FirebaseUser currentUser = FirebaseUser._(data, app);
     return currentUser;
   }
@@ -93,7 +93,7 @@ class FirebaseAuth {
   }) async {
     assert(email != null);
     assert(password != null);
-    final Map<dynamic, dynamic> data = await channel.invokeMethod<Map<dynamic, dynamic>>(
+    final Map<dynamic, dynamic> data = await channel.invokeMapMethod<dynamic, dynamic>(
       'createUserWithEmailAndPassword',
       <String, String>{'email': email, 'password': password, 'app': app.name},
     );
@@ -187,7 +187,7 @@ class FirebaseAuth {
   ///   • `ERROR_OPERATION_NOT_ALLOWED` - Indicates that Google accounts are not enabled.
   Future<FirebaseUser> signInWithCredential(AuthCredential credential) async {
     assert(credential != null);
-    final Map<dynamic, dynamic> data = await channel.invokeMethod<Map<dynamic, dynamic>>(
+    final Map<dynamic, dynamic> data = await channel.invokeMapMethod<dynamic, dynamic>(
       'signInWithCredential',
       <String, dynamic>{
         'app': app.name,
@@ -290,7 +290,7 @@ class FirebaseAuth {
   ///     Ensure your app's SHA1 is correct in the Firebase console.
   Future<FirebaseUser> signInWithCustomToken({@required String token}) async {
     assert(token != null);
-    final Map<dynamic, dynamic> data = await channel.invokeMethod<Map<dynamic, dynamic>>(
+    final Map<dynamic, dynamic> data = await channel.invokeMapMethod<dynamic, dynamic>(
       'signInWithCustomToken',
       <String, String>{'token': token, 'app': app.name},
     );
@@ -310,7 +310,7 @@ class FirebaseAuth {
   /// Returns the currently signed-in [FirebaseUser] or [null] if there is none.
   Future<FirebaseUser> currentUser() async {
     final Map<dynamic, dynamic> data = await channel
-        .invokeMethod<Map<dynamic, dynamic>>("currentUser", <String, String>{'app': app.name});
+        .invokeMapMethod<dynamic, dynamic>("currentUser", <String, String>{'app': app.name});
     final FirebaseUser currentUser =
         data == null ? null : FirebaseUser._(data, app);
     return currentUser;
@@ -332,7 +332,7 @@ class FirebaseAuth {
   ///   • `ERROR_OPERATION_NOT_ALLOWED` - Indicates that this type of account is not enabled.
   Future<FirebaseUser> linkWithCredential(AuthCredential credential) async {
     assert(credential != null);
-    final Map<dynamic, dynamic> data = await channel.invokeMethod<Map<dynamic, dynamic>>(
+    final Map<dynamic, dynamic> data = await channel.invokeMapMethod<dynamic, dynamic>(
       'linkWithCredential',
       <String, dynamic>{
         'app': app.name,

--- a/packages/firebase_auth/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/lib/src/firebase_auth.dart
@@ -44,20 +44,14 @@ class FirebaseAuth {
 
     StreamController<FirebaseUser> controller;
     controller = StreamController<FirebaseUser>.broadcast(onListen: () {
-      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-      // https://github.com/flutter/flutter/issues/26431
-      // ignore: strong_mode_implicit_dynamic_method
-      _handle = channel.invokeMethod('startListeningAuthState',
+      _handle = channel.invokeMethod<int>('startListeningAuthState',
           <String, String>{"app": app.name}).then<int>((dynamic v) => v);
       _handle.then((int handle) {
         _authStateChangedControllers[handle] = controller;
       });
     }, onCancel: () {
       _handle.then((int handle) async {
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        await channel.invokeMethod("stopListeningAuthState",
+        await channel.invokeMethod<void>("stopListeningAuthState",
             <String, dynamic>{"id": handle, "app": app.name});
         _authStateChangedControllers.remove(handle);
       });
@@ -79,10 +73,7 @@ class FirebaseAuth {
   ///   • `ERROR_OPERATION_NOT_ALLOWED` - Indicates that Anonymous accounts are not enabled.
   Future<FirebaseUser> signInAnonymously() async {
     final Map<dynamic, dynamic> data = await channel
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        .invokeMethod('signInAnonymously', <String, String>{"app": app.name});
+        .invokeMethod<Map<dynamic, dynamic>>('signInAnonymously', <String, String>{"app": app.name});
     final FirebaseUser currentUser = FirebaseUser._(data, app);
     return currentUser;
   }
@@ -102,10 +93,7 @@ class FirebaseAuth {
   }) async {
     assert(email != null);
     assert(password != null);
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    final Map<dynamic, dynamic> data = await channel.invokeMethod(
+    final Map<dynamic, dynamic> data = await channel.invokeMethod<Map<dynamic, dynamic>>(
       'createUserWithEmailAndPassword',
       <String, String>{'email': email, 'password': password, 'app': app.name},
     );
@@ -126,10 +114,7 @@ class FirebaseAuth {
     @required String email,
   }) async {
     assert(email != null);
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    final List<dynamic> providers = await channel.invokeMethod(
+    final List<dynamic> providers = await channel.invokeMethod<List<dynamic>>(
       'fetchSignInMethodsForEmail',
       <String, String>{'email': email, 'app': app.name},
     );
@@ -147,10 +132,7 @@ class FirebaseAuth {
     @required String email,
   }) async {
     assert(email != null);
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return await channel.invokeMethod(
+    return await channel.invokeMethod<void>(
       'sendPasswordResetEmail',
       <String, String>{'email': email, 'app': app.name},
     );
@@ -205,10 +187,7 @@ class FirebaseAuth {
   ///   • `ERROR_OPERATION_NOT_ALLOWED` - Indicates that Google accounts are not enabled.
   Future<FirebaseUser> signInWithCredential(AuthCredential credential) async {
     assert(credential != null);
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    final Map<dynamic, dynamic> data = await channel.invokeMethod(
+    final Map<dynamic, dynamic> data = await channel.invokeMethod<Map<dynamic, dynamic>>(
       'signInWithCredential',
       <String, dynamic>{
         'app': app.name,
@@ -288,10 +267,7 @@ class FirebaseAuth {
       'app': app.name,
     };
 
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    await channel.invokeMethod('verifyPhoneNumber', params);
+    await channel.invokeMethod<void>('verifyPhoneNumber', params);
   }
 
   /// Tries to sign in a user with a given Custom Token [token].
@@ -314,10 +290,7 @@ class FirebaseAuth {
   ///     Ensure your app's SHA1 is correct in the Firebase console.
   Future<FirebaseUser> signInWithCustomToken({@required String token}) async {
     assert(token != null);
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    final Map<dynamic, dynamic> data = await channel.invokeMethod(
+    final Map<dynamic, dynamic> data = await channel.invokeMethod<Map<dynamic, dynamic>>(
       'signInWithCustomToken',
       <String, String>{'token': token, 'app': app.name},
     );
@@ -331,19 +304,13 @@ class FirebaseAuth {
   /// the [onAuthStateChanged] stream.
   Future<void> signOut() async {
     return await channel
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        .invokeMethod("signOut", <String, String>{'app': app.name});
+        .invokeMethod<void>("signOut", <String, String>{'app': app.name});
   }
 
   /// Returns the currently signed-in [FirebaseUser] or [null] if there is none.
   Future<FirebaseUser> currentUser() async {
     final Map<dynamic, dynamic> data = await channel
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        .invokeMethod("currentUser", <String, String>{'app': app.name});
+        .invokeMethod<Map<dynamic, dynamic>>("currentUser", <String, String>{'app': app.name});
     final FirebaseUser currentUser =
         data == null ? null : FirebaseUser._(data, app);
     return currentUser;
@@ -365,10 +332,7 @@ class FirebaseAuth {
   ///   • `ERROR_OPERATION_NOT_ALLOWED` - Indicates that this type of account is not enabled.
   Future<FirebaseUser> linkWithCredential(AuthCredential credential) async {
     assert(credential != null);
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    final Map<dynamic, dynamic> data = await channel.invokeMethod(
+    final Map<dynamic, dynamic> data = await channel.invokeMethod<Map<dynamic, dynamic>>(
       'linkWithCredential',
       <String, dynamic>{
         'app': app.name,
@@ -385,10 +349,7 @@ class FirebaseAuth {
   /// code should follow the conventions defined by the IETF in BCP47.
   Future<void> setLanguageCode(String language) async {
     assert(language != null);
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    await FirebaseAuth.channel.invokeMethod('setLanguageCode', <String, String>{
+    await FirebaseAuth.channel.invokeMethod<void>('setLanguageCode', <String, String>{
       'language': language,
       'app': app.name,
     });

--- a/packages/firebase_auth/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/lib/src/firebase_auth.dart
@@ -72,8 +72,8 @@ class FirebaseAuth {
   /// Errors:
   ///   • `ERROR_OPERATION_NOT_ALLOWED` - Indicates that Anonymous accounts are not enabled.
   Future<FirebaseUser> signInAnonymously() async {
-    final Map<dynamic, dynamic> data = await channel
-        .invokeMapMethod<dynamic, dynamic>('signInAnonymously', <String, String>{"app": app.name});
+    final Map<String, dynamic> data = await channel
+        .invokeMapMethod<String, dynamic>('signInAnonymously', <String, String>{"app": app.name});
     final FirebaseUser currentUser = FirebaseUser._(data, app);
     return currentUser;
   }
@@ -93,7 +93,7 @@ class FirebaseAuth {
   }) async {
     assert(email != null);
     assert(password != null);
-    final Map<dynamic, dynamic> data = await channel.invokeMapMethod<dynamic, dynamic>(
+    final Map<String, dynamic> data = await channel.invokeMapMethod<String, dynamic>(
       'createUserWithEmailAndPassword',
       <String, String>{'email': email, 'password': password, 'app': app.name},
     );
@@ -186,7 +186,7 @@ class FirebaseAuth {
   ///   • `ERROR_OPERATION_NOT_ALLOWED` - Indicates that Google accounts are not enabled.
   Future<FirebaseUser> signInWithCredential(AuthCredential credential) async {
     assert(credential != null);
-    final Map<dynamic, dynamic> data = await channel.invokeMapMethod<dynamic, dynamic>(
+    final Map<String, dynamic> data = await channel.invokeMapMethod<String, dynamic>(
       'signInWithCredential',
       <String, dynamic>{
         'app': app.name,
@@ -289,7 +289,7 @@ class FirebaseAuth {
   ///     Ensure your app's SHA1 is correct in the Firebase console.
   Future<FirebaseUser> signInWithCustomToken({@required String token}) async {
     assert(token != null);
-    final Map<dynamic, dynamic> data = await channel.invokeMapMethod<dynamic, dynamic>(
+    final Map<String, dynamic> data = await channel.invokeMapMethod<String, dynamic>(
       'signInWithCustomToken',
       <String, String>{'token': token, 'app': app.name},
     );
@@ -308,8 +308,8 @@ class FirebaseAuth {
 
   /// Returns the currently signed-in [FirebaseUser] or [null] if there is none.
   Future<FirebaseUser> currentUser() async {
-    final Map<dynamic, dynamic> data = await channel
-        .invokeMapMethod<dynamic, dynamic>("currentUser", <String, String>{'app': app.name});
+    final Map<String, dynamic> data = await channel
+        .invokeMapMethod<String, dynamic>("currentUser", <String, String>{'app': app.name});
     final FirebaseUser currentUser =
         data == null ? null : FirebaseUser._(data, app);
     return currentUser;
@@ -331,7 +331,7 @@ class FirebaseAuth {
   ///   • `ERROR_OPERATION_NOT_ALLOWED` - Indicates that this type of account is not enabled.
   Future<FirebaseUser> linkWithCredential(AuthCredential credential) async {
     assert(credential != null);
-    final Map<dynamic, dynamic> data = await channel.invokeMapMethod<dynamic, dynamic>(
+    final Map<String, dynamic> data = await channel.invokeMapMethod<String, dynamic>(
       'linkWithCredential',
       <String, dynamic>{
         'app': app.name,

--- a/packages/firebase_auth/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/lib/src/firebase_auth.dart
@@ -73,7 +73,8 @@ class FirebaseAuth {
   ///   • `ERROR_OPERATION_NOT_ALLOWED` - Indicates that Anonymous accounts are not enabled.
   Future<FirebaseUser> signInAnonymously() async {
     final Map<String, dynamic> data = await channel
-        .invokeMapMethod<String, dynamic>('signInAnonymously', <String, String>{"app": app.name});
+        .invokeMapMethod<String, dynamic>(
+            'signInAnonymously', <String, String>{"app": app.name});
     final FirebaseUser currentUser = FirebaseUser._(data, app);
     return currentUser;
   }
@@ -93,7 +94,8 @@ class FirebaseAuth {
   }) async {
     assert(email != null);
     assert(password != null);
-    final Map<String, dynamic> data = await channel.invokeMapMethod<String, dynamic>(
+    final Map<String, dynamic> data =
+        await channel.invokeMapMethod<String, dynamic>(
       'createUserWithEmailAndPassword',
       <String, String>{'email': email, 'password': password, 'app': app.name},
     );
@@ -186,7 +188,8 @@ class FirebaseAuth {
   ///   • `ERROR_OPERATION_NOT_ALLOWED` - Indicates that Google accounts are not enabled.
   Future<FirebaseUser> signInWithCredential(AuthCredential credential) async {
     assert(credential != null);
-    final Map<String, dynamic> data = await channel.invokeMapMethod<String, dynamic>(
+    final Map<String, dynamic> data =
+        await channel.invokeMapMethod<String, dynamic>(
       'signInWithCredential',
       <String, dynamic>{
         'app': app.name,
@@ -289,7 +292,8 @@ class FirebaseAuth {
   ///     Ensure your app's SHA1 is correct in the Firebase console.
   Future<FirebaseUser> signInWithCustomToken({@required String token}) async {
     assert(token != null);
-    final Map<String, dynamic> data = await channel.invokeMapMethod<String, dynamic>(
+    final Map<String, dynamic> data =
+        await channel.invokeMapMethod<String, dynamic>(
       'signInWithCustomToken',
       <String, String>{'token': token, 'app': app.name},
     );
@@ -309,7 +313,8 @@ class FirebaseAuth {
   /// Returns the currently signed-in [FirebaseUser] or [null] if there is none.
   Future<FirebaseUser> currentUser() async {
     final Map<String, dynamic> data = await channel
-        .invokeMapMethod<String, dynamic>("currentUser", <String, String>{'app': app.name});
+        .invokeMapMethod<String, dynamic>(
+            "currentUser", <String, String>{'app': app.name});
     final FirebaseUser currentUser =
         data == null ? null : FirebaseUser._(data, app);
     return currentUser;
@@ -331,7 +336,8 @@ class FirebaseAuth {
   ///   • `ERROR_OPERATION_NOT_ALLOWED` - Indicates that this type of account is not enabled.
   Future<FirebaseUser> linkWithCredential(AuthCredential credential) async {
     assert(credential != null);
-    final Map<String, dynamic> data = await channel.invokeMapMethod<String, dynamic>(
+    final Map<String, dynamic> data =
+        await channel.invokeMapMethod<String, dynamic>(
       'linkWithCredential',
       <String, dynamic>{
         'app': app.name,
@@ -348,7 +354,8 @@ class FirebaseAuth {
   /// code should follow the conventions defined by the IETF in BCP47.
   Future<void> setLanguageCode(String language) async {
     assert(language != null);
-    await FirebaseAuth.channel.invokeMethod<void>('setLanguageCode', <String, String>{
+    await FirebaseAuth.channel
+        .invokeMethod<void>('setLanguageCode', <String, String>{
       'language': language,
       'app': app.name,
     });

--- a/packages/firebase_auth/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/lib/src/firebase_auth.dart
@@ -114,11 +114,10 @@ class FirebaseAuth {
     @required String email,
   }) async {
     assert(email != null);
-    final List<dynamic> providers = await channel.invokeMethod<List<dynamic>>(
+    return await channel.invokeListMethod<String>(
       'fetchSignInMethodsForEmail',
       <String, String>{'email': email, 'app': app.name},
     );
-    return providers?.cast<String>();
   }
 
   /// Triggers the Firebase Authentication backend to send a password-reset

--- a/packages/firebase_auth/lib/src/firebase_user.dart
+++ b/packages/firebase_auth/lib/src/firebase_user.dart
@@ -35,10 +35,7 @@ class FirebaseUser extends UserInfo {
   /// Completes with an error if the user is signed out.
   Future<String> getIdToken({bool refresh = false}) async {
     return await FirebaseAuth.channel
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        .invokeMethod('getIdToken', <String, dynamic>{
+        .invokeMethod<String>('getIdToken', <String, dynamic>{
       'refresh': refresh,
       'app': _app.name,
     });
@@ -46,10 +43,7 @@ class FirebaseUser extends UserInfo {
 
   /// Initiates email verification for the user.
   Future<void> sendEmailVerification() async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    await FirebaseAuth.channel.invokeMethod(
+    await FirebaseAuth.channel.invokeMethod<void>(
         'sendEmailVerification', <String, String>{'app': _app.name});
   }
 
@@ -57,19 +51,13 @@ class FirebaseUser extends UserInfo {
   /// attached providers, display name, and so on).
   Future<void> reload() async {
     await FirebaseAuth.channel
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        .invokeMethod('reload', <String, String>{'app': _app.name});
+        .invokeMethod<void>('reload', <String, String>{'app': _app.name});
   }
 
   /// Deletes the user record from your Firebase project's database.
   Future<void> delete() async {
     await FirebaseAuth.channel
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        .invokeMethod('delete', <String, String>{'app': _app.name});
+        .invokeMethod<void>('delete', <String, String>{'app': _app.name});
   }
 
   /// Updates the email address of the user.
@@ -90,10 +78,7 @@ class FirebaseUser extends UserInfo {
   ///   • `ERROR_OPERATION_NOT_ALLOWED` - Indicates that Email & Password accounts are not enabled.
   Future<void> updateEmail(String email) async {
     assert(email != null);
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return await FirebaseAuth.channel.invokeMethod(
+    return await FirebaseAuth.channel.invokeMethod<void>(
       'updateEmail',
       <String, String>{'email': email, 'app': _app.name},
     );
@@ -115,10 +100,7 @@ class FirebaseUser extends UserInfo {
   ///   • `ERROR_OPERATION_NOT_ALLOWED` - Indicates that Email & Password accounts are not enabled.
   Future<void> updatePassword(String password) async {
     assert(password != null);
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return await FirebaseAuth.channel.invokeMethod(
+    return await FirebaseAuth.channel.invokeMethod<void>(
       'updatePassword',
       <String, String>{'password': password, 'app': _app.name},
     );
@@ -133,10 +115,7 @@ class FirebaseUser extends UserInfo {
     assert(userUpdateInfo != null);
     final Map<String, String> data = userUpdateInfo._updateData;
     data['app'] = _app.name;
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return await FirebaseAuth.channel.invokeMethod(
+    return await FirebaseAuth.channel.invokeMethod<void>(
       'updateProfile',
       data,
     );
@@ -161,10 +140,7 @@ class FirebaseUser extends UserInfo {
   Future<FirebaseUser> reauthenticateWithCredential(
       AuthCredential credential) async {
     assert(credential != null);
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    await FirebaseAuth.channel.invokeMethod(
+    await FirebaseAuth.channel.invokeMethod<void>(
       'reauthenticateWithCredential',
       <String, dynamic>{
         'app': _app.name,
@@ -190,10 +166,7 @@ class FirebaseUser extends UserInfo {
   ///   • `ERROR_REQUIRES_RECENT_LOGIN` - If the user's last sign-in time does not meet the security threshold. Use reauthenticate methods to resolve.
   Future<void> unlinkFromProvider(String provider) async {
     assert(provider != null);
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return await FirebaseAuth.channel.invokeMethod(
+    return await FirebaseAuth.channel.invokeMethod<void>(
       'unlinkFromProvider',
       <String, String>{'provider': provider, 'app': _app.name},
     );

--- a/packages/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Firebase Auth, enabling Android and iOS
   like Google, Facebook and Twitter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_auth
-version: "0.8.1+5"
+version: "0.8.1+6"
 
 flutter:
   plugin:

--- a/packages/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/pubspec.yaml
@@ -29,4 +29,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.1.4 <2.0.0"
+  flutter: ">=1.2.0 <2.0.0"

--- a/packages/firebase_core/CHANGELOG.md
+++ b/packages/firebase_core/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.1+2
+
+* Bump the minimum flutter version to 1.2.0.
+* Add Template type parameter to `invokeMethod` calls.
+
 ## 0.3.1+1
 
 * Add nil check on static functions to prevent crashes or unwanted behaviors.

--- a/packages/firebase_core/lib/src/firebase_app.dart
+++ b/packages/firebase_core/lib/src/firebase_app.dart
@@ -24,7 +24,7 @@ class FirebaseApp {
   /// This getter is asynchronous because apps can also be configured by native
   /// code.
   Future<FirebaseOptions> get options async {
-    final Map<dynamic, dynamic> app = await channel.invokeMapMethod<dynamic, dynamic>(
+    final Map<String, dynamic> app = await channel.invokeMapMethod<String, dynamic>(
       'FirebaseApp#appNamed',
       name,
     );
@@ -35,7 +35,7 @@ class FirebaseApp {
   /// Returns a previously created FirebaseApp instance with the given name,
   /// or null if no such app exists.
   static Future<FirebaseApp> appNamed(String name) async {
-    final Map<dynamic, dynamic> app = await channel.invokeMapMethod<dynamic, dynamic>(
+    final Map<String, dynamic> app = await channel.invokeMapMethod<String, dynamic>(
       'FirebaseApp#appNamed',
       name,
     );
@@ -75,12 +75,12 @@ class FirebaseApp {
   /// Returns a list of all extant FirebaseApp instances, or null if there are
   /// no FirebaseApp instances.
   static Future<List<FirebaseApp>> allApps() async {
-    final List<dynamic> result = await channel.invokeListMethod<dynamic>(
+    final List<Map<String, dynamic>> result = await channel.invokeListMethod<Map<String, dynamic>>(
       'FirebaseApp#allApps',
     );
     return result
         ?.map<FirebaseApp>(
-          (dynamic app) => FirebaseApp(name: app['name']),
+          (Map<String, dynamic> app) => FirebaseApp(name: app['name']),
         )
         ?.toList();
   }

--- a/packages/firebase_core/lib/src/firebase_app.dart
+++ b/packages/firebase_core/lib/src/firebase_app.dart
@@ -24,7 +24,8 @@ class FirebaseApp {
   /// This getter is asynchronous because apps can also be configured by native
   /// code.
   Future<FirebaseOptions> get options async {
-    final Map<String, dynamic> app = await channel.invokeMapMethod<String, dynamic>(
+    final Map<String, dynamic> app =
+        await channel.invokeMapMethod<String, dynamic>(
       'FirebaseApp#appNamed',
       name,
     );
@@ -35,7 +36,8 @@ class FirebaseApp {
   /// Returns a previously created FirebaseApp instance with the given name,
   /// or null if no such app exists.
   static Future<FirebaseApp> appNamed(String name) async {
-    final Map<String, dynamic> app = await channel.invokeMapMethod<String, dynamic>(
+    final Map<String, dynamic> app =
+        await channel.invokeMapMethod<String, dynamic>(
       'FirebaseApp#appNamed',
       name,
     );
@@ -75,7 +77,8 @@ class FirebaseApp {
   /// Returns a list of all extant FirebaseApp instances, or null if there are
   /// no FirebaseApp instances.
   static Future<List<FirebaseApp>> allApps() async {
-    final List<Map<String, dynamic>> result = await channel.invokeListMethod<Map<String, dynamic>>(
+    final List<Map<String, dynamic>> result =
+        await channel.invokeListMethod<Map<String, dynamic>>(
       'FirebaseApp#allApps',
     );
     return result

--- a/packages/firebase_core/lib/src/firebase_app.dart
+++ b/packages/firebase_core/lib/src/firebase_app.dart
@@ -24,10 +24,7 @@ class FirebaseApp {
   /// This getter is asynchronous because apps can also be configured by native
   /// code.
   Future<FirebaseOptions> get options async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    final Map<dynamic, dynamic> app = await channel.invokeMethod(
+    final Map<dynamic, dynamic> app = await channel.invokeMethod<Map<dynamic, dynamic>>(
       'FirebaseApp#appNamed',
       name,
     );
@@ -38,10 +35,7 @@ class FirebaseApp {
   /// Returns a previously created FirebaseApp instance with the given name,
   /// or null if no such app exists.
   static Future<FirebaseApp> appNamed(String name) async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    final Map<dynamic, dynamic> app = await channel.invokeMethod(
+    final Map<dynamic, dynamic> app = await channel.invokeMethod<Map<dynamic, dynamic>>(
       'FirebaseApp#appNamed',
       name,
     );
@@ -70,10 +64,8 @@ class FirebaseApp {
     if (existingApp != null) {
       return existingApp;
     }
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    await channel.invokeMethod(
+
+    await channel.invokeMethod<void>(
       'FirebaseApp#configure',
       <String, dynamic>{'name': name, 'options': options.asMap},
     );
@@ -83,10 +75,7 @@ class FirebaseApp {
   /// Returns a list of all extant FirebaseApp instances, or null if there are
   /// no FirebaseApp instances.
   static Future<List<FirebaseApp>> allApps() async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    final List<dynamic> result = await channel.invokeMethod(
+    final List<dynamic> result = await channel.invokeMethod<List<dynamic>>(
       'FirebaseApp#allApps',
     );
     return result

--- a/packages/firebase_core/lib/src/firebase_app.dart
+++ b/packages/firebase_core/lib/src/firebase_app.dart
@@ -24,7 +24,7 @@ class FirebaseApp {
   /// This getter is asynchronous because apps can also be configured by native
   /// code.
   Future<FirebaseOptions> get options async {
-    final Map<dynamic, dynamic> app = await channel.invokeMethod<Map<dynamic, dynamic>>(
+    final Map<dynamic, dynamic> app = await channel.invokeMapMethod<dynamic, dynamic>(
       'FirebaseApp#appNamed',
       name,
     );
@@ -35,7 +35,7 @@ class FirebaseApp {
   /// Returns a previously created FirebaseApp instance with the given name,
   /// or null if no such app exists.
   static Future<FirebaseApp> appNamed(String name) async {
-    final Map<dynamic, dynamic> app = await channel.invokeMethod<Map<dynamic, dynamic>>(
+    final Map<dynamic, dynamic> app = await channel.invokeMapMethod<dynamic, dynamic>(
       'FirebaseApp#appNamed',
       name,
     );
@@ -75,7 +75,7 @@ class FirebaseApp {
   /// Returns a list of all extant FirebaseApp instances, or null if there are
   /// no FirebaseApp instances.
   static Future<List<FirebaseApp>> allApps() async {
-    final List<dynamic> result = await channel.invokeMethod<List<dynamic>>(
+    final List<dynamic> result = await channel.invokeListMethod<dynamic>(
       'FirebaseApp#allApps',
     );
     return result

--- a/packages/firebase_core/pubspec.yaml
+++ b/packages/firebase_core/pubspec.yaml
@@ -22,4 +22,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.1.4 <2.0.0"
+  flutter: ">=1.2.0 <2.0.0"

--- a/packages/firebase_core/pubspec.yaml
+++ b/packages/firebase_core/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Core, enabling connecting to multiple
   Firebase apps.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_core
-version: 0.3.1+1
+version: 0.3.1+2
 
 flutter:
   plugin:

--- a/packages/firebase_database/lib/src/database_reference.dart
+++ b/packages/firebase_database/lib/src/database_reference.dart
@@ -70,10 +70,7 @@ class DatabaseReference extends Query {
   /// Passing null for the new value means all data at this location or any
   /// child location will be deleted.
   Future<void> set(dynamic value, {dynamic priority}) {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return _database._channel.invokeMethod(
+    return _database._channel.invokeMethod<void>(
       'DatabaseReference#set',
       <String, dynamic>{
         'app': _database.app?.name,
@@ -87,10 +84,7 @@ class DatabaseReference extends Query {
 
   /// Update the node with the `value`
   Future<void> update(Map<String, dynamic> value) {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return _database._channel.invokeMethod(
+    return _database._channel.invokeMethod<void>(
       'DatabaseReference#update',
       <String, dynamic>{
         'app': _database.app?.name,
@@ -126,10 +120,7 @@ class DatabaseReference extends Query {
   /// floating-point numbers. Keys are always stored as strings and are treated
   /// as numbers only when they can be parsed as a 32-bit integer.
   Future<void> setPriority(dynamic priority) async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return _database._channel.invokeMethod(
+    return _database._channel.invokeMethod<void>(
       'DatabaseReference#setPriority',
       <String, dynamic>{
         'app': _database.app?.name,
@@ -180,10 +171,7 @@ class DatabaseReference extends Query {
     }
 
     _database._channel
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        .invokeMethod('DatabaseReference#runTransaction', <String, dynamic>{
+        .invokeMethod<dynamic>('DatabaseReference#runTransaction', <String, dynamic>{
       'app': _database.app?.name,
       'databaseURL': _database.databaseURL,
       'path': path,

--- a/packages/firebase_database/lib/src/database_reference.dart
+++ b/packages/firebase_database/lib/src/database_reference.dart
@@ -170,8 +170,8 @@ class DatabaseReference extends Query {
       return TransactionResult._(databaseError, committed, dataSnapshot);
     }
 
-    _database._channel
-        .invokeMethod<dynamic>('DatabaseReference#runTransaction', <String, dynamic>{
+    _database._channel.invokeMethod<dynamic>(
+        'DatabaseReference#runTransaction', <String, dynamic>{
       'app': _database.app?.name,
       'databaseURL': _database.databaseURL,
       'path': path,

--- a/packages/firebase_database/lib/src/firebase_database.dart
+++ b/packages/firebase_database/lib/src/firebase_database.dart
@@ -88,10 +88,7 @@ class FirebaseDatabase {
   /// thus be available again when the app is restarted (even when there is no
   /// network connectivity at that time).
   Future<bool> setPersistenceEnabled(bool enabled) async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    final bool result = await _channel.invokeMethod(
+    final bool result = await _channel.invokeMethod<bool>(
       'FirebaseDatabase#setPersistenceEnabled',
       <String, dynamic>{
         'app': app?.name,
@@ -120,10 +117,7 @@ class FirebaseDatabase {
   /// on disk may temporarily exceed it at times. Cache sizes smaller than 1 MB
   /// or greater than 100 MB are not supported.
   Future<bool> setPersistenceCacheSizeBytes(int cacheSize) async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    final bool result = await _channel.invokeMethod(
+    final bool result = await _channel.invokeMethod<bool>(
       'FirebaseDatabase#setPersistenceCacheSizeBytes',
       <String, dynamic>{
         'app': app?.name,
@@ -137,10 +131,7 @@ class FirebaseDatabase {
   /// Resumes our connection to the Firebase Database backend after a previous
   /// [goOffline] call.
   Future<void> goOnline() {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return _channel.invokeMethod(
+    return _channel.invokeMethod<void>(
       'FirebaseDatabase#goOnline',
       <String, dynamic>{
         'app': app?.name,
@@ -152,10 +143,7 @@ class FirebaseDatabase {
   /// Shuts down our connection to the Firebase Database backend until
   /// [goOnline] is called.
   Future<void> goOffline() {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return _channel.invokeMethod(
+    return _channel.invokeMethod<void>(
       'FirebaseDatabase#goOffline',
       <String, dynamic>{
         'app': app?.name,
@@ -175,10 +163,7 @@ class FirebaseDatabase {
   /// affected event listeners, and the client will not (re-)send them to the
   /// Firebase Database backend.
   Future<void> purgeOutstandingWrites() {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return _channel.invokeMethod(
+    return _channel.invokeMethod<void>(
       'FirebaseDatabase#purgeOutstandingWrites',
       <String, dynamic>{
         'app': app?.name,

--- a/packages/firebase_database/lib/src/on_disconnect.dart
+++ b/packages/firebase_database/lib/src/on_disconnect.dart
@@ -8,10 +8,7 @@ class OnDisconnect {
   final String path;
 
   Future<void> set(dynamic value, {dynamic priority}) {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return _database._channel.invokeMethod(
+    return _database._channel.invokeMethod<void>(
       'OnDisconnect#set',
       <String, dynamic>{
         'app': _database.app?.name,
@@ -26,10 +23,7 @@ class OnDisconnect {
   Future<void> remove() => set(null);
 
   Future<void> cancel() {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return _database._channel.invokeMethod(
+    return _database._channel.invokeMethod<void>(
       'OnDisconnect#cancel',
       <String, dynamic>{
         'app': _database.app?.name,
@@ -40,10 +34,7 @@ class OnDisconnect {
   }
 
   Future<void> update(Map<String, dynamic> value) {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return _database._channel.invokeMethod(
+    return _database._channel.invokeMethod<void>(
       'OnDisconnect#update',
       <String, dynamic>{
         'app': _database.app?.name,

--- a/packages/firebase_database/lib/src/query.dart
+++ b/packages/firebase_database/lib/src/query.dart
@@ -47,10 +47,7 @@ class Query {
     StreamController<Event> controller; // ignore: close_sinks
     controller = StreamController<Event>.broadcast(
       onListen: () {
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        _handle = _database._channel.invokeMethod(
+        _handle = _database._channel.invokeMethod<int>(
           'Query#observe',
           <String, dynamic>{
             'app': _database.app?.name,
@@ -66,10 +63,7 @@ class Query {
       },
       onCancel: () {
         _handle.then((int handle) async {
-          // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-          // https://github.com/flutter/flutter/issues/26431
-          // ignore: strong_mode_implicit_dynamic_method
-          await _database._channel.invokeMethod(
+          await _database._channel.invokeMethod<void>(
             'Query#removeObserver',
             <String, dynamic>{
               'app': _database.app?.name,
@@ -212,10 +206,7 @@ class Query {
   /// attached for that location. Additionally, while a location is kept synced,
   /// it will not be evicted from the persistent disk cache.
   Future<void> keepSynced(bool value) {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return _database._channel.invokeMethod(
+    return _database._channel.invokeMethod<void>(
       'Query#keepSynced',
       <String, dynamic>{
         'app': _database.app?.name,

--- a/packages/firebase_database/pubspec.yaml
+++ b/packages/firebase_database/pubspec.yaml
@@ -24,4 +24,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.1.4 <2.0.0"
+  flutter: ">=1.2.0 <2.0.0"

--- a/packages/firebase_dynamic_links/CHANGELOG.md
+++ b/packages/firebase_dynamic_links/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.0+5
+
+* Bump the minimum flutter version to 1.2.0.
+* Add Template type parameter to `invokeMethod` calls.
+
 ## 0.2.0+4
 
 * Fix crash when receiving `ShortDynamicLink` warnings.

--- a/packages/firebase_dynamic_links/lib/src/dynamic_link_parameters.dart
+++ b/packages/firebase_dynamic_links/lib/src/dynamic_link_parameters.dart
@@ -65,8 +65,8 @@ class DynamicLinkParameters {
   /// using [DynamicLinkParameters].
   static Future<ShortDynamicLink> shortenUrl(Uri url,
       [DynamicLinkParametersOptions options]) async {
-    final Map<dynamic, dynamic> reply = await FirebaseDynamicLinks.channel
-        .invokeMapMethod<dynamic, dynamic>('DynamicLinkParameters#shortenUrl', <String, dynamic>{
+    final Map<String, dynamic> reply = await FirebaseDynamicLinks.channel
+        .invokeMapMethod<String, dynamic>('DynamicLinkParameters#shortenUrl', <String, dynamic>{
       'url': url.toString(),
       'dynamicLinkParametersOptions': options?._data,
     });
@@ -95,8 +95,8 @@ class DynamicLinkParameters {
 
   /// Generate a short Dynamic Link.
   Future<ShortDynamicLink> buildShortLink() async {
-    final Map<dynamic, dynamic> reply = await FirebaseDynamicLinks.channel
-        .invokeMapMethod<dynamic, dynamic>('DynamicLinkParameters#buildShortLink', _data);
+    final Map<String, dynamic> reply = await FirebaseDynamicLinks.channel
+        .invokeMapMethod<String, dynamic>('DynamicLinkParameters#buildShortLink', _data);
     return _parseShortLink(reply);
   }
 

--- a/packages/firebase_dynamic_links/lib/src/dynamic_link_parameters.dart
+++ b/packages/firebase_dynamic_links/lib/src/dynamic_link_parameters.dart
@@ -66,10 +66,7 @@ class DynamicLinkParameters {
   static Future<ShortDynamicLink> shortenUrl(Uri url,
       [DynamicLinkParametersOptions options]) async {
     final Map<dynamic, dynamic> reply = await FirebaseDynamicLinks.channel
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        .invokeMethod('DynamicLinkParameters#shortenUrl', <String, dynamic>{
+        .invokeMethod<Map<dynamic, dynamic> >('DynamicLinkParameters#shortenUrl', <String, dynamic>{
       'url': url.toString(),
       'dynamicLinkParametersOptions': options?._data,
     });
@@ -92,20 +89,14 @@ class DynamicLinkParameters {
   /// Generate a long Dynamic Link URL.
   Future<Uri> buildUrl() async {
     final String url = await FirebaseDynamicLinks.channel
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        .invokeMethod('DynamicLinkParameters#buildUrl', _data);
+        .invokeMethod<String>('DynamicLinkParameters#buildUrl', _data);
     return Uri.parse(url);
   }
 
   /// Generate a short Dynamic Link.
   Future<ShortDynamicLink> buildShortLink() async {
     final Map<dynamic, dynamic> reply = await FirebaseDynamicLinks.channel
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        .invokeMethod('DynamicLinkParameters#buildShortLink', _data);
+        .invokeMethod<Map<dynamic, dynamic>>('DynamicLinkParameters#buildShortLink', _data);
     return _parseShortLink(reply);
   }
 

--- a/packages/firebase_dynamic_links/lib/src/dynamic_link_parameters.dart
+++ b/packages/firebase_dynamic_links/lib/src/dynamic_link_parameters.dart
@@ -66,7 +66,8 @@ class DynamicLinkParameters {
   static Future<ShortDynamicLink> shortenUrl(Uri url,
       [DynamicLinkParametersOptions options]) async {
     final Map<String, dynamic> reply = await FirebaseDynamicLinks.channel
-        .invokeMapMethod<String, dynamic>('DynamicLinkParameters#shortenUrl', <String, dynamic>{
+        .invokeMapMethod<String, dynamic>(
+            'DynamicLinkParameters#shortenUrl', <String, dynamic>{
       'url': url.toString(),
       'dynamicLinkParametersOptions': options?._data,
     });
@@ -96,7 +97,8 @@ class DynamicLinkParameters {
   /// Generate a short Dynamic Link.
   Future<ShortDynamicLink> buildShortLink() async {
     final Map<String, dynamic> reply = await FirebaseDynamicLinks.channel
-        .invokeMapMethod<String, dynamic>('DynamicLinkParameters#buildShortLink', _data);
+        .invokeMapMethod<String, dynamic>(
+            'DynamicLinkParameters#buildShortLink', _data);
     return _parseShortLink(reply);
   }
 

--- a/packages/firebase_dynamic_links/lib/src/dynamic_link_parameters.dart
+++ b/packages/firebase_dynamic_links/lib/src/dynamic_link_parameters.dart
@@ -66,7 +66,7 @@ class DynamicLinkParameters {
   static Future<ShortDynamicLink> shortenUrl(Uri url,
       [DynamicLinkParametersOptions options]) async {
     final Map<dynamic, dynamic> reply = await FirebaseDynamicLinks.channel
-        .invokeMethod<Map<dynamic, dynamic> >('DynamicLinkParameters#shortenUrl', <String, dynamic>{
+        .invokeMapMethod<dynamic, dynamic>('DynamicLinkParameters#shortenUrl', <String, dynamic>{
       'url': url.toString(),
       'dynamicLinkParametersOptions': options?._data,
     });
@@ -96,7 +96,7 @@ class DynamicLinkParameters {
   /// Generate a short Dynamic Link.
   Future<ShortDynamicLink> buildShortLink() async {
     final Map<dynamic, dynamic> reply = await FirebaseDynamicLinks.channel
-        .invokeMethod<Map<dynamic, dynamic>>('DynamicLinkParameters#buildShortLink', _data);
+        .invokeMapMethod<dynamic, dynamic>('DynamicLinkParameters#buildShortLink', _data);
     return _parseShortLink(reply);
   }
 

--- a/packages/firebase_dynamic_links/lib/src/firebase_dynamic_links.dart
+++ b/packages/firebase_dynamic_links/lib/src/firebase_dynamic_links.dart
@@ -23,8 +23,8 @@ class FirebaseDynamicLinks {
   /// there is no pending dynamic link or any call to this method after the
   /// the first attempt.
   Future<PendingDynamicLinkData> retrieveDynamicLink() async {
-    final Map<dynamic, dynamic> linkData =
-        await channel.invokeMapMethod<dynamic, dynamic>('FirebaseDynamicLinks#retrieveDynamicLink');
+    final Map<String, dynamic> linkData =
+        await channel.invokeMapMethod<String, dynamic>('FirebaseDynamicLinks#retrieveDynamicLink');
 
     if (linkData == null) return null;
 

--- a/packages/firebase_dynamic_links/lib/src/firebase_dynamic_links.dart
+++ b/packages/firebase_dynamic_links/lib/src/firebase_dynamic_links.dart
@@ -24,10 +24,7 @@ class FirebaseDynamicLinks {
   /// the first attempt.
   Future<PendingDynamicLinkData> retrieveDynamicLink() async {
     final Map<dynamic, dynamic> linkData =
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        await channel.invokeMethod('FirebaseDynamicLinks#retrieveDynamicLink');
+        await channel.invokeMethod<Map<dynamic, dynamic>>('FirebaseDynamicLinks#retrieveDynamicLink');
 
     if (linkData == null) return null;
 

--- a/packages/firebase_dynamic_links/lib/src/firebase_dynamic_links.dart
+++ b/packages/firebase_dynamic_links/lib/src/firebase_dynamic_links.dart
@@ -24,7 +24,8 @@ class FirebaseDynamicLinks {
   /// the first attempt.
   Future<PendingDynamicLinkData> retrieveDynamicLink() async {
     final Map<String, dynamic> linkData =
-        await channel.invokeMapMethod<String, dynamic>('FirebaseDynamicLinks#retrieveDynamicLink');
+        await channel.invokeMapMethod<String, dynamic>(
+            'FirebaseDynamicLinks#retrieveDynamicLink');
 
     if (linkData == null) return null;
 

--- a/packages/firebase_dynamic_links/lib/src/firebase_dynamic_links.dart
+++ b/packages/firebase_dynamic_links/lib/src/firebase_dynamic_links.dart
@@ -24,7 +24,7 @@ class FirebaseDynamicLinks {
   /// the first attempt.
   Future<PendingDynamicLinkData> retrieveDynamicLink() async {
     final Map<dynamic, dynamic> linkData =
-        await channel.invokeMethod<Map<dynamic, dynamic>>('FirebaseDynamicLinks#retrieveDynamicLink');
+        await channel.invokeMapMethod<dynamic, dynamic>('FirebaseDynamicLinks#retrieveDynamicLink');
 
     if (linkData == null) return null;
 

--- a/packages/firebase_dynamic_links/pubspec.yaml
+++ b/packages/firebase_dynamic_links/pubspec.yaml
@@ -24,4 +24,4 @@ flutter:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.2.4 <2.0.0"
+  flutter: ">=1.2.0 <2.0.0"

--- a/packages/firebase_dynamic_links/pubspec.yaml
+++ b/packages/firebase_dynamic_links/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_dynamic_links
 description: Flutter plugin for Google Dynamic Links for Firebase, an app solution for creating
   and handling links across multiple platforms.
-version: 0.2.0+4
+version: 0.2.0+5
 
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_dynamic_links

--- a/packages/firebase_messaging/CHANGELOG.md
+++ b/packages/firebase_messaging/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.0.1
+
+* Bump the minimum flutter version to 1.2.0.
+* Add Template type parameter to `invokeMethod` calls.
+
 ## 4.0.0+1
 
 * Log messages about automatic configuration of the default app are now less confusing.

--- a/packages/firebase_messaging/lib/firebase_messaging.dart
+++ b/packages/firebase_messaging/lib/firebase_messaging.dart
@@ -42,10 +42,8 @@ class FirebaseMessaging {
     if (!_platform.isIOS) {
       return;
     }
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    _channel.invokeMethod(
+
+    _channel.invokeMethod<void>(
         'requestNotificationPermissions', iosSettings.toMap());
   }
 
@@ -69,10 +67,7 @@ class FirebaseMessaging {
     _onLaunch = onLaunch;
     _onResume = onResume;
     _channel.setMethodCallHandler(_handleMethod);
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    _channel.invokeMethod('configure');
+    _channel.invokeMethod<void>('configure');
   }
 
   final StreamController<String> _tokenStreamController =
@@ -85,10 +80,7 @@ class FirebaseMessaging {
 
   /// Returns the FCM token.
   Future<String> getToken() async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return await _channel.invokeMethod('getToken');
+    return await _channel.invokeMethod<String>('getToken');
   }
 
   /// Subscribe to topic in background.
@@ -96,18 +88,12 @@ class FirebaseMessaging {
   /// [topic] must match the following regular expression:
   /// "[a-zA-Z0-9-_.~%]{1,900}".
   void subscribeToTopic(String topic) {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    _channel.invokeMethod('subscribeToTopic', topic);
+    _channel.invokeMethod<void>('subscribeToTopic', topic);
   }
 
   /// Unsubscribe from topic in background.
   void unsubscribeFromTopic(String topic) {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    _channel.invokeMethod('unsubscribeFromTopic', topic);
+    _channel.invokeMethod<void>('unsubscribeFromTopic', topic);
   }
 
   /// Resets Instance ID and revokes all tokens. In iOS, it also unregisters from remote notifications.
@@ -116,26 +102,17 @@ class FirebaseMessaging {
   ///
   /// returns true if the operations executed successfully and false if an error ocurred
   Future<bool> deleteInstanceID() async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return await _channel.invokeMethod('deleteInstanceID');
+    return await _channel.invokeMethod<bool>('deleteInstanceID');
   }
 
   /// Determine whether FCM auto-initialization is enabled or disabled.
   Future<bool> autoInitEnabled() async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return await _channel.invokeMethod('autoInitEnabled');
+    return await _channel.invokeMethod<bool>('autoInitEnabled');
   }
 
   /// Enable or disable auto-initialization of Firebase Cloud Messaging.
   Future<void> setAutoInitEnabled(bool enabled) async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    await _channel.invokeMethod('setAutoInitEnabled', enabled);
+    await _channel.invokeMethod<void>('setAutoInitEnabled', enabled);
   }
 
   Future<dynamic> _handleMethod(MethodCall call) async {

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -26,4 +26,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.1.4 <2.0.0"
+  flutter: ">=1.2.0 <2.0.0"

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Cloud Messaging, a cross-platform
   messaging solution that lets you reliably deliver messages on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_messaging
-version: 4.0.0+1
+version: 4.0.1
 
 flutter:
   plugin:

--- a/packages/firebase_messaging/test/firebase_messaging_test.dart
+++ b/packages/firebase_messaging/test/firebase_messaging_test.dart
@@ -22,20 +22,14 @@ void main() {
 
   test('requestNotificationPermissions on ios with default permissions', () {
     firebaseMessaging.requestNotificationPermissions();
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    verify(mockChannel.invokeMethod('requestNotificationPermissions',
+    verify(mockChannel.invokeMethod<dynamic>('requestNotificationPermissions',
         <String, bool>{'sound': true, 'badge': true, 'alert': true}));
   });
 
   test('requestNotificationPermissions on ios with custom permissions', () {
     firebaseMessaging.requestNotificationPermissions(
         const IosNotificationSettings(sound: false));
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    verify(mockChannel.invokeMethod('requestNotificationPermissions',
+    verify(mockChannel.invokeMethod<dynamic>('requestNotificationPermissions',
         <String, bool>{'sound': false, 'badge': true, 'alert': true}));
   });
 
@@ -58,10 +52,7 @@ void main() {
   test('configure', () {
     firebaseMessaging.configure();
     verify(mockChannel.setMethodCallHandler(any));
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    verify(mockChannel.invokeMethod('configure'));
+    verify(mockChannel.invokeMethod<dynamic>('configure'));
   });
 
   test('incoming token', () async {
@@ -134,42 +125,27 @@ void main() {
 
   test('subscribe to topic', () {
     firebaseMessaging.subscribeToTopic(myTopic);
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    verify(mockChannel.invokeMethod('subscribeToTopic', myTopic));
+    verify(mockChannel.invokeMethod<dynamic>('subscribeToTopic', myTopic));
   });
 
   test('unsubscribe from topic', () {
     firebaseMessaging.unsubscribeFromTopic(myTopic);
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    verify(mockChannel.invokeMethod('unsubscribeFromTopic', myTopic));
+    verify(mockChannel.invokeMethod<dynamic>('unsubscribeFromTopic', myTopic));
   });
 
   test('getToken', () {
     firebaseMessaging.getToken();
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    verify(mockChannel.invokeMethod('getToken'));
+    verify(mockChannel.invokeMethod<dynamic>('getToken'));
   });
 
   test('deleteInstanceID', () {
     firebaseMessaging.deleteInstanceID();
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    verify(mockChannel.invokeMethod('deleteInstanceID'));
+    verify(mockChannel.invokeMethod<dynamic>('deleteInstanceID'));
   });
 
   test('autoInitEnabled', () {
     firebaseMessaging.autoInitEnabled();
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    verify(mockChannel.invokeMethod('autoInitEnabled'));
+    verify(mockChannel.invokeMethod<dynamic>('autoInitEnabled'));
   });
 
   test('setAutoInitEnabled', () {
@@ -179,10 +155,7 @@ void main() {
     firebaseMessaging.setAutoInitEnabled(true);
 
     // assert we called the method with enabled = true
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    verify(mockChannel.invokeMethod('setAutoInitEnabled', true));
+    verify(mockChannel.invokeMethod<dynamic>('setAutoInitEnabled', true));
 
     // assert that enabled = false was not yet called
     verifyNever(firebaseMessaging.setAutoInitEnabled(false));
@@ -190,10 +163,7 @@ void main() {
     firebaseMessaging.setAutoInitEnabled(false);
 
     // assert call with enabled = false was properly done
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    verify(mockChannel.invokeMethod('setAutoInitEnabled', false));
+    verify(mockChannel.invokeMethod<dynamic>('setAutoInitEnabled', false));
   });
 }
 

--- a/packages/firebase_ml_vision/CHANGELOG.md
+++ b/packages/firebase_ml_vision/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.0+3
+
+* Bump the minimum flutter version to 1.2.0.
+* Add Template type parameter to `invokeMethod` calls.
+
 ## 0.6.0+2
 
 * Update README.md

--- a/packages/firebase_ml_vision/lib/src/barcode_detector.dart
+++ b/packages/firebase_ml_vision/lib/src/barcode_detector.dart
@@ -190,7 +190,8 @@ class BarcodeDetector {
 
   /// Detects barcodes in the input image.
   Future<List<Barcode>> detectInImage(FirebaseVisionImage visionImage) async {
-    final List<Map<String, dynamic>> reply = await FirebaseVision.channel.invokeListMethod<Map<String, dynamic>>(
+    final List<Map<String, dynamic>> reply =
+        await FirebaseVision.channel.invokeListMethod<Map<String, dynamic>>(
       'BarcodeDetector#detectInImage',
       <String, dynamic>{
         'options': <String, dynamic>{
@@ -226,7 +227,7 @@ class BarcodeDetectorOptions {
 
 /// Represents a single recognized barcode and its value.
 class Barcode {
-  Barcode._(Map<String, dynamic>_data)
+  Barcode._(Map<String, dynamic> _data)
       : boundingBox = _data['left'] != null
             ? Rect.fromLTWH(
                 _data['left'],

--- a/packages/firebase_ml_vision/lib/src/barcode_detector.dart
+++ b/packages/firebase_ml_vision/lib/src/barcode_detector.dart
@@ -190,7 +190,7 @@ class BarcodeDetector {
 
   /// Detects barcodes in the input image.
   Future<List<Barcode>> detectInImage(FirebaseVisionImage visionImage) async {
-    final List<dynamic> reply = await FirebaseVision.channel.invokeMethod<List<dynamic>>(
+    final List<dynamic> reply = await FirebaseVision.channel.invokeListMethod<dynamic>(
       'BarcodeDetector#detectInImage',
       <String, dynamic>{
         'options': <String, dynamic>{

--- a/packages/firebase_ml_vision/lib/src/barcode_detector.dart
+++ b/packages/firebase_ml_vision/lib/src/barcode_detector.dart
@@ -190,7 +190,7 @@ class BarcodeDetector {
 
   /// Detects barcodes in the input image.
   Future<List<Barcode>> detectInImage(FirebaseVisionImage visionImage) async {
-    final List<dynamic> reply = await FirebaseVision.channel.invokeListMethod<dynamic>(
+    final List<Map<String, dynamic>> reply = await FirebaseVision.channel.invokeListMethod<Map<String, dynamic>>(
       'BarcodeDetector#detectInImage',
       <String, dynamic>{
         'options': <String, dynamic>{
@@ -200,7 +200,7 @@ class BarcodeDetector {
     );
 
     final List<Barcode> barcodes = <Barcode>[];
-    reply.forEach((dynamic barcode) {
+    reply.forEach((Map<String, dynamic> barcode) {
       barcodes.add(Barcode._(barcode));
     });
 
@@ -226,7 +226,7 @@ class BarcodeDetectorOptions {
 
 /// Represents a single recognized barcode and its value.
 class Barcode {
-  Barcode._(Map<dynamic, dynamic> _data)
+  Barcode._(Map<String, dynamic>_data)
       : boundingBox = _data['left'] != null
             ? Rect.fromLTWH(
                 _data['left'],

--- a/packages/firebase_ml_vision/lib/src/barcode_detector.dart
+++ b/packages/firebase_ml_vision/lib/src/barcode_detector.dart
@@ -190,10 +190,7 @@ class BarcodeDetector {
 
   /// Detects barcodes in the input image.
   Future<List<Barcode>> detectInImage(FirebaseVisionImage visionImage) async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    final List<dynamic> reply = await FirebaseVision.channel.invokeMethod(
+    final List<dynamic> reply = await FirebaseVision.channel.invokeMethod<List<dynamic>>(
       'BarcodeDetector#detectInImage',
       <String, dynamic>{
         'options': <String, dynamic>{

--- a/packages/firebase_ml_vision/lib/src/face_detector.dart
+++ b/packages/firebase_ml_vision/lib/src/face_detector.dart
@@ -45,7 +45,7 @@ class FaceDetector {
 
   /// Detects faces in the input image.
   Future<List<Face>> processImage(FirebaseVisionImage visionImage) async {
-    final List<dynamic> reply = await FirebaseVision.channel.invokeListMethod<dynamic>(
+    final List<Map<String, dynamic>> reply = await FirebaseVision.channel.invokeListMethod<Map<String, dynamic>>(
       'FaceDetector#processImage',
       <String, dynamic>{
         'options': <String, dynamic>{
@@ -59,7 +59,7 @@ class FaceDetector {
     );
 
     final List<Face> faces = <Face>[];
-    for (dynamic data in reply) {
+    for (Map<String, dynamic> data in reply) {
       faces.add(Face._(data));
     }
 
@@ -111,7 +111,7 @@ class FaceDetectorOptions {
 
 /// Represents a face detected by [FaceDetector].
 class Face {
-  Face._(dynamic data)
+  Face._(Map<String, dynamic> data)
       : boundingBox = Rect.fromLTWH(
           data['left'],
           data['top'],

--- a/packages/firebase_ml_vision/lib/src/face_detector.dart
+++ b/packages/firebase_ml_vision/lib/src/face_detector.dart
@@ -45,7 +45,8 @@ class FaceDetector {
 
   /// Detects faces in the input image.
   Future<List<Face>> processImage(FirebaseVisionImage visionImage) async {
-    final List<Map<String, dynamic>> reply = await FirebaseVision.channel.invokeListMethod<Map<String, dynamic>>(
+    final List<Map<String, dynamic>> reply =
+        await FirebaseVision.channel.invokeListMethod<Map<String, dynamic>>(
       'FaceDetector#processImage',
       <String, dynamic>{
         'options': <String, dynamic>{

--- a/packages/firebase_ml_vision/lib/src/face_detector.dart
+++ b/packages/firebase_ml_vision/lib/src/face_detector.dart
@@ -45,10 +45,7 @@ class FaceDetector {
 
   /// Detects faces in the input image.
   Future<List<Face>> processImage(FirebaseVisionImage visionImage) async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    final List<dynamic> reply = await FirebaseVision.channel.invokeMethod(
+    final List<dynamic> reply = await FirebaseVision.channel.invokeMethod<List<dynamic>>(
       'FaceDetector#processImage',
       <String, dynamic>{
         'options': <String, dynamic>{

--- a/packages/firebase_ml_vision/lib/src/face_detector.dart
+++ b/packages/firebase_ml_vision/lib/src/face_detector.dart
@@ -45,7 +45,7 @@ class FaceDetector {
 
   /// Detects faces in the input image.
   Future<List<Face>> processImage(FirebaseVisionImage visionImage) async {
-    final List<dynamic> reply = await FirebaseVision.channel.invokeMethod<List<dynamic>>(
+    final List<dynamic> reply = await FirebaseVision.channel.invokeListMethod<dynamic>(
       'FaceDetector#processImage',
       <String, dynamic>{
         'options': <String, dynamic>{

--- a/packages/firebase_ml_vision/lib/src/label_detector.dart
+++ b/packages/firebase_ml_vision/lib/src/label_detector.dart
@@ -34,7 +34,8 @@ class LabelDetector {
 
   /// Detects entities in the input image.
   Future<List<Label>> detectInImage(FirebaseVisionImage visionImage) async {
-    final List<Map<String, dynamic>> reply = await FirebaseVision.channel.invokeListMethod<Map<String, dynamic>>(
+    final List<Map<String, dynamic>> reply =
+        await FirebaseVision.channel.invokeListMethod<Map<String, dynamic>>(
       'LabelDetector#detectInImage',
       <String, dynamic>{
         'options': <String, dynamic>{
@@ -82,7 +83,8 @@ class CloudLabelDetector {
 
   /// Detects entities in the input image.
   Future<List<Label>> detectInImage(FirebaseVisionImage visionImage) async {
-    final List<Map<String, dynamic>> reply = await FirebaseVision.channel.invokeListMethod<Map<String, dynamic>>(
+    final List<Map<String, dynamic>> reply =
+        await FirebaseVision.channel.invokeListMethod<Map<String, dynamic>>(
       'CloudLabelDetector#detectInImage',
       <String, dynamic>{
         'options': options._serialize(),

--- a/packages/firebase_ml_vision/lib/src/label_detector.dart
+++ b/packages/firebase_ml_vision/lib/src/label_detector.dart
@@ -34,7 +34,7 @@ class LabelDetector {
 
   /// Detects entities in the input image.
   Future<List<Label>> detectInImage(FirebaseVisionImage visionImage) async {
-    final List<dynamic> reply = await FirebaseVision.channel.invokeMethod<List<dynamic>>(
+    final List<dynamic> reply = await FirebaseVision.channel.invokeListMethod<dynamic>(
       'LabelDetector#detectInImage',
       <String, dynamic>{
         'options': <String, dynamic>{
@@ -82,7 +82,7 @@ class CloudLabelDetector {
 
   /// Detects entities in the input image.
   Future<List<Label>> detectInImage(FirebaseVisionImage visionImage) async {
-    final List<dynamic> reply = await FirebaseVision.channel.invokeMethod<List<dynamic>>(
+    final List<dynamic> reply = await FirebaseVision.channel.invokeListMethod<dynamic>(
       'CloudLabelDetector#detectInImage',
       <String, dynamic>{
         'options': options._serialize(),

--- a/packages/firebase_ml_vision/lib/src/label_detector.dart
+++ b/packages/firebase_ml_vision/lib/src/label_detector.dart
@@ -34,7 +34,7 @@ class LabelDetector {
 
   /// Detects entities in the input image.
   Future<List<Label>> detectInImage(FirebaseVisionImage visionImage) async {
-    final List<dynamic> reply = await FirebaseVision.channel.invokeListMethod<dynamic>(
+    final List<Map<String, dynamic>> reply = await FirebaseVision.channel.invokeListMethod<Map<String, dynamic>>(
       'LabelDetector#detectInImage',
       <String, dynamic>{
         'options': <String, dynamic>{
@@ -44,7 +44,7 @@ class LabelDetector {
     );
 
     final List<Label> labels = <Label>[];
-    for (dynamic data in reply) {
+    for (Map<String, dynamic> data in reply) {
       labels.add(Label._(data));
     }
 
@@ -82,7 +82,7 @@ class CloudLabelDetector {
 
   /// Detects entities in the input image.
   Future<List<Label>> detectInImage(FirebaseVisionImage visionImage) async {
-    final List<dynamic> reply = await FirebaseVision.channel.invokeListMethod<dynamic>(
+    final List<Map<String, dynamic>> reply = await FirebaseVision.channel.invokeListMethod<Map<String, dynamic>>(
       'CloudLabelDetector#detectInImage',
       <String, dynamic>{
         'options': options._serialize(),
@@ -90,7 +90,7 @@ class CloudLabelDetector {
     );
 
     final List<Label> labels = <Label>[];
-    for (dynamic data in reply) {
+    for (Map<String, dynamic> data in reply) {
       labels.add(Label._(data));
     }
 
@@ -121,7 +121,7 @@ class LabelDetectorOptions {
 
 /// Represents an entity label detected by [LabelDetector].
 class Label {
-  Label._(dynamic data)
+  Label._(Map<String, dynamic> data)
       : confidence = data['confidence'],
         entityId = data['entityId'],
         label = data['label'];

--- a/packages/firebase_ml_vision/lib/src/label_detector.dart
+++ b/packages/firebase_ml_vision/lib/src/label_detector.dart
@@ -34,10 +34,7 @@ class LabelDetector {
 
   /// Detects entities in the input image.
   Future<List<Label>> detectInImage(FirebaseVisionImage visionImage) async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    final List<dynamic> reply = await FirebaseVision.channel.invokeMethod(
+    final List<dynamic> reply = await FirebaseVision.channel.invokeMethod<List<dynamic>>(
       'LabelDetector#detectInImage',
       <String, dynamic>{
         'options': <String, dynamic>{
@@ -85,10 +82,7 @@ class CloudLabelDetector {
 
   /// Detects entities in the input image.
   Future<List<Label>> detectInImage(FirebaseVisionImage visionImage) async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    final List<dynamic> reply = await FirebaseVision.channel.invokeMethod(
+    final List<dynamic> reply = await FirebaseVision.channel.invokeMethod<List<dynamic>>(
       'CloudLabelDetector#detectInImage',
       <String, dynamic>{
         'options': options._serialize(),

--- a/packages/firebase_ml_vision/lib/src/text_recognizer.dart
+++ b/packages/firebase_ml_vision/lib/src/text_recognizer.dart
@@ -23,8 +23,8 @@ class TextRecognizer {
 
   /// Detects [VisionText] from a [FirebaseVisionImage].
   Future<VisionText> processImage(FirebaseVisionImage visionImage) async {
-    final Map<dynamic, dynamic> reply =
-        await FirebaseVision.channel.invokeMapMethod<dynamic, dynamic>(
+    final Map<String, dynamic> reply =
+        await FirebaseVision.channel.invokeMapMethod<String, dynamic>(
       'TextRecognizer#processImage',
       <String, dynamic>{
         'options': <String, dynamic>{},

--- a/packages/firebase_ml_vision/lib/src/text_recognizer.dart
+++ b/packages/firebase_ml_vision/lib/src/text_recognizer.dart
@@ -24,10 +24,7 @@ class TextRecognizer {
   /// Detects [VisionText] from a [FirebaseVisionImage].
   Future<VisionText> processImage(FirebaseVisionImage visionImage) async {
     final Map<dynamic, dynamic> reply =
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        await FirebaseVision.channel.invokeMethod(
+        await FirebaseVision.channel.invokeMethod<Map<dynamic, dynamic>>(
       'TextRecognizer#processImage',
       <String, dynamic>{
         'options': <String, dynamic>{},

--- a/packages/firebase_ml_vision/lib/src/text_recognizer.dart
+++ b/packages/firebase_ml_vision/lib/src/text_recognizer.dart
@@ -24,7 +24,7 @@ class TextRecognizer {
   /// Detects [VisionText] from a [FirebaseVisionImage].
   Future<VisionText> processImage(FirebaseVisionImage visionImage) async {
     final Map<dynamic, dynamic> reply =
-        await FirebaseVision.channel.invokeMethod<Map<dynamic, dynamic>>(
+        await FirebaseVision.channel.invokeMapMethod<dynamic, dynamic>(
       'TextRecognizer#processImage',
       <String, dynamic>{
         'options': <String, dynamic>{},

--- a/packages/firebase_ml_vision/pubspec.yaml
+++ b/packages/firebase_ml_vision/pubspec.yaml
@@ -22,4 +22,4 @@ flutter:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.2.4 <2.0.0"
+  flutter: ">=1.2.0 <2.0.0"

--- a/packages/firebase_ml_vision/pubspec.yaml
+++ b/packages/firebase_ml_vision/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_ml_vision
 description: Flutter plugin for Firebase machine learning vision services.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_ml_vision
-version: 0.6.0+2
+version: 0.6.0+3
 
 dependencies:
   flutter:

--- a/packages/firebase_performance/CHANGELOG.md
+++ b/packages/firebase_performance/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.0+5
+
+* Bump the minimum flutter version to 1.2.0.
+* Add Template type parameter to `invokeMethod` calls.
+
 ## 0.1.0+4
 
 * Remove deprecated methods for iOS.

--- a/packages/firebase_performance/lib/src/firebase_performance.dart
+++ b/packages/firebase_performance/lib/src/firebase_performance.dart
@@ -30,10 +30,7 @@ class FirebasePerformance {
   /// does not reflect whether instrumentation is enabled/disabled.
   Future<bool> isPerformanceCollectionEnabled() async {
     final bool isEnabled = await channel
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        .invokeMethod('FirebasePerformance#isPerformanceCollectionEnabled');
+        .invokeMethod<bool>('FirebasePerformance#isPerformanceCollectionEnabled');
     return isEnabled;
   }
 
@@ -42,10 +39,7 @@ class FirebasePerformance {
   /// This setting is persisted and applied on future invocations of your
   /// application. By default, performance monitoring is enabled.
   Future<void> setPerformanceCollectionEnabled(bool enable) async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    await channel.invokeMethod(
+    await channel.invokeMethod<void>(
         'FirebasePerformance#setPerformanceCollectionEnabled', enable);
   }
 

--- a/packages/firebase_performance/lib/src/firebase_performance.dart
+++ b/packages/firebase_performance/lib/src/firebase_performance.dart
@@ -29,8 +29,8 @@ class FirebasePerformance {
   /// monitoring is disabled. This is for dynamic enable/disable state. This
   /// does not reflect whether instrumentation is enabled/disabled.
   Future<bool> isPerformanceCollectionEnabled() async {
-    final bool isEnabled = await channel
-        .invokeMethod<bool>('FirebasePerformance#isPerformanceCollectionEnabled');
+    final bool isEnabled = await channel.invokeMethod<bool>(
+        'FirebasePerformance#isPerformanceCollectionEnabled');
     return isEnabled;
   }
 

--- a/packages/firebase_performance/lib/src/http_metric.dart
+++ b/packages/firebase_performance/lib/src/http_metric.dart
@@ -48,10 +48,7 @@ class HttpMetric extends PerformanceAttributes {
 
     _hasStarted = true;
     return FirebasePerformance.channel
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        .invokeMethod('HttpMetric#start', <String, dynamic>{
+        .invokeMethod<void>('HttpMetric#start', <String, dynamic>{
       'handle': _handle,
       'url': _url,
       'httpMethod': _httpMethod.index,
@@ -79,10 +76,7 @@ class HttpMetric extends PerformanceAttributes {
     };
 
     _hasStopped = true;
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return FirebasePerformance.channel.invokeMethod('HttpMetric#stop', data);
+    return FirebasePerformance.channel.invokeMethod<void>('HttpMetric#stop', data);
   }
 
   /// Sets a String [value] for the specified [attribute].

--- a/packages/firebase_performance/lib/src/http_metric.dart
+++ b/packages/firebase_performance/lib/src/http_metric.dart
@@ -76,7 +76,8 @@ class HttpMetric extends PerformanceAttributes {
     };
 
     _hasStopped = true;
-    return FirebasePerformance.channel.invokeMethod<void>('HttpMetric#stop', data);
+    return FirebasePerformance.channel
+        .invokeMethod<void>('HttpMetric#stop', data);
   }
 
   /// Sets a String [value] for the specified [attribute].

--- a/packages/firebase_performance/lib/src/trace.dart
+++ b/packages/firebase_performance/lib/src/trace.dart
@@ -48,10 +48,7 @@ class Trace extends PerformanceAttributes {
 
     _hasStarted = true;
     return FirebasePerformance.channel
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        .invokeMethod('Trace#start', <String, dynamic>{
+        .invokeMethod<void>('Trace#start', <String, dynamic>{
       'handle': _handle,
       'name': _name,
     });
@@ -76,10 +73,7 @@ class Trace extends PerformanceAttributes {
     };
 
     _hasStopped = true;
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return FirebasePerformance.channel.invokeMethod('Trace#stop', data);
+    return FirebasePerformance.channel.invokeMethod<void>('Trace#stop', data);
   }
 
   /// Increments the counter with the given [name] by [incrementBy].

--- a/packages/firebase_performance/pubspec.yaml
+++ b/packages/firebase_performance/pubspec.yaml
@@ -24,4 +24,4 @@ flutter:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.2.4 <2.0.0"
+  flutter: ">=1.2.0 <2.0.0"

--- a/packages/firebase_performance/pubspec.yaml
+++ b/packages/firebase_performance/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Google Performance Monitoring for Firebase, an a
   iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_performance
-version: 0.1.0+4
+version: 0.1.0+5
 
 dependencies:
   flutter:

--- a/packages/firebase_remote_config/CHANGELOG.md
+++ b/packages/firebase_remote_config/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.0+3
+
+* Bump the minimum flutter version to 1.2.0.
+* Add Template type parameter to `invokeMethod` calls.
+
 ## 0.1.0+2
 
 * Log messages about automatic configuration of the default app are now less confusing.

--- a/packages/firebase_remote_config/lib/src/remote_config.dart
+++ b/packages/firebase_remote_config/lib/src/remote_config.dart
@@ -36,7 +36,7 @@ class RemoteConfig extends ChangeNotifier {
 
   static void _getRemoteConfigInstance() async {
     final Map<dynamic, dynamic> properties =
-        await channel.invokeMethod<Map<dynamic, dynamic> >('RemoteConfig#instance');
+        await channel.invokeMapMethod<dynamic, dynamic>('RemoteConfig#instance');
 
     final RemoteConfig instance = RemoteConfig();
 
@@ -113,7 +113,7 @@ class RemoteConfig extends ChangeNotifier {
   /// Expiration must be defined in seconds.
   Future<void> fetch({Duration expiration = const Duration(hours: 12)}) async {
     try {
-      final Map<dynamic, dynamic> properties = await channel.invokeMethod<Map<dynamic, dynamic>>(
+      final Map<dynamic, dynamic> properties = await channel.invokeMapMethod<dynamic, dynamic>(
           'RemoteConfig#fetch',
           <dynamic, dynamic>{'expiration': expiration.inSeconds});
       _lastFetchTime =
@@ -138,7 +138,7 @@ class RemoteConfig extends ChangeNotifier {
   /// from the currently activated config, it contains false otherwise.
   Future<bool> activateFetched() async {
     final Map<dynamic, dynamic> properties =
-        await channel.invokeMethod<Map<dynamic, dynamic>>('RemoteConfig#activate');
+        await channel.invokeMapMethod<dynamic, dynamic>('RemoteConfig#activate');
     final Map<dynamic, dynamic> rawParameters = properties['parameters'];
     final bool newConfig = properties['newConfig'];
     final Map<String, RemoteConfigValue> fetchedParameters =

--- a/packages/firebase_remote_config/lib/src/remote_config.dart
+++ b/packages/firebase_remote_config/lib/src/remote_config.dart
@@ -36,10 +36,7 @@ class RemoteConfig extends ChangeNotifier {
 
   static void _getRemoteConfigInstance() async {
     final Map<dynamic, dynamic> properties =
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        await channel.invokeMethod('RemoteConfig#instance');
+        await channel.invokeMethod<Map<dynamic, dynamic> >('RemoteConfig#instance');
 
     final RemoteConfig instance = RemoteConfig();
 
@@ -102,10 +99,7 @@ class RemoteConfig extends ChangeNotifier {
   Future<void> setConfigSettings(
       RemoteConfigSettings remoteConfigSettings) async {
     await channel
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        .invokeMethod('RemoteConfig#setConfigSettings', <String, dynamic>{
+        .invokeMethod<void>('RemoteConfig#setConfigSettings', <String, dynamic>{
       'debugMode': remoteConfigSettings.debugMode,
     });
     _remoteConfigSettings = remoteConfigSettings;
@@ -119,10 +113,7 @@ class RemoteConfig extends ChangeNotifier {
   /// Expiration must be defined in seconds.
   Future<void> fetch({Duration expiration = const Duration(hours: 12)}) async {
     try {
-      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-      // https://github.com/flutter/flutter/issues/26431
-      // ignore: strong_mode_implicit_dynamic_method
-      final Map<dynamic, dynamic> properties = await channel.invokeMethod(
+      final Map<dynamic, dynamic> properties = await channel.invokeMethod<Map<dynamic, dynamic>>(
           'RemoteConfig#fetch',
           <dynamic, dynamic>{'expiration': expiration.inSeconds});
       _lastFetchTime =
@@ -147,10 +138,7 @@ class RemoteConfig extends ChangeNotifier {
   /// from the currently activated config, it contains false otherwise.
   Future<bool> activateFetched() async {
     final Map<dynamic, dynamic> properties =
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        await channel.invokeMethod('RemoteConfig#activate');
+        await channel.invokeMethod<Map<dynamic, dynamic>>('RemoteConfig#activate');
     final Map<dynamic, dynamic> rawParameters = properties['parameters'];
     final bool newConfig = properties['newConfig'];
     final Map<String, RemoteConfigValue> fetchedParameters =
@@ -176,10 +164,7 @@ class RemoteConfig extends ChangeNotifier {
         _parameters[key] = remoteConfigValue;
       }
     });
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    await channel.invokeMethod(
+    await channel.invokeMethod<void>(
         'RemoteConfig#setDefaults', <String, dynamic>{'defaults': defaults});
   }
 

--- a/packages/firebase_remote_config/lib/src/remote_config.dart
+++ b/packages/firebase_remote_config/lib/src/remote_config.dart
@@ -113,9 +113,9 @@ class RemoteConfig extends ChangeNotifier {
   /// Expiration must be defined in seconds.
   Future<void> fetch({Duration expiration = const Duration(hours: 12)}) async {
     try {
-      final Map<String, dynamic> properties = await channel.invokeMapMethod<String, dynamic>(
-          'RemoteConfig#fetch',
-          <dynamic, dynamic>{'expiration': expiration.inSeconds});
+      final Map<String, dynamic> properties = await channel
+          .invokeMapMethod<String, dynamic>('RemoteConfig#fetch',
+              <dynamic, dynamic>{'expiration': expiration.inSeconds});
       _lastFetchTime =
           DateTime.fromMillisecondsSinceEpoch(properties['lastFetchTime']);
       _lastFetchStatus = _parseLastFetchStatus(properties['lastFetchStatus']);

--- a/packages/firebase_remote_config/lib/src/remote_config.dart
+++ b/packages/firebase_remote_config/lib/src/remote_config.dart
@@ -35,8 +35,8 @@ class RemoteConfig extends ChangeNotifier {
   }
 
   static void _getRemoteConfigInstance() async {
-    final Map<dynamic, dynamic> properties =
-        await channel.invokeMapMethod<dynamic, dynamic>('RemoteConfig#instance');
+    final Map<String, dynamic> properties =
+        await channel.invokeMapMethod<String, dynamic>('RemoteConfig#instance');
 
     final RemoteConfig instance = RemoteConfig();
 
@@ -113,7 +113,7 @@ class RemoteConfig extends ChangeNotifier {
   /// Expiration must be defined in seconds.
   Future<void> fetch({Duration expiration = const Duration(hours: 12)}) async {
     try {
-      final Map<dynamic, dynamic> properties = await channel.invokeMapMethod<dynamic, dynamic>(
+      final Map<String, dynamic> properties = await channel.invokeMapMethod<String, dynamic>(
           'RemoteConfig#fetch',
           <dynamic, dynamic>{'expiration': expiration.inSeconds});
       _lastFetchTime =
@@ -137,8 +137,8 @@ class RemoteConfig extends ChangeNotifier {
   /// The returned Future completes true if the fetched config is different
   /// from the currently activated config, it contains false otherwise.
   Future<bool> activateFetched() async {
-    final Map<dynamic, dynamic> properties =
-        await channel.invokeMapMethod<dynamic, dynamic>('RemoteConfig#activate');
+    final Map<String, dynamic> properties =
+        await channel.invokeMapMethod<String, dynamic>('RemoteConfig#activate');
     final Map<dynamic, dynamic> rawParameters = properties['parameters'];
     final bool newConfig = properties['newConfig'];
     final Map<String, RemoteConfigValue> fetchedParameters =

--- a/packages/firebase_remote_config/pubspec.yaml
+++ b/packages/firebase_remote_config/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Remote Config. Update your application 
   re-releasing.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_remote_config
-version: 0.1.0+2
+version: 0.1.0+3
 
 dependencies:
   flutter:

--- a/packages/firebase_remote_config/pubspec.yaml
+++ b/packages/firebase_remote_config/pubspec.yaml
@@ -21,4 +21,4 @@ flutter:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.1.4 <2.0.0"
+  flutter: ">=1.2.0 <2.0.0"

--- a/packages/firebase_storage/CHANGELOG.md
+++ b/packages/firebase_storage/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.1
+
+* Bump the minimum flutter version to 1.2.0.
+* Add Template type parameter to `invokeMethod` calls.
+
 ## 2.1.0+1
 
 * Reverting error.code casting/formatting to what it was until version 2.0.1.

--- a/packages/firebase_storage/lib/src/firebase_storage.dart
+++ b/packages/firebase_storage/lib/src/firebase_storage.dart
@@ -58,10 +58,7 @@ class FirebaseStorage {
   StorageReference ref() => StorageReference._(const <String>[], this);
 
   Future<int> getMaxDownloadRetryTimeMillis() async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return await channel.invokeMethod(
+    return await channel.invokeMethod<int>(
         "FirebaseStorage#getMaxDownloadRetryTime", <String, dynamic>{
       'app': app?.name,
       'bucket': storageBucket,
@@ -69,10 +66,7 @@ class FirebaseStorage {
   }
 
   Future<int> getMaxUploadRetryTimeMillis() async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return await channel.invokeMethod(
+    return await channel.invokeMethod<int>(
         "FirebaseStorage#getMaxUploadRetryTime", <String, dynamic>{
       'app': app?.name,
       'bucket': storageBucket,
@@ -80,10 +74,7 @@ class FirebaseStorage {
   }
 
   Future<int> getMaxOperationRetryTimeMillis() async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return await channel.invokeMethod(
+    return await channel.invokeMethod<int>(
         "FirebaseStorage#getMaxOperationRetryTime", <String, dynamic>{
       'app': app?.name,
       'bucket': storageBucket,
@@ -91,10 +82,7 @@ class FirebaseStorage {
   }
 
   Future<void> setMaxDownloadRetryTimeMillis(int time) {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return channel.invokeMethod(
+    return channel.invokeMethod<void>(
         "FirebaseStorage#setMaxDownloadRetryTime", <String, dynamic>{
       'app': app?.name,
       'bucket': storageBucket,
@@ -103,10 +91,7 @@ class FirebaseStorage {
   }
 
   Future<void> setMaxUploadRetryTimeMillis(int time) {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return channel.invokeMethod(
+    return channel.invokeMethod<void>(
         "FirebaseStorage#setMaxUploadRetryTime", <String, dynamic>{
       'app': app?.name,
       'bucket': storageBucket,
@@ -115,10 +100,7 @@ class FirebaseStorage {
   }
 
   Future<void> setMaxOperationRetryTimeMillis(int time) {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return channel.invokeMethod(
+    return channel.invokeMethod<void>(
         "FirebaseStorage#setMaxOperationRetryTime", <String, dynamic>{
       'app': app?.name,
       'bucket': storageBucket,
@@ -152,10 +134,7 @@ class StorageFileDownloadTask {
   final File _file;
 
   Future<void> _start() async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    final int totalByteCount = await FirebaseStorage.channel.invokeMethod(
+    final int totalByteCount = await FirebaseStorage.channel.invokeMethod<void>(
       "StorageReference#writeToFile",
       <String, dynamic>{
         'app': _firebaseStorage.app?.name,

--- a/packages/firebase_storage/lib/src/firebase_storage.dart
+++ b/packages/firebase_storage/lib/src/firebase_storage.dart
@@ -134,7 +134,7 @@ class StorageFileDownloadTask {
   final File _file;
 
   Future<void> _start() async {
-    final int totalByteCount = await FirebaseStorage.channel.invokeMethod<void>(
+    final int totalByteCount = await FirebaseStorage.channel.invokeMethod<int>(
       "StorageReference#writeToFile",
       <String, dynamic>{
         'app': _firebaseStorage.app?.name,

--- a/packages/firebase_storage/lib/src/firebase_storage.dart
+++ b/packages/firebase_storage/lib/src/firebase_storage.dart
@@ -111,7 +111,7 @@ class FirebaseStorage {
   /// Creates a [StorageReference] given a gs:// or // URL pointing to a Firebase
   /// Storage location.
   Future<StorageReference> getReferenceFromUrl(String fullUrl) async {
-    final String path = await channel.invokeMethod(
+    final String path = await channel.invokeMethod<String>(
         "FirebaseStorage#getReferenceFromUrl", <String, dynamic>{
       'app': app?.name,
       'bucket': storageBucket,

--- a/packages/firebase_storage/lib/src/storage_metadata.dart
+++ b/packages/firebase_storage/lib/src/storage_metadata.dart
@@ -27,7 +27,7 @@ class StorageMetadata {
             ? null
             : Map<String, String>.unmodifiable(customMetadata);
 
-  StorageMetadata._fromMap(Map<dynamic, dynamic> map)
+  StorageMetadata._fromMap(Map<String, dynamic> map)
       : bucket = map['bucket'],
         generation = map['generation'],
         metadataGeneration = map['metadataGeneration'],

--- a/packages/firebase_storage/lib/src/storage_reference.dart
+++ b/packages/firebase_storage/lib/src/storage_reference.dart
@@ -152,7 +152,7 @@ class StorageReference {
   /// Retrieves metadata associated with an object at this [StorageReference].
   Future<StorageMetadata> getMetadata() async {
     return StorageMetadata._fromMap(await FirebaseStorage.channel
-        .invokeMethod<Map<dynamic, dynamic>>("StorageReference#getMetadata", <String, String>{
+        .invokeMapMethod<dynamic, dynamic>("StorageReference#getMetadata", <String, String>{
       'app': _firebaseStorage.app?.name,
       'bucket': _firebaseStorage.storageBucket,
       'path': _pathComponents.join("/"),
@@ -168,7 +168,7 @@ class StorageReference {
   /// by passing the empty string.
   Future<StorageMetadata> updateMetadata(StorageMetadata metadata) async {
     return StorageMetadata._fromMap(await FirebaseStorage.channel
-        .invokeMethod<Map<dynamic, dynamic>>("StorageReference#updateMetadata", <String, dynamic>{
+        .invokeMapMethod<dynamic, dynamic>("StorageReference#updateMetadata", <String, dynamic>{
       'app': _firebaseStorage.app?.name,
       'bucket': _firebaseStorage.storageBucket,
       'path': _pathComponents.join("/"),

--- a/packages/firebase_storage/lib/src/storage_reference.dart
+++ b/packages/firebase_storage/lib/src/storage_reference.dart
@@ -152,7 +152,7 @@ class StorageReference {
   /// Retrieves metadata associated with an object at this [StorageReference].
   Future<StorageMetadata> getMetadata() async {
     return StorageMetadata._fromMap(await FirebaseStorage.channel
-        .invokeMapMethod<dynamic, dynamic>("StorageReference#getMetadata", <String, String>{
+        .invokeMapMethod<String, dynamic>("StorageReference#getMetadata", <String, String>{
       'app': _firebaseStorage.app?.name,
       'bucket': _firebaseStorage.storageBucket,
       'path': _pathComponents.join("/"),
@@ -168,7 +168,7 @@ class StorageReference {
   /// by passing the empty string.
   Future<StorageMetadata> updateMetadata(StorageMetadata metadata) async {
     return StorageMetadata._fromMap(await FirebaseStorage.channel
-        .invokeMapMethod<dynamic, dynamic>("StorageReference#updateMetadata", <String, dynamic>{
+        .invokeMapMethod<String, dynamic>("StorageReference#updateMetadata", <String, dynamic>{
       'app': _firebaseStorage.app?.name,
       'bucket': _firebaseStorage.storageBucket,
       'path': _pathComponents.join("/"),

--- a/packages/firebase_storage/lib/src/storage_reference.dart
+++ b/packages/firebase_storage/lib/src/storage_reference.dart
@@ -132,8 +132,8 @@ class StorageReference {
   /// This can be used to share the file with others, but can be revoked by a
   /// developer in the Firebase Console if desired.
   Future<dynamic> getDownloadURL() async {
-    return await FirebaseStorage.channel
-        .invokeMethod<dynamic>("StorageReference#getDownloadUrl", <String, String>{
+    return await FirebaseStorage.channel.invokeMethod<dynamic>(
+        "StorageReference#getDownloadUrl", <String, String>{
       'app': _firebaseStorage.app?.name,
       'bucket': _firebaseStorage.storageBucket,
       'path': _pathComponents.join("/"),
@@ -152,7 +152,8 @@ class StorageReference {
   /// Retrieves metadata associated with an object at this [StorageReference].
   Future<StorageMetadata> getMetadata() async {
     return StorageMetadata._fromMap(await FirebaseStorage.channel
-        .invokeMapMethod<String, dynamic>("StorageReference#getMetadata", <String, String>{
+        .invokeMapMethod<String, dynamic>(
+            "StorageReference#getMetadata", <String, String>{
       'app': _firebaseStorage.app?.name,
       'bucket': _firebaseStorage.storageBucket,
       'path': _pathComponents.join("/"),
@@ -168,7 +169,8 @@ class StorageReference {
   /// by passing the empty string.
   Future<StorageMetadata> updateMetadata(StorageMetadata metadata) async {
     return StorageMetadata._fromMap(await FirebaseStorage.channel
-        .invokeMapMethod<String, dynamic>("StorageReference#updateMetadata", <String, dynamic>{
+        .invokeMapMethod<String, dynamic>(
+            "StorageReference#updateMetadata", <String, dynamic>{
       'app': _firebaseStorage.app?.name,
       'bucket': _firebaseStorage.storageBucket,
       'path': _pathComponents.join("/"),

--- a/packages/firebase_storage/lib/src/storage_reference.dart
+++ b/packages/firebase_storage/lib/src/storage_reference.dart
@@ -77,10 +77,7 @@ class StorageReference {
   /// Returns the Google Cloud Storage bucket that holds this object.
   Future<String> getBucket() async {
     return await FirebaseStorage.channel
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        .invokeMethod("StorageReference#getBucket", <String, String>{
+        .invokeMethod<String>("StorageReference#getBucket", <String, String>{
       'app': _firebaseStorage.app?.name,
       'bucket': _firebaseStorage.storageBucket,
       'path': _pathComponents.join("/"),
@@ -91,10 +88,7 @@ class StorageReference {
   /// Storage bucket.
   Future<String> getPath() async {
     return await FirebaseStorage.channel
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        .invokeMethod("StorageReference#getPath", <String, String>{
+        .invokeMethod<String>("StorageReference#getPath", <String, String>{
       'app': _firebaseStorage.app?.name,
       'bucket': _firebaseStorage.storageBucket,
       'path': _pathComponents.join("/"),
@@ -104,10 +98,7 @@ class StorageReference {
   /// Returns the short name of this object.
   Future<String> getName() async {
     return await FirebaseStorage.channel
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        .invokeMethod("StorageReference#getName", <String, String>{
+        .invokeMethod<String>("StorageReference#getName", <String, String>{
       'app': _firebaseStorage.app?.name,
       'bucket': _firebaseStorage.storageBucket,
       'path': _pathComponents.join("/"),
@@ -117,10 +108,7 @@ class StorageReference {
   /// Asynchronously downloads the object at the StorageReference to a list in memory.
   /// A list of the provided max size will be allocated.
   Future<Uint8List> getData(int maxSize) async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return await FirebaseStorage.channel.invokeMethod(
+    return await FirebaseStorage.channel.invokeMethod<Uint8List>(
       "StorageReference#getData",
       <String, dynamic>{
         'app': _firebaseStorage.app?.name,
@@ -145,10 +133,7 @@ class StorageReference {
   /// developer in the Firebase Console if desired.
   Future<dynamic> getDownloadURL() async {
     return await FirebaseStorage.channel
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        .invokeMethod("StorageReference#getDownloadUrl", <String, String>{
+        .invokeMethod<dynamic>("StorageReference#getDownloadUrl", <String, String>{
       'app': _firebaseStorage.app?.name,
       'bucket': _firebaseStorage.storageBucket,
       'path': _pathComponents.join("/"),
@@ -157,10 +142,7 @@ class StorageReference {
 
   Future<void> delete() {
     return FirebaseStorage.channel
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        .invokeMethod("StorageReference#delete", <String, String>{
+        .invokeMethod<void>("StorageReference#delete", <String, String>{
       'app': _firebaseStorage.app?.name,
       'bucket': _firebaseStorage.storageBucket,
       'path': _pathComponents.join("/")
@@ -170,10 +152,7 @@ class StorageReference {
   /// Retrieves metadata associated with an object at this [StorageReference].
   Future<StorageMetadata> getMetadata() async {
     return StorageMetadata._fromMap(await FirebaseStorage.channel
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        .invokeMethod("StorageReference#getMetadata", <String, String>{
+        .invokeMethod<Map<dynamic, dynamic>>("StorageReference#getMetadata", <String, String>{
       'app': _firebaseStorage.app?.name,
       'bucket': _firebaseStorage.storageBucket,
       'path': _pathComponents.join("/"),
@@ -189,10 +168,7 @@ class StorageReference {
   /// by passing the empty string.
   Future<StorageMetadata> updateMetadata(StorageMetadata metadata) async {
     return StorageMetadata._fromMap(await FirebaseStorage.channel
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        .invokeMethod("StorageReference#updateMetadata", <String, dynamic>{
+        .invokeMethod<Map<dynamic, dynamic>>("StorageReference#updateMetadata", <String, dynamic>{
       'app': _firebaseStorage.app?.name,
       'bucket': _firebaseStorage.storageBucket,
       'path': _pathComponents.join("/"),

--- a/packages/firebase_storage/lib/src/upload_task.dart
+++ b/packages/firebase_storage/lib/src/upload_task.dart
@@ -89,10 +89,7 @@ abstract class StorageUploadTask {
   }
 
   /// Pause the upload
-  // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-  // https://github.com/flutter/flutter/issues/26431
-  // ignore: strong_mode_implicit_dynamic_method
-  void pause() => FirebaseStorage.channel.invokeMethod(
+  void pause() => FirebaseStorage.channel.invokeMethod<void>(
         'UploadTask#pause',
         <String, dynamic>{
           'app': _firebaseStorage.app?.name,
@@ -102,10 +99,7 @@ abstract class StorageUploadTask {
       );
 
   /// Resume the upload
-  // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-  // https://github.com/flutter/flutter/issues/26431
-  // ignore: strong_mode_implicit_dynamic_method
-  void resume() => FirebaseStorage.channel.invokeMethod(
+  void resume() => FirebaseStorage.channel.invokeMethod<void>(
         'UploadTask#resume',
         <String, dynamic>{
           'app': _firebaseStorage.app?.name,
@@ -115,10 +109,7 @@ abstract class StorageUploadTask {
       );
 
   /// Cancel the upload
-  // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-  // https://github.com/flutter/flutter/issues/26431
-  // ignore: strong_mode_implicit_dynamic_method
-  void cancel() => FirebaseStorage.channel.invokeMethod(
+  void cancel() => FirebaseStorage.channel.invokeMethod<void>(
         'UploadTask#cancel',
         <String, dynamic>{
           'app': _firebaseStorage.app?.name,
@@ -137,10 +128,7 @@ class _StorageFileUploadTask extends StorageUploadTask {
 
   @override
   Future<dynamic> _platformStart() {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return FirebaseStorage.channel.invokeMethod(
+    return FirebaseStorage.channel.invokeMethod<dynamic>(
       'StorageReference#putFile',
       <String, dynamic>{
         'app': _firebaseStorage.app?.name,
@@ -163,10 +151,7 @@ class _StorageDataUploadTask extends StorageUploadTask {
 
   @override
   Future<dynamic> _platformStart() {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return FirebaseStorage.channel.invokeMethod(
+    return FirebaseStorage.channel.invokeMethod<dynamic>(
       'StorageReference#putData',
       <String, dynamic>{
         'app': _firebaseStorage.app?.name,

--- a/packages/firebase_storage/lib/src/upload_task.dart
+++ b/packages/firebase_storage/lib/src/upload_task.dart
@@ -11,7 +11,7 @@ abstract class StorageUploadTask {
   final StorageReference _ref;
   final StorageMetadata _metadata;
 
-  Future<dynamic> _platformStart();
+  Future<int> _platformStart();
 
   int _handle;
 
@@ -127,8 +127,8 @@ class _StorageFileUploadTask extends StorageUploadTask {
   final File _file;
 
   @override
-  Future<dynamic> _platformStart() {
-    return FirebaseStorage.channel.invokeMethod<dynamic>(
+  Future<int> _platformStart() {
+    return FirebaseStorage.channel.invokeMethod<int>(
       'StorageReference#putFile',
       <String, dynamic>{
         'app': _firebaseStorage.app?.name,
@@ -150,8 +150,8 @@ class _StorageDataUploadTask extends StorageUploadTask {
   final Uint8List _bytes;
 
   @override
-  Future<dynamic> _platformStart() {
-    return FirebaseStorage.channel.invokeMethod<dynamic>(
+  Future<int> _platformStart() {
+    return FirebaseStorage.channel.invokeMethod<int>(
       'StorageReference#putData',
       <String, dynamic>{
         'app': _firebaseStorage.app?.name,

--- a/packages/firebase_storage/pubspec.yaml
+++ b/packages/firebase_storage/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Cloud Storage, a powerful, simple, and
   cost-effective object storage service for Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_storage
-version: 2.1.0+1
+version: 2.1.1
 
 flutter:
   plugin:

--- a/packages/firebase_storage/pubspec.yaml
+++ b/packages/firebase_storage/pubspec.yaml
@@ -24,4 +24,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.1.4 <2.0.0"
+  flutter: ">=1.2.0 <2.0.0"

--- a/packages/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.0+4
+
+* Bump the minimum flutter version to 1.2.0.
+* Add Template type parameter to `invokeMethod` calls.
+
 ## 0.4.0
 
 * Change events are call backs on GoogleMap widget.

--- a/packages/google_maps_flutter/lib/src/controller.dart
+++ b/packages/google_maps_flutter/lib/src/controller.dart
@@ -23,10 +23,7 @@ class GoogleMapController {
     assert(id != null);
     final MethodChannel channel =
         MethodChannel('plugins.flutter.io/google_maps_$id');
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    await channel.invokeMethod('map#waitForMap');
+    await channel.invokeMethod<void>('map#waitForMap');
     return GoogleMapController._(
       channel,
       initialCameraPosition,
@@ -76,10 +73,7 @@ class GoogleMapController {
   /// The returned [Future] completes after listeners have been notified.
   Future<void> _updateMapOptions(Map<String, dynamic> optionsUpdate) async {
     assert(optionsUpdate != null);
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    await _channel.invokeMethod(
+    await _channel.invokeMethod<void>(
       'map#update',
       <String, dynamic>{
         'options': optionsUpdate,
@@ -95,10 +89,7 @@ class GoogleMapController {
   /// The returned [Future] completes after listeners have been notified.
   Future<void> _updateMarkers(_MarkerUpdates markerUpdates) async {
     assert(markerUpdates != null);
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    await _channel.invokeMethod(
+    await _channel.invokeMethod<void>(
       'markers#update',
       markerUpdates._toMap(),
     );
@@ -109,10 +100,7 @@ class GoogleMapController {
   /// The returned [Future] completes after the change has been started on the
   /// platform side.
   Future<void> animateCamera(CameraUpdate cameraUpdate) async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    await _channel.invokeMethod('camera#animate', <String, dynamic>{
+    await _channel.invokeMethod<void>('camera#animate', <String, dynamic>{
       'cameraUpdate': cameraUpdate._toJson(),
     });
   }
@@ -122,10 +110,7 @@ class GoogleMapController {
   /// The returned [Future] completes after the change has been made on the
   /// platform side.
   Future<void> moveCamera(CameraUpdate cameraUpdate) async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    await _channel.invokeMethod('camera#move', <String, dynamic>{
+    await _channel.invokeMethod<void>('camera#move', <String, dynamic>{
       'cameraUpdate': cameraUpdate._toJson(),
     });
   }

--- a/packages/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter
-version: 0.4.0
+version: 0.4.0+1
 
 dependencies:
   flutter:

--- a/packages/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/pubspec.yaml
@@ -21,4 +21,4 @@ flutter:
 
 environment:
   sdk: ">=2.0.0-dev.47.0 <3.0.0"
-  flutter: ">=0.11.9 <2.0.0"
+  flutter: ">=1.2.0 <2.0.0"

--- a/packages/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.2
+
+* Bump the minimum flutter version to 1.2.0.
+* Add Template type parameter to `invokeMethod` calls.
+
 ## 4.0.1+1
 
 * Remove categories.

--- a/packages/google_sign_in/lib/google_sign_in.dart
+++ b/packages/google_sign_in/lib/google_sign_in.dart
@@ -79,10 +79,7 @@ class GoogleSignInAccount implements GoogleIdentity {
     }
 
     final Map<dynamic, dynamic> response =
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        await GoogleSignIn.channel.invokeMethod(
+        await GoogleSignIn.channel.invokeMethod<Map<dynamic, dynamic>>(
       'getTokens',
       <String, dynamic>{
         'email': email,
@@ -111,10 +108,7 @@ class GoogleSignInAccount implements GoogleIdentity {
   /// this method and grab `authHeaders` once again.
   Future<void> clearAuthCache() async {
     final String token = (await authentication).accessToken;
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    await GoogleSignIn.channel.invokeMethod(
+    await GoogleSignIn.channel.invokeMethod<void>(
       'clearAuthCache',
       <String, dynamic>{'token': token},
     );
@@ -220,10 +214,7 @@ class GoogleSignIn {
   Future<GoogleSignInAccount> _callMethod(String method) async {
     await _ensureInitialized();
 
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    final Map<dynamic, dynamic> response = await channel.invokeMethod(method);
+    final Map<dynamic, dynamic> response = await channel.invokeMethod<Map<dynamic, dynamic>>(method);
     return _setCurrentUser(response != null && response.isNotEmpty
         ? GoogleSignInAccount._(this, response)
         : null);
@@ -239,10 +230,7 @@ class GoogleSignIn {
 
   Future<void> _ensureInitialized() {
     if (_initialization == null) {
-      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-      // https://github.com/flutter/flutter/issues/26431
-      // ignore: strong_mode_implicit_dynamic_method
-      _initialization = channel.invokeMethod('init', <String, dynamic>{
+      _initialization = channel.invokeMethod<void>('init', <String, dynamic>{
         'signInOption': (signInOption ?? SignInOption.standard).toString(),
         'scopes': scopes ?? <String>[],
         'hostedDomain': hostedDomain,
@@ -318,10 +306,7 @@ class GoogleSignIn {
   /// Returns a future that resolves to whether a user is currently signed in.
   Future<bool> isSignedIn() async {
     await _ensureInitialized();
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    final bool result = await channel.invokeMethod('isSignedIn');
+    final bool result = await channel.invokeMethod<bool>('isSignedIn');
     return result;
   }
 

--- a/packages/google_sign_in/lib/google_sign_in.dart
+++ b/packages/google_sign_in/lib/google_sign_in.dart
@@ -78,8 +78,8 @@ class GoogleSignInAccount implements GoogleIdentity {
       throw StateError('User is no longer signed in.');
     }
 
-    final Map<dynamic, dynamic> response =
-        await GoogleSignIn.channel.invokeMapMethod<dynamic, dynamic>(
+    final Map<String, dynamic> response =
+        await GoogleSignIn.channel.invokeMapMethod<String, dynamic>(
       'getTokens',
       <String, dynamic>{
         'email': email,
@@ -214,7 +214,7 @@ class GoogleSignIn {
   Future<GoogleSignInAccount> _callMethod(String method) async {
     await _ensureInitialized();
 
-    final Map<dynamic, dynamic> response = await channel.invokeMapMethod<dynamic, dynamic>(method);
+    final Map<String, dynamic> response = await channel.invokeMapMethod<String, dynamic>(method);
     return _setCurrentUser(response != null && response.isNotEmpty
         ? GoogleSignInAccount._(this, response)
         : null);

--- a/packages/google_sign_in/lib/google_sign_in.dart
+++ b/packages/google_sign_in/lib/google_sign_in.dart
@@ -79,7 +79,7 @@ class GoogleSignInAccount implements GoogleIdentity {
     }
 
     final Map<dynamic, dynamic> response =
-        await GoogleSignIn.channel.invokeMethod<Map<dynamic, dynamic>>(
+        await GoogleSignIn.channel.invokeMapMethod<dynamic, dynamic>(
       'getTokens',
       <String, dynamic>{
         'email': email,
@@ -214,7 +214,7 @@ class GoogleSignIn {
   Future<GoogleSignInAccount> _callMethod(String method) async {
     await _ensureInitialized();
 
-    final Map<dynamic, dynamic> response = await channel.invokeMethod<Map<dynamic, dynamic>>(method);
+    final Map<dynamic, dynamic> response = await channel.invokeMapMethod<dynamic, dynamic>(method);
     return _setCurrentUser(response != null && response.isNotEmpty
         ? GoogleSignInAccount._(this, response)
         : null);

--- a/packages/google_sign_in/lib/google_sign_in.dart
+++ b/packages/google_sign_in/lib/google_sign_in.dart
@@ -214,7 +214,8 @@ class GoogleSignIn {
   Future<GoogleSignInAccount> _callMethod(String method) async {
     await _ensureInitialized();
 
-    final Map<String, dynamic> response = await channel.invokeMapMethod<String, dynamic>(method);
+    final Map<String, dynamic> response =
+        await channel.invokeMapMethod<String, dynamic>(method);
     return _setCurrentUser(response != null && response.isNotEmpty
         ? GoogleSignInAccount._(this, response)
         : null);

--- a/packages/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/pubspec.yaml
@@ -23,4 +23,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.1.4 <2.0.0"
+  flutter: ">=1.2.0 <2.0.0"

--- a/packages/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_sign_in
-version: 4.0.1+1
+version: 4.0.2
 
 flutter:
   plugin:

--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.0+8
+
+* Fixed wrong GooglePhotos authority of image Uri
+
 ## 0.5.0+7
 * Fix a crash when selecting images from yandex.disk and dropbox.
 

--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,8 +1,13 @@
+## 0.5.0+9
+
+* Remove unnecessary temp video file path.
+
 ## 0.5.0+8
 
-* Fixed wrong GooglePhotos authority of image Uri
+* Fixed wrong GooglePhotos authority of image Uri.
 
 ## 0.5.0+7
+
 * Fix a crash when selecting images from yandex.disk and dropbox.
 
 ## 0.5.0+6
@@ -11,11 +16,11 @@
 
 ## 0.5.0+5
 
-Remove unnecessary camera permmision.
+* Remove unnecessary camera permission.
 
 ## 0.5.0+4
 
-Preserve transparency when saving images.
+* Preserve transparency when saving images.
 
 ## 0.5.0+3
 

--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.0+10
+
+* Bump the minimum flutter version to 1.2.0.
+* Add Template type parameter to `invokeMethod` calls.
+
 ## 0.5.0+9
 
 * Remove unnecessary temp video file path.

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
@@ -187,6 +187,6 @@ class FileUtils {
   }
 
   private static boolean isGooglePhotosUri(Uri uri) {
-    return "com.google.android.apps.photos.content".equals(uri.getAuthority());
+    return "com.google.android.apps.photos.contentprovider".equals(uri.getAuthority());
   }
 }

--- a/packages/image_picker/ios/Classes/ImagePickerPlugin.m
+++ b/packages/image_picker/ios/Classes/ImagePickerPlugin.m
@@ -136,19 +136,7 @@ static const int SOURCE_GALLERY = 1;
     return;
   }
   if (videoURL != nil) {
-    NSData *data = [NSData dataWithContentsOfURL:videoURL];
-    NSString *guid = [[NSProcessInfo processInfo] globallyUniqueString];
-    NSString *tmpFile = [NSString stringWithFormat:@"image_picker_%@.MOV", guid];
-    NSString *tmpDirectory = NSTemporaryDirectory();
-    NSString *tmpPath = [tmpDirectory stringByAppendingPathComponent:tmpFile];
-
-    if ([[NSFileManager defaultManager] createFileAtPath:tmpPath contents:data attributes:nil]) {
-      _result(tmpPath);
-    } else {
-      _result([FlutterError errorWithCode:@"create_error"
-                                  message:@"Temporary file could not be created"
-                                  details:nil]);
-    }
+    _result(videoURL.description);
   } else {
     if (image == nil) {
       image = [info objectForKey:UIImagePickerControllerOriginalImage];

--- a/packages/image_picker/lib/image_picker.dart
+++ b/packages/image_picker/lib/image_picker.dart
@@ -44,10 +44,7 @@ class ImagePicker {
       throw ArgumentError.value(maxHeight, 'maxHeight cannot be negative');
     }
 
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    final String path = await _channel.invokeMethod(
+    final String path = await _channel.invokeMethod<String>(
       'pickImage',
       <String, dynamic>{
         'source': source.index,
@@ -64,10 +61,7 @@ class ImagePicker {
   }) async {
     assert(source != null);
 
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    final String path = await _channel.invokeMethod(
+    final String path = await _channel.invokeMethod<String>(
       'pickVideo',
       <String, dynamic>{
         'source': source.index,

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -5,7 +5,7 @@ authors:
   - Flutter Team <flutter-dev@googlegroups.com>
   - Rhodes Davis Jr. <rody.davis.jr@gmail.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.5.0+8
+version: 0.5.0+9
 
 flutter:
   plugin:

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -5,7 +5,7 @@ authors:
   - Flutter Team <flutter-dev@googlegroups.com>
   - Rhodes Davis Jr. <rody.davis.jr@gmail.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.5.0+7
+version: 0.5.0+8
 
 flutter:
   plugin:

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -24,4 +24,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.1.4 <2.0.0"
+  flutter: ">=1.2.0 <2.0.0"

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -5,7 +5,7 @@ authors:
   - Flutter Team <flutter-dev@googlegroups.com>
   - Rhodes Davis Jr. <rody.davis.jr@gmail.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.5.0+9
+version: 0.5.0+10
 
 flutter:
   plugin:

--- a/packages/in_app_purchase/example/pubspec.yaml
+++ b/packages/in_app_purchase/example/pubspec.yaml
@@ -19,4 +19,4 @@ flutter:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.4.4 <2.0.0"
+  flutter: ">=1.2.0 <2.0.0"

--- a/packages/in_app_purchase/lib/src/billing_client_wrappers/billing_client_wrapper.dart
+++ b/packages/in_app_purchase/lib/src/billing_client_wrappers/billing_client_wrapper.dart
@@ -67,7 +67,7 @@ class BillingClient {
   /// [`BillingClient#isReady()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.html#isReady())
   /// to get the ready status of the BillingClient instance.
   Future<bool> isReady() async =>
-      await channel.invokeMethod('BillingClient#isReady()');
+      await channel.invokeMethod<void>('BillingClient#isReady()');
 
   /// Calls
   /// [`BillingClient#startConnection(BillingClientStateListener)`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.html#startconnection)
@@ -85,7 +85,7 @@ class BillingClient {
     List<Function> disconnectCallbacks =
         _callbacks[_kOnBillingServiceDisconnected] ??= [];
     disconnectCallbacks.add(onBillingServiceDisconnected);
-    return BillingResponseConverter().fromJson(await channel.invokeMethod(
+    return BillingResponseConverter().fromJson(await channel.invokeMethod<int>(
         "BillingClient#startConnection(BillingClientStateListener)",
         <String, dynamic>{'handle': disconnectCallbacks.length - 1}));
   }
@@ -98,7 +98,7 @@ class BillingClient {
   ///
   /// This triggers the destruction of the `BillingClient` instance in Java.
   Future<void> endConnection() async {
-    return channel.invokeMethod("BillingClient#endConnection()", null);
+    return channel.invokeMethod<void>("BillingClient#endConnection()", null);
   }
 
   /// Returns a list of [SkuDetailsWrapper]s that have [SkuDetailsWrapper.sku]
@@ -152,7 +152,7 @@ class BillingClient {
       'sku': skuDetails.sku,
       'accountId': accountId,
     };
-    return BillingResponseConverter().fromJson(await channel.invokeMethod(
+    return BillingResponseConverter().fromJson(await channel.invokeMethod<int>(
         'BillingClient#launchBillingFlow(Activity, BillingFlowParams)',
         arguments));
   }

--- a/packages/in_app_purchase/lib/src/billing_client_wrappers/billing_client_wrapper.dart
+++ b/packages/in_app_purchase/lib/src/billing_client_wrappers/billing_client_wrapper.dart
@@ -67,7 +67,7 @@ class BillingClient {
   /// [`BillingClient#isReady()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.html#isReady())
   /// to get the ready status of the BillingClient instance.
   Future<bool> isReady() async =>
-      await channel.invokeMethod<void>('BillingClient#isReady()');
+      await channel.invokeMethod<bool>('BillingClient#isReady()');
 
   /// Calls
   /// [`BillingClient#startConnection(BillingClientStateListener)`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.html#startconnection)

--- a/packages/in_app_purchase/lib/src/store_kit_wrappers/sk_payment_queue_wrapper.dart
+++ b/packages/in_app_purchase/lib/src/store_kit_wrappers/sk_payment_queue_wrapper.dart
@@ -35,7 +35,7 @@ class SKPaymentQueueWrapper {
 
   /// Calls [`-[SKPaymentQueue canMakePayments:]`](https://developer.apple.com/documentation/storekit/skpaymentqueue/1506139-canmakepayments?language=objc).
   static Future<bool> canMakePayments() async =>
-      await channel.invokeMethod('-[SKPaymentQueue canMakePayments:]');
+      await channel.invokeMethod<bool>('-[SKPaymentQueue canMakePayments:]');
 
   /// Sets a transaction observer to listen to all the transaction events of the payment queue.
   ///
@@ -61,7 +61,7 @@ class SKPaymentQueueWrapper {
     assert(_observer != null,
         '[in_app_purchase]: Trying to add a payment without an observer. Observer must be set using `setTransactionObserver` before adding a payment `setTransactionObserver`. It is mandatory to set the observer at the moment when app launches.');
     Map requestMap = payment.toMap();
-    await channel.invokeMethod(
+    await channel.invokeMethod<void>(
       '-[InAppPurchasePlugin addPayment:result:]',
       requestMap,
     );
@@ -75,7 +75,7 @@ class SKPaymentQueueWrapper {
   /// This method calls StoreKit's [`-[SKPaymentQueue finishTransaction:]`](https://developer.apple.com/documentation/storekit/skpaymentqueue/1506003-finishtransaction?language=objc).
   Future<void> finishTransaction(
       SKPaymentTransactionWrapper transaction) async {
-    await channel.invokeMethod(
+    await channel.invokeMethod<void>(
         '-[InAppPurchasePlugin finishTransaction:result:]',
         transaction.transactionIdentifier);
   }
@@ -91,7 +91,7 @@ class SKPaymentQueueWrapper {
   /// This method either triggers [`-[SKPayment restoreCompletedTransactions]`](https://developer.apple.com/documentation/storekit/skpaymentqueue/1506123-restorecompletedtransactions?language=objc) or [`-[SKPayment restoreCompletedTransactionsWithApplicationUsername:]`](https://developer.apple.com/documentation/storekit/skpaymentqueue/1505992-restorecompletedtransactionswith?language=objc)
   /// depends on weather the `applicationUserName` is passed.
   Future<void> restoreTransactions({String applicationUserName}) async {
-    await channel.invokeMethod(
+    await channel.invokeMethod<void>(
         '-[InAppPurchasePlugin restoreTransactions:result:]',
         applicationUserName);
   }

--- a/packages/in_app_purchase/lib/src/store_kit_wrappers/sk_receipt_manager.dart
+++ b/packages/in_app_purchase/lib/src/store_kit_wrappers/sk_receipt_manager.dart
@@ -16,6 +16,6 @@ class SKReceiptManager {
   /// If the receipt is invalid or missing, you can use [SKRequestMaker.startRefreshReceiptRequest] to request a new receipt.
   static Future<String> retrieveReceiptData() {
     return channel
-        .invokeMethod('-[InAppPurchasePlugin retrieveReceiptData:result:]');
+        .invokeMethod<String>('-[InAppPurchasePlugin retrieveReceiptData:result:]');
   }
 }

--- a/packages/in_app_purchase/lib/src/store_kit_wrappers/sk_receipt_manager.dart
+++ b/packages/in_app_purchase/lib/src/store_kit_wrappers/sk_receipt_manager.dart
@@ -15,7 +15,7 @@ class SKReceiptManager {
   /// For more details on how to validate the receipt data, you can refer to Apple's document about [`About Receipt Validation`](https://developer.apple.com/library/archive/releasenotes/General/ValidateAppStoreReceipt/Introduction.html#//apple_ref/doc/uid/TP40010573-CH105-SW1).
   /// If the receipt is invalid or missing, you can use [SKRequestMaker.startRefreshReceiptRequest] to request a new receipt.
   static Future<String> retrieveReceiptData() {
-    return channel
-        .invokeMethod<String>('-[InAppPurchasePlugin retrieveReceiptData:result:]');
+    return channel.invokeMethod<String>(
+        '-[InAppPurchasePlugin retrieveReceiptData:result:]');
   }
 }

--- a/packages/in_app_purchase/lib/src/store_kit_wrappers/sk_request_maker.dart
+++ b/packages/in_app_purchase/lib/src/store_kit_wrappers/sk_request_maker.dart
@@ -24,7 +24,7 @@ class SKRequestMaker {
   /// A [PlatformException] is thrown if the platform code making the request fails.
   Future<SkProductResponseWrapper> startProductRequest(
       List<String> productIdentifiers) async {
-    final Map productResponseMap = await channel.invokeMethod<Map>(
+    final Map productResponseMap = await channel.invokeMapMethod(
       '-[InAppPurchasePlugin startProductRequest:result:]',
       productIdentifiers,
     );

--- a/packages/in_app_purchase/lib/src/store_kit_wrappers/sk_request_maker.dart
+++ b/packages/in_app_purchase/lib/src/store_kit_wrappers/sk_request_maker.dart
@@ -24,7 +24,7 @@ class SKRequestMaker {
   /// A [PlatformException] is thrown if the platform code making the request fails.
   Future<SkProductResponseWrapper> startProductRequest(
       List<String> productIdentifiers) async {
-    final Map productResponseMap = await channel.invokeMethod(
+    final Map productResponseMap = await channel.invokeMethod<Map>(
       '-[InAppPurchasePlugin startProductRequest:result:]',
       productIdentifiers,
     );
@@ -47,7 +47,7 @@ class SKRequestMaker {
   /// * isRevoked: whether the receipt has been revoked.
   /// * isVolumePurchase: whether the receipt is a Volume Purchase Plan receipt.
   Future<void> startRefreshReceiptRequest({Map receiptProperties}) {
-    return channel.invokeMethod(
+    return channel.invokeMethod<void>(
       '-[InAppPurchasePlugin refreshReceipt:result:]',
       receiptProperties,
     );

--- a/packages/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/pubspec.yaml
@@ -30,5 +30,5 @@ flutter:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.4.4 <2.0.0"
+  flutter: ">=1.2.0 <2.0.0"
 

--- a/packages/local_auth/CHANGELOG.md
+++ b/packages/local_auth/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.0+2
+
+* Bump the minimum flutter version to 1.2.0.
+* Add Template type parameter to `invokeMethod` calls.
+
 ## 0.4.0+1
 
 * Log a more detailed warning at build time about the previous AndroidX

--- a/packages/local_auth/lib/local_auth.dart
+++ b/packages/local_auth/lib/local_auth.dart
@@ -79,7 +79,7 @@ class LocalAuthentication {
   ///
   /// Returns a [Future] bool true or false:
   Future<bool> get canCheckBiometrics async =>
-      (await _channel.invokeMethod<List<dynamic>>('getAvailableBiometrics')).isNotEmpty;
+      (await _channel.invokeListMethod<String>('getAvailableBiometrics')).isNotEmpty;
 
   /// Returns a list of enrolled biometrics
   ///
@@ -89,7 +89,7 @@ class LocalAuthentication {
   /// - BiometricType.iris (not yet implemented)
   Future<List<BiometricType>> getAvailableBiometrics() async {
     final List<String> result =
-        (await _channel.invokeMethod<List<dynamic>>('getAvailableBiometrics')).cast<String>();
+        (await _channel.invokeListMethod<String>('getAvailableBiometrics'));
     final List<BiometricType> biometrics = <BiometricType>[];
     result.forEach((String value) {
       switch (value) {

--- a/packages/local_auth/lib/local_auth.dart
+++ b/packages/local_auth/lib/local_auth.dart
@@ -72,14 +72,16 @@ class LocalAuthentication {
               'operating systems.',
           details: 'Your operating system is ${Platform.operatingSystem}');
     }
-    return await _channel.invokeMethod<bool>('authenticateWithBiometrics', args);
+    return await _channel.invokeMethod<bool>(
+        'authenticateWithBiometrics', args);
   }
 
   /// Returns true if device is capable of checking biometrics
   ///
   /// Returns a [Future] bool true or false:
   Future<bool> get canCheckBiometrics async =>
-      (await _channel.invokeListMethod<String>('getAvailableBiometrics')).isNotEmpty;
+      (await _channel.invokeListMethod<String>('getAvailableBiometrics'))
+          .isNotEmpty;
 
   /// Returns a list of enrolled biometrics
   ///

--- a/packages/local_auth/lib/local_auth.dart
+++ b/packages/local_auth/lib/local_auth.dart
@@ -72,20 +72,14 @@ class LocalAuthentication {
               'operating systems.',
           details: 'Your operating system is ${Platform.operatingSystem}');
     }
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return await _channel.invokeMethod('authenticateWithBiometrics', args);
+    return await _channel.invokeMethod<bool>('authenticateWithBiometrics', args);
   }
 
   /// Returns true if device is capable of checking biometrics
   ///
   /// Returns a [Future] bool true or false:
   Future<bool> get canCheckBiometrics async =>
-      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-      // https://github.com/flutter/flutter/issues/26431
-      // ignore: strong_mode_implicit_dynamic_method
-      (await _channel.invokeMethod('getAvailableBiometrics')).isNotEmpty;
+      (await _channel.invokeMethod<List<dynamic>>('getAvailableBiometrics')).isNotEmpty;
 
   /// Returns a list of enrolled biometrics
   ///
@@ -95,10 +89,7 @@ class LocalAuthentication {
   /// - BiometricType.iris (not yet implemented)
   Future<List<BiometricType>> getAvailableBiometrics() async {
     final List<String> result =
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        (await _channel.invokeMethod('getAvailableBiometrics')).cast<String>();
+        (await _channel.invokeMethod<List<dynamic>>('getAvailableBiometrics')).cast<String>();
     final List<BiometricType> biometrics = <BiometricType>[];
     result.forEach((String value) {
       switch (value) {

--- a/packages/local_auth/pubspec.yaml
+++ b/packages/local_auth/pubspec.yaml
@@ -19,4 +19,4 @@ dependencies:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.1.4 <2.0.0"
+  flutter: ">=1.2.0 <2.0.0"

--- a/packages/local_auth/pubspec.yaml
+++ b/packages/local_auth/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Android and iOS device authentication sensors
   such as Fingerprint Reader and Touch ID.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/local_auth
-version: 0.4.0+1
+version: 0.4.0+2
 
 flutter:
   plugin:

--- a/packages/location_background/CHANGELOG.md
+++ b/packages/location_background/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.0+2
+
+* Bump the minimum flutter version to 1.2.0.
+* Add Template type parameter to `invokeMethod` calls.
+
 ## 0.1.0+1
 
 * Log a more detailed warning at build time about the previous AndroidX

--- a/packages/location_background/lib/location_background_plugin.dart
+++ b/packages/location_background/lib/location_background_plugin.dart
@@ -118,10 +118,7 @@ class LocationBackgroundPlugin {
         PluginUtilities.getCallbackHandle(_backgroundCallbackDispatcher);
     assert(handle != null, 'Unable to lookup callback.');
     _channel
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        .invokeMethod(_kStartHeadlessService, <dynamic>[handle.toRawHandle()]);
+        .invokeMethod<void>(_kStartHeadlessService, <dynamic>[handle.toRawHandle()]);
   }
 
   // The method channel we'll use to communicate with the native portion of our
@@ -147,10 +144,7 @@ class LocationBackgroundPlugin {
       throw ArgumentError.notNull('callback');
     }
     final CallbackHandle handle = PluginUtilities.getCallbackHandle(callback);
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return _channel.invokeMethod(_kMonitorLocationChanges, <dynamic>[
+    return _channel.invokeMethod<bool>(_kMonitorLocationChanges, <dynamic>[
       handle.toRawHandle(),
       pauseLocationUpdatesAutomatically,
       showsBackgroundLocationIndicator,
@@ -160,8 +154,5 @@ class LocationBackgroundPlugin {
 
   /// Stop all location updates.
   Future<void> cancelLocationUpdates() =>
-      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-      // https://github.com/flutter/flutter/issues/26431
-      // ignore: strong_mode_implicit_dynamic_method
-      _channel.invokeMethod(_kCancelLocationUpdates);
+      _channel.invokeMethod<void>(_kCancelLocationUpdates);
 }

--- a/packages/location_background/lib/location_background_plugin.dart
+++ b/packages/location_background/lib/location_background_plugin.dart
@@ -117,8 +117,8 @@ class LocationBackgroundPlugin {
     final CallbackHandle handle =
         PluginUtilities.getCallbackHandle(_backgroundCallbackDispatcher);
     assert(handle != null, 'Unable to lookup callback.');
-    _channel
-        .invokeMethod<void>(_kStartHeadlessService, <dynamic>[handle.toRawHandle()]);
+    _channel.invokeMethod<void>(
+        _kStartHeadlessService, <dynamic>[handle.toRawHandle()]);
   }
 
   // The method channel we'll use to communicate with the native portion of our

--- a/packages/location_background/pubspec.yaml
+++ b/packages/location_background/pubspec.yaml
@@ -2,7 +2,7 @@ name: location_background_plugin
 description: A new flutter plugin project.
 author:  Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/location_background
-version: 0.1.0+1
+version: 0.1.0+2
 publish_to: none
 
 dependencies:

--- a/packages/location_background/pubspec.yaml
+++ b/packages/location_background/pubspec.yaml
@@ -20,4 +20,4 @@ flutter:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.4.4 <2.0.0"
+  flutter: ">=1.2.0 <2.0.0"

--- a/packages/package_info/CHANGELOG.md
+++ b/packages/package_info/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.0+3
+
+* Bump the minimum flutter version to 1.2.0.
+* Add Template type parameter to `invokeMethod` calls.
+
 ## 0.4.0+2
 
 * Android: Using new method for BuildNumber in new android versions

--- a/packages/package_info/lib/package_info.dart
+++ b/packages/package_info/lib/package_info.dart
@@ -32,14 +32,13 @@ class PackageInfo {
     if (_fromPlatform == null) {
       final Completer<PackageInfo> completer = Completer<PackageInfo>();
 
-      _kChannel.invokeMethod<dynamic>('getAll').then((dynamic result) {
-        final Map<dynamic, dynamic> map = result;
+      _kChannel.invokeListMethod<Map<String, dynamic>>('getAll').then((Map<String, dynamic> result) {
 
         completer.complete(PackageInfo(
-          appName: map["appName"],
-          packageName: map["packageName"],
-          version: map["version"],
-          buildNumber: map["buildNumber"],
+          appName: result["appName"],
+          packageName: result["packageName"],
+          version: result["version"],
+          buildNumber: result["buildNumber"],
         ));
       }, onError: completer.completeError);
 

--- a/packages/package_info/lib/package_info.dart
+++ b/packages/package_info/lib/package_info.dart
@@ -32,8 +32,8 @@ class PackageInfo {
     if (_fromPlatform == null) {
       final Completer<PackageInfo> completer = Completer<PackageInfo>();
 
-      _kChannel.invokeListMethod<Map<String, dynamic>>('getAll').then((Map<String, dynamic> result) {
-
+      _kChannel.invokeListMethod<Map<String, dynamic>>('getAll').then(
+          (Map<String, dynamic> result) {
         completer.complete(PackageInfo(
           appName: result["appName"],
           packageName: result["packageName"],

--- a/packages/package_info/lib/package_info.dart
+++ b/packages/package_info/lib/package_info.dart
@@ -32,7 +32,7 @@ class PackageInfo {
     if (_fromPlatform == null) {
       final Completer<PackageInfo> completer = Completer<PackageInfo>();
 
-      _kChannel.invokeListMethod<Map<String, dynamic>>('getAll').then(
+      _kChannel.invokeMapMethod<String, dynamic>('getAll').then(
           (Map<String, dynamic> result) {
         completer.complete(PackageInfo(
           appName: result["appName"],

--- a/packages/package_info/lib/package_info.dart
+++ b/packages/package_info/lib/package_info.dart
@@ -32,10 +32,7 @@ class PackageInfo {
     if (_fromPlatform == null) {
       final Completer<PackageInfo> completer = Completer<PackageInfo>();
 
-      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-      // https://github.com/flutter/flutter/issues/26431
-      // ignore: strong_mode_implicit_dynamic_method
-      _kChannel.invokeMethod('getAll').then((dynamic result) {
+      _kChannel.invokeMethod<dynamic>('getAll').then((dynamic result) {
         final Map<dynamic, dynamic> map = result;
 
         completer.complete(PackageInfo(

--- a/packages/package_info/pubspec.yaml
+++ b/packages/package_info/pubspec.yaml
@@ -17,4 +17,4 @@ dependencies:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.1.4 <2.0.0"
+  flutter: ">=1.2.0 <2.0.0"

--- a/packages/package_info/pubspec.yaml
+++ b/packages/package_info/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for querying information about the application
   package, such as CFBundleVersion on iOS or versionCode on Android.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/package_info
-version: 0.4.0+2
+version: 0.4.0+3
 
 flutter:
   plugin:

--- a/packages/path_provider/CHANGELOG.md
+++ b/packages/path_provider/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.0+2
+
+* Bump the minimum flutter version to 1.2.0.
+* Add Template type parameter to `invokeMethod` calls.
+
 ## 0.5.0+1
 
 * Log a more detailed warning at build time about the previous AndroidX

--- a/packages/path_provider/lib/path_provider.dart
+++ b/packages/path_provider/lib/path_provider.dart
@@ -21,7 +21,8 @@ const MethodChannel _channel =
 ///
 /// On Android, this uses the `getCacheDir` API on the context.
 Future<Directory> getTemporaryDirectory() async {
-  final String path = await _channel.invokeMethod<String>('getTemporaryDirectory');
+  final String path =
+      await _channel.invokeMethod<String>('getTemporaryDirectory');
   if (path == null) {
     return null;
   }
@@ -55,7 +56,8 @@ Future<Directory> getApplicationDocumentsDirectory() async {
 Future<Directory> getExternalStorageDirectory() async {
   if (Platform.isIOS)
     throw UnsupportedError("Functionality not available on iOS");
-  final String path = await _channel.invokeMethod<String>('getStorageDirectory');
+  final String path =
+      await _channel.invokeMethod<String>('getStorageDirectory');
   if (path == null) {
     return null;
   }

--- a/packages/path_provider/lib/path_provider.dart
+++ b/packages/path_provider/lib/path_provider.dart
@@ -21,10 +21,7 @@ const MethodChannel _channel =
 ///
 /// On Android, this uses the `getCacheDir` API on the context.
 Future<Directory> getTemporaryDirectory() async {
-  // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-  // https://github.com/flutter/flutter/issues/26431
-  // ignore: strong_mode_implicit_dynamic_method
-  final String path = await _channel.invokeMethod('getTemporaryDirectory');
+  final String path = await _channel.invokeMethod<String>('getTemporaryDirectory');
   if (path == null) {
     return null;
   }
@@ -40,10 +37,7 @@ Future<Directory> getTemporaryDirectory() async {
 /// On Android, this returns the AppData directory.
 Future<Directory> getApplicationDocumentsDirectory() async {
   final String path =
-      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-      // https://github.com/flutter/flutter/issues/26431
-      // ignore: strong_mode_implicit_dynamic_method
-      await _channel.invokeMethod('getApplicationDocumentsDirectory');
+      await _channel.invokeMethod<String>('getApplicationDocumentsDirectory');
   if (path == null) {
     return null;
   }
@@ -61,10 +55,7 @@ Future<Directory> getApplicationDocumentsDirectory() async {
 Future<Directory> getExternalStorageDirectory() async {
   if (Platform.isIOS)
     throw UnsupportedError("Functionality not available on iOS");
-  // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-  // https://github.com/flutter/flutter/issues/26431
-  // ignore: strong_mode_implicit_dynamic_method
-  final String path = await _channel.invokeMethod('getStorageDirectory');
+  final String path = await _channel.invokeMethod<String>('getStorageDirectory');
   if (path == null) {
     return null;
   }

--- a/packages/path_provider/pubspec.yaml
+++ b/packages/path_provider/pubspec.yaml
@@ -21,4 +21,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.1.4 <2.0.0"
+  flutter: ">=1.2.0 <2.0.0"

--- a/packages/path_provider/pubspec.yaml
+++ b/packages/path_provider/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for getting commonly used locations on the Android &
   iOS file systems, such as the temp and app data directories.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/path_provider
-version: 0.5.0+1
+version: 0.5.0+2
 
 flutter:
   plugin:

--- a/packages/quick_actions/CHANGELOG.md
+++ b/packages/quick_actions/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.0+2
+
+* Bump the minimum flutter version to 1.2.0.
+* Add Template type parameter to `invokeMethod` calls.
+
 ## 0.3.0+1
 
 * Log a more detailed warning at build time about the previous AndroidX

--- a/packages/quick_actions/lib/quick_actions.dart
+++ b/packages/quick_actions/lib/quick_actions.dart
@@ -52,18 +52,12 @@ class QuickActions {
   Future<void> setShortcutItems(List<ShortcutItem> items) async {
     final List<Map<String, String>> itemsList =
         items.map(_serializeItem).toList();
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    await _kChannel.invokeMethod('setShortcutItems', itemsList);
+    await _kChannel.invokeMethod<void>('setShortcutItems', itemsList);
   }
 
   /// Removes all [ShortcutItem]s registered for the app.
   Future<void> clearShortcutItems() =>
-      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-      // https://github.com/flutter/flutter/issues/26431
-      // ignore: strong_mode_implicit_dynamic_method
-      _kChannel.invokeMethod('clearShortcutItems');
+      _kChannel.invokeMethod<void>('clearShortcutItems');
 
   Map<String, String> _serializeItem(ShortcutItem item) {
     return <String, String>{

--- a/packages/quick_actions/pubspec.yaml
+++ b/packages/quick_actions/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for creating shortcuts on home screen, also known as
   Quick Actions on iOS and App Shortcuts on Android.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/quick_actions
-version: 0.3.0+1
+version: 0.3.0+2
 
 flutter:
   plugin:

--- a/packages/quick_actions/pubspec.yaml
+++ b/packages/quick_actions/pubspec.yaml
@@ -18,4 +18,4 @@ dependencies:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.1.4 <2.0.0"
+  flutter: ">=1.2.0 <2.0.0"

--- a/packages/sensors/pubspec.yaml
+++ b/packages/sensors/pubspec.yaml
@@ -22,4 +22,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=1.2.0 <2.0.0"
+  flutter: ">=0.1.4 <2.0.0"

--- a/packages/sensors/pubspec.yaml
+++ b/packages/sensors/pubspec.yaml
@@ -22,4 +22,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.1.4 <2.0.0"
+  flutter: ">=1.2.0 <2.0.0"

--- a/packages/share/CHANGELOG.md
+++ b/packages/share/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.0+2
+
+* Bump the minimum flutter version to 1.2.0.
+* Add Template type parameter to `invokeMethod` calls.
+
 ## 0.6.0+1
 
 * Log a more detailed warning at build time about the previous AndroidX

--- a/packages/share/lib/share.dart
+++ b/packages/share/lib/share.dart
@@ -41,9 +41,6 @@ class Share {
       params['originHeight'] = sharePositionOrigin.height;
     }
 
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return channel.invokeMethod('share', params);
+    return channel.invokeMethod<void>('share', params);
   }
 }

--- a/packages/share/pubspec.yaml
+++ b/packages/share/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for sharing content via the platform share UI, using
   the ACTION_SEND intent on Android and UIActivityViewController on iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/share
-version: 0.6.0+1
+version: 0.6.0+2
 
 flutter:
   plugin:

--- a/packages/share/pubspec.yaml
+++ b/packages/share/pubspec.yaml
@@ -24,4 +24,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.1.4 <2.0.0"
+  flutter: ">=1.2.0 <2.0.0"

--- a/packages/share/test/share_test.dart
+++ b/packages/share/test/share_test.dart
@@ -17,10 +17,7 @@ void main() {
     mockChannel = MockMethodChannel();
     // Re-pipe to mockito for easier verifies.
     Share.channel.setMockMethodCallHandler((MethodCall call) async {
-      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-      // https://github.com/flutter/flutter/issues/26431
-      // ignore: strong_mode_implicit_dynamic_method
-      mockChannel.invokeMethod(call.method, call.arguments);
+      mockChannel.invokeMethod<void>(call.method, call.arguments);
     });
   });
 
@@ -45,10 +42,7 @@ void main() {
       'some text to share',
       sharePositionOrigin: Rect.fromLTWH(1.0, 2.0, 3.0, 4.0),
     );
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    verify(mockChannel.invokeMethod('share', <String, dynamic>{
+    verify(mockChannel.invokeMethod<void>('share', <String, dynamic>{
       'text': 'some text to share',
       'originX': 1.0,
       'originY': 2.0,

--- a/packages/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.1+3
+
+* Bump the minimum flutter version to 1.2.0.
+* Add Template type parameter to `invokeMethod` calls.
+
 ## 0.5.1+2
 
 * Add a driver test

--- a/packages/shared_preferences/lib/shared_preferences.dart
+++ b/packages/shared_preferences/lib/shared_preferences.dart
@@ -22,7 +22,7 @@ class SharedPreferences {
   static Future<SharedPreferences> getInstance() async {
     if (_instance == null) {
       final Map<Object, Object> fromSystem =
-          await _kChannel.invokeMethod<Map<Object, Object> >('getAll');
+          await _kChannel.invokeMapMethod<Object, Object>('getAll');
       assert(fromSystem != null);
       // Strip the flutter. prefix from the returned preferences.
       final Map<String, Object> preferencesMap = <String, Object>{};

--- a/packages/shared_preferences/lib/shared_preferences.dart
+++ b/packages/shared_preferences/lib/shared_preferences.dart
@@ -22,10 +22,7 @@ class SharedPreferences {
   static Future<SharedPreferences> getInstance() async {
     if (_instance == null) {
       final Map<Object, Object> fromSystem =
-          // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-          // https://github.com/flutter/flutter/issues/26431
-          // ignore: strong_mode_implicit_dynamic_method
-          await _kChannel.invokeMethod('getAll');
+          await _kChannel.invokeMethod<Map<Object, Object> >('getAll');
       assert(fromSystem != null);
       // Strip the flutter. prefix from the returned preferences.
       final Map<String, Object> preferencesMap = <String, Object>{};
@@ -121,19 +118,13 @@ class SharedPreferences {
     if (value == null) {
       _preferenceCache.remove(key);
       return _kChannel
-          // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-          // https://github.com/flutter/flutter/issues/26431
-          // ignore: strong_mode_implicit_dynamic_method
-          .invokeMethod('remove', params)
+          .invokeMethod<bool>('remove', params)
           .then<bool>((dynamic result) => result);
     } else {
       _preferenceCache[key] = value;
       params['value'] = value;
       return _kChannel
-          // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-          // https://github.com/flutter/flutter/issues/26431
-          // ignore: strong_mode_implicit_dynamic_method
-          .invokeMethod('set$valueType', params)
+          .invokeMethod<bool>('set$valueType', params)
           .then<bool>((dynamic result) => result);
     }
   }
@@ -141,18 +132,12 @@ class SharedPreferences {
   /// Always returns true.
   /// On iOS, synchronize is marked deprecated. On Android, we commit every set.
   @deprecated
-  // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-  // https://github.com/flutter/flutter/issues/26431
-  // ignore: strong_mode_implicit_dynamic_method
-  Future<bool> commit() async => await _kChannel.invokeMethod('commit');
+  Future<bool> commit() async => await _kChannel.invokeMethod<bool>('commit');
 
   /// Completes with true once the user preferences for the app has been cleared.
   Future<bool> clear() async {
     _preferenceCache.clear();
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return await _kChannel.invokeMethod('clear');
+    return await _kChannel.invokeMethod<bool>('clear');
   }
 
   /// Initializes the shared preferences with mock values for testing.

--- a/packages/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/pubspec.yaml
@@ -25,4 +25,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.1.4 <2.0.0"
+  flutter: ">=1.2.0 <2.0.0"

--- a/packages/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for reading and writing simple key-value pairs.
   Wraps NSUserDefaults on iOS and SharedPreferences on Android.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/shared_preferences
-version: 0.5.1+2
+version: 0.5.1+3
 
 flutter:
   plugin:

--- a/packages/shared_preferences/test/shared_preferences_test.dart
+++ b/packages/shared_preferences/test/shared_preferences_test.dart
@@ -136,9 +136,11 @@ void main() {
     });
 
     test('mocking', () async {
-      expect(await channel.invokeMapMethod<Object, Object>('getAll'), kTestValues);
+      expect(
+          await channel.invokeMapMethod<Object, Object>('getAll'), kTestValues);
       SharedPreferences.setMockInitialValues(kTestValues2);
-      expect(await channel.invokeMapMethod<Object, Object>('getAll'), kTestValues2);
+      expect(await channel.invokeMapMethod<Object, Object>('getAll'),
+          kTestValues2);
     });
   });
 }

--- a/packages/shared_preferences/test/shared_preferences_test.dart
+++ b/packages/shared_preferences/test/shared_preferences_test.dart
@@ -136,15 +136,9 @@ void main() {
     });
 
     test('mocking', () async {
-      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-      // https://github.com/flutter/flutter/issues/26431
-      // ignore: strong_mode_implicit_dynamic_method
-      expect(await channel.invokeMethod('getAll'), kTestValues);
+      expect(await channel.invokeMethod<Map<Object, Object>>('getAll'), kTestValues);
       SharedPreferences.setMockInitialValues(kTestValues2);
-      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-      // https://github.com/flutter/flutter/issues/26431
-      // ignore: strong_mode_implicit_dynamic_method
-      expect(await channel.invokeMethod('getAll'), kTestValues2);
+      expect(await channel.invokeMethod<Map<Object, Object> >('getAll'), kTestValues2);
     });
   });
 }

--- a/packages/shared_preferences/test/shared_preferences_test.dart
+++ b/packages/shared_preferences/test/shared_preferences_test.dart
@@ -136,9 +136,9 @@ void main() {
     });
 
     test('mocking', () async {
-      expect(await channel.invokeMethod<Map<Object, Object>>('getAll'), kTestValues);
+      expect(await channel.invokeMapMethod<Object, Object>('getAll'), kTestValues);
       SharedPreferences.setMockInitialValues(kTestValues2);
-      expect(await channel.invokeMethod<Map<Object, Object> >('getAll'), kTestValues2);
+      expect(await channel.invokeMapMethod<Object, Object>('getAll'), kTestValues2);
     });
   });
 }

--- a/packages/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/CHANGELOG.md
@@ -1,4 +1,9 @@
-## 5.0.2
+## 5.0.3
+
+* Bump the minimum flutter version to 1.2.0.
+* Add Template type parameter to `invokeMethod` calls.
+
+# 5.0.2
 * Fixes `closeWebView` failure on iOS.
 
 ## 5.0.1

--- a/packages/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/lib/url_launcher.dart
@@ -79,10 +79,7 @@ Future<bool> launch(
         ? SystemUiOverlayStyle.dark
         : SystemUiOverlayStyle.light);
   }
-  // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-  // https://github.com/flutter/flutter/issues/26431
-  // ignore: strong_mode_implicit_dynamic_method
-  final bool result = await _channel.invokeMethod(
+  final bool result = await _channel.invokeMethod<bool>(
     'launch',
     <String, Object>{
       'url': urlString,
@@ -105,10 +102,7 @@ Future<bool> canLaunch(String urlString) async {
   if (urlString == null) {
     return false;
   }
-  // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-  // https://github.com/flutter/flutter/issues/26431
-  // ignore: strong_mode_implicit_dynamic_method
-  return await _channel.invokeMethod(
+  return await _channel.invokeMethod<bool>(
     'canLaunch',
     <String, Object>{'url': urlString},
   );
@@ -126,8 +120,5 @@ Future<bool> canLaunch(String urlString) async {
 /// SafariViewController is only available on IOS version >= 9.0, this method does not do anything
 /// on IOS version below 9.0
 Future<void> closeWebView() async {
-  // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-  // https://github.com/flutter/flutter/issues/26431
-  // ignore: strong_mode_implicit_dynamic_method
-  return await _channel.invokeMethod('closeWebView');
+  return await _channel.invokeMethod<void>('closeWebView');
 }

--- a/packages/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for launching a URL on Android and iOS. Supports
   web, phone, SMS, and email schemes.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher
-version: 5.0.2
+version: 5.0.3
 
 flutter:
   plugin:

--- a/packages/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/pubspec.yaml
@@ -21,4 +21,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.5.6 <2.0.0"
+  flutter: ">=1.2.0 <2.0.0"

--- a/packages/video_player/CHANGELOG.md
+++ b/packages/video_player/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.10.0+5
+
+* Bump the minimum flutter version to 1.2.0.
+* Add Template type parameter to `invokeMethod` calls.
+
 ## 0.10.0+4
 
 * Android: Upgrade ExoPlayer to 2.9.6.

--- a/packages/video_player/lib/video_player.dart
+++ b/packages/video_player/lib/video_player.dart
@@ -205,7 +205,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
       case DataSourceType.file:
         dataSourceDescription = <String, dynamic>{'uri': dataSource};
     }
-    final Map<dynamic, dynamic> response = await _channel.invokeMethod<Map<dynamic, dynamic>>(
+    final Map<dynamic, dynamic> response = await _channel.invokeMapMethod<dynamic, dynamic>(
       'create',
       dataSourceDescription,
     );

--- a/packages/video_player/lib/video_player.dart
+++ b/packages/video_player/lib/video_player.dart
@@ -12,10 +12,7 @@ import 'package:meta/meta.dart';
 final MethodChannel _channel = const MethodChannel('flutter.io/videoPlayer')
   // This will clear all open videos on the platform when a full restart is
   // performed.
-  // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-  // https://github.com/flutter/flutter/issues/26431
-  // ignore: strong_mode_implicit_dynamic_method
-  ..invokeMethod('init');
+  ..invokeMethod<void>('init');
 
 class DurationRange {
   DurationRange(this.start, this.end);
@@ -208,10 +205,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
       case DataSourceType.file:
         dataSourceDescription = <String, dynamic>{'uri': dataSource};
     }
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    final Map<dynamic, dynamic> response = await _channel.invokeMethod(
+    final Map<dynamic, dynamic> response = await _channel.invokeMethod<Map<dynamic, dynamic>>(
       'create',
       dataSourceDescription,
     );
@@ -284,10 +278,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
         _isDisposed = true;
         _timer?.cancel();
         await _eventSubscription?.cancel();
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        await _channel.invokeMethod(
+        await _channel.invokeMethod<void>(
           'dispose',
           <String, dynamic>{'textureId': _textureId},
         );
@@ -317,10 +308,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
     if (!value.initialized || _isDisposed) {
       return;
     }
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    _channel.invokeMethod(
+    _channel.invokeMethod<void>(
       'setLooping',
       <String, dynamic>{'textureId': _textureId, 'looping': value.isLooping},
     );
@@ -331,10 +319,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
       return;
     }
     if (value.isPlaying) {
-      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-      // https://github.com/flutter/flutter/issues/26431
-      // ignore: strong_mode_implicit_dynamic_method
-      await _channel.invokeMethod(
+      await _channel.invokeMethod<void>(
         'play',
         <String, dynamic>{'textureId': _textureId},
       );
@@ -353,10 +338,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
       );
     } else {
       _timer?.cancel();
-      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-      // https://github.com/flutter/flutter/issues/26431
-      // ignore: strong_mode_implicit_dynamic_method
-      await _channel.invokeMethod(
+      await _channel.invokeMethod<void>(
         'pause',
         <String, dynamic>{'textureId': _textureId},
       );
@@ -367,10 +349,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
     if (!value.initialized || _isDisposed) {
       return;
     }
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    await _channel.invokeMethod(
+    await _channel.invokeMethod<void>(
       'setVolume',
       <String, dynamic>{'textureId': _textureId, 'volume': value.volume},
     );
@@ -382,10 +361,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
       return null;
     }
     return Duration(
-      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-      // https://github.com/flutter/flutter/issues/26431
-      // ignore: strong_mode_implicit_dynamic_method
-      milliseconds: await _channel.invokeMethod(
+      milliseconds: await _channel.invokeMethod<int>(
         'position',
         <String, dynamic>{'textureId': _textureId},
       ),
@@ -401,10 +377,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
     } else if (moment < const Duration()) {
       moment = const Duration();
     }
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    await _channel.invokeMethod('seekTo', <String, dynamic>{
+    await _channel.invokeMethod<void>('seekTo', <String, dynamic>{
       'textureId': _textureId,
       'location': moment.inMilliseconds,
     });

--- a/packages/video_player/lib/video_player.dart
+++ b/packages/video_player/lib/video_player.dart
@@ -205,7 +205,8 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
       case DataSourceType.file:
         dataSourceDescription = <String, dynamic>{'uri': dataSource};
     }
-    final Map<String, dynamic> response = await _channel.invokeMapMethod<String, dynamic>(
+    final Map<String, dynamic> response =
+        await _channel.invokeMapMethod<String, dynamic>(
       'create',
       dataSourceDescription,
     );

--- a/packages/video_player/lib/video_player.dart
+++ b/packages/video_player/lib/video_player.dart
@@ -205,7 +205,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
       case DataSourceType.file:
         dataSourceDescription = <String, dynamic>{'uri': dataSource};
     }
-    final Map<dynamic, dynamic> response = await _channel.invokeMapMethod<dynamic, dynamic>(
+    final Map<String, dynamic> response = await _channel.invokeMapMethod<String, dynamic>(
       'create',
       dataSourceDescription,
     );

--- a/packages/video_player/pubspec.yaml
+++ b/packages/video_player/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player
 description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
-version: 0.10.0+4
+version: 0.10.0+5
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player
 
 flutter:

--- a/packages/video_player/pubspec.yaml
+++ b/packages/video_player/pubspec.yaml
@@ -22,4 +22,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.2.5 <2.0.0"
+  flutter: ">=1.2.0 <2.0.0"

--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.5
+
+* Added an onPageFinished callback.
+
 ## 0.3.4
 
 * Support specifying navigation delegates that can prevent navigations from being executed.

--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.5+1
+
+* Bump the minimum flutter version to 1.2.0.
+* Add Template type parameter to `invokeMethod` calls.
+
 ## 0.3.5
 
 * Added an onPageFinished callback.

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -525,7 +525,8 @@ class WebViewController {
           'removeJavascriptChannels', channelsToRemove.toList());
     }
     if (channelsToAdd.isNotEmpty) {
-      _channel.invokeMethod<void>('addJavascriptChannels', channelsToAdd.toList());
+      _channel.invokeMethod<void>(
+          'addJavascriptChannels', channelsToAdd.toList());
     }
     _updateJavascriptChannelsFromSet(newChannels);
   }
@@ -564,8 +565,8 @@ class WebViewController {
     if (javascriptString == null) {
       throw ArgumentError('The argument javascriptString must not be null. ');
     }
-    final String result =
-        await _channel.invokeMethod<String>('evaluateJavascript', javascriptString);
+    final String result = await _channel.invokeMethod<String>(
+        'evaluateJavascript', javascriptString);
     return result;
   }
 }

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -436,10 +436,7 @@ class WebViewController {
   Future<void> loadUrl(String url) async {
     assert(url != null);
     _validateUrlString(url);
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return _channel.invokeMethod('loadUrl', url);
+    return _channel.invokeMethod<void>('loadUrl', url);
   }
 
   /// Accessor to the current URL that the WebView is displaying.
@@ -450,10 +447,7 @@ class WebViewController {
   /// words, by the time this future completes, the WebView may be displaying a
   /// different URL).
   Future<String> currentUrl() async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    final String url = await _channel.invokeMethod('currentUrl');
+    final String url = await _channel.invokeMethod<String>('currentUrl');
     return url;
   }
 
@@ -462,10 +456,7 @@ class WebViewController {
   /// Note that this operation is asynchronous, and it is possible that the "canGoBack" state has
   /// changed by the time the future completed.
   Future<bool> canGoBack() async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    final bool canGoBack = await _channel.invokeMethod("canGoBack");
+    final bool canGoBack = await _channel.invokeMethod<bool>("canGoBack");
     return canGoBack;
   }
 
@@ -474,10 +465,7 @@ class WebViewController {
   /// Note that this operation is asynchronous, and it is possible that the "canGoForward" state has
   /// changed by the time the future completed.
   Future<bool> canGoForward() async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    final bool canGoForward = await _channel.invokeMethod("canGoForward");
+    final bool canGoForward = await _channel.invokeMethod<bool>("canGoForward");
     return canGoForward;
   }
 
@@ -485,28 +473,19 @@ class WebViewController {
   ///
   /// If there is no back history item this is a no-op.
   Future<void> goBack() async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return _channel.invokeMethod("goBack");
+    return _channel.invokeMethod<void>("goBack");
   }
 
   /// Goes forward in the history of this WebView.
   ///
   /// If there is no forward history item this is a no-op.
   Future<void> goForward() async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return _channel.invokeMethod("goForward");
+    return _channel.invokeMethod<void>("goForward");
   }
 
   /// Reloads the current URL.
   Future<void> reload() async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return _channel.invokeMethod("reload");
+    return _channel.invokeMethod<void>("reload");
   }
 
   /// Clears all caches used by the [WebView].
@@ -520,10 +499,7 @@ class WebViewController {
   ///
   /// Note: Calling this method also triggers a reload.
   Future<void> clearCache() async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    await _channel.invokeMethod("clearCache");
+    await _channel.invokeMethod<void>("clearCache");
     return reload();
   }
 
@@ -533,10 +509,7 @@ class WebViewController {
       return null;
     }
     _settings = setting;
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return _channel.invokeMethod('updateSettings', updateMap);
+    return _channel.invokeMethod<void>('updateSettings', updateMap);
   }
 
   Future<void> _updateJavascriptChannels(
@@ -548,17 +521,11 @@ class WebViewController {
     final Set<String> channelsToRemove =
         currentChannels.difference(newChannelNames);
     if (channelsToRemove.isNotEmpty) {
-      // TODO(amirh): remove this when the invokeMethod update makes it to stable Flutter.
-      // https://github.com/flutter/flutter/issues/26431
-      // ignore: strong_mode_implicit_dynamic_method
-      _channel.invokeMethod(
+      _channel.invokeMethod<void>(
           'removeJavascriptChannels', channelsToRemove.toList());
     }
     if (channelsToAdd.isNotEmpty) {
-      // TODO(amirh): remove this when the invokeMethod update makes it to stable Flutter.
-      // https://github.com/flutter/flutter/issues/26431
-      // ignore: strong_mode_implicit_dynamic_method
-      _channel.invokeMethod('addJavascriptChannels', channelsToAdd.toList());
+      _channel.invokeMethod<void>('addJavascriptChannels', channelsToAdd.toList());
     }
     _updateJavascriptChannelsFromSet(newChannels);
   }
@@ -597,11 +564,8 @@ class WebViewController {
     if (javascriptString == null) {
       throw ArgumentError('The argument javascriptString must not be null. ');
     }
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
     final String result =
-        await _channel.invokeMethod('evaluateJavascript', javascriptString);
+        await _channel.invokeMethod<String>('evaluateJavascript', javascriptString);
     return result;
   }
 }
@@ -625,10 +589,7 @@ class CookieManager {
   ///
   /// Returns true if cookies were present before clearing, else false.
   Future<bool> clearCookies() => _channel
-      // TODO(amirh): remove this when the invokeMethod update makes it to stable Flutter.
-      // https://github.com/flutter/flutter/issues/26431
-      // ignore: strong_mode_implicit_dynamic_method
-      .invokeMethod('clearCookies')
+      .invokeMethod<bool>('clearCookies')
       .then<bool>((dynamic result) => result);
 }
 

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
-version: 0.3.5
+version: 0.3.5+1
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/webview_flutter
 

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
-version: 0.3.4
+version: 0.3.5
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/webview_flutter
 

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://github.com/flutter/plugins/tree/master/packages/webview_flutte
 
 environment:
   sdk: ">=2.0.0-dev.68.0 <3.0.0"
-  flutter: ">=0.11.9 <2.0.0"
+  flutter: ">=1.2.0 <2.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Bump min flutter version to 1.2.0 for most plugins.
Add template type parameter for `invokeMethod` calls.
Updated invokeMethod and invokeMethod to using invokeListMethod and invokeMapMethod. Reopen the PR.

Anything that will change the type of a public API should not be included in this PR. 

`Sensor` plugin has not been changed since no `invokeMethod` is called in the plugin.
The plugin version of `in app purchase` has not be updated because it is still under development. 

Need to publish all plugins after this PR is merged, except `in_app_purchase` and `sensor`.

https://github.com/flutter/flutter/issues/26431
