### PR TITLE
[firebase_core] fix BoM-related build incompatibility regression

### DIFF
--- a/packages/firebase_core/CHANGELOG.md
+++ b/packages/firebase_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.4
+
+* Updates Android firebase-core dependency to a version that is compatible with other Flutterfire plugins.
+
 ## 0.3.3
 
 * Remove Gradle BoM to avoid Gradle version issues.

--- a/packages/firebase_core/android/build.gradle
+++ b/packages/firebase_core/android/build.gradle
@@ -45,6 +45,6 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        api 'com.google.firebase:firebase-core:16.0.8'
+        api 'com.google.firebase:firebase-core:16.0.4'
     }
 }

--- a/packages/firebase_core/pubspec.yaml
+++ b/packages/firebase_core/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Core, enabling connecting to multiple
   Firebase apps.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_core
-version: 0.3.3
+version: 0.3.4
 
 flutter:
   plugin:


### PR DESCRIPTION
This change brings firebase_core back to the firebase-core Android dependency that it had at 0.3.1+1.

Fixes https://github.com/flutter/flutter/issues/30634
Fixes https://github.com/flutter/flutter/issues/30631
Fixes https://github.com/flutter/flutter/issues/30629
Fixes https://github.com/flutter/flutter/issues/30573
