### PR TITLE
[android_alarm_manager] Added comments and refactored android_alarm_manager plugin for clarity.

### DIFF
--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AlarmBroadcastReceiver.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AlarmBroadcastReceiver.java
@@ -11,15 +11,15 @@ import android.content.Intent;
 public class AlarmBroadcastReceiver extends BroadcastReceiver {
   /**
    * Invoked by the OS when a timer goes off.
-   * <p>
-   * The associated timer was registered in {@link AlarmService}.
-   * <p>
-   * In Android, timer notifications require a {@link BroadcastReceiver} as
+   *
+   * <p>The associated timer was registered in {@link AlarmService}.
+   *
+   * <p>In Android, timer notifications require a {@link BroadcastReceiver} as
    * the artifact that is notifed when the timer goes off. As a result, this
    * method is kept simple, immediately offloading any work to
    * {@link AlarmService#enqueueAlarmProcessing(Context, Intent)}.
-   * <p>
-   * This method is the beginning of an execution path that will eventually
+   *
+   * <p>This method is the beginning of an execution path that will eventually
    * execute a desired Dart callback function, as registed by the Dart side
    * of the android_alarm_manager plugin. However, there may be asynchronous
    * gaps between {@code onReceive()} and the eventual invocation of the Dart

--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AlarmBroadcastReceiver.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AlarmBroadcastReceiver.java
@@ -9,6 +9,23 @@ import android.content.Context;
 import android.content.Intent;
 
 public class AlarmBroadcastReceiver extends BroadcastReceiver {
+  /**
+   * Invoked by the OS when a timer goes off.
+   * <p>
+   * The associated timer was registered in {@link AlarmService}.
+   * <p>
+   * In Android, timer notifications require a {@link BroadcastReceiver} as
+   * the artifact that is notifed when the timer goes off. As a result, this
+   * method is kept simple, immediately offloading any work to
+   * {@link AlarmService#enqueueAlarmProcessing(Context, Intent)}.
+   * <p>
+   * This method is the beginning of an execution path that will eventually
+   * execute a desired Dart callback function, as registed by the Dart side
+   * of the android_alarm_manager plugin. However, there may be asynchronous
+   * gaps between {@code onReceive()} and the eventual invocation of the Dart
+   * callback because {@link AlarmService} may need to spin up a Flutter
+   * execution context before the callback can be invoked.
+   */
   @Override
   public void onReceive(Context context, Intent intent) {
     AlarmService.enqueueAlarmProcessing(context, intent);

--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AlarmBroadcastReceiver.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AlarmBroadcastReceiver.java
@@ -14,17 +14,15 @@ public class AlarmBroadcastReceiver extends BroadcastReceiver {
    *
    * <p>The associated timer was registered in {@link AlarmService}.
    *
-   * <p>In Android, timer notifications require a {@link BroadcastReceiver} as
-   * the artifact that is notifed when the timer goes off. As a result, this
-   * method is kept simple, immediately offloading any work to
-   * {@link AlarmService#enqueueAlarmProcessing(Context, Intent)}.
+   * <p>In Android, timer notifications require a {@link BroadcastReceiver} as the artifact that is
+   * notified when the timer goes off. As a result, this method is kept simple, immediately
+   * offloading any work to {@link AlarmService#enqueueAlarmProcessing(Context, Intent)}.
    *
-   * <p>This method is the beginning of an execution path that will eventually
-   * execute a desired Dart callback function, as registed by the Dart side
-   * of the android_alarm_manager plugin. However, there may be asynchronous
-   * gaps between {@code onReceive()} and the eventual invocation of the Dart
-   * callback because {@link AlarmService} may need to spin up a Flutter
-   * execution context before the callback can be invoked.
+   * <p>This method is the beginning of an execution path that will eventually execute a desired
+   * Dart callback function, as registed by the Dart side of the android_alarm_manager plugin.
+   * However, there may be asynchronous gaps between {@code onReceive()} and the eventual invocation
+   * of the Dart callback because {@link AlarmService} may need to spin up a Flutter execution
+   * context before the callback can be invoked.
    */
   @Override
   public void onReceive(Context context, Intent intent) {

--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AlarmService.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AlarmService.java
@@ -73,10 +73,10 @@ public class AlarmService extends JobIntentService {
    * <p>Preconditions:
    *
    * <ul>
-   *   <li>The given {@code callbackHandle} must correspond to a registered Dart callback.
-   *   If the handle does not resolve to a Dart callback then this method does nothing.
-   *   <li>A static {@link #sPluginRegistrantCallback} must exist, otherwise a
-   *   {@link PluginRegistrantException} will be thrown.
+   *   <li>The given {@code callbackHandle} must correspond to a registered Dart callback. If the
+   *       handle does not resolve to a Dart callback then this method does nothing.
+   *   <li>A static {@link #sPluginRegistrantCallback} must exist, otherwise a {@link
+   *       PluginRegistrantException} will be thrown.
    * </ul>
    */
   public static void startBackgroundIsolate(Context context, long callbackHandle) {
@@ -253,7 +253,7 @@ public class AlarmService extends JobIntentService {
   }
 
   public static void setPeriodic(
-          Context context, AndroidAlarmManagerPlugin.PeriodicRequest request) {
+      Context context, AndroidAlarmManagerPlugin.PeriodicRequest request) {
     final boolean repeating = true;
     scheduleAlarm(
         context,

--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AlarmService.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AlarmService.java
@@ -43,9 +43,7 @@ public class AlarmService extends JobIntentService {
   // TODO(mattcarroll): make sAlarmQueue per-instance, not static.
   private static List<Intent> sAlarmQueue = Collections.synchronizedList(new LinkedList<Intent>());
 
-  /**
-   * Background Dart execution context.
-   */
+  /** Background Dart execution context. */
   private static FlutterNativeView sBackgroundFlutterView;
 
   /**
@@ -63,20 +61,22 @@ public class AlarmService extends JobIntentService {
 
   /**
    * Starts running a background Dart isolate within a new {@link FlutterNativeView}.
-   * <p>
-   * The isolate is configured as follows:
+   *
+   * <p>The isolate is configured as follows:
+   *
    * <ul>
-   *   <li>Bundle Path: {@code FlutterMain.findAppBundlePath(context)}.</li>
-   *   <li>Entrypoint: The Dart method represented by {@code callbackHandle}.</li>
-   *   <li>Run args: none.</li>
+   *   <li>Bundle Path: {@code FlutterMain.findAppBundlePath(context)}.
+   *   <li>Entrypoint: The Dart method represented by {@code callbackHandle}.
+   *   <li>Run args: none.
    * </ul>
-   * <p>
-   * Preconditions:
+   *
+   * <p>Preconditions:
+   *
    * <ul>
    *   <li>The given {@code callbackHandle} must correspond to a registered Dart callback.
-   *   If the handle does not resolve to a Dart callback then this method does nothing.</li>
+   *   If the handle does not resolve to a Dart callback then this method does nothing.
    *   <li>A static {@link #sPluginRegistrantCallback} must exist, otherwise a
-   *   {@link PluginRegistrantException} will be thrown.</li>
+   *   {@link PluginRegistrantException} will be thrown.
    * </ul>
    */
   public static void startBackgroundIsolate(Context context, long callbackHandle) {
@@ -112,9 +112,10 @@ public class AlarmService extends JobIntentService {
 
   /**
    * Called once the Dart isolate ({@code sBackgroundFlutterView}) has finished initializing.
-   * <p>
-   * Invoked by {@link AndroidAlarmManagerPlugin} when it receives the {@code "AlarmService.initialized"}
-   * message. Processes all alarm events that came in while the isolate was starting.
+   *
+   * <p>Invoked by {@link AndroidAlarmManagerPlugin} when it receives the {@code
+   * AlarmService.initialized} message. Processes all alarm events that came in while the isolate
+   * was starting.
    */
   // TODO(mattcarroll): consider making this method package private
   public static void onInitialized() {
@@ -132,8 +133,8 @@ public class AlarmService extends JobIntentService {
   }
 
   /**
-   * Sets the {@link MethodChannel} that is used to communicate with Dart callbacks that
-   * are invoked in the background by the android_alarm_manager plugin.
+   * Sets the {@link MethodChannel} that is used to communicate with Dart callbacks that are invoked
+   * in the background by the android_alarm_manager plugin.
    */
   public static void setBackgroundChannel(MethodChannel channel) {
     sBackgroundChannel = channel;
@@ -163,8 +164,8 @@ public class AlarmService extends JobIntentService {
 
   /**
    * Executes the desired Dart callback in a background Dart isolate.
-   * <p>
-   * The given {@code intent} should contain a {@code long} extra called "callbackHandle", which
+   *
+   * <p>The given {@code intent} should contain a {@code long} extra called "callbackHandle", which
    * corresponds to a callback registered with the Dart VM.
    */
   private static void executeDartCallbackInBackgroundIsolate(Intent intent) {
@@ -175,8 +176,7 @@ public class AlarmService extends JobIntentService {
     if (sBackgroundChannel == null) {
       Log.e(
           TAG,
-          "setBackgroundChannel was not called before alarms were scheduled." + " Bailing out."
-      );
+          "setBackgroundChannel was not called before alarms were scheduled." + " Bailing out.");
       return;
     }
     // Handle the alarm event in Dart. Note that for this plugin, we don't
@@ -249,11 +249,11 @@ public class AlarmService extends JobIntentService {
         request.startMillis,
         0,
         request.rescheduleOnReboot,
-        request.callbackHandle
-    );
+        request.callbackHandle);
   }
 
-  public static void setPeriodic(Context context, AndroidAlarmManagerPlugin.PeriodicRequest request) {
+  public static void setPeriodic(
+          Context context, AndroidAlarmManagerPlugin.PeriodicRequest request) {
     final boolean repeating = true;
     scheduleAlarm(
         context,
@@ -264,8 +264,7 @@ public class AlarmService extends JobIntentService {
         request.startMillis,
         request.intervalMillis,
         request.rescheduleOnReboot,
-        request.callbackHandle
-    );
+        request.callbackHandle);
   }
 
   public static void cancel(Context context, int requestCode) {
@@ -317,7 +316,8 @@ public class AlarmService extends JobIntentService {
         RebootBroadcastReceiver.enableRescheduleOnReboot(context);
       }
       persistentAlarms.add(Integer.toString(requestCode));
-      prefs.edit()
+      prefs
+          .edit()
           .putString(key, obj.toString())
           .putStringSet(PERSISTENT_ALARMS_SET_KEY, persistentAlarms)
           .commit();
@@ -409,16 +409,16 @@ public class AlarmService extends JobIntentService {
 
   /**
    * Executes a Dart callback, as specified within the incoming {@code intent}.
-   * <p>
-   * Invoked by our {@link JobIntentService} superclass after a call to
-   * {@link JobIntentService#enqueueWork(Context, Class, int, Intent);}.
-   * <p>
-   * If there are no pre-existing callback execution requests, other than the
-   * incoming {@code intent}, then the desired Dart callback is invoked immediately.
-   * <p>
-   * If there are any pre-existing callback requests that have yet to be executed,
-   * the incoming {@code intent} is added to the {@link #sAlarmQueue} to invoked
-   * later, after all pre-existing callbacks have been executed.
+   *
+   * <p>Invoked by our {@link JobIntentService} superclass after a call to {@link
+   * JobIntentService#enqueueWork(Context, Class, int, Intent);}.
+   *
+   * <p>If there are no pre-existing callback execution requests, other than the incoming {@code
+   * intent}, then the desired Dart callback is invoked immediately.
+   *
+   * <p>If there are any pre-existing callback requests that have yet to be executed, the incoming
+   * {@code intent} is added to the {@link #sAlarmQueue} to invoked later, after all pre-existing
+   * callbacks have been executed.
    */
   @Override
   protected void onHandleWork(Intent intent) {

--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AlarmService.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AlarmService.java
@@ -29,70 +29,65 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 public class AlarmService extends JobIntentService {
+  // TODO(mattcarroll): tags should be private. Make private if no public usage.
   public static final String TAG = "AlarmService";
   private static final String CALLBACK_HANDLE_KEY = "callback_handle";
   private static final String PERSISTENT_ALARMS_SET_KEY = "persistent_alarm_ids";
   private static final String SHARED_PREFERENCES_KEY = "io.flutter.android_alarm_manager_plugin";
   private static final int JOB_ID = 1984; // Random job ID.
   private static final Object sPersistentAlarmsLock = new Object();
-  private static AtomicBoolean sStarted = new AtomicBoolean(false);
+
+  // TODO(mattcarroll): make sIsIsolateRunning per-instance, not static.
+  private static AtomicBoolean sIsIsolateRunning = new AtomicBoolean(false);
+
+  // TODO(mattcarroll): make sAlarmQueue per-instance, not static.
   private static List<Intent> sAlarmQueue = Collections.synchronizedList(new LinkedList<Intent>());
+
+  /**
+   * Background Dart execution context.
+   */
   private static FlutterNativeView sBackgroundFlutterView;
+
+  /**
+   * The {@link MethodChannel} that connects the Android side of this plugin with the background
+   * Dart isolate that was created by this plugin.
+   */
   private static MethodChannel sBackgroundChannel;
+
   private static PluginRegistrantCallback sPluginRegistrantCallback;
-
-  private String mAppBundlePath;
-
-  @Override
-  public void onCreate() {
-    super.onCreate();
-    Context context = getApplicationContext();
-    FlutterMain.ensureInitializationComplete(context, null);
-    mAppBundlePath = FlutterMain.findAppBundlePath(context);
-    if (!sStarted.get()) {
-      SharedPreferences p = context.getSharedPreferences(SHARED_PREFERENCES_KEY, 0);
-      long callbackHandle = p.getLong(CALLBACK_HANDLE_KEY, 0);
-      startAlarmService(context, callbackHandle);
-    }
-  }
 
   // Schedule the alarm to be handled by the AlarmService.
   public static void enqueueAlarmProcessing(Context context, Intent alarmContext) {
     enqueueWork(context, AlarmService.class, JOB_ID, alarmContext);
   }
 
-  // Called once the Dart isolate (sBackgroundFlutterView) has finished
-  // initializing. Processes all alarm events that came in while the isolate
-  // was starting.
-  public static void onInitialized() {
-    Log.i(TAG, "AlarmService started!");
-    sStarted.set(true);
-    synchronized (sAlarmQueue) {
-      // Handle all the alarm events received before the Dart isolate was fully
-      // initialized and clear the queue.
-      Iterator<Intent> i = sAlarmQueue.iterator();
-      while (i.hasNext()) {
-        invokeCallbackDispatcher(i.next());
-      }
-      sAlarmQueue.clear();
-    }
-  }
-
-  // Here we start the AlarmService. This method does a few things:
-  //   - Retrieves the callback information for the handle associated with the
-  //     callback dispatcher in the Dart portion of the plugin.
-  //   - Builds the arguments object for running in a new FlutterNativeView.
-  //   - Enters the isolate owned by the FlutterNativeView at the callback
-  //     represented by `callbackHandle` and initializes the callback
-  //     dispatcher.
-  //   - Registers the FlutterNativeView's PluginRegistry to receive
-  //     MethodChannel messages.
-  public static void startAlarmService(Context context, long callbackHandle) {
+  /**
+   * Starts running a background Dart isolate within a new {@link FlutterNativeView}.
+   * <p>
+   * The isolate is configured as follows:
+   * <ul>
+   *   <li>Bundle Path: {@code FlutterMain.findAppBundlePath(context)}.</li>
+   *   <li>Entrypoint: The Dart method represented by {@code callbackHandle}.</li>
+   *   <li>Run args: none.</li>
+   * </ul>
+   * <p>
+   * Preconditions:
+   * <ul>
+   *   <li>The given {@code callbackHandle} must correspond to a registered Dart callback.
+   *   If the handle does not resolve to a Dart callback then this method does nothing.</li>
+   *   <li>A static {@link #sPluginRegistrantCallback} must exist, otherwise a
+   *   {@link PluginRegistrantException} will be thrown.</li>
+   * </ul>
+   */
+  public static void startBackgroundIsolate(Context context, long callbackHandle) {
+    // TODO(mattcarroll): re-arrange order of operations. The order is strange - there are 3
+    // conditions that must be met for this method to do anything but they're split up for no
+    // apparent reason. Do the qualification checks first, then execute the method's logic.
     FlutterMain.ensureInitializationComplete(context, null);
     String mAppBundlePath = FlutterMain.findAppBundlePath(context);
-    FlutterCallbackInformation cb =
+    FlutterCallbackInformation flutterCallback =
         FlutterCallbackInformation.lookupCallbackInformation(callbackHandle);
-    if (cb == null) {
+    if (flutterCallback == null) {
       Log.e(TAG, "Fatal: failed to find callback");
       return;
     }
@@ -101,27 +96,56 @@ public class AlarmService extends JobIntentService {
     // FlutterNativeView constructor. This specifies the FlutterNativeView
     // as a background view and does not create a drawing surface.
     sBackgroundFlutterView = new FlutterNativeView(context, true);
-    if (mAppBundlePath != null && !sStarted.get()) {
+    if (mAppBundlePath != null && !sIsIsolateRunning.get()) {
       if (sPluginRegistrantCallback == null) {
         throw new PluginRegistrantException();
       }
       Log.i(TAG, "Starting AlarmService...");
       FlutterRunArguments args = new FlutterRunArguments();
       args.bundlePath = mAppBundlePath;
-      args.entrypoint = cb.callbackName;
-      args.libraryPath = cb.callbackLibraryPath;
+      args.entrypoint = flutterCallback.callbackName;
+      args.libraryPath = flutterCallback.callbackLibraryPath;
       sBackgroundFlutterView.runFromBundle(args);
       sPluginRegistrantCallback.registerWith(sBackgroundFlutterView.getPluginRegistry());
     }
   }
 
+  /**
+   * Called once the Dart isolate ({@code sBackgroundFlutterView}) has finished initializing.
+   * <p>
+   * Invoked by {@link AndroidAlarmManagerPlugin} when it receives the {@code "AlarmService.initialized"}
+   * message. Processes all alarm events that came in while the isolate was starting.
+   */
+  // TODO(mattcarroll): consider making this method package private
+  public static void onInitialized() {
+    Log.i(TAG, "AlarmService started!");
+    sIsIsolateRunning.set(true);
+    synchronized (sAlarmQueue) {
+      // Handle all the alarm events received before the Dart isolate was
+      // initialized, then clear the queue.
+      Iterator<Intent> i = sAlarmQueue.iterator();
+      while (i.hasNext()) {
+        executeDartCallbackInBackgroundIsolate(i.next());
+      }
+      sAlarmQueue.clear();
+    }
+  }
+
+  /**
+   * Sets the {@link MethodChannel} that is used to communicate with Dart callbacks that
+   * are invoked in the background by the android_alarm_manager plugin.
+   */
   public static void setBackgroundChannel(MethodChannel channel) {
     sBackgroundChannel = channel;
   }
 
+  /**
+   * Sets the Dart callback handle for the Dart method that is responsible for initializing the
+   * background Dart isolate, preparing it to receive Dart callback tasks requests.
+   */
   public static void setCallbackDispatcher(Context context, long callbackHandle) {
-    SharedPreferences p = context.getSharedPreferences(SHARED_PREFERENCES_KEY, 0);
-    p.edit().putLong(CALLBACK_HANDLE_KEY, callbackHandle).apply();
+    SharedPreferences prefs = context.getSharedPreferences(SHARED_PREFERENCES_KEY, 0);
+    prefs.edit().putLong(CALLBACK_HANDLE_KEY, callbackHandle).apply();
   }
 
   public static boolean setBackgroundFlutterView(FlutterNativeView view) {
@@ -137,23 +161,13 @@ public class AlarmService extends JobIntentService {
     sPluginRegistrantCallback = callback;
   }
 
-  @Override
-  protected void onHandleWork(Intent intent) {
-    // If we're in the middle of processing queued alarms, block until they're
-    // done before processing new alarms.
-    synchronized (sAlarmQueue) {
-      if (!sStarted.get()) {
-        Log.i(TAG, "AlarmService has not yet started.");
-        sAlarmQueue.add(intent);
-        return;
-      }
-    }
-    invokeCallbackDispatcher(intent);
-  }
-
-  // This is where we handle alarm events before sending them to our callback
-  // dispatcher in Dart.
-  private static void invokeCallbackDispatcher(Intent intent) {
+  /**
+   * Executes the desired Dart callback in a background Dart isolate.
+   * <p>
+   * The given {@code intent} should contain a {@code long} extra called "callbackHandle", which
+   * corresponds to a callback registered with the Dart VM.
+   */
+  private static void executeDartCallbackInBackgroundIsolate(Intent intent) {
     // Grab the handle for the callback associated with this alarm. Pay close
     // attention to the type of the callback handle as storing this value in a
     // variable of the wrong size will cause the callback lookup to fail.
@@ -161,12 +175,15 @@ public class AlarmService extends JobIntentService {
     if (sBackgroundChannel == null) {
       Log.e(
           TAG,
-          "setBackgroundChannel was not called before alarms were scheduled." + " Bailing out.");
+          "setBackgroundChannel was not called before alarms were scheduled." + " Bailing out."
+      );
       return;
     }
     // Handle the alarm event in Dart. Note that for this plugin, we don't
     // care about the method name as we simply lookup and invoke the callback
     // provided.
+    // TODO(mattcarroll): consider giving a method name anyway for the purpose of developer discoverability
+    //                    when reading the source code. Especially on the Dart side.
     sBackgroundChannel.invokeMethod("", new Object[] {callbackHandle});
   }
 
@@ -221,47 +238,34 @@ public class AlarmService extends JobIntentService {
     }
   }
 
-  public static void setOneShot(
-      Context context,
-      int requestCode,
-      boolean exact,
-      boolean wakeup,
-      long startMillis,
-      boolean rescheduleOnReboot,
-      long callbackHandle) {
+  public static void setOneShot(Context context, AndroidAlarmManagerPlugin.OneShotRequest request) {
     final boolean repeating = false;
     scheduleAlarm(
         context,
-        requestCode,
+        request.requestCode,
         repeating,
-        exact,
-        wakeup,
-        startMillis,
+        request.exact,
+        request.wakeup,
+        request.startMillis,
         0,
-        rescheduleOnReboot,
-        callbackHandle);
+        request.rescheduleOnReboot,
+        request.callbackHandle
+    );
   }
 
-  public static void setPeriodic(
-      Context context,
-      int requestCode,
-      boolean exact,
-      boolean wakeup,
-      long startMillis,
-      long intervalMillis,
-      boolean rescheduleOnReboot,
-      long callbackHandle) {
+  public static void setPeriodic(Context context, AndroidAlarmManagerPlugin.PeriodicRequest request) {
     final boolean repeating = true;
     scheduleAlarm(
         context,
-        requestCode,
+        request.requestCode,
         repeating,
-        exact,
-        wakeup,
-        startMillis,
-        intervalMillis,
-        rescheduleOnReboot,
-        callbackHandle);
+        request.exact,
+        request.wakeup,
+        request.startMillis,
+        request.intervalMillis,
+        request.rescheduleOnReboot,
+        request.callbackHandle
+    );
   }
 
   public static void cancel(Context context, int requestCode) {
@@ -302,10 +306,10 @@ public class AlarmService extends JobIntentService {
     alarmSettings.put("callbackHandle", callbackHandle);
     JSONObject obj = new JSONObject(alarmSettings);
     String key = getPersistentAlarmKey(requestCode);
-    SharedPreferences p = context.getSharedPreferences(SHARED_PREFERENCES_KEY, 0);
+    SharedPreferences prefs = context.getSharedPreferences(SHARED_PREFERENCES_KEY, 0);
 
     synchronized (sPersistentAlarmsLock) {
-      Set<String> persistentAlarms = p.getStringSet(PERSISTENT_ALARMS_SET_KEY, null);
+      Set<String> persistentAlarms = prefs.getStringSet(PERSISTENT_ALARMS_SET_KEY, null);
       if (persistentAlarms == null) {
         persistentAlarms = new HashSet<>();
       }
@@ -313,7 +317,7 @@ public class AlarmService extends JobIntentService {
         RebootBroadcastReceiver.enableRescheduleOnReboot(context);
       }
       persistentAlarms.add(Integer.toString(requestCode));
-      p.edit()
+      prefs.edit()
           .putString(key, obj.toString())
           .putStringSet(PERSISTENT_ALARMS_SET_KEY, persistentAlarms)
           .commit();
@@ -384,5 +388,52 @@ public class AlarmService extends JobIntentService {
         }
       }
     }
+  }
+
+  private String mAppBundlePath;
+
+  @Override
+  public void onCreate() {
+    super.onCreate();
+
+    Context context = getApplicationContext();
+    FlutterMain.ensureInitializationComplete(context, null);
+    mAppBundlePath = FlutterMain.findAppBundlePath(context);
+
+    if (!sIsIsolateRunning.get()) {
+      SharedPreferences p = context.getSharedPreferences(SHARED_PREFERENCES_KEY, 0);
+      long callbackHandle = p.getLong(CALLBACK_HANDLE_KEY, 0);
+      startBackgroundIsolate(context, callbackHandle);
+    }
+  }
+
+  /**
+   * Executes a Dart callback, as specified within the incoming {@code intent}.
+   * <p>
+   * Invoked by our {@link JobIntentService} superclass after a call to
+   * {@link JobIntentService#enqueueWork(Context, Class, int, Intent);}.
+   * <p>
+   * If there are no pre-existing callback execution requests, other than the
+   * incoming {@code intent}, then the desired Dart callback is invoked immediately.
+   * <p>
+   * If there are any pre-existing callback requests that have yet to be executed,
+   * the incoming {@code intent} is added to the {@link #sAlarmQueue} to invoked
+   * later, after all pre-existing callbacks have been executed.
+   */
+  @Override
+  protected void onHandleWork(Intent intent) {
+    // If we're in the middle of processing queued alarms, add the incoming
+    // intent to the queue and return.
+    synchronized (sAlarmQueue) {
+      if (!sIsIsolateRunning.get()) {
+        Log.i(TAG, "AlarmService has not yet started.");
+        sAlarmQueue.add(intent);
+        return;
+      }
+    }
+
+    // There were no pre-existing callback requests. Execute the callback
+    // specified by the incoming intent.
+    executeDartCallbackInBackgroundIsolate(intent);
   }
 }

--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AndroidAlarmManagerPlugin.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AndroidAlarmManagerPlugin.java
@@ -164,7 +164,7 @@ public class AndroidAlarmManagerPlugin implements MethodCallHandler, ViewDestroy
   }
 
   /** A request to schedule a one-shot Dart task. */
-  final static class OneShotRequest {
+  static final class OneShotRequest {
     static OneShotRequest fromJson(JSONArray json) throws JSONException {
       int requestCode = json.getInt(0);
       boolean exact = json.getBoolean(1);
@@ -173,7 +173,8 @@ public class AndroidAlarmManagerPlugin implements MethodCallHandler, ViewDestroy
       boolean rescheduleOnReboot = json.getBoolean(4);
       long callbackHandle = json.getLong(5);
 
-      return new OneShotRequest(requestCode, exact, wakeup, startMillis, rescheduleOnReboot, callbackHandle);
+      return new OneShotRequest(
+          requestCode, exact, wakeup, startMillis, rescheduleOnReboot, callbackHandle);
     }
 
     final int requestCode;
@@ -200,7 +201,7 @@ public class AndroidAlarmManagerPlugin implements MethodCallHandler, ViewDestroy
   }
 
   /** A request to schedule a periodic Dart task. */
-  final static class PeriodicRequest {
+  static final class PeriodicRequest {
     static PeriodicRequest fromJson(JSONArray json) throws JSONException {
       int requestCode = json.getInt(0);
       boolean exact = json.getBoolean(1);

--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AndroidAlarmManagerPlugin.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AndroidAlarmManagerPlugin.java
@@ -19,32 +19,33 @@ import org.json.JSONException;
 
 /**
  * Flutter plugin for running one-shot and periodic tasks sometime in the future on Android.
- * <p>
- * Plugin initialization goes through these steps:
+ *
+ * <p>Plugin initialization goes through these steps:
+ *
  * <ol>
- *   <li>Flutter app instructs this plugin to initialize() on the Dart side.</li>
- *   <li>The Dart side of this plugin sends the Android side a "AlarmService.start" message,
- *   along with a Dart callback handle for a Dart callback that should be immediately invoked
- *   by a background Dart isolate.</li>
+ *   <li>Flutter app instructs this plugin to initialize() on the Dart side.
+ *   <li>The Dart side of this plugin sends the Android side a "AlarmService.start" message, along
+ *       with a Dart callback handle for a Dart callback that should be immediately invoked by a
+ *       background Dart isolate.
  *   <li>The Android side of this plugin spins up a background {@link FlutterNativeView}, which
- *   includes a background Dart isolate.</li>
- *   <li>The Android side of this plugin instructs the new background Dart isolate to execute
- *   the callback that was received in the "AlarmService.start" message.</li>
- *   <li>The Dart side of this plugin, running within the new background isolate, executes
- *   the designated callback. This callback prepares the background isolate to then execute
- *   any given Dart callback from that point forward. Thus, at this moment the plugin is
- *   fully initialized and ready to execute arbitrary Dart tasks in the background. The Dart
- *   side of this plugin sends the Android side a "AlarmService.initialized" message to
- *   signify that the Dart is ready to execute tasks.</li>
+ *       includes a background Dart isolate.
+ *   <li>The Android side of this plugin instructs the new background Dart isolate to execute the
+ *       callback that was received in the "AlarmService.start" message.
+ *   <li>The Dart side of this plugin, running within the new background isolate, executes the
+ *       designated callback. This callback prepares the background isolate to then execute any
+ *       given Dart callback from that point forward. Thus, at this moment the plugin is fully
+ *       initialized and ready to execute arbitrary Dart tasks in the background. The Dart side of
+ *       this plugin sends the Android side a "AlarmService.initialized" message to signify that the
+ *       Dart is ready to execute tasks.
  * </ol>
  */
 public class AndroidAlarmManagerPlugin implements MethodCallHandler, ViewDestroyListener {
   /**
-   * Registers this plugin with an associated Flutter execution context, represented by
-   * the given {@link Registrar}.
-   * <p>
-   * Once this method is executed, an instance of {@code AndroidAlarmManagerPlugin}
-   * will be connected to, and running against, the associated Flutter execution context.
+   * Registers this plugin with an associated Flutter execution context, represented by the given
+   * {@link Registrar}.
+   *
+   * <p>Once this method is executed, an instance of {@code AndroidAlarmManagerPlugin} will be
+   * connected to, and running against, the associated Flutter execution context.
    */
   public static void registerWith(Registrar registrar) {
     // alarmManagerPluginChannel is the channel responsible for receiving the following messages
@@ -95,9 +96,7 @@ public class AndroidAlarmManagerPlugin implements MethodCallHandler, ViewDestroy
     this.mContext = context;
   }
 
-  /**
-   * Invoked when the Flutter side of this plugin sends a message to the Android side.
-   */
+  /** Invoked when the Flutter side of this plugin sends a message to the Android side. */
   @Override
   public void onMethodCall(MethodCall call, Result result) {
     String method = call.method;
@@ -150,23 +149,21 @@ public class AndroidAlarmManagerPlugin implements MethodCallHandler, ViewDestroy
   }
 
   /**
-   * Transitions the Flutter execution context that owns this plugin from foreground execution
-   * to background execution.
-   * <p>
-   * Invoked when the {@link FlutterView} connected to the given {@link FlutterNativeView} is
+   * Transitions the Flutter execution context that owns this plugin from foreground execution to
+   * background execution.
+   *
+   * <p>Invoked when the {@link FlutterView} connected to the given {@link FlutterNativeView} is
    * destroyed.
-   * <p>
-   * Returns true if the given {@code nativeView} was successfully stored by this plugin, or false
-   * if a different {@link FlutterNativeView} was already registered with this plugin.
+   *
+   * <p>Returns true if the given {@code nativeView} was successfully stored by this plugin, or
+   * false if a different {@link FlutterNativeView} was already registered with this plugin.
    */
   @Override
   public boolean onViewDestroy(FlutterNativeView nativeView) {
     return AlarmService.setBackgroundFlutterView(nativeView);
   }
 
-  /**
-   * A request to schedule a one-shot Dart task.
-   */
+  /** A request to schedule a one-shot Dart task. */
   final static class OneShotRequest {
     static OneShotRequest fromJson(JSONArray json) throws JSONException {
       int requestCode = json.getInt(0);
@@ -176,14 +173,7 @@ public class AndroidAlarmManagerPlugin implements MethodCallHandler, ViewDestroy
       boolean rescheduleOnReboot = json.getBoolean(4);
       long callbackHandle = json.getLong(5);
 
-      return new OneShotRequest(
-          requestCode,
-          exact,
-          wakeup,
-          startMillis,
-          rescheduleOnReboot,
-          callbackHandle
-      );
+      return new OneShotRequest(requestCode, exact, wakeup, startMillis, rescheduleOnReboot, callbackHandle);
     }
 
     final int requestCode;
@@ -199,8 +189,7 @@ public class AndroidAlarmManagerPlugin implements MethodCallHandler, ViewDestroy
         boolean wakeup,
         long startMillis,
         boolean rescheduleOnReboot,
-        long callbackHandle
-    ) {
+        long callbackHandle) {
       this.requestCode = requestCode;
       this.exact = exact;
       this.wakeup = wakeup;
@@ -210,9 +199,7 @@ public class AndroidAlarmManagerPlugin implements MethodCallHandler, ViewDestroy
     }
   }
 
-  /**
-   * A request to schedule a periodic Dart task.
-   */
+  /** A request to schedule a periodic Dart task. */
   final static class PeriodicRequest {
     static PeriodicRequest fromJson(JSONArray json) throws JSONException {
       int requestCode = json.getInt(0);
@@ -230,8 +217,7 @@ public class AndroidAlarmManagerPlugin implements MethodCallHandler, ViewDestroy
           startMillis,
           intervalMillis,
           rescheduleOnReboot,
-          callbackHandle
-      );
+          callbackHandle);
     }
 
     final int requestCode;
@@ -249,8 +235,7 @@ public class AndroidAlarmManagerPlugin implements MethodCallHandler, ViewDestroy
         long startMillis,
         long intervalMillis,
         boolean rescheduleOnReboot,
-        long callbackHandle
-    ) {
+        long callbackHandle) {
       this.requestCode = requestCode;
       this.exact = exact;
       this.wakeup = wakeup;

--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AndroidAlarmManagerPlugin.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AndroidAlarmManagerPlugin.java
@@ -5,7 +5,6 @@
 package io.flutter.plugins.androidalarmmanager;
 
 import android.content.Context;
-
 import io.flutter.plugin.common.JSONMethodCodec;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;

--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AndroidAlarmManagerPlugin.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AndroidAlarmManagerPlugin.java
@@ -5,6 +5,7 @@
 package io.flutter.plugins.androidalarmmanager;
 
 import android.content.Context;
+
 import io.flutter.plugin.common.JSONMethodCodec;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
@@ -16,25 +17,76 @@ import io.flutter.view.FlutterNativeView;
 import org.json.JSONArray;
 import org.json.JSONException;
 
-/** AndroidAlarmManagerPlugin */
+/**
+ * Flutter plugin for running one-shot and periodic tasks sometime in the future on Android.
+ * <p>
+ * Plugin initialization goes through these steps:
+ * <ol>
+ *   <li>Flutter app instructs this plugin to initialize() on the Dart side.</li>
+ *   <li>The Dart side of this plugin sends the Android side a "AlarmService.start" message,
+ *   along with a Dart callback handle for a Dart callback that should be immediately invoked
+ *   by a background Dart isolate.</li>
+ *   <li>The Android side of this plugin spins up a background {@link FlutterNativeView}, which
+ *   includes a background Dart isolate.</li>
+ *   <li>The Android side of this plugin instructs the new background Dart isolate to execute
+ *   the callback that was received in the "AlarmService.start" message.</li>
+ *   <li>The Dart side of this plugin, running within the new background isolate, executes
+ *   the designated callback. This callback prepares the background isolate to then execute
+ *   any given Dart callback from that point forward. Thus, at this moment the plugin is
+ *   fully initialized and ready to execute arbitrary Dart tasks in the background. The Dart
+ *   side of this plugin sends the Android side a "AlarmService.initialized" message to
+ *   signify that the Dart is ready to execute tasks.</li>
+ * </ol>
+ */
 public class AndroidAlarmManagerPlugin implements MethodCallHandler, ViewDestroyListener {
-  /** Plugin registration. */
+  /**
+   * Registers this plugin with an associated Flutter execution context, represented by
+   * the given {@link Registrar}.
+   * <p>
+   * Once this method is executed, an instance of {@code AndroidAlarmManagerPlugin}
+   * will be connected to, and running against, the associated Flutter execution context.
+   */
   public static void registerWith(Registrar registrar) {
-    final MethodChannel channel =
+    // alarmManagerPluginChannel is the channel responsible for receiving the following messages
+    // from the main Flutter app:
+    // - "AlarmService.start"
+    // - "Alarm.oneShot"
+    // - "Alarm.periodic"
+    // - "Alarm.cancel"
+    final MethodChannel alarmManagerPluginChannel =
         new MethodChannel(
             registrar.messenger(),
             "plugins.flutter.io/android_alarm_manager",
             JSONMethodCodec.INSTANCE);
-    final MethodChannel backgroundChannel =
+
+    // backgroundCallbackChannel is the channel responsible for receiving the following messages
+    // from the background isolate that was setup by this plugin:
+    // - "AlarmService.initialized"
+    //
+    // This channel is also responsible for sending requests from Android to Dart to execute Dart
+    // callbacks in the background isolate. Those messages are sent with an empty method name because
+    // they are the only messages that this channel sends to Dart.
+    final MethodChannel backgroundCallbackChannel =
         new MethodChannel(
             registrar.messenger(),
             "plugins.flutter.io/android_alarm_manager_background",
             JSONMethodCodec.INSTANCE);
+
+    // Instantiate a new AndroidAlarmManagerPlugin, connect the primary and background
+    // method channels for Android/Flutter communication, and listen for FlutterView
+    // destruction so that this plugin can move itself to background mode.
     AndroidAlarmManagerPlugin plugin = new AndroidAlarmManagerPlugin(registrar.context());
-    channel.setMethodCallHandler(plugin);
-    backgroundChannel.setMethodCallHandler(plugin);
+    alarmManagerPluginChannel.setMethodCallHandler(plugin);
+    backgroundCallbackChannel.setMethodCallHandler(plugin);
     registrar.addViewDestroyListener(plugin);
-    AlarmService.setBackgroundChannel(backgroundChannel);
+
+    // The AlarmService expects to hold a static reference to the plugin's background
+    // method channel.
+    // TODO(mattcarroll): this static reference implies that only one instance of this plugin
+    //                    can exist at a time. Moreover, calling registerWith() a 2nd time would
+    //                    seem to overwrite the previously registered background channel without
+    //                    notice.
+    AlarmService.setBackgroundChannel(backgroundCallbackChannel);
   }
 
   private Context mContext;
@@ -43,25 +95,49 @@ public class AndroidAlarmManagerPlugin implements MethodCallHandler, ViewDestroy
     this.mContext = context;
   }
 
+  /**
+   * Invoked when the Flutter side of this plugin sends a message to the Android side.
+   */
   @Override
   public void onMethodCall(MethodCall call, Result result) {
     String method = call.method;
     Object arguments = call.arguments;
     try {
       if (method.equals("AlarmService.start")) {
-        startService((JSONArray) arguments);
+        // This message is sent when the Dart side of this plugin is told to initialize.
+        long callbackHandle = ((JSONArray) arguments).getLong(0);
+        // In response, this (native) side of the plugin needs to spin up a background
+        // Dart isolate by using the given callbackHandle, and then setup a background
+        // method channel to communicate with the new background isolate. Once completed,
+        // this onMethodCall() method will receive messages from both the primary and background
+        // method channels.
+        AlarmService.setCallbackDispatcher(mContext, callbackHandle);
+        AlarmService.startBackgroundIsolate(mContext, callbackHandle);
         result.success(true);
       } else if (method.equals("AlarmService.initialized")) {
+        // This message is sent by the background method channel as soon as the background isolate
+        // is running. From this point forward, the Android side of this plugin can send
+        // callback handles through the background method channel, and the Dart side will execute
+        // the Dart methods corresponding to those callback handles.
         AlarmService.onInitialized();
         result.success(true);
       } else if (method.equals("Alarm.periodic")) {
-        periodic((JSONArray) arguments);
+        // This message indicates that the Flutter app would like to schedule a periodic
+        // task.
+        PeriodicRequest periodicRequest = PeriodicRequest.fromJson((JSONArray) arguments);
+        AlarmService.setPeriodic(mContext, periodicRequest);
         result.success(true);
       } else if (method.equals("Alarm.oneShot")) {
-        oneShot((JSONArray) arguments);
+        // This message indicates that the Flutter app would like to schedule a one-time
+        // task.
+        OneShotRequest oneShotRequest = OneShotRequest.fromJson((JSONArray) arguments);
+        AlarmService.setOneShot(mContext, oneShotRequest);
         result.success(true);
       } else if (method.equals("Alarm.cancel")) {
-        cancel((JSONArray) arguments);
+        // This message indicates that the Flutter app would like to cancel a previously
+        // scheduled task.
+        int requestCode = ((JSONArray) arguments).getInt(0);
+        AlarmService.cancel(mContext, requestCode);
         result.success(true);
       } else {
         result.notImplemented();
@@ -73,49 +149,115 @@ public class AndroidAlarmManagerPlugin implements MethodCallHandler, ViewDestroy
     }
   }
 
-  private void startService(JSONArray arguments) throws JSONException {
-    long callbackHandle = arguments.getLong(0);
-    AlarmService.setCallbackDispatcher(mContext, callbackHandle);
-    AlarmService.startAlarmService(mContext, callbackHandle);
-  }
-
-  private void oneShot(JSONArray arguments) throws JSONException {
-    int requestCode = arguments.getInt(0);
-    boolean exact = arguments.getBoolean(1);
-    boolean wakeup = arguments.getBoolean(2);
-    long startMillis = arguments.getLong(3);
-    boolean rescheduleOnReboot = arguments.getBoolean(4);
-    long callbackHandle = arguments.getLong(5);
-    AlarmService.setOneShot(
-        mContext, requestCode, exact, wakeup, startMillis, rescheduleOnReboot, callbackHandle);
-  }
-
-  private void periodic(JSONArray arguments) throws JSONException {
-    int requestCode = arguments.getInt(0);
-    boolean exact = arguments.getBoolean(1);
-    boolean wakeup = arguments.getBoolean(2);
-    long startMillis = arguments.getLong(3);
-    long intervalMillis = arguments.getLong(4);
-    boolean rescheduleOnReboot = arguments.getBoolean(5);
-    long callbackHandle = arguments.getLong(6);
-    AlarmService.setPeriodic(
-        mContext,
-        requestCode,
-        exact,
-        wakeup,
-        startMillis,
-        intervalMillis,
-        rescheduleOnReboot,
-        callbackHandle);
-  }
-
-  private void cancel(JSONArray arguments) throws JSONException {
-    int requestCode = arguments.getInt(0);
-    AlarmService.cancel(mContext, requestCode);
-  }
-
+  /**
+   * Transitions the Flutter execution context that owns this plugin from foreground execution
+   * to background execution.
+   * <p>
+   * Invoked when the {@link FlutterView} connected to the given {@link FlutterNativeView} is
+   * destroyed.
+   * <p>
+   * Returns true if the given {@code nativeView} was successfully stored by this plugin, or false
+   * if a different {@link FlutterNativeView} was already registered with this plugin.
+   */
   @Override
   public boolean onViewDestroy(FlutterNativeView nativeView) {
     return AlarmService.setBackgroundFlutterView(nativeView);
+  }
+
+  /**
+   * A request to schedule a one-shot Dart task.
+   */
+  final static class OneShotRequest {
+    static OneShotRequest fromJson(JSONArray json) throws JSONException {
+      int requestCode = json.getInt(0);
+      boolean exact = json.getBoolean(1);
+      boolean wakeup = json.getBoolean(2);
+      long startMillis = json.getLong(3);
+      boolean rescheduleOnReboot = json.getBoolean(4);
+      long callbackHandle = json.getLong(5);
+
+      return new OneShotRequest(
+          requestCode,
+          exact,
+          wakeup,
+          startMillis,
+          rescheduleOnReboot,
+          callbackHandle
+      );
+    }
+
+    final int requestCode;
+    final boolean exact;
+    final boolean wakeup;
+    final long startMillis;
+    final boolean rescheduleOnReboot;
+    final long callbackHandle;
+
+    OneShotRequest(
+        int requestCode,
+        boolean exact,
+        boolean wakeup,
+        long startMillis,
+        boolean rescheduleOnReboot,
+        long callbackHandle
+    ) {
+      this.requestCode = requestCode;
+      this.exact = exact;
+      this.wakeup = wakeup;
+      this.startMillis = startMillis;
+      this.rescheduleOnReboot = rescheduleOnReboot;
+      this.callbackHandle = callbackHandle;
+    }
+  }
+
+  /**
+   * A request to schedule a periodic Dart task.
+   */
+  final static class PeriodicRequest {
+    static PeriodicRequest fromJson(JSONArray json) throws JSONException {
+      int requestCode = json.getInt(0);
+      boolean exact = json.getBoolean(1);
+      boolean wakeup = json.getBoolean(2);
+      long startMillis = json.getLong(3);
+      long intervalMillis = json.getLong(4);
+      boolean rescheduleOnReboot = json.getBoolean(5);
+      long callbackHandle = json.getLong(6);
+
+      return new PeriodicRequest(
+          requestCode,
+          exact,
+          wakeup,
+          startMillis,
+          intervalMillis,
+          rescheduleOnReboot,
+          callbackHandle
+      );
+    }
+
+    final int requestCode;
+    final boolean exact;
+    final boolean wakeup;
+    final long startMillis;
+    final long intervalMillis;
+    final boolean rescheduleOnReboot;
+    final long callbackHandle;
+
+    PeriodicRequest(
+        int requestCode,
+        boolean exact,
+        boolean wakeup,
+        long startMillis,
+        long intervalMillis,
+        boolean rescheduleOnReboot,
+        long callbackHandle
+    ) {
+      this.requestCode = requestCode;
+      this.exact = exact;
+      this.wakeup = wakeup;
+      this.startMillis = startMillis;
+      this.intervalMillis = intervalMillis;
+      this.rescheduleOnReboot = rescheduleOnReboot;
+      this.callbackHandle = callbackHandle;
+    }
   }
 }

--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/RebootBroadcastReceiver.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/RebootBroadcastReceiver.java
@@ -11,7 +11,27 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.util.Log;
 
+/**
+ * Reschedules background work after the Android device reboots.
+ * <p>
+ * When an Android device reboots, all previously scheduled {@link AlarmManager}
+ * timers are cleared.
+ * <p>
+ * Timer callbacks registered with the android_alarm_manager plugin can be
+ * designated "persistent" and therefore, upon device reboot, should be
+ * rescheduled for execution. To accomplish this rescheduling, 
+ * {@code RebootBroadcastReceiver} is scheduled by {@link AlarmService} to run 
+ * on {@code BOOT_COMPLETED} and do the rescheduling.
+ */
 public class RebootBroadcastReceiver extends BroadcastReceiver {
+  /**
+   * Invoked by the OS whenever a broadcast is received by this app.
+   * <p>
+   * If the broadcast's action is {@code BOOT_COMPLETED} then this
+   * {@code RebootBroadcastReceiver} reschedules all persistent timer
+   * callbacks. That rescheduling work is handled by
+   * {@link AlarmService#reschedulePersistentAlarms(Context)}.
+   */
   @Override
   public void onReceive(Context context, Intent intent) {
     if (intent.getAction().equals("android.intent.action.BOOT_COMPLETED")) {
@@ -20,10 +40,19 @@ public class RebootBroadcastReceiver extends BroadcastReceiver {
     }
   }
 
+  /**
+   * Schedules this {@code RebootBroadcastReceiver} to be run whenever the
+   * Android device reboots.
+   */
   public static void enableRescheduleOnReboot(Context context) {
     scheduleOnReboot(context, PackageManager.COMPONENT_ENABLED_STATE_ENABLED);
   }
 
+  /**
+   * Unschedules this {@code RebootBroadcastReceiver} to be run whenever the
+   * Android device reboots. This {@code RebootBroadcastReceiver} will no longer
+   * be run upon reboot.
+   */
   public static void disableRescheduleOnReboot(Context context) {
     scheduleOnReboot(context, PackageManager.COMPONENT_ENABLED_STATE_DISABLED);
   }

--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/RebootBroadcastReceiver.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/RebootBroadcastReceiver.java
@@ -13,24 +13,22 @@ import android.util.Log;
 
 /**
  * Reschedules background work after the Android device reboots.
- * <p>
- * When an Android device reboots, all previously scheduled {@link AlarmManager}
- * timers are cleared.
- * <p>
- * Timer callbacks registered with the android_alarm_manager plugin can be
- * designated "persistent" and therefore, upon device reboot, should be
- * rescheduled for execution. To accomplish this rescheduling, 
- * {@code RebootBroadcastReceiver} is scheduled by {@link AlarmService} to run 
- * on {@code BOOT_COMPLETED} and do the rescheduling.
+ *
+ * <p>When an Android device reboots, all previously scheduled {@link AlarmManager} timers are
+ * cleared.
+ *
+ * <p>Timer callbacks registered with the android_alarm_manager plugin can be designated
+ * "persistent" and therefore, upon device reboot, should be rescheduled for execution. To
+ * accomplish this rescheduling, {@code RebootBroadcastReceiver} is scheduled by {@link
+ * AlarmService} to run on {@code BOOT_COMPLETED} and do the rescheduling.
  */
 public class RebootBroadcastReceiver extends BroadcastReceiver {
   /**
    * Invoked by the OS whenever a broadcast is received by this app.
-   * <p>
-   * If the broadcast's action is {@code BOOT_COMPLETED} then this
-   * {@code RebootBroadcastReceiver} reschedules all persistent timer
-   * callbacks. That rescheduling work is handled by
-   * {@link AlarmService#reschedulePersistentAlarms(Context)}.
+   *
+   * <p>If the broadcast's action is {@code BOOT_COMPLETED} then this {@code
+   * RebootBroadcastReceiver} reschedules all persistent timer callbacks. That rescheduling work is
+   * handled by {@link AlarmService#reschedulePersistentAlarms(Context)}.
    */
   @Override
   public void onReceive(Context context, Intent intent) {
@@ -41,17 +39,15 @@ public class RebootBroadcastReceiver extends BroadcastReceiver {
   }
 
   /**
-   * Schedules this {@code RebootBroadcastReceiver} to be run whenever the
-   * Android device reboots.
+   * Schedules this {@code RebootBroadcastReceiver} to be run whenever the Android device reboots.
    */
   public static void enableRescheduleOnReboot(Context context) {
     scheduleOnReboot(context, PackageManager.COMPONENT_ENABLED_STATE_ENABLED);
   }
 
   /**
-   * Unschedules this {@code RebootBroadcastReceiver} to be run whenever the
-   * Android device reboots. This {@code RebootBroadcastReceiver} will no longer
-   * be run upon reboot.
+   * Unschedules this {@code RebootBroadcastReceiver} to be run whenever the Android device reboots.
+   * This {@code RebootBroadcastReceiver} will no longer be run upon reboot.
    */
   public static void disableRescheduleOnReboot(Context context) {
     scheduleOnReboot(context, PackageManager.COMPONENT_ENABLED_STATE_DISABLED);


### PR DESCRIPTION
## Description

I started reading through android_alarm_manager to determine how it would work with the new Android plugin API but I had a difficult time tracing the execution paths and interpreting the intent of the code. So I decided to go through and document everything I could to make better sense of it. I'd like to commit those comments and minor refactorings so that hopefully it's a little more clear for everyone.

Added comments and refactored android_alarm_manager plugin for clarity.

- Added many comments, both on public members and within private source code.
- Moved all static behavior above instance behavior in `AlarmService` to clearly demonstrate how much behavior has been defined statically (which I think we very much want to move to instance behavior).
- Renamed some methods to shift them from ambiguous naming to explicit.
- Created request data structures to parse and hold information about desired one-shot and periodic tasks.

Recommendations for further refactoring:

- I think we should move all the plugin behavior out of `AlarmService` and into its own object because `AlarmService` lives and dies based on the OS, regardless of whether that timing is convenient for our plugin behavior.
- On a similar note, we should adjust the API to work with multiple Flutter execution contexts instead of just one. This will be a requirement for add-to-app scenarios, regardless of what the new Android embedding API looks like.
- I would recommend codifying the method channel messages in its own object instead of combining it with the associated logic. This will also make it much easier in the future to replace hand-coded message handling with a generated version.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x ] I updated/added relevant documentation (doc comments with `///`).
- [x ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [ x] I read and followed the [Flutter Style Guide].
- [x ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x ] I signed the [CLA].
- [x ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ x] No, this is *not* a breaking change.
