### PR TITLE
[image_picker] Fix exif orientation for pictures taken from camera

### DIFF
--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.0+10
+
+* Fixed photos rotated on 90 degrees.
+
 ## 0.5.0+9
 
 * Remove unnecessary temp video file path.

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
@@ -426,8 +426,9 @@ public class ImagePickerDelegate
     if (pendingResult != null) {
       Double maxWidth = methodCall.argument("maxWidth");
       Double maxHeight = methodCall.argument("maxHeight");
+      Boolean rotate = methodCall.argument("rotate");
 
-      String finalImagePath = imageResizer.resizeImageIfNeeded(path, maxWidth, maxHeight);
+      String finalImagePath = imageResizer.resizeImageIfNeeded(path, maxWidth, maxHeight, rotate);
       finishWithSuccess(finalImagePath);
 
       //delete original file if scaled

--- a/packages/image_picker/example/android/app/src/test/java/io/flutter/plugins/imagepicker/ImagePickerDelegateTest.java
+++ b/packages/image_picker/example/android/app/src/test/java/io/flutter/plugins/imagepicker/ImagePickerDelegateTest.java
@@ -60,12 +60,15 @@ public class ImagePickerDelegateTest {
     when(mockFileUtils.getPathFromUri(any(Context.class), any(Uri.class)))
         .thenReturn("pathFromUri");
 
-    when(mockImageResizer.resizeImageIfNeeded("pathFromUri", null, null))
+    when(mockImageResizer.resizeImageIfNeeded("pathFromUri", null, null, null))
         .thenReturn("originalPath");
-    when(mockImageResizer.resizeImageIfNeeded("pathFromUri", WIDTH, HEIGHT))
+    when(mockImageResizer.resizeImageIfNeeded("pathFromUri", WIDTH, HEIGHT, null))
         .thenReturn("scaledPath");
-    when(mockImageResizer.resizeImageIfNeeded("pathFromUri", WIDTH, null)).thenReturn("scaledPath");
-    when(mockImageResizer.resizeImageIfNeeded("pathFromUri", null, HEIGHT))
+    when(mockImageResizer.resizeImageIfNeeded("pathFromUri", WIDTH, null, null))
+        .thenReturn("scaledPath");
+    when(mockImageResizer.resizeImageIfNeeded("pathFromUri", null, HEIGHT, null))
+        .thenReturn("scaledPath");
+    when(mockImageResizer.resizeImageIfNeeded("pathFromUri", null, null, true))
         .thenReturn("scaledPath");
 
     mockFileUriResolver = new MockFileUriResolver();
@@ -266,6 +269,19 @@ public class ImagePickerDelegateTest {
         ImagePickerDelegate.REQUEST_CODE_TAKE_VIDEO_WITH_CAMERA, Activity.RESULT_OK, mockIntent);
 
     verify(mockResult).success("pathFromUri");
+    verifyNoMoreInteractions(mockResult);
+  }
+
+  @Test
+  public void
+      onActivityResult_WhenImageTakenWithCamera_AndRotateNeeded_FinishesWithScaledImagePath() {
+    when(mockMethodCall.argument("rotate")).thenReturn(true);
+
+    ImagePickerDelegate delegate = createDelegateWithPendingResultAndMethodCall();
+    delegate.onActivityResult(
+        ImagePickerDelegate.REQUEST_CODE_TAKE_IMAGE_WITH_CAMERA, Activity.RESULT_OK, mockIntent);
+
+    verify(mockResult).success("scaledPath");
     verifyNoMoreInteractions(mockResult);
   }
 

--- a/packages/image_picker/lib/image_picker.dart
+++ b/packages/image_picker/lib/image_picker.dart
@@ -33,6 +33,7 @@ class ImagePicker {
     @required ImageSource source,
     double maxWidth,
     double maxHeight,
+    bool rotate,
   }) async {
     assert(source != null);
 
@@ -53,6 +54,7 @@ class ImagePicker {
         'source': source.index,
         'maxWidth': maxWidth,
         'maxHeight': maxHeight,
+        'rotate': rotate,
       },
     );
 

--- a/packages/image_picker/test/image_picker_test.dart
+++ b/packages/image_picker/test/image_picker_test.dart
@@ -34,11 +34,13 @@ void main() {
               'source': 0,
               'maxWidth': null,
               'maxHeight': null,
+              'rotate': null,
             }),
             isMethodCall('pickImage', arguments: <String, dynamic>{
               'source': 1,
               'maxWidth': null,
               'maxHeight': null,
+              'rotate': null,
             }),
           ],
         );
@@ -59,6 +61,16 @@ void main() {
           maxWidth: 10.0,
           maxHeight: 20.0,
         );
+        await ImagePicker.pickImage(
+          source: ImageSource.camera,
+          rotate: true,
+        );
+        await ImagePicker.pickImage(
+          source: ImageSource.camera,
+          maxWidth: 10.0,
+          maxHeight: 20.0,
+          rotate: true,
+        );
 
         expect(
           log,
@@ -67,21 +79,37 @@ void main() {
               'source': 0,
               'maxWidth': null,
               'maxHeight': null,
+              'rotate': null,
             }),
             isMethodCall('pickImage', arguments: <String, dynamic>{
               'source': 0,
               'maxWidth': 10.0,
               'maxHeight': null,
+              'rotate': null,
             }),
             isMethodCall('pickImage', arguments: <String, dynamic>{
               'source': 0,
               'maxWidth': null,
               'maxHeight': 10.0,
+              'rotate': null,
             }),
             isMethodCall('pickImage', arguments: <String, dynamic>{
               'source': 0,
               'maxWidth': 10.0,
               'maxHeight': 20.0,
+              'rotate': null,
+            }),
+            isMethodCall('pickImage', arguments: <String, dynamic>{
+              'source': 0,
+              'maxWidth': null,
+              'maxHeight': null,
+              'rotate': true,
+            }),
+            isMethodCall('pickImage', arguments: <String, dynamic>{
+              'source': 0,
+              'maxWidth': 10.0,
+              'maxHeight': 20.0,
+              'rotate': true,
             }),
           ],
         );


### PR DESCRIPTION
Added ability to automatically rotate picture taken from camera, with exif preservation.

## Description

Problem:

Some phones take pictures with rotation `right, top` which causes photo to "rotate" 90 degrees when exif data is stripped.  This PR adds one variable to automatically rotate picture and write right exif data.

## Related Issues

This fixes this: https://github.com/flutter/flutter/issues/19458

looking forward to suggestions / changes to this PR. Thanks!