### PR TITLE
Move clearCookies behind the platform abstraction

### DIFF
--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.9
+
+* Allow external packages to provide webview implementations for new platforms.
+
 ## 0.3.8+1
 
 * Suppress deprecation warning for BinaryMessages. See: https://github.com/flutter/flutter/issues/33446

--- a/packages/webview_flutter/lib/platform_interface.dart
+++ b/packages/webview_flutter/lib/platform_interface.dart
@@ -10,20 +10,20 @@ import 'package:flutter/widgets.dart';
 
 import 'webview_flutter.dart';
 
-/// Interface for callbacks made by [WebViewPlatform].
+/// Interface for callbacks made by [WebViewPlatformController].
 ///
-/// The webview plugin implements this class, and passes an instance to the [WebViewPlatform].
-/// [WebViewPlatform] is notifying this handler on events that happened on the platform's webview.
+/// The webview plugin implements this class, and passes an instance to the [WebViewPlatformController].
+/// [WebViewPlatformController] is notifying this handler on events that happened on the platform's webview.
 abstract class WebViewPlatformCallbacksHandler {
-  /// Invoked by [WebViewPlatform] when a JavaScript channel message is received.
+  /// Invoked by [WebViewPlatformController] when a JavaScript channel message is received.
   void onJavaScriptChannelMessage(String channel, String message);
 
-  /// Invoked by [WebViewPlatform] when a navigation request is pending.
+  /// Invoked by [WebViewPlatformController] when a navigation request is pending.
   ///
   /// If true is returned the navigation is allowed, otherwise it is blocked.
   bool onNavigationRequest({String url, bool isForMainFrame});
 
-  /// Invoked by [WebViewPlatform] when a page has finished loading.
+  /// Invoked by [WebViewPlatformController] when a page has finished loading.
   void onPageFinished(String url);
 }
 
