### PR TITLE
[webview_flutter] platform_interface: Use Dart objects for creationParams and webSettings.

### DIFF
--- a/packages/webview_flutter/lib/platform_interface.dart
+++ b/packages/webview_flutter/lib/platform_interface.dart
@@ -59,9 +59,10 @@ class WebSettings {
     this.debuggingEnabled,
   });
 
+  /// The JavaScript execution mode to be used by the webview.
   final JavascriptMode javascriptMode;
 
-  /// Whether a [NavigationDelegate] should be used for this webview.
+  /// Whether the [WebView] has a [NavigationDelegate] set.
   final bool hasNavigationDelegate;
 
   /// Whether to enable the platform's webview content debugging tools.
@@ -92,7 +93,7 @@ class CreationParams {
 
   /// The initial set of JavaScript channels that are configured for this webview.
   ///
-  /// For each value in this list the platform's webview should make sure that a corresponding
+  /// For each value in this set the platform's webview should make sure that a corresponding
   /// property with a postMessage method is set on `window`. For example for a JavaScript channel
   /// named `Foo` it should be possible for JavaScript code executing in the webview to do
   ///

--- a/packages/webview_flutter/lib/platform_interface.dart
+++ b/packages/webview_flutter/lib/platform_interface.dart
@@ -8,6 +8,8 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 
+import 'webview_flutter.dart';
+
 /// Interface for talking to the webview's platform implementation.
 ///
 /// An instance implementing this interface is passed to the `onWebViewPlatformCreated` callback that is
@@ -29,12 +31,82 @@ abstract class WebViewPlatform {
         "WebView loadUrl is not implemented on the current platform");
   }
 
+  /// Updates the webview settings.
+  ///
+  /// Any non null field in `settings` will be set as the new setting value.
+  /// All null fields in `settings` are ignored.
+  Future<void> updateSettings(WebSettings setting) {
+    throw UnimplementedError(
+        "WebView updateSettings is not implemented on the current platform");
+  }
+
   // As the PR currently focus about the wiring I've only moved loadUrl to the new way, so
   // the discussion is more focused.
   // In this temporary state WebViewController still uses a method channel directly for all other
   // method calls so we need to expose the webview ID.
   // TODO(amirh): remove this before publishing this package.
   int get id;
+}
+
+/// Settings for configuring a WebViewPlatform.
+///
+/// Initial settings are passed as part of [CreationParams], settings updates are sent with
+/// [WebViewPlatform#updateSettings].
+class WebSettings {
+  WebSettings({
+    this.javascriptMode,
+    this.hasNavigationDelegate,
+    this.debuggingEnabled,
+  });
+
+  final JavascriptMode javascriptMode;
+
+  /// Whether a [NavigationDelegate] should be used for this webview.
+  final bool hasNavigationDelegate;
+
+  /// Whether to enable the platform's webview content debugging tools.
+  ///
+  /// See also: [WebView.debuggingEnabled].
+  final bool debuggingEnabled;
+
+  @override
+  String toString() {
+    return 'WebSettings(javascriptMode: $javascriptMode, hasNavigationDelegate: $hasNavigationDelegate, debuggingEnabled: $debuggingEnabled)';
+  }
+}
+
+/// Configuration to use when creating a new [WebViewPlatform].
+class CreationParams {
+  CreationParams(
+      {this.initialUrl, this.webSettings, this.javascriptChannelNames});
+
+  /// The initialUrl to load in the webview.
+  ///
+  /// When null the webview will be created without loading any page.
+  final String initialUrl;
+
+  /// The initial [WebSettings] for the new webview.
+  ///
+  /// This can later be updated with [WebViewPlatform.updateSettings].
+  final WebSettings webSettings;
+
+  /// The initial set of JavaScript channels that are configured for this webview.
+  ///
+  /// For each value in this list the platform's webview should make sure that a corresponding
+  /// property with a postMessage method is set on `window`. For example for a JavaScript channel
+  /// named `Foo` it should be possible for JavaScript code executing in the webview to do
+  ///
+  /// ```javascript
+  /// Foo.postMessage('hello');
+  /// ```
+  // TODO(amirh): describe what should happen when postMessage is called once that code is migrated
+  // to PlatformWebView.
+  final Set<String> javascriptChannelNames;
+
+  @override
+  String toString() {
+    return '$runtimeType(initialUrl: $initialUrl, settings: $webSettings, javascriptChannelNames: $javascriptChannelNames)';
+  }
 }
 
 typedef WebViewPlatformCreatedCallback = void Function(
@@ -67,7 +139,7 @@ abstract class WebViewBuilder {
     // TODO(amirh): convert this to be the actual parameters.
     // I'm starting without it as the PR is starting to become pretty big.
     // I'll followup with the conversion PR.
-    Map<String, dynamic> creationParams,
+    CreationParams creationParams,
     WebViewPlatformCreatedCallback onWebViewPlatformCreated,
     Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers,
   });

