### PR TITLE
[video_player] Fixed orientation and position issue for some videos metadata.

### DIFF
--- a/packages/video_player/CHANGELOG.md
+++ b/packages/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.0+5
+
+* iOS: Fixed orientation and position issue for some videos metadata.
+
 ## 0.10.0+4
 
 * Android: Upgrade ExoPlayer to 2.9.6.

--- a/packages/video_player/ios/Classes/VideoPlayerPlugin.m
+++ b/packages/video_player/ios/Classes/VideoPlayerPlugin.m
@@ -154,19 +154,27 @@ static void* playbackBufferFullContext = &playbackBufferFullContext;
   // At least 2 user videos show a black screen when in portrait mode if we directly use the
   // videoTrack.preferredTransform Setting tx to the height of the video instead of 0, properly
   // displays the video https://github.com/flutter/flutter/issues/17606#issuecomment-413473181
-  if (transform.tx == 0 && transform.ty == 0) {
-    NSInteger rotationDegrees = (NSInteger)round(radiansToDegrees(atan2(transform.b, transform.a)));
-    NSLog(@"TX and TY are 0. Rotation: %ld. Natural width,height: %f, %f", (long)rotationDegrees,
-          videoTrack.naturalSize.width, videoTrack.naturalSize.height);
+  NSInteger rotationDegrees = (NSInteger)round(radiansToDegrees(atan2(transform.b, transform.a)));
+  // This prevents the video to be rendered out of the screen if the metadata contain a rotation but
+  // no translation to compensate the shift induced by the rotation.
+  if (rotationDegrees != 0 && transform.tx == 0 && transform.ty == 0) {
+    NSLog(@"Adding translation to compensate rotation. Rotation = %ld. Natural (width, height) = "
+          @"(%f, %f)",
+          (long)rotationDegrees, videoTrack.naturalSize.width, videoTrack.naturalSize.height);
+    NSLog(@"Uncompensated transform (a, b, c, d, tx, ty) = (%f, %f, %f, %f, %f, %f)", transform.a,
+          transform.b, transform.c, transform.d, transform.tx, transform.ty);
     if (rotationDegrees == 90) {
-      NSLog(@"Setting transform tx");
       transform.tx = videoTrack.naturalSize.height;
       transform.ty = 0;
+    } else if (rotationDegrees == 180) {
+      transform.tx = videoTrack.naturalSize.width;
+      transform.ty = videoTrack.naturalSize.height;
     } else if (rotationDegrees == 270) {
-      NSLog(@"Setting transform ty");
       transform.tx = 0;
       transform.ty = videoTrack.naturalSize.width;
     }
+    NSLog(@"Compensated transform (a, b, c, d, tx, ty) = (%f, %f, %f, %f, %f, %f)", transform.a,
+          transform.b, transform.c, transform.d, transform.tx, transform.ty);
   }
   return transform;
 }

--- a/packages/video_player/pubspec.yaml
+++ b/packages/video_player/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player
 description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
-version: 0.10.0+4
+version: 0.10.0+5
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player
 
 flutter:


### PR DESCRIPTION
## Description

The video was not always displaying properly on iOS depending on the rotation metadata (iOS need the tx and ty of the transform to have an offset if the video is rotated, unlike Android or VLC). This fixes it.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/29951
Fixes https://github.com/flutter/flutter/issues/27201
Fixes https://github.com/flutter/flutter/issues/29500

NOTE: The camera plugin also need an update to add rotation metadata to the recorded videos. This is done in this other PR: https://github.com/flutter/plugins/pull/1452

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.