### PR TITLE
Add Android debug mode

### DIFF
--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -32,6 +32,10 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
   FlutterWebView(Context context, BinaryMessenger messenger, int id, Map<String, Object> params) {
     webView = new WebView(context);
     platformThreadHandler = new Handler(context.getMainLooper());
+    boolean debug = (boolean) params.get("debug") || false;
+
+    WebView.setWebContentsDebuggingEnabled(debug);
+
     // Allow local storage.
     webView.getSettings().setDomStorageEnabled(true);
 

--- a/packages/webview_flutter/example/lib/main.dart
+++ b/packages/webview_flutter/example/lib/main.dart
@@ -64,6 +64,7 @@ class WebViewExample extends StatelessWidget {
           onPageFinished: (String url) {
             print('Page finished loading: $url');
           },
+          debug: true,
         );
       }),
       floatingActionButton: favoriteButton(),

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -117,6 +117,7 @@ class WebView extends StatefulWidget {
     this.navigationDelegate,
     this.gestureRecognizers,
     this.onPageFinished,
+    this.debug
   })  : assert(javascriptMode != null),
         super(key: key);
 
@@ -204,6 +205,7 @@ class WebView extends StatefulWidget {
   /// directly in the HTML has been loaded and code injected with
   /// [WebViewController.evaluateJavascript] can assume this.
   final PageFinishedCallback onPageFinished;
+  final bool debug;
 
   @override
   State<StatefulWidget> createState() => _WebViewState();
@@ -294,7 +296,7 @@ Set<String> _extractChannelNames(Set<JavascriptChannel> channels) {
 
 class _CreationParams {
   _CreationParams(
-      {this.initialUrl, this.settings, this.javascriptChannelNames});
+      {this.initialUrl, this.settings, this.javascriptChannelNames, this.debug});
 
   static _CreationParams fromWidget(WebView widget) {
     return _CreationParams(
@@ -302,6 +304,7 @@ class _CreationParams {
       settings: _WebSettings.fromWidget(widget),
       javascriptChannelNames:
           _extractChannelNames(widget.javascriptChannels).toList(),
+      debug: widget.debug
     );
   }
 
@@ -310,12 +313,14 @@ class _CreationParams {
   final _WebSettings settings;
 
   final List<String> javascriptChannelNames;
+  final bool debug;
 
   Map<String, dynamic> toMap() {
     return <String, dynamic>{
       'initialUrl': initialUrl,
       'settings': settings.toMap(),
       'javascriptChannelNames': javascriptChannelNames,
+      'debug': debug
     };
   }
 }


### PR DESCRIPTION
It's hard for developers to debug their communications in browsers when developing webwiews with Android, so they add a new parameter to open debug mode, hoping to pass it.