### PR TITLE
[webview_flutter] iOS specific initialization configuration, for enabling video playback.

### DIFF
--- a/packages/webview_flutter/example/lib/main.dart
+++ b/packages/webview_flutter/example/lib/main.dart
@@ -53,8 +53,12 @@ class WebViewExample extends StatelessWidget {
           javascriptChannels: <JavascriptChannel>[
             _toasterJavascriptChannel(context),
           ].toSet(),
+          iOSWebViewConfiguration: const IOSWebViewConfiguration(
+            allowsInlineMediaPlayback: true,
+          ),
           navigationDelegate: (NavigationRequest request) {
-            if (request.url.startsWith('https://www.youtube.com/')) {
+            if (request.url.startsWith('https://www.youtube.com/') &&
+                !request.url.contains('embed')) {
               print('blocking navigation to $request}');
               return NavigationDecision.prevent;
             }


### PR DESCRIPTION
## Description

Right now video playback is not supported on iOS because it's by default disabled, while on Android it is enabled by default.
WKWebView provides configuration options for configuring video playback. I have implemented most options to configure them. This required a iOS specific configuration object.

Unfortunately I am not sure how to test this behavior, because it simply allows video playback which does not provide any checkable events afaik? I could provide a method to query those iOS configuration options, but since this is only useful in tests, i'm not sure if this makes sense..

I have changed the example application to allow inline video playback (and removed the blocking of embedded youtube videos, but youtube.com itself is still blocked. I wasn't sure what the initial intent was to block youtube.com, so hope this is okay).

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
