### PR TITLE
Fixes merge conflict in shared_preferences release of 0.5.2+2

### DIFF
--- a/packages/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/CHANGELOG.md
@@ -1,6 +1,10 @@
-## 0.5.2+1
+## 0.5.2+2
 
 * Updated Gradle tooling to match Android Studio 3.4.
+
+## 0.5.2+1
+
+* .commit() calls are now run in an async background task on Android.
 
 ## 0.5.2
 

--- a/packages/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for reading and writing simple key-value pairs.
   Wraps NSUserDefaults on iOS and SharedPreferences on Android.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/shared_preferences
-version: 0.5.2+1
+version: 0.5.2+2
 
 flutter:
   plugin:


### PR DESCRIPTION
There was a merge conflict in #1653 that was missed by the tests/bots. This fixes the version number in pubspec.yaml so that we can publish the latest.