### PR TITLE
[image_picker]remove unnecessary dev dependency.

### DIFF
--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.3+1
+
+* Remove unnecessary video_player dev dependency.
+
 ## 0.5.3
 
 * Fixed incorrect path being returned from Google Photos on Android.

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -5,7 +5,7 @@ authors:
   - Flutter Team <flutter-dev@googlegroups.com>
   - Rhodes Davis Jr. <rody.davis.jr@gmail.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.5.3
+version: 0.5.3+1
 
 flutter:
   plugin:

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -18,7 +18,6 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  video_player: 0.5.2
   flutter_test:
     sdk: flutter
 


### PR DESCRIPTION
Removed video_player dev dependency since we don't seem to use video_player anywhere in this plugin.
