### PR TITLE
[firebase_core] Use Gradle BoM with firebase_core

### DIFF
--- a/packages/firebase_core/CHANGELOG.md
+++ b/packages/firebase_core/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.2
+
+* Move Android dependency to Gradle BoM to help maintain compatability
+  with other FlutterFire plugins.
+
 ## 0.3.1+1
 
 * Add nil check on static functions to prevent crashes or unwanted behaviors.

--- a/packages/firebase_core/android/build.gradle
+++ b/packages/firebase_core/android/build.gradle
@@ -45,6 +45,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        api 'com.google.firebase:firebase-core:16.0.4'
+        implementation 'com.google.firebase:firebase-bom:17.0.0'
+        api 'com.google.firebase:firebase-core'
     }
 }

--- a/packages/firebase_core/example/android/settings.gradle
+++ b/packages/firebase_core/example/android/settings.gradle
@@ -13,3 +13,5 @@ plugins.each { name, path ->
     include ":$name"
     project(":$name").projectDir = pluginDirectory
 }
+
+enableFeaturePreview('IMPROVED_POM_SUPPORT')

--- a/packages/firebase_core/pubspec.yaml
+++ b/packages/firebase_core/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Core, enabling connecting to multiple
   Firebase apps.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_core
-version: 0.3.1+1
+version: 0.3.2
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

[Firebase now supports Gradle BoM](https://firebase.google.com/docs/android/setup) (Bill of Materials). This allows a single Firebase version to determine the appropriate version number of specific Firebase dependencies.

Since all other FlutterFire plugins depend on `firebase_core` this will be the first of the FlutterFire plugins to be updated to BoM then all others will follow once this change is merged.

NOTE: Users of FlutterFire will have to add `enableFeaturePreview('IMPROVED_POM_SUPPORT')` to their Android app's settings.gradle file till Flutter moves over to Gradle 5+