### PR TITLE
[webview_flutter] Add initial e2e tests

### DIFF
--- a/packages/webview_flutter/example/pubspec.yaml
+++ b/packages/webview_flutter/example/pubspec.yaml
@@ -15,6 +15,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  flutter_driver:
+    sdk: flutter
 
 flutter:
   uses-material-design: true

--- a/packages/webview_flutter/example/test_driver/webview.dart
+++ b/packages/webview_flutter/example/test_driver/webview.dart
@@ -14,46 +14,44 @@ void main() {
   enableFlutterDriverExtension(handler: (_) => allTestsCompleter.future);
   tearDownAll(() => allTestsCompleter.complete(null));
 
-  group('$WebView', () {
-    test('initalUrl', () async {
-      final Completer<WebViewController> controllerCompleter =
-          Completer<WebViewController>();
-      runApp(
-        Directionality(
-          textDirection: TextDirection.ltr,
-          child: WebView(
-            key: GlobalKey(),
-            initialUrl: 'https://flutter.dev/',
-            onWebViewCreated: (WebViewController controller) {
-              controllerCompleter.complete(controller);
-            },
-          ),
+  test('initalUrl', () async {
+    final Completer<WebViewController> controllerCompleter =
+        Completer<WebViewController>();
+    runApp(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: WebView(
+          key: GlobalKey(),
+          initialUrl: 'https://flutter.dev/',
+          onWebViewCreated: (WebViewController controller) {
+            controllerCompleter.complete(controller);
+          },
         ),
-      );
-      final WebViewController controller = await controllerCompleter.future;
-      final String currentUrl = await controller.currentUrl();
-      expect(currentUrl, 'https://flutter.dev/');
-    });
+      ),
+    );
+    final WebViewController controller = await controllerCompleter.future;
+    final String currentUrl = await controller.currentUrl();
+    expect(currentUrl, 'https://flutter.dev/');
+  });
 
-    test('loadUrl', () async {
-      final Completer<WebViewController> controllerCompleter =
-          Completer<WebViewController>();
-      runApp(
-        Directionality(
-          textDirection: TextDirection.ltr,
-          child: WebView(
-            key: GlobalKey(),
-            initialUrl: 'https://flutter.dev/',
-            onWebViewCreated: (WebViewController controller) {
-              controllerCompleter.complete(controller);
-            },
-          ),
+  test('loadUrl', () async {
+    final Completer<WebViewController> controllerCompleter =
+        Completer<WebViewController>();
+    runApp(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: WebView(
+          key: GlobalKey(),
+          initialUrl: 'https://flutter.dev/',
+          onWebViewCreated: (WebViewController controller) {
+            controllerCompleter.complete(controller);
+          },
         ),
-      );
-      final WebViewController controller = await controllerCompleter.future;
-      await controller.loadUrl('https://www.google.com/');
-      final String currentUrl = await controller.currentUrl();
-      expect(currentUrl, 'https://www.google.com/');
-    });
+      ),
+    );
+    final WebViewController controller = await controllerCompleter.future;
+    await controller.loadUrl('https://www.google.com/');
+    final String currentUrl = await controller.currentUrl();
+    expect(currentUrl, 'https://www.google.com/');
   });
 }

--- a/packages/webview_flutter/example/test_driver/webview.dart
+++ b/packages/webview_flutter/example/test_driver/webview.dart
@@ -1,0 +1,59 @@
+// Copyright 2019, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_driver/driver_extension.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+void main() {
+  final Completer<String> allTestsCompleter = Completer<String>();
+  enableFlutterDriverExtension(handler: (_) => allTestsCompleter.future);
+  tearDownAll(() => allTestsCompleter.complete(null));
+
+  group('$WebView', () {
+    test('initalUrl', () async {
+      final Completer<WebViewController> controllerCompleter =
+          Completer<WebViewController>();
+      runApp(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: WebView(
+            key: GlobalKey(),
+            initialUrl: 'https://flutter.dev/',
+            onWebViewCreated: (WebViewController controller) {
+              controllerCompleter.complete(controller);
+            },
+          ),
+        ),
+      );
+      final WebViewController controller = await controllerCompleter.future;
+      final String currentUrl = await controller.currentUrl();
+      expect(currentUrl, 'https://flutter.dev/');
+    });
+
+    test('loadUrl', () async {
+      final Completer<WebViewController> controllerCompleter =
+          Completer<WebViewController>();
+      runApp(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: WebView(
+            key: GlobalKey(),
+            initialUrl: 'https://flutter.dev/',
+            onWebViewCreated: (WebViewController controller) {
+              controllerCompleter.complete(controller);
+            },
+          ),
+        ),
+      );
+      final WebViewController controller = await controllerCompleter.future;
+      await controller.loadUrl('https://www.google.com/');
+      final String currentUrl = await controller.currentUrl();
+      expect(currentUrl, 'https://www.google.com/');
+    });
+  });
+}

--- a/packages/webview_flutter/example/test_driver/webview_test.dart
+++ b/packages/webview_flutter/example/test_driver/webview_test.dart
@@ -1,0 +1,13 @@
+// Copyright 2019, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_driver/flutter_driver.dart';
+
+Future<void> main() async {
+  final FlutterDriver driver = await FlutterDriver.connect();
+  await driver.requestData(null, timeout: const Duration(minutes: 1));
+  driver.close();
+}

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -15,6 +15,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  flutter_driver:
+    sdk: flutter
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Add initial flutter driver based e2e tests for webview_flutter.

@collinjackson a few notes for stuff I ran into while writing this:
  * I'm not using the example app at all other than it's iOS project setup, not a big deal but might make sense to consider supporting such an integration test out of the `example/` folder.
  * I couldn't use the WidgetTester as it is asserting that the platform is flutter_tester, maybe we should change that?
  * Because I couldn't use the widget tester I used `runApp()` directly in each test, while it works it's not starting each test from a clean widget tree state(that's why I included global keys for the widgets to ensure their state is lost). I also experimented with doing `runApp(Container())` in `setUp()` but I think it didn't work as nothing was waiting for the widget tree to be pumped so I never got a frame with `Container()`, I guess that's one of the things WidgetTester is providing. 

All in all this looks like this approach can get us pretty decent test coverage for the webview plugin.

Fixes https://github.com/flutter/flutter/issues/29637.

## Related Issues

https://github.com/flutter/flutter/issues/29637

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
