### PR TITLE
[cloud_firestore] Support for FieldValue.increment

### DIFF
--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.13+2
+
+* Support `FieldValue.incrementDouble` and `FieldValue.incrementInteger`.
+
 ## 0.9.13+1
 
 * Added an integration test for transactions.

--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.9.13+2
 
-* Support `FieldValue.incrementDouble` and `FieldValue.incrementInteger`.
+* Support for `FieldValue.increment`.
 
 ## 0.9.13+1
 

--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 0.9.13+2
+## 0.10.0
 
 * Support for `FieldValue.increment`.
+* Remove `FieldValue.type` and `FieldValue.value` from public API.
 * Additional integration testing.
 
 ## 0.9.13+1

--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.9.13+2
 
 * Support for `FieldValue.increment`.
+* Additional integration testing.
 
 ## 0.9.13+1
 

--- a/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
+++ b/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
@@ -654,6 +654,8 @@ final class FirestoreMessageCodec extends StandardMessageCodec {
   private static final byte DELETE = (byte) 134;
   private static final byte SERVER_TIMESTAMP = (byte) 135;
   private static final byte TIMESTAMP = (byte) 136;
+  private static final byte INCREMENT_INTEGER = (byte) 137;
+  private static final byte INCREMENT_DOUBLE = (byte) 138;
 
   @Override
   protected void writeValue(ByteArrayOutputStream stream, Object value) {
@@ -711,6 +713,10 @@ final class FirestoreMessageCodec extends StandardMessageCodec {
         return FieldValue.delete();
       case SERVER_TIMESTAMP:
         return FieldValue.serverTimestamp();
+      case INCREMENT_INTEGER:
+        return FieldValue.increment(buffer.getLong());
+      case INCREMENT_DOUBLE:
+        return FieldValue.increment(buffer.getDouble());
       default:
         return super.readValueOfType(type, buffer);
     }

--- a/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
+++ b/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
@@ -714,9 +714,11 @@ final class FirestoreMessageCodec extends StandardMessageCodec {
       case SERVER_TIMESTAMP:
         return FieldValue.serverTimestamp();
       case INCREMENT_INTEGER:
-        return FieldValue.increment(buffer.getLong());
+        final Number integerIncrementValue = (Number) readValue(buffer);
+        return FieldValue.increment(integerIncrementValue.intValue());
       case INCREMENT_DOUBLE:
-        return FieldValue.increment(buffer.getDouble());
+        final Number doubleIncrementValue = (Number) readValue(buffer);
+        return FieldValue.increment(doubleIncrementValue.doubleValue());
       default:
         return super.readValueOfType(type, buffer);
     }

--- a/packages/cloud_firestore/example/test_driver/cloud_firestore.dart
+++ b/packages/cloud_firestore/example/test_driver/cloud_firestore.dart
@@ -46,16 +46,17 @@ void main() {
         'message': 1,
         'created_at': FieldValue.serverTimestamp(),
       });
-      await ref.setData(<String, dynamic>{
-        'message': FieldValue.increment(1),
-        'created_at': FieldValue.serverTimestamp(),
-      });
       DocumentSnapshot snapshot = await ref.get();
-      expect(snapshot.data['message'], 2);
-      await ref.setData(<String, dynamic>{
-        'message': FieldValue.increment(40.0),
-        'created_at': FieldValue.serverTimestamp(),
+      expect(snapshot.data['message'], 1);
+      await ref.updateData(<String, dynamic>{
+        'message': FieldValue.increment(1),
       });
+      snapshot = await ref.get();
+      expect(snapshot.data['message'], 2);
+      await ref.updateData(<String, dynamic>{
+        'message': FieldValue.increment(40.0),
+      });
+      snapshot = await ref.get();
       expect(snapshot.data['message'], 42.0);
       await ref.delete();
     });

--- a/packages/cloud_firestore/example/test_driver/cloud_firestore.dart
+++ b/packages/cloud_firestore/example/test_driver/cloud_firestore.dart
@@ -47,11 +47,17 @@ void main() {
         'created_at': FieldValue.serverTimestamp(),
       });
       await ref.setData(<String, dynamic>{
-        'message': FieldValue.incrementInteger(1),
+        'message': FieldValue.increment(1),
         'created_at': FieldValue.serverTimestamp(),
       });
       DocumentSnapshot snapshot = await ref.get();
       expect(snapshot.data['message'], 2);
