### PR TITLE
[Image_picker] ios minimum deployment target to 8.0.

### DIFF
--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.3
+
+* Update minimum deploy iOS version to 8.0.
+
 ## 0.5.3
 
 * Fixed incorrect path being returned from Google Photos on Android.

--- a/packages/image_picker/ios/image_picker.podspec
+++ b/packages/image_picker/ios/image_picker.podspec
@@ -14,5 +14,6 @@ Flutter plugin that shows an image picker.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
+  s.ios.deployment_target = '8.0'
   s.dependency 'Flutter'
 end

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -5,7 +5,7 @@ authors:
   - Flutter Team <flutter-dev@googlegroups.com>
   - Rhodes Davis Jr. <rody.davis.jr@gmail.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.5.3
+version: 0.6.3
 
 flutter:
   plugin:


### PR DESCRIPTION
Flutter requires minimum iOS to be 8.0 so the plugin should be the same. 