### PR TITLE
[image_picker] Fix path of returned File objects when picking videos

### DIFF
--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.0
+
+* Breaking change iOS: Returned `File` objects when picking videos now always holds the correct path. Before this change, the path returned could have `file://` prepended to it.
+
 ## 0.5.4+3
 
 * Fix the example app failing to load picked video.
@@ -16,7 +20,7 @@
 
 ## 0.5.3+2
 
-* Android: fix a crash when the MainActivity is destroyed after selecting the image/video. 
+* Android: fix a crash when the MainActivity is destroyed after selecting the image/video.
 
 ## 0.5.3+1
 

--- a/packages/image_picker/ios/Classes/ImagePickerPlugin.m
+++ b/packages/image_picker/ios/Classes/ImagePickerPlugin.m
@@ -191,7 +191,7 @@ static const int SOURCE_GALLERY = 1;
     return;
   }
   if (videoURL != nil) {
-    _result(videoURL.description);
+    _result(videoURL.path);
   } else {
     if (image == nil) {
       image = [info objectForKey:UIImagePickerControllerOriginalImage];

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -5,7 +5,7 @@ authors:
   - Flutter Team <flutter-dev@googlegroups.com>
   - Rhodes Davis Jr. <rody.davis.jr@gmail.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.5.4+3
+version: 0.6.0
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Returning `.description` on a `NSURL` gave back an url that starts with `file:///`, when passing this url to the `File` object it constructed a path like `/file:///foo/bar/baz.ext`.

This fixes this logic to use `.path` instead, which returns the path to the file.

Here is some more background to how I found this: https://github.com/firebase/firebase-ios-sdk/pull/2458/files#r276273826

## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/

-----

Not sure how to add tests since the tests since to mock out the Objective-C part of the plugins, any help would be appreciated!