### PR TITLE
Add missing import for UIKit

### DIFF
--- a/packages/image_picker/ios/Classes/ImagePickerMetaDataUtil.h
+++ b/packages/image_picker/ios/Classes/ImagePickerMetaDataUtil.h
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
Simple change to add a missing import that is breaking google3 builds.