### PR TITLE
Remove BoM to avoid Gradle issues

### DIFF
--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.13
+
+* Remove Gradle BoM to avoid Gradle version issues. 
+
 ## 0.9.12
 
 * Move Android dependency to Gradle BoM to help maintain compatibility

--- a/packages/cloud_firestore/android/build.gradle
+++ b/packages/cloud_firestore/android/build.gradle
@@ -47,8 +47,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        implementation 'com.google.firebase:firebase-bom:17.0.0'
-        api 'com.google.firebase:firebase-firestore'
+        api 'com.google.firebase:firebase-firestore:18.2.0'
         implementation 'androidx.annotation:annotation:1.0.0'
     }
 }

--- a/packages/cloud_firestore/example/android/settings.gradle
+++ b/packages/cloud_firestore/example/android/settings.gradle
@@ -13,5 +13,3 @@ plugins.each { name, path ->
     include ":$name"
     project(":$name").projectDir = pluginDirectory
 }
-
-enableFeaturePreview('IMPROVED_POM_SUPPORT')

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_firestore
-version: 0.9.12
+version: 0.9.13
 
 flutter:
   plugin:

--- a/packages/firebase_core/CHANGELOG.md
+++ b/packages/firebase_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.3
+
+* Remove Gradle BoM to avoid Gradle version issues.
+
 ## 0.3.2
 
 * Move Android dependency to Gradle BoM to help maintain compatability

--- a/packages/firebase_core/android/build.gradle
+++ b/packages/firebase_core/android/build.gradle
@@ -45,7 +45,6 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        implementation 'com.google.firebase:firebase-bom:17.0.0'
-        api 'com.google.firebase:firebase-core'
+        api 'com.google.firebase:firebase-core:16.0.8'
     }
 }

--- a/packages/firebase_core/example/android/settings.gradle
+++ b/packages/firebase_core/example/android/settings.gradle
@@ -14,4 +14,3 @@ plugins.each { name, path ->
     project(":$name").projectDir = pluginDirectory
 }
 
-enableFeaturePreview('IMPROVED_POM_SUPPORT')

--- a/packages/firebase_core/pubspec.yaml
+++ b/packages/firebase_core/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Core, enabling connecting to multiple
   Firebase apps.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_core
-version: 0.3.2
+version: 0.3.3
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

fixes: https://github.com/flutter/flutter/issues/30606

Due to BoM handling being different on Gradle 4 and 5, this removes `firebase-bom` usage and these dependencies will be applied manually going forward till a more stable BoM solution is found.