### PR TITLE
[image_picker] ios: copy all meta data from the original image.

### DIFF
--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.0+5
+
+* iOS: Picked image now has all the correct meta data from the original image, includes GPS, orientation and etc.
+
 ## 0.6.0+4
 
 * iOS: Using first byte to determine original image type.

--- a/packages/image_picker/example/ios/image_picker_exampleTests/MetaDataUtilTests.m
+++ b/packages/image_picker/example/ios/image_picker_exampleTests/MetaDataUtilTests.m
@@ -52,6 +52,24 @@
   XCTAssertEqual([exif[(NSString *)kCGImagePropertyExifPixelXDimension] integerValue], 12);
 }
 
+- (void)testWriteMetaData {
+  NSData *dataJPG = [NSData dataWithContentsOfFile:[self.testBundle pathForResource:@"jpgImage"
+                                                                             ofType:@"jpg"]];
+  NSDictionary *metaData = [ImagePickerMetaDataUtil getMetaDataFromImageData:dataJPG];
+  NSString *tmpFile = [NSString stringWithFormat:@"image_picker_test.jpg"];
+  NSString *tmpDirectory = NSTemporaryDirectory();
+  NSString *tmpPath = [tmpDirectory stringByAppendingPathComponent:tmpFile];
+  NSData *newData = [ImagePickerMetaDataUtil updateMetaData:metaData toImage:dataJPG];
+  if ([[NSFileManager defaultManager] createFileAtPath:tmpPath contents:newData attributes:nil]) {
+    NSData *savedTmpImageData = [NSData dataWithContentsOfFile:tmpPath];
+    NSDictionary *tmpMetaData =
+        [ImagePickerMetaDataUtil getMetaDataFromImageData:savedTmpImageData];
+    XCTAssert([tmpMetaData isEqualToDictionary:metaData]);
+  } else {
+    XCTAssert(NO);
+  }
+}
+
 - (void)testGetEXIFData {
   NSData *dataJPG = [NSData dataWithContentsOfFile:[self.testBundle pathForResource:@"jpgImage"
                                                                              ofType:@"jpg"]];
@@ -65,8 +83,7 @@
 - (void)testWriteEXIFData {
   NSData *dataJPG = [NSData dataWithContentsOfFile:[self.testBundle pathForResource:@"jpgImage"
                                                                              ofType:@"jpg"]];
-  NSDictionary *metaData = [ImagePickerMetaDataUtil getMetaDataFromImageData:dataJPG];
-  NSDictionary *exif = [metaData objectForKey:(NSString *)kCGImagePropertyExifDictionary];
+  NSDictionary *exif = [ImagePickerMetaDataUtil getEXIFFromImageData:dataJPG];
   NSString *tmpFile = [NSString stringWithFormat:@"image_picker_test.jpg"];
   NSString *tmpDirectory = NSTemporaryDirectory();
   NSString *tmpPath = [tmpDirectory stringByAppendingPathComponent:tmpFile];
@@ -104,4 +121,40 @@
                                                 quality:@(0.5)],
                   @"setting quality when converting to PNG throws exception");
 }
+
+- (void)testGetNormalizedUIImageOrientationFromCGImagePropertyOrientation {
+  XCTAssertEqual(
+      [ImagePickerMetaDataUtil getNormalizedUIImageOrientationFromCGImagePropertyOrientation:
+                                   kCGImagePropertyOrientationUp],
+      UIImageOrientationUp);
+  XCTAssertEqual(
+      [ImagePickerMetaDataUtil getNormalizedUIImageOrientationFromCGImagePropertyOrientation:
+                                   kCGImagePropertyOrientationDown],
+      UIImageOrientationDown);
+  XCTAssertEqual(
+      [ImagePickerMetaDataUtil getNormalizedUIImageOrientationFromCGImagePropertyOrientation:
+                                   kCGImagePropertyOrientationLeft],
+      UIImageOrientationRight);
+  XCTAssertEqual(
+      [ImagePickerMetaDataUtil getNormalizedUIImageOrientationFromCGImagePropertyOrientation:
+                                   kCGImagePropertyOrientationRight],
+      UIImageOrientationLeft);
+  XCTAssertEqual(
+      [ImagePickerMetaDataUtil getNormalizedUIImageOrientationFromCGImagePropertyOrientation:
+                                   kCGImagePropertyOrientationUpMirrored],
+      UIImageOrientationUpMirrored);
+  XCTAssertEqual(
+      [ImagePickerMetaDataUtil getNormalizedUIImageOrientationFromCGImagePropertyOrientation:
+                                   kCGImagePropertyOrientationDownMirrored],
+      UIImageOrientationDownMirrored);
+  XCTAssertEqual(
+      [ImagePickerMetaDataUtil getNormalizedUIImageOrientationFromCGImagePropertyOrientation:
+                                   kCGImagePropertyOrientationLeftMirrored],
+      UIImageOrientationRightMirrored);
+  XCTAssertEqual(
+      [ImagePickerMetaDataUtil getNormalizedUIImageOrientationFromCGImagePropertyOrientation:
+                                   kCGImagePropertyOrientationRightMirrored],
+      UIImageOrientationLeftMirrored);
+}
+
 @end

