### PR TITLE
[video_player] Fixed example and add texts

### DIFF
--- a/packages/video_player/CHANGELOG.md
+++ b/packages/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.1+2
+
+* Example: Fixed tab display and added scroll view
+
 ## 0.10.1+1
 
 * iOS: Avoid deprecated `seekToTime` API

--- a/packages/video_player/example/lib/main.dart
+++ b/packages/video_player/example/lib/main.dart
@@ -362,38 +362,60 @@ void main() {
   runApp(
     MaterialApp(
       home: DefaultTabController(
-        length: 2,
+        length: 3,
         child: Scaffold(
           appBar: AppBar(
             title: const Text('Video player example'),
             bottom: const TabBar(
               isScrollable: true,
               tabs: <Widget>[
-                Tab(icon: Icon(Icons.fullscreen)),
-                Tab(icon: Icon(Icons.list)),
+                Tab(
+                  icon: Icon(Icons.cloud),
+                  text: "Remote",
+                ),
+                Tab(icon: Icon(Icons.insert_drive_file), text: "Asset"),
+                Tab(icon: Icon(Icons.list), text: "List example"),
               ],
             ),
           ),
           body: TabBarView(
             children: <Widget>[
-              Column(
-                children: <Widget>[
-                  const Text('With remote mp4'),
-                  NetworkPlayerLifeCycle(
-                    'http://www.sample-videos.com/video123/mp4/720/big_buck_bunny_720p_20mb.mp4',
-                    (BuildContext context, VideoPlayerController controller) =>
-                        AspectRatioVideo(controller),
-                  ),
-                  Container(
-                    padding: const EdgeInsets.only(top: 20.0),
-                  ),
-                  const Text('With remote m3u8'),
-                  NetworkPlayerLifeCycle(
-                    'http://184.72.239.149/vod/smil:BigBuckBunny.smil/playlist.m3u8',
-                    (BuildContext context, VideoPlayerController controller) =>
-                        AspectRatioVideo(controller),
-                  ),
-                ],
+              SingleChildScrollView(
+                child: Column(
+                  children: <Widget>[
+                    Container(
+                      padding: const EdgeInsets.only(top: 20.0),
+                    ),
+                    const Text('With remote m3u8'),
+                    Container(
+                      padding: const EdgeInsets.all(20),
+                      child: NetworkPlayerLifeCycle(
+                        'http://184.72.239.149/vod/smil:BigBuckBunny.smil/playlist.m3u8',
+                        (BuildContext context,
+                                VideoPlayerController controller) =>
+                            AspectRatioVideo(controller),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              SingleChildScrollView(
+                child: Column(
+                  children: <Widget>[
+                    Container(
+                      padding: const EdgeInsets.only(top: 20.0),
+                    ),
+                    const Text('With assets mp4'),
+                    Container(
+                      padding: const EdgeInsets.all(20),
+                      child: AssetPlayerLifeCycle(
+                          'assets/Butterfly-209.mp4',
+                          (BuildContext context,
+                                  VideoPlayerController controller) =>
+                              AspectRatioVideo(controller)),
+                    ),
+                  ],
+                ),
               ),
               AssetPlayerLifeCycle(
                   'assets/Butterfly-209.mp4',

--- a/packages/video_player/example/lib/main.dart
+++ b/packages/video_player/example/lib/main.dart
@@ -346,10 +346,9 @@ class AspectRatioVideoState extends State<AspectRatioVideo> {
   @override
   Widget build(BuildContext context) {
     if (initialized) {
-      final Size size = controller.value.size;
       return Center(
         child: AspectRatio(
-          aspectRatio: size.width / size.height,
+          aspectRatio: controller.value.aspectRatio,
           child: VideoPlayPause(controller),
         ),
       );
@@ -379,6 +378,7 @@ void main() {
             children: <Widget>[
               Column(
                 children: <Widget>[
+                  const Text('With remote mp4'),
                   NetworkPlayerLifeCycle(
                     'http://www.sample-videos.com/video123/mp4/720/big_buck_bunny_720p_20mb.mp4',
                     (BuildContext context, VideoPlayerController controller) =>
@@ -387,17 +387,13 @@ void main() {
                   Container(
                     padding: const EdgeInsets.only(top: 20.0),
                   ),
+                  const Text('With remote m3u8'),
                   NetworkPlayerLifeCycle(
                     'http://184.72.239.149/vod/smil:BigBuckBunny.smil/playlist.m3u8',
                     (BuildContext context, VideoPlayerController controller) =>
                         AspectRatioVideo(controller),
                   ),
                 ],
-              ),
-              NetworkPlayerLifeCycle(
-                'http://www.sample-videos.com/video123/mp4/720/big_buck_bunny_720p_20mb.mp4',
-                (BuildContext context, VideoPlayerController controller) =>
-                    AspectRatioVideo(controller),
               ),
               AssetPlayerLifeCycle(
                   'assets/Butterfly-209.mp4',

--- a/packages/video_player/pubspec.yaml
+++ b/packages/video_player/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player
 description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
-version: 0.10.1+1
+version: 0.10.1+2
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player
 
 flutter:


### PR DESCRIPTION
## Description

Just a simple fix to make the example work again. The tab count value was 2 for 3 children.
I also added some text widget to know what the type of the video and where it come from. (source and extension infos)

## Related Issues


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