--- a/packages/webview_flutter/lib/src/webview_android.dart
+++ b/packages/webview_flutter/lib/src/webview_android.dart
@@ -46,7 +46,8 @@ class AndroidWebViewBuilder implements WebViewBuilder {
         // we explicitly set it here so that the widget doesn't require an ambient
         // directionality.
         layoutDirection: TextDirection.rtl,
-        creationParams: MethodChannelWebViewPlatform.creationParamsToMap(creationParams),
+        creationParams:
+            MethodChannelWebViewPlatform.creationParamsToMap(creationParams),
         creationParamsCodec: const StandardMessageCodec(),
       ),
     );

--- a/packages/webview_flutter/lib/src/webview_android.dart
+++ b/packages/webview_flutter/lib/src/webview_android.dart
@@ -19,7 +19,7 @@ class AndroidWebViewBuilder implements WebViewBuilder {
   @override
   Widget build({
     BuildContext context,
-    Map<String, dynamic> creationParams,
+    CreationParams creationParams,
     WebViewPlatformCreatedCallback onWebViewPlatformCreated,
     Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers,
   }) {
@@ -46,7 +46,7 @@ class AndroidWebViewBuilder implements WebViewBuilder {
         // we explicitly set it here so that the widget doesn't require an ambient
         // directionality.
         layoutDirection: TextDirection.rtl,
-        creationParams: creationParams,
+        creationParams: MethodChannelWebViewPlatform.creationParamsToMap(creationParams),
         creationParamsCodec: const StandardMessageCodec(),
       ),
     );

--- a/packages/webview_flutter/lib/src/webview_cupertino.dart
+++ b/packages/webview_flutter/lib/src/webview_cupertino.dart
@@ -32,7 +32,8 @@ class CupertinoWebViewBuilder implements WebViewBuilder {
         onWebViewPlatformCreated(MethodChannelWebViewPlatform(id));
       },
       gestureRecognizers: gestureRecognizers,
-      creationParams: MethodChannelWebViewPlatform.creationParamsToMap(creationParams),
+      creationParams:
+          MethodChannelWebViewPlatform.creationParamsToMap(creationParams),
       creationParamsCodec: const StandardMessageCodec(),
     );
   }

--- a/packages/webview_flutter/lib/src/webview_cupertino.dart
+++ b/packages/webview_flutter/lib/src/webview_cupertino.dart
@@ -19,7 +19,7 @@ class CupertinoWebViewBuilder implements WebViewBuilder {
   @override
   Widget build({
     BuildContext context,
-    Map<String, dynamic> creationParams,
+    CreationParams creationParams,
     WebViewPlatformCreatedCallback onWebViewPlatformCreated,
     Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers,
   }) {
@@ -32,7 +32,7 @@ class CupertinoWebViewBuilder implements WebViewBuilder {
         onWebViewPlatformCreated(MethodChannelWebViewPlatform(id));
       },
       gestureRecognizers: gestureRecognizers,
-      creationParams: creationParams,
+      creationParams: MethodChannelWebViewPlatform.creationParamsToMap(creationParams),
       creationParamsCodec: const StandardMessageCodec(),
     );
   }

