### PR TITLE
[firebase_storage]Add missing template type parameter to `invokeMethod` calls. Bump minimum Flutter version to 1.5.0. Replace invokeMethod with invokeMapMethod wherever necessary.

### DIFF
--- a/packages/firebase_storage/CHANGELOG.md
+++ b/packages/firebase_storage/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.0.1
+
+* Add missing template type parameter to `invokeMethod` calls.
+* Bump minimum Flutter version to 1.5.0.
+* Replace invokeMethod with invokeMapMethod wherever necessary.
+
 ## 3.0.0
 
 * Update Android dependencies to latest.

--- a/packages/firebase_storage/lib/src/event.dart
+++ b/packages/firebase_storage/lib/src/event.dart
@@ -16,14 +16,14 @@ enum StorageTaskEventType {
 class StorageTaskEvent {
   StorageTaskEvent._(int type, StorageReference ref, Map<dynamic, dynamic> data)
       : type = StorageTaskEventType.values[type],
-        snapshot = StorageTaskSnapshot._(ref, data);
+        snapshot = StorageTaskSnapshot._(ref, data.cast<String, dynamic>());
 
   final StorageTaskEventType type;
   final StorageTaskSnapshot snapshot;
 }
 
 class StorageTaskSnapshot {
-  StorageTaskSnapshot._(this.ref, Map<dynamic, dynamic> m)
+  StorageTaskSnapshot._(this.ref, Map<String, dynamic> m)
       : error = m['error'],
         bytesTransferred = m['bytesTransferred'],
         totalByteCount = m['totalByteCount'],
@@ -31,7 +31,8 @@ class StorageTaskSnapshot {
             ? Uri.parse(m['uploadSessionUri'])
             : null,
         storageMetadata = m['storageMetadata'] != null
-            ? StorageMetadata._fromMap(m['storageMetadata'])
+            ? StorageMetadata._fromMap(
+                m['storageMetadata'].cast<String, dynamic>())
             : null;
 
   final StorageReference ref;

--- a/packages/firebase_storage/lib/src/firebase_storage.dart
+++ b/packages/firebase_storage/lib/src/firebase_storage.dart
@@ -58,10 +58,7 @@ class FirebaseStorage {
   StorageReference ref() => StorageReference._(const <String>[], this);
 
   Future<int> getMaxDownloadRetryTimeMillis() async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return await channel.invokeMethod(
+    return await channel.invokeMethod<int>(
         "FirebaseStorage#getMaxDownloadRetryTime", <String, dynamic>{
       'app': app?.name,
       'bucket': storageBucket,
@@ -69,10 +66,7 @@ class FirebaseStorage {
   }
 
   Future<int> getMaxUploadRetryTimeMillis() async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return await channel.invokeMethod(
+    return await channel.invokeMethod<int>(
         "FirebaseStorage#getMaxUploadRetryTime", <String, dynamic>{
       'app': app?.name,
       'bucket': storageBucket,
@@ -80,10 +74,7 @@ class FirebaseStorage {
   }
 
   Future<int> getMaxOperationRetryTimeMillis() async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return await channel.invokeMethod(
+    return await channel.invokeMethod<int>(
         "FirebaseStorage#getMaxOperationRetryTime", <String, dynamic>{
       'app': app?.name,
       'bucket': storageBucket,
@@ -91,10 +82,7 @@ class FirebaseStorage {
   }
 
   Future<void> setMaxDownloadRetryTimeMillis(int time) {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return channel.invokeMethod(
+    return channel.invokeMethod<void>(
         "FirebaseStorage#setMaxDownloadRetryTime", <String, dynamic>{
       'app': app?.name,
       'bucket': storageBucket,
@@ -103,10 +91,7 @@ class FirebaseStorage {
   }
 
   Future<void> setMaxUploadRetryTimeMillis(int time) {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return channel.invokeMethod(
+    return channel.invokeMethod<void>(
         "FirebaseStorage#setMaxUploadRetryTime", <String, dynamic>{
       'app': app?.name,
       'bucket': storageBucket,
@@ -115,10 +100,7 @@ class FirebaseStorage {
   }
 
   Future<void> setMaxOperationRetryTimeMillis(int time) {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return channel.invokeMethod(
+    return channel.invokeMethod<void>(
         "FirebaseStorage#setMaxOperationRetryTime", <String, dynamic>{
       'app': app?.name,
       'bucket': storageBucket,
@@ -129,7 +111,7 @@ class FirebaseStorage {
   /// Creates a [StorageReference] given a gs:// or // URL pointing to a Firebase
   /// Storage location.
   Future<StorageReference> getReferenceFromUrl(String fullUrl) async {
-    final String path = await channel.invokeMethod(
+    final String path = await channel.invokeMethod<String>(
         "FirebaseStorage#getReferenceFromUrl", <String, dynamic>{
       'app': app?.name,
       'bucket': storageBucket,
@@ -152,10 +134,7 @@ class StorageFileDownloadTask {
   final File _file;
 
   Future<void> _start() async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    final int totalByteCount = await FirebaseStorage.channel.invokeMethod(
+    final int totalByteCount = await FirebaseStorage.channel.invokeMethod<int>(
       "StorageReference#writeToFile",
       <String, dynamic>{
         'app': _firebaseStorage.app?.name,

--- a/packages/firebase_storage/lib/src/storage_metadata.dart
+++ b/packages/firebase_storage/lib/src/storage_metadata.dart
@@ -27,7 +27,7 @@ class StorageMetadata {
             ? null
             : Map<String, String>.unmodifiable(customMetadata);
 
-  StorageMetadata._fromMap(Map<dynamic, dynamic> map)
+  StorageMetadata._fromMap(Map<String, dynamic> map)
       : bucket = map['bucket'],
         generation = map['generation'],
         metadataGeneration = map['metadataGeneration'],

--- a/packages/firebase_storage/lib/src/storage_reference.dart
+++ b/packages/firebase_storage/lib/src/storage_reference.dart
@@ -78,10 +78,7 @@ class StorageReference {
   /// Returns the Google Cloud Storage bucket that holds this object.
   Future<String> getBucket() async {
     return await FirebaseStorage.channel
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        .invokeMethod("StorageReference#getBucket", <String, String>{
+        .invokeMethod<String>("StorageReference#getBucket", <String, String>{
       'app': _firebaseStorage.app?.name,
       'bucket': _firebaseStorage.storageBucket,
       'path': _pathComponents.join("/"),
@@ -92,10 +89,7 @@ class StorageReference {
   /// Storage bucket.
   Future<String> getPath() async {
     return await FirebaseStorage.channel
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        .invokeMethod("StorageReference#getPath", <String, String>{
+        .invokeMethod<String>("StorageReference#getPath", <String, String>{
       'app': _firebaseStorage.app?.name,
       'bucket': _firebaseStorage.storageBucket,
       'path': _pathComponents.join("/"),
@@ -105,10 +99,7 @@ class StorageReference {
   /// Returns the short name of this object.
   Future<String> getName() async {
     return await FirebaseStorage.channel
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        .invokeMethod("StorageReference#getName", <String, String>{
+        .invokeMethod<String>("StorageReference#getName", <String, String>{
       'app': _firebaseStorage.app?.name,
       'bucket': _firebaseStorage.storageBucket,
       'path': _pathComponents.join("/"),
@@ -118,10 +109,7 @@ class StorageReference {
   /// Asynchronously downloads the object at the StorageReference to a list in memory.
   /// A list of the provided max size will be allocated.
   Future<Uint8List> getData(int maxSize) async {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return await FirebaseStorage.channel.invokeMethod(
+    return await FirebaseStorage.channel.invokeMethod<Uint8List>(
       "StorageReference#getData",
       <String, dynamic>{
         'app': _firebaseStorage.app?.name,
@@ -145,11 +133,8 @@ class StorageReference {
   /// This can be used to share the file with others, but can be revoked by a
   /// developer in the Firebase Console if desired.
   Future<dynamic> getDownloadURL() async {
-    return await FirebaseStorage.channel
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        .invokeMethod("StorageReference#getDownloadUrl", <String, String>{
+    return await FirebaseStorage.channel.invokeMethod<dynamic>(
+        "StorageReference#getDownloadUrl", <String, String>{
       'app': _firebaseStorage.app?.name,
       'bucket': _firebaseStorage.storageBucket,
       'path': _pathComponents.join("/"),
@@ -158,10 +143,7 @@ class StorageReference {
 
   Future<void> delete() {
     return FirebaseStorage.channel
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        .invokeMethod("StorageReference#delete", <String, String>{
+        .invokeMethod<void>("StorageReference#delete", <String, String>{
       'app': _firebaseStorage.app?.name,
       'bucket': _firebaseStorage.storageBucket,
       'path': _pathComponents.join("/")
@@ -171,10 +153,8 @@ class StorageReference {
   /// Retrieves metadata associated with an object at this [StorageReference].
   Future<StorageMetadata> getMetadata() async {
     return StorageMetadata._fromMap(await FirebaseStorage.channel
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        .invokeMethod("StorageReference#getMetadata", <String, String>{
+        .invokeMapMethod<String, dynamic>(
+            "StorageReference#getMetadata", <String, String>{
       'app': _firebaseStorage.app?.name,
       'bucket': _firebaseStorage.storageBucket,
       'path': _pathComponents.join("/"),
@@ -190,10 +170,8 @@ class StorageReference {
   /// by passing the empty string.
   Future<StorageMetadata> updateMetadata(StorageMetadata metadata) async {
     return StorageMetadata._fromMap(await FirebaseStorage.channel
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        .invokeMethod("StorageReference#updateMetadata", <String, dynamic>{
+        .invokeMapMethod<String, dynamic>(
+            "StorageReference#updateMetadata", <String, dynamic>{
       'app': _firebaseStorage.app?.name,
       'bucket': _firebaseStorage.storageBucket,
       'path': _pathComponents.join("/"),

--- a/packages/firebase_storage/lib/src/upload_task.dart
+++ b/packages/firebase_storage/lib/src/upload_task.dart
@@ -89,10 +89,7 @@ abstract class StorageUploadTask {
   }
 
   /// Pause the upload
-  // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-  // https://github.com/flutter/flutter/issues/26431
-  // ignore: strong_mode_implicit_dynamic_method
-  void pause() => FirebaseStorage.channel.invokeMethod(
+  void pause() => FirebaseStorage.channel.invokeMethod<void>(
         'UploadTask#pause',
         <String, dynamic>{
           'app': _firebaseStorage.app?.name,
@@ -102,10 +99,7 @@ abstract class StorageUploadTask {
       );
 
   /// Resume the upload
-  // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-  // https://github.com/flutter/flutter/issues/26431
-  // ignore: strong_mode_implicit_dynamic_method
-  void resume() => FirebaseStorage.channel.invokeMethod(
+  void resume() => FirebaseStorage.channel.invokeMethod<void>(
         'UploadTask#resume',
         <String, dynamic>{
           'app': _firebaseStorage.app?.name,
@@ -115,10 +109,7 @@ abstract class StorageUploadTask {
       );
 
   /// Cancel the upload
-  // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-  // https://github.com/flutter/flutter/issues/26431
-  // ignore: strong_mode_implicit_dynamic_method
-  void cancel() => FirebaseStorage.channel.invokeMethod(
+  void cancel() => FirebaseStorage.channel.invokeMethod<void>(
         'UploadTask#cancel',
         <String, dynamic>{
           'app': _firebaseStorage.app?.name,
@@ -137,10 +128,7 @@ class _StorageFileUploadTask extends StorageUploadTask {
 
   @override
   Future<dynamic> _platformStart() {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return FirebaseStorage.channel.invokeMethod(
+    return FirebaseStorage.channel.invokeMethod<dynamic>(
       'StorageReference#putFile',
       <String, dynamic>{
         'app': _firebaseStorage.app?.name,
@@ -163,10 +151,7 @@ class _StorageDataUploadTask extends StorageUploadTask {
 
   @override
   Future<dynamic> _platformStart() {
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return FirebaseStorage.channel.invokeMethod(
+    return FirebaseStorage.channel.invokeMethod<dynamic>(
       'StorageReference#putData',
       <String, dynamic>{
         'app': _firebaseStorage.app?.name,

--- a/packages/firebase_storage/pubspec.yaml
+++ b/packages/firebase_storage/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Cloud Storage, a powerful, simple, and
   cost-effective object storage service for Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_storage
-version: 3.0.0
+version: 3.0.1
 
 flutter:
   plugin:
@@ -27,4 +27,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.1.4 <2.0.0"
+  flutter: ">=1.5.0 <2.0.0"


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/26431