### PR TITLE
[firebase_auth] Added two assert functions to the README.md

### DIFF
--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.4+6
+
+* Adds error checking in the documentation of Register a User
+
 ## 0.8.4+5
 
 * Increase Firebase/Auth CocoaPod dependency to '~> 5.19'.

--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.8.4+6
 
-* Adds error checking in the documentation of Register a User
+* Adds try/catch block in register_page.dart for error-checking
 
 ## 0.8.4+5
 

--- a/packages/firebase_auth/README.md
+++ b/packages/firebase_auth/README.md
@@ -91,7 +91,7 @@ final FirebaseUser user = await _auth.createUserWithEmailAndPassword(
       password: 'a password',
     );
 ```
-For extra error checking, assert that the user was created successfully.
+For more details on registering a user, see the example directory.
 
 ```dart
 assert (user != null);

--- a/packages/firebase_auth/README.md
+++ b/packages/firebase_auth/README.md
@@ -91,6 +91,12 @@ final FirebaseUser user = await _auth.createUserWithEmailAndPassword(
       password: 'a password',
     );
 ```
+For extra error checking, assert that the user was created successfully.
+
+```dart
+assert (user != null);
+assert(await user.getIdToken() != null);
+```
 
 ### Supported Firebase authentication methods
 

--- a/packages/firebase_auth/README.md
+++ b/packages/firebase_auth/README.md
@@ -93,11 +93,6 @@ final FirebaseUser user = await _auth.createUserWithEmailAndPassword(
 ```
 For more details on registering a user, see the example directory.
 
-```dart
-assert (user != null);
-assert(await user.getIdToken() != null);
-```
-
 ### Supported Firebase authentication methods
 
 * Google

--- a/packages/firebase_auth/example/lib/register_page.dart
+++ b/packages/firebase_auth/example/lib/register_page.dart
@@ -84,13 +84,13 @@ class RegisterPageState extends State<RegisterPage> {
       email: _emailController.text,
       password: _passwordController.text,
     );
-    if (user != null) {
-      setState(() {
-        _success = true;
-        _userEmail = user.email;
-      });
-    } else {
-      _success = false;
+    try {
+	setState(() {
+		_success = true;
+		_userEmail = user.email;
+	});
+    } on Exception catch(e) {
+	print('Exception details:\n $e');
     }
   }
 }

--- a/packages/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Firebase Auth, enabling Android and iOS
   like Google, Facebook and Twitter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_auth
-version: "0.8.4+5"
+version: "0.8.4+6"
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

This pull request adds two assert functions to the firebase_auth README.md while maintaining the proper format of the document. Currently, in the Register a User section, there is a call to createUserWithEmailAndPassword(). This PR simply adds a statement in that section that presents optional error checking: two assert functions that ensure that the FirebaseUser user has been created successfully. 

Although creating a user properly may be a given for the seasoned developers, a few error checking functions greatly helps the new developers. As a new developer, I recently implemented the firebase_auth plugin, and another source mentioned these error checking statements. When I finally ran my code, the assert statements caught some weird errors for me, and saved me lots of time. I'm trying to make the road for new developers smoother down the line.

## Related Issues

fixes flutter/flutter#31386

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
