### PR TITLE
[firebase_performance] Deprecate incrementCounter in favor of incrementMetric

### DIFF
--- a/packages/firebase_performance/CHANGELOG.md
+++ b/packages/firebase_performance/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1
+
+* Deprecate `Trace.incrementCounter` and add `Trace.incrementMetric`.
+
 ## 0.1.0+4
 
 * Remove deprecated methods for iOS.

--- a/packages/firebase_performance/CHANGELOG.md
+++ b/packages/firebase_performance/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.1.1
 
 * Deprecate `Trace.incrementCounter` and add `Trace.incrementMetric`.
+* Additional integration testing.
 
 ## 0.1.0+4
 

--- a/packages/firebase_performance/README.md
+++ b/packages/firebase_performance/README.md
@@ -24,9 +24,9 @@ myTrace.start();
 
 final Item item = cache.fetch("item");
 if (item != null) {
-  myTrace.incrementCounter("item_cache_hit");
+  myTrace.incrementMetric("item_cache_hit", 1);
 } else {
-  myTrace.incrementCounter("item_cache_miss");
+  myTrace.incrementMetric("item_cache_miss", 1);
 }
 
 myTrace.stop();

--- a/packages/firebase_performance/android/src/main/java/io/flutter/plugins/firebaseperformance/FirebasePerformancePlugin.java
+++ b/packages/firebase_performance/android/src/main/java/io/flutter/plugins/firebaseperformance/FirebasePerformancePlugin.java
@@ -76,9 +76,9 @@ public class FirebasePerformancePlugin implements MethodCallHandler {
     Integer handle = call.argument("handle");
     Trace trace = traces.get(handle);
 
-    Map<String, Integer> counters = call.argument("counters");
-    for (Map.Entry<String, Integer> entry : counters.entrySet()) {
-      trace.incrementCounter(entry.getKey(), entry.getValue());
+    Map<String, Integer> metrics = call.argument("metrics");
+    for (Map.Entry<String, Integer> entry : metrics.entrySet()) {
+      trace.incrementMetric(entry.getKey(), entry.getValue());
     }
 
     Map<String, String> attributes = call.argument("attributes");

--- a/packages/firebase_performance/example/lib/main.dart
+++ b/packages/firebase_performance/example/lib/main.dart
@@ -77,7 +77,7 @@ class _MyAppState extends State<MyApp> {
     });
 
     final Trace trace = _performance.newTrace("test");
-    trace.incrementCounter("counter1", 16);
+    trace.incrementMetric("metric1", 16);
     trace.putAttribute("favorite_color", "blue");
 
     await trace.start();

--- a/packages/firebase_performance/example/test_driver/firebase_performance.dart
+++ b/packages/firebase_performance/example/test_driver/firebase_performance.dart
@@ -12,9 +12,11 @@ void main() {
   group('firebase_performance test driver', () {
     final FirebasePerformance performance = FirebasePerformance.instance;
 
-    test('setPerformanceCollectionEnabled', () async {
+    setUp(() async {
       await performance.setPerformanceCollectionEnabled(true);
+    });
 
+    test('setPerformanceCollectionEnabled', () async {
       final bool enabled = await performance.isPerformanceCollectionEnabled();
       expect(enabled, isTrue);
 
@@ -22,5 +24,19 @@ void main() {
       final bool disabled = await performance.isPerformanceCollectionEnabled();
       expect(disabled, isFalse);
     });
+
+    test('metric', () async {
+      final Trace trace = await performance.newTrace('test');
+      trace.putAttribute('testAttribute', 'foo');
+      trace.attributes['testAttribute2'] = 'bar';
+      await trace.start();
+      trace.incrementMetric('testMetric', 1);
+      await trace.stop();
+      expect(trace.getAttribute('testAttribute'), 'foo');
+      expect(trace.attributes['testAttribute'], 'foo');
+      expect(trace.getAttribute('testAttribute2'), null);
+      expect(trace.getAttribute('testMetric'), null);
+    });
+
   });
 }

--- a/packages/firebase_performance/example/test_driver/firebase_performance.dart
+++ b/packages/firebase_performance/example/test_driver/firebase_performance.dart
@@ -26,7 +26,7 @@ void main() {
     });
 
     test('metric', () async {
-      final Trace trace = await performance.newTrace('test');
+      final Trace trace = performance.newTrace('test');
       trace.putAttribute('testAttribute', 'foo');
       trace.attributes['testAttribute2'] = 'bar';
       await trace.start();
@@ -37,6 +37,5 @@ void main() {
       expect(trace.getAttribute('testAttribute2'), null);
       expect(trace.getAttribute('testMetric'), null);
     });
-
   });
 }

--- a/packages/firebase_performance/ios/Classes/FirebasePerformancePlugin.m
+++ b/packages/firebase_performance/ios/Classes/FirebasePerformancePlugin.m
@@ -70,8 +70,8 @@
   NSNumber *handle = call.arguments[@"handle"];
   FIRTrace *trace = [_traces objectForKey:handle];
 
-  NSDictionary *counters = call.arguments[@"counters"];
-  [counters enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSNumber *value, BOOL *stop) {
+  NSDictionary *metrics = call.arguments[@"metrics"];
+  [metrics enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSNumber *value, BOOL *stop) {
     [trace setIntValue:[value longLongValue] forMetric:key];
   }];
 

--- a/packages/firebase_performance/lib/src/trace.dart
+++ b/packages/firebase_performance/lib/src/trace.dart
@@ -9,7 +9,7 @@ part of firebase_performance;
 /// A trace is a report of performance data associated with some of the
 /// code in your app. You can have multiple custom traces, and it is
 /// possible to have more than one custom trace running at a time. Each custom
-/// trace can have multiple counters and attributes added to help measure
+/// trace can have multiple metrics and attributes added to help measure
 /// performance related events. A trace also measures the time between calling
 /// start() and stop().
 ///
@@ -35,7 +35,7 @@ class Trace extends PerformanceAttributes {
   bool _hasStarted = false;
   bool _hasStopped = false;
 
-  final HashMap<String, int> _counters = HashMap<String, int>();
+  final HashMap<String, int> _metrics = HashMap<String, int>();
 
   /// Starts this trace.
   ///
@@ -71,7 +71,7 @@ class Trace extends PerformanceAttributes {
     final Map<String, dynamic> data = <String, dynamic>{
       'handle': _handle,
       'name': _name,
-      'counters': _counters,
+      'metrics': _metrics,
       'attributes': _attributes,
     };
 
@@ -92,15 +92,28 @@ class Trace extends PerformanceAttributes {
   /// The name of the counter requires no leading or
   /// trailing whitespace, no leading underscore _ character, and max length of
   /// 32 characters.
+  @Deprecated('Use `incrementMetric` instead.')
   void incrementCounter(String name, [int incrementBy = 1]) {
+    incrementMetric(name, incrementBy);
+  }
+
+  /// Increments the metric with the given [name] by [incrementBy].
+  ///
+  /// If a metric does not already exist, a new one will be created with the
+  /// initial value [incrementBy]. If the trace has not been started or has
+  /// already been stopped, an assertion error is thrown.
+  ///
+  /// The name of the metric requires no leading or trailing whitespace, no
+  /// leading underscore _ character, and max length of 32 characters.
+  void incrementMetric(String name, int incrementBy) {
     assert(!_hasStopped);
     assert(name != null);
     assert(!name.startsWith(RegExp(r'[_\s]')));
     assert(!name.contains(RegExp(r'[_\s]$')));
     assert(name.length <= 32);
 
-    _counters.putIfAbsent(name, () => 0);
-    _counters[name] += incrementBy;
+    _metrics.putIfAbsent(name, () => 0);
+    _metrics[name] += incrementBy;
   }
 
   /// Sets a String [value] for the specified [attribute].

--- a/packages/firebase_performance/pubspec.yaml
+++ b/packages/firebase_performance/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Google Performance Monitoring for Firebase, an a
   iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_performance
-version: 0.1.0+4
+version: 0.1.1
 
 dependencies:
   flutter:

--- a/packages/firebase_performance/test/firebase_performance_test.dart
+++ b/packages/firebase_performance/test/firebase_performance_test.dart
@@ -170,7 +170,7 @@ void main() {
             arguments: <String, dynamic>{
               'handle': currentTraceHandle,
               'name': 'test',
-              'counters': <String, int>{},
+              'metrics': <String, int>{},
               'attributes': <String, String>{},
             },
           ),
@@ -179,14 +179,21 @@ void main() {
 
       test('incrementCounter', () async {
         final Trace trace = performance.newTrace('test');
+
+        // ignore: deprecated_member_use_from_same_package
         trace.incrementCounter('counter1');
 
+        // ignore: deprecated_member_use_from_same_package
         trace.incrementCounter('counter2');
+        // ignore: deprecated_member_use_from_same_package
         trace.incrementCounter('counter2');
 
+        // ignore: deprecated_member_use_from_same_package
         trace.incrementCounter('counter3', 5);
+        // ignore: deprecated_member_use_from_same_package
         trace.incrementCounter('counter3', 5);
 
+        // ignore: deprecated_member_use_from_same_package
         trace.incrementCounter('counter4', -5);
 
         await trace.start();
@@ -205,11 +212,51 @@ void main() {
             arguments: <String, dynamic>{
               'handle': currentTraceHandle,
               'name': 'test',
-              'counters': <String, int>{
+              'metrics': <String, int>{
                 'counter1': 1,
                 'counter2': 2,
                 'counter3': 10,
                 'counter4': -5,
+              },
+              'attributes': <String, String>{},
+            },
+          ),
+        ]);
+      });
+
+      test('incrementMetric', () async {
+        final Trace trace = performance.newTrace('test');
+        trace.incrementMetric('metric1', 1);
+
+        trace.incrementMetric('metric2', 1);
+        trace.incrementMetric('metric2', 1);
+
+        trace.incrementMetric('metric3', 5);
+        trace.incrementMetric('metric3', 5);
+
+        trace.incrementMetric('metric4', -5);
+
+        await trace.start();
+        await trace.stop();
+
+        expect(log, <Matcher>[
+          isMethodCall(
+            'Trace#start',
+            arguments: <String, Object>{
+              'handle': currentTraceHandle,
+              'name': 'test',
+            },
+          ),
+          isMethodCall(
+            'Trace#stop',
+            arguments: <String, dynamic>{
+              'handle': currentTraceHandle,
+              'name': 'test',
+              'metrics': <String, int>{
+                'metric1': 1,
+                'metric2': 2,
+                'metric3': 10,
+                'metric4': -5,
               },
               'attributes': <String, String>{},
             },


### PR DESCRIPTION
## Description

Add `incrementMetric` and mark `incrementCounter` as deprecated.

`incrementCounter` is deprecated in the Java SDK and it's been replaced with `incrementMetric`. Let's make `firebase_performance` match that.

See: https://firebase.google.com/docs/reference/android/com/google/firebase/perf/metrics/Trace.html#incrementCounter(java.lang.String,%20long)

## Related Issues

Fixes flutter/flutter#29775

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.