### PR TITLE
[flutter_fire] Use Gradle BoM with FlutterFire

### DIFF
--- a/packages/cloud_firestore/README.md
+++ b/packages/cloud_firestore/README.md
@@ -23,6 +23,14 @@ with Xcode, and within Xcode place the file inside ios/Runner. Don't follow the 
 "Add Firebase SDK" and "Add initialization code" in the Firebase assistant.
 1. Add `cloud_firestore` as a [dependency in your pubspec.yaml file](https://flutter.io/platform-plugins/).
 
+## Gradle BoM setup 
+
+If you are using a Gradle version earlier than Gradle 5 then you must add `enableFeaturePreview('IMPROVED_POM_SUPPORT')`
+to the Android app's `settings.gradle` file. See example app.
+
+The use of Gradle BoM (Bill of Materials) helps ensure that the latest versions of the FlutterFire plugins
+work well together.
+
 ## Usage
 
 ```dart

--- a/packages/cloud_functions/CHANGELOG.md
+++ b/packages/cloud_functions/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.3
+
+* Move Android dependency to Gradle BoM to help maintain compatability
+  with other FlutterFire plugins.
+
 ## 0.1.2+1
 
 * Added a driver test.

--- a/packages/cloud_functions/README.md
+++ b/packages/cloud_functions/README.md
@@ -23,6 +23,14 @@ with Xcode, and within Xcode place the file inside ios/Runner. Don't follow the 
 "Add Firebase SDK" and "Add initialization code" in the Firebase assistant.
 1. Add `cloud_functions` as a [dependency in your pubspec.yaml file](https://flutter.io/platform-plugins/).
 
+## Gradle BoM setup 
+
+If you are using a Gradle version earlier than Gradle 5 then you must add `enableFeaturePreview('IMPROVED_POM_SUPPORT')`
+to the Android app's `settings.gradle` file. See example app.
+
+The use of Gradle BoM (Bill of Materials) helps ensure that the latest versions of the FlutterFire plugins
+work well together.
+
 ## Usage
 
 ```dart

--- a/packages/cloud_functions/android/build.gradle
+++ b/packages/cloud_functions/android/build.gradle
@@ -45,7 +45,8 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        api 'com.google.firebase:firebase-functions:16.1.1'
+        implementation 'com.google.firebase:firebase-bom:17.0.0'
+        api 'com.google.firebase:firebase-functions'
         implementation 'androidx.annotation:annotation:1.0.0'
     }
 }

--- a/packages/cloud_functions/example/android/settings.gradle
+++ b/packages/cloud_functions/example/android/settings.gradle
@@ -13,3 +13,5 @@ plugins.each { name, path ->
     include ":$name"
     project(":$name").projectDir = pluginDirectory
 }
+
+enableFeaturePreview('IMPROVED_POM_SUPPORT')

--- a/packages/cloud_functions/example/pubspec.yaml
+++ b/packages/cloud_functions/example/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   cupertino_icons: ^0.1.2
   cloud_functions:
     path: ..
-  firebase_core: ^0.3.1
+  firebase_core: ^0.3.2
 
 dev_dependencies:
   flutter_test:

--- a/packages/cloud_functions/pubspec.yaml
+++ b/packages/cloud_functions/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cloud_functions
 description: Flutter plugin for Cloud Functions.
-version: 0.1.2+1
+version: 0.1.3
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_functions
 
@@ -13,7 +13,7 @@ dependencies:
   meta: ^1.1.6
   flutter:
     sdk: flutter
-  firebase_core: ^0.3.0
+  firebase_core: ^0.3.2
 
 dev_dependencies:
   flutter_test:

--- a/packages/firebase_admob/CHANGELOG.md
+++ b/packages/firebase_admob/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.8.1
+
+* Move Android dependency to Gradle BoM to help maintain compatability
+  with other FlutterFire plugins.
+
 ## 0.8.0+3
 
 * Log messages about automatic configuration of the default app are now less confusing.

--- a/packages/firebase_admob/README.md
+++ b/packages/firebase_admob/README.md
@@ -50,6 +50,14 @@ Failure to add this tag will result in the app crashing at app launch with a mes
 On Android, this value must be the same as the App ID value set in your 
 `AndroidManifest.xml`.
 
+## Gradle BoM setup 
+
+If you are using a Gradle version earlier than Gradle 5 then you must add `enableFeaturePreview('IMPROVED_POM_SUPPORT')`
+to the Android app's `settings.gradle` file. See example app.
+
+The use of Gradle BoM (Bill of Materials) helps ensure that the latest versions of the FlutterFire plugins
+work well together.
+
 ## Using banners and interstitials
 Banner and interstitial ads can be configured with target information.
 And in the example below, the ads are given test ad unit IDs for a quick start.

