### PR TITLE
[camera] Enable camera plugin to compile with earlier android apis with custom AndroidManifest settings

### DIFF
--- a/packages/camera/CHANGELOG.md
+++ b/packages/camera/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.5.1
+
+* Can now be compiled with earlier Android sdks when
+`<uses-sdk tools:overrideLibrary="io.flutter.plugins.camera"/>` has been added to the project
+`AndroidManifest.xml`.
+
 ## 0.5.0
 
 * **Breaking Change** This plugin no longer handles closing and opening the camera on Android

--- a/packages/camera/CHANGELOG.md
+++ b/packages/camera/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## 0.5.1
 
-* Can now be compiled with earlier Android sdks when
+* Can now be compiled with earlier Android sdks below 21 when
 `<uses-sdk tools:overrideLibrary="io.flutter.plugins.camera"/>` has been added to the project
-`AndroidManifest.xml`.
+`AndroidManifest.xml`. For sdks below 21, the plugin won't be registered and calls to it will throw
+a `MissingPluginException.`
 
 ## 0.5.0
 

--- a/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
+++ b/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
@@ -200,6 +200,9 @@ public class CameraPlugin implements MethodCallHandler {
     }
   }
 
+  // We move catching CameraAccessException out of onMethodCall because it causes a crash
+  // on plugin registration for sdks incompatible with Camera2 (< 21). We want this plugin to
+  // to be able to compile with <21 sdks for apps that want the camera and support earlier version.
   @SuppressWarnings("ConstantConditions")
   private void handleException(Exception exception, Result result) {
     if (exception instanceof CameraAccessException) {

--- a/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
+++ b/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
@@ -82,11 +82,13 @@ public class CameraPlugin implements MethodCallHandler {
   }
 
   public static void registerWith(Registrar registrar) {
-    if (registrar.activity() == null) {
+    if (registrar.activity() == null || Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
       // When a background flutter view tries to register the plugin, the registrar has no activity.
-      // We stop the registration process as this plugin is foreground only.
+      // We stop the registration process as this plugin is foreground only. Also, if the sdk is
+      // less than 21 (min sdk for Camera2) we don't register the plugin.
       return;
     }
+
     final MethodChannel channel =
         new MethodChannel(registrar.messenger(), "plugins.flutter.io/camera");
 
@@ -126,8 +128,8 @@ public class CameraPlugin implements MethodCallHandler {
             cameras.add(details);
           }
           result.success(cameras);
-        } catch (CameraAccessException e) {
-          result.error("cameraAccess", e.getMessage(), null);
+        } catch (Exception e) {
+          handleException(e, result);
         }
         break;
       case "initialize":
@@ -168,8 +170,8 @@ public class CameraPlugin implements MethodCallHandler {
           try {
             camera.startPreviewWithImageStream();
             result.success(null);
-          } catch (CameraAccessException e) {
-            result.error("CameraAccess", e.getMessage(), null);
+          } catch (Exception e) {
+            handleException(e, result);
           }
           break;
         }
@@ -178,8 +180,8 @@ public class CameraPlugin implements MethodCallHandler {
           try {
             camera.startPreview();
             result.success(null);
-          } catch (CameraAccessException e) {
-            result.error("CameraAccess", e.getMessage(), null);
+          } catch (Exception e) {
+            handleException(e, result);
           }
           break;
         }
@@ -196,6 +198,15 @@ public class CameraPlugin implements MethodCallHandler {
         result.notImplemented();
         break;
     }
+  }
+
+  @SuppressWarnings("ConstantConditions")
+  private void handleException(Exception exception, Result result) {
+    if (exception instanceof CameraAccessException) {
+      result.error("CameraAccess", exception.getMessage(), null);
+    }
+
+    throw (RuntimeException) exception;
   }
 
   private static class CompareSizesByArea implements Comparator<Size> {

--- a/packages/camera/pubspec.yaml
+++ b/packages/camera/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera
 description: A Flutter plugin for getting information about and controlling the
   camera on Android and iOS. Supports previewing the camera feed, capturing images, capturing video,
   and streaming image buffers to dart.
-version: 0.5.0
+version: 0.5.1
 authors:
   - Flutter Team <flutter-dev@googlegroups.com>
   - Luigi Agosti <luigi@tengio.com>


### PR DESCRIPTION
## Description

Enable camera plugin to compile with earlier android sdks with custom AndroidManifest settings. 
Catching `CameraAccessException`s in the `onMethodCall` prevented compilation on <21. This separates handling them into another method. 

## Related Issues

Original PR: https://github.com/flutter/plugins/pull/1482
Fixes https://github.com/flutter/flutter/issues/30854

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
