### PR TITLE
Tests to validate Google Maps SDK calls

### DIFF
--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/ActionRecorder.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/ActionRecorder.java
@@ -4,21 +4,20 @@ import androidx.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ActionRecorder {
+class ActionRecorder {
 
   private boolean recordActions = false;
   private final List<String> recordedActions = new ArrayList<>();
 
-  public void startRecordingActions() {
+  void startRecordingActions() {
     recordActions = true;
   }
 
-  // TODO need to implement in delegater
-  public void stopRecordingActions() {
+  void stopRecordingActions() {
     recordActions = false;
   }
 
-  public void clearRecordedActions() {
+  void clearRecordedActions() {
     recordedActions.clear();
   }
 
@@ -38,5 +37,4 @@ public class ActionRecorder {
   List<String> getRecordedActions() {
     return recordedActions;
   }
-
 }

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/ActionRecorder.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/ActionRecorder.java
@@ -1,0 +1,42 @@
+package io.flutter.plugins.googlemaps;
+
+import androidx.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ActionRecorder {
+
+  private boolean recordActions = false;
+  private final List<String> recordedActions = new ArrayList<>();
+
+  public void startRecordingActions() {
+    recordActions = true;
+  }
+
+  // TODO need to implement in delegater
+  public void stopRecordingActions() {
+    recordActions = false;
+  }
+
+  public void clearRecordedActions() {
+    recordedActions.clear();
+  }
+
+  void recordAction(String actionName, @Nullable Object value) {
+    if (!recordActions) {
+      return;
+    }
+    StringBuilder sb = new StringBuilder();
+    sb.append(actionName);
+    if (value != null) {
+      sb.append(" ");
+      sb.append(value);
+    }
+    recordedActions.add(sb.toString());
+  }
+
+  List<String> getRecordedActions() {
+    return recordedActions;
+  }
+
+}

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
@@ -209,10 +209,21 @@ final class GoogleMapController
           result.success(null);
           break;
         }
-        // todo specify in contract for when recordActions is false.
       case "map#getRecordedActions":
         {
           result.success(actionRecorder.getRecordedActions());
+          break;
+        }
+      case "map#clearRecordedActions":
+        {
+          actionRecorder.clearRecordedActions();
+          result.success(null);
+          break;
+        }
+      case "map#stopRecordingActions":
+        {
+          actionRecorder.stopRecordingActions();
+          result.success(null);
           break;
         }
       default:
@@ -329,7 +340,7 @@ final class GoogleMapController
 
   @Override
   public void setCompassEnabled(boolean compassEnabled) {
-    // TODO add this for more methods.
+    // TODO(iskakaushik): record actions to all methods.
     actionRecorder.recordAction("setCompassEnabled", compassEnabled);
     googleMap.getUiSettings().setCompassEnabled(compassEnabled);
   }

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
@@ -67,6 +67,7 @@ final class GoogleMapController
   private final Context context;
   private final MarkersController markersController;
   private List<Object> initialMarkers;
+  private final ActionRecorder actionRecorder = new ActionRecorder();
 
   GoogleMapController(
       int id,
@@ -199,6 +200,19 @@ final class GoogleMapController
           markersController.changeMarkers((List<Object>) markersToChange);
           Object markerIdsToRemove = call.argument("markerIdsToRemove");
           markersController.removeMarkers((List<Object>) markerIdsToRemove);
+          result.success(null);
+          break;
+        }
+      case "map#startRecordingActions":
+        {
+          actionRecorder.startRecordingActions();
+          result.success(null);
+          break;
+        }
+        // todo specify in contract for when recordActions is false.
+      case "map#getRecordedActions":
+        {
+          result.success(actionRecorder.getRecordedActions());
           break;
         }
       default:
@@ -315,6 +329,8 @@ final class GoogleMapController
 
   @Override
   public void setCompassEnabled(boolean compassEnabled) {
+    // TODO add this for more methods.
+    actionRecorder.recordAction("setCompassEnabled", compassEnabled);
     googleMap.getUiSettings().setCompassEnabled(compassEnabled);
   }
 

--- a/packages/google_maps_flutter/example/lib/main.dart
+++ b/packages/google_maps_flutter/example/lib/main.dart
@@ -2,7 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'animate_camera.dart';
 import 'map_ui.dart';
 import 'move_camera.dart';
@@ -10,8 +13,17 @@ import 'page.dart';
 import 'place_marker.dart';
 import 'scrolling_map.dart';
 
+typedef void OnMapCreated(GoogleMapController controller);
+
+// This is used by example driver tests to verify SDK calls.
+Completer<GoogleMapController> controller = Completer<GoogleMapController>();
+
+void _setController(GoogleMapController _controller) {
+  controller.complete(_controller);
+}
+
 final List<Page> _allPages = <Page>[
-  MapUiPage(),
+  MapUiPage(_setController),
   AnimateCameraPage(),
   MoveCameraPage(),
   PlaceMarkerPage(),
@@ -34,6 +46,7 @@ class MapsDemo extends StatelessWidget {
       body: ListView.builder(
         itemCount: _allPages.length,
         itemBuilder: (_, int index) => ListTile(
+              key: ValueKey<String>(_allPages[index].title),
               leading: _allPages[index].leading,
               title: Text(_allPages[index].title),
               onTap: () => _pushPage(context, _allPages[index]),

--- a/packages/google_maps_flutter/example/lib/map_ui.dart
+++ b/packages/google_maps_flutter/example/lib/map_ui.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:google_maps_flutter_example/main.dart';
 
 import 'page.dart';
 
@@ -13,16 +14,20 @@ final LatLngBounds sydneyBounds = LatLngBounds(
 );
 
 class MapUiPage extends Page {
-  MapUiPage() : super(const Icon(Icons.map), 'User interface');
+  MapUiPage(this.callback) : super(const Icon(Icons.map), 'User interface');
+
+  final OnMapCreated callback;
 
   @override
   Widget build(BuildContext context) {
-    return const MapUiBody();
+    return MapUiBody(callback);
   }
 }
 
 class MapUiBody extends StatefulWidget {
-  const MapUiBody();
+  const MapUiBody(this.callback);
+
+  final OnMapCreated callback;
 
   @override
   State<StatefulWidget> createState() => MapUiBodyState();
@@ -61,6 +66,7 @@ class MapUiBodyState extends State<MapUiBody> {
 
   Widget _compassToggler() {
     return FlatButton(
+      key: const ValueKey<String>('compassButton'),
       child: Text('${_compassEnabled ? 'disable' : 'enable'} compass'),
       onPressed: () {
         setState(() {
@@ -240,6 +246,9 @@ class MapUiBodyState extends State<MapUiBody> {
   }
 
   void onMapCreated(GoogleMapController controller) {
+    if (widget.callback != null) {
+      widget.callback(controller);
+    }
     setState(() {
       _isMapCreated = true;
     });

--- a/packages/google_maps_flutter/example/lib/map_ui.dart
+++ b/packages/google_maps_flutter/example/lib/map_ui.dart
@@ -4,8 +4,8 @@
 
 import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
-import 'package:google_maps_flutter_example/main.dart';
 
+import 'main.dart';
 import 'page.dart';
 
 final LatLngBounds sydneyBounds = LatLngBounds(

--- a/packages/google_maps_flutter/example/pubspec.yaml
+++ b/packages/google_maps_flutter/example/pubspec.yaml
@@ -15,6 +15,9 @@ dev_dependencies:
 
   google_maps_flutter:
     path: ../
+  flutter_driver:
+    sdk: flutter
+  test: any
 
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec

--- a/packages/google_maps_flutter/example/test_driver/app.dart
+++ b/packages/google_maps_flutter/example/test_driver/app.dart
@@ -1,0 +1,39 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_driver/driver_extension.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+
+import '../lib/main.dart' as app;
+
+Future<String> _handler(String message) async {
+  final GoogleMapController controller = await app.controller.future;
+
+  if (message == 'startRecordingActions') {
+    await controller.startRecordingActions();
+    return null;
+  }
+
+  if (message == 'getRecordedActions') {
+    final List<String> recordedActions = await controller.getRecordedActions();
+    return recordedActions.join(',');
+  }
+
+  if (message == 'clearRecordedActions') {
+    await controller.clearRecordedActions();
+    return null;
+  }
+
+  if (message == 'stopRecordingActions') {
+    await controller.stopRecordingActions();
+    return null;
+  }
+
+  return null;
+}
+
+void main() {
+  enableFlutterDriverExtension(handler: _handler);
+  app.main();
+}

--- a/packages/google_maps_flutter/example/test_driver/app_test.dart
+++ b/packages/google_maps_flutter/example/test_driver/app_test.dart
@@ -1,0 +1,50 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_driver/flutter_driver.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Google Maps App', () {
+    final SerializableFinder userInterface = find.byValueKey('User interface');
+
+    FlutterDriver driver;
+
+    setUpAll(() async {
+      driver = await FlutterDriver.connect();
+    });
+
+    tearDownAll(() async {
+      if (driver != null) {
+        driver.close();
+      }
+    });
+
+    Future<void> assertActions(String expectedActions) async {
+      final String actions = await driver.requestData('getRecordedActions');
+      expect(actions, equals(expectedActions));
+    }
+
+    test('Test Compass Enable/Disable', () async {
+      await driver.waitFor(userInterface);
+      await driver.tap(userInterface);
+      await driver.waitUntilNoTransientCallbacks();
+
+      final SerializableFinder compassButton = find.byValueKey('compassButton');
+
+      await driver.requestData('startRecordingActions');
+      await driver.waitFor(compassButton);
+      await driver.tap(compassButton);
+      await driver.waitUntilNoTransientCallbacks();
+      await assertActions('setCompassEnabled false');
+      await driver.requestData('clearRecordedActions');
+
+      await driver.requestData('startRecordingActions');
+      await driver.tap(compassButton);
+      await driver.waitUntilNoTransientCallbacks();
+      await assertActions('setCompassEnabled true');
+      await driver.requestData('clearRecordedActions');
+    });
+  });
+}

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapActionRecorder.h
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapActionRecorder.h
@@ -1,0 +1,15 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <Flutter/Flutter.h>
+
+@interface GoogleMapActionRecorder : NSObject
+- (instancetype)init;
+- (void)startRecordingActions;
+- (void)stopRecordingActions;
+- (void)clearRecordedActions;
+- (void)recordAction:(NSString*)action value:(NSString*)value;
+- (void)recordAction:(NSString*)action boolValue:(BOOL)value;
+- (NSArray*)getRecordedActions;
+@end

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapActionRecorder.m
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapActionRecorder.m
@@ -1,0 +1,60 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "GoogleMapActionRecorder.h"
+
+@implementation GoogleMapActionRecorder {
+  NSMutableArray* actions;
+  BOOL recordActions;
+}
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    actions = [[NSMutableArray alloc] init];
+    recordActions = NO;
+  }
+  return self;
+}
+- (void)startRecordingActions {
+  recordActions = YES;
+}
+- (void)stopRecordingActions {
+  recordActions = NO;
+}
+- (void)clearRecordedActions {
+  [actions removeAllObjects];
+}
+- (void)recordAction:(NSString*)action value:(NSString*)value {
+  if (!recordActions) {
+    return;
+  }
+  NSMutableString* str = [[NSMutableString alloc] initWithCapacity:1000];
+  [str appendString:action];
+  if (value) {
+    [str appendString:@" "];
+    [str appendString:value];
+  }
+  [actions addObject:str];
+}
+- (void)recordAction:(NSString*)action boolValue:(BOOL)value {
+  if (!recordActions) {
+    return;
+  }
+  NSUInteger capacity = [action length] + 5;
+  NSMutableString* str = [[NSMutableString alloc] initWithCapacity:capacity];
+  [str appendString:action];
+  [str appendString:@" "];
+  if (value) {
+    [str appendString:@"true"];
+  } else {
+    [str appendString:@"false"];
+  }
+  [actions addObject:str];
+}
+
+- (NSArray*)getRecordedActions {
+  return actions;
+}
+
+@end

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapController.m
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapController.m
@@ -221,7 +221,7 @@ static double ToDouble(NSNumber* data) { return [FLTGoogleMapJsonConversions toD
 #pragma mark - GMSMapViewDelegate methods
 
 - (void)mapView:(GMSMapView*)mapView willMove:(BOOL)gesture {
-  [_channel invokeMethod:@"camera#onMoveStarted" arguments:@{@"isGesture": @(gesture)}];
+  [_channel invokeMethod:@"camera#onMoveStarted" arguments:@{@"isGesture" : @(gesture)}];
 }
 
 - (void)mapView:(GMSMapView*)mapView didChangeCameraPosition:(GMSCameraPosition*)position {
@@ -236,7 +236,7 @@ static double ToDouble(NSNumber* data) { return [FLTGoogleMapJsonConversions toD
     [mapView moveCamera:[GMSCameraUpdate setCamera:_mapView.camera]];
   }
   if (_trackCameraPosition) {
-    [_channel invokeMethod:@"camera#onMove" arguments:@{@"position": PositionToJson(position)}];
+    [_channel invokeMethod:@"camera#onMove" arguments:@{@"position" : PositionToJson(position)}];
   }
 }
 
@@ -259,7 +259,7 @@ static double ToDouble(NSNumber* data) { return [FLTGoogleMapJsonConversions toD
 #pragma mark - Implementations of JSON conversion functions.
 
 static NSArray* LocationToJson(CLLocationCoordinate2D position) {
-  return @[@(position.latitude), @(position.longitude)];
+  return @[ @(position.latitude), @(position.longitude) ];
 }
 
 static NSDictionary* PositionToJson(GMSCameraPosition* position) {
@@ -267,10 +267,10 @@ static NSDictionary* PositionToJson(GMSCameraPosition* position) {
     return nil;
   }
   return @{
-      @"target": LocationToJson([position target]),
-      @"zoom": @([position zoom]),
-      @"bearing": @([position bearing]),
-      @"tilt": @([position viewingAngle]),
+    @"target" : LocationToJson([position target]),
+    @"zoom" : @([position zoom]),
+    @"bearing" : @([position bearing]),
+    @"tilt" : @([position viewingAngle]),
   };
 }
 
@@ -308,7 +308,7 @@ static GMSCoordinateBounds* ToOptionalBounds(NSArray* data) {
 
 static GMSMapViewType ToMapViewType(NSNumber* json) {
   int value = ToInt(json);
-  return (GMSMapViewType) (value == 0 ? 5 : value);
+  return (GMSMapViewType)(value == 0 ? 5 : value);
 }
 
 static GMSCameraUpdate* ToCameraUpdate(NSArray* data) {

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapController.m
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapController.m
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #import "GoogleMapController.h"
+#import "GoogleMapActionRecorder.h"
 #import "JsonConversions.h"
 
 #pragma mark - Conversion of JSON-like values sent via platform channels. Forward declarations.
@@ -52,6 +53,7 @@ static double ToDouble(NSNumber* data) { return [FLTGoogleMapJsonConversions toD
   // https://github.com/flutter/flutter/issues/27550
   BOOL _cameraDidInitialSetup;
   FLTMarkersController* _markersController;
+  GoogleMapActionRecorder* _actionRecorder;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -81,6 +83,7 @@ static double ToDouble(NSNumber* data) { return [FLTGoogleMapJsonConversions toD
     _markersController = [[FLTMarkersController alloc] init:_channel
                                                     mapView:_mapView
                                                   registrar:registrar];
+    _actionRecorder = [[GoogleMapActionRecorder alloc] init];
     id markersToAdd = args[@"markersToAdd"];
     if ([markersToAdd isKindOfClass:[NSArray class]]) {
       [_markersController addMarkers:markersToAdd];
@@ -125,6 +128,17 @@ static double ToDouble(NSNumber* data) { return [FLTGoogleMapJsonConversions toD
       [_markersController removeMarkerIds:markerIdsToRemove];
     }
     result(nil);
+  } else if ([call.method isEqualToString:@"map#startRecordingActions"]) {
+    [_actionRecorder startRecordingActions];
+    result(nil);
+  } else if ([call.method isEqualToString:@"map#stopRecordingActions"]) {
+    [_actionRecorder stopRecordingActions];
+    result(nil);
+  } else if ([call.method isEqualToString:@"map#clearRecordedActions"]) {
+    [_actionRecorder clearRecordedActions];
+    result(nil);
+  } else if ([call.method isEqualToString:@"map#getRecordedActions"]) {
+    result([_actionRecorder getRecordedActions]);
   } else {
     result(FlutterMethodNotImplemented);
   }
@@ -167,6 +181,7 @@ static double ToDouble(NSNumber* data) { return [FLTGoogleMapJsonConversions toD
 }
 
 - (void)setCompassEnabled:(BOOL)enabled {
+  [_actionRecorder recordAction:@"setCompassEnabled" boolValue:enabled];
   _mapView.settings.compassButton = enabled;
 }
 
@@ -206,7 +221,7 @@ static double ToDouble(NSNumber* data) { return [FLTGoogleMapJsonConversions toD
 #pragma mark - GMSMapViewDelegate methods
 
 - (void)mapView:(GMSMapView*)mapView willMove:(BOOL)gesture {
-  [_channel invokeMethod:@"camera#onMoveStarted" arguments:@{@"isGesture" : @(gesture)}];
+  [_channel invokeMethod:@"camera#onMoveStarted" arguments:@{@"isGesture": @(gesture)}];
 }
 
 - (void)mapView:(GMSMapView*)mapView didChangeCameraPosition:(GMSCameraPosition*)position {
@@ -221,7 +236,7 @@ static double ToDouble(NSNumber* data) { return [FLTGoogleMapJsonConversions toD
     [mapView moveCamera:[GMSCameraUpdate setCamera:_mapView.camera]];
   }
   if (_trackCameraPosition) {
-    [_channel invokeMethod:@"camera#onMove" arguments:@{@"position" : PositionToJson(position)}];
+    [_channel invokeMethod:@"camera#onMove" arguments:@{@"position": PositionToJson(position)}];
   }
 }
 
@@ -244,7 +259,7 @@ static double ToDouble(NSNumber* data) { return [FLTGoogleMapJsonConversions toD
 #pragma mark - Implementations of JSON conversion functions.
 
 static NSArray* LocationToJson(CLLocationCoordinate2D position) {
-  return @[ @(position.latitude), @(position.longitude) ];
+  return @[@(position.latitude), @(position.longitude)];
 }
 
 static NSDictionary* PositionToJson(GMSCameraPosition* position) {
@@ -252,10 +267,10 @@ static NSDictionary* PositionToJson(GMSCameraPosition* position) {
     return nil;
   }
   return @{
-    @"target" : LocationToJson([position target]),
-    @"zoom" : @([position zoom]),
-    @"bearing" : @([position bearing]),
-    @"tilt" : @([position viewingAngle]),
+      @"target": LocationToJson([position target]),
+      @"zoom": @([position zoom]),
+      @"bearing": @([position bearing]),
+      @"tilt": @([position viewingAngle]),
   };
 }
 
@@ -293,7 +308,7 @@ static GMSCoordinateBounds* ToOptionalBounds(NSArray* data) {
 
 static GMSMapViewType ToMapViewType(NSNumber* json) {
   int value = ToInt(json);
-  return (GMSMapViewType)(value == 0 ? 5 : value);
+  return (GMSMapViewType) (value == 0 ? 5 : value);
 }
 
 static GMSCameraUpdate* ToCameraUpdate(NSArray* data) {

--- a/packages/google_maps_flutter/lib/src/controller.dart
+++ b/packages/google_maps_flutter/lib/src/controller.dart
@@ -127,5 +127,35 @@ class GoogleMapController {
     });
   }
 
-  // TODO method to get recorded actions.
+  // Record SDK calls. This is used for testing.
+
+  Future<void> startRecordingActions() async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
+    await _channel.invokeMethod('map#startRecordingActions');
+  }
+
+  Future<void> stopRecordingActions() async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
+    await _channel.invokeMethod('map#stopRecordingActions');
+  }
+
+  Future<void> clearRecordedActions() async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
+    await _channel.invokeMethod('map#clearRecordedActions');
+  }
+
+  Future<List<String>> getRecordedActions() async {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
+    final List<String> recordedActions =
+        await _channel.invokeMethod('map#getRecordedActions');
+    return recordedActions;
+  }
 }

--- a/packages/google_maps_flutter/lib/src/controller.dart
+++ b/packages/google_maps_flutter/lib/src/controller.dart
@@ -127,7 +127,7 @@ class GoogleMapController {
     });
   }
 
-  // Record SDK calls. This is used for testing.
+  // Record SDK calls. These are used primarily for testing.
 
   Future<void> startRecordingActions() async {
     // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
@@ -154,8 +154,8 @@ class GoogleMapController {
     // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
     // https://github.com/flutter/flutter/issues/26431
     // ignore: strong_mode_implicit_dynamic_method
-    final List<String> recordedActions =
+    final List<dynamic> recordedActions =
         await _channel.invokeMethod('map#getRecordedActions');
-    return recordedActions;
+    return recordedActions.cast<String>();
   }
 }

--- a/packages/google_maps_flutter/lib/src/controller.dart
+++ b/packages/google_maps_flutter/lib/src/controller.dart
@@ -8,7 +8,6 @@ part of google_maps_flutter;
 class GoogleMapController {
   GoogleMapController._(
     MethodChannel channel,
-    CameraPosition initialCameraPosition,
     this._googleMapState,
   )   : assert(channel != null),
         _channel = channel {
@@ -17,7 +16,6 @@ class GoogleMapController {
 
   static Future<GoogleMapController> init(
     int id,
-    CameraPosition initialCameraPosition,
     _GoogleMapState googleMapState,
   ) async {
     assert(id != null);
@@ -29,7 +27,6 @@ class GoogleMapController {
     await channel.invokeMethod('map#waitForMap');
     return GoogleMapController._(
       channel,
-      initialCameraPosition,
       googleMapState,
     );
   }
@@ -129,4 +126,6 @@ class GoogleMapController {
       'cameraUpdate': cameraUpdate._toJson(),
     });
   }
+
+  // TODO method to get recorded actions.
 }

--- a/packages/google_maps_flutter/lib/src/google_map.dart
+++ b/packages/google_maps_flutter/lib/src/google_map.dart
@@ -199,11 +199,8 @@ class _GoogleMapState extends State<GoogleMap> {
   }
 
   Future<void> onPlatformViewCreated(int id) async {
-    final GoogleMapController controller = await GoogleMapController.init(
-      id,
-      widget.initialCameraPosition,
-      this,
-    );
+    final GoogleMapController controller =
+        await GoogleMapController.init(id, this);
     _controller.complete(controller);
     if (widget.onMapCreated != null) {
       widget.onMapCreated(controller);

--- a/packages/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/pubspec.yaml
@@ -11,6 +11,11 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  # TODO(iskakaushik): The following dependencies can be removed once
+  # https://github.com/dart-lang/pub/issues/2101 is resolved.
+  flutter_driver:
+    sdk: flutter
+  test: any
 
 flutter:
   plugin:


### PR DESCRIPTION
Adds a mechanism which allows for testing Google Maps plugin's SDK calls. This adds some additional methods to the GoogleMapController that let us recordActions, where each action is any call made to the google maps sdk.

Once we do a "handoff" to the google maps sdk, apart from the platform view rendering, we can be relatively confident about the propagation of the action done by the user.