--- a/packages/firebase_admob/android/build.gradle
+++ b/packages/firebase_admob/android/build.gradle
@@ -45,6 +45,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        api 'com.google.firebase:firebase-ads:17.0.0'
+        implementation 'com.google.firebase:firebase-bom:17.0.0'
+        api 'com.google.firebase:firebase-ads'
     }
 }

--- a/packages/firebase_admob/example/android/settings.gradle
+++ b/packages/firebase_admob/example/android/settings.gradle
@@ -13,3 +13,5 @@ plugins.each { name, path ->
     include ":$name"
     project(":$name").projectDir = pluginDirectory
 }
+
+enableFeaturePreview('IMPROVED_POM_SUPPORT')

--- a/packages/firebase_admob/example/pubspec.yaml
+++ b/packages/firebase_admob/example/pubspec.yaml
@@ -6,7 +6,7 @@ dependencies:
     sdk: flutter
   firebase_admob:
     path: ../
-  firebase_core: ^0.3.0
+  firebase_core: ^0.3.2
 
 flutter:
   uses-material-design: true

--- a/packages/firebase_admob/pubspec.yaml
+++ b/packages/firebase_admob/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_admob
 description: Firebase AdMob plugin for Flutter applications.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_admob
-version: 0.8.0+3
+version: 0.8.1
 
 flutter:
   plugin:

--- a/packages/firebase_analytics/CHANGELOG.md
+++ b/packages/firebase_analytics/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.2
+
+* Move Android dependency to Gradle BoM to help maintain compatability
+  with other FlutterFire plugins.
+
 ## 2.1.1
 
 * Added screen_view tracking of Navigator.pushReplacement

--- a/packages/firebase_analytics/README.md
+++ b/packages/firebase_analytics/README.md
@@ -11,6 +11,14 @@ For Flutter plugins for other Firebase products, see [FlutterFire.md](https://gi
 ## Usage
 To use this plugin, add `firebase_analytics` as a [dependency in your pubspec.yaml file](https://flutter.io/platform-plugins/). You must also configure firebase analytics for each platform project: Android and iOS (see the example folder or https://codelabs.developers.google.com/codelabs/flutter-firebase/#4 for step by step details).
 
+## Gradle BoM setup 
+
+If you are using a Gradle version earlier than Gradle 5 then you must add `enableFeaturePreview('IMPROVED_POM_SUPPORT')`
+to the Android app's `settings.gradle` file. See example app.
+
+The use of Gradle BoM (Bill of Materials) helps ensure that the latest versions of the FlutterFire plugins
+work well together.
+
 ## Track PageRoute Transitions
 
 To track `PageRoute` transitions, add a `FirebaseAnalyticsObserver` to the list of `NavigatorObservers` on your

--- a/packages/firebase_analytics/android/build.gradle
+++ b/packages/firebase_analytics/android/build.gradle
@@ -45,6 +45,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        api 'com.google.firebase:firebase-analytics:16.0.4'
+        implementation 'com.google.firebase:firebase-bom:17.0.0'
+        api 'com.google.firebase:firebase-analytics'
     }
 }

--- a/packages/firebase_analytics/example/android/settings.gradle
+++ b/packages/firebase_analytics/example/android/settings.gradle
@@ -13,3 +13,5 @@ plugins.each { name, path ->
     include ":$name"
     project(":$name").projectDir = pluginDirectory
 }
+
+enableFeaturePreview('IMPROVED_POM_SUPPORT')

--- a/packages/firebase_analytics/example/pubspec.yaml
+++ b/packages/firebase_analytics/example/pubspec.yaml
@@ -6,7 +6,7 @@ dependencies:
     sdk: flutter
   firebase_analytics:
     path: ../
-  firebase_core: ^0.3.0
+  firebase_core: ^0.3.2
 
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec

--- a/packages/firebase_analytics/pubspec.yaml
+++ b/packages/firebase_analytics/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Analytics for Firebase, an app measuremen
   solution that provides insight on app usage and user engagement on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_analytics
-version: 2.1.1
+version: 2.1.2
 
 flutter:
   plugin:

--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.8.5
+
+* Move Android dependency to Gradle BoM to help maintain compatability
+  with other FlutterFire plugins.
+
 ## 0.8.4
 
 * Adds support for email link authentication.

--- a/packages/firebase_auth/README.md
+++ b/packages/firebase_auth/README.md
@@ -45,6 +45,14 @@ Make sure to call FirebaseApp.initializeApp(Context) first.
 *Note:* When you are debugging on android, use a device or AVD with Google Play services.
 Otherwise you will not be able to authenticate.
 
+## Gradle BoM setup 
+
+If you are using a Gradle version earlier than Gradle 5 then you must add `enableFeaturePreview('IMPROVED_POM_SUPPORT')`
+to the Android app's `settings.gradle` file. See example app.
+
+The use of Gradle BoM (Bill of Materials) helps ensure that the latest versions of the FlutterFire plugins
+work well together.
+
 ### Use the plugin
 
 Add the following imports to your Dart code:

