### PR TITLE
[firebase_ml_vision] Update sample to use new ImageStreamListener API

### DIFF
--- a/packages/firebase_ml_vision/CHANGELOG.md
+++ b/packages/firebase_ml_vision/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.0+1
+
+* Update the sample to use the new ImageStreamListener API introduced in https://github.com/flutter/flutter/pull/32936.
+
 ## 0.8.0
 
 * Update Android dependencies to latest.

--- a/packages/firebase_ml_vision/example/lib/main.dart
+++ b/packages/firebase_ml_vision/example/lib/main.dart
@@ -48,12 +48,12 @@ class _MyHomePageState extends State<_MyHomePage> {
 
     final Image image = Image.file(imageFile);
     image.image.resolve(const ImageConfiguration()).addListener(
-      (ImageInfo info, bool _) {
+      ImageStreamListener((ImageInfo info, bool _) {
         completer.complete(Size(
           info.image.width.toDouble(),
           info.image.height.toDouble(),
         ));
-      },
+      }),
     );
 
     final Size imageSize = await completer.future;

--- a/packages/firebase_ml_vision/pubspec.yaml
+++ b/packages/firebase_ml_vision/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_ml_vision
 description: Flutter plugin for Firebase machine learning vision services.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_ml_vision
-version: 0.8.0
+version: 0.8.0+1
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Description

This updates the sample to adapt to the ImageStream listener API changes
in flutter/flutter#32936

This is similar to the change we did to Google Maps in https://github.com/flutter/plugins/pull/1640, unfortunately in the firebase_ml_vision case where we commented out the sample that used the ImageStream listener API. Unfortunately in the firebase_ml_vision case, there's no point in the sample without the ImageStream listener(you need it to pick an image), so I'm just updating the sample to the new API knowing that it won't compile on stable until the breaking change makes it there.

## Related Issues

https://github.com/flutter/flutter/issues/33440 discuss the more general issue of how breaking framework changes are affecting plugins.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
 