### PR TITLE
[google_maps_flutter] Add failing test verifying that only changed markers are updated

### DIFF
--- a/packages/google_maps_flutter/test/marker_updates_test.dart
+++ b/packages/google_maps_flutter/test/marker_updates_test.dart
@@ -172,4 +172,32 @@ void main() {
     expect(platformGoogleMap.markersToAdd.first, equals(m1));
     expect(platformGoogleMap.markerIdsToRemove.first, equals(m3.markerId));
   });
+
+  testWidgets(
+    "Partial Update",
+    (WidgetTester tester) async {
+      Marker m1 = Marker(markerId: MarkerId("marker_1"));
+      Marker m2 = Marker(markerId: MarkerId("marker_2"));
+      final Set<Marker> prev = _toSet(m1: m1, m2: m2);
+      m2 = Marker(markerId: MarkerId("marker_2"), draggable: true);
+      final Set<Marker> cur = _toSet(m1: m1, m2: m2);
+
+      await tester.pumpWidget(_mapWithMarkers(prev));
+      await tester.pumpWidget(_mapWithMarkers(cur));
+
+      final FakePlatformGoogleMap platformGoogleMap =
+          fakePlatformViewsController.lastCreatedView;
+
+      expect(platformGoogleMap.markersToChange,
+        <Marker>[m2].toSet()
+      );
+      expect(platformGoogleMap.markerIdsToRemove.isEmpty, true);
+      expect(platformGoogleMap.markersToAdd.isEmpty, true);
+    },
+    // The test is currently broken due to a bug (we're updating all markers
+    // instead of just the ones that were changed):
+    // https://github.com/flutter/flutter/issues/27823
+    // TODO(amirh): enable this test when the issue is fixed.
+    skip: true,
+  );
 }

--- a/packages/google_maps_flutter/test/marker_updates_test.dart
+++ b/packages/google_maps_flutter/test/marker_updates_test.dart
@@ -176,7 +176,7 @@ void main() {
   testWidgets(
     "Partial Update",
     (WidgetTester tester) async {
-      Marker m1 = Marker(markerId: MarkerId("marker_1"));
+      final Marker m1 = Marker(markerId: MarkerId("marker_1"));
       Marker m2 = Marker(markerId: MarkerId("marker_2"));
       final Set<Marker> prev = _toSet(m1: m1, m2: m2);
       m2 = Marker(markerId: MarkerId("marker_2"), draggable: true);
@@ -188,9 +188,7 @@ void main() {
       final FakePlatformGoogleMap platformGoogleMap =
           fakePlatformViewsController.lastCreatedView;
 
-      expect(platformGoogleMap.markersToChange,
-        <Marker>[m2].toSet()
-      );
+      expect(platformGoogleMap.markersToChange, _toSet(m2: m2));
       expect(platformGoogleMap.markerIdsToRemove.isEmpty, true);
       expect(platformGoogleMap.markersToAdd.isEmpty, true);
     },


### PR DESCRIPTION
## Description

Currently the maps plugin is updating over the platform channel all markers instead of just the ones that were actually changed.

This adds a failing test (that's currently skipped) that should pass once the bug is fixed.

## Related Issues

https://github.com/flutter/flutter/issues/27823

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