--- a/packages/firebase_auth/android/build.gradle
+++ b/packages/firebase_auth/android/build.gradle
@@ -46,6 +46,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        api 'com.google.firebase:firebase-auth:16.0.5'
+        implementation 'com.google.firebase:firebase-bom:17.0.0'
+        api 'com.google.firebase:firebase-auth'
     }
 }

--- a/packages/firebase_auth/example/android/settings.gradle
+++ b/packages/firebase_auth/example/android/settings.gradle
@@ -13,3 +13,5 @@ plugins.each { name, path ->
     include ":$name"
     project(":$name").projectDir = pluginDirectory
 }
+
+enableFeaturePreview('IMPROVED_POM_SUPPORT')

--- a/packages/firebase_auth/example/pubspec.yaml
+++ b/packages/firebase_auth/example/pubspec.yaml
@@ -8,12 +8,8 @@ dependencies:
   firebase_auth:
     path: ../
   google_sign_in: ^4.0.0
-<<<<<<< Updated upstream
-  firebase_core: ^0.3.0
-  firebase_dynamic_links: ^0.2.0+3
-=======
   firebase_core: ^0.3.2
->>>>>>> Stashed changes
+  firebase_dynamic_links: ^0.2.0+3
 
 dev_dependencies:
   flutter_driver:

--- a/packages/firebase_auth/example/pubspec.yaml
+++ b/packages/firebase_auth/example/pubspec.yaml
@@ -8,8 +8,12 @@ dependencies:
   firebase_auth:
     path: ../
   google_sign_in: ^4.0.0
+<<<<<<< Updated upstream
   firebase_core: ^0.3.0
   firebase_dynamic_links: ^0.2.0+3
+=======
+  firebase_core: ^0.3.2
+>>>>>>> Stashed changes
 
 dev_dependencies:
   flutter_driver:

--- a/packages/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Firebase Auth, enabling Android and iOS
   like Google, Facebook and Twitter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_auth
-version: "0.8.4"
+version: "0.8.5"
 
 flutter:
   plugin:

--- a/packages/firebase_core/README.md
+++ b/packages/firebase_core/README.md
@@ -8,6 +8,14 @@ For Flutter plugins for other Firebase products, see [FlutterFire.md](https://gi
 
 *Note*: This plugin is still under development, and some APIs might not be available yet. [Feedback](https://github.com/flutter/flutter/issues) and [Pull Requests](https://github.com/flutter/plugins/pulls) are most welcome!
 
+## Gradle BoM setup 
+
+If you are using a Gradle version earlier than Gradle 5 then you must add `enableFeaturePreview('IMPROVED_POM_SUPPORT')`
+to the Android app's `settings.gradle` file. See example app.
+
+The use of Gradle BoM (Bill of Materials) helps ensure that the latest versions of the FlutterFire plugins
+work well together.
+
 ## Usage
 To use this plugin, add `firebase_core` as a [dependency in your pubspec.yaml file](https://flutter.io/platform-plugins/).
 

--- a/packages/firebase_crashlytics/CHANGELOG.md
+++ b/packages/firebase_crashlytics/CHANGELOG.md
@@ -1,3 +1,4 @@
+<<<<<<< Updated upstream
 ## 0.0.4+1
 
 * Added an integration test.
@@ -9,6 +10,12 @@
 ## 0.0.3
 
 * Rely on firebase_core to add the Android dependency on Firebase instead of hardcoding the version ourselves.
+=======
+## 0.0.3
+
+* Move Android dependency to Gradle BoM to help maintain compatability
+  with other FlutterFire plugins.
+>>>>>>> Stashed changes
 
 ## 0.0.2+1
 

--- a/packages/firebase_crashlytics/CHANGELOG.md
+++ b/packages/firebase_crashlytics/CHANGELOG.md
@@ -1,4 +1,8 @@
-<<<<<<< Updated upstream
+## 0.0.5
+
+* Move Android dependency to Gradle BoM to help maintain compatability
+  with other FlutterFire plugins.
+
 ## 0.0.4+1
 
 * Added an integration test.
@@ -10,12 +14,6 @@
 ## 0.0.3
 
 * Rely on firebase_core to add the Android dependency on Firebase instead of hardcoding the version ourselves.
-=======
-## 0.0.3
-
-* Move Android dependency to Gradle BoM to help maintain compatability
-  with other FlutterFire plugins.
->>>>>>> Stashed changes
 
 ## 0.0.2+1
 

--- a/packages/firebase_crashlytics/README.md
+++ b/packages/firebase_crashlytics/README.md
@@ -58,6 +58,14 @@ Make sure to call FirebaseApp.initializeApp(Context) first.
 *Note:* When you are debugging on Android, use a device or AVD with Google Play services.
 Otherwise you will not be able to use Firebase Crashlytics.
 
+## Gradle BoM setup 
+
+If you are using a Gradle version earlier than Gradle 5 then you must add `enableFeaturePreview('IMPROVED_POM_SUPPORT')`
+to the Android app's `settings.gradle` file. See example app.
+
+The use of Gradle BoM (Bill of Materials) helps ensure that the latest versions of the FlutterFire plugins
+work well together.
+
 ### iOS Integration
 
 Add the Crashlytics run scripts

--- a/packages/firebase_crashlytics/android/build.gradle
+++ b/packages/firebase_crashlytics/android/build.gradle
@@ -37,10 +37,6 @@ android {
 }
 
 dependencies {
-<<<<<<< Updated upstream
-    implementation 'com.crashlytics.sdk.android:crashlytics:2.9.9'
-=======
     implementation 'com.google.firebase:firebase-bom:17.0.0'
     implementation 'com.crashlytics.sdk.android:crashlytics'
->>>>>>> Stashed changes
 }

--- a/packages/firebase_crashlytics/android/build.gradle
+++ b/packages/firebase_crashlytics/android/build.gradle
@@ -37,5 +37,10 @@ android {
 }
 
 dependencies {
+<<<<<<< Updated upstream
     implementation 'com.crashlytics.sdk.android:crashlytics:2.9.9'
+=======
+    implementation 'com.google.firebase:firebase-bom:17.0.0'
+    implementation 'com.crashlytics.sdk.android:crashlytics'
+>>>>>>> Stashed changes
 }

--- a/packages/firebase_crashlytics/example/android/settings.gradle
+++ b/packages/firebase_crashlytics/example/android/settings.gradle
@@ -13,3 +13,5 @@ plugins.each { name, path ->
     include ":$name"
     project(":$name").projectDir = pluginDirectory
 }
+
+enableFeaturePreview('IMPROVED_POM_SUPPORT')

--- a/packages/firebase_crashlytics/pubspec.yaml
+++ b/packages/firebase_crashlytics/pubspec.yaml
@@ -1,11 +1,7 @@
 name: firebase_crashlytics
 description: Flutter plugin for Firebase Crashlytics. It reports uncaught errors to the
   Firebase console.
-<<<<<<< Updated upstream
-version: 0.0.4+1
-=======
-version: 0.0.3
->>>>>>> Stashed changes
+version: 0.0.5
 author: Flutter Team <flutter-dev@google.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_crashlytics
 

--- a/packages/firebase_crashlytics/pubspec.yaml
+++ b/packages/firebase_crashlytics/pubspec.yaml
@@ -1,7 +1,11 @@
 name: firebase_crashlytics
 description: Flutter plugin for Firebase Crashlytics. It reports uncaught errors to the
   Firebase console.
+<<<<<<< Updated upstream
 version: 0.0.4+1
+=======
+version: 0.0.3
+>>>>>>> Stashed changes
 author: Flutter Team <flutter-dev@google.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_crashlytics
 

--- a/packages/firebase_database/CHANGELOG.md
+++ b/packages/firebase_database/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.3
+
+* Move Android dependency to Gradle BoM to help maintain compatability
+  with other FlutterFire plugins.
+
 ## 2.0.2
 
 * Fix the issue that `getDictionaryFromError` always returns non nil result even when the parameter is nil.

--- a/packages/firebase_database/README.md
+++ b/packages/firebase_database/README.md
@@ -8,6 +8,14 @@ For Flutter plugins for other Firebase products, see [FlutterFire.md](https://gi
 
 *Note*: This plugin is still under development, and some APIs might not be available yet. [Feedback](https://github.com/flutter/flutter/issues) and [Pull Requests](https://github.com/flutter/plugins/pulls) are most welcome!
 
+## Gradle BoM setup 
+
+If you are using a Gradle version earlier than Gradle 5 then you must add `enableFeaturePreview('IMPROVED_POM_SUPPORT')`
+to the Android app's `settings.gradle` file. See example app.
+
+The use of Gradle BoM (Bill of Materials) helps ensure that the latest versions of the FlutterFire plugins
+work well together.
+
 ## Usage
 To use this plugin, add `firebase_database` as a [dependency in your pubspec.yaml file](https://flutter.io/platform-plugins/).
 

--- a/packages/firebase_database/android/build.gradle
+++ b/packages/firebase_database/android/build.gradle
@@ -45,6 +45,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        api 'com.google.firebase:firebase-database:16.0.3'
+        implementation 'com.google.firebase:firebase-bom:17.0.0'
+        api 'com.google.firebase:firebase-database'
     }
 }

--- a/packages/firebase_database/example/android/settings.gradle
+++ b/packages/firebase_database/example/android/settings.gradle
@@ -13,3 +13,5 @@ plugins.each { name, path ->
     include ":$name"
     project(":$name").projectDir = pluginDirectory
 }
+
+enableFeaturePreview('IMPROVED_POM_SUPPORT')

--- a/packages/firebase_database/example/pubspec.yaml
+++ b/packages/firebase_database/example/pubspec.yaml
@@ -6,7 +6,7 @@ dependencies:
     sdk: flutter
   firebase_database:
     path: ../
-  firebase_core: ^0.3.0
+  firebase_core: ^0.3.2
 
 flutter:
   uses-material-design: true

--- a/packages/firebase_database/pubspec.yaml
+++ b/packages/firebase_database/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Database, a cloud-hosted NoSQL database
   with realtime data syncing across Android and iOS clients, and offline access.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_database
-version: 2.0.2
+version: 2.0.3
 
 flutter:
   plugin:

--- a/packages/firebase_dynamic_links/CHANGELOG.md
+++ b/packages/firebase_dynamic_links/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.2
+
+* Move Android dependency to Gradle BoM to help maintain compatability
+  with other FlutterFire plugins.
+
 ## 0.2.1
 
 * Throw `PlatformException` if there is an error retrieving dynamic link.

--- a/packages/firebase_dynamic_links/README.md
+++ b/packages/firebase_dynamic_links/README.md
@@ -12,6 +12,14 @@ For Flutter plugins for other Firebase products, see [FlutterFire.md](https://gi
 
 *Note*: This plugin is still under development, and some APIs might not be available yet. [Feedback](https://github.com/flutter/flutter/issues) and [Pull Requests](https://github.com/flutter/plugins/pulls) are most welcome!
 
+## Gradle BoM setup 
+
+If you are using a Gradle version earlier than Gradle 5 then you must add `enableFeaturePreview('IMPROVED_POM_SUPPORT')`
+to the Android app's `settings.gradle` file. See example app.
+
+The use of Gradle BoM (Bill of Materials) helps ensure that the latest versions of the FlutterFire plugins
+work well together.
+
 ## Usage
 
 To use this plugin, add `firebase_dynamic_links` as a [dependency in your pubspec.yaml file](https://flutter.io/platform-plugins/). You must also configure firebase dynamic links for each platform project: Android and iOS (see the example folder or https://codelabs.developers.google.com/codelabs/flutter-firebase/#4 for step by step details).

--- a/packages/firebase_dynamic_links/android/build.gradle
+++ b/packages/firebase_dynamic_links/android/build.gradle
@@ -45,7 +45,8 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        api 'com.google.firebase:firebase-dynamic-links:16.1.2'
+        implementation 'com.google.firebase:firebase-bom:17.0.0'
+        api 'com.google.firebase:firebase-dynamic-links'
         implementation 'androidx.annotation:annotation:1.0.0'
     }
 }

--- a/packages/firebase_dynamic_links/example/android/settings.gradle
+++ b/packages/firebase_dynamic_links/example/android/settings.gradle
@@ -13,3 +13,5 @@ plugins.each { name, path ->
     include ":$name"
     project(":$name").projectDir = pluginDirectory
 }
+
+enableFeaturePreview('IMPROVED_POM_SUPPORT')

--- a/packages/firebase_dynamic_links/example/pubspec.yaml
+++ b/packages/firebase_dynamic_links/example/pubspec.yaml
@@ -7,7 +7,7 @@ dependencies:
 
   firebase_dynamic_links:
     path: ../
-  firebase_core: ^0.3.0
+  firebase_core: ^0.3.2
 
   url_launcher: ^4.2.0
 

--- a/packages/firebase_dynamic_links/pubspec.yaml
+++ b/packages/firebase_dynamic_links/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_dynamic_links
 description: Flutter plugin for Google Dynamic Links for Firebase, an app solution for creating
   and handling links across multiple platforms.
-version: 0.2.1
+version: 0.2.2
 
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_dynamic_links

--- a/packages/firebase_messaging/CHANGELOG.md
+++ b/packages/firebase_messaging/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.0.1
+
+* Move Android dependency to Gradle BoM to help maintain compatability
+  with other FlutterFire plugins.
+
 ## 4.0.0+1
 
 * Log messages about automatic configuration of the default app are now less confusing.

--- a/packages/firebase_messaging/README.md
+++ b/packages/firebase_messaging/README.md
@@ -30,6 +30,14 @@ To integrate your plugin into the Android part of your app, follow these steps:
       <category android:name="android.intent.category.DEFAULT" />
   </intent-filter>
   ```
+  
+## Gradle BoM setup 
+
+If you are using a Gradle version earlier than Gradle 5 then you must add `enableFeaturePreview('IMPROVED_POM_SUPPORT')`
+to the Android app's `settings.gradle` file. See example app.
+
+The use of Gradle BoM (Bill of Materials) helps ensure that the latest versions of the FlutterFire plugins
+work well together.
 
 ### iOS Integration
 

--- a/packages/firebase_messaging/android/build.gradle
+++ b/packages/firebase_messaging/android/build.gradle
@@ -45,7 +45,8 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        api 'com.google.firebase:firebase-messaging:17.3.3'
+        implementation 'com.google.firebase:firebase-bom:17.0.0'
+        api 'com.google.firebase:firebase-messaging'
         implementation 'androidx.annotation:annotation:1.0.0'
         implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
     }

--- a/packages/firebase_messaging/example/android/settings.gradle
+++ b/packages/firebase_messaging/example/android/settings.gradle
@@ -13,3 +13,5 @@ plugins.each { name, path ->
     include ":$name"
     project(":$name").projectDir = pluginDirectory
 }
+
+enableFeaturePreview('IMPROVED_POM_SUPPORT')

--- a/packages/firebase_messaging/example/pubspec.yaml
+++ b/packages/firebase_messaging/example/pubspec.yaml
@@ -6,7 +6,7 @@ dependencies:
     sdk: flutter
   firebase_messaging:
     path: ../
-  firebase_core: ^0.3.0
+  firebase_core: ^0.3.2
 
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Cloud Messaging, a cross-platform
   messaging solution that lets you reliably deliver messages on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_messaging
-version: 4.0.0+1
+version: 4.0.1
 
 flutter:
   plugin:

--- a/packages/firebase_ml_vision/CHANGELOG.md
+++ b/packages/firebase_ml_vision/CHANGELOG.md
@@ -1,4 +1,8 @@
-<<<<<<< Updated upstream
+## 0.7.1
+
+* Move Android dependency to Gradle BoM to help maintain compatability
+  with other FlutterFire plugins.
+
 ## 0.7.0
 
 * **Breaking Change** Unified and enhanced on-device and cloud image-labeling API.
@@ -7,12 +11,6 @@
   `Label` renamed to `ImageLabel`.
   `LabelDetector` renamed to `ImageLabeler`.
   Removed `CloudLabelDetector` and replaced it with a cloud `ImageLabeler`.
-=======
-## 0.6.1
-
-* Move Android dependency to Gradle BoM to help maintain compatability
-  with other FlutterFire plugins.
->>>>>>> Stashed changes
 
 ## 0.6.0+2
 

--- a/packages/firebase_ml_vision/CHANGELOG.md
+++ b/packages/firebase_ml_vision/CHANGELOG.md
@@ -1,3 +1,4 @@
+<<<<<<< Updated upstream
 ## 0.7.0
 
 * **Breaking Change** Unified and enhanced on-device and cloud image-labeling API.
@@ -6,6 +7,12 @@
   `Label` renamed to `ImageLabel`.
   `LabelDetector` renamed to `ImageLabeler`.
   Removed `CloudLabelDetector` and replaced it with a cloud `ImageLabeler`.
+=======
+## 0.6.1
+
+* Move Android dependency to Gradle BoM to help maintain compatability
+  with other FlutterFire plugins.
+>>>>>>> Stashed changes
 
 ## 0.6.0+2
 

--- a/packages/firebase_ml_vision/README.md
+++ b/packages/firebase_ml_vision/README.md
@@ -39,6 +39,14 @@ Optional but recommended: If you use the on-device API, configure your app to au
 </application>
 ```
 
+## Gradle BoM setup 
+
+If you are using a Gradle version earlier than Gradle 5 then you must add `enableFeaturePreview('IMPROVED_POM_SUPPORT')`
+to the Android app's `settings.gradle` file. See example app.
+
+The use of Gradle BoM (Bill of Materials) helps ensure that the latest versions of the FlutterFire plugins
+work well together.
+
 ### iOS
 If you're using one of the on-device APIs, include the corresponding ML Kit library model in your
 `Podfile`. Then run `pod update` in a terminal within the same directory as your `Podfile`.

--- a/packages/firebase_ml_vision/android/build.gradle
+++ b/packages/firebase_ml_vision/android/build.gradle
@@ -45,7 +45,12 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
+<<<<<<< Updated upstream
         api 'com.google.firebase:firebase-ml-vision:19.0.2'
+=======
+        implementation 'com.google.firebase:firebase-bom:17.0.0'
+        api 'com.google.firebase:firebase-ml-vision'
+>>>>>>> Stashed changes
         implementation 'androidx.annotation:annotation:1.0.0'
         implementation 'androidx.exifinterface:exifinterface:1.0.0'
     }

--- a/packages/firebase_ml_vision/android/build.gradle
+++ b/packages/firebase_ml_vision/android/build.gradle
@@ -45,12 +45,8 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-<<<<<<< Updated upstream
-        api 'com.google.firebase:firebase-ml-vision:19.0.2'
-=======
         implementation 'com.google.firebase:firebase-bom:17.0.0'
         api 'com.google.firebase:firebase-ml-vision'
->>>>>>> Stashed changes
         implementation 'androidx.annotation:annotation:1.0.0'
         implementation 'androidx.exifinterface:exifinterface:1.0.0'
     }

--- a/packages/firebase_ml_vision/example/android/settings.gradle
+++ b/packages/firebase_ml_vision/example/android/settings.gradle
@@ -13,3 +13,5 @@ plugins.each { name, path ->
     include ":$name"
     project(":$name").projectDir = pluginDirectory
 }
+
+enableFeaturePreview('IMPROVED_POM_SUPPORT')

--- a/packages/firebase_ml_vision/example/pubspec.yaml
+++ b/packages/firebase_ml_vision/example/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   cupertino_icons: ^0.1.2
   firebase_ml_vision:
     path: ../
-  firebase_core: ^0.3.0
+  firebase_core: ^0.3.2
 
 flutter:
   uses-material-design: true

--- a/packages/firebase_ml_vision/pubspec.yaml
+++ b/packages/firebase_ml_vision/pubspec.yaml
@@ -2,7 +2,11 @@ name: firebase_ml_vision
 description: Flutter plugin for Firebase machine learning vision services.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_ml_vision
+<<<<<<< Updated upstream
 version: 0.7.0
+=======
+version: 0.6.1
+>>>>>>> Stashed changes
 
 dependencies:
   flutter:

--- a/packages/firebase_ml_vision/pubspec.yaml
+++ b/packages/firebase_ml_vision/pubspec.yaml
@@ -2,11 +2,7 @@ name: firebase_ml_vision
 description: Flutter plugin for Firebase machine learning vision services.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_ml_vision
-<<<<<<< Updated upstream
-version: 0.7.0
-=======
-version: 0.6.1
->>>>>>> Stashed changes
+version: 0.7.1
 
 dependencies:
   flutter:

--- a/packages/firebase_performance/CHANGELOG.md
+++ b/packages/firebase_performance/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.1
+
+* Move Android dependency to Gradle BoM to help maintain compatability
+  with other FlutterFire plugins.
+
 ## 0.1.0+4
 
 * Remove deprecated methods for iOS.

--- a/packages/firebase_performance/README.md
+++ b/packages/firebase_performance/README.md
@@ -8,6 +8,14 @@ For Flutter plugins for other Firebase products, see [FlutterFire.md](https://gi
 
 *Note*: This plugin is still under development, and some APIs might not be available yet. [Feedback](https://github.com/flutter/flutter/issues) and [Pull Requests](https://github.com/flutter/plugins/pulls) are most welcome!
 
+## Gradle BoM setup 
+
+If you are using a Gradle version earlier than Gradle 5 then you must add `enableFeaturePreview('IMPROVED_POM_SUPPORT')`
+to the Android app's `settings.gradle` file. See example app.
+
+The use of Gradle BoM (Bill of Materials) helps ensure that the latest versions of the FlutterFire plugins
+work well together.
+
 ## Usage
 
 To use this plugin, add `firebase_performance` as a [dependency in your pubspec.yaml file](https://flutter.io/platform-plugins/). You must also configure firebase performance monitoring for each platform project: Android and iOS (see the example folder or https://codelabs.developers.google.com/codelabs/flutter-firebase/#4 for step by step details).

--- a/packages/firebase_performance/android/build.gradle
+++ b/packages/firebase_performance/android/build.gradle
@@ -45,6 +45,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        api 'com.google.firebase:firebase-perf:16.1.2'
+        implementation 'com.google.firebase:firebase-bom:17.0.0'
+        api 'com.google.firebase:firebase-perf'
     }
 }

--- a/packages/firebase_performance/example/android/settings.gradle
+++ b/packages/firebase_performance/example/android/settings.gradle
@@ -13,3 +13,5 @@ plugins.each { name, path ->
     include ":$name"
     project(":$name").projectDir = pluginDirectory
 }
+
+enableFeaturePreview('IMPROVED_POM_SUPPORT')

--- a/packages/firebase_performance/example/pubspec.yaml
+++ b/packages/firebase_performance/example/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
     sdk: flutter
   firebase_performance:
     path: ../
-  firebase_core: ^0.3.0
+  firebase_core: ^0.3.2
 
 dev_dependencies:
   flutter_test:

--- a/packages/firebase_performance/pubspec.yaml
+++ b/packages/firebase_performance/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Google Performance Monitoring for Firebase, an a
   iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_performance
-version: 0.1.0+4
+version: 0.1.1
 
 dependencies:
   flutter:

--- a/packages/firebase_remote_config/CHANGELOG.md
+++ b/packages/firebase_remote_config/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.1
+
+* Move Android dependency to Gradle BoM to help maintain compatability
+  with other FlutterFire plugins.
+
 ## 0.1.0+2
 
 * Log messages about automatic configuration of the default app are now less confusing.

--- a/packages/firebase_remote_config/README.md
+++ b/packages/firebase_remote_config/README.md
@@ -43,6 +43,14 @@ Make sure to call FirebaseApp.initializeApp(Context) first.
 *Note:* When you are debugging on android, use a device or AVD with Google Play services.
 Otherwise you will not be able to use Firebase Remote Config.
 
+## Gradle BoM setup 
+
+If you are using a Gradle version earlier than Gradle 5 then you must add `enableFeaturePreview('IMPROVED_POM_SUPPORT')`
+to the Android app's `settings.gradle` file. See example app.
+
+The use of Gradle BoM (Bill of Materials) helps ensure that the latest versions of the FlutterFire plugins
+work well together.
+
 ### Use the plugin
 
 Add the following imports to your Dart code:

--- a/packages/firebase_remote_config/android/build.gradle
+++ b/packages/firebase_remote_config/android/build.gradle
@@ -45,7 +45,8 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        api 'com.google.firebase:firebase-config:16.0.1'
+        implementation 'com.google.firebase:firebase-bom:17.0.0'
+        api 'com.google.firebase:firebase-config'
         implementation 'androidx.annotation:annotation:1.0.0'
     }
 }

--- a/packages/firebase_remote_config/example/android/settings.gradle
+++ b/packages/firebase_remote_config/example/android/settings.gradle
@@ -13,3 +13,5 @@ plugins.each { name, path ->
     include ":$name"
     project(":$name").projectDir = pluginDirectory
 }
+
+enableFeaturePreview('IMPROVED_POM_SUPPORT')

--- a/packages/firebase_remote_config/example/pubspec.yaml
+++ b/packages/firebase_remote_config/example/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   cupertino_icons: ^0.1.0
   firebase_remote_config:
     path: ../
-  firebase_core: ^0.3.0
+  firebase_core: ^0.3.2
 
 dev_dependencies:
   flutter_test:

--- a/packages/firebase_remote_config/pubspec.yaml
+++ b/packages/firebase_remote_config/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Remote Config. Update your application 
   re-releasing.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_remote_config
-version: 0.1.0+2
+version: 0.1.1
 
 dependencies:
   flutter:

--- a/packages/firebase_storage/CHANGELOG.md
+++ b/packages/firebase_storage/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.1
+
+* Move Android dependency to Gradle BoM to help maintain compatability
+  with other FlutterFire plugins.
+
 ## 2.1.0+1
 
 * Reverting error.code casting/formatting to what it was until version 2.0.1.

--- a/packages/firebase_storage/README.md
+++ b/packages/firebase_storage/README.md
@@ -8,6 +8,14 @@ For Flutter plugins for other Firebase products, see [FlutterFire.md](https://gi
 
 *Note*: This plugin is still under development, and some APIs might not be available yet. [Feedback](https://github.com/flutter/flutter/issues) and [Pull Requests](https://github.com/flutter/plugins/pulls) are most welcome!
 
+## Gradle BoM setup 
+
+If you are using a Gradle version earlier than Gradle 5 then you must add `enableFeaturePreview('IMPROVED_POM_SUPPORT')`
+to the Android app's `settings.gradle` file. See example app.
+
+The use of Gradle BoM (Bill of Materials) helps ensure that the latest versions of the FlutterFire plugins
+work well together.
+
 ## Usage
 To use this plugin, add `firebase_storage` as a [dependency in your pubspec.yaml file](https://flutter.io/platform-plugins/).
 

--- a/packages/firebase_storage/android/build.gradle
+++ b/packages/firebase_storage/android/build.gradle
@@ -53,7 +53,8 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        api 'com.google.firebase:firebase-storage:16.0.3'
+        implementation 'com.google.firebase:firebase-bom:17.0.0'
+        api 'com.google.firebase:firebase-storage'
         implementation 'androidx.annotation:annotation:1.0.0'
     }
 }

--- a/packages/firebase_storage/example/android/settings.gradle
+++ b/packages/firebase_storage/example/android/settings.gradle
@@ -13,3 +13,5 @@ plugins.each { name, path ->
     include ":$name"
     project(":$name").projectDir = pluginDirectory
 }
+
+enableFeaturePreview('IMPROVED_POM_SUPPORT')

--- a/packages/firebase_storage/example/pubspec.yaml
+++ b/packages/firebase_storage/example/pubspec.yaml
@@ -7,7 +7,7 @@ dependencies:
     sdk: flutter
   firebase_storage:
     path: ../
-  firebase_core: ^0.3.0
+  firebase_core: ^0.3.2
   uuid: "^1.0.0"
   http: ^0.12.0
 

--- a/packages/firebase_storage/pubspec.yaml
+++ b/packages/firebase_storage/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Cloud Storage, a powerful, simple, and
   cost-effective object storage service for Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_storage
-version: 2.1.0+1
+version: 2.1.1
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Use Gradle BoM to keep Android dependencies compatible.
