### PR TITLE
[firebase_crashlytics] use static framework

### DIFF
--- a/packages/firebase_crashlytics/ios/firebase_crashlytics.podspec
+++ b/packages/firebase_crashlytics/ios/firebase_crashlytics.podspec
@@ -19,5 +19,6 @@ A new flutter plugin project.
   s.dependency 'Fabric'
   s.dependency 'Crashlytics'
   s.dependency 'Firebase/Core'
+  s.static_framework = true
 end
 


### PR DESCRIPTION
similar to other firebase plugins: need to be set as static framework in podspec