### PR TITLE
[firebase_messaging]Add missing template type parameter to `invokeMethod` calls. Bump minimum Flutter version to 1.5.0. Replace invokeMethod with invokeMapMethod wherever necessary.

### DIFF
--- a/packages/firebase_messaging/CHANGELOG.md
+++ b/packages/firebase_messaging/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 5.0.2
+
+* Add missing template type parameter to `invokeMethod` calls.
+* Bump minimum Flutter version to 1.5.0.
+* Replace invokeMethod with invokeMapMethod wherever necessary.
+ 
 ## 5.0.1+1
 
 * Enable support for `onMessage` on iOS using `shouldEstablishDirectChannel`.

--- a/packages/firebase_messaging/lib/firebase_messaging.dart
+++ b/packages/firebase_messaging/lib/firebase_messaging.dart
@@ -42,10 +42,7 @@ class FirebaseMessaging {
     if (!_platform.isIOS) {
       return;
     }
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    _channel.invokeMethod(
+    _channel.invokeMethod<void>(
         'requestNotificationPermissions', iosSettings.toMap());
   }
 
@@ -69,10 +66,7 @@ class FirebaseMessaging {
     _onLaunch = onLaunch;
     _onResume = onResume;
     _channel.setMethodCallHandler(_handleMethod);
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    _channel.invokeMethod('configure');
+    _channel.invokeMethod<void>('configure');
   }
 
   final StreamController<String> _tokenStreamController =
@@ -85,10 +79,7 @@ class FirebaseMessaging {
 
   /// Returns the FCM token.
   Future<String> getToken() async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return await _channel.invokeMethod('getToken');
+    return await _channel.invokeMethod<String>('getToken');
   }
 
   /// Subscribe to topic in background.
@@ -96,18 +87,12 @@ class FirebaseMessaging {
   /// [topic] must match the following regular expression:
   /// "[a-zA-Z0-9-_.~%]{1,900}".
   void subscribeToTopic(String topic) {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    _channel.invokeMethod('subscribeToTopic', topic);
+    _channel.invokeMethod<void>('subscribeToTopic', topic);
   }
 
   /// Unsubscribe from topic in background.
   void unsubscribeFromTopic(String topic) {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    _channel.invokeMethod('unsubscribeFromTopic', topic);
+    _channel.invokeMethod<void>('unsubscribeFromTopic', topic);
   }
 
   /// Resets Instance ID and revokes all tokens. In iOS, it also unregisters from remote notifications.
@@ -116,26 +101,17 @@ class FirebaseMessaging {
   ///
   /// returns true if the operations executed successfully and false if an error ocurred
   Future<bool> deleteInstanceID() async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return await _channel.invokeMethod('deleteInstanceID');
+    return await _channel.invokeMethod<bool>('deleteInstanceID');
   }
 
   /// Determine whether FCM auto-initialization is enabled or disabled.
   Future<bool> autoInitEnabled() async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return await _channel.invokeMethod('autoInitEnabled');
+    return await _channel.invokeMethod<bool>('autoInitEnabled');
   }
 
   /// Enable or disable auto-initialization of Firebase Cloud Messaging.
   Future<void> setAutoInitEnabled(bool enabled) async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    await _channel.invokeMethod('setAutoInitEnabled', enabled);
+    await _channel.invokeMethod<void>('setAutoInitEnabled', enabled);
   }
 
   Future<dynamic> _handleMethod(MethodCall call) async {

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Cloud Messaging, a cross-platform
   messaging solution that lets you reliably deliver messages on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_messaging
-version: 5.0.1+1
+version: 5.0.2
 
 flutter:
   plugin:
@@ -26,4 +26,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.1.4 <2.0.0"
+  flutter: ">=1.5.0 <2.0.0"

--- a/packages/firebase_messaging/test/firebase_messaging_test.dart
+++ b/packages/firebase_messaging/test/firebase_messaging_test.dart
@@ -22,20 +22,14 @@ void main() {
 
   test('requestNotificationPermissions on ios with default permissions', () {
     firebaseMessaging.requestNotificationPermissions();
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    verify(mockChannel.invokeMethod('requestNotificationPermissions',
+    verify(mockChannel.invokeMethod<void>('requestNotificationPermissions',
         <String, bool>{'sound': true, 'badge': true, 'alert': true}));
   });
 
   test('requestNotificationPermissions on ios with custom permissions', () {
     firebaseMessaging.requestNotificationPermissions(
         const IosNotificationSettings(sound: false));
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    verify(mockChannel.invokeMethod('requestNotificationPermissions',
+    verify(mockChannel.invokeMethod<void>('requestNotificationPermissions',
         <String, bool>{'sound': false, 'badge': true, 'alert': true}));
   });
 
@@ -58,10 +52,7 @@ void main() {
   test('configure', () {
     firebaseMessaging.configure();
     verify(mockChannel.setMethodCallHandler(any));
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    verify(mockChannel.invokeMethod('configure'));
+    verify(mockChannel.invokeMethod<void>('configure'));
   });
 
   test('incoming token', () async {
@@ -134,42 +125,27 @@ void main() {
 
   test('subscribe to topic', () {
     firebaseMessaging.subscribeToTopic(myTopic);
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    verify(mockChannel.invokeMethod('subscribeToTopic', myTopic));
+    verify(mockChannel.invokeMethod<void>('subscribeToTopic', myTopic));
   });
 
   test('unsubscribe from topic', () {
     firebaseMessaging.unsubscribeFromTopic(myTopic);
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    verify(mockChannel.invokeMethod('unsubscribeFromTopic', myTopic));
+    verify(mockChannel.invokeMethod<void>('unsubscribeFromTopic', myTopic));
   });
 
   test('getToken', () {
     firebaseMessaging.getToken();
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    verify(mockChannel.invokeMethod('getToken'));
+    verify(mockChannel.invokeMethod<String>('getToken'));
   });
 
   test('deleteInstanceID', () {
     firebaseMessaging.deleteInstanceID();
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    verify(mockChannel.invokeMethod('deleteInstanceID'));
+    verify(mockChannel.invokeMethod<bool>('deleteInstanceID'));
   });
 
   test('autoInitEnabled', () {
     firebaseMessaging.autoInitEnabled();
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    verify(mockChannel.invokeMethod('autoInitEnabled'));
+    verify(mockChannel.invokeMethod<bool>('autoInitEnabled'));
   });
 
   test('setAutoInitEnabled', () {
@@ -178,22 +154,14 @@ void main() {
 
     firebaseMessaging.setAutoInitEnabled(true);
 
-    // assert we called the method with enabled = true
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    verify(mockChannel.invokeMethod('setAutoInitEnabled', true));
+    verify(mockChannel.invokeMethod<void>('setAutoInitEnabled', true));
 
     // assert that enabled = false was not yet called
     verifyNever(firebaseMessaging.setAutoInitEnabled(false));
 
     firebaseMessaging.setAutoInitEnabled(false);
 
-    // assert call with enabled = false was properly done
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    verify(mockChannel.invokeMethod('setAutoInitEnabled', false));
+    verify(mockChannel.invokeMethod<void>('setAutoInitEnabled', false));
   });
 }
 


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/26431