### PR TITLE
Update firebase_core dependency

### DIFF
--- a/packages/firebase_core/CHANGELOG.md
+++ b/packages/firebase_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0
+
+* Update Android dependencies to latest.
+
 ## 0.3.4
 
 * Updates Android firebase-core dependency to a version that is compatible with other Flutterfire plugins.

--- a/packages/firebase_core/android/build.gradle
+++ b/packages/firebase_core/android/build.gradle
@@ -45,6 +45,6 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        api 'com.google.firebase:firebase-core:16.0.4'
+        api 'com.google.firebase:firebase-core:16.0.9'
     }
 }

--- a/packages/firebase_core/pubspec.yaml
+++ b/packages/firebase_core/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Core, enabling connecting to multiple
   Firebase apps.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_core
-version: 0.3.4
+version: 0.4.0
 
 flutter:
   plugin:


### PR DESCRIPTION
Since all the other plugins have a dependency on firebase_core, using 0.4.0 to get them to agree on newer versions of Android dependencies.