### PR TITLE
[firebase_ml_vision] Add missing template type parameter to `invokeMethod` calls. Bump minimum Flutter version to 1.5.0. Replace invokeMethod with invokeMapMethod wherever necessary.

### DIFF
--- a/packages/firebase_ml_vision/CHANGELOG.md
+++ b/packages/firebase_ml_vision/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.8.0+3
+
+* Add missing template type parameter to `invokeMethod` calls.
+* Bump minimum Flutter version to 1.5.0.
+* Replace invokeMethod with invokeMapMethod wherever necessary.
+
 ## 0.8.0+2
 
 * Fix crash when passing contact info from barcode.

--- a/packages/firebase_ml_vision/lib/src/barcode_detector.dart
+++ b/packages/firebase_ml_vision/lib/src/barcode_detector.dart
@@ -190,10 +190,8 @@ class BarcodeDetector {
 
   /// Detects barcodes in the input image.
   Future<List<Barcode>> detectInImage(FirebaseVisionImage visionImage) async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    final List<dynamic> reply = await FirebaseVision.channel.invokeMethod(
+    final List<dynamic> reply =
+        await FirebaseVision.channel.invokeListMethod<dynamic>(
       'BarcodeDetector#detectInImage',
       <String, dynamic>{
         'options': <String, dynamic>{

--- a/packages/firebase_ml_vision/lib/src/face_detector.dart
+++ b/packages/firebase_ml_vision/lib/src/face_detector.dart
@@ -45,10 +45,8 @@ class FaceDetector {
 
   /// Detects faces in the input image.
   Future<List<Face>> processImage(FirebaseVisionImage visionImage) async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    final List<dynamic> reply = await FirebaseVision.channel.invokeMethod(
+    final List<dynamic> reply =
+        await FirebaseVision.channel.invokeListMethod<dynamic>(
       'FaceDetector#processImage',
       <String, dynamic>{
         'options': <String, dynamic>{

--- a/packages/firebase_ml_vision/lib/src/image_labeler.dart
+++ b/packages/firebase_ml_vision/lib/src/image_labeler.dart
@@ -39,10 +39,8 @@ class ImageLabeler {
 
   /// Finds entities in the input image.
   Future<List<ImageLabel>> processImage(FirebaseVisionImage visionImage) async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    final List<dynamic> reply = await FirebaseVision.channel.invokeMethod(
+    final List<dynamic> reply =
+        await FirebaseVision.channel.invokeListMethod<dynamic>(
       'ImageLabeler#processImage',
       <String, dynamic>{
         'options': <String, dynamic>{

--- a/packages/firebase_ml_vision/lib/src/text_recognizer.dart
+++ b/packages/firebase_ml_vision/lib/src/text_recognizer.dart
@@ -23,11 +23,8 @@ class TextRecognizer {
 
   /// Detects [VisionText] from a [FirebaseVisionImage].
   Future<VisionText> processImage(FirebaseVisionImage visionImage) async {
-    final Map<dynamic, dynamic> reply =
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        await FirebaseVision.channel.invokeMethod(
+    final Map<String, dynamic> reply =
+        await FirebaseVision.channel.invokeMapMethod<String, dynamic>(
       'TextRecognizer#processImage',
       <String, dynamic>{
         'options': <String, dynamic>{},
@@ -40,7 +37,7 @@ class TextRecognizer {
 
 /// Recognized text in an image.
 class VisionText {
-  VisionText._(Map<dynamic, dynamic> data)
+  VisionText._(Map<String, dynamic> data)
       : text = data['text'],
         blocks = List<TextBlock>.unmodifiable(data['blocks']
             .map<TextBlock>((dynamic block) => TextBlock._(block)));

--- a/packages/firebase_ml_vision/pubspec.yaml
+++ b/packages/firebase_ml_vision/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_ml_vision
 description: Flutter plugin for Firebase machine learning vision services.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_ml_vision
-version: 0.8.0+2
+version: 0.8.0+3
 
 dependencies:
   flutter:
@@ -27,4 +27,4 @@ flutter:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.2.4 <2.0.0"
+  flutter: ">=1.5.0 <2.0.0"


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/26431