### PR TITLE
Update firebase_auth CocoaPod dependency

### DIFF
--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.4+4
+
+* Update FirebaseAuth CocoaPod dependency to ensure availability of `FIRAuthErrorUserInfoNameKey`.
+
 ## 0.8.4+3
 
 * Updated deprecated API usage on iOS to use non-deprecated versions.

--- a/packages/firebase_auth/ios/firebase_auth.podspec
+++ b/packages/firebase_auth/ios/firebase_auth.podspec
@@ -16,7 +16,7 @@ Firebase Auth plugin for Flutter.
   s.public_header_files = 'Classes/**/*.h'
   s.ios.deployment_target = '8.0'
   s.dependency 'Flutter'
-  s.dependency 'Firebase/Auth', '~> 5.0'
+  s.dependency 'Firebase/Auth', '~> 5.4'
   s.dependency 'Firebase/Core'
   s.static_framework = true
 end

--- a/packages/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Firebase Auth, enabling Android and iOS
   like Google, Facebook and Twitter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_auth
-version: "0.8.4+3"
+version: "0.8.4+4"
 
 flutter:
   plugin:


### PR DESCRIPTION
See discussion in https://github.com/flutter/plugins/commit/8bdd77661c1cfc899eaad9cd14b9222611f49a39

Changes to firebase_auth require a "~> 5.4" version of FirebaseAuth CocoaPod to ensure that `FIRAuthErrorUserInfoNameKey` is available.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/