### PR TITLE
[local_auth] The thread for executor needs to be UI thread.

### DIFF
--- a/packages/local_auth/CHANGELOG.md
+++ b/packages/local_auth/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.5.2
+* Executor thread needs to be UI thread.
+
 ## 0.5.1
 * Fix crash on Android versions earlier than 28.
 * [`authenticateWithBiometrics`](https://pub.dev/documentation/local_auth/latest/local_auth/LocalAuthentication/authenticateWithBiometrics.html) will not return result unless Biometric Dialog is closed.

--- a/packages/local_auth/pubspec.yaml
+++ b/packages/local_auth/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Android and iOS device authentication sensors
   such as Fingerprint Reader and Touch ID.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/local_auth
-version: 0.5.1
+version: 0.5.2
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Two bug fixes:
- The thread passed to FP needs to be UI thread. Callbacks are executed on that thread and we also don't want any synchronization issues.
- We should not be calling .error() then .success() on the same result object. This does not cause any exceptions but it is bad form.