### PR TITLE
[cloud_firestore] Add metadata field to DocumentSnapshot

### DIFF
--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.0
+
+* Add metadata field to DocumentSnapshot.
+
 ## 0.9.7+1
 
 * Update README with example of getting a document.

--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.10.0
+## 0.9.8
 
 * Add metadata field to DocumentSnapshot.
 

--- a/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
+++ b/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
@@ -131,7 +131,8 @@ public class CloudFirestorePlugin implements MethodCallHandler {
       change.put("document", documentChange.getDocument().getData());
       change.put("path", documentChange.getDocument().getReference().getPath());
       Map<String, Object> metadata = new HashMap();
-      metadata.put("hasPendingWrites", documentChange.getDocument().getMetadata().hasPendingWrites());
+      metadata.put(
+          "hasPendingWrites", documentChange.getDocument().getMetadata().hasPendingWrites());
       metadata.put("isFromCache", documentChange.getDocument().getMetadata().isFromCache());
       change.put("metadata", metadata);
       documentChanges.add(change);
@@ -355,8 +356,8 @@ public class CloudFirestorePlugin implements MethodCallHandler {
                   snapshotMap.put("data", null);
                 }
                 Map<String, Object> metadata = new HashMap();
-                  metadata.put("hasPendingWrites", documentSnapshot.getMetadata().hasPendingWrites());
-                  metadata.put("isFromCache", documentSnapshot.getMetadata().isFromCache());
+                metadata.put("hasPendingWrites", documentSnapshot.getMetadata().hasPendingWrites());
+                metadata.put("isFromCache", documentSnapshot.getMetadata().isFromCache());
                 snapshotMap.put("metadata", metadata);
                 result.success(snapshotMap);
               } catch (FirebaseFirestoreException e) {
@@ -564,7 +565,8 @@ public class CloudFirestorePlugin implements MethodCallHandler {
                     public void onSuccess(DocumentSnapshot documentSnapshot) {
                       Map<String, Object> snapshotMap = new HashMap<>();
                       Map<String, Object> metadata = new HashMap<>();
-                      metadata.put("hasPendingWrites", documentSnapshot.getMetadata().hasPendingWrites());
+                      metadata.put(
+                          "hasPendingWrites", documentSnapshot.getMetadata().hasPendingWrites());
                       metadata.put("isFromCache", documentSnapshot.getMetadata().isFromCache());
                       snapshotMap.put("metadata", metadata);
                       snapshotMap.put("path", documentSnapshot.getReference().getPath());

--- a/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
+++ b/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
@@ -97,12 +97,18 @@ public class CloudFirestorePlugin implements MethodCallHandler {
     Map<String, Object> data = new HashMap<>();
     List<String> paths = new ArrayList<>();
     List<Map<String, Object>> documents = new ArrayList<>();
+    List<Map<String, Object>> metadatas = new ArrayList<>();
     for (DocumentSnapshot document : querySnapshot.getDocuments()) {
       paths.add(document.getReference().getPath());
       documents.add(document.getData());
+      Map<String, Object> metadata = new HashMap<String, Object>();
+      metadata.put("hasPendingWrites", document.getMetadata().hasPendingWrites());
+      metadata.put("isFromCache", document.getMetadata().isFromCache());
+      metadatas.add(metadata);
     }
     data.put("paths", paths);
     data.put("documents", documents);
+    data.put("metadatas", metadatas);
 
     List<Map<String, Object>> documentChanges = new ArrayList<>();
     for (DocumentChange documentChange : querySnapshot.getDocumentChanges()) {
@@ -124,6 +130,10 @@ public class CloudFirestorePlugin implements MethodCallHandler {
       change.put("newIndex", documentChange.getNewIndex());
       change.put("document", documentChange.getDocument().getData());
       change.put("path", documentChange.getDocument().getReference().getPath());
+      Map<String, Object> metadata = new HashMap();
+      metadata.put("hasPendingWrites", documentChange.getDocument().getMetadata().hasPendingWrites());
+      metadata.put("isFromCache", documentChange.getDocument().getMetadata().isFromCache());
+      change.put("metadata", metadata);
       documentChanges.add(change);
     }
     data.put("documentChanges", documentChanges);
@@ -205,7 +215,11 @@ public class CloudFirestorePlugin implements MethodCallHandler {
         return;
       }
       Map<String, Object> arguments = new HashMap<>();
+      Map<String, Object> metadata = new HashMap<>();
       arguments.put("handle", handle);
+      metadata.put("hasPendingWrites", documentSnapshot.getMetadata().hasPendingWrites());
+      metadata.put("isFromCache", documentSnapshot.getMetadata().isFromCache());
+      arguments.put("metadata", metadata);
       if (documentSnapshot.exists()) {
         arguments.put("data", documentSnapshot.getData());
         arguments.put("path", documentSnapshot.getReference().getPath());
@@ -340,6 +354,10 @@ public class CloudFirestorePlugin implements MethodCallHandler {
                 } else {
                   snapshotMap.put("data", null);
                 }
+                Map<String, Object> metadata = new HashMap();
+                  metadata.put("hasPendingWrites", documentSnapshot.getMetadata().hasPendingWrites());
+                  metadata.put("isFromCache", documentSnapshot.getMetadata().isFromCache());
+                snapshotMap.put("metadata", metadata);
                 result.success(snapshotMap);
               } catch (FirebaseFirestoreException e) {
                 result.error("Error performing Transaction#get", e.getMessage(), null);
@@ -545,6 +563,10 @@ public class CloudFirestorePlugin implements MethodCallHandler {
                     @Override
                     public void onSuccess(DocumentSnapshot documentSnapshot) {
                       Map<String, Object> snapshotMap = new HashMap<>();
+                      Map<String, Object> metadata = new HashMap<>();
+                      metadata.put("hasPendingWrites", documentSnapshot.getMetadata().hasPendingWrites());
+                      metadata.put("isFromCache", documentSnapshot.getMetadata().isFromCache());
+                      snapshotMap.put("metadata", metadata);
                       snapshotMap.put("path", documentSnapshot.getReference().getPath());
                       if (documentSnapshot.exists()) {
                         snapshotMap.put("data", documentSnapshot.getData());

--- a/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
+++ b/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
@@ -88,9 +88,14 @@ FIRQuery *getQuery(NSDictionary *arguments) {
 NSDictionary *parseQuerySnapshot(FIRQuerySnapshot *snapshot) {
   NSMutableArray *paths = [NSMutableArray array];
   NSMutableArray *documents = [NSMutableArray array];
+  NSMutableArray *metadatas = [NSMutableArray array];
   for (FIRDocumentSnapshot *document in snapshot.documents) {
     [paths addObject:document.reference.path];
     [documents addObject:document.data];
+    [metadatas addObject:@{
+      @"hasPendingWrites" : @(document.metadata.hasPendingWrites),
+      @"isFromCache" : @(document.metadata.isFromCache),
+    }];
   }
   NSMutableArray *documentChanges = [NSMutableArray array];
   for (FIRDocumentChange *documentChange in snapshot.documentChanges) {
@@ -112,12 +117,17 @@ NSDictionary *parseQuerySnapshot(FIRQuerySnapshot *snapshot) {
       @"path" : documentChange.document.reference.path,
       @"oldIndex" : [NSNumber numberWithUnsignedInteger:documentChange.oldIndex],
       @"newIndex" : [NSNumber numberWithUnsignedInteger:documentChange.newIndex],
+      @"metadata" : @{
+        @"hasPendingWrites" : @(documentChange.document.metadata.hasPendingWrites),
+        @"isFromCache" : @(documentChange.document.metadata.isFromCache),
+      },
     }];
   }
   return @{
     @"paths" : paths,
     @"documentChanges" : documentChanges,
     @"documents" : documents,
+    @"metadatas" : metadatas,
   };
 }
 
@@ -338,7 +348,11 @@ const UInt8 TIMESTAMP = 136;
       } else if (snapshot != nil) {
         result(@{
           @"path" : snapshot.reference.path,
-          @"data" : snapshot.exists ? snapshot.data : [NSNull null]
+          @"data" : snapshot.exists ? snapshot.data : [NSNull null],
+          @"metadata" : @{
+            @"hasPendingWrites" : @(snapshot.metadata.hasPendingWrites),
+            @"isFromCache" : @(snapshot.metadata.isFromCache),
+          },
         });
       } else {
         result(nil);
@@ -395,7 +409,11 @@ const UInt8 TIMESTAMP = 136;
       } else {
         result(@{
           @"path" : snapshot.reference.path,
-          @"data" : snapshot.exists ? snapshot.data : [NSNull null]
+          @"data" : snapshot.exists ? snapshot.data : [NSNull null],
+          @"metadata" : @{
+            @"hasPendingWrites" : @(snapshot.metadata.hasPendingWrites),
+            @"isFromCache" : @(snapshot.metadata.isFromCache),
+          },
         });
       }
     }];
@@ -435,6 +453,10 @@ const UInt8 TIMESTAMP = 136;
                              @"handle" : handle,
                              @"path" : snapshot ? snapshot.reference.path : [NSNull null],
                              @"data" : snapshot && snapshot.exists ? snapshot.data : [NSNull null],
+                             @"metadata" : snapshot ? @{
+                               @"hasPendingWrites" : @(snapshot.metadata.hasPendingWrites),
+                               @"isFromCache" : @(snapshot.metadata.isFromCache),
+                             } : [NSNull null],
                            }];
         }];
     _listeners[handle] = listener;

--- a/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
+++ b/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
@@ -456,7 +456,8 @@ const UInt8 TIMESTAMP = 136;
                              @"metadata" : snapshot ? @{
                                @"hasPendingWrites" : @(snapshot.metadata.hasPendingWrites),
                                @"isFromCache" : @(snapshot.metadata.isFromCache),
-                             } : [NSNull null],
+                             }
+                                                    : [NSNull null],
                            }];
         }];
     _listeners[handle] = listener;

