### PR TITLE
[firebase_ml_vision] [share] Fix analyzer warnings from const Rect constructor.

### DIFF
--- a/packages/firebase_ml_vision/CHANGELOG.md
+++ b/packages/firebase_ml_vision/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.7.0+2
 
-* Fix analyzer warnings about const Rect in tests.
+* Fix analyzer warnings about `const Rect` in tests.
 
 ## 0.7.0+1
 

--- a/packages/firebase_ml_vision/CHANGELOG.md
+++ b/packages/firebase_ml_vision/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.0+2
+
+* Fix analyzer warnings about const Rect in tests.
+
 ## 0.7.0+1
 
 * Update README to match latest version.

--- a/packages/firebase_ml_vision/pubspec.yaml
+++ b/packages/firebase_ml_vision/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_ml_vision
 description: Flutter plugin for Firebase machine learning vision services.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_ml_vision
-version: 0.7.0+1
+version: 0.7.0+2
 
 dependencies:
   flutter:

--- a/packages/firebase_ml_vision/test/firebase_ml_vision_test.dart
+++ b/packages/firebase_ml_vision/test/firebase_ml_vision_test.dart
@@ -136,7 +136,7 @@ void main() {
 
         final Barcode barcode = barcodes[0];
         expect(barcode.valueType, BarcodeValueType.unknown);
-        expect(barcode.boundingBox, Rect.fromLTWH(1.0, 2.0, 3.0, 4.0));
+        expect(barcode.boundingBox, const Rect.fromLTWH(1.0, 2.0, 3.0, 4.0));
         expect(barcode.rawValue, 'hello:raw');
         expect(barcode.displayValue, 'hello:display');
         expect(barcode.cornerPoints, const <Offset>[
@@ -562,7 +562,7 @@ void main() {
         ]);
 
         final Face face = faces[0];
-        expect(face.boundingBox, Rect.fromLTWH(0.0, 1.0, 2.0, 3.0));
+        expect(face.boundingBox, const Rect.fromLTWH(0.0, 1.0, 2.0, 3.0));
         expect(face.headEulerAngleY, 4.0);
         expect(face.headEulerAngleZ, 5.0);
         expect(face.leftEyeOpenProbability, 0.4);
@@ -756,7 +756,7 @@ void main() {
           expect(text.blocks, hasLength(2));
 
           TextBlock block = text.blocks[0];
-          expect(block.boundingBox, Rect.fromLTWH(13.0, 14.0, 15.0, 16.0));
+          expect(block.boundingBox, const Rect.fromLTWH(13.0, 14.0, 15.0, 16.0));
           expect(block.text, 'friend');
           expect(block.cornerPoints, const <Offset>[
             Offset(17.0, 18.0),
@@ -768,7 +768,7 @@ void main() {
           expect(block.confidence, 0.5);
 
           block = text.blocks[1];
-          expect(block.boundingBox, Rect.fromLTWH(14.0, 13.0, 16.0, 15.0));
+          expect(block.boundingBox, const Rect.fromLTWH(14.0, 13.0, 16.0, 15.0));
           expect(block.text, 'hello');
           expect(block.cornerPoints, const <Offset>[
             Offset(18.0, 17.0),
@@ -783,7 +783,7 @@ void main() {
           final VisionText text = await recognizer.processImage(image);
 
           TextLine line = text.blocks[0].lines[0];
-          expect(line.boundingBox, Rect.fromLTWH(5, 6, 7, 8));
+          expect(line.boundingBox, const Rect.fromLTWH(5, 6, 7, 8));
           expect(line.text, 'friend');
           expect(line.cornerPoints, const <Offset>[
             Offset(9.0, 10.0),
@@ -795,7 +795,7 @@ void main() {
           expect(line.confidence, 0.3);
 
           line = text.blocks[0].lines[1];
-          expect(line.boundingBox, Rect.fromLTWH(8.0, 7.0, 4.0, 5.0));
+          expect(line.boundingBox, const Rect.fromLTWH(8.0, 7.0, 4.0, 5.0));
           expect(line.text, 'how');
           expect(line.cornerPoints, const <Offset>[
             Offset(10.0, 9.0),
@@ -810,7 +810,7 @@ void main() {
           final VisionText text = await recognizer.processImage(image);
 
           TextElement element = text.blocks[0].lines[0].elements[0];
-          expect(element.boundingBox, Rect.fromLTWH(1.0, 2.0, 3.0, 4.0));
+          expect(element.boundingBox, const Rect.fromLTWH(1.0, 2.0, 3.0, 4.0));
           expect(element.text, 'hello');
           expect(element.cornerPoints, const <Offset>[
             Offset(5.0, 6.0),
@@ -822,7 +822,7 @@ void main() {
           expect(element.confidence, 0.1);
 
           element = text.blocks[0].lines[0].elements[1];
-          expect(element.boundingBox, Rect.fromLTWH(4.0, 3.0, 2.0, 1.0));
+          expect(element.boundingBox, const Rect.fromLTWH(4.0, 3.0, 2.0, 1.0));
           expect(element.text, 'my');
           expect(element.cornerPoints, const <Offset>[
             Offset(6.0, 5.0),

--- a/packages/firebase_ml_vision/test/firebase_ml_vision_test.dart
+++ b/packages/firebase_ml_vision/test/firebase_ml_vision_test.dart
@@ -136,7 +136,9 @@ void main() {
 
         final Barcode barcode = barcodes[0];
         expect(barcode.valueType, BarcodeValueType.unknown);
-        expect(barcode.boundingBox, const Rect.fromLTWH(1.0, 2.0, 3.0, 4.0));
+        // TODO(jackson): Use const Rect when available in minimum Flutter SDK
+        // ignore: prefer_const_constructors
+        expect(barcode.boundingBox, Rect.fromLTWH(1.0, 2.0, 3.0, 4.0));
         expect(barcode.rawValue, 'hello:raw');
         expect(barcode.displayValue, 'hello:display');
         expect(barcode.cornerPoints, const <Offset>[
@@ -562,7 +564,9 @@ void main() {
         ]);
 
         final Face face = faces[0];
-        expect(face.boundingBox, const Rect.fromLTWH(0.0, 1.0, 2.0, 3.0));
+        // TODO(jackson): Use const Rect when available in minimum Flutter SDK
+        // ignore: prefer_const_constructors
+        expect(face.boundingBox, Rect.fromLTWH(0.0, 1.0, 2.0, 3.0));
         expect(face.headEulerAngleY, 4.0);
         expect(face.headEulerAngleZ, 5.0);
         expect(face.leftEyeOpenProbability, 0.4);
@@ -756,7 +760,9 @@ void main() {
           expect(text.blocks, hasLength(2));
 
           TextBlock block = text.blocks[0];
-          expect(block.boundingBox, const Rect.fromLTWH(13.0, 14.0, 15.0, 16.0));
+          // TODO(jackson): Use const Rect when available in minimum Flutter SDK
+          // ignore: prefer_const_constructors
+          expect(block.boundingBox, Rect.fromLTWH(13.0, 14.0, 15.0, 16.0));
           expect(block.text, 'friend');
           expect(block.cornerPoints, const <Offset>[
             Offset(17.0, 18.0),
@@ -768,7 +774,10 @@ void main() {
           expect(block.confidence, 0.5);
 
           block = text.blocks[1];
-          expect(block.boundingBox, const Rect.fromLTWH(14.0, 13.0, 16.0, 15.0));
+          // ignore: prefer_const_constructors
+          // TODO(jackson): Use const Rect when available in minimum Flutter SDK
+          // ignore: prefer_const_constructors
+          expect(block.boundingBox, Rect.fromLTWH(14.0, 13.0, 16.0, 15.0));
           expect(block.text, 'hello');
           expect(block.cornerPoints, const <Offset>[
             Offset(18.0, 17.0),
@@ -783,7 +792,9 @@ void main() {
           final VisionText text = await recognizer.processImage(image);
 
           TextLine line = text.blocks[0].lines[0];
-          expect(line.boundingBox, const Rect.fromLTWH(5, 6, 7, 8));
+          // TODO(jackson): Use const Rect when available in minimum Flutter SDK
+          // ignore: prefer_const_constructors
+          expect(line.boundingBox, Rect.fromLTWH(5, 6, 7, 8));
           expect(line.text, 'friend');
           expect(line.cornerPoints, const <Offset>[
             Offset(9.0, 10.0),
@@ -795,7 +806,9 @@ void main() {
           expect(line.confidence, 0.3);
 
           line = text.blocks[0].lines[1];
-          expect(line.boundingBox, const Rect.fromLTWH(8.0, 7.0, 4.0, 5.0));
+          // TODO(jackson): Use const Rect when available in minimum Flutter SDK
+          // ignore: prefer_const_constructors
+          expect(line.boundingBox, Rect.fromLTWH(8.0, 7.0, 4.0, 5.0));
           expect(line.text, 'how');
           expect(line.cornerPoints, const <Offset>[
             Offset(10.0, 9.0),
@@ -810,7 +823,8 @@ void main() {
           final VisionText text = await recognizer.processImage(image);
 
           TextElement element = text.blocks[0].lines[0].elements[0];
-          expect(element.boundingBox, const Rect.fromLTWH(1.0, 2.0, 3.0, 4.0));
+          // ignore: prefer_const_constructors
+          expect(element.boundingBox, Rect.fromLTWH(1.0, 2.0, 3.0, 4.0));
           expect(element.text, 'hello');
           expect(element.cornerPoints, const <Offset>[
             Offset(5.0, 6.0),
@@ -822,7 +836,9 @@ void main() {
           expect(element.confidence, 0.1);
 
           element = text.blocks[0].lines[0].elements[1];
-          expect(element.boundingBox, const Rect.fromLTWH(4.0, 3.0, 2.0, 1.0));
+          // TODO(jackson): Use const Rect when available in minimum Flutter SDK
+          // ignore: prefer_const_constructors
+          expect(element.boundingBox, Rect.fromLTWH(4.0, 3.0, 2.0, 1.0));
           expect(element.text, 'my');
           expect(element.cornerPoints, const <Offset>[
             Offset(6.0, 5.0),

--- a/packages/share/CHANGELOG.md
+++ b/packages/share/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.1+1
+
+* Fix analyzer warnings about const Rect in tests.
+
 ## 0.6.1
 
 * Updated Android compileSdkVersion to 28 to match other plugins.

--- a/packages/share/CHANGELOG.md
+++ b/packages/share/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.6.1+1
 
-* Fix analyzer warnings about const Rect in tests.
+* Fix analyzer warnings about `const Rect` in tests.
 
 ## 0.6.1
 

--- a/packages/share/pubspec.yaml
+++ b/packages/share/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for sharing content via the platform share UI, using
   the ACTION_SEND intent on Android and UIActivityViewController on iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/share
-version: 0.6.1
+version: 0.6.1+1
 
 flutter:
   plugin:

--- a/packages/share/test/share_test.dart
+++ b/packages/share/test/share_test.dart
@@ -43,7 +43,9 @@ void main() {
   test('sharing origin sets the right params', () async {
     await Share.share(
       'some text to share',
-      sharePositionOrigin: const Rect.fromLTWH(1.0, 2.0, 3.0, 4.0),
+      // TODO(jackson): Use const Rect when available in minimum Flutter SDK
+      // ignore: prefer_const_constructors
+      sharePositionOrigin: Rect.fromLTWH(1.0, 2.0, 3.0, 4.0),
     );
     // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
     // https://github.com/flutter/flutter/issues/26431

--- a/packages/share/test/share_test.dart
+++ b/packages/share/test/share_test.dart
@@ -43,7 +43,7 @@ void main() {
   test('sharing origin sets the right params', () async {
     await Share.share(
       'some text to share',
-      sharePositionOrigin: Rect.fromLTWH(1.0, 2.0, 3.0, 4.0),
+      sharePositionOrigin: const Rect.fromLTWH(1.0, 2.0, 3.0, 4.0),
     );
     // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
     // https://github.com/flutter/flutter/issues/26431


### PR DESCRIPTION
## Description

Fixes analyzer warnings for two plugins in flutter/plugins due to introduction of const Rect constructor.

* firebase_ml_vision
* share

I'm not using the const constructor yet since the presence of const Rect isn't assured.