+      await ref.setData(<String, dynamic>{
+        'message': FieldValue.increment(40.0),
+        'created_at': FieldValue.serverTimestamp(),
+      });
+      expect(snapshot.data['message'], 42.0);
+      await ref.delete();
     });
 
     test('runTransaction', () async {

--- a/packages/cloud_firestore/example/test_driver/cloud_firestore.dart
+++ b/packages/cloud_firestore/example/test_driver/cloud_firestore.dart
@@ -40,6 +40,20 @@ void main() {
       expect(snapshot.data['message'], 'Hello world!');
     });
 
+    test('increment', () async {
+      final DocumentReference ref = firestore.collection('messages').document();
+      await ref.setData(<String, dynamic>{
+        'message': 1,
+        'created_at': FieldValue.serverTimestamp(),
+      });
+      await ref.setData(<String, dynamic>{
+        'message': FieldValue.incrementInteger(1),
+        'created_at': FieldValue.serverTimestamp(),
+      });
+      DocumentSnapshot snapshot = await ref.get();
+      expect(snapshot.data['message'], 2);
+    });
+
     test('runTransaction', () async {
       final DocumentReference ref = firestore.collection('messages').document();
       await ref.setData(<String, dynamic>{

--- a/packages/cloud_firestore/example/test_driver/cloud_firestore_test.dart
+++ b/packages/cloud_firestore/example/test_driver/cloud_firestore_test.dart
@@ -1,10 +1,7 @@
 import 'package:flutter_driver/flutter_driver.dart';
-import 'package:test/test.dart';
 
-void main() {
-  test('CloudFirestore driver test', () async {
-    final FlutterDriver driver = await FlutterDriver.connect();
-    await driver.requestData(null, timeout: const Duration(minutes: 1));
-    driver.close();
-  });
+void main() async {
+  final FlutterDriver driver = await FlutterDriver.connect();
+  await driver.requestData(null, timeout: const Duration(minutes: 1));
+  driver.close();
 }

--- a/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
+++ b/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
@@ -237,10 +237,12 @@ const UInt8 INCREMENT_INTEGER = 138;
       return [FIRFieldValue fieldValueForServerTimestamp];
     }
     case INCREMENT_DOUBLE: {
-      return [FIRFieldValue fieldValueForDoubleIncrement:[self readValue]];
+      NSNumber *value = [self readValue];
+      return [FIRFieldValue fieldValueForDoubleIncrement:value.doubleValue];
     }
     case INCREMENT_INTEGER: {
-      return [FIRFieldValue fieldValueForIntegerIncrement:[self readValue]];
+      NSNumber *value = [self readValue];
+      return [FIRFieldValue fieldValueForIntegerIncrement:value.intValue];
     }
     default:
       return [super readValueOfType:type];

--- a/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
+++ b/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
@@ -140,6 +140,8 @@ const UInt8 ARRAY_REMOVE = 133;
 const UInt8 DELETE = 134;
 const UInt8 SERVER_TIMESTAMP = 135;
 const UInt8 TIMESTAMP = 136;
+const UInt8 INCREMENT_DOUBLE = 137;
+const UInt8 INCREMENT_INTEGER = 138;
 
 @interface FirestoreWriter : FlutterStandardWriter
 - (void)writeValue:(id)value;
@@ -233,6 +235,12 @@ const UInt8 TIMESTAMP = 136;
     }
     case SERVER_TIMESTAMP: {
       return [FIRFieldValue fieldValueForServerTimestamp];
+    }
+    case INCREMENT_DOUBLE: {
+      return [FIRFieldValue fieldValueForDoubleIncrement:[self readValue]];
+    }
+    case INCREMENT_INTEGER: {
+      return [FIRFieldValue fieldValueForIntegerIncrement:[self readValue]];
     }
     default:
       return [super readValueOfType:type];

--- a/packages/cloud_firestore/lib/src/field_value.dart
+++ b/packages/cloud_firestore/lib/src/field_value.dart
@@ -4,13 +4,14 @@
 
 part of cloud_firestore;
 
+@visibleForTesting
 enum FieldValueType {
   arrayUnion,
   arrayRemove,
   delete,
   serverTimestamp,
   incrementDouble,
-  incrementInteger
+  incrementInteger,
 }
 
 /// Sentinel values that can be used when writing document fields with set() or
@@ -18,7 +19,10 @@ enum FieldValueType {
 class FieldValue {
   FieldValue._(this.type, this.value);
 
+  @visibleForTesting
   final FieldValueType type;
+
+  @visibleForTesting
   final dynamic value;
 
   /// Returns a special value that tells the server to union the given elements

--- a/packages/cloud_firestore/lib/src/field_value.dart
+++ b/packages/cloud_firestore/lib/src/field_value.dart
@@ -48,7 +48,7 @@ class FieldValue {
     if (num is double) {
       FieldValue._(FieldValueType.incrementDouble, value);
     } else if (num is int) {
-      FieldValue._(FieldValueType.incrementDouble, value);
+      FieldValue._(FieldValueType.incrementInteger, value);
     }
   }
 }

--- a/packages/cloud_firestore/lib/src/field_value.dart
+++ b/packages/cloud_firestore/lib/src/field_value.dart
@@ -42,12 +42,13 @@ class FieldValue {
       FieldValue._(FieldValueType.serverTimestamp, null);
 
   /// Returns a special value for use with set() or update() that tells the
-  /// server to increment the field’s current value by the given double value.
-  static FieldValue incrementDouble(double value) =>
+  /// server to increment the field’s current value by the given value.
+  static FieldValue increment(num value) {
+    assert(num is int || num is double);
+    if (num is double) {
       FieldValue._(FieldValueType.incrementDouble, value);
-
-  /// Returns a special value for use with set() or update() that tells the
-  /// server to increment the field’s current value by the given integer value.
-  static FieldValue incrementInteger(int value) =>
-      FieldValue._(FieldValueType.incrementInteger, value);
+    } else if (num is int) {
+      FieldValue._(FieldValueType.incrementDouble, value);
+    }
+  }
 }

--- a/packages/cloud_firestore/lib/src/field_value.dart
+++ b/packages/cloud_firestore/lib/src/field_value.dart
@@ -46,9 +46,9 @@ class FieldValue {
   static FieldValue increment(num value) {
     assert(value is int || value is double);
     if (value is double) {
-      FieldValue._(FieldValueType.incrementDouble, value);
+      return FieldValue._(FieldValueType.incrementDouble, value);
     } else if (value is int) {
-      FieldValue._(FieldValueType.incrementInteger, value);
+      return FieldValue._(FieldValueType.incrementInteger, value);
     }
   }
 }

--- a/packages/cloud_firestore/lib/src/field_value.dart
+++ b/packages/cloud_firestore/lib/src/field_value.dart
@@ -4,7 +4,7 @@
 
 part of cloud_firestore;
 
-enum FieldValueType { arrayUnion, arrayRemove, delete, serverTimestamp }
+enum FieldValueType { arrayUnion, arrayRemove, delete, serverTimestamp, incrementDouble, incrementInteger }
 
 /// Sentinel values that can be used when writing document fields with set() or
 /// update().
@@ -40,4 +40,14 @@ class FieldValue {
   /// server-generated timestamp in the written data.
   static FieldValue serverTimestamp() =>
       FieldValue._(FieldValueType.serverTimestamp, null);
+
+  /// Returns a special value for use with set() or update() that tells the
+  /// server to increment the field’s current value by the given double value.
+  static FieldValue incrementDouble(double value) =>
+      FieldValue._(FieldValueType.incrementDouble, value);
+
+  /// Returns a special value for use with set() or update() that tells the
+  /// server to increment the field’s current value by the given integer value.
+  static FieldValue incrementInteger(int value) =>
+      FieldValue._(FieldValueType.incrementInteger, value);
 }

--- a/packages/cloud_firestore/lib/src/field_value.dart
+++ b/packages/cloud_firestore/lib/src/field_value.dart
@@ -44,11 +44,14 @@ class FieldValue {
   /// Returns a special value for use with set() or update() that tells the
   /// server to increment the field’s current value by the given value.
   static FieldValue increment(num value) {
+    // It is a compile-time error for any type other than int or double to
+    // attempt to extend or implement num.
     assert(value is int || value is double);
     if (value is double) {
       return FieldValue._(FieldValueType.incrementDouble, value);
     } else if (value is int) {
       return FieldValue._(FieldValueType.incrementInteger, value);
     }
+    return null;
   }
 }

--- a/packages/cloud_firestore/lib/src/field_value.dart
+++ b/packages/cloud_firestore/lib/src/field_value.dart
@@ -4,7 +4,14 @@
 
 part of cloud_firestore;
 
-enum FieldValueType { arrayUnion, arrayRemove, delete, serverTimestamp, incrementDouble, incrementInteger }
+enum FieldValueType {
+  arrayUnion,
+  arrayRemove,
+  delete,
+  serverTimestamp,
+  incrementDouble,
+  incrementInteger
+}
 
 /// Sentinel values that can be used when writing document fields with set() or
 /// update().

--- a/packages/cloud_firestore/lib/src/field_value.dart
+++ b/packages/cloud_firestore/lib/src/field_value.dart
@@ -44,10 +44,10 @@ class FieldValue {
   /// Returns a special value for use with set() or update() that tells the
   /// server to increment the field’s current value by the given value.
   static FieldValue increment(num value) {
-    assert(num is int || num is double);
-    if (num is double) {
+    assert(value is int || value is double);
+    if (value is double) {
       FieldValue._(FieldValueType.incrementDouble, value);
-    } else if (num is int) {
+    } else if (value is int) {
       FieldValue._(FieldValueType.incrementInteger, value);
     }
   }

--- a/packages/cloud_firestore/lib/src/firestore_message_codec.dart
+++ b/packages/cloud_firestore/lib/src/firestore_message_codec.dart
@@ -17,6 +17,8 @@ class FirestoreMessageCodec extends StandardMessageCodec {
   static const int _kDelete = 134;
   static const int _kServerTimestamp = 135;
   static const int _kTimestamp = 136;
+  static const int _kIncrementDouble = 137;
+  static const int _kIncrementInteger = 138;
 
   static const Map<FieldValueType, int> _kFieldValueCodes =
       <FieldValueType, int>{
@@ -24,6 +26,8 @@ class FirestoreMessageCodec extends StandardMessageCodec {
     FieldValueType.arrayRemove: _kArrayRemove,
     FieldValueType.delete: _kDelete,
     FieldValueType.serverTimestamp: _kServerTimestamp,
+    FieldValueType.incrementDouble: _kIncrementDouble,
+    FieldValueType.incrementInteger: _kIncrementInteger,
   };
 
   @override
@@ -94,6 +98,12 @@ class FirestoreMessageCodec extends StandardMessageCodec {
         return FieldValue.delete();
       case _kServerTimestamp:
         return FieldValue.serverTimestamp();
+      case _kIncrementDouble:
+        final double value = readValue(buffer);
+        return FieldValue.increment(value);
+      case _kIncrementInteger:
+        final int value = readValue(buffer);
+        return FieldValue.increment(value);
       default:
         return super.readValueOfType(type, buffer);
     }

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_firestore
-version: 0.9.13+1
+version: 0.9.13+2
 
 flutter:
   plugin:

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_firestore
-version: 0.9.13+2
+version: 0.10.0
 
 flutter:
   plugin:

--- a/packages/cloud_firestore/test/cloud_firestore_test.dart
+++ b/packages/cloud_firestore/test/cloud_firestore_test.dart
@@ -609,6 +609,8 @@ void main() {
         _checkEncodeDecode<dynamic>(codec, FieldValue.arrayRemove(<int>[123]));
         _checkEncodeDecode<dynamic>(codec, FieldValue.delete());
         _checkEncodeDecode<dynamic>(codec, FieldValue.serverTimestamp());
+        _checkEncodeDecode<dynamic>(codec, FieldValue.incrementDouble(1.0));
+        _checkEncodeDecode<dynamic>(codec, FieldValue.incrementInteger(1));
       });
     });
 

--- a/packages/cloud_firestore/test/cloud_firestore_test.dart
+++ b/packages/cloud_firestore/test/cloud_firestore_test.dart
@@ -609,8 +609,8 @@ void main() {
         _checkEncodeDecode<dynamic>(codec, FieldValue.arrayRemove(<int>[123]));
         _checkEncodeDecode<dynamic>(codec, FieldValue.delete());
         _checkEncodeDecode<dynamic>(codec, FieldValue.serverTimestamp());
-        _checkEncodeDecode<dynamic>(codec, FieldValue.incrementDouble(1.0));
-        _checkEncodeDecode<dynamic>(codec, FieldValue.incrementInteger(1));
+        _checkEncodeDecode<dynamic>(codec, FieldValue.increment(1.0));
+        _checkEncodeDecode<dynamic>(codec, FieldValue.increment(1));
       });
     });
 

--- a/packages/cloud_firestore/test/cloud_firestore_test.dart
+++ b/packages/cloud_firestore/test/cloud_firestore_test.dart
@@ -883,5 +883,7 @@ bool _deepEqualsMap(
 bool _deepEqualsFieldValue(FieldValue valueA, FieldValue valueB) {
   if (valueA.type != valueB.type) return false;
   if (valueA.value == null) return valueB.value == null;
-  return _deepEqualsList(valueA.value, valueB.value);
+  if (valueA.value is List) return _deepEqualsList(valueA.value, valueB.value);
+  if (valueA.value is Map) return _deepEqualsMap(valueA.value, valueB.value);
+  return valueA.value == valueB.value;
 }


### PR DESCRIPTION
## Description

This PR adds support for incrementing using `FieldValue`.

Example usage:

```dart
      final DocumentReference ref = firestore.collection('mycollection').document();
      await ref.setData(<String, dynamic>{
        'value': 1,
        'created_at': FieldValue.serverTimestamp(),
      });
      await ref.updateData(<String, dynamic>{
        'value': FieldValue.increment(1),
      });
      DocumentSnapshot snapshot = await ref.get();
      expect(snapshot.data['value'], 2);
```

I thought about naming the API `incrementDouble/incrementInteger` but leaning towards overloading `increment`. I'd love to get feedback on this.

## Related Issues

Fixes flutter/flutter#31034

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [X] No, this is *not* a breaking change.
