### PR TITLE
[image_picker] Fix invalid path being returned from Google Photos

### DIFF
--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.5.3
-* Fixed incorrect path being returned from GooglePhotos
+
+* Fixed incorrect path being returned from Google Photos on Android.
 
 ## 0.5.2
 

--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.5.3
+* Fixed incorrect path being returned from GooglePhotos
+
 ## 0.5.2
 
 * Check iOS camera authorizationStatus and return an error, if the access was

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
@@ -95,7 +95,7 @@ class FileUtils {
 
       // Return the remote address
       if (isGooglePhotosUri(uri)) {
-        return uri.getLastPathSegment();
+        return null;
       }
 
       return getDataColumn(context, uri, null, null);

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -5,7 +5,7 @@ authors:
   - Flutter Team <flutter-dev@googlegroups.com>
   - Rhodes Davis Jr. <rody.davis.jr@gmail.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.5.2
+version: 0.5.3
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Currently, `getPathFromLocalUri` returns a string purely consisting of integers when the user selects a photo from Google Photos through the sidebar entry. This fixes the issue by returning `null`, which causes `getPathFromUri` to fallback to `getPathFromRemoteUri` (which returns the correct path, see  https://github.com/flutter/flutter/issues/29667#issuecomment-480462248).

## Related Issues

* Fixes https://github.com/flutter/flutter/issues/29667

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
