### PR TITLE
[in_app_purchase] Fix issue with empty purchase updates

### DIFF
--- a/packages/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.0+2
+
+* Fix bug where error only purchases updates weren't propagated correctly in
+  `google_play_connection.dart`.
+
 ## 0.1.0+1
 
 Add more consumable handling to the example app.

--- a/packages/in_app_purchase/lib/src/in_app_purchase/google_play_connection.dart
+++ b/packages/in_app_purchase/lib/src/in_app_purchase/google_play_connection.dart
@@ -183,7 +183,7 @@ class GooglePlayConnection
     } else {
       error = PurchaseError(
         source: PurchaseSource.GooglePlay,
-        code: kRestoredPurchaseErrorCode,
+        code: kPurchaseErrorCode,
         message: {'message': resultWrapper.responseCode.toString()},
       );
       status = PurchaseStatus.error;
@@ -194,7 +194,19 @@ class GooglePlayConnection
         ..status = status
         ..error = error);
     }).toList();
-    return Future.wait(purchases);
+    if (!purchases.isEmpty) {
+      return Future.wait(purchases);
+    } else {
+      return [
+        PurchaseDetails(
+            purchaseID: null,
+            productID: null,
+            transactionDate: null,
+            verificationData: null)
+          ..status = PurchaseStatus.error
+          ..error = error
+      ];
+    }
   }
 
   static Future<PurchaseDetails> _maybeAutoConsumePurchase(

--- a/packages/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase
 description: A Flutter plugin for in-app purchases.
 author:  Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/in_app_purchase
-version: 0.1.0+1
+version: 0.1.0+2
 
 dependencies:
   async: ^2.0.8


### PR DESCRIPTION
## Description

Previously the code was failing to propagate errors from BillingClient
if there were no actual purchases to attach them to.

Also updates the error code. This situation can arise in more situations
than just restoring purchases.

## Related Issues

flutter/flutter#31417

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
