### PR TITLE
[in_app_purchase] Add auto-consume errors to PurchaseDetails

### DIFF
--- a/packages/in_app_purchase/lib/src/in_app_purchase/google_play_connection.dart
+++ b/packages/in_app_purchase/lib/src/in_app_purchase/google_play_connection.dart
@@ -186,7 +186,7 @@ class GooglePlayConnection
         code: kRestoredPurchaseErrorCode,
         message: {'message': resultWrapper.responseCode.toString()},
       );
-      status = PurchaseStatus.purchased;
+      status = PurchaseStatus.error;
     }
     List<PurchaseDetails> purchases = [];
     for (PurchaseWrapper purchase in resultWrapper.purchasesList) {

--- a/packages/in_app_purchase/lib/src/in_app_purchase/google_play_connection.dart
+++ b/packages/in_app_purchase/lib/src/in_app_purchase/google_play_connection.dart
@@ -188,16 +188,16 @@ class GooglePlayConnection
       );
       status = PurchaseStatus.error;
     }
-    List<PurchaseDetails> purchases = [];
-    for (PurchaseWrapper purchase in resultWrapper.purchasesList) {
-      purchases.add(await _autoConsumePurchase(purchase.toPurchaseDetails()
+    final List<Future<PurchaseDetails>> purchases =
+        resultWrapper.purchasesList.map((PurchaseWrapper purchase) {
+      return _maybeAutoConsumePurchase(purchase.toPurchaseDetails()
         ..status = status
-        ..error = error));
-    }
-    return purchases;
+        ..error = error);
+    }).toList();
+    return Future.wait(purchases);
   }
 
