### PR TITLE
[in_app_purchase] Only fetch owned purchases

### DIFF
--- a/packages/in_app_purchase/lib/src/billing_client_wrappers/billing_client_wrapper.dart
+++ b/packages/in_app_purchase/lib/src/billing_client_wrappers/billing_client_wrapper.dart
@@ -160,11 +160,11 @@ class BillingClient {
 
   /// Fetches recent purchases for the given [SkuType].
   ///
-  /// This only fetches whatever purchase history Play happens to have cached
-  /// in memory.
+  /// Unlike [queryPurchaseHistory], This does not make a network request and
+  /// does not return items that are no longer owned.
   ///
-  /// All purchase information should also be verified manually, with your server
-  /// if at all possible. See ["Verify a
+  /// All purchase information should also be verified manually, with your
+  /// server if at all possible. See ["Verify a
   /// purchase"](https://developer.android.com/google/play/billing/billing_library_overview#Verify).
   ///
   /// This wraps [`BillingClient#queryPurchases(String
@@ -178,8 +178,9 @@ class BillingClient {
 
   /// Fetches purchase history for the given [SkuType].
   ///
-  /// This makes a network request via Play and returns the most recent purchase
-  /// for each [SkuDetailsWrapper] of the given [SkuType].
+  /// Unlike [queryPurchases], this makes a network request via Play and returns
+  /// the most recent purchase for each [SkuDetailsWrapper] of the given
+  /// [SkuType] even if the item is no longer owned.
   ///
   /// All purchase information should also be verified manually, with your
   /// server if at all possible. See ["Verify a

--- a/packages/in_app_purchase/lib/src/in_app_purchase/google_play_connection.dart
+++ b/packages/in_app_purchase/lib/src/in_app_purchase/google_play_connection.dart
@@ -78,8 +78,8 @@ class GooglePlayConnection
   Future<QueryPurchaseDetailsResponse> queryPastPurchases(
       {String applicationUserName}) async {
     final List<PurchasesResultWrapper> responses = await Future.wait([
-      billingClient.queryPurchaseHistory(SkuType.inapp),
-      billingClient.queryPurchaseHistory(SkuType.subs)
+      billingClient.queryPurchases(SkuType.inapp),
+      billingClient.queryPurchases(SkuType.subs)
     ]);
 
     Set errorCodeSet = responses

--- a/packages/in_app_purchase/test/in_app_purchase_connection/google_play_connection_test.dart
+++ b/packages/in_app_purchase/test/in_app_purchase_connection/google_play_connection_test.dart
@@ -120,8 +120,7 @@ void main() {
   });
 
   group('queryPurchaseDetails', () {
-    final String queryMethodName =
-        'BillingClient#queryPurchaseHistoryAsync(String, PurchaseHistoryResponseListener)';
+    const String queryMethodName = 'BillingClient#queryPurchases(String)';
     test('handles error', () async {
       final BillingResponse responseCode = BillingResponse.developerError;
       stubPlatform.addResponse(name: queryMethodName, value: <dynamic, dynamic>{


### PR DESCRIPTION
## Description

Previously `GooglePlayConnection#queryPastPurchases` was calling through
to `BillingClientWrapper#queryPastPurchaseHistory`, which includes
purchases that are no longer owned. Switch that out for
`BillingClientWrapper#queryPurchases` instead since that's a better fit
for the unified API.

Also update the BillingClientWrapper docs to try and make this
distinction more clear.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
