### PR TITLE
Remove flaky timeout test

### DIFF
--- a/packages/cloud_functions/CHANGELOG.md
+++ b/packages/cloud_functions/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0+1
+
+* Removed flaky timeout test.
+
 ## 0.2.0
 
 * **Breaking change**. Updated Dart API to replace `call` with `getHttpsCallable`.

--- a/packages/cloud_functions/example/test/cloud_functions.dart
+++ b/packages/cloud_functions/example/test/cloud_functions.dart
@@ -33,19 +33,6 @@ void main() {
       });
       expect(response2.data['repeat_message'], 'bar');
       expect(response2.data['repeat_count'], 43);
-
-      // impossibly short timeout
-      callable.timeout = const Duration(milliseconds: 1);
-      bool timedOut = false;
-      try {
-        await callable.call(<String, dynamic>{
-          'message': 'impossible',
-          'count': 9001,
-        });
-      } on CloudFunctionsException {
-        timedOut = true;
-      }
-      expect(timedOut, true);
     });
   });
 }

--- a/packages/cloud_functions/pubspec.yaml
+++ b/packages/cloud_functions/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cloud_functions
 description: Flutter plugin for Cloud Functions.
-version: 0.2.0
+version: 0.2.0+1
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_functions
 


### PR DESCRIPTION
When I run the cloud_functions timeout integration test locally on Android, it doesn't timeout even though the timeout value is very short. I guess this is just how the native SDK works.