--- a/packages/image_picker/example/ios/image_picker_exampleTests/MetaDataUtilTests.m
+++ b/packages/image_picker/example/ios/image_picker_exampleTests/MetaDataUtilTests.m
@@ -70,35 +70,6 @@
   }
 }
 
-- (void)testGetEXIFData {
-  NSData *dataJPG = [NSData dataWithContentsOfFile:[self.testBundle pathForResource:@"jpgImage"
-                                                                             ofType:@"jpg"]];
-  NSDictionary *exif = [ImagePickerMetaDataUtil getEXIFFromImageData:dataJPG];
-  XCTAssertNotNil(exif);
-  // hard coded test case based on the test image file saved in directory.
-  XCTAssertEqualObjects(exif[@"PixelXDimension"], @(12));
-  XCTAssertEqualObjects(exif[@"PixelYDimension"], @(7));
-}
-
-- (void)testWriteEXIFData {
-  NSData *dataJPG = [NSData dataWithContentsOfFile:[self.testBundle pathForResource:@"jpgImage"
-                                                                             ofType:@"jpg"]];
-  NSDictionary *exif = [ImagePickerMetaDataUtil getEXIFFromImageData:dataJPG];
-  NSString *tmpFile = [NSString stringWithFormat:@"image_picker_test.jpg"];
-  NSString *tmpDirectory = NSTemporaryDirectory();
-  NSString *tmpPath = [tmpDirectory stringByAppendingPathComponent:tmpFile];
-  NSData *newData = [ImagePickerMetaDataUtil updateEXIFData:exif toImage:dataJPG];
-  if ([[NSFileManager defaultManager] createFileAtPath:tmpPath contents:newData attributes:nil]) {
-    NSData *savedTmpImageData = [NSData dataWithContentsOfFile:tmpPath];
-    NSDictionary *tmpMetaData =
-        [ImagePickerMetaDataUtil getMetaDataFromImageData:savedTmpImageData];
-    NSDictionary *tmpExif = [tmpMetaData objectForKey:(NSString *)kCGImagePropertyExifDictionary];
-    XCTAssert([tmpExif isEqualToDictionary:exif]);
-  } else {
-    XCTAssert(NO);
-  }
-}
-
 - (void)testConvertImageToData {
   NSData *dataJPG = [NSData dataWithContentsOfFile:[self.testBundle pathForResource:@"jpgImage"
                                                                              ofType:@"jpg"]];

--- a/packages/image_picker/example/ios/image_picker_exampleTests/PhotoAssetUtilTests.m
+++ b/packages/image_picker/example/ios/image_picker_exampleTests/PhotoAssetUtilTests.m
@@ -28,6 +28,11 @@
   XCTAssertNotNil(savedPathJPG);
   XCTAssertEqualObjects([savedPathJPG substringFromIndex:savedPathJPG.length - 4], @".jpg");
 
+  NSDictionary *originalMetaDataJPG = [ImagePickerMetaDataUtil getMetaDataFromImageData:dataJPG];
+  NSData *newDataJPG = [NSData dataWithContentsOfFile:savedPathJPG];
+  NSDictionary *newMetaDataJPG = [ImagePickerMetaDataUtil getMetaDataFromImageData:newDataJPG];
+  XCTAssertEqualObjects(originalMetaDataJPG[@"ProfileName"], newMetaDataJPG[@"ProfileName"]);
+
   // test png
   NSData *dataPNG = [NSData dataWithContentsOfFile:[self.testBundle pathForResource:@"pngImage"
                                                                              ofType:@"png"]];
@@ -36,6 +41,11 @@
                                                                                image:imagePNG];
   XCTAssertNotNil(savedPathPNG);
   XCTAssertEqualObjects([savedPathPNG substringFromIndex:savedPathPNG.length - 4], @".png");
