### PR TITLE
[cloud_firestore] Fix wrong FieldValue

### DIFF
--- a/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
+++ b/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
@@ -654,8 +654,8 @@ final class FirestoreMessageCodec extends StandardMessageCodec {
   private static final byte DELETE = (byte) 134;
   private static final byte SERVER_TIMESTAMP = (byte) 135;
   private static final byte TIMESTAMP = (byte) 136;
-  private static final byte INCREMENT_INTEGER = (byte) 137;
-  private static final byte INCREMENT_DOUBLE = (byte) 138;
+  private static final byte INCREMENT_DOUBLE = (byte) 137;
+  private static final byte INCREMENT_INTEGER = (byte) 138;
 
   @Override
   protected void writeValue(ByteArrayOutputStream stream, Object value) {

--- a/packages/cloud_firestore/example/test_driver/cloud_firestore.dart
+++ b/packages/cloud_firestore/example/test_driver/cloud_firestore.dart
@@ -54,10 +54,10 @@ void main() {
       snapshot = await ref.get();
       expect(snapshot.data['message'], 2);
       await ref.updateData(<String, dynamic>{
-        'message': FieldValue.increment(40.0),
+        'message': FieldValue.increment(40.1),
       });
       snapshot = await ref.get();
-      expect(snapshot.data['message'], 42.0);
+      expect(snapshot.data['message'], 42.1);
       await ref.delete();
     });
 


### PR DESCRIPTION
Slight mistake that occured in https://github.com/flutter/plugins/pull/1491.

As version `0.10.0` has not even been rolled out to Pub yet, I do not think that I need to bump the version.

Still, I am wondering why `0.10.0` is still not on Pub as it has been 3 days.