--- a/packages/webview_flutter/lib/src/webview_method_channel.dart
+++ b/packages/webview_flutter/lib/src/webview_method_channel.dart
@@ -37,7 +37,7 @@ class MethodChannelWebViewPlatform implements WebViewPlatform {
     // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
     // https://github.com/flutter/flutter/issues/26431
     // ignore: strong_mode_implicit_dynamic_method
-    final Map<String, dynamic>  updatesMap = _webSettingsToMap(settings);
+    final Map<String, dynamic> updatesMap = _webSettingsToMap(settings);
     if (updatesMap.isEmpty) {
       return null;
     }
@@ -59,12 +59,12 @@ class MethodChannelWebViewPlatform implements WebViewPlatform {
     return map;
   }
 
-
   /// Converts a [CreationParams] object to a map as expected by `platform_views` channel.
   ///
   /// This is used for the `creationParams` argument of the platform views created by
   /// [AndroidWebViewBuilder] and [CupertinoWebViewBuilder].
-  static Map<String, dynamic> creationParamsToMap(CreationParams creationParams) {
+  static Map<String, dynamic> creationParamsToMap(
+      CreationParams creationParams) {
     return <String, dynamic>{
       'initialUrl': creationParams.initialUrl,
       'settings': _webSettingsToMap(creationParams.webSettings),

--- a/packages/webview_flutter/lib/src/webview_method_channel.dart
+++ b/packages/webview_flutter/lib/src/webview_method_channel.dart
@@ -33,5 +33,41 @@ class MethodChannelWebViewPlatform implements WebViewPlatform {
   }
 
   @override
+  Future<void> updateSettings(WebSettings settings) {
+    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
+    // https://github.com/flutter/flutter/issues/26431
+    // ignore: strong_mode_implicit_dynamic_method
+    final Map<String, dynamic>  updatesMap = _webSettingsToMap(settings);
+    if (updatesMap.isEmpty) {
+      return null;
+    }
+    return _channel.invokeMethod('updateSettings', updatesMap);
+  }
+
+  static Map<String, dynamic> _webSettingsToMap(WebSettings settings) {
+    final Map<String, dynamic> map = <String, dynamic>{};
+    void _addIfNonNull(String key, dynamic value) {
+      if (value == null) {
+        return;
+      }
+      map[key] = value;
+    }
+
+    _addIfNonNull('jsMode', settings.javascriptMode?.index);
+    _addIfNonNull('hasNavigationDelegate', settings.hasNavigationDelegate);
+    _addIfNonNull('debuggingEnabled', settings.debuggingEnabled);
+    return map;
+  }
+
+
+  static Map<String, dynamic> creationParamsToMap(CreationParams creationParams) {
+    return <String, dynamic>{
+      'initialUrl': creationParams.initialUrl,
+      'settings': _webSettingsToMap(creationParams.webSettings),
+      'javascriptChannelNames': creationParams.javascriptChannelNames.toList(),
+    };
+  }
+
+  @override
   int get id => _id;
 }

--- a/packages/webview_flutter/lib/src/webview_method_channel.dart
+++ b/packages/webview_flutter/lib/src/webview_method_channel.dart
@@ -60,6 +60,10 @@ class MethodChannelWebViewPlatform implements WebViewPlatform {
   }
 
 
+  /// Converts a [CreationParams] object to a map as expected by `platform_views` channel.
+  ///
+  /// This is used for the `creationParams` argument of the platform views created by
+  /// [AndroidWebViewBuilder] and [CupertinoWebViewBuilder].
   static Map<String, dynamic> creationParamsToMap(CreationParams creationParams) {
     return <String, dynamic>{
       'initialUrl': creationParams.initialUrl,

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -311,8 +311,7 @@ CreationParams _creationParamsfromWidget(WebView widget) {
   return CreationParams(
     initialUrl: widget.initialUrl,
     webSettings: _webSettingsFromWidget(widget),
-    javascriptChannelNames:
-    _extractChannelNames(widget.javascriptChannels),
+    javascriptChannelNames: _extractChannelNames(widget.javascriptChannels),
   );
 }
 
@@ -343,10 +342,9 @@ WebSettings _webSettingsUpdate(WebSettings currentValue, WebSettings newValue) {
   }
 
   return WebSettings(
-    javascriptMode: javascriptMode,
-    hasNavigationDelegate: hasNavigationDelegate,
-    debuggingEnabled: debuggingEnabled
-  );
+      javascriptMode: javascriptMode,
+      hasNavigationDelegate: hasNavigationDelegate,
+      debuggingEnabled: debuggingEnabled);
 }
 
 Set<String> _extractChannelNames(Set<JavascriptChannel> channels) {

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -328,6 +328,9 @@ WebSettings _webSettingsUpdate(WebSettings currentValue, WebSettings newValue) {
   assert(currentValue.javascriptMode != null);
   assert(currentValue.hasNavigationDelegate != null);
   assert(currentValue.debuggingEnabled != null);
+  assert(newValue.javascriptMode != null);
+  assert(newValue.hasNavigationDelegate != null);
+  assert(newValue.debuggingEnabled != null);
   JavascriptMode javascriptMode;
   bool hasNavigationDelegate;
   bool debuggingEnabled;

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -324,7 +324,8 @@ WebSettings _webSettingsFromWidget(WebView widget) {
 }
 
 // This method assumes that no fields in `currentValue` are null.
-WebSettings _webSettingsUpdate(WebSettings currentValue, WebSettings newValue) {
+WebSettings _clearUnchangedWebSettings(
+    WebSettings currentValue, WebSettings newValue) {
   assert(currentValue.javascriptMode != null);
   assert(currentValue.hasNavigationDelegate != null);
   assert(currentValue.debuggingEnabled != null);
@@ -525,7 +526,8 @@ class WebViewController {
   }
 
   Future<void> _updateSettings(WebSettings newSettings) {
-    final WebSettings update = _webSettingsUpdate(_settings, newSettings);
+    final WebSettings update =
+        _clearUnchangedWebSettings(_settings, newSettings);
     _settings = newSettings;
     return _platformInterface.updateSettings(update);
   }

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -324,7 +324,11 @@ WebSettings _webSettingsFromWidget(WebView widget) {
   );
 }
 
+// This method assumes that no fields in `currentValue` are null.
 WebSettings _webSettingsUpdate(WebSettings currentValue, WebSettings newValue) {
+  assert(currentValue.javascriptMode != null);
+  assert(currentValue.hasNavigationDelegate != null);
+  assert(currentValue.debuggingEnabled != null);
   JavascriptMode javascriptMode;
   bool hasNavigationDelegate;
   bool debuggingEnabled;

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -268,9 +268,9 @@ class _WebViewState extends State<WebView> {
   Widget build(BuildContext context) {
     return WebView.platformBuilder.build(
       context: context,
-      creationParams: _CreationParams.fromWidget(widget).toMap(),
       onWebViewPlatformCreated: _onWebViewPlatformCreated,
       gestureRecognizers: widget.gestureRecognizers,
+      creationParams: _creationParamsfromWidget(widget),
     );
   }
 
@@ -307,6 +307,44 @@ class _WebViewState extends State<WebView> {
   }
 }
 
+CreationParams _creationParamsfromWidget(WebView widget) {
+  return CreationParams(
+    initialUrl: widget.initialUrl,
+    webSettings: _webSettingsFromWidget(widget),
+    javascriptChannelNames:
+    _extractChannelNames(widget.javascriptChannels),
+  );
+}
+
+WebSettings _webSettingsFromWidget(WebView widget) {
+  return WebSettings(
+    javascriptMode: widget.javascriptMode,
+    hasNavigationDelegate: widget.navigationDelegate != null,
+    debuggingEnabled: widget.debuggingEnabled,
+  );
+}
+
+WebSettings _webSettingsUpdate(WebSettings currentValue, WebSettings newValue) {
+  JavascriptMode javascriptMode;
+  bool hasNavigationDelegate;
+  bool debuggingEnabled;
+  if (currentValue.javascriptMode != newValue.javascriptMode) {
+    javascriptMode = newValue.javascriptMode;
+  }
+  if (currentValue.hasNavigationDelegate != newValue.hasNavigationDelegate) {
+    hasNavigationDelegate = newValue.hasNavigationDelegate;
+  }
+  if (currentValue.debuggingEnabled != newValue.debuggingEnabled) {
+    debuggingEnabled = newValue.debuggingEnabled;
+  }
+
+  return WebSettings(
+    javascriptMode: javascriptMode,
+    hasNavigationDelegate: hasNavigationDelegate,
+    debuggingEnabled: debuggingEnabled
+  );
+}
+
 Set<String> _extractChannelNames(Set<JavascriptChannel> channels) {
   final Set<String> channelNames = channels == null
       // TODO(iskakaushik): Remove this when collection literals makes it to stable.
@@ -314,78 +352,6 @@ Set<String> _extractChannelNames(Set<JavascriptChannel> channels) {
       ? Set<String>()
       : channels.map((JavascriptChannel channel) => channel.name).toSet();
   return channelNames;
-}
-
-class _CreationParams {
-  _CreationParams(
-      {this.initialUrl, this.settings, this.javascriptChannelNames});
-
-  static _CreationParams fromWidget(WebView widget) {
-    return _CreationParams(
-      initialUrl: widget.initialUrl,
-      settings: _WebSettings.fromWidget(widget),
-      javascriptChannelNames:
-          _extractChannelNames(widget.javascriptChannels).toList(),
-    );
-  }
-
-  final String initialUrl;
-
-  final _WebSettings settings;
-
-  final List<String> javascriptChannelNames;
-
-  Map<String, dynamic> toMap() {
-    return <String, dynamic>{
-      'initialUrl': initialUrl,
-      'settings': settings.toMap(),
-      'javascriptChannelNames': javascriptChannelNames,
-    };
-  }
-}
-
-class _WebSettings {
-  _WebSettings({
-    this.javascriptMode,
-    this.hasNavigationDelegate,
-    this.debuggingEnabled,
-  });
-
-  static _WebSettings fromWidget(WebView widget) {
-    return _WebSettings(
-      javascriptMode: widget.javascriptMode,
-      hasNavigationDelegate: widget.navigationDelegate != null,
-      debuggingEnabled: widget.debuggingEnabled,
-    );
-  }
-
-  final JavascriptMode javascriptMode;
-  final bool hasNavigationDelegate;
-  final bool debuggingEnabled;
-
-  Map<String, dynamic> toMap() {
-    return <String, dynamic>{
-      'jsMode': javascriptMode.index,
-      'hasNavigationDelegate': hasNavigationDelegate,
-      'debuggingEnabled': debuggingEnabled,
-    };
-  }
-
-  Map<String, dynamic> updatesMap(_WebSettings newSettings) {
-    final Map<String, dynamic> updates = <String, dynamic>{};
-    if (javascriptMode != newSettings.javascriptMode) {
-      updates['jsMode'] = newSettings.javascriptMode.index;
-    }
-    if (hasNavigationDelegate != newSettings.hasNavigationDelegate) {
-      updates['hasNavigationDelegate'] = newSettings.hasNavigationDelegate;
-    }
-
-    if (debuggingEnabled != newSettings.debuggingEnabled) {
-      updates['debuggingEnabled'] = newSettings.debuggingEnabled;
-    }
-
-    return updates;
-  }
 }
 
 /// Controls a [WebView].
@@ -398,7 +364,7 @@ class WebViewController {
     this._platformInterface,
     this._widget,
   ) : _channel = MethodChannel('plugins.flutter.io/webview_$id') {
-    _settings = _WebSettings.fromWidget(_widget);
+    _settings = _webSettingsFromWidget(_widget);
     _updateJavascriptChannelsFromSet(_widget.javascriptChannels);
     _channel.setMethodCallHandler(_onMethodCall);
   }
@@ -407,7 +373,7 @@ class WebViewController {
 
   final WebViewPlatform _platformInterface;
 
-  _WebSettings _settings;
+  WebSettings _settings;
 
   WebView _widget;
 
@@ -549,20 +515,14 @@ class WebViewController {
 
   Future<void> _updateWidget(WebView widget) async {
     _widget = widget;
-    await _updateSettings(_WebSettings.fromWidget(widget));
+    await _updateSettings(_webSettingsFromWidget(widget));
     await _updateJavascriptChannels(widget.javascriptChannels);
   }
 
-  Future<void> _updateSettings(_WebSettings setting) async {
-    final Map<String, dynamic> updateMap = _settings.updatesMap(setting);
-    if (updateMap == null || updateMap.isEmpty) {
-      return null;
-    }
-    _settings = setting;
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return _channel.invokeMethod('updateSettings', updateMap);
+  Future<void> _updateSettings(WebSettings newSettings) {
+    final WebSettings update = _webSettingsUpdate(_settings, newSettings);
+    _settings = newSettings;
+    return _platformInterface.updateSettings(update);
   }
 
   Future<void> _updateJavascriptChannels(

--- a/packages/webview_flutter/test/webview_flutter_test.dart
+++ b/packages/webview_flutter/test/webview_flutter_test.dart
@@ -768,12 +768,13 @@ void main() {
       final MyWebViewBuilder builder = WebView.platformBuilder;
       final MyWebViewPlatform platform = builder.lastPlatformBuilt;
 
-      expect(platform.creationParams,
+      expect(
+          platform.creationParams,
           MatchesCreationParams(CreationParams(
             initialUrl: 'https://youtube.com',
             webSettings: WebSettings(
-              javascriptMode:  JavascriptMode.disabled,
-              hasNavigationDelegate:  false,
+              javascriptMode: JavascriptMode.disabled,
+              hasNavigationDelegate: false,
               debuggingEnabled: false,
             ),
             // TODO(iskakaushik): Remove this when collection literals makes it to stable.
@@ -1073,17 +1074,20 @@ class MyWebViewPlatform extends WebViewPlatform {
 
 class MatchesWebSettings extends Matcher {
   MatchesWebSettings(this._webSettings);
-  
+
   final WebSettings _webSettings;
-  
-  @override
-  Description describe(Description description) => description.add('$_webSettings');
 
   @override
-  bool matches(covariant WebSettings webSettings, Map<dynamic, dynamic> matchState) {
-    return _webSettings.javascriptMode == webSettings.javascriptMode
-      && _webSettings.hasNavigationDelegate == webSettings.hasNavigationDelegate
-      && _webSettings.debuggingEnabled == webSettings.debuggingEnabled;
+  Description describe(Description description) =>
+      description.add('$_webSettings');
+
+  @override
+  bool matches(
+      covariant WebSettings webSettings, Map<dynamic, dynamic> matchState) {
+    return _webSettings.javascriptMode == webSettings.javascriptMode &&
+        _webSettings.hasNavigationDelegate ==
+            webSettings.hasNavigationDelegate &&
+        _webSettings.debuggingEnabled == webSettings.debuggingEnabled;
   }
 }
 
@@ -1093,12 +1097,16 @@ class MatchesCreationParams extends Matcher {
   final CreationParams _creationParams;
 
   @override
-  Description describe(Description description) => description.add('$_creationParams');
+  Description describe(Description description) =>
+      description.add('$_creationParams');
 
   @override
-  bool matches(covariant CreationParams creationParams, Map<dynamic, dynamic> matchState) {
-    return _creationParams.initialUrl == creationParams.initialUrl
-        && MatchesWebSettings(_creationParams.webSettings).matches(creationParams.webSettings, matchState)
-        && orderedEquals(_creationParams.javascriptChannelNames).matches(creationParams.javascriptChannelNames, matchState);
+  bool matches(covariant CreationParams creationParams,
+      Map<dynamic, dynamic> matchState) {
+    return _creationParams.initialUrl == creationParams.initialUrl &&
+        MatchesWebSettings(_creationParams.webSettings)
+            .matches(creationParams.webSettings, matchState) &&
+        orderedEquals(_creationParams.javascriptChannelNames)
+            .matches(creationParams.javascriptChannelNames, matchState);
   }
 }

--- a/packages/webview_flutter/test/webview_flutter_test.dart
+++ b/packages/webview_flutter/test/webview_flutter_test.dart
@@ -66,7 +66,6 @@ void main() {
       initialUrl: 'https://youtube.com',
       javascriptMode: JavascriptMode.disabled,
     ));
-
     expect(platformWebView.javascriptMode, JavascriptMode.disabled);
   });
 
@@ -769,15 +768,18 @@ void main() {
       final MyWebViewBuilder builder = WebView.platformBuilder;
       final MyWebViewPlatform platform = builder.lastPlatformBuilt;
 
-      expect(platform.creationParams, <String, dynamic>{
-        'initialUrl': 'https://youtube.com',
-        'settings': <String, dynamic>{
-          'jsMode': 0,
-          'hasNavigationDelegate': false,
-          'debuggingEnabled': false
-        },
-        'javascriptChannelNames': <String>[],
-      });
+      expect(platform.creationParams,
+          MatchesCreationParams(CreationParams(
+            initialUrl: 'https://youtube.com',
+            webSettings: WebSettings(
+              javascriptMode:  JavascriptMode.disabled,
+              hasNavigationDelegate:  false,
+              debuggingEnabled: false,
+            ),
+            // TODO(iskakaushik): Remove this when collection literals makes it to stable.
+            // ignore: prefer_collection_literals
+            javascriptChannelNames: Set<String>(),
+          )));
     });
 
     testWidgets('loadUrl', (WidgetTester tester) async {
@@ -1036,7 +1038,7 @@ class MyWebViewBuilder implements WebViewBuilder {
   @override
   Widget build({
     BuildContext context,
-    Map<String, dynamic> creationParams,
+    CreationParams creationParams,
     @required WebViewPlatformCreatedCallback onWebViewPlatformCreated,
     Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers,
   }) {
@@ -1050,7 +1052,7 @@ class MyWebViewBuilder implements WebViewBuilder {
 class MyWebViewPlatform extends WebViewPlatform {
   MyWebViewPlatform(this.creationParams, this.gestureRecognizers);
 
-  Map<String, dynamic> creationParams;
+  CreationParams creationParams;
   Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers;
 
   String lastUrlLoaded;
@@ -1058,6 +1060,7 @@ class MyWebViewPlatform extends WebViewPlatform {
 
   @override
   Future<void> loadUrl(String url, Map<String, String> headers) {
+    equals(1, 1);
     lastUrlLoaded = url;
     lastRequestHeaders = headers;
     return null;
@@ -1066,4 +1069,36 @@ class MyWebViewPlatform extends WebViewPlatform {
   @override
   // TODO: implement id
   int get id => 1;
+}
+
+class MatchesWebSettings extends Matcher {
+  MatchesWebSettings(this._webSettings);
+  
+  final WebSettings _webSettings;
+  
+  @override
+  Description describe(Description description) => description.add('$_webSettings');
+
+  @override
+  bool matches(covariant WebSettings webSettings, Map<dynamic, dynamic> matchState) {
+    return _webSettings.javascriptMode == webSettings.javascriptMode
+      && _webSettings.hasNavigationDelegate == webSettings.hasNavigationDelegate
+      && _webSettings.debuggingEnabled == webSettings.debuggingEnabled;
+  }
+}
+
+class MatchesCreationParams extends Matcher {
+  MatchesCreationParams(this._creationParams);
+
+  final CreationParams _creationParams;
+
+  @override
+  Description describe(Description description) => description.add('$_creationParams');
+
+  @override
+  bool matches(covariant CreationParams creationParams, Map<dynamic, dynamic> matchState) {
+    return _creationParams.initialUrl == creationParams.initialUrl
+        && MatchesWebSettings(_creationParams.webSettings).matches(creationParams.webSettings, matchState)
+        && orderedEquals(_creationParams.javascriptChannelNames).matches(creationParams.javascriptChannelNames, matchState);
+  }
 }


### PR DESCRIPTION
As a temporary step we passed these objects as maps that were sent across the method channel. This PR replaces the maps with proper Dart objects.