### PR TITLE
[google_maps_flutter] Fix LatLng returning slight different values

### DIFF
--- a/packages/google_maps_flutter/lib/src/location.dart
+++ b/packages/google_maps_flutter/lib/src/location.dart
@@ -18,7 +18,7 @@ class LatLng {
         assert(longitude != null),
         latitude =
             (latitude < -90.0 ? -90.0 : (90.0 < latitude ? 90.0 : latitude)),
-        longitude = (longitude + 180.0) % 360.0 - 180.0;
+        longitude = longitude > 180 ? (longitude + 180.0) % 360.0 - 180.0 : longitude;
 
   /// The latitude in degrees between -90.0 and 90.0, both inclusive.
   final double latitude;

--- a/packages/google_maps_flutter/lib/src/location.dart
+++ b/packages/google_maps_flutter/lib/src/location.dart
@@ -19,7 +19,9 @@ class LatLng {
         latitude =
             (latitude < -90.0 ? -90.0 : (90.0 < latitude ? 90.0 : latitude)),
         longitude =
-            longitude > 180 ? (longitude + 180.0) % 360.0 - 180.0 : longitude;
+            (longitude < -180.0 || longitude >= 180.0)
+            ? (longitude + 180.0) % 360.0 - 180.0
+            : longitude;
 
   /// The latitude in degrees between -90.0 and 90.0, both inclusive.
   final double latitude;

--- a/packages/google_maps_flutter/lib/src/location.dart
+++ b/packages/google_maps_flutter/lib/src/location.dart
@@ -19,7 +19,8 @@ class LatLng {
         latitude =
             (latitude < -90.0 ? -90.0 : (90.0 < latitude ? 90.0 : latitude)),
         longitude = (longitude < -180.0 || longitude >= 180.0)
-            ? (longitude + 180.0) % 360.0 - 180.0 : longitude;
+            ? (longitude + 180.0) % 360.0 - 180.0
+            : longitude;
 
   /// The latitude in degrees between -90.0 and 90.0, both inclusive.
   final double latitude;

--- a/packages/google_maps_flutter/lib/src/location.dart
+++ b/packages/google_maps_flutter/lib/src/location.dart
@@ -18,10 +18,8 @@ class LatLng {
         assert(longitude != null),
         latitude =
             (latitude < -90.0 ? -90.0 : (90.0 < latitude ? 90.0 : latitude)),
-        longitude =
-            (longitude < -180.0 || longitude >= 180.0)
-            ? (longitude + 180.0) % 360.0 - 180.0
-            : longitude;
+        longitude = (longitude < -180.0 || longitude >= 180.0)
+            ? (longitude + 180.0) % 360.0 - 180.0 : longitude;
 
   /// The latitude in degrees between -90.0 and 90.0, both inclusive.
   final double latitude;

--- a/packages/google_maps_flutter/lib/src/location.dart
+++ b/packages/google_maps_flutter/lib/src/location.dart
@@ -18,7 +18,8 @@ class LatLng {
         assert(longitude != null),
         latitude =
             (latitude < -90.0 ? -90.0 : (90.0 < latitude ? 90.0 : latitude)),
-        longitude = longitude > 180 ? (longitude + 180.0) % 360.0 - 180.0 : longitude;
+        longitude =
+            longitude > 180 ? (longitude + 180.0) % 360.0 - 180.0 : longitude;
 
   /// The latitude in degrees between -90.0 and 90.0, both inclusive.
   final double latitude;


### PR DESCRIPTION
## Description
Previously
```dart
LatLng location = LatLng(50, 6.123456789);
print(location.latitude.toString() + ', ' + location.longitude.toString());
```
would produce:
```dart
50, 6.123456788999988
```
Now it produces:
```dart
50, 6.123456789
```