### PR TITLE
Return image picker method call results on the platform thread

### DIFF
--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.0+3
+
+* Android: fixed assertion failures due to reply messages that were sent on the wrong thread.
+
 ## 0.6.0+2
 
 * Android: images are saved with their real extension instead of always using `.jpg`.

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -8,6 +8,8 @@ import android.app.Activity;
 import android.app.Application;
 import android.os.Bundle;
 import android.os.Environment;
+import android.os.Handler;
+import android.os.Looper;
 import androidx.annotation.VisibleForTesting;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
@@ -94,12 +96,58 @@ public class ImagePickerPlugin implements MethodChannel.MethodCallHandler {
     }
   }
 
+  // MethodChannel.Result wrapper that responds on the platform thread.
+  private static class MethodResultWrapper implements MethodChannel.Result {
+    private MethodChannel.Result methodResult;
+    private Handler handler;
+
+    MethodResultWrapper(MethodChannel.Result result) {
+      methodResult = result;
+      handler = new Handler(Looper.getMainLooper());
+    }
+
+    @Override
+    public void success(final Object result) {
+      handler.post(
+          new Runnable() {
+            @Override
+            public void run() {
+              methodResult.success(result);
+            }
+          });
+    }
+
+    @Override
+    public void error(
+        final String errorCode, final String errorMessage, final Object errorDetails) {
+      handler.post(
+          new Runnable() {
+            @Override
+            public void run() {
+              methodResult.error(errorCode, errorMessage, errorDetails);
+            }
+          });
+    }
+
+    @Override
+    public void notImplemented() {
+      handler.post(
+          new Runnable() {
+            @Override
+            public void run() {
+              methodResult.notImplemented();
+            }
+          });
+    }
+  }
+
   @Override
-  public void onMethodCall(MethodCall call, MethodChannel.Result result) {
+  public void onMethodCall(MethodCall call, MethodChannel.Result rawResult) {
     if (registrar.activity() == null) {
-      result.error("no_activity", "image_picker plugin requires a foreground activity.", null);
+      rawResult.error("no_activity", "image_picker plugin requires a foreground activity.", null);
       return;
     }
+    MethodChannel.Result result = new MethodResultWrapper(rawResult);
     int imageSource;
     switch (call.method) {
       case METHOD_CALL_IMAGE:

--- a/packages/image_picker/example/android/app/src/test/java/io/flutter/plugins/imagepicker/ImagePickerPluginTest.java
+++ b/packages/image_picker/example/android/app/src/test/java/io/flutter/plugins/imagepicker/ImagePickerPluginTest.java
@@ -1,6 +1,8 @@
 package io.flutter.plugins.imagepicker;
 
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
@@ -81,7 +83,7 @@ public class ImagePickerPluginTest {
 
     plugin.onMethodCall(call, mockResult);
 
-    verify(mockImagePickerDelegate).chooseImageFromGallery(call, mockResult);
+    verify(mockImagePickerDelegate).chooseImageFromGallery(eq(call), any());
     verifyZeroInteractions(mockResult);
   }
 
@@ -92,7 +94,7 @@ public class ImagePickerPluginTest {
 
     plugin.onMethodCall(call, mockResult);
 
-    verify(mockImagePickerDelegate).takeImageWithCamera(call, mockResult);
+    verify(mockImagePickerDelegate).takeImageWithCamera(eq(call), any());
     verifyZeroInteractions(mockResult);
   }
 

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -5,7 +5,7 @@ authors:
   - Flutter Team <flutter-dev@googlegroups.com>
   - Rhodes Davis Jr. <rody.davis.jr@gmail.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.6.0+2
+version: 0.6.0+3
 
 flutter:
   plugin:


### PR DESCRIPTION
The MediaScanConnection.scanFile callback is invoked on a background thread.
However, MethodChannel results must be provided on the platform thread.

Fixes https://github.com/flutter/flutter/issues/32315
