### PR TITLE
[Image_picker] Android: fix a crash when the MainActivity is destroyed after selecting the image/video. 

### DIFF
--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.3+2
+
+* Android: fix a crash when the MainActivity is destroyed after selecting the image/video. 
+
 ## 0.5.3+1
 
 * Update minimum deploy iOS version to 8.0.

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
@@ -142,7 +142,7 @@ public class ImagePickerDelegate
           public void getFullImagePath(final Uri imageUri, final OnPathReadyListener listener) {
             MediaScannerConnection.scanFile(
                 activity,
-                new String[] {imageUri.getPath()},
+                new String[] {(imageUri != null) ? imageUri.getPath() : ""},
                 null,
                 new MediaScannerConnection.OnScanCompletedListener() {
                   @Override
@@ -389,9 +389,6 @@ public class ImagePickerDelegate
   }
 
   private void handleCaptureImageResult(int resultCode) {
-    if (pendingCameraMediaUri == null) {
-      return;
-    }
     if (resultCode == Activity.RESULT_OK) {
       fileUriResolver.getFullImagePath(
           pendingCameraMediaUri,
@@ -409,9 +406,6 @@ public class ImagePickerDelegate
   }
 
   private void handleCaptureVideoResult(int resultCode) {
-    if (pendingCameraMediaUri == null) {
-      return;
-    }
     if (resultCode == Activity.RESULT_OK) {
       fileUriResolver.getFullImagePath(
           pendingCameraMediaUri,

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
@@ -389,6 +389,9 @@ public class ImagePickerDelegate
   }
 
   private void handleCaptureImageResult(int resultCode) {
+    if (pendingCameraMediaUri == null) {
+      return;
+    }
     if (resultCode == Activity.RESULT_OK) {
       fileUriResolver.getFullImagePath(
           pendingCameraMediaUri,
@@ -406,6 +409,9 @@ public class ImagePickerDelegate
   }
 
   private void handleCaptureVideoResult(int resultCode) {
+    if (pendingCameraMediaUri == null) {
+      return;
+    }
     if (resultCode == Activity.RESULT_OK) {
       fileUriResolver.getFullImagePath(
           pendingCameraMediaUri,
@@ -434,17 +440,11 @@ public class ImagePickerDelegate
       if (!finalImagePath.equals(path) && shouldDeleteOriginalIfScaled) {
         new File(path).delete();
       }
-    } else {
-      throw new IllegalStateException("Received image from picker that was not requested");
     }
   }
 
   private void handleVideoResult(String path) {
-    if (pendingResult != null) {
-      finishWithSuccess(path);
-    } else {
-      throw new IllegalStateException("Received video from picker that was not requested");
-    }
+    finishWithSuccess(path);
   }
 
   private boolean setPendingMethodCallAndResult(
@@ -459,6 +459,9 @@ public class ImagePickerDelegate
   }
 
   private void finishWithSuccess(String imagePath) {
+    if (pendingResult == null) {
+      return;
+    }
     pendingResult.success(imagePath);
     clearMethodCallAndResult();
   }
@@ -468,6 +471,9 @@ public class ImagePickerDelegate
   }
 
   private void finishWithError(String errorCode, String errorMessage) {
+    if (pendingResult == null) {
+      return;
+    }
     pendingResult.error(errorCode, errorMessage, null);
     clearMethodCallAndResult();
   }

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -5,7 +5,7 @@ authors:
   - Flutter Team <flutter-dev@googlegroups.com>
   - Rhodes Davis Jr. <rody.davis.jr@gmail.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.5.3+1
+version: 0.5.3+2
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

On Android, the MainActivity can be killed and restarted after launching the image picker for various of reasons. this can be tested by selecting `don't keep activities alive' option in the developer options in phone's setting app.

This PR first prevents the crash by not trying to access the already nulled pendingResult.

I will also finalize a solution to retrieve the lost data due to this issue and provide a PR for that later.

## Related Issues

Directly fixing the crashing in flutter/flutter#17950

Possibly: flutter/flutter#23788, flutter/flutter#21102,
flutter/flutter#18700

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