-  static Future<PurchaseDetails> _autoConsumePurchase(
+  static Future<PurchaseDetails> _maybeAutoConsumePurchase(
       PurchaseDetails purchaseDetails) async {
     if (!(purchaseDetails.status == PurchaseStatus.purchased &&
         _productIdsToConsume.contains(purchaseDetails.productID))) {

--- a/packages/in_app_purchase/lib/src/in_app_purchase/google_play_connection.dart
+++ b/packages/in_app_purchase/lib/src/in_app_purchase/google_play_connection.dart
@@ -18,9 +18,10 @@ class GooglePlayConnection
     with WidgetsBindingObserver
     implements InAppPurchaseConnection {
   GooglePlayConnection._()
-      : billingClient = BillingClient((PurchasesResultWrapper resultWrapper) {
+      : billingClient =
+            BillingClient((PurchasesResultWrapper resultWrapper) async {
           _purchaseUpdatedController
-              .add(_getPurchaseDetailsFromResult(resultWrapper));
+              .add(await _getPurchaseDetailsFromResult(resultWrapper));
         }) {
     _readyFuture = _connect();
     WidgetsBinding.instance.addObserver(this);
@@ -38,7 +39,7 @@ class GooglePlayConnection
   final BillingClient billingClient;
 
   Future<void> _readyFuture;
-  static Set<String> _productIDsToConsume;
+  static Set<String> _productIdsToConsume = Set<String>();
 
   @override
   Future<bool> isAvailable() async {
@@ -56,11 +57,8 @@ class GooglePlayConnection
   @override
   void buyConsumable(
       {@required PurchaseParam purchaseParam, bool autoConsume = true}) {
-    if (autoConsume == true) {
-      if (_productIDsToConsume == null) {
-        _productIDsToConsume = Set<String>();
-        _productIDsToConsume.add(purchaseParam.productDetails.id);
-      }
+    if (autoConsume) {
+      _productIdsToConsume.add(purchaseParam.productDetails.id);
     }
     buyNonConsumable(purchaseParam: purchaseParam);
   }
@@ -143,10 +141,6 @@ class GooglePlayConnection
     return _instance;
   }
 
-  static _consume(PurchaseDetails purchase) {
-    instance.consumePurchase(purchase);
-  }
-
   Future<void> _connect() =>
       billingClient.startConnection(onBillingServiceDisconnected: () {});
 
@@ -179,34 +173,49 @@ class GooglePlayConnection
         productDetails: productDetails, notFoundIDs: notFoundIDS);
   }
 
-  static List<PurchaseDetails> _getPurchaseDetailsFromResult(
-      PurchasesResultWrapper resultWrapper) {
-    return resultWrapper.purchasesList.map(
-      (PurchaseWrapper purchase) {
-        PurchaseError error = null;
-        if (resultWrapper.responseCode != BillingResponse.ok) {
-          error = PurchaseError(
-            source: PurchaseSource.GooglePlay,
-            code: kRestoredPurchaseErrorCode,
-            message: {'message': resultWrapper.responseCode.toString()},
-          );
-        }
-        PurchaseDetails purchaseDetails = purchase.toPurchaseDetails()
-          ..status = resultWrapper.responseCode == BillingResponse.ok
-              ? PurchaseStatus.purchased
-              : PurchaseStatus.error
-          ..error = error;
-        // auto consume logic for buyConsumable.
-        if (_productIDsToConsume != null &&
-            _productIDsToConsume.contains(purchaseDetails.productID)) {
-          _consume(purchaseDetails);
-          _productIDsToConsume.remove(purchaseDetails.productID);
-          if (_productIDsToConsume.isEmpty) {
-            _productIDsToConsume = null;
-          }
-        }
-        return purchaseDetails;
-      },
-    ).toList();
+  static Future<List<PurchaseDetails>> _getPurchaseDetailsFromResult(
+      PurchasesResultWrapper resultWrapper) async {
+    PurchaseError error;
+    PurchaseStatus status;
+    if (resultWrapper.responseCode == BillingResponse.ok) {
+      error = null;
+      status = PurchaseStatus.purchased;
+    } else {
+      error = PurchaseError(
+        source: PurchaseSource.GooglePlay,
+        code: kRestoredPurchaseErrorCode,
+        message: {'message': resultWrapper.responseCode.toString()},
+      );
+      status = PurchaseStatus.purchased;
+    }
+    List<PurchaseDetails> purchases = [];
+    for (PurchaseWrapper purchase in resultWrapper.purchasesList) {
+      purchases.add(await _autoConsumePurchase(purchase.toPurchaseDetails()
+        ..status = status
+        ..error = error));
+    }
+    return purchases;
+  }
+
+  static Future<PurchaseDetails> _autoConsumePurchase(
+      PurchaseDetails purchaseDetails) async {
+    if (!(purchaseDetails.status == PurchaseStatus.purchased &&
+        _productIdsToConsume.contains(purchaseDetails.productID))) {
+      return purchaseDetails;
+    }
+
+    final BillingResponse consumedResponse =
+        await instance.consumePurchase(purchaseDetails);
+    if (consumedResponse != BillingResponse.ok) {
+      purchaseDetails.status = PurchaseStatus.error;
+      purchaseDetails.error = PurchaseError(
+        source: PurchaseSource.GooglePlay,
+        code: kConsumptionFailedErrorCode,
+        message: {'message': consumedResponse.toString()},
+      );
+    }
+    _productIdsToConsume.remove(purchaseDetails.productID);
+
+    return purchaseDetails;
   }
 }

--- a/packages/in_app_purchase/lib/src/in_app_purchase/purchase_details.dart
+++ b/packages/in_app_purchase/lib/src/in_app_purchase/purchase_details.dart
@@ -9,6 +9,7 @@ import './product_details.dart';
 
 final String kPurchaseErrorCode = 'purchase_error';
 final String kRestoredPurchaseErrorCode = 'restore_transactions_failed';
+final String kConsumptionFailedErrorCode = 'consume_purchase_failed';
 
 /// Represents the data that is used to verify purchases.
 ///


### PR DESCRIPTION
## Description

Previously this was consuming the purchases in the background and
ignoring the output.

Also some minor code cleanup.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