+
+  NSDictionary *originalMetaDataPNG = [ImagePickerMetaDataUtil getMetaDataFromImageData:dataPNG];
+  NSData *newDataPNG = [NSData dataWithContentsOfFile:savedPathPNG];
+  NSDictionary *newMetaDataPNG = [ImagePickerMetaDataUtil getMetaDataFromImageData:newDataPNG];
+  XCTAssertEqualObjects(originalMetaDataPNG[@"ProfileName"], newMetaDataPNG[@"ProfileName"]);
 }
 
 - (void)testSaveImageWithPickerInfo_ShouldSaveWithDefaultExtention {
@@ -63,8 +73,10 @@
   NSString *savedPathJPG = [ImagePickerPhotoAssetUtil saveImageWithPickerInfo:dummyInfo
                                                                         image:imageJPG];
   NSData *data = [NSData dataWithContentsOfFile:savedPathJPG];
-  NSDictionary *exif = [ImagePickerMetaDataUtil getEXIFFromImageData:data];
-  XCTAssertEqualObjects(exif[(__bridge NSString *)kCGImagePropertyExifMakerNote], @"aNote");
+  NSDictionary *meta = [ImagePickerMetaDataUtil getMetaDataFromImageData:data];
+  XCTAssertEqualObjects(meta[(__bridge NSString *)kCGImagePropertyExifDictionary]
+                            [(__bridge NSString *)kCGImagePropertyExifMakerNote],
+                        @"aNote");
 }
 
 @end

--- a/packages/image_picker/example/lib/main.dart
+++ b/packages/image_picker/example/lib/main.dart
@@ -59,7 +59,8 @@ class _MyHomePageState extends State<MyHomePage> {
       });
     } else {
       try {
-        _imageFile = await ImagePicker.pickImage(source: source);
+        _imageFile =
+            await ImagePicker.pickImage(source: source, maxHeight: 200);
       } catch (e) {
         _pickImageError = e;
       }

--- a/packages/image_picker/example/lib/main.dart
+++ b/packages/image_picker/example/lib/main.dart
@@ -60,7 +60,7 @@ class _MyHomePageState extends State<MyHomePage> {
     } else {
       try {
         _imageFile =
-            await ImagePicker.pickImage(source: source, maxHeight: 200);
+            await ImagePicker.pickImage(source: source);
       } catch (e) {
         _pickImageError = e;
       }

--- a/packages/image_picker/ios/Classes/ImagePickerMetaDataUtil.h
+++ b/packages/image_picker/ios/Classes/ImagePickerMetaDataUtil.h
@@ -27,10 +27,6 @@ extern const FlutterImagePickerMIMEType kFlutterImagePickerMIMETypeDefault;
 
 + (NSData *)updateMetaData:(NSDictionary *)metaData toImage:(NSData *)imageData;
 
-+ (NSDictionary *)getEXIFFromImageData:(NSData *)imageData;
-
-+ (NSData *)updateEXIFData:(NSDictionary *)exifData toImage:(NSData *)imageData;
-
 + (UIImageOrientation)getNormalizedUIImageOrientationFromCGImagePropertyOrientation:
     (CGImagePropertyOrientation)cgImageOrientation;
 

--- a/packages/image_picker/ios/Classes/ImagePickerMetaDataUtil.h
+++ b/packages/image_picker/ios/Classes/ImagePickerMetaDataUtil.h
@@ -25,9 +25,14 @@ extern const FlutterImagePickerMIMEType kFlutterImagePickerMIMETypeDefault;
 
 + (NSDictionary *)getMetaDataFromImageData:(NSData *)imageData;
 
++ (NSData *)updateMetaData:(NSDictionary *)metaData toImage:(NSData *)imageData;
+
 + (NSDictionary *)getEXIFFromImageData:(NSData *)imageData;
 
 + (NSData *)updateEXIFData:(NSDictionary *)exifData toImage:(NSData *)imageData;
+
++ (UIImageOrientation)getNormalizedUIImageOrientationFromCGImagePropertyOrientation:
+    (CGImagePropertyOrientation)cgImageOrientation;
 
 // Converting UIImage to a NSData with the type proveide.
 //

--- a/packages/image_picker/ios/Classes/ImagePickerMetaDataUtil.m
+++ b/packages/image_picker/ios/Classes/ImagePickerMetaDataUtil.m
@@ -44,6 +44,18 @@ const FlutterImagePickerMIMEType kFlutterImagePickerMIMETypeDefault =
   return metadata;
 }
 
++ (NSData *)updateMetaData:(NSDictionary *)metaData toImage:(NSData *)imageData {
+  NSMutableData *mutableData = [NSMutableData data];
+  CGImageSourceRef cgImage = CGImageSourceCreateWithData((__bridge CFDataRef)imageData, NULL);
+  CGImageDestinationRef destination = CGImageDestinationCreateWithData(
+      (__bridge CFMutableDataRef)mutableData, CGImageSourceGetType(cgImage), 1, nil);
+  CGImageDestinationAddImageFromSource(destination, cgImage, 0, (__bridge CFDictionaryRef)metaData);
+  CGImageDestinationFinalize(destination);
+  CFRelease(cgImage);
+  CFRelease(destination);
+  return mutableData;
+}
+
 + (NSDictionary *)getEXIFFromImageData:(NSData *)imageData {
   NSDictionary *metaData = [self getMetaDataFromImageData:imageData];
   return metaData[(__bridge NSString *)kCGImagePropertyExifDictionary];
@@ -88,6 +100,31 @@ const FlutterImagePickerMIMEType kFlutterImagePickerMIMETypeDefault =
       return UIImageJPEGRepresentation(image, qualityFloat);
     }
   }
