### PR TITLE
[firebase_auth] Increase iOS Firebase/Auth CocoaPods dependency to 5.19

### DIFF
--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.4+5
+
+* Increase Firebase/Auth CocoaPod dependency to '~> 5.19'.
+
 ## 0.8.4+4
 
 * Update FirebaseAuth CocoaPod dependency to ensure availability of `FIRAuthErrorUserInfoNameKey`.

--- a/packages/firebase_auth/ios/firebase_auth.podspec
+++ b/packages/firebase_auth/ios/firebase_auth.podspec
@@ -16,7 +16,7 @@ Firebase Auth plugin for Flutter.
   s.public_header_files = 'Classes/**/*.h'
   s.ios.deployment_target = '8.0'
   s.dependency 'Flutter'
-  s.dependency 'Firebase/Auth', '~> 5.4'
+  s.dependency 'Firebase/Auth', '~> 5.19'
   s.dependency 'Firebase/Core'
   s.static_framework = true
 end

--- a/packages/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Firebase Auth, enabling Android and iOS
   like Google, Facebook and Twitter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_auth
-version: "0.8.4+4"
+version: "0.8.4+5"
 
 flutter:
   plugin:


### PR DESCRIPTION
This is necessary to pick up the FirebaseAuth 5.4 CocoaPod.

This will actually achieve what I was trying to achieve in https://github.com/flutter/plugins/pull/1503

See discussion in 8bdd776