### PR TITLE
[firebase_admob] Update documentation to add app id in Info.plist

### DIFF
--- a/packages/firebase_admob/README.md
+++ b/packages/firebase_admob/README.md
@@ -25,13 +25,26 @@ initialize the plugin in your Dart code.
 See https://goo.gl/fQ2neu for more information about configuring `AndroidManifest.xml`
 and setting up your App ID.
 
+## Info.plist changes
+
+Admob 7.42.0 requires the App ID to be included in `Info.plist`. Failure to do so will result in a crash on launch of your app. The lines should look like:
+
+```xml
+<key>GADApplicationIdentifier</key>
+<string>[ADMOB_APP_ID]</string>
+```
+
+where `[ADMOB_APP_ID]` is your App ID.  You must pass the same value when you initialize the plugin in your Dart code.
+
+See https://developers.google.com/admob/ios/quick-start#update_your_infoplist for more information about configuring `Info.plist` and setting up your App ID.
+
 ## Initializing the plugin
 The AdMob plugin must be initialized with an AdMob App ID.
 
 ```dart
 FirebaseAdMob.instance.initialize(appId: appId);
 ```
-*Note Android*:
+### Android
 Starting in version 17.0.0, if you are an AdMob publisher you are now required to add your AdMob app ID in your **AndroidManifest.xml** file. Once you find your AdMob app ID in the AdMob UI, add it to your manifest adding the following tag:
 
 ```xml
@@ -49,6 +62,18 @@ Failure to add this tag will result in the app crashing at app launch with a mes
 
 On Android, this value must be the same as the App ID value set in your 
 `AndroidManifest.xml`.
+
+### iOS
+Starting in version 7.42.0, you are required to add your AdMob app ID in your **Info.plist** file under the Runner directory. You can add it using Xcode or edit the file manually:
+
+```xml
+<dict>
+	<key>GADApplicationIdentifier</key>
+	<string>ca-app-pub-################~##########</string>
+</dict>
+```
+
+Failure to add this tag will result in the app crashing at app launch with a message including *"GADVerifyApplicationID."*
 
 ## Using banners and interstitials
 Banner and interstitial ads can be configured with target information.


### PR DESCRIPTION
## Description

Update the documentation to add app ID in Info.plist. This is a new requirement for ios admob 7.42.0. App crashes without the app id.

## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contribution Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin user to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
