### PR TITLE
[firebase_auth] Update to latest CocoaPod

### DIFF
--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.10.1
+## 0.10.0+1
 
 * Increase Firebase/Auth CocoaPod dependency to '~> 6.0'.
 

--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.1
+
+* Increase Firebase/Auth CocoaPod dependency to '~> 6.0'.
+
 ## 0.10.0
 
 * Update firebase_dynamic_links dependency.

--- a/packages/firebase_auth/ios/firebase_auth.podspec
+++ b/packages/firebase_auth/ios/firebase_auth.podspec
@@ -16,7 +16,7 @@ Firebase Auth plugin for Flutter.
   s.public_header_files = 'Classes/**/*.h'
   s.ios.deployment_target = '8.0'
   s.dependency 'Flutter'
-  s.dependency 'Firebase/Auth', '~> 5.19'
+  s.dependency 'Firebase/Auth', '~> 6.0'
   s.dependency 'Firebase/Core'
   s.static_framework = true
 end

--- a/packages/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Firebase Auth, enabling Android and iOS
   like Google, Facebook and Twitter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_auth
-version: "0.10.1"
+version: "0.10.0+1"
 
 flutter:
   plugin:

--- a/packages/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Firebase Auth, enabling Android and iOS
   like Google, Facebook and Twitter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_auth
-version: "0.10.0"
+version: "0.10.1"
 
 flutter:
   plugin:


### PR DESCRIPTION
Most of our Flutterfire plugins don't specify a particular version, but right now we're using the optimistic operator with `Firebase/Auth`, '~> 5.19'. This change gets us onto Firebase 6.x, which should increase the chance of find compatible pods for other plugins that are using 6.x stuff in the future.

I think I need to get Cirrus to run `pod repo update` and pick up 6.0 before this change will pass tests. The CocoaPods just went live a few hours ago.