### PR TITLE
[in_app_purchase] Guard against dupe onBillingSetupFinished calls

### DIFF
--- a/packages/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0+3
+
+* Guard against multiple onSetupFinished() calls.
+
 ## 0.1.0+2
 
 * Fix bug where error only purchases updates weren't propagated correctly in

--- a/packages/in_app_purchase/android/src/main/java/io/flutter/plugins/inapppurchase/InAppPurchasePlugin.java
+++ b/packages/in_app_purchase/android/src/main/java/io/flutter/plugins/inapppurchase/InAppPurchasePlugin.java
@@ -10,6 +10,7 @@ import static io.flutter.plugins.inapppurchase.Translator.fromSkuDetailsList;
 
 import android.app.Activity;
 import android.content.Context;
+import android.util.Log;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import com.android.billingclient.api.BillingClient;
@@ -34,6 +35,7 @@ import java.util.Map;
 
 /** Wraps a {@link BillingClient} instance and responds to Dart calls for it. */
 public class InAppPurchasePlugin implements MethodCallHandler {
+  private static final String TAG = "InAppPurchasePlugin";
   private @Nullable BillingClient billingClient;
   private final Activity activity;
   private final Context context;
@@ -126,8 +128,15 @@ public class InAppPurchasePlugin implements MethodCallHandler {
 
     billingClient.startConnection(
         new BillingClientStateListener() {
+          private boolean alreadyFinished = false;
+
           @Override
           public void onBillingSetupFinished(int responseCode) {
+            if (alreadyFinished) {
+              Log.d(TAG, "Tried to call onBilllingSetupFinished multiple times.");
+              return;
+            }
+            alreadyFinished = true;
             // Consider the fact that we've finished a success, leave it to the Dart side to validate the responseCode.
             result.success(responseCode);
           }

--- a/packages/in_app_purchase/example/android/app/build.gradle
+++ b/packages/in_app_purchase/example/android/app/build.gradle
@@ -95,6 +95,10 @@ android {
             }
         }
     }
+
+    testOptions {
+        unitTests.returnDefaultValues = true
+    }
 }
 
 flutter {

--- a/packages/in_app_purchase/example/android/app/src/test/java/io/flutter/plugins/inapppurchase/InAppPurchasePluginTest.java
+++ b/packages/in_app_purchase/example/android/app/src/test/java/io/flutter/plugins/inapppurchase/InAppPurchasePluginTest.java
@@ -119,6 +119,25 @@ public class InAppPurchasePluginTest {
   }
 
   @Test
+  public void startConnection_multipleCalls() {
+    Map<String, Integer> arguments = new HashMap<>();
+    arguments.put("handle", 1);
+    MethodCall call = new MethodCall(START_CONNECTION, arguments);
+    ArgumentCaptor<BillingClientStateListener> captor =
+        ArgumentCaptor.forClass(BillingClientStateListener.class);
+    doNothing().when(mockBillingClient).startConnection(captor.capture());
+
+    plugin.onMethodCall(call, result);
+    verify(result, never()).success(any());
+    captor.getValue().onBillingSetupFinished(100);
+    captor.getValue().onBillingSetupFinished(200);
+    captor.getValue().onBillingSetupFinished(300);
+
+    verify(result, times(1)).success(100);
+    verify(result, times(1)).success(any());
+  }
+
+  @Test
   public void endConnection() {
     // Set up a connected BillingClient instance
     final int disconnectCallbackHandle = 22;

--- a/packages/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase
 description: A Flutter plugin for in-app purchases.
 author:  Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/in_app_purchase
-version: 0.1.0+2
+version: 0.1.0+3
 
 dependencies:
   async: ^2.0.8


### PR DESCRIPTION
## Description

Theoretically this API should only be called once, but there's an open
issue that suggests that in some cases this is being triggered multiple
times. Check for multiple calls and bail instead of sending multiple
replies.

## Related Issues

flutter/flutter#31417
Fixes flutter/flutter#32462

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
