### PR TITLE
Adjust user agent name

### DIFF
--- a/packages/firebase_core/CHANGELOG.md
+++ b/packages/firebase_core/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.4.0+2
+
+* Update user agent name. Set to `flutter-fire-core` for consistency with other
+  libraries.
+
 ## 0.4.0+1
 
 * Send user agent to Firebase.

--- a/packages/firebase_core/CHANGELOG.md
+++ b/packages/firebase_core/CHANGELOG.md
@@ -1,4 +1,4 @@
-0.4.0+2
+## 0.4.0+2
 
 * Update user agent name. Set to `flutter-fire-core` for consistency with other
   libraries.

--- a/packages/firebase_core/android/src/main/java/io/flutter/plugins/firebase/core/FlutterFirebaseAppRegistrar.java
+++ b/packages/firebase_core/android/src/main/java/io/flutter/plugins/firebase/core/FlutterFirebaseAppRegistrar.java
@@ -7,7 +7,7 @@ import java.util.Collections;
 import java.util.List;
 
 public class FlutterFirebaseAppRegistrar implements ComponentRegistrar {
-  private static final String LIBRARY_NAME = "flutter-firebase_core";
+  private static final String LIBRARY_NAME = "flutter-fire-core";
   private static final String LIBRARY_VERSION = "0.4.0+1";
 
   @Override

--- a/packages/firebase_core/android/src/main/java/io/flutter/plugins/firebase/core/FlutterFirebaseAppRegistrar.java
+++ b/packages/firebase_core/android/src/main/java/io/flutter/plugins/firebase/core/FlutterFirebaseAppRegistrar.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public class FlutterFirebaseAppRegistrar implements ComponentRegistrar {
   private static final String LIBRARY_NAME = "flutter-fire-core";
-  private static final String LIBRARY_VERSION = "0.4.0+1";
+  private static final String LIBRARY_VERSION = "0.4.0+2";
 
   @Override
   public List<Component<?>> getComponents() {

--- a/packages/firebase_core/ios/Classes/FirebaseCorePlugin.m
+++ b/packages/firebase_core/ios/Classes/FirebaseCorePlugin.m
@@ -7,7 +7,7 @@
 #import <Firebase/Firebase.h>
 
 #define LIBRARY_NAME @"flutter-fire-core"
-#define LIBRARY_VERSION @"0.4.0+1"
+#define LIBRARY_VERSION @"0.4.0+2"
 
 static NSDictionary *getDictionaryFromFIROptions(FIROptions *options) {
   if (!options) {

--- a/packages/firebase_core/ios/Classes/FirebaseCorePlugin.m
+++ b/packages/firebase_core/ios/Classes/FirebaseCorePlugin.m
@@ -6,7 +6,7 @@
 
 #import <Firebase/Firebase.h>
 
-#define LIBRARY_NAME @"flutter-firebase_core"
+#define LIBRARY_NAME @"flutter-fire-core"
 #define LIBRARY_VERSION @"0.4.0+1"
 
 static NSDictionary *getDictionaryFromFIROptions(FIROptions *options) {

--- a/packages/firebase_core/pubspec.yaml
+++ b/packages/firebase_core/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Core, enabling connecting to multiple
   Firebase apps.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_core
-version: 0.4.0+1
+version: 0.4.0+2
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Update user agent name of `firebase_core` plugin. Setting it to `flutter-fire-core` to be consistent with other libraries.

Eg: in the [Firebase Android SDK](https://github.com/firebase/firebase-android-sdk/blob/3097f24b2f251e32275a1a1efbcfadc68c678875/firebase-common/src/androidTest/java/com/google/firebase/FirebaseAppTest.java#L153) where `fire-core` is used.