### PR TITLE
Allow changing the webview's platform specific implementation

### DIFF
--- a/packages/webview_flutter/lib/platform_interface.dart
+++ b/packages/webview_flutter/lib/platform_interface.dart
@@ -29,7 +29,8 @@ abstract class WebViewPlatform {
   int get id;
 }
 
-typedef WebViewCreatedCallback = void Function(WebViewPlatform webViewPlatform);
+typedef WebViewPlatformCreatedCallback = void Function(
+    WebViewPlatform webViewPlatform);
 
 /// Interface for a platform specific webview implementation.
 ///
@@ -40,7 +41,7 @@ abstract class WebViewBuilder {
   Widget build({
     BuildContext context,
     Map<String, dynamic> creationParams,
-    WebViewCreatedCallback onWebViewCreated,
+    WebViewPlatformCreatedCallback onWebViewPlatformCreated,
     Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers,
   });
 }

--- a/packages/webview_flutter/lib/platform_interface.dart
+++ b/packages/webview_flutter/lib/platform_interface.dart
@@ -8,11 +8,19 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 
-/// Interface for talking to the webview controller on the platform side.
+/// Interface for talking to the webview's platform implementation.
 ///
-/// An instance implementing this interface is passed to the `onWebViewCreated` callback that is
-/// passed to [WebViewPlatformInterface#onWebViewCreated].
+/// An instance implementing this interface is passed to the `onWebViewPlatformCreated` callback that is
+/// passed to [WebViewPlatformBuilder#onWebViewPlatformCreated].
 abstract class WebViewPlatform {
+  /// Loads the specified URL.
+  ///
+  /// If `headers` is not null and the URL is an HTTP URL, the key value paris in `headers` will
+  /// be added as key value pairs of HTTP headers for the request.
+  ///
+  /// `url` must not be null.
+  ///
+  /// Throws an ArgumentError if `url` is not a valid URL string.
   Future<void> loadUrl(
     String url,
     Map<String, String> headers,
@@ -32,14 +40,33 @@ abstract class WebViewPlatform {
 typedef WebViewPlatformCreatedCallback = void Function(
     WebViewPlatform webViewPlatform);
 
-/// Interface for a platform specific webview implementation.
+/// Interface building a platform WebView implementation.
 ///
-/// [WebView#iplatformBuilder] controls the platform interface that is used by [WebView].
-/// [WebViewAndroidImplementation] and [WebViewIosImplementation] are the default implementations
+/// [WebView#platformBuilder] controls the builder that is used by [WebView].
+/// [AndroidWebViewPlatform] and [CupertinoWebViewPlatform] are the default implementations
 /// for Android and iOS respectively.
 abstract class WebViewBuilder {
+  /// Builds a new WebView.
+  ///
+  /// Returns a Widget tree that embeds the created webview.
+  ///
+  /// `creationParams` are the initial parameters used to setup the webview.
+  ///
+  /// `onWebViewPlatformCreated` will be invoked after the platform specific [WebViewPlatform]
+  /// implementation is created with the [WebViewPlatform] instance as a parameter.
+  ///
+  /// `gestureRecognizers` specifies which gestures should be consumed by the web view.
+  /// It is possible for other gesture recognizers to be competing with the web view on pointer
+  /// events, e.g if the web view is inside a [ListView] the [ListView] will want to handle
+  /// vertical drags. The web view will claim gestures that are recognized by any of the
+  /// recognizers on this list.
+  /// When `gestureRecognizers` is empty or null, the web view will only handle pointer events for gestures that
+  /// were not claimed by any other gesture recognizer.
   Widget build({
     BuildContext context,
+    // TODO(amirh): convert this to be the actual parameters.
+    // I'm starting without it as the PR is starting to become pretty big.
+    // I'll followup with the conversion PR.
     Map<String, dynamic> creationParams,
     WebViewPlatformCreatedCallback onWebViewPlatformCreated,
     Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers,

--- a/packages/webview_flutter/lib/platform_interface.dart
+++ b/packages/webview_flutter/lib/platform_interface.dart
@@ -1,0 +1,44 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/widgets.dart';
+
+/// Interface for talking to the webview controller on the platform side.
+/// 
+/// An instance implementing this interface is passed to the `onWebViewCreated` callback that is
+/// passed to [WebViewPlatformInterface#onWebViewCreated].
+abstract class WebViewPlatformControllerInterface {
+  Future<void> loadUrl(
+      String url,
+      Map<String, String> headers,
+      );
+
+  // As the PR currently focus about the wiring I've only moved loadUrl to the new way, so
+  // the discussion is more focused.
+  // In this temporary state WebViewController still uses a method channel directly for all other
+  // method calls so we need to expose the webview ID.
+  // TODO(amirh): remove this before submitting this PR(after getting an LGTM for the overall approach).
+  int get id;
+}
+
+typedef WebViewCreatedCallback = void Function(WebViewPlatformControllerInterface);
+
+/// Interface for a platform specific webview implementation.
+///
+/// [WebView#implementation] controls the platform interface that is used by [WebView].
+/// [WebViewAndroidImplementation] and [WebViewIosImplementation] are the default implementations
+/// for Android and iOS respectively.
+abstract class WebViewPlatformInterface {
+  Widget build({
+    BuildContext context,
+    Map<String, dynamic> creationParams,
+    WebViewCreatedCallback onWebViewCreated,
+    Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers,
+  });
+}
+

--- a/packages/webview_flutter/lib/platform_interface.dart
+++ b/packages/webview_flutter/lib/platform_interface.dart
@@ -25,7 +25,7 @@ abstract class WebViewPlatform {
   // the discussion is more focused.
   // In this temporary state WebViewController still uses a method channel directly for all other
   // method calls so we need to expose the webview ID.
-  // TODO(amirh): remove this before submitting this PR(after getting an LGTM for the overall approach).
+  // TODO(amirh): remove this before publishing this package.
   int get id;
 }
 

--- a/packages/webview_flutter/lib/platform_interface.dart
+++ b/packages/webview_flutter/lib/platform_interface.dart
@@ -9,14 +9,17 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 
 /// Interface for talking to the webview controller on the platform side.
-/// 
+///
 /// An instance implementing this interface is passed to the `onWebViewCreated` callback that is
 /// passed to [WebViewPlatformInterface#onWebViewCreated].
-abstract class WebViewPlatformControllerInterface {
+abstract class WebViewPlatform {
   Future<void> loadUrl(
-      String url,
-      Map<String, String> headers,
-      );
+    String url,
+    Map<String, String> headers,
+  ) {
+    throw UnimplementedError(
+        "WebView loadUrl is not implemented on the current platform");
+  }
 
   // As the PR currently focus about the wiring I've only moved loadUrl to the new way, so
   // the discussion is more focused.
@@ -26,14 +29,14 @@ abstract class WebViewPlatformControllerInterface {
   int get id;
 }
 
-typedef WebViewCreatedCallback = void Function(WebViewPlatformControllerInterface);
+typedef WebViewCreatedCallback = void Function(WebViewPlatform webViewPlatform);
 
 /// Interface for a platform specific webview implementation.
 ///
-/// [WebView#implementation] controls the platform interface that is used by [WebView].
+/// [WebView#iplatformBuilder] controls the platform interface that is used by [WebView].
 /// [WebViewAndroidImplementation] and [WebViewIosImplementation] are the default implementations
 /// for Android and iOS respectively.
-abstract class WebViewPlatformInterface {
+abstract class WebViewBuilder {
   Widget build({
     BuildContext context,
     Map<String, dynamic> creationParams,
@@ -41,4 +44,3 @@ abstract class WebViewPlatformInterface {
     Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers,
   });
 }
-

--- a/packages/webview_flutter/lib/src/webview_android.dart
+++ b/packages/webview_flutter/lib/src/webview_android.dart
@@ -10,9 +10,13 @@ import 'package:flutter/widgets.dart';
 import '../platform_interface.dart';
 import 'webview_method_channel.dart';
 
-class WebViewAndroidImplementation implements WebViewPlatformInterface {
+class AndroidWebViewBuilder implements WebViewBuilder {
   @override
-  Widget build({BuildContext context, Map<String, dynamic> creationParams, WebViewCreatedCallback onWebViewCreated, Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers}) {
+  Widget build(
+      {BuildContext context,
+      Map<String, dynamic> creationParams,
+      WebViewCreatedCallback onWebViewCreated,
+      Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers}) {
     return GestureDetector(
       // We prevent text selection by intercepting the long press event.
       // This is a temporary stop gap due to issues with text selection on Android:
@@ -26,7 +30,10 @@ class WebViewAndroidImplementation implements WebViewPlatformInterface {
       child: AndroidView(
         viewType: 'plugins.flutter.io/webview',
         onPlatformViewCreated: (int id) {
-          onWebViewCreated(WebViewMethodChannelController(id));
+          if (onWebViewCreated == null) {
+            return;
+          }
+          onWebViewCreated(MethodChannelWebViewPlatform(id));
         },
         gestureRecognizers: gestureRecognizers,
         // WebView content is not affected by the Android view's layout direction,

--- a/packages/webview_flutter/lib/src/webview_android.dart
+++ b/packages/webview_flutter/lib/src/webview_android.dart
@@ -10,13 +10,19 @@ import 'package:flutter/widgets.dart';
 import '../platform_interface.dart';
 import 'webview_method_channel.dart';
 
+/// Builds an Android webview.
+///
+/// This is used as the default implementation for [WebView.platformBuilder] on Android. It uses
+/// an [AndroidView] to embed the webview in the widget hierarchy, and uses a method channel to
+/// communicate with the platform code.
 class AndroidWebViewBuilder implements WebViewBuilder {
   @override
-  Widget build(
-      {BuildContext context,
-      Map<String, dynamic> creationParams,
-      WebViewPlatformCreatedCallback onWebViewPlatformCreated,
-      Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers}) {
+  Widget build({
+    BuildContext context,
+    Map<String, dynamic> creationParams,
+    WebViewPlatformCreatedCallback onWebViewPlatformCreated,
+    Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers,
+  }) {
     return GestureDetector(
       // We prevent text selection by intercepting the long press event.
       // This is a temporary stop gap due to issues with text selection on Android:

--- a/packages/webview_flutter/lib/src/webview_android.dart
+++ b/packages/webview_flutter/lib/src/webview_android.dart
@@ -1,0 +1,41 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+
+import '../platform_interface.dart';
+import 'webview_method_channel.dart';
+
+class WebViewAndroidImplementation implements WebViewPlatformInterface {
+  @override
+  Widget build({BuildContext context, Map<String, dynamic> creationParams, WebViewCreatedCallback onWebViewCreated, Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers}) {
+    return GestureDetector(
+      // We prevent text selection by intercepting the long press event.
+      // This is a temporary stop gap due to issues with text selection on Android:
+      // https://github.com/flutter/flutter/issues/24585 - the text selection
+      // dialog is not responding to touch events.
+      // https://github.com/flutter/flutter/issues/24584 - the text selection
+      // handles are not showing.
+      // TODO(amirh): remove this when the issues above are fixed.
+      onLongPress: () {},
+      excludeFromSemantics: true,
+      child: AndroidView(
+        viewType: 'plugins.flutter.io/webview',
+        onPlatformViewCreated: (int id) {
+          onWebViewCreated(WebViewMethodChannelController(id));
+        },
+        gestureRecognizers: gestureRecognizers,
+        // WebView content is not affected by the Android view's layout direction,
+        // we explicitly set it here so that the widget doesn't require an ambient
+        // directionality.
+        layoutDirection: TextDirection.rtl,
+        creationParams: creationParams,
+        creationParamsCodec: const StandardMessageCodec(),
+      ),
+    );
+  }
+}

--- a/packages/webview_flutter/lib/src/webview_android.dart
+++ b/packages/webview_flutter/lib/src/webview_android.dart
@@ -15,7 +15,7 @@ class AndroidWebViewBuilder implements WebViewBuilder {
   Widget build(
       {BuildContext context,
       Map<String, dynamic> creationParams,
-      WebViewCreatedCallback onWebViewCreated,
+      WebViewPlatformCreatedCallback onWebViewPlatformCreated,
       Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers}) {
     return GestureDetector(
       // We prevent text selection by intercepting the long press event.
@@ -30,10 +30,10 @@ class AndroidWebViewBuilder implements WebViewBuilder {
       child: AndroidView(
         viewType: 'plugins.flutter.io/webview',
         onPlatformViewCreated: (int id) {
-          if (onWebViewCreated == null) {
+          if (onWebViewPlatformCreated == null) {
             return;
           }
-          onWebViewCreated(MethodChannelWebViewPlatform(id));
+          onWebViewPlatformCreated(MethodChannelWebViewPlatform(id));
         },
         gestureRecognizers: gestureRecognizers,
         // WebView content is not affected by the Android view's layout direction,

--- a/packages/webview_flutter/lib/src/webview_cupertino.dart
+++ b/packages/webview_flutter/lib/src/webview_cupertino.dart
@@ -15,15 +15,15 @@ class CupertinoWebViewBuilder implements WebViewBuilder {
   Widget build(
       {BuildContext context,
       Map<String, dynamic> creationParams,
-      WebViewCreatedCallback onWebViewCreated,
+      WebViewPlatformCreatedCallback onWebViewPlatformCreated,
       Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers}) {
     return UiKitView(
       viewType: 'plugins.flutter.io/webview',
       onPlatformViewCreated: (int id) {
-        if (onWebViewCreated == null) {
+        if (onWebViewPlatformCreated == null) {
           return;
         }
-        onWebViewCreated(MethodChannelWebViewPlatform(id));
+        onWebViewPlatformCreated(MethodChannelWebViewPlatform(id));
       },
       gestureRecognizers: gestureRecognizers,
       creationParams: creationParams,

--- a/packages/webview_flutter/lib/src/webview_cupertino.dart
+++ b/packages/webview_flutter/lib/src/webview_cupertino.dart
@@ -10,13 +10,19 @@ import 'package:flutter/widgets.dart';
 import '../platform_interface.dart';
 import 'webview_method_channel.dart';
 
+/// Builds an iOS webview.
+///
+/// This is used as the default implementation for [WebView.platformBuilder] on iOS. It uses
+/// a [UiKitView] to embed the webview in the widget hierarchy, and uses a method channel to
+/// communicate with the platform code.
 class CupertinoWebViewBuilder implements WebViewBuilder {
   @override
-  Widget build(
-      {BuildContext context,
-      Map<String, dynamic> creationParams,
-      WebViewPlatformCreatedCallback onWebViewPlatformCreated,
-      Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers}) {
+  Widget build({
+    BuildContext context,
+    Map<String, dynamic> creationParams,
+    WebViewPlatformCreatedCallback onWebViewPlatformCreated,
+    Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers,
+  }) {
     return UiKitView(
       viewType: 'plugins.flutter.io/webview',
       onPlatformViewCreated: (int id) {

--- a/packages/webview_flutter/lib/src/webview_cupertino.dart
+++ b/packages/webview_flutter/lib/src/webview_cupertino.dart
@@ -10,13 +10,20 @@ import 'package:flutter/widgets.dart';
 import '../platform_interface.dart';
 import 'webview_method_channel.dart';
 
-class WebViewIosImplementation implements WebViewPlatformInterface {
+class CupertinoWebViewBuilder implements WebViewBuilder {
   @override
-  Widget build({BuildContext context, Map<String, dynamic> creationParams, WebViewCreatedCallback onWebViewCreated, Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers}) {
+  Widget build(
+      {BuildContext context,
+      Map<String, dynamic> creationParams,
+      WebViewCreatedCallback onWebViewCreated,
+      Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers}) {
     return UiKitView(
       viewType: 'plugins.flutter.io/webview',
       onPlatformViewCreated: (int id) {
-        onWebViewCreated(WebViewMethodChannelController(id));
+        if (onWebViewCreated == null) {
+          return;
+        }
+        onWebViewCreated(MethodChannelWebViewPlatform(id));
       },
       gestureRecognizers: gestureRecognizers,
       creationParams: creationParams,

--- a/packages/webview_flutter/lib/src/webview_ios.dart
+++ b/packages/webview_flutter/lib/src/webview_ios.dart
@@ -1,0 +1,26 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+
+import '../platform_interface.dart';
+import 'webview_method_channel.dart';
+
+class WebViewIosImplementation implements WebViewPlatformInterface {
+  @override
+  Widget build({BuildContext context, Map<String, dynamic> creationParams, WebViewCreatedCallback onWebViewCreated, Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers}) {
+    return UiKitView(
+      viewType: 'plugins.flutter.io/webview',
+      onPlatformViewCreated: (int id) {
+        onWebViewCreated(WebViewMethodChannelController(id));
+      },
+      gestureRecognizers: gestureRecognizers,
+      creationParams: creationParams,
+      creationParamsCodec: const StandardMessageCodec(),
+    );
+  }
+}

--- a/packages/webview_flutter/lib/src/webview_method_channel.dart
+++ b/packages/webview_flutter/lib/src/webview_method_channel.dart
@@ -1,13 +1,17 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'dart:async';
 
 import 'package:flutter/services.dart';
 
 import '../platform_interface.dart';
 
-/// A [WebViewPlatformControllerInterface] that uses a method channel to control the webview.
-class WebViewMethodChannelController implements WebViewPlatformControllerInterface {
-
-  WebViewMethodChannelController(this._id) : _channel = MethodChannel('plugins.flutter.io/webview_$_id');
+/// A [WebViewPlatform] that uses a method channel to control the webview.
+class MethodChannelWebViewPlatform implements WebViewPlatform {
+  MethodChannelWebViewPlatform(this._id)
+      : _channel = MethodChannel('plugins.flutter.io/webview_$_id');
 
   final int _id;
 
@@ -15,9 +19,9 @@ class WebViewMethodChannelController implements WebViewPlatformControllerInterfa
 
   @override
   Future<void> loadUrl(
-      String url,
-      Map<String, String> headers,
-      ) async {
+    String url,
+    Map<String, String> headers,
+  ) async {
     assert(url != null);
     // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
     // https://github.com/flutter/flutter/issues/26431

--- a/packages/webview_flutter/lib/src/webview_method_channel.dart
+++ b/packages/webview_flutter/lib/src/webview_method_channel.dart
@@ -1,0 +1,33 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+
+import '../platform_interface.dart';
+
+/// A [WebViewPlatformControllerInterface] that uses a method channel to control the webview.
+class WebViewMethodChannelController implements WebViewPlatformControllerInterface {
+
+  WebViewMethodChannelController(this._id) : _channel = MethodChannel('plugins.flutter.io/webview_$_id');
+
+  final int _id;
+
+  final MethodChannel _channel;
+
+  @override
+  Future<void> loadUrl(
+      String url,
+      Map<String, String> headers,
+      ) async {
+    assert(url != null);
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
+    return _channel.invokeMethod('loadUrl', <String, dynamic>{
+      'url': url,
+      'headers': headers,
+    });
+  }
+
+  @override
+  int get id => _id;
+}

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -9,6 +9,10 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
+import 'platform_interface.dart';
+import 'src/webview_android.dart';
+import 'src/webview_ios.dart';
+
 typedef void WebViewCreatedCallback(WebViewController controller);
 
 enum JavascriptMode {
@@ -121,6 +125,28 @@ class WebView extends StatefulWidget {
   })  : assert(javascriptMode != null),
         super(key: key);
 
+  static WebViewPlatformInterface _implementation;
+
+  static set implementation(WebViewPlatformInterface implementation) {
+    _implementation = implementation;
+  }
+
+  static WebViewPlatformInterface get implementation {
+    if (_implementation != null) {
+      return implementation;
+    }
+
+    if (defaultTargetPlatform == TargetPlatform.android) {
+      return WebViewAndroidImplementation();
+    }
+
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      return WebViewIosImplementation();
+    }
+
+    throw UnsupportedError("Trying to use the default webview implementation for $defaultTargetPlatform but there isn't a default one");
+  }
+
   /// If not null invoked once the web view is created.
   final WebViewCreatedCallback onWebViewCreated;
 
@@ -229,40 +255,12 @@ class _WebViewState extends State<WebView> {
 
   @override
   Widget build(BuildContext context) {
-    if (defaultTargetPlatform == TargetPlatform.android) {
-      return GestureDetector(
-        // We prevent text selection by intercepting the long press event.
-        // This is a temporary stop gap due to issues with text selection on Android:
-        // https://github.com/flutter/flutter/issues/24585 - the text selection
-        // dialog is not responding to touch events.
-        // https://github.com/flutter/flutter/issues/24584 - the text selection
-        // handles are not showing.
-        // TODO(amirh): remove this when the issues above are fixed.
-        onLongPress: () {},
-        excludeFromSemantics: true,
-        child: AndroidView(
-          viewType: 'plugins.flutter.io/webview',
-          onPlatformViewCreated: _onPlatformViewCreated,
-          gestureRecognizers: widget.gestureRecognizers,
-          // WebView content is not affected by the Android view's layout direction,
-          // we explicitly set it here so that the widget doesn't require an ambient
-          // directionality.
-          layoutDirection: TextDirection.rtl,
-          creationParams: _CreationParams.fromWidget(widget).toMap(),
-          creationParamsCodec: const StandardMessageCodec(),
-        ),
-      );
-    } else if (defaultTargetPlatform == TargetPlatform.iOS) {
-      return UiKitView(
-        viewType: 'plugins.flutter.io/webview',
-        onPlatformViewCreated: _onPlatformViewCreated,
-        gestureRecognizers: widget.gestureRecognizers,
-        creationParams: _CreationParams.fromWidget(widget).toMap(),
-        creationParamsCodec: const StandardMessageCodec(),
-      );
-    }
-    return Text(
-        '$defaultTargetPlatform is not yet supported by the webview_flutter plugin');
+    return WebView.implementation.build(
+      context: context,
+      creationParams: _CreationParams.fromWidget(widget).toMap(),
+      onWebViewCreated: _onWebViewControllerCreated,
+      gestureRecognizers: widget.gestureRecognizers,
+    );
   }
 
   @override
@@ -279,8 +277,9 @@ class _WebViewState extends State<WebView> {
         (WebViewController controller) => controller._updateWidget(widget));
   }
 
-  void _onPlatformViewCreated(int id) {
-    final WebViewController controller = WebViewController._(id, widget);
+  void _onWebViewControllerCreated(WebViewPlatformControllerInterface platformController) {
+    final WebViewController controller =
+      WebViewController._(platformController.id, platformController, widget);
     _controller.complete(controller);
     if (widget.onWebViewCreated != null) {
       widget.onWebViewCreated(controller);
@@ -385,6 +384,7 @@ class _WebSettings {
 class WebViewController {
   WebViewController._(
     int id,
+    this._platformInterface,
     this._widget,
   ) : _channel = MethodChannel('plugins.flutter.io/webview_$id') {
     _settings = _WebSettings.fromWidget(_widget);
@@ -393,6 +393,8 @@ class WebViewController {
   }
 
   final MethodChannel _channel;
+
+  final WebViewPlatformControllerInterface _platformInterface;
 
   _WebSettings _settings;
 
@@ -443,13 +445,7 @@ class WebViewController {
   }) async {
     assert(url != null);
     _validateUrlString(url);
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return _channel.invokeMethod('loadUrl', <String, dynamic>{
-      'url': url,
-      'headers': headers,
-    });
+    return _platformInterface.loadUrl(url, headers);
   }
 
   /// Accessor to the current URL that the WebView is displaying.

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -127,10 +127,20 @@ class WebView extends StatefulWidget {
 
   static WebViewBuilder _platformBuilder;
 
+  /// Sets a custom [WebViewBuilder].
+  ///
+  /// This property can be set to use a custom platform implementation for WebViews.
+  ///
+  /// Setting `platformBuilder` doesn't affect [WebView]s that were already created.
+  ///
+  /// The default value is [AndroidWebViewBuilder] on Android and [CupertinoWebViewBuilder] on iOs.
   static set platformBuilder(WebViewBuilder platformBuilder) {
     _platformBuilder = platformBuilder;
   }
 
+  /// The [WebViewBuilder] that's used to create new [WebView]s.
+  ///
+  /// The default value is [AndroidWebViewBuilder] on Android and [CupertinoWebViewBuilder] on iOs.
   static WebViewBuilder get platformBuilder {
     if (_platformBuilder == null) {
       switch (defaultTargetPlatform) {
@@ -436,6 +446,9 @@ class WebViewController {
   }
 
   /// Loads the specified URL.
+  ///
+  /// If `headers` is not null and the URL is an HTTP URL, the key value paris in `headers` will
+  /// be added as key value pairs of HTTP headers for the request.
   ///
   /// `url` must not be null.
   ///

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -259,7 +259,7 @@ class _WebViewState extends State<WebView> {
     return WebView.platformBuilder.build(
       context: context,
       creationParams: _CreationParams.fromWidget(widget).toMap(),
-      onWebViewCreated: _onWebViewControllerCreated,
+      onWebViewPlatformCreated: _onWebViewPlatformCreated,
       gestureRecognizers: widget.gestureRecognizers,
     );
   }
@@ -278,7 +278,7 @@ class _WebViewState extends State<WebView> {
         (WebViewController controller) => controller._updateWidget(widget));
   }
 
-  void _onWebViewControllerCreated(WebViewPlatform platformController) {
+  void _onWebViewPlatformCreated(WebViewPlatform platformController) {
     final WebViewController controller =
         WebViewController._(platformController.id, platformController, widget);
     _controller.complete(controller);

--- a/packages/webview_flutter/test/webview_flutter_test.dart
+++ b/packages/webview_flutter/test/webview_flutter_test.dart
@@ -1025,11 +1025,12 @@ class MyWebViewBuilder implements WebViewBuilder {
   MyWebViewPlatform lastPlatformBuilt;
 
   @override
-  Widget build(
-      {BuildContext context,
-      Map<String, dynamic> creationParams,
-      @required WebViewPlatformCreatedCallback onWebViewPlatformCreated,
-      Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers}) {
+  Widget build({
+    BuildContext context,
+    Map<String, dynamic> creationParams,
+    @required WebViewPlatformCreatedCallback onWebViewPlatformCreated,
+    Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers,
+  }) {
     assert(onWebViewPlatformCreated != null);
     lastPlatformBuilt = MyWebViewPlatform(creationParams, gestureRecognizers);
     onWebViewPlatformCreated(lastPlatformBuilt);

--- a/packages/webview_flutter/test/webview_flutter_test.dart
+++ b/packages/webview_flutter/test/webview_flutter_test.dart
@@ -6,8 +6,11 @@ import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:flutter/services.dart';
+import 'package:flutter/src/foundation/basic_types.dart';
+import 'package:flutter/src/gestures/recognizer.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:webview_flutter/platform_interface.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
 typedef void VoidCallback();
@@ -747,6 +750,60 @@ void main() {
       expect(platformWebView.debuggingEnabled, false);
     });
   });
+
+  group('Custom platform implementation', () {
+    setUpAll(() {
+      WebView.platformBuilder = MyWebViewBuilder();
+    });
+    tearDownAll(() {
+      WebView.platformBuilder = null;
+    });
+
+    testWidgets('creation', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const WebView(
+          initialUrl: 'https://youtube.com',
+        ),
+      );
+
+      final MyWebViewBuilder builder = WebView.platformBuilder;
+      final MyWebViewPlatform platform = builder.lastPlatformBuilt;
+
+      expect(platform.creationParams, <String, dynamic>{
+        'initialUrl': 'https://youtube.com',
+        'settings': <String, dynamic>{
+          'jsMode': 0,
+          'hasNavigationDelegate': false,
+          'debuggingEnabled': false
+        },
+        'javascriptChannelNames': <String>[],
+      });
+    });
+
+    testWidgets('loadUrl', (WidgetTester tester) async {
+      WebViewController controller;
+      await tester.pumpWidget(
+        WebView(
+          initialUrl: 'https://youtube.com',
+          onWebViewCreated: (WebViewController webViewController) {
+            controller = webViewController;
+          },
+        ),
+      );
+
+      final MyWebViewBuilder builder = WebView.platformBuilder;
+      final MyWebViewPlatform platform = builder.lastPlatformBuilt;
+
+      final Map<String, String> headers = <String, String>{
+        'header': 'value',
+      };
+
+      await controller.loadUrl('https://google.com', headers: headers);
+
+      expect(platform.lastUrlLoaded, 'https://google.com');
+      expect(platform.lastRequestHeaders, headers);
+    });
+  });
 }
 
 class FakePlatformWebView {
@@ -962,4 +1019,41 @@ class _FakeCookieManager {
   void reset() {
     hasCookies = true;
   }
+}
+
+class MyWebViewBuilder implements WebViewBuilder {
+  MyWebViewPlatform lastPlatformBuilt;
+
+  @override
+  Widget build(
+      {BuildContext context,
+      Map<String, dynamic> creationParams,
+      @required WebViewPlatformCreatedCallback onWebViewPlatformCreated,
+      Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers}) {
+    assert(onWebViewPlatformCreated != null);
+    lastPlatformBuilt = MyWebViewPlatform(creationParams, gestureRecognizers);
+    onWebViewPlatformCreated(lastPlatformBuilt);
+    return Container();
+  }
+}
+
+class MyWebViewPlatform extends WebViewPlatform {
+  MyWebViewPlatform(this.creationParams, this.gestureRecognizers);
+
+  Map<String, dynamic> creationParams;
+  Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers;
+
+  String lastUrlLoaded;
+  Map<String, String> lastRequestHeaders;
+
+  @override
+  Future<void> loadUrl(String url, Map<String, String> headers) {
+    lastUrlLoaded = url;
+    lastRequestHeaders = headers;
+    return null;
+  }
+
+  @override
+  // TODO: implement id
+  int get id => 1;
 }


### PR DESCRIPTION
The goal of this PR is to allow separate packages to extend the plugin to work on more platforms.
This is done by abstracting all the platform specific logic behind the `WebViewPlatform` and `WebViewBuilder` interfaces(in `platform_interface.dart`), and adding a static `WebView.platformBuilder` field that can be set to change the the platform specific code.

For example, in order to extend the webview to support Fuchsia, a `fuchsia_webview_flutter` plugin can implement  `WebViewBuilder` and `WebViewPlatform`(reference implementations available in `webview_android.dart` and `webview_cupertino.dart`).

When running on Fuchsia the plugin(or the app developer if the plugin doesn't have the right hooks) can then set itself as the implementation for the webview by running:
```dart
WebView.platformBuilder = FuchsiaWebViewBuilder();
``` 