--- a/packages/cloud_firestore/lib/src/document_change.dart
+++ b/packages/cloud_firestore/lib/src/document_change.dart
@@ -29,6 +29,8 @@ class DocumentChange {
         document = DocumentSnapshot._(
           data['path'],
           _asStringKeyedMap(data['document']),
+          SnapshotMetadata._(data["metadata"]["hasPendingWrites"],
+              data["metadata"]["isFromCache"]),
           _firestore,
         ),
         type = DocumentChangeType.values.firstWhere((DocumentChangeType type) {

--- a/packages/cloud_firestore/lib/src/document_reference.dart
+++ b/packages/cloud_firestore/lib/src/document_reference.dart
@@ -88,6 +88,8 @@ class DocumentReference {
     return DocumentSnapshot._(
       data['path'],
       _asStringKeyedMap(data['data']),
+      SnapshotMetadata._(data['metadata']['hasPendingWrites'],
+          data['metadata']['isFromCache']),
       firestore,
     );
   }

--- a/packages/cloud_firestore/lib/src/document_snapshot.dart
+++ b/packages/cloud_firestore/lib/src/document_snapshot.dart
@@ -10,7 +10,7 @@ part of cloud_firestore;
 /// The data can be extracted with the data property or by using subscript
 /// syntax to access a specific field.
 class DocumentSnapshot {
-  DocumentSnapshot._(this._path, this.data, this._firestore);
+  DocumentSnapshot._(this._path, this.data, this.metadata, this._firestore);
 
   final String _path;
   final Firestore _firestore;
@@ -20,6 +20,10 @@ class DocumentSnapshot {
 
   /// Contains all the data of this snapshot
   final Map<String, dynamic> data;
+
+  /// Metadata about this snapshot concerning its source and if it has local
+  /// modifications.
+  final SnapshotMetadata metadata;
 
   /// Reads individual values from the snapshot
   dynamic operator [](String key) => data[key];

--- a/packages/cloud_firestore/lib/src/firestore.dart
+++ b/packages/cloud_firestore/lib/src/firestore.dart
@@ -18,6 +18,8 @@ class Firestore {
         final DocumentSnapshot snapshot = DocumentSnapshot._(
           call.arguments['path'],
           _asStringKeyedMap(call.arguments['data']),
+          SnapshotMetadata._(call.arguments['metadata']['hasPendingWrites'],
+              call.arguments['metadata']['isFromCache']),
           this,
         );
         _documentObservers[call.arguments['handle']].add(snapshot);

--- a/packages/cloud_firestore/lib/src/query_snapshot.dart
+++ b/packages/cloud_firestore/lib/src/query_snapshot.dart
@@ -12,6 +12,10 @@ class QuerySnapshot {
           return DocumentSnapshot._(
             data['paths'][index],
             _asStringKeyedMap(data['documents'][index]),
+            SnapshotMetadata._(
+              data['metadatas'][index]['hasPendingWrites'],
+              data['metadatas'][index]['isFromCache'],
+            ),
             _firestore,
           );
         }),

--- a/packages/cloud_firestore/lib/src/transaction.dart
+++ b/packages/cloud_firestore/lib/src/transaction.dart
@@ -24,8 +24,12 @@ class Transaction {
       'path': documentReference.path,
     });
     if (result != null) {
-      return DocumentSnapshot._(documentReference.path,
-          result['data']?.cast<String, dynamic>(), _firestore);
+      return DocumentSnapshot._(
+          documentReference.path,
+          result['data']?.cast<String, dynamic>(),
+          SnapshotMetadata._(result['metadata']['hasPendingWrites'],
+              result['metadata']['isFromCache']),
+          _firestore);
     } else {
       return null;
     }

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_firestore
-version: 0.9.7+1
+version: 0.10.0
 
 flutter:
   plugin:

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_firestore
-version: 0.10.0
+version: 0.9.8
 
 flutter:
   plugin:

--- a/packages/cloud_firestore/test/cloud_firestore_test.dart
+++ b/packages/cloud_firestore/test/cloud_firestore_test.dart
@@ -21,6 +21,10 @@ void main() {
     const Map<String, dynamic> kMockDocumentSnapshotData = <String, dynamic>{
       '1': 2
     };
+    const Map<String, dynamic> kMockSnapshotMetadata = <String, dynamic>{
+      "hasPendingWrites": false,
+      "isFromCache": false,
+    };
 
     setUp(() async {
       mockHandleId = 0;
@@ -54,12 +58,14 @@ void main() {
                     'handle': handle,
                     'paths': <String>["${methodCall.arguments['path']}/0"],
                     'documents': <dynamic>[kMockDocumentSnapshotData],
+                    'metadatas': [kMockSnapshotMetadata],
                     'documentChanges': <dynamic>[
                       <String, dynamic>{
                         'oldIndex': -1,
                         'newIndex': 0,
                         'type': 'DocumentChangeType.added',
                         'document': kMockDocumentSnapshotData,
+                        'metadata': kMockSnapshotMetadata,
                       },
                     ],
                   }),
@@ -80,6 +86,7 @@ void main() {
                     'handle': handle,
                     'path': methodCall.arguments['path'],
                     'data': kMockDocumentSnapshotData,
+                    'metadata': kMockSnapshotMetadata,
                   }),
                 ),
                 (_) {},
@@ -90,12 +97,14 @@ void main() {
             return <String, dynamic>{
               'paths': <String>["${methodCall.arguments['path']}/0"],
               'documents': <dynamic>[kMockDocumentSnapshotData],
+              'metadatas': [kMockSnapshotMetadata],
               'documentChanges': <dynamic>[
                 <String, dynamic>{
                   'oldIndex': -1,
                   'newIndex': 0,
                   'type': 'DocumentChangeType.added',
                   'document': kMockDocumentSnapshotData,
+                  'metadata': kMockSnapshotMetadata,
                 },
               ],
             };
@@ -105,10 +114,15 @@ void main() {
             if (methodCall.arguments['path'] == 'foo/bar') {
               return <String, dynamic>{
                 'path': 'foo/bar',
-                'data': <String, dynamic>{'key1': 'val1'}
+                'data': <String, dynamic>{'key1': 'val1'},
+                'metadata': kMockSnapshotMetadata,
               };
             } else if (methodCall.arguments['path'] == 'foo/notExists') {
-              return <String, dynamic>{'path': 'foo/notExists', 'data': null};
+              return <String, dynamic>{
+                'path': 'foo/notExists',
+                'data': null,
+                'metadata': kMockSnapshotMetadata,
+              };
             }
             throw PlatformException(code: 'UNKNOWN_PATH');
           case 'Firestore#runTransaction':
@@ -117,10 +131,15 @@ void main() {
             if (methodCall.arguments['path'] == 'foo/bar') {
               return <String, dynamic>{
                 'path': 'foo/bar',
-                'data': <String, dynamic>{'key1': 'val1'}
+                'data': <String, dynamic>{'key1': 'val1'},
+                'metadata': kMockSnapshotMetadata,
               };
             } else if (methodCall.arguments['path'] == 'foo/notExists') {
-              return <String, dynamic>{'path': 'foo/notExists', 'data': null};
+              return <String, dynamic>{
+                'path': 'foo/notExists',
+                'data': null,
+                'metadata': kMockSnapshotMetadata,
+              };
             }
             throw PlatformException(code: 'UNKNOWN_PATH');
           case 'Transaction#set':

--- a/packages/cloud_firestore/test/cloud_firestore_test.dart
+++ b/packages/cloud_firestore/test/cloud_firestore_test.dart
@@ -58,7 +58,7 @@ void main() {
                     'handle': handle,
                     'paths': <String>["${methodCall.arguments['path']}/0"],
                     'documents': <dynamic>[kMockDocumentSnapshotData],
-                    'metadatas': [kMockSnapshotMetadata],
+                    'metadatas': <Map<String, dynamic>>[kMockSnapshotMetadata],
                     'documentChanges': <dynamic>[
                       <String, dynamic>{
                         'oldIndex': -1,
@@ -97,7 +97,7 @@ void main() {
             return <String, dynamic>{
               'paths': <String>["${methodCall.arguments['path']}/0"],
               'documents': <dynamic>[kMockDocumentSnapshotData],
-              'metadatas': [kMockSnapshotMetadata],
+              'metadatas': <Map<String, dynamic>>[kMockSnapshotMetadata],
               'documentChanges': <dynamic>[
                 <String, dynamic>{
                   'oldIndex': -1,


### PR DESCRIPTION
## Description

Add SnapshotMetadata to DocumentSnapshot. SnapshotMetadata has two boolean field hasPendingWrites and isFromCache. This PR enables to know snapshot is from server or local cache.


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
