### PR TITLE
[image_picker]Add argument maxDuration to video record

### DIFF
--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
@@ -259,6 +259,12 @@ public class ImagePickerDelegate
     intent.putExtra(MediaStore.EXTRA_OUTPUT, videoUri);
     grantUriPermissions(intent, videoUri);
 
+    Double maxDuration = methodCall.argument("maxDuration");
+    if(maxDuration != null) {
+      int maxDurationToInt = maxDuration.intValue();
+      intent.putExtra(MediaStore.EXTRA_DURATION_LIMIT, maxDurationToInt);
+    }
+
     activity.startActivityForResult(intent, REQUEST_CODE_TAKE_VIDEO_WITH_CAMERA);
   }
 

--- a/packages/image_picker/ios/Classes/ImagePickerPlugin.m
+++ b/packages/image_picker/ios/Classes/ImagePickerPlugin.m
@@ -81,13 +81,12 @@ static const int SOURCE_GALLERY = 1;
       (NSString *)kUTTypeMPEG4
     ];
     _imagePickerController.videoQuality = UIImagePickerControllerQualityTypeHigh;
-    
 
     _result = result;
     _arguments = call.arguments;
   
     NSNumber *maxDuration = [_arguments objectForKey:@"maxDuration"];
-    if (maxDuration != (id)[NSNull null]) {
+    if ([maxDuration isKindOfClass:[NSNumber class]]) {
         double maxDurationToDouble = [maxDuration doubleValue];
         [_imagePickerController setVideoMaximumDuration:maxDurationToDouble];
     }

--- a/packages/image_picker/ios/Classes/ImagePickerPlugin.m
+++ b/packages/image_picker/ios/Classes/ImagePickerPlugin.m
@@ -81,9 +81,16 @@ static const int SOURCE_GALLERY = 1;
       (NSString *)kUTTypeMPEG4
     ];
     _imagePickerController.videoQuality = UIImagePickerControllerQualityTypeHigh;
+    
 
     _result = result;
     _arguments = call.arguments;
+  
+    NSNumber *maxDuration = [_arguments objectForKey:@"maxDuration"];
+    if (maxDuration != (id)[NSNull null]) {
+        double maxDurationToDouble = [maxDuration doubleValue];
+        [_imagePickerController setVideoMaximumDuration:maxDurationToDouble];
+    }
 
     int imageSource = [[_arguments objectForKey:@"source"] intValue];
 

--- a/packages/image_picker/lib/image_picker.dart
+++ b/packages/image_picker/lib/image_picker.dart
@@ -77,15 +77,14 @@ class ImagePicker {
   /// in this call. You can then call [retrieveLostData] when your app relaunches to retrieve the lost data.
   static Future<File> pickVideo({
     @required ImageSource source,
-    double maxDuration
+    Duration maxDuration
   }) async {
     assert(source != null);
-
+    final double durationSeconds = (maxDuration==null) ? null : maxDuration.inSeconds.toDouble();
+    
     // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
     // https://github.com/flutter/flutter/issues/26431
     // ignore: strong_mode_implicit_dynamic_method
-    double durationSeconds = (maxDuration==null) ? null : maxDuration.inSeconds.toDouble();
-
     final String path = await _channel.invokeMethod(
       'pickVideo',
       <String, dynamic>{

--- a/packages/image_picker/lib/image_picker.dart
+++ b/packages/image_picker/lib/image_picker.dart
@@ -70,20 +70,27 @@ class ImagePicker {
   /// The [source] argument controls where the video comes from. This can
   /// be either [ImageSource.camera] or [ImageSource.gallery].
   ///
+  /// The [maxDuration] is the maximum amount of Seconds (eg. 30.0) that is available to be recorded
+  /// after which the video record will immediately finish and the [File] will be returned.
+  ///
   /// In Android, the MainActivity can be destroyed for various fo reasons. If that happens, the result will be lost
   /// in this call. You can then call [retrieveLostData] when your app relaunches to retrieve the lost data.
   static Future<File> pickVideo({
     @required ImageSource source,
+    double maxDuration
   }) async {
     assert(source != null);
 
     // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
     // https://github.com/flutter/flutter/issues/26431
     // ignore: strong_mode_implicit_dynamic_method
+    double durationSeconds = (maxDuration==null) ? null : maxDuration.inSeconds.toDouble();
+
     final String path = await _channel.invokeMethod(
       'pickVideo',
       <String, dynamic>{
         'source': source.index,
+        'maxDuration':durationSeconds
       },
     );
     return path == null ? null : File(path);


### PR DESCRIPTION
## Description

Can pass a double of seconds to maxDuration to limit the duration of the video record.
This is a fork of https://github.com/flutter/plugins/pull/674. Due to the inactivity of the original author, I am taking over his change and going to work on it from now on.
