### PR TITLE
Fix break in firebase_analytics CocoaPod

### DIFF
--- a/packages/firebase_analytics/CHANGELOG.md
+++ b/packages/firebase_analytics/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 3.0.1
 
-* Update usage of renamed method `setAnalyticsCollectionEnabled` for compatibility
+* Switch to using renamed method `setAnalyticsCollectionEnabled` for compatibility
   with Firebase Analytics iOS CocoaPod version 6.0.
+* Update podspec to ensure availability of `setAnalyticsCollectionEnabled`.
 
 ## 3.0.0
 

--- a/packages/firebase_analytics/CHANGELOG.md
+++ b/packages/firebase_analytics/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 3.0.1
 
-* Switch to using renamed method `setAnalyticsCollectionEnabled` for compatibility
-  with Firebase Analytics iOS CocoaPod version 6.0.
+* Switch to using the `FIRAnalytics` version of `setAnalyticsCollectionEnabled` for
+  compatibility with Firebase Analytics iOS CocoaPod version 6.0.
 * Update podspec to ensure availability of `setAnalyticsCollectionEnabled`.
 
 ## 3.0.0

--- a/packages/firebase_analytics/CHANGELOG.md
+++ b/packages/firebase_analytics/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.1
+
+* Update usage of renamed method `setAnalyticsCollectionEnabled` for compatibility
+  with Firebase Analytics iOS CocoaPod version 6.0.
+
 ## 3.0.0
 
 * Update Android dependencies to latest.

--- a/packages/firebase_analytics/ios/Classes/FirebaseAnalyticsPlugin.m
+++ b/packages/firebase_analytics/ios/Classes/FirebaseAnalyticsPlugin.m
@@ -57,7 +57,7 @@
     result(nil);
   } else if ([@"setAnalyticsCollectionEnabled" isEqualToString:call.method]) {
     NSNumber *enabled = [NSNumber numberWithBool:call.arguments];
-    [[FIRAnalyticsConfiguration sharedInstance] setAnalyticsCollectionEnabled:[enabled boolValue]];
+    [FIRAnalytics setAnalyticsCollectionEnabled:[enabled boolValue]];
     result(nil);
   } else if ([@"resetAnalyticsData" isEqualToString:call.method]) {
     [FIRAnalytics resetAnalyticsData];

--- a/packages/firebase_analytics/ios/firebase_analytics.podspec
+++ b/packages/firebase_analytics/ios/firebase_analytics.podspec
@@ -17,5 +17,6 @@ Firebase Analytics plugin for Flutter.
   s.ios.deployment_target = '8.0'
   s.dependency 'Flutter'
   s.dependency 'Firebase/Core'
+  s.dependency 'Firebase/Analytics', '~> 6.0'
   s.static_framework = true
 end

--- a/packages/firebase_analytics/pubspec.yaml
+++ b/packages/firebase_analytics/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Analytics for Firebase, an app measuremen
   solution that provides insight on app usage and user engagement on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_analytics
-version: 3.0.0
+version: 3.0.1
 
 flutter:
   plugin:


### PR DESCRIPTION
Fixes flutter/flutter#32252.

Resolves compile errors due to removal of the `FIRAnalyticsConfiguration` class in CocoaPod version 6.0.