+}
+
++ (UIImageOrientation)getNormalizedUIImageOrientationFromCGImagePropertyOrientation:
+    (CGImagePropertyOrientation)cgImageOrientation {
+  switch (cgImageOrientation) {
+    case kCGImagePropertyOrientationUp:
+      return UIImageOrientationUp;
+    case kCGImagePropertyOrientationDown:
+      return UIImageOrientationDown;
+    case kCGImagePropertyOrientationLeft:
+      return UIImageOrientationRight;
+    case kCGImagePropertyOrientationRight:
+      return UIImageOrientationLeft;
+    case kCGImagePropertyOrientationUpMirrored:
+      return UIImageOrientationUpMirrored;
+    case kCGImagePropertyOrientationDownMirrored:
+      return UIImageOrientationDownMirrored;
+    case kCGImagePropertyOrientationLeftMirrored:
+      return UIImageOrientationRightMirrored;
+    case kCGImagePropertyOrientationRightMirrored:
+      return UIImageOrientationLeftMirrored;
+    default:
+      return UIImageOrientationUp;
+  }
+  return UIImageOrientationUp;
 }
 
 @end

--- a/packages/image_picker/ios/Classes/ImagePickerMetaDataUtil.m
+++ b/packages/image_picker/ios/Classes/ImagePickerMetaDataUtil.m
@@ -56,25 +56,6 @@ const FlutterImagePickerMIMEType kFlutterImagePickerMIMETypeDefault =
   return mutableData;
 }
 
