### PR TITLE
[firebase_crashlytics] Rely on firebase_core to set up Firebase Analytics dependency

### DIFF
--- a/packages/firebase_crashlytics/CHANGELOG.md
+++ b/packages/firebase_crashlytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.3
+
+* Rely on firebase_core to add the Android dependency on Firebase instead of hardcoding the version ourselves
+
 ## 0.0.2+1
 
 * Update variable name `enableInDevMode` in README.

--- a/packages/firebase_crashlytics/android/build.gradle
+++ b/packages/firebase_crashlytics/android/build.gradle
@@ -37,6 +37,5 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.firebase:firebase-core:16.0.8'
     implementation 'com.crashlytics.sdk.android:crashlytics:2.9.9'
 }

--- a/packages/firebase_crashlytics/pubspec.yaml
+++ b/packages/firebase_crashlytics/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_crashlytics
 description: Flutter plugin for Firebase Crashlytics. It reports uncaught errors to the
   Firebase console.
-version: 0.0.2+1
+version: 0.0.3
 author: Flutter Team <flutter-dev@google.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_crashlytics
 


### PR DESCRIPTION
## Description

Rely on firebase_core to set up Firebase Analytics dependency instead of setting it ourselves. This stops firebase_crashlytics from conflicting with other Firebase plugins on Android. 

## Related Issues

Fixes flutter/flutter#30037

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] ~My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).~
- [x] ~All existing and new tests are passing.~
- [x] ~I updated/added relevant documentation (doc comments with `///`).~
- [x] ~The analyzer (`flutter analyze`) does not report any problems on my PR.~
- [x] ~I read and followed the [Flutter Style Guide].~
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
