### PR TITLE
[shared_preferences] Updated Gradle tooling to match Android Studio 3.4.

### DIFF
--- a/packages/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.5.2+1
 
-* .commit() calls are now run in an async background task on Android.
+* Updated Gradle tooling to match Android Studio 3.4.
 
 ## 0.5.2
 

--- a/packages/shared_preferences/android/build.gradle
+++ b/packages/shared_preferences/android/build.gradle
@@ -21,7 +21,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0'
+        classpath 'com.android.tools.build:gradle:3.4.0'
     }
 }
 

--- a/packages/shared_preferences/example/android/app/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/shared_preferences/example/android/app/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/packages/shared_preferences/example/android/build.gradle
+++ b/packages/shared_preferences/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0'
+        classpath 'com.android.tools.build:gradle:3.4.0'
     }
 }
 

--- a/packages/shared_preferences/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/shared_preferences/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
This is a partial landing of #1595, updating the Gradle to match Android Studio 3.4.

If there are no issues, we'll go ahead and update all the other plugins.