@@ -31,13 +31,13 @@ abstract class WebViewPlatformCallbacksHandler {
 ///
 /// An instance implementing this interface is passed to the `onWebViewPlatformCreated` callback that is
 /// passed to [WebViewPlatformBuilder#onWebViewPlatformCreated].
-abstract class WebViewPlatform {
+abstract class WebViewPlatformController {
   /// Creates a new WebViewPlatform.
   ///
   /// Callbacks made by the WebView will be delegated to `handler`.
   ///
   /// The `handler` parameter must not be null.
-  WebViewPlatform(WebViewPlatformCallbacksHandler handler);
+  WebViewPlatformController(WebViewPlatformCallbacksHandler handler);
 
   /// Loads the specified URL.
   ///
@@ -182,7 +182,7 @@ class WebSettings {
   }
 }
 
-/// Configuration to use when creating a new [WebViewPlatform].
+/// Configuration to use when creating a new [WebViewPlatformController].
 class CreationParams {
   CreationParams(
       {this.initialUrl, this.webSettings, this.javascriptChannelNames});
@@ -194,7 +194,7 @@ class CreationParams {
 
   /// The initial [WebSettings] for the new webview.
   ///
-  /// This can later be updated with [WebViewPlatform.updateSettings].
+  /// This can later be updated with [WebViewPlatformController.updateSettings].
   final WebSettings webSettings;
 
   /// The initial set of JavaScript channels that are configured for this webview.
@@ -217,14 +217,14 @@ class CreationParams {
 }
 
 typedef WebViewPlatformCreatedCallback = void Function(
-    WebViewPlatform webViewPlatform);
+    WebViewPlatformController webViewPlatform);
 
-/// Interface building a platform WebView implementation.
+/// Interface for a platform implementation of a WebView.
 ///
-/// [WebView#platformBuilder] controls the builder that is used by [WebView].
+/// [WebView.platform] controls the builder that is used by [WebView].
 /// [AndroidWebViewPlatform] and [CupertinoWebViewPlatform] are the default implementations
 /// for Android and iOS respectively.
-abstract class WebViewBuilder {
+abstract class WebViewPlatform {
   /// Builds a new WebView.
   ///
   /// Returns a Widget tree that embeds the created webview.
@@ -232,10 +232,10 @@ abstract class WebViewBuilder {
   /// `creationParams` are the initial parameters used to setup the webview.
   ///
   /// `webViewPlatformHandler` will be used for handling callbacks that are made by the created
-  /// [WebViewPlatform].
+  /// [WebViewPlatformController].
   ///
-  /// `onWebViewPlatformCreated` will be invoked after the platform specific [WebViewPlatform]
-  /// implementation is created with the [WebViewPlatform] instance as a parameter.
+  /// `onWebViewPlatformCreated` will be invoked after the platform specific [WebViewPlatformController]
+  /// implementation is created with the [WebViewPlatformController] instance as a parameter.
   ///
   /// `gestureRecognizers` specifies which gestures should be consumed by the web view.
   /// It is possible for other gesture recognizers to be competing with the web view on pointer
@@ -256,4 +256,12 @@ abstract class WebViewBuilder {
     WebViewPlatformCreatedCallback onWebViewPlatformCreated,
     Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers,
   });
+
+  /// Clears all cookies for all [WebView] instances.
+  ///
+  /// Returns true if cookies were present before clearing, else false.
+  Future<bool> clearCookies() {
+    throw UnimplementedError(
+        "WebView clearCookies is not implemented on the current platform");
+  }
 }

--- a/packages/webview_flutter/lib/platform_interface.dart
+++ b/packages/webview_flutter/lib/platform_interface.dart
@@ -217,7 +217,7 @@ class CreationParams {
 }
 
 typedef WebViewPlatformCreatedCallback = void Function(
-    WebViewPlatformController webViewPlatform);
+    WebViewPlatformController webViewPlatformController);
 
 /// Interface for a platform implementation of a WebView.
 ///

--- a/packages/webview_flutter/lib/src/webview_android.dart
+++ b/packages/webview_flutter/lib/src/webview_android.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/services.dart';
@@ -12,10 +14,10 @@ import 'webview_method_channel.dart';
 
 /// Builds an Android webview.
 ///
-/// This is used as the default implementation for [WebView.platformBuilder] on Android. It uses
+/// This is used as the default implementation for [WebView.platform] on Android. It uses
 /// an [AndroidView] to embed the webview in the widget hierarchy, and uses a method channel to
 /// communicate with the platform code.
-class AndroidWebViewBuilder implements WebViewBuilder {
+class AndroidWebView implements WebViewPlatform {
   @override
   Widget build({
     BuildContext context,
@@ -55,4 +57,7 @@ class AndroidWebViewBuilder implements WebViewBuilder {
       ),
     );
   }
+
+  @override
+  Future<bool> clearCookies() => MethodChannelWebViewPlatform.clearCookies();
 }

--- a/packages/webview_flutter/lib/src/webview_cupertino.dart
+++ b/packages/webview_flutter/lib/src/webview_cupertino.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/services.dart';
@@ -12,10 +14,10 @@ import 'webview_method_channel.dart';
 
 /// Builds an iOS webview.
 ///
-/// This is used as the default implementation for [WebView.platformBuilder] on iOS. It uses
+/// This is used as the default implementation for [WebView.platform] on iOS. It uses
 /// a [UiKitView] to embed the webview in the widget hierarchy, and uses a method channel to
 /// communicate with the platform code.
-class CupertinoWebViewBuilder implements WebViewBuilder {
+class CupertinoWebView implements WebViewPlatform {
   @override
   Widget build({
     BuildContext context,
@@ -39,4 +41,7 @@ class CupertinoWebViewBuilder implements WebViewBuilder {
       creationParamsCodec: const StandardMessageCodec(),
     );
   }
+
+  @override
+  Future<bool> clearCookies() => MethodChannelWebViewPlatform.clearCookies();
 }

--- a/packages/webview_flutter/lib/src/webview_method_channel.dart
+++ b/packages/webview_flutter/lib/src/webview_method_channel.dart
@@ -8,8 +8,8 @@ import 'package:flutter/services.dart';
 
 import '../platform_interface.dart';
 
-/// A [WebViewPlatform] that uses a method channel to control the webview.
-class MethodChannelWebViewPlatform implements WebViewPlatform {
+/// A [WebViewPlatformController] that uses a method channel to control the webview.
+class MethodChannelWebViewPlatform implements WebViewPlatformController {
   MethodChannelWebViewPlatform(int id, this._platformCallbacksHandler)
       : assert(_platformCallbacksHandler != null),
         _channel = MethodChannel('plugins.flutter.io/webview_$id') {
@@ -19,6 +19,9 @@ class MethodChannelWebViewPlatform implements WebViewPlatform {
   final WebViewPlatformCallbacksHandler _platformCallbacksHandler;
 
   final MethodChannel _channel;
+
+  static const MethodChannel _cookieManagerChannel =
+      MethodChannel('plugins.flutter.io/cookie_manager');
 
   Future<bool> _onMethodCall(MethodCall call) async {
     switch (call.method) {
@@ -103,6 +106,16 @@ class MethodChannelWebViewPlatform implements WebViewPlatform {
   Future<void> removeJavascriptChannels(Set<String> javascriptChannelNames) {
     return _channel.invokeMethod(
         'removeJavascriptChannels', javascriptChannelNames.toList());
+  }
+
+  /// Method channel mplementation for [WebViewPlatform.clearCookies].
+  static Future<bool> clearCookies() {
+    return _cookieManagerChannel
+        // TODO(amirh): remove this when the invokeMethod update makes it to stable Flutter.
+        // https://github.com/flutter/flutter/issues/26431
+        // ignore: strong_mode_implicit_dynamic_method
+        .invokeMethod('clearCookies')
+        .then<bool>((dynamic result) => result);
   }
 
   static Map<String, dynamic> _webSettingsToMap(WebSettings settings) {

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -132,9 +132,9 @@ class WebView extends StatefulWidget {
   ///
   /// Setting `platform` doesn't affect [WebView]s that were already created.
   ///
-  /// The default value is [AndroidWebView] on Android and [CupertinoWebView] on iOs.
-  static set platform(WebViewPlatform platformBuilder) {
-    _platform = platformBuilder;
+  /// The default value is [AndroidWebView] on Android and [CupertinoWebView] on iOS.
+  static set platform(WebViewPlatform platform) {
+    _platform = platform;
   }
 
   /// The WebView platform that's used by this WebView.
@@ -415,13 +415,13 @@ class _PlatformCallbacksHandler implements WebViewPlatformCallbacksHandler {
 class WebViewController {
   WebViewController._(
     this._widget,
-    this._webViewPlatform,
+    this._webViewPlatformController,
     this._platformCallbacksHandler,
-  ) : assert(_webViewPlatform != null) {
+  ) : assert(_webViewPlatformController != null) {
     _settings = _webSettingsFromWidget(_widget);
   }
 
-  final WebViewPlatformController _webViewPlatform;
+  final WebViewPlatformController _webViewPlatformController;
 
   final _PlatformCallbacksHandler _platformCallbacksHandler;
 
@@ -443,7 +443,7 @@ class WebViewController {
   }) async {
     assert(url != null);
     _validateUrlString(url);
-    return _webViewPlatform.loadUrl(url, headers);
+    return _webViewPlatformController.loadUrl(url, headers);
   }
 
   /// Accessor to the current URL that the WebView is displaying.
@@ -454,7 +454,7 @@ class WebViewController {
   /// words, by the time this future completes, the WebView may be displaying a
   /// different URL).
   Future<String> currentUrl() {
-    return _webViewPlatform.currentUrl();
+    return _webViewPlatformController.currentUrl();
   }
 
   /// Checks whether there's a back history item.
@@ -462,7 +462,7 @@ class WebViewController {
   /// Note that this operation is asynchronous, and it is possible that the "canGoBack" state has
   /// changed by the time the future completed.
   Future<bool> canGoBack() {
-    return _webViewPlatform.canGoBack();
+    return _webViewPlatformController.canGoBack();
   }
 
   /// Checks whether there's a forward history item.
@@ -470,26 +470,26 @@ class WebViewController {
   /// Note that this operation is asynchronous, and it is possible that the "canGoForward" state has
   /// changed by the time the future completed.
   Future<bool> canGoForward() {
-    return _webViewPlatform.canGoForward();
+    return _webViewPlatformController.canGoForward();
   }
 
   /// Goes back in the history of this WebView.
   ///
   /// If there is no back history item this is a no-op.
   Future<void> goBack() {
-    return _webViewPlatform.goBack();
+    return _webViewPlatformController.goBack();
   }
 
   /// Goes forward in the history of this WebView.
   ///
   /// If there is no forward history item this is a no-op.
   Future<void> goForward() {
-    return _webViewPlatform.goForward();
+    return _webViewPlatformController.goForward();
   }
 
   /// Reloads the current URL.
   Future<void> reload() {
-    return _webViewPlatform.reload();
+    return _webViewPlatformController.reload();
   }
 
   /// Clears all caches used by the [WebView].
@@ -503,7 +503,7 @@ class WebViewController {
   ///
   /// Note: Calling this method also triggers a reload.
   Future<void> clearCache() async {
-    await _webViewPlatform.clearCache();
+    await _webViewPlatformController.clearCache();
     return reload();
   }
 
@@ -517,7 +517,7 @@ class WebViewController {
     final WebSettings update =
         _clearUnchangedWebSettings(_settings, newSettings);
     _settings = newSettings;
-    return _webViewPlatform.updateSettings(update);
+    return _webViewPlatformController.updateSettings(update);
   }
 
   Future<void> _updateJavascriptChannels(
@@ -530,10 +530,10 @@ class WebViewController {
     final Set<String> channelsToRemove =
         currentChannels.difference(newChannelNames);
     if (channelsToRemove.isNotEmpty) {
-      _webViewPlatform.removeJavascriptChannels(channelsToRemove);
+      _webViewPlatformController.removeJavascriptChannels(channelsToRemove);
     }
     if (channelsToAdd.isNotEmpty) {
-      _webViewPlatform.addJavascriptChannels(channelsToAdd);
+      _webViewPlatformController.addJavascriptChannels(channelsToAdd);
     }
     _platformCallbacksHandler._updateJavascriptChannelsFromSet(newChannels);
   }
@@ -566,7 +566,7 @@ class WebViewController {
     // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
     // https://github.com/flutter/flutter/issues/26431
     // ignore: strong_mode_implicit_dynamic_method
-    return _webViewPlatform.evaluateJavascript(javascriptString);
+    return _webViewPlatformController.evaluateJavascript(javascriptString);
   }
 }
 

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
-version: 0.3.8+1
+version: 0.3.9
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/webview_flutter
 

--- a/packages/webview_flutter/test/webview_flutter_test.dart
+++ b/packages/webview_flutter/test/webview_flutter_test.dart
@@ -752,7 +752,7 @@ void main() {
 
   group('Custom platform implementation', () {
     setUpAll(() {
-      WebView.platform = MyWebViewBuilder();
+      WebView.platform = MyWebViewPlatform();
     });
     tearDownAll(() {
       WebView.platform = null;
@@ -765,8 +765,8 @@ void main() {
         ),
       );
 
-      final MyWebViewBuilder builder = WebView.platform;
-      final MyWebViewPlatform platform = builder.lastPlatformBuilt;
+      final MyWebViewPlatform builder = WebView.platform;
+      final MyWebViewPlatformController platform = builder.lastPlatformBuilt;
 
       expect(
           platform.creationParams,
@@ -794,8 +794,8 @@ void main() {
         ),
       );
 
-      final MyWebViewBuilder builder = WebView.platform;
-      final MyWebViewPlatform platform = builder.lastPlatformBuilt;
+      final MyWebViewPlatform builder = WebView.platform;
+      final MyWebViewPlatformController platform = builder.lastPlatformBuilt;
 
       final Map<String, String> headers = <String, String>{
         'header': 'value',
@@ -1033,8 +1033,8 @@ class _FakeCookieManager {
   }
 }
 
-class MyWebViewBuilder implements WebViewPlatform {
-  MyWebViewPlatform lastPlatformBuilt;
+class MyWebViewPlatform implements WebViewPlatform {
+  MyWebViewPlatformController lastPlatformBuilt;
 
   @override
   Widget build({
@@ -1045,7 +1045,7 @@ class MyWebViewBuilder implements WebViewPlatform {
     Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers,
   }) {
     assert(onWebViewPlatformCreated != null);
-    lastPlatformBuilt = MyWebViewPlatform(
+    lastPlatformBuilt = MyWebViewPlatformController(
         creationParams, gestureRecognizers, webViewPlatformCallbacksHandler);
     onWebViewPlatformCreated(lastPlatformBuilt);
     return Container();
@@ -1057,8 +1057,8 @@ class MyWebViewBuilder implements WebViewPlatform {
   }
 }
 
-class MyWebViewPlatform extends WebViewPlatformController {
-  MyWebViewPlatform(this.creationParams, this.gestureRecognizers,
+class MyWebViewPlatformController extends WebViewPlatformController {
+  MyWebViewPlatformController(this.creationParams, this.gestureRecognizers,
       WebViewPlatformCallbacksHandler platformHandler)
       : super(platformHandler);
 

--- a/packages/webview_flutter/test/webview_flutter_test.dart
+++ b/packages/webview_flutter/test/webview_flutter_test.dart
@@ -752,10 +752,10 @@ void main() {
 
   group('Custom platform implementation', () {
     setUpAll(() {
-      WebView.platformBuilder = MyWebViewBuilder();
+      WebView.platform = MyWebViewBuilder();
     });
     tearDownAll(() {
-      WebView.platformBuilder = null;
+      WebView.platform = null;
     });
 
     testWidgets('creation', (WidgetTester tester) async {
@@ -765,7 +765,7 @@ void main() {
         ),
       );
 
-      final MyWebViewBuilder builder = WebView.platformBuilder;
+      final MyWebViewBuilder builder = WebView.platform;
       final MyWebViewPlatform platform = builder.lastPlatformBuilt;
 
       expect(
@@ -794,7 +794,7 @@ void main() {
         ),
       );
 
-      final MyWebViewBuilder builder = WebView.platformBuilder;
+      final MyWebViewBuilder builder = WebView.platform;
       final MyWebViewPlatform platform = builder.lastPlatformBuilt;
 
       final Map<String, String> headers = <String, String>{
@@ -1033,7 +1033,7 @@ class _FakeCookieManager {
   }
 }
 
-class MyWebViewBuilder implements WebViewBuilder {
+class MyWebViewBuilder implements WebViewPlatform {
   MyWebViewPlatform lastPlatformBuilt;
 
   @override
@@ -1050,9 +1050,14 @@ class MyWebViewBuilder implements WebViewBuilder {
     onWebViewPlatformCreated(lastPlatformBuilt);
     return Container();
   }
+
+  @override
+  Future<bool> clearCookies() {
+    return Future<bool>.sync(() => null);
+  }
 }
 
-class MyWebViewPlatform extends WebViewPlatform {
+class MyWebViewPlatform extends WebViewPlatformController {
   MyWebViewPlatform(this.creationParams, this.gestureRecognizers,
       WebViewPlatformCallbacksHandler platformHandler)
       : super(platformHandler);


### PR DESCRIPTION
This is a followup for #1618, #1624, and #1645, and moves the `plugins.flutter.io/cookie_manager` method channel behind the platform interface which allows a third party package to provide a new platform implementation the cooke manager.

See the description for #1618 for more details.

Following this PR all platform specific code can be replaced by an external package.

### Note on renamed classes

Before this PR we had a `WebViewBuilder` class(which had the build method) and a `WebViewPlatform` class (which abstracted what's currently done on the webview method channel).
A `WebViewPlatform` instance existed per `WebView` instance, and `WebViewBuilder` needs to exist once.

As `clearCookies` is not associated with a `WebView` instance I added it to what was previously named `WebViewBuilder` and renamed both classes:
  * `WebViewPlatform` -> `WebViewPlatformController`
  * `WebViewBuilder` -> `WebViewPlatform`

With this, to replace the platform implementation you do `WebView.platform = FuchsiaWebView();`.

I'm far from being in love with the current names, and happy to do something else (we haven't published the plugin yet so this isn't a breaking change yet).

An alternative option I have in mind is to add a separate `CookieManagerPlatform` interface (this will mean we have to not only do `WebView.platformBuilder = FuchsiaWebViewBuilder()` but also `CookieManager.platform = FuchsiaCookieManager()`.

@nkoroste, @cyanglaz  any thouhgs?
@Hixie you had opinions on these names in #1618, curious to see what you think.