### PR TITLE
[image_picker] Android: Save state of the image picker to handle data lost if the MainActivity is killed by system.

### DIFF
--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.4
+
+* Android: Prevent crash when MainActivity is killed by system.
+* Add `retrieveLostData` to retrieve lost data after MainActivity is killed.
+
 ## 0.5.3+1
 
 * Update minimum deploy iOS version to 8.0.

--- a/packages/image_picker/README.md
+++ b/packages/image_picker/README.md
@@ -65,7 +65,7 @@ class _MyHomePageState extends State<MyHomePage> {
 }
 ```
 
-### Handling MainActivity Destruction on Android
+### Handling MainActivity destruction on Android
 
 Android system -- although very rarely -- sometimes kills the MainActivity after the image_picker finishes. When this happens, we lost the data selected from the image_picker. You can use `retrieveLostData` to retrieve the lost data in this situation. For example: 
 

--- a/packages/image_picker/README.md
+++ b/packages/image_picker/README.md
@@ -64,3 +64,28 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 }
 ```
+
+### Handling MainActivity Destruction on Android
+
+Android system -- although very rarely -- sometimes kills the MainActivity after the image_picker finishes. When this happens, we lost the data selected from the image_picker. You can use `retrieveLostData` to retrieve the lost data in this situation. For example: 
+
+```dart
+Future<void> retrieveLostData() async {
+  final RetrieveLostDataResponse response =
+      await ImagePicker.retrieveLostData();
+  if (response == null) {
+    return;
+  }
+  if (response.file != null) {
+    setState(() {
+      if (response.type == RetrieveType.video) {
+        _handleVideo(response.file);
+      } else {
+        _handleImage(response.file);
+      }
+    });
+  } else {
+    _handleError(response.exception);
+  }
+}
+```

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
@@ -82,7 +82,8 @@ public class ImagePickerDelegate
   static final String SHARED_PREFERENCE_MAX_WIDTH_KEY = "flutter_image_picker_max_width";
   static final String SHARED_PREFERENCE_MAX_HEIGHT_KEY = "flutter_image_picker_max_height";
   static final String SHARED_PREFERENCE_TYPE_KEY = "flutter_image_picker_type";
-  static final String SHARED_PREFERENCE_PENDING_IMAGE_URI_PATH_KEY = "flutter_image_picker_pending_image_uri";
+  static final String SHARED_PREFERENCE_PENDING_IMAGE_URI_PATH_KEY =
+      "flutter_image_picker_pending_image_uri";
 
   private final Activity activity;
   private final File externalFilesDirectory;
