### PR TITLE
[firebase_messaging] more graceful handling of failed token read on startup

### DIFF
--- a/packages/firebase_messaging/CHANGELOG.md
+++ b/packages/firebase_messaging/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.1
+
+* Fix error in the logs on startup if unable to retrieve token on startup on Android.
+
 ## 5.0.0
 
 * Update Android dependencies to latest.

--- a/packages/firebase_messaging/android/src/main/java/io/flutter/plugins/firebasemessaging/FirebaseMessagingPlugin.java
+++ b/packages/firebase_messaging/android/src/main/java/io/flutter/plugins/firebasemessaging/FirebaseMessagingPlugin.java
@@ -108,7 +108,6 @@ public class FirebaseMessagingPlugin extends BroadcastReceiver
                 public void onComplete(@NonNull Task<InstanceIdResult> task) {
                   if (!task.isSuccessful()) {
                     Log.w(TAG, "getToken, error fetching instanceID: ", task.getException());
-                    result.success(null);
                     return;
                   }
                   channel.invokeMethod("onToken", task.getResult().getToken());

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Cloud Messaging, a cross-platform
   messaging solution that lets you reliably deliver messages on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_messaging
-version: 5.0.0
+version: 5.0.1
 
 flutter:
   plugin:


### PR DESCRIPTION
Fixes an error in the logs when calling `configure` if the user's token could not be read. Instead, a warning message is logged.