### PR TITLE
Temporarily disable plugin integration on CI tests due to Cirrus flakiness

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -82,4 +82,4 @@ task:
     - export PATH=`pwd`/flutter/bin:`pwd`/flutter/bin/cache/dart-sdk/bin:$PATH
     - ./script/incremental_build.sh build-examples --ipa
     # TODO(jackson): Re-enable integration tests when the tests aren't timing out
-    - ./script/incremental_build.sh drive-examples
+    # - ./script/incremental_build.sh drive-examples

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -60,14 +60,10 @@ task:
   env:
     PATH: $PATH:/usr/local/bin
     matrix:
-      PLUGIN_SHARDING: "--shardIndex 0 --shardCount 8"
-      PLUGIN_SHARDING: "--shardIndex 1 --shardCount 8"
-      PLUGIN_SHARDING: "--shardIndex 2 --shardCount 8"
-      PLUGIN_SHARDING: "--shardIndex 3 --shardCount 8"
-      PLUGIN_SHARDING: "--shardIndex 4 --shardCount 8"
-      PLUGIN_SHARDING: "--shardIndex 5 --shardCount 8"
-      PLUGIN_SHARDING: "--shardIndex 6 --shardCount 8"
-      PLUGIN_SHARDING: "--shardIndex 7 --shardCount 8"
+      PLUGIN_SHARDING: "--shardIndex 0 --shardCount 4"
+      PLUGIN_SHARDING: "--shardIndex 1 --shardCount 4"
+      PLUGIN_SHARDING: "--shardIndex 2 --shardCount 4"
+      PLUGIN_SHARDING: "--shardIndex 3 --shardCount 4"
     SIMCTL_CHILD_MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
   setup_script:
     - brew update
@@ -80,8 +76,10 @@ task:
     - export PATH=`pwd`/flutter/bin:`pwd`/flutter/bin/cache/dart-sdk/bin:$PATH
     - flutter doctor
     - pub global activate flutter_plugin_tools
-    - xcrun simctl create Flutter-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-X com.apple.CoreSimulator.SimRuntime.iOS-12-1 | xargs xcrun simctl boot
+    # TODO(jackson): Re-enable simulator when tests aren't timing out
+    # - xcrun simctl create Flutter-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-X com.apple.CoreSimulator.SimRuntime.iOS-12-1 | xargs xcrun simctl boot
   build_script:
     - export PATH=`pwd`/flutter/bin:`pwd`/flutter/bin/cache/dart-sdk/bin:$PATH
     - ./script/incremental_build.sh build-examples --ipa
+    # TODO(jackson): Re-enable integration tests when the tests aren't timing out
     - ./script/incremental_build.sh drive-examples

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -60,10 +60,14 @@ task:
   env:
     PATH: $PATH:/usr/local/bin
     matrix:
-      PLUGIN_SHARDING: "--shardIndex 0 --shardCount 4"
-      PLUGIN_SHARDING: "--shardIndex 1 --shardCount 4"
-      PLUGIN_SHARDING: "--shardIndex 2 --shardCount 4"
-      PLUGIN_SHARDING: "--shardIndex 3 --shardCount 4"
+      PLUGIN_SHARDING: "--shardIndex 0 --shardCount 8"
+      PLUGIN_SHARDING: "--shardIndex 1 --shardCount 8"
+      PLUGIN_SHARDING: "--shardIndex 2 --shardCount 8"
+      PLUGIN_SHARDING: "--shardIndex 3 --shardCount 8"
+      PLUGIN_SHARDING: "--shardIndex 4 --shardCount 8"
+      PLUGIN_SHARDING: "--shardIndex 5 --shardCount 8"
+      PLUGIN_SHARDING: "--shardIndex 6 --shardCount 8"
+      PLUGIN_SHARDING: "--shardIndex 7 --shardCount 8"
     SIMCTL_CHILD_MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
   setup_script:
     - brew update


### PR DESCRIPTION
Cirrus bots have been timing out. https://cirrus-ci.com/github/flutter/plugins/master

Originally I tried adding more shards but that didn't help. Disabling for the moment to get the build back to green and I will explore alternatives.

Note that integration tests are disabled on framework at this time, see https://github.com/flutter/flutter/commit/20d8ea78f4faaa160d10023f6a3739d657525305#diff-0f7067c31caedf7df2739c9b07efa122