### PR TITLE
[path_provider] Release as 1.0 and add integration tests

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -26,6 +26,7 @@ packages/google_sign_in/* @cyanglaz @mehmetf
 packages/image_picker/* @cyanglaz
 packages/in_app_purchase/* @mklim @cyanglaz
 packages/package_info/* @cyanglaz
+packages/path_provider/* @collinjackson
 packages/shared_preferences/* @collinjackson
 packages/video_player/* @iskakaushik @cyanglaz
 packages/webview_flutter/* @amirh @iskakaushik

--- a/packages/path_provider/CHANGELOG.md
+++ b/packages/path_provider/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0
+
+* Added integration tests.
+
 ## 0.5.0+1
 
 * Log a more detailed warning at build time about the previous AndroidX

--- a/packages/path_provider/example/pubspec.yaml
+++ b/packages/path_provider/example/pubspec.yaml
@@ -6,6 +6,12 @@ dependencies:
     sdk: flutter
   path_provider:
     path: ../
+  uuid: "^1.0.0"
+
+dev_dependencies:
+  flutter_driver:
+    sdk: flutter
+  test: any
 
 flutter:
   uses-material-design: true

--- a/packages/path_provider/example/test_driver/path_provider.dart
+++ b/packages/path_provider/example/test_driver/path_provider.dart
@@ -46,5 +46,4 @@ void main() {
       expect(result.path.length, isNonZero);
     }
   });
-
 }

--- a/packages/path_provider/example/test_driver/path_provider.dart
+++ b/packages/path_provider/example/test_driver/path_provider.dart
@@ -1,0 +1,50 @@
+// Copyright 2019, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'dart:io';
+import 'package:flutter_driver/driver_extension.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:uuid/uuid.dart';
+
+void main() {
+  final Completer<String> allTestsCompleter = Completer<String>();
+  enableFlutterDriverExtension(handler: (_) => allTestsCompleter.future);
+  tearDownAll(() => allTestsCompleter.complete(null));
+
+  test('getTemporaryDirectory', () async {
+    Directory result = await getTemporaryDirectory();
+    final String uuid = Uuid().v1();
+    final File file = File('${result.path}/$uuid.txt');
+    file.writeAsStringSync('Hello world!');
+    expect(file.readAsStringSync(), 'Hello world!');
+    expect(result.listSync(), isNotEmpty);
+    file.deleteSync();
+  });
+
+  test('getApplicationDocumentsDirectory', () async {
+    Directory result = await getApplicationDocumentsDirectory();
+    final String uuid = Uuid().v1();
+    final File file = File('${result.path}/$uuid.txt');
+    file.writeAsStringSync('Hello world!');
+    expect(file.readAsStringSync(), 'Hello world!');
+    expect(result.listSync(), isNotEmpty);
+    file.deleteSync();
+  });
+
+  test('getExternalStorageDirectory', () async {
+    if (Platform.isIOS) {
+      Future<Directory> result = getExternalStorageDirectory();
+      expect(result, throwsA(isInstanceOf<UnsupportedError>()));
+    } else if (Platform.isAndroid) {
+      Directory result = await getExternalStorageDirectory();
+      // This directory is not accessible in Android emulators.
+      // However, it should at least have a fake path returned.
+      expect(result.path.length, isNonZero);
+    }
+  });
+
+}

--- a/packages/path_provider/example/test_driver/path_provider.dart
+++ b/packages/path_provider/example/test_driver/path_provider.dart
@@ -16,7 +16,7 @@ void main() {
   tearDownAll(() => allTestsCompleter.complete(null));
 
   test('getTemporaryDirectory', () async {
-    Directory result = await getTemporaryDirectory();
+    final Directory result = await getTemporaryDirectory();
     final String uuid = Uuid().v1();
     final File file = File('${result.path}/$uuid.txt');
     file.writeAsStringSync('Hello world!');
@@ -26,7 +26,7 @@ void main() {
   });
 
   test('getApplicationDocumentsDirectory', () async {
-    Directory result = await getApplicationDocumentsDirectory();
+    final Directory result = await getApplicationDocumentsDirectory();
     final String uuid = Uuid().v1();
     final File file = File('${result.path}/$uuid.txt');
     file.writeAsStringSync('Hello world!');
@@ -37,10 +37,10 @@ void main() {
 
   test('getExternalStorageDirectory', () async {
     if (Platform.isIOS) {
-      Future<Directory> result = getExternalStorageDirectory();
+      final Future<Directory> result = getExternalStorageDirectory();
       expect(result, throwsA(isInstanceOf<UnsupportedError>()));
     } else if (Platform.isAndroid) {
-      Directory result = await getExternalStorageDirectory();
+      final Directory result = await getExternalStorageDirectory();
       // This directory is not accessible in Android emulators.
       // However, it should at least have a fake path returned.
       expect(result.path.length, isNonZero);

--- a/packages/path_provider/example/test_driver/path_provider_test.dart
+++ b/packages/path_provider/example/test_driver/path_provider_test.dart
@@ -1,0 +1,13 @@
+// Copyright 2019, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_driver/flutter_driver.dart';
+
+Future<void> main() async {
+  final FlutterDriver driver = await FlutterDriver.connect();
+  await driver.requestData(null, timeout: const Duration(minutes: 1));
+  driver.close();
+}

--- a/packages/path_provider/pubspec.yaml
+++ b/packages/path_provider/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for getting commonly used locations on the Android &
   iOS file systems, such as the temp and app data directories.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/path_provider
-version: 0.5.0+1
+version: 1.0.0
 
 flutter:
   plugin:

--- a/packages/path_provider/pubspec.yaml
+++ b/packages/path_provider/pubspec.yaml
@@ -18,6 +18,10 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  flutter_driver:
+    sdk: flutter
+  test: any
+  uuid: "^1.0.0"
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"


### PR DESCRIPTION
Fixes flutter/flutter#32042

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [X] No, this is *not* a breaking change.

This is not a breaking change but I'm updating the version to 1.0 since the plugin is mature enough for that.