### PR TITLE
[video_player] Prevent Div/0 during network playback initialization.

### DIFF
--- a/packages/video_player/CHANGELOG.md
+++ b/packages/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.1
+
+* iOS: Consider a player only `initialized` once duration is determined.
+
 ## 0.10.0+8
 
 * iOS: Fix an issue where the player sends initialization message incorrectly.

--- a/packages/video_player/ios/Classes/VideoPlayerPlugin.m
+++ b/packages/video_player/ios/Classes/VideoPlayerPlugin.m
@@ -334,8 +334,6 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 }
 
 - (int64_t)duration {
-  NSLog(@"[_player currentItem]           : %@", [_player currentItem]);
-  NSLog(@"[[_player currentItem] duration]: %llu", [[_player currentItem] duration].value);
   return FLTCMTimeToMillis([[_player currentItem] duration]);
 }
 

--- a/packages/video_player/ios/Classes/VideoPlayerPlugin.m
+++ b/packages/video_player/ios/Classes/VideoPlayerPlugin.m
@@ -304,6 +304,10 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     if (height == CGSizeZero.height && width == CGSizeZero.width) {
       return;
     }
+    // The player may be initialized but still needs to determine the duration.
+    if ([self duration] == 0) {
+      return;
+    }
 
     _isInitialized = true;
     _eventSink(@{
@@ -330,6 +334,8 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 }
 
 - (int64_t)duration {
+  NSLog(@"[_player currentItem]           : %@", [_player currentItem]);
+  NSLog(@"[[_player currentItem] duration]: %llu", [[_player currentItem] duration].value);
   return FLTCMTimeToMillis([[_player currentItem] duration]);
 }
 

--- a/packages/video_player/pubspec.yaml
+++ b/packages/video_player/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player
 description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
-version: 0.10.0+8
+version: 0.10.1
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player
 
 flutter:


### PR DESCRIPTION
## Description

During network playback (HTTP), the duration may take a little longer to determine. 
Until it is determined, the player must not be considered "initialized", else div/0 will occur during the progress indicator display.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/