### PR TITLE
[connectivity] Fixes lint error by using getApplicationContext()

### DIFF
--- a/packages/connectivity/CHANGELOG.md
+++ b/packages/connectivity/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.4
+
+* Fixes lint error by using `getApplicationContext()` when accessing the Wifi Service.
+
 ## 0.4.3
 
 * Add getWifiBSSID to obtain current wifi network's BSSID.

--- a/packages/connectivity/CHANGELOG.md
+++ b/packages/connectivity/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.4.4
+## 0.4.3+1
 
 * Fixes lint error by using `getApplicationContext()` when accessing the Wifi Service.
 

--- a/packages/connectivity/android/src/main/java/io/flutter/plugins/connectivity/ConnectivityPlugin.java
+++ b/packages/connectivity/android/src/main/java/io/flutter/plugins/connectivity/ConnectivityPlugin.java
@@ -41,7 +41,7 @@ public class ConnectivityPlugin implements MethodCallHandler, StreamHandler {
   private ConnectivityPlugin(Registrar registrar) {
     this.registrar = registrar;
     this.manager =
-        (ConnectivityManager) registrar.context().getSystemService(Context.CONNECTIVITY_SERVICE);
+        (ConnectivityManager) registrar.context().getApplicationContext().getSystemService(Context.CONNECTIVITY_SERVICE);
   }
 
   @Override
@@ -104,7 +104,7 @@ public class ConnectivityPlugin implements MethodCallHandler, StreamHandler {
 
   private WifiInfo getWifiInfo() {
     WifiManager wifiManager =
-        (WifiManager) registrar.context().getSystemService(Context.WIFI_SERVICE);
+        (WifiManager) registrar.context().getApplicationContext().getSystemService(Context.WIFI_SERVICE);
     return wifiManager == null ? null : wifiManager.getConnectionInfo();
   }
 
@@ -125,7 +125,7 @@ public class ConnectivityPlugin implements MethodCallHandler, StreamHandler {
 
   private void handleWifiIPAddress(MethodCall call, final Result result) {
     WifiManager wifiManager =
-        (WifiManager) registrar.context().getSystemService(Context.WIFI_SERVICE);
+        (WifiManager) registrar.context().getApplicationContext().getSystemService(Context.WIFI_SERVICE);
 
     WifiInfo wifiInfo = null;
     if (wifiManager != null) wifiInfo = wifiManager.getConnectionInfo();

--- a/packages/connectivity/android/src/main/java/io/flutter/plugins/connectivity/ConnectivityPlugin.java
+++ b/packages/connectivity/android/src/main/java/io/flutter/plugins/connectivity/ConnectivityPlugin.java
@@ -41,7 +41,11 @@ public class ConnectivityPlugin implements MethodCallHandler, StreamHandler {
   private ConnectivityPlugin(Registrar registrar) {
     this.registrar = registrar;
     this.manager =
-        (ConnectivityManager) registrar.context().getApplicationContext().getSystemService(Context.CONNECTIVITY_SERVICE);
+        (ConnectivityManager)
+            registrar
+                .context()
+                .getApplicationContext()
+                .getSystemService(Context.CONNECTIVITY_SERVICE);
   }
 
   @Override
@@ -104,7 +108,8 @@ public class ConnectivityPlugin implements MethodCallHandler, StreamHandler {
 
   private WifiInfo getWifiInfo() {
     WifiManager wifiManager =
-        (WifiManager) registrar.context().getApplicationContext().getSystemService(Context.WIFI_SERVICE);
+        (WifiManager)
+            registrar.context().getApplicationContext().getSystemService(Context.WIFI_SERVICE);
     return wifiManager == null ? null : wifiManager.getConnectionInfo();
   }
 
@@ -125,7 +130,8 @@ public class ConnectivityPlugin implements MethodCallHandler, StreamHandler {
 
   private void handleWifiIPAddress(MethodCall call, final Result result) {
     WifiManager wifiManager =
-        (WifiManager) registrar.context().getApplicationContext().getSystemService(Context.WIFI_SERVICE);
+        (WifiManager)
+            registrar.context().getApplicationContext().getSystemService(Context.WIFI_SERVICE);
 
     WifiInfo wifiInfo = null;
     if (wifiManager != null) wifiInfo = wifiManager.getConnectionInfo();

--- a/packages/connectivity/pubspec.yaml
+++ b/packages/connectivity/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for discovering the state of the network (WiFi &
   mobile/cellular) connectivity on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/connectivity
-version: 0.4.3
+version: 0.4.4
 
 flutter:
   plugin:

--- a/packages/connectivity/pubspec.yaml
+++ b/packages/connectivity/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for discovering the state of the network (WiFi &
   mobile/cellular) connectivity on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/connectivity
-version: 0.4.4
+version: 0.4.3+1
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

When running Android Lint on a project using the connectivity plugin, Lint gives the following error:

`The WIFI_SERVICE must be looked up on the Application context or memory will leak on devices < Android N. Try changing registrar.context() to registrar.context().getApplicationContext()`

This applies the suggested change.

## Related Issues

https://github.com/flutter/flutter/issues/28928

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
