### PR TITLE
[video_player] Explicitly indicate that self should be retained

### DIFF
--- a/packages/video_player/CHANGELOG.md
+++ b/packages/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.0+5
+
+* Fixed iOS build warnings about implicit retains.
+
 ## 0.10.0+4
 
 * Android: Upgrade ExoPlayer to 2.9.6.

--- a/packages/video_player/ios/Classes/VideoPlayerPlugin.m
+++ b/packages/video_player/ios/Classes/VideoPlayerPlugin.m
@@ -86,12 +86,12 @@ static void* playbackBufferFullContext = &playbackBufferFullContext;
                                                     object:[_player currentItem]
                                                      queue:[NSOperationQueue mainQueue]
                                                 usingBlock:^(NSNotification* note) {
-                                                  if (_isLooping) {
+                                                  if (self->_isLooping) {
                                                     AVPlayerItem* p = [note object];
                                                     [p seekToTime:kCMTimeZero];
                                                   } else {
-                                                    if (_eventSink) {
-                                                      _eventSink(@{@"event" : @"completed"});
+                                                    if (self->_eventSink) {
+                                                      self->_eventSink(@{@"event" : @"completed"});
                                                     }
                                                   }
                                                 }];
@@ -185,17 +185,17 @@ static void* playbackBufferFullContext = &playbackBufferFullContext;
       if ([tracks count] > 0) {
         AVAssetTrack* videoTrack = [tracks objectAtIndex:0];
         void (^trackCompletionHandler)(void) = ^{
-          if (_disposed) return;
+          if (self->_disposed) return;
           if ([videoTrack statusOfValueForKey:@"preferredTransform"
                                         error:nil] == AVKeyValueStatusLoaded) {
             // Rotate the video by using a videoComposition and the preferredTransform
-            _preferredTransform = [self fixTransform:videoTrack];
+            self->_preferredTransform = [self fixTransform:videoTrack];
             // Note:
             // https://developer.apple.com/documentation/avfoundation/avplayeritem/1388818-videocomposition
             // Video composition can only be used with file-based media and is not supported for
             // use with media served using HTTP Live Streaming.
             AVMutableVideoComposition* videoComposition =
-                [self getVideoCompositionWithTransform:_preferredTransform
+                [self getVideoCompositionWithTransform:self->_preferredTransform
                                              withAsset:asset
                                         withVideoTrack:videoTrack];
             item.videoComposition = videoComposition;

--- a/packages/video_player/pubspec.yaml
+++ b/packages/video_player/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player
 description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
-version: 0.10.0+4
+version: 0.10.0+5
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player
 
 flutter:


### PR DESCRIPTION
## Description

Fixes the `implicit-retain-self` warnings that otherwise prints whenever you build this project:

```
video_player-0.10.0+4/ios/Classes/VideoPlayerPlugin.m:89:55: warning: block implicitly retains 'self'; explicitly mention 'self' to
      indicate this is intended behavior [-Wimplicit-retain-self]
                                                  if (_isLooping) {
                                                      ^
                                                      self->
video_player-0.10.0+4/ios/Classes/VideoPlayerPlugin.m:93:57: warning: block implicitly retains 'self'; explicitly mention 'self' to
      indicate this is intended behavior [-Wimplicit-retain-self]
                                                    if (_eventSink) {
                                                        ^
                                                        self->
video_player-0.10.0+4/ios/Classes/VideoPlayerPlugin.m:94:55: warning: block implicitly retains 'self'; explicitly mention 'self' to
      indicate this is intended behavior [-Wimplicit-retain-self]
                                                      _eventSink(@{@"event" : @"completed"});
                                                      ^
                                                      self->
video_player-0.10.0+4/ios/Classes/VideoPlayerPlugin.m:188:15: warning: block implicitly retains 'self'; explicitly mention 'self' to
      indicate this is intended behavior [-Wimplicit-retain-self]
          if (_disposed) return;
              ^
              self->
video_player-0.10.0+4/ios/Classes/VideoPlayerPlugin.m:192:13: warning: block implicitly retains 'self'; explicitly mention 'self' to
      indicate this is intended behavior [-Wimplicit-retain-self]
            _preferredTransform = [self fixTransform:videoTrack];
            ^
            self->
video_player-0.10.0+4/ios/Classes/VideoPlayerPlugin.m:198:56: warning: block implicitly retains 'self'; explicitly mention 'self' to
      indicate this is intended behavior [-Wimplicit-retain-self]
                [self getVideoCompositionWithTransform:_preferredTransform
                                                       ^
                                                       self->
6 warnings generated.
```

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [n/a] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