-+ (NSDictionary *)getEXIFFromImageData:(NSData *)imageData {
-  NSDictionary *metaData = [self getMetaDataFromImageData:imageData];
-  return metaData[(__bridge NSString *)kCGImagePropertyExifDictionary];
-}
-
-+ (NSData *)updateEXIFData:(NSDictionary *)exifData toImage:(NSData *)imageData {
-  NSMutableData *mutableData = [NSMutableData data];
-  CGImageSourceRef cgImage = CGImageSourceCreateWithData((__bridge CFDataRef)imageData, NULL);
-  CGImageDestinationRef destination = CGImageDestinationCreateWithData(
-      (__bridge CFMutableDataRef)mutableData, CGImageSourceGetType(cgImage), 1, nil);
-  CGImageDestinationAddImageFromSource(
-      destination, cgImage, 0,
-      (__bridge CFDictionaryRef) @{(__bridge NSString *)kCGImagePropertyExifDictionary : exifData});
-  CGImageDestinationFinalize(destination);
-  CFRelease(cgImage);
-  CFRelease(destination);
-  return mutableData;
-}
-
 + (NSData *)convertImage:(UIImage *)image
                usingType:(FlutterImagePickerMIMEType)type
                  quality:(nullable NSNumber *)quality {

--- a/packages/image_picker/ios/Classes/ImagePickerPhotoAssetUtil.h
+++ b/packages/image_picker/ios/Classes/ImagePickerPhotoAssetUtil.h
@@ -14,10 +14,10 @@ typedef void (^FetchAssetsCompletion)(PHAuthorizationStatus status,
 
 + (PHAsset *)getAssetFromImagePickerInfo:(NSDictionary *)info;
 
-// Save image with correct exif data and extention copied from the original asset.
+// Save image with correct meta data and extention copied from the original asset.
 + (NSString *)saveImageWithOriginalImageData:(NSData *)originalImageData image:(UIImage *)image;
 
-// Save image with correct exif data and extention copied from image picker result info.
+// Save image with correct meta data and extention copied from image picker result info.
 + (NSString *)saveImageWithPickerInfo:(nullable NSDictionary *)info image:(UIImage *)image;
 
 @end

--- a/packages/image_picker/ios/Classes/ImagePickerPhotoAssetUtil.m
+++ b/packages/image_picker/ios/Classes/ImagePickerPhotoAssetUtil.m
@@ -20,33 +20,41 @@
 + (NSString *)saveImageWithOriginalImageData:(NSData *)originalImageData image:(UIImage *)image {
   NSString *suffix = kFlutterImagePickerDefaultSuffix;
   FlutterImagePickerMIMEType type = kFlutterImagePickerMIMETypeDefault;
-  NSDictionary *exifData = nil;
+  NSDictionary *metaData = nil;
   // Getting the image type from the original image data if necessary.
   if (originalImageData) {
     type = [ImagePickerMetaDataUtil getImageMIMETypeFromImageData:originalImageData];
     suffix =
         [ImagePickerMetaDataUtil imageTypeSuffixFromType:type] ?: kFlutterImagePickerDefaultSuffix;
-    exifData = [ImagePickerMetaDataUtil getEXIFFromImageData:originalImageData];
+    metaData = [ImagePickerMetaDataUtil getMetaDataFromImageData:originalImageData];
   }
-  return [self saveImageWithExif:exifData image:image suffix:suffix type:type];
+  return [self saveImageWithMetaData:metaData image:image suffix:suffix type:type];
 }
 
 + (NSString *)saveImageWithPickerInfo:(nullable NSDictionary *)info image:(UIImage *)image {
-  NSDictionary *exif = info[UIImagePickerControllerMediaMetadata]
-                           [(__bridge NSString *)kCGImagePropertyExifDictionary];
-  return [self saveImageWithExif:exif
-                           image:image
-                          suffix:kFlutterImagePickerDefaultSuffix
-                            type:kFlutterImagePickerMIMETypeDefault];
+  NSDictionary *metaData = info[UIImagePickerControllerMediaMetadata];
+  return [self saveImageWithMetaData:metaData
+                               image:image
+                              suffix:kFlutterImagePickerDefaultSuffix
+                                type:kFlutterImagePickerMIMETypeDefault];
 }
 
-+ (NSString *)saveImageWithExif:(NSDictionary *)exif
-                          image:(UIImage *)image
-                         suffix:(NSString *)suffix
-                           type:(FlutterImagePickerMIMEType)type {
-  NSData *data = [ImagePickerMetaDataUtil convertImage:image usingType:type quality:nil];
-  if (exif) {
-    data = [ImagePickerMetaDataUtil updateEXIFData:exif toImage:data];
++ (NSString *)saveImageWithMetaData:(NSDictionary *)metaData
+                              image:(UIImage *)image
+                             suffix:(NSString *)suffix
+                               type:(FlutterImagePickerMIMEType)type {
+  CGImagePropertyOrientation orientation = (CGImagePropertyOrientation)[metaData[(
+      __bridge NSString *)kCGImagePropertyOrientation] integerValue];
+  UIImage *newImage = [UIImage
+      imageWithCGImage:[image CGImage]
+                 scale:1.0
+           orientation:
+               [ImagePickerMetaDataUtil
+                   getNormalizedUIImageOrientationFromCGImagePropertyOrientation:orientation]];
+
+  NSData *data = [ImagePickerMetaDataUtil convertImage:newImage usingType:type quality:nil];
+  if (metaData) {
+    data = [ImagePickerMetaDataUtil updateMetaData:metaData toImage:data];
   }
 
   NSString *fileExtension = [@"image_picker_%@" stringByAppendingString:suffix];

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -5,7 +5,7 @@ authors:
   - Flutter Team <flutter-dev@googlegroups.com>
   - Rhodes Davis Jr. <rody.davis.jr@gmail.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.6.0+4
+version: 0.6.0+5
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Follow up https://github.com/flutter/plugins/pull/1586. Copying over all the metadata, including GPS, orientation and more.

Note that because orientation is copied, we have to revert the orientation that iOS has done on the picked image to make the image show up in a correct way on the phone.

## Related Issues

flutter/flutter#31751

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
