### PR TITLE
[firebase_analytics] Added Navigator.pushReplacement screen tracking

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -27,3 +27,4 @@ Mike Diarmid <mike@invertase.io>
 Invertase <oss@invertase.io>
 Elliot Hesp <elliot@invertase.io>
 Katarina Sheremet <katarina@sheremet.ch>
+Thomas Stockx <thomas@stockxit.com>

--- a/packages/firebase_analytics/CHANGELOG.md
+++ b/packages/firebase_analytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.1
+
+* Added screen_view tracking of Navigator.pushReplacement
+
 ## 2.1.0
 
 * Add Login event support

--- a/packages/firebase_analytics/lib/observer.dart
+++ b/packages/firebase_analytics/lib/observer.dart
@@ -32,6 +32,10 @@ String defaultNameExtractor(RouteSettings settings) => settings.name;
 ///   settings: RouteSettings(name: '/contact/123',
 ///   builder: ContactDetail(123)))),
 ///
+/// Navigator.pushReplacement(context, MaterialPageRoute(
+///   settings: RouteSettings(name: '/contact/123',
+///   builder: ContactDetail(123)))),
+///
 /// Navigator.pop(context);
 /// ```
 ///

--- a/packages/firebase_analytics/lib/observer.dart
+++ b/packages/firebase_analytics/lib/observer.dart
@@ -93,7 +93,7 @@ class FirebaseAnalyticsObserver extends RouteObserver<PageRoute<dynamic>> {
       _sendScreenView(route);
     }
   }
-  
+
   @override
   void didReplace({Route<dynamic> newRoute, Route<dynamic> oldRoute}) {
     super.didReplace(newRoute: newRoute, oldRoute: oldRoute);

--- a/packages/firebase_analytics/lib/observer.dart
+++ b/packages/firebase_analytics/lib/observer.dart
@@ -93,6 +93,14 @@ class FirebaseAnalyticsObserver extends RouteObserver<PageRoute<dynamic>> {
       _sendScreenView(route);
     }
   }
+  
+  @override
+  void didReplace({Route<dynamic> newRoute, Route<dynamic> oldRoute}) {
+    super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
+    if (newRoute is PageRoute) {
+      _sendScreenView(newRoute);
+    }
+  }
 
   @override
   void didPop(Route<dynamic> route, Route<dynamic> previousRoute) {

--- a/packages/firebase_analytics/pubspec.yaml
+++ b/packages/firebase_analytics/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Analytics for Firebase, an app measuremen
   solution that provides insight on app usage and user engagement on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_analytics
-version: 2.1.0
+version: 2.1.1
 
 flutter:
   plugin:

--- a/packages/firebase_analytics/test/observer_test.dart
+++ b/packages/firebase_analytics/test/observer_test.dart
@@ -57,6 +57,16 @@ void main() {
       verify(analytics.setCurrentScreen(screenName: 'route')).called(1);
     });
 
+    test('setCurrentScreen on route pushReplacement', () {
+      final PageRoute<dynamic> route = MockPageRoute();
+      final PageRoute<dynamic> previousRoute = MockPageRoute();
+      when(route.settings).thenReturn(const RouteSettings(name: 'route'));
+
+      observer.didReplace(newRoute: route, oldRoute: previousRoute);
+
+      verify(analytics.setCurrentScreen(screenName: 'route')).called(1);
+    });
+
     test('uses nameExtractor', () {
       observer = FirebaseAnalyticsObserver(
         analytics: analytics,


### PR DESCRIPTION
## Description

Currently only standard push and pops were automatically logged to Firebase. However, this resulted in missing screen_view events for apps with more complex navigation.

## Related Issues

/

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
