### PR TITLE
[webview_flutter] Refactor WebViewController to have a reference to the widget, to minimize necessary update calls.

### DIFF
--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.5+1
+
+* Fix a bug where updates to onPageFinished were ignored.
+
 ## 0.3.5
 
 * Added an onPageFinished callback.

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -272,6 +272,7 @@ class _WebViewState extends State<WebView> {
     controller._updateSettings(settings);
     controller._updateJavascriptChannels(widget.javascriptChannels);
     controller._navigationDelegate = widget.navigationDelegate;
+    controller._onPageFinished = widget.onPageFinished;
   }
 
   void _onPlatformViewCreated(int id) {
@@ -392,7 +393,7 @@ class WebViewController {
 
   _WebSettings _settings;
 
-  final PageFinishedCallback _onPageFinished;
+  PageFinishedCallback _onPageFinished;
 
   // Maps a channel name to a channel.
   Map<String, JavascriptChannel> _javascriptChannels =

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
-version: 0.3.5
+version: 0.3.5+1
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/webview_flutter
 

--- a/packages/webview_flutter/test/webview_flutter_test.dart
+++ b/packages/webview_flutter/test/webview_flutter_test.dart
@@ -608,6 +608,29 @@ void main() {
       // to test that it does not crash on a null callback.
       platformWebView.fakeOnPageFinishedCallback();
     });
+
+    testWidgets('onPageFinished changed', (WidgetTester tester) async {
+      String returnedUrl;
+
+      await tester.pumpWidget(WebView(
+        initialUrl: 'https://youtube.com',
+        onPageFinished: (String url) {},
+      ));
+
+      await tester.pumpWidget(WebView(
+        initialUrl: 'https://youtube.com',
+        onPageFinished: (String url) {
+          returnedUrl = url;
+        },
+      ));
+
+      final FakePlatformWebView platformWebView =
+          fakePlatformViewsController.lastCreatedView;
+
+      platformWebView.fakeOnPageFinishedCallback();
+
+      expect(platformWebView.currentUrl, returnedUrl);
+    });
   });
 
   group('navigationDelegate', () {


### PR DESCRIPTION
discussed with @amirh - refactor `WebViewController` to hold a reference to the `WebView` widget. Basically to make it less error prone/less code to add more web callback handlers to the widget for later PRs.