### PR TITLE
[firebase_crashlytics] Support compatibility with Swift plugins

### DIFF
--- a/packages/firebase_crashlytics/CHANGELOG.md
+++ b/packages/firebase_crashlytics/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.0.2
 
-* Updated the iOS podspec to support compatibility with Swift plugins.
+* Updated the iOS podspec to a static framework to support compatibility with Swift plugins.
 
 ## 0.0.1
 

--- a/packages/firebase_crashlytics/CHANGELOG.md
+++ b/packages/firebase_crashlytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.2
+
+* Updates the iOS podspec to support compatibility with Swift plugins.
+
 ## 0.0.1
 
 * Initial release of Firebase Crashlytics plugin.

--- a/packages/firebase_crashlytics/CHANGELOG.md
+++ b/packages/firebase_crashlytics/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.0.2
 
-* Updates the iOS podspec to support compatibility with Swift plugins.
+* Updated the iOS podspec to support compatibility with Swift plugins.
 
 ## 0.0.1
 

--- a/packages/firebase_crashlytics/ios/firebase_crashlytics.podspec
+++ b/packages/firebase_crashlytics/ios/firebase_crashlytics.podspec
@@ -15,6 +15,7 @@ A new flutter plugin project.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.ios.deployment_target = '8.0'
+  s.static_framework = true
   s.dependency 'Flutter'
   s.dependency 'Fabric'
   s.dependency 'Crashlytics'

--- a/packages/firebase_crashlytics/pubspec.yaml
+++ b/packages/firebase_crashlytics/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_crashlytics
 description: Flutter plugin for Firebase Crashlytics. It reports uncaught errors to the
   Firebase console.
-version: 0.0.1
+version: 0.0.2
 author: Flutter Team <flutter-dev@google.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_crashlytics
 


### PR DESCRIPTION
## Description

`[!] The 'Pods-Runner' target has transitive dependencies that include static binaries:
    (/Users/leofarias/Documents/Projects/brand-app/ios/Pods/Crashlytics/iOS/Crashlytics.framework and
    /Users/leofarias/Documents/Projects/brand-app/ios/Pods/Fabric/iOS/Fabric.framework)`

Whenever building the plugin using swift I am getting the error above.
`s.static_framework = true` seems to do the trick