@@ -427,7 +428,7 @@ public class ImagePickerDelegate
   private void handleCaptureVideoResult(int resultCode) {
     if (resultCode == Activity.RESULT_OK) {
       fileUriResolver.getFullImagePath(
-              Uri.parse(getPendingCameraMediaUriPath()),
+          Uri.parse(getPendingCameraMediaUriPath()),
           new OnPathReadyListener() {
             @Override
             public void onPathReady(String path) {
@@ -446,13 +447,13 @@ public class ImagePickerDelegate
       saveResult(path, null, null);
       return;
     }
-      String finalImagePath = getFinalImagePath(path);
-      finishWithSuccess(finalImagePath);
+    String finalImagePath = getFinalImagePath(path);
+    finishWithSuccess(finalImagePath);
 
-      //delete original file if scaled
-      if (!finalImagePath.equals(path) && shouldDeleteOriginalIfScaled) {
-        new File(path).delete();
-      }
+    //delete original file if scaled
+    if (!finalImagePath.equals(path) && shouldDeleteOriginalIfScaled) {
+      new File(path).delete();
+    }
   }
 
   private String getFinalImagePath(String originalPath) {
@@ -465,8 +466,7 @@ public class ImagePickerDelegate
     finishWithSuccess(path);
   }
 
-  private boolean setPendingResult(
-     MethodChannel.Result result) {
+  private boolean setPendingResult(MethodChannel.Result result) {
     if (pendingResult != null) {
       return false;
     }
@@ -504,8 +504,8 @@ public class ImagePickerDelegate
     pendingResult = null;
   }
 
-  void saveResult( String path, String errorCode, String errorMessage) {
-    SharedPreferences.Editor editor =  ImagePickerPlugin.getFilePref.edit();
+  void saveResult(String path, String errorCode, String errorMessage) {
+    SharedPreferences.Editor editor = ImagePickerPlugin.getFilePref.edit();
     if (path != null) {
       editor.putString(FLUTTER_IMAGE_PICKER_IMAGE_PATH_KEY, path);
     }
@@ -525,18 +525,21 @@ public class ImagePickerDelegate
   Map<String, String> resultMapFromPendingResult() {
     Map<String, String> resultMap = new HashMap<>();
     Boolean hasData = false;
-    String filePath = ImagePickerPlugin.getFilePref.getString(FLUTTER_IMAGE_PICKER_IMAGE_PATH_KEY, null);
-    if (filePath != null ) {
+    String filePath =
+        ImagePickerPlugin.getFilePref.getString(FLUTTER_IMAGE_PICKER_IMAGE_PATH_KEY, null);
+    if (filePath != null) {
       String finalPath = getFinalImagePath(filePath);
       resultMap.put("path", finalPath);
       hasData = true;
     }
-    String errorCode = ImagePickerPlugin.getFilePref.getString(SHARED_PREFERENCE_ERROR_CODE_KEY, null);
-    if (errorCode != null ) {
+    String errorCode =
+        ImagePickerPlugin.getFilePref.getString(SHARED_PREFERENCE_ERROR_CODE_KEY, null);
+    if (errorCode != null) {
       resultMap.put("errorCode", errorCode);
       hasData = true;
-      String errorMessage = ImagePickerPlugin.getFilePref.getString(SHARED_PREFERENCE_ERROR_MESSAGE_KEY, null);
-      if (errorMessage != null ) {
+      String errorMessage =
+          ImagePickerPlugin.getFilePref.getString(SHARED_PREFERENCE_ERROR_MESSAGE_KEY, null);
+      if (errorMessage != null) {
         resultMap.put("errorMessage", errorMessage);
       }
     }
@@ -554,18 +557,20 @@ public class ImagePickerDelegate
     if (!ImagePickerPlugin.getFilePref.contains(SHARED_PREFERENCE_MAX_WIDTH_KEY)) {
       return null;
     }
-    return Double.longBitsToDouble(ImagePickerPlugin.getFilePref.getLong(SHARED_PREFERENCE_MAX_WIDTH_KEY, 0));
+    return Double.longBitsToDouble(
+        ImagePickerPlugin.getFilePref.getLong(SHARED_PREFERENCE_MAX_WIDTH_KEY, 0));
   }
 
   Double getMaxHeight() {
     if (!ImagePickerPlugin.getFilePref.contains(SHARED_PREFERENCE_MAX_HEIGHT_KEY)) {
       return null;
     }
-    return Double.longBitsToDouble(ImagePickerPlugin.getFilePref.getLong(SHARED_PREFERENCE_MAX_HEIGHT_KEY, 0));
+    return Double.longBitsToDouble(
+        ImagePickerPlugin.getFilePref.getLong(SHARED_PREFERENCE_MAX_HEIGHT_KEY, 0));
   }
 
   void saveMaxDemension(Double maxWidth, Double maxHeight) {
-    SharedPreferences.Editor editor =  ImagePickerPlugin.getFilePref.edit();
+    SharedPreferences.Editor editor = ImagePickerPlugin.getFilePref.edit();
     if (maxWidth != null) {
       editor.putLong(SHARED_PREFERENCE_MAX_WIDTH_KEY, Double.doubleToRawLongBits(maxWidth));
     }
@@ -580,12 +585,14 @@ public class ImagePickerDelegate
   }
 
   void setPendingCameraMediaUriPath(String path) {
-    ImagePickerPlugin.getFilePref.edit().putString(SHARED_PREFERENCE_PENDING_IMAGE_URI_PATH_KEY, path).apply();
+    ImagePickerPlugin.getFilePref
+        .edit()
+        .putString(SHARED_PREFERENCE_PENDING_IMAGE_URI_PATH_KEY, path)
+        .apply();
   }
 
   String getPendingCameraMediaUriPath() {
-    return ImagePickerPlugin.getFilePref.getString(SHARED_PREFERENCE_PENDING_IMAGE_URI_PATH_KEY, "");
+    return ImagePickerPlugin.getFilePref.getString(
+        SHARED_PREFERENCE_PENDING_IMAGE_URI_PATH_KEY, "");
   }
-
-
 }

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
@@ -262,7 +262,7 @@ public class ImagePickerDelegate
       finishWithAlreadyActiveError(result);
       return;
     }
-    preparePresistentDataBeforeImageIntent(methodCall);
+    preparePersistentDataBeforeImageIntent(methodCall);
 
     if (!permissionManager.isPermissionGranted(Manifest.permission.READ_EXTERNAL_STORAGE)) {
       permissionManager.askForPermission(
@@ -285,12 +285,12 @@ public class ImagePickerDelegate
       finishWithAlreadyActiveError(result);
       return;
     }
-    preparePresistentDataBeforeImageIntent(methodCall);
+    preparePersistentDataBeforeImageIntent(methodCall);
 
     launchTakeImageWithCameraIntent();
   }
 
-  private void preparePresistentDataBeforeImageIntent(MethodCall methodCall) {
+  private void preparePersistentDataBeforeImageIntent(MethodCall methodCall) {
     setType("image");
     Double maxWidth = methodCall.argument("maxWidth");
     Double maxHeight = methodCall.argument("maxHeight");

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
@@ -294,7 +294,7 @@ public class ImagePickerDelegate
     setType("image");
     Double maxWidth = methodCall.argument("maxWidth");
     Double maxHeight = methodCall.argument("maxHeight");
-    saveMaxDemension(maxWidth, maxHeight);
+    saveMaxDimension(maxWidth, maxHeight);
   }
 
   private void launchTakeImageWithCameraIntent() {
@@ -462,20 +462,19 @@ public class ImagePickerDelegate
   }
 
   private void handleImageResult(String path, boolean shouldDeleteOriginalIfScaled) {
-    if (pendingResult == null || methodCall == null) {
-      saveResult(path, null, null);
-      return;
-    }
+    if (pendingResult != null && methodCall != null) {
+      Double maxWidth = methodCall.argument("maxWidth");
+      Double maxHeight = methodCall.argument("maxHeight");
+      String finalImagePath = imageResizer.resizeImageIfNeeded(path, maxWidth, maxHeight);
 
-    Double maxWidth = methodCall.argument("maxWidth");
-    Double maxHeight = methodCall.argument("maxHeight");
-    String finalImagePath = imageResizer.resizeImageIfNeeded(path, maxWidth, maxHeight);
+      finishWithSuccess(finalImagePath);
 
-    finishWithSuccess(finalImagePath);
-
-    //delete original file if scaled
-    if (!finalImagePath.equals(path) && shouldDeleteOriginalIfScaled) {
-      new File(path).delete();
+      //delete original file if scaled
+      if (!finalImagePath.equals(path) && shouldDeleteOriginalIfScaled) {
+        new File(path).delete();
+      }
+    } else {
+      finishWithSuccess(path);
     }
   }
 
@@ -607,14 +606,14 @@ public class ImagePickerDelegate
         ImagePickerPlugin.getFilePref.getLong(SHARED_PREFERENCE_MAX_HEIGHT_KEY, 0));
   }
 
-  private void saveMaxDemension(Double maxWidth, Double maxHeight) {
+  private void saveMaxDimension(Double maxWidth, Double maxHeight) {
     if (ImagePickerPlugin.getFilePref != null) {
       SharedPreferences.Editor editor = ImagePickerPlugin.getFilePref.edit();
       if (maxWidth != null) {
         editor.putLong(SHARED_PREFERENCE_MAX_WIDTH_KEY, Double.doubleToRawLongBits(maxWidth));
       }
       if (maxHeight != null) {
-        editor.putLong(SHARED_PREFERENCE_MAX_WIDTH_KEY, Double.doubleToRawLongBits(maxHeight));
+        editor.putLong(SHARED_PREFERENCE_MAX_HEIGHT_KEY, Double.doubleToRawLongBits(maxHeight));
       }
       editor.apply();
     }

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
@@ -504,7 +504,7 @@ public class ImagePickerDelegate
     pendingResult = null;
   }
 
-  void saveResult(String path, String errorCode, String errorMessage) {
+  private void saveResult(String path, String errorCode, String errorMessage) {
     SharedPreferences.Editor editor = ImagePickerPlugin.getFilePref.edit();
     if (path != null) {
       editor.putString(FLUTTER_IMAGE_PICKER_IMAGE_PATH_KEY, path);
@@ -518,11 +518,11 @@ public class ImagePickerDelegate
     editor.apply();
   }
 
-  void cleanPendingResultPref() {
+  private void cleanPendingResultPref() {
     ImagePickerPlugin.getFilePref.edit().clear().apply();
   }
 
-  Map<String, String> resultMapFromPendingResult() {
+  private Map<String, String> resultMapFromPendingResult() {
     Map<String, String> resultMap = new HashMap<>();
     Boolean hasData = false;
     String filePath =
@@ -553,7 +553,7 @@ public class ImagePickerDelegate
     return resultMap;
   }
 
-  Double getMaxWidth() {
+  private Double getMaxWidth() {
     if (!ImagePickerPlugin.getFilePref.contains(SHARED_PREFERENCE_MAX_WIDTH_KEY)) {
       return null;
     }
@@ -561,7 +561,7 @@ public class ImagePickerDelegate
         ImagePickerPlugin.getFilePref.getLong(SHARED_PREFERENCE_MAX_WIDTH_KEY, 0));
   }
 
-  Double getMaxHeight() {
+  private Double getMaxHeight() {
     if (!ImagePickerPlugin.getFilePref.contains(SHARED_PREFERENCE_MAX_HEIGHT_KEY)) {
       return null;
     }
@@ -580,18 +580,18 @@ public class ImagePickerDelegate
     editor.apply();
   }
 
-  void setType(String type) {
+  private void setType(String type) {
     ImagePickerPlugin.getFilePref.edit().putString(SHARED_PREFERENCE_TYPE_KEY, type).apply();
   }
 
-  void setPendingCameraMediaUriPath(String path) {
+  private void setPendingCameraMediaUriPath(String path) {
     ImagePickerPlugin.getFilePref
         .edit()
         .putString(SHARED_PREFERENCE_PENDING_IMAGE_URI_PATH_KEY, path)
         .apply();
   }
 
-  String getPendingCameraMediaUriPath() {
+  private String getPendingCameraMediaUriPath() {
     return ImagePickerPlugin.getFilePref.getString(
         SHARED_PREFERENCE_PENDING_IMAGE_URI_PATH_KEY, "");
   }

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -71,10 +71,10 @@ public class ImagePickerPlugin implements MethodChannel.MethodCallHandler {
       int imageSource = call.argument("source");
       switch (imageSource) {
         case SOURCE_GALLERY:
-          delegate.chooseImageFromGallery(result);
+          delegate.chooseImageFromGallery(call, result);
           break;
         case SOURCE_CAMERA:
-          delegate.takeImageWithCamera(result);
+          delegate.takeImageWithCamera(call, result);
           break;
         default:
           throw new IllegalArgumentException("Invalid image source: " + imageSource);
@@ -83,10 +83,10 @@ public class ImagePickerPlugin implements MethodChannel.MethodCallHandler {
       int imageSource = call.argument("source");
       switch (imageSource) {
         case SOURCE_GALLERY:
-          delegate.chooseVideoFromGallery(result);
+          delegate.chooseVideoFromGallery(call, result);
           break;
         case SOURCE_CAMERA:
-          delegate.takeVideoWithCamera(result);
+          delegate.takeVideoWithCamera(call, result);
           break;
         default:
           throw new IllegalArgumentException("Invalid video source: " + imageSource);

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -31,24 +31,26 @@ public class ImagePickerPlugin implements MethodChannel.MethodCallHandler {
       // we stop the registering process immediately because the ImagePicker requires an activity.
       return;
     }
-    ImagePickerPlugin.getFilePref = registrar.activity().getApplicationContext().getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE);
+    ImagePickerPlugin.getFilePref =
+        registrar
+            .activity()
+            .getApplicationContext()
+            .getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE);
 
     final MethodChannel channel = new MethodChannel(registrar.messenger(), CHANNEL);
 
     final File externalFilesDirectory =
-            registrar.activity().getExternalFilesDir(Environment.DIRECTORY_PICTURES);
+        registrar.activity().getExternalFilesDir(Environment.DIRECTORY_PICTURES);
     final ExifDataCopier exifDataCopier = new ExifDataCopier();
     final ImageResizer imageResizer = new ImageResizer(externalFilesDirectory, exifDataCopier);
     final ImagePickerDelegate delegate =
-              new ImagePickerDelegate(registrar.activity(), externalFilesDirectory, imageResizer);
+        new ImagePickerDelegate(registrar.activity(), externalFilesDirectory, imageResizer);
 
     registrar.addActivityResultListener(delegate);
     registrar.addRequestPermissionsResultListener(delegate);
     final ImagePickerPlugin instance = new ImagePickerPlugin(registrar, delegate);
     channel.setMethodCallHandler(instance);
   }
-
-
 
   @VisibleForTesting
   ImagePickerPlugin(PluginRegistry.Registrar registrar, ImagePickerDelegate delegate) {
@@ -95,5 +97,4 @@ public class ImagePickerPlugin implements MethodChannel.MethodCallHandler {
       throw new IllegalArgumentException("Unknown method " + call.method);
     }
   }
-
 }

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -65,9 +65,6 @@ public class ImagePickerPlugin implements MethodChannel.MethodCallHandler {
       return;
     }
     if (call.method.equals("pickImage")) {
-      Double maxWidth = call.argument("maxWidth");
-      Double maxHeight = call.argument("maxHeight");
-      delegate.saveMaxDemension(maxWidth, maxHeight);
       int imageSource = call.argument("source");
       switch (imageSource) {
         case SOURCE_GALLERY:

--- a/packages/image_picker/example/lib/main.dart
+++ b/packages/image_picker/example/lib/main.dart
@@ -60,8 +60,7 @@ class _MyHomePageState extends State<MyHomePage> {
       });
     } else {
       try {
-        _imageFile = await ImagePicker.pickImage(
-            source: source, maxHeight: 50, maxWidth: 50);
+        _imageFile = await ImagePicker.pickImage(source: source);
       } catch (e) {
         _pickImageError = e;
       }

--- a/packages/image_picker/example/lib/main.dart
+++ b/packages/image_picker/example/lib/main.dart
@@ -254,7 +254,7 @@ class _MyHomePageState extends State<MyHomePage> {
       final Text result = Text(_retrieveDataError);
       _retrieveDataError = null;
       return result;
-    } 
+    }
     return null;
   }
 }

--- a/packages/image_picker/example/lib/main.dart
+++ b/packages/image_picker/example/lib/main.dart
@@ -33,34 +33,39 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  Future<File> _imageFile;
+  File _imageFile;
+  dynamic _pickImageError;
   bool isVideo = false;
   VideoPlayerController _controller;
-  VoidCallback listener;
+  VoidCallback listener = () {};
+  String _retrieveDataError;
 
-  void _onImageButtonPressed(ImageSource source) {
-    setState(() {
-      if (_controller != null) {
-        _controller.setVolume(0.0);
-        _controller.removeListener(listener);
+  void _onImageButtonPressed(ImageSource source) async {
+    if (_controller != null) {
+      _controller.setVolume(0.0);
+      _controller.removeListener(listener);
+    }
+    if (isVideo) {
+      ImagePicker.pickVideo(source: source).then((File file) {
+        if (file != null && mounted) {
+          setState(() {
+            _controller = VideoPlayerController.file(file)
+              ..addListener(listener)
+              ..setVolume(1.0)
+              ..initialize()
+              ..setLooping(true)
+              ..play();
+          });
+        }
+      });
+    } else {
+      try {
+        _imageFile = await ImagePicker.pickImage(source: source);
+      } catch (e) {
+        _pickImageError = e;
       }
-      if (isVideo) {
-        ImagePicker.pickVideo(source: source).then((File file) {
-          if (file != null && mounted) {
-            setState(() {
-              _controller = VideoPlayerController.file(file)
-                ..addListener(listener)
-                ..setVolume(1.0)
-                ..initialize()
-                ..setLooping(true)
-                ..play();
-            });
-          }
-        });
-      } else {
-        _imageFile = ImagePicker.pickImage(source: source);
-      }
-    });
+      setState(() {});
+    }
   }
 
   @override
@@ -80,15 +85,11 @@ class _MyHomePageState extends State<MyHomePage> {
     super.dispose();
   }
 
-  @override
-  void initState() {
-    super.initState();
-    listener = () {
-      setState(() {});
-    };
-  }
-
   Widget _previewVideo(VideoPlayerController controller) {
+    final Text retrieveError = _getRetrieveErrorWidget();
+    if (retrieveError != null) {
+      return retrieveError;
+    }
     if (controller == null) {
       return const Text(
         'You have not yet picked a video',
@@ -108,24 +109,50 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 
   Widget _previewImage() {
-    return FutureBuilder<File>(
-        future: _imageFile,
-        builder: (BuildContext context, AsyncSnapshot<File> snapshot) {
-          if (snapshot.connectionState == ConnectionState.done &&
-              snapshot.data != null) {
-            return Image.file(snapshot.data);
-          } else if (snapshot.error != null) {
-            return const Text(
-              'Error picking image.',
-              textAlign: TextAlign.center,
-            );
-          } else {
-            return const Text(
-              'You have not yet picked an image.',
-              textAlign: TextAlign.center,
-            );
-          }
-        });
+    final Text retrieveError = _getRetrieveErrorWidget();
+    if (retrieveError != null) {
+      return retrieveError;
+    }
+    if (_imageFile != null) {
+      return Image.file(_imageFile);
+    } else if (_pickImageError != null) {
+      return Text(
+        'Pick image error: $_pickImageError',
+        textAlign: TextAlign.center,
+      );
+    } else {
+      return const Text(
+        'You have not yet picked an image.',
+        textAlign: TextAlign.center,
+      );
+    }
+  }
+
+  Future<void> retrieveLostData() async {
+    final RetrieveLostDataResponse response =
+        await ImagePicker.retrieveLostData();
+    if (response == null) {
+      return;
+    }
+    if (response.file != null) {
+      setState(() {
+        if (response.type == RetrieveType.video) {
+          isVideo = true;
+          _controller = VideoPlayerController.file(response.file)
+            ..addListener(listener)
+            ..setVolume(1.0)
+            ..initialize()
+            ..setLooping(true)
+            ..play();
+          ;
+        } else {
+          isVideo = false;
+          _imageFile = response.file;
+        }
+      });
+    } else {
+      _retrieveDataError = response.exception.code;
+    }
   }
 
   @override
@@ -135,7 +162,37 @@ class _MyHomePageState extends State<MyHomePage> {
         title: Text(widget.title),
       ),
       body: Center(
-        child: isVideo ? _previewVideo(_controller) : _previewImage(),
+        child: Platform.isAndroid
+            ? FutureBuilder<void>(
+                future: retrieveLostData(),
+                builder: (BuildContext context, AsyncSnapshot snapshot) {
+                  switch (snapshot.connectionState) {
+                    case ConnectionState.none:
+                    case ConnectionState.waiting:
+                      return const Text(
+                        'You have not yet picked an image.',
+                        textAlign: TextAlign.center,
+                      );
+                    case ConnectionState.done:
+                      return isVideo
+                          ? _previewVideo(_controller)
+                          : _previewImage();
+                    default:
+                      if (snapshot.hasError) {
+                        return Text(
+                          'Pick image/video error: ${snapshot.error}}',
+                          textAlign: TextAlign.center,
+                        );
+                      } else {
+                        const Text(
+                          'You have not yet picked an image.',
+                          textAlign: TextAlign.center,
+                        );
+                      }
+                  }
+                },
+              )
+            : (isVideo ? _previewVideo(_controller) : _previewImage()),
       ),
       floatingActionButton: Column(
         mainAxisAlignment: MainAxisAlignment.end,
@@ -190,6 +247,15 @@ class _MyHomePageState extends State<MyHomePage> {
         ],
       ),
     );
+  }
+
+  Text _getRetrieveErrorWidget() {
+    if (_retrieveDataError != null) {
+      final Text result = Text(_retrieveDataError);
+      _retrieveDataError = null;
+      return result;
+    } 
+    return null;
   }
 }
 

--- a/packages/image_picker/example/lib/main.dart
+++ b/packages/image_picker/example/lib/main.dart
@@ -60,7 +60,8 @@ class _MyHomePageState extends State<MyHomePage> {
       });
     } else {
       try {
-        _imageFile = await ImagePicker.pickImage(source: source);
+        _imageFile = await ImagePicker.pickImage(
+            source: source, maxHeight: 50, maxWidth: 50);
       } catch (e) {
         _pickImageError = e;
       }

--- a/packages/image_picker/example/lib/main.dart
+++ b/packages/image_picker/example/lib/main.dart
@@ -144,7 +144,6 @@ class _MyHomePageState extends State<MyHomePage> {
             ..initialize()
             ..setLooping(true)
             ..play();
-          ;
         } else {
           isVideo = false;
           _imageFile = response.file;
@@ -165,7 +164,7 @@ class _MyHomePageState extends State<MyHomePage> {
         child: Platform.isAndroid
             ? FutureBuilder<void>(
                 future: retrieveLostData(),
-                builder: (BuildContext context, AsyncSnapshot snapshot) {
+                builder: (BuildContext context, AsyncSnapshot<void> snapshot) {
                   switch (snapshot.connectionState) {
                     case ConnectionState.none:
                     case ConnectionState.waiting:

--- a/packages/image_picker/lib/image_picker.dart
+++ b/packages/image_picker/lib/image_picker.dart
@@ -105,7 +105,8 @@ class ImagePicker {
     // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
     // https://github.com/flutter/flutter/issues/26431
     // ignore: strong_mode_implicit_dynamic_method
-    final Map<dynamic, dynamic> result = await _channel.invokeMethod('retrieve');
+    final Map<dynamic, dynamic> result =
+        await _channel.invokeMethod('retrieve');
     if (result == null) {
       return null;
     }
@@ -119,16 +120,16 @@ class ImagePicker {
       retrieveType = RetrieveType.image;
     } else if (type == 'video') {
       retrieveType = RetrieveType.video;
-    } 
+    }
 
     PlatformException exception;
     if (result.containsKey('errorCode')) {
-      exception =
-        PlatformException(code: result['errorCode'], message: result['errorMessage']);
+      exception = PlatformException(
+          code: result['errorCode'], message: result['errorMessage']);
     }
 
     final String path = result['path'];
-    
+
     return RetrieveLostDataResponse(
         file: path == null ? null : File(path),
         exception: exception,
@@ -155,7 +156,7 @@ class RetrieveLostDataResponse {
   /// exception.
   /// You should handle this exception as if the [pickImage] or [pickVideo] got an exception when the MainActivity was not destroyed.
   ///
-  /// Note that it is not the exception caused the destruction of the MainActivity. 
+  /// Note that it is not the exception caused the destruction of the MainActivity.
   final PlatformException exception;
 
   /// Can either be [RetrieveType.image] or [RetrieveType.video];

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -5,7 +5,7 @@ authors:
   - Flutter Team <flutter-dev@googlegroups.com>
   - Rhodes Davis Jr. <rody.davis.jr@gmail.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.5.3+1
+version: 0.5.4
 
 flutter:
   plugin:

--- a/packages/image_picker/test/image_picker_test.dart
+++ b/packages/image_picker/test/image_picker_test.dart
@@ -107,5 +107,54 @@ void main() {
         expect(await ImagePicker.pickImage(source: ImageSource.camera), isNull);
       });
     });
+
+    group('#retrieveLostData', () {
+      test('retrieveLostData get success response', () async {
+        channel.setMockMethodCallHandler((MethodCall methodCall) async {
+          return <String, String>{
+            'type': 'image',
+            'path': '/example/path',
+          };
+        });
+        final RetrieveLostDataResponse response =
+            await ImagePicker.retrieveLostData();
+        expect(response.type, RetrieveType.image);
+        expect(response.file.path, '/example/path');
+      });
+
+      test('retrieveLostData get error response', () async {
+        channel.setMockMethodCallHandler((MethodCall methodCall) async {
+          return <String, String>{
+            'type': 'video',
+            'errorCode': 'test_error_code',
+            'errorMessage': 'test_error_message',
+          };
+        });
+        final RetrieveLostDataResponse response =
+            await ImagePicker.retrieveLostData();
+        expect(response.type, RetrieveType.video);
+        expect(response.exception.code, 'test_error_code');
+        expect(response.exception.message, 'test_error_message');
+      });
+
+      test('retrieveLostData get null response', () async {
+        channel.setMockMethodCallHandler((MethodCall methodCall) async {
+          return null;
+        });
+        expect(await ImagePicker.retrieveLostData(), isNull);
+      });
+
+      test('retrieveLostData get both path and error should throw', () async {
+        channel.setMockMethodCallHandler((MethodCall methodCall) async {
+          return <String, String>{
+            'type': 'video',
+            'errorCode': 'test_error_code',
+            'errorMessage': 'test_error_message',
+            'path': '/example/path',
+          };
+        });
+        expect(ImagePicker.retrieveLostData(), throwsAssertionError);
+      });
+    });
   });
 }


### PR DESCRIPTION
## Description

On Android, the MainActivity can be killed and restarted after launching the image picker for various of reasons. this can be tested by selecting `don't keep activities alive' option in the developer options in phone's setting app.

This PR first prevents the crash by not trying to access the already nulled `pendingResult`, then also save the information of the image/video that was picked in the SharedPreference.

This PR also added a `retrieveLostData` method to retrieve the data saved in the SharedPreference.

There were also some refactoring being done in the example app in order to demonstrate the `retrieveLostData` method.

Also updated dart doc on pickImage and pickVideo methods to explain this situation.

## Related Issues

Directly fixing https://github.com/flutter/flutter/issues/17950

Possibly: https://github.com/flutter/flutter/issues/23788, https://github.com/flutter/flutter/issues/21102,
https://github.com/flutter/flutter/issues/18700

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
