### PR TITLE
BitmapDescriptor#fromBytes should be consistent across platforms

### DIFF
--- a/packages/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.9
+
+* BitmapDescriptor#fromBytes accounts for screen scale on ios.
+
 ## 0.5.8
 
 * Remove some unused variables and rename method

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapMarkerController.m
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapMarkerController.m
@@ -199,7 +199,8 @@ static UIImage* ExtractIcon(NSObject<FlutterPluginRegistrar>* registrar, NSArray
     if (iconData.count == 2) {
       @try {
         FlutterStandardTypedData* byteData = iconData[1];
-        image = [UIImage imageWithData:[byteData data]];
+        CGFloat screenScale = [[UIScreen mainScreen] scale];
+        image = [UIImage imageWithData:[byteData data] scale:screenScale];
       } @catch (NSException* exception) {
         @throw [NSException exceptionWithName:@"InvalidByteDescriptor"
                                        reason:@"Unable to interpret bytes as a valid image."

--- a/packages/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter
-version: 0.5.8
+version: 0.5.9
 
 dependencies:
   flutter:


### PR DESCRIPTION
- Android Bitmaps scale images to account for dpi.
- iOS UIImages do not, we need to account for that.