### PR TITLE
[firebase_dynamic_links] support clicking on link while app is running.

### DIFF
--- a/packages/firebase_dynamic_links/CHANGELOG.md
+++ b/packages/firebase_dynamic_links/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.0+1
+
+* Fixed bug where link persists after starting an app with a Dynamic Link.
+* Fixed bug where retrieving a link would fail when app was already running.
+
 ## 0.4.0
 
 * Update dependency on firebase_core to 0.4.0.

--- a/packages/firebase_dynamic_links/example/lib/main.dart
+++ b/packages/firebase_dynamic_links/example/lib/main.dart
@@ -36,6 +36,7 @@ class _MainScreenState extends State<_MainScreen> with WidgetsBindingObserver {
   @override
   void initState() {
     super.initState();
+    _retrieveDynamicLink();
     WidgetsBinding.instance.addObserver(this);
   }
 

--- a/packages/firebase_dynamic_links/pubspec.yaml
+++ b/packages/firebase_dynamic_links/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_dynamic_links
 description: Flutter plugin for Google Dynamic Links for Firebase, an app solution for creating
   and handling links across multiple platforms.
-version: 0.4.0
+version: 0.4.0+1
 
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_dynamic_links


### PR DESCRIPTION
## Background:
On Android there is a different behavior than in iOS which I think is the expected one.
1. When clicking on a link while the app is running and then trying to get the link via a call to "retrieveDynamicLink" the result is null.
2. Calling to "retrieveDynamicLink" doesn't clean the old value which makes it impossible for the application to know if/when the user has clicked a link or it is a  result of an old click.

To solve the first problem I added a check for the existence of a dynamic link on every new intent instead of the current behavior that checks only on the fluter activity intent.

In addition (for the second problem) I added a cleanup for the old link  every time it was retrieved
successfully by the user.

This PR matches the behavior on iOS.

## Breaking Change
The `retrieveDynamicLinks` will now clean the value that it returns, means it will return a specific link only once.