### PR TITLE
Format Java code with google-java-format 1.7

### DIFF
--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AlarmService.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AlarmService.java
@@ -182,8 +182,8 @@ public class AlarmService extends JobIntentService {
     // Handle the alarm event in Dart. Note that for this plugin, we don't
     // care about the method name as we simply lookup and invoke the callback
     // provided.
-    // TODO(mattcarroll): consider giving a method name anyway for the purpose of developer discoverability
-    //                    when reading the source code. Especially on the Dart side.
+    // TODO(mattcarroll): consider giving a method name anyway for the purpose of developer
+    //                    discoverability when reading the source code. Especially on the Dart side.
     sBackgroundChannel.invokeMethod("", new Object[] {callbackHandle});
   }
 

--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AndroidAlarmManagerPlugin.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AndroidAlarmManagerPlugin.java
@@ -64,8 +64,8 @@ public class AndroidAlarmManagerPlugin implements MethodCallHandler, ViewDestroy
     // - "AlarmService.initialized"
     //
     // This channel is also responsible for sending requests from Android to Dart to execute Dart
-    // callbacks in the background isolate. Those messages are sent with an empty method name because
-    // they are the only messages that this channel sends to Dart.
+    // callbacks in the background isolate. Those messages are sent with an empty method name
+    // because they are the only messages that this channel sends to Dart.
     final MethodChannel backgroundCallbackChannel =
         new MethodChannel(
             registrar.messenger(),

--- a/packages/firebase_core/CHANGELOG.md
+++ b/packages/firebase_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.4+1
+
+* Format Java code using google-java-format 1.7
+
 ## 0.3.4
 
 * Updates Android firebase-core dependency to a version that is compatible with other Flutterfire plugins.

--- a/packages/firebase_core/android/src/main/java/io/flutter/plugins/firebase/core/FirebaseCorePlugin.java
+++ b/packages/firebase_core/android/src/main/java/io/flutter/plugins/firebase/core/FirebaseCorePlugin.java
@@ -12,7 +12,6 @@ import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry;
-import java.lang.String;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/packages/firebase_core/pubspec.yaml
+++ b/packages/firebase_core/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Core, enabling connecting to multiple
   Firebase apps.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_core
-version: 0.3.4
+version: 0.3.4+1
 
 flutter:
   plugin:

--- a/packages/firebase_database/android/src/main/java/io/flutter/plugins/firebase/database/FirebaseDatabasePlugin.java
+++ b/packages/firebase_database/android/src/main/java/io/flutter/plugins/firebase/database/FirebaseDatabasePlugin.java
@@ -326,8 +326,8 @@ public class FirebaseDatabasePlugin implements MethodCallHandler {
               new Transaction.Handler() {
                 @Override
                 public Transaction.Result doTransaction(MutableData mutableData) {
-                  // Tasks are used to allow native execution of doTransaction to wait while Snapshot is
-                  // processed by logic on the Dart side.
+                  // Tasks are used to allow native execution of doTransaction to wait while
+                  // Snapshot is processed by logic on the Dart side.
                   final TaskCompletionSource<Map<String, Object>> updateMutableDataTCS =
                       new TaskCompletionSource<>();
                   final Task<Map<String, Object>> updateMutableDataTCSTask =

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
@@ -118,7 +118,7 @@ class FileUtils {
       if (cursor != null && cursor.moveToFirst()) {
         final int column_index = cursor.getColumnIndex(column);
 
-        //yandex.disk and dropbox do not have _data column
+        // yandex.disk and dropbox do not have _data column
         if (column_index == -1) {
           return null;
         }

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
@@ -504,7 +504,7 @@ public class ImagePickerDelegate
 
       finishWithSuccess(finalImagePath);
 
-      //delete original file if scaled
+      // delete original file if scaled
       if (!finalImagePath.equals(path) && shouldDeleteOriginalIfScaled) {
         new File(path).delete();
       }

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -31,8 +31,9 @@ public class ImagePickerPlugin implements MethodChannel.MethodCallHandler {
 
   public static void registerWith(PluginRegistry.Registrar registrar) {
     if (registrar.activity() == null) {
-      // If a background flutter view tries to register the plugin, there will be no activity from the registrar,
-      // we stop the registering process immediately because the ImagePicker requires an activity.
+      // If a background flutter view tries to register the plugin, there will be no activity from
+      // the registrar, we stop the registering process immediately because the ImagePicker requires
+      // an activity.
       return;
     }
     ImagePickerCache.setUpWithActivity(registrar.activity());

--- a/packages/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.2+1
+
+* Format Java code using google-java-format 1.7
+
 ## 0.0.2
 
 * Added missing flutter_test package dependency.

--- a/packages/in_app_purchase/android/src/main/java/io/flutter/plugins/inapppurchase/InAppPurchasePlugin.java
+++ b/packages/in_app_purchase/android/src/main/java/io/flutter/plugins/inapppurchase/InAppPurchasePlugin.java
@@ -27,7 +27,6 @@ import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
-import java.lang.Override;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -128,7 +127,8 @@ public class InAppPurchasePlugin implements MethodCallHandler {
         new BillingClientStateListener() {
           @Override
           public void onBillingSetupFinished(int responseCode) {
-            // Consider the fact that we've finished a success, leave it to the Dart side to validate the responseCode.
+            // Consider the fact that we've finished a success, leave it to the Dart side to
+            // validate the responseCode.
             result.success(responseCode);
           }
 
@@ -222,7 +222,8 @@ public class InAppPurchasePlugin implements MethodCallHandler {
       return;
     }
 
-    // Like in our connect call, consider the billing client responding a "success" here regardless of status code.
+    // Like in our connect call, consider the billing client responding a "success" here regardless
+    // of status code.
     result.success(fromPurchasesResult(billingClient.queryPurchases(skuType)));
   }
 

--- a/packages/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase
 description: A Flutter plugin for in-app purchases.
 author:  Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/in_app_purchase
-version: 0.0.2
+version: 0.0.2+1
 publish_to: none # Not ready to be uploaded
 
 dependencies:

--- a/packages/shared_preferences/android/src/main/java/io/flutter/plugins/sharedpreferences/SharedPreferencesPlugin.java
+++ b/packages/shared_preferences/android/src/main/java/io/flutter/plugins/sharedpreferences/SharedPreferencesPlugin.java
@@ -104,8 +104,9 @@ public class SharedPreferencesPlugin implements MethodCallHandler {
                   .putString(key, LIST_IDENTIFIER + encodeList(listValue))
                   .commit();
           if (!success) {
-            // If we are unable to migrate the existing preferences, it means we potentially lost them.
-            // In this case, an error from getAllPrefs() is appropriate since it will alert the app during plugin initialization.
+            // If we are unable to migrate the existing preferences, it means we potentially lost
+            // them. In this case, an error from getAllPrefs() is appropriate since it will alert
+            // the app during plugin initialization.
             throw new IOException("Could not migrate set to list");
           }
           value = listValue;

--- a/packages/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -303,9 +303,9 @@ public class VideoPlayerPlugin implements MethodCallHandler {
   }
 
   private void onDestroy() {
-    // The whole FlutterView is being destroyed. Here we release resources acquired for all instances
-    // of VideoPlayer. Once https://github.com/flutter/flutter/issues/19358 is resolved this may
-    // be replaced with just asserting that videoPlayers.isEmpty().
+    // The whole FlutterView is being destroyed. Here we release resources acquired for all
+    // instances of VideoPlayer. Once https://github.com/flutter/flutter/issues/19358 is resolved
+    // this may be replaced with just asserting that videoPlayers.isEmpty().
     // https://github.com/flutter/flutter/issues/20989 tracks this.
     disposeAllPlayers();
   }


### PR DESCRIPTION
This is a sequel to flutter/plugin_tools#32

## Description

Format Java code with the newest [google-java-format 1.7](https://github.com/google/google-java-format/releases). 

flutter/plugin_tools#32 updates the Java formatter from google-java-format 1.3 to 1.7. This PR reformats all Java code to match the google-java-format 1.7 style. Mostly code comments are affected.

## Related Issues

flutter/plugin_tools#32

## Note

I didn't update the version numbers in `pubspec.yaml` for packages where only non-documentation (double-slash `//`) comments were modified. If these also need a version bump, please let me know.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [ ] *See Note section above.* I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
