### PR TITLE
[google_maps_flutter] Support Color's alpha channel when converting to UIColor on iOS

### DIFF
--- a/packages/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.10
+
+* Support Color's alpha channel when converting to UIColor on iOS.
+
 ## 0.5.9
 
 * BitmapDescriptor#fromBytes accounts for screen scale on ios.

--- a/packages/google_maps_flutter/ios/Classes/JsonConversions.m
+++ b/packages/google_maps_flutter/ios/Classes/JsonConversions.m
@@ -37,11 +37,11 @@
 }
 
 + (UIColor*)toColor:(NSNumber*)numberColor {
-  long value = [numberColor longValue];
+  unsigned long value = [numberColor unsignedLongValue];
   return [UIColor colorWithRed:((float)((value & 0xFF0000) >> 16)) / 255.0
                          green:((float)((value & 0xFF00) >> 8)) / 255.0
                           blue:((float)(value & 0xFF)) / 255.0
-                         alpha:1.0];
+                         alpha:((float)((value & 0xFF000000) >> 24)) / 255.0];
 }
 
 + (NSArray<CLLocation*>*)toPoints:(NSArray*)data {

--- a/packages/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter
-version: 0.5.9
+version: 0.5.10
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Description

Support Color's alpha channel when converting to UIColor on iOS. This allows polylines and other overlays to be added in the future (e.g. circles and polygons) to be translucent, to match the behavior on Android.

Tested manually using a translucent polyline in the iOS simulator.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
