### PR TITLE
[in_app_purchase]Add missing template type parameter to `invokeMethod` calls. Bump minimum Flutter version to 1.5.0. Replace invokeMethod with invokeMapMethod wherever necessary.

### DIFF
--- a/packages/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.1.1+2
+
+* Add missing template type parameter to `invokeMethod` calls.
+* Bump minimum Flutter version to 1.5.0.
+* Replace invokeMethod with invokeMapMethod wherever necessary.
+
 ## 0.1.1+1
 
 * Make `AdditionalSteps`(Used in the unit test) a void function.

--- a/packages/in_app_purchase/lib/src/billing_client_wrappers/billing_client_wrapper.dart
+++ b/packages/in_app_purchase/lib/src/billing_client_wrappers/billing_client_wrapper.dart
@@ -68,7 +68,7 @@ class BillingClient {
   /// [`BillingClient#isReady()`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.html#isReady())
   /// to get the ready status of the BillingClient instance.
   Future<bool> isReady() async =>
-      await channel.invokeMethod('BillingClient#isReady()');
+      await channel.invokeMethod<bool>('BillingClient#isReady()');
 
   /// Calls
   /// [`BillingClient#startConnection(BillingClientStateListener)`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.html#startconnection)
@@ -86,7 +86,7 @@ class BillingClient {
     List<Function> disconnectCallbacks =
         _callbacks[_kOnBillingServiceDisconnected] ??= [];
     disconnectCallbacks.add(onBillingServiceDisconnected);
-    return BillingResponseConverter().fromJson(await channel.invokeMethod(
+    return BillingResponseConverter().fromJson(await channel.invokeMethod<int>(
         "BillingClient#startConnection(BillingClientStateListener)",
         <String, dynamic>{'handle': disconnectCallbacks.length - 1}));
   }
@@ -99,7 +99,7 @@ class BillingClient {
   ///
   /// This triggers the destruction of the `BillingClient` instance in Java.
   Future<void> endConnection() async {
-    return channel.invokeMethod("BillingClient#endConnection()", null);
+    return channel.invokeMethod<void>("BillingClient#endConnection()", null);
   }
 
   /// Returns a list of [SkuDetailsWrapper]s that have [SkuDetailsWrapper.sku]
@@ -153,7 +153,7 @@ class BillingClient {
       'sku': sku,
       'accountId': accountId,
     };
-    return BillingResponseConverter().fromJson(await channel.invokeMethod(
+    return BillingResponseConverter().fromJson(await channel.invokeMethod<int>(
         'BillingClient#launchBillingFlow(Activity, BillingFlowParams)',
         arguments));
   }
@@ -171,9 +171,10 @@ class BillingClient {
   /// skutype)`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#querypurchases).
   Future<PurchasesResultWrapper> queryPurchases(SkuType skuType) async {
     assert(skuType != null);
-    return PurchasesResultWrapper.fromJson(await channel.invokeMapMethod(
-        'BillingClient#queryPurchases(String)',
-        <String, dynamic>{'skuType': SkuTypeConverter().toJson(skuType)}));
+    return PurchasesResultWrapper.fromJson(await channel
+        .invokeMapMethod<String, dynamic>(
+            'BillingClient#queryPurchases(String)',
+            <String, dynamic>{'skuType': SkuTypeConverter().toJson(skuType)}));
   }
 
   /// Fetches purchase history for the given [SkuType].
@@ -191,9 +192,10 @@ class BillingClient {
   /// listener)`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient#querypurchasehistoryasync).
   Future<PurchasesResultWrapper> queryPurchaseHistory(SkuType skuType) async {
     assert(skuType != null);
-    return PurchasesResultWrapper.fromJson(await channel.invokeMapMethod(
-        'BillingClient#queryPurchaseHistoryAsync(String, PurchaseHistoryResponseListener)',
-        <String, dynamic>{'skuType': SkuTypeConverter().toJson(skuType)}));
+    return PurchasesResultWrapper.fromJson(await channel
+        .invokeMapMethod<String, dynamic>(
+            'BillingClient#queryPurchaseHistoryAsync(String, PurchaseHistoryResponseListener)',
+            <String, dynamic>{'skuType': SkuTypeConverter().toJson(skuType)}));
   }
 
   /// Consumes a given in-app product.
@@ -204,7 +206,7 @@ class BillingClient {
   /// This wraps [`BillingClient#consumeAsync(String, ConsumeResponseListener)`](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.html#consumeAsync(java.lang.String,%20com.android.billingclient.api.ConsumeResponseListener))
   Future<BillingResponse> consumeAsync(String purchaseToken) async {
     assert(purchaseToken != null);
-    return BillingResponseConverter().fromJson(await channel.invokeMethod(
+    return BillingResponseConverter().fromJson(await channel.invokeMethod<int>(
       'BillingClient#consumeAsync(String, ConsumeResponseListener)',
       <String, String>{'purchaseToken': purchaseToken},
     ));

--- a/packages/in_app_purchase/lib/src/billing_client_wrappers/purchase_wrapper.dart
+++ b/packages/in_app_purchase/lib/src/billing_client_wrappers/purchase_wrapper.dart
@@ -104,7 +104,7 @@ class PurchasesResultWrapper {
       {@required BillingResponse this.responseCode,
       @required List<PurchaseWrapper> this.purchasesList});
 
-  factory PurchasesResultWrapper.fromJson(Map map) =>
+  factory PurchasesResultWrapper.fromJson(Map<String, dynamic> map) =>
       _$PurchasesResultWrapperFromJson(map);
 
   @override

--- a/packages/in_app_purchase/lib/src/store_kit_wrappers/sk_payment_queue_wrapper.dart
+++ b/packages/in_app_purchase/lib/src/store_kit_wrappers/sk_payment_queue_wrapper.dart
@@ -42,7 +42,7 @@ class SKPaymentQueueWrapper {
 
   /// Calls [`-[SKPaymentQueue canMakePayments:]`](https://developer.apple.com/documentation/storekit/skpaymentqueue/1506139-canmakepayments?language=objc).
   static Future<bool> canMakePayments() async =>
-      await channel.invokeMethod('-[SKPaymentQueue canMakePayments:]');
+      await channel.invokeMethod<bool>('-[SKPaymentQueue canMakePayments:]');
 
   /// Sets an observer to listen to all incoming transaction events.
   ///
@@ -78,7 +78,7 @@ class SKPaymentQueueWrapper {
     assert(_observer != null,
         '[in_app_purchase]: Trying to add a payment without an observer. One must be set using `SkPaymentQueueWrapper.setTransactionObserver` before the app launches.');
     Map requestMap = payment.toMap();
-    await channel.invokeMethod(
+    await channel.invokeMethod<void>(
       '-[InAppPurchasePlugin addPayment:result:]',
       requestMap,
     );
@@ -97,7 +97,7 @@ class SKPaymentQueueWrapper {
   /// finishTransaction:]`](https://developer.apple.com/documentation/storekit/skpaymentqueue/1506003-finishtransaction?language=objc).
   Future<void> finishTransaction(
       SKPaymentTransactionWrapper transaction) async {
-    await channel.invokeMethod(
+    await channel.invokeMethod<void>(
         '-[InAppPurchasePlugin finishTransaction:result:]',
         transaction.transactionIdentifier);
   }
@@ -122,7 +122,7 @@ class SKPaymentQueueWrapper {
   /// or [`-[SKPayment restoreCompletedTransactionsWithApplicationUsername:]`](https://developer.apple.com/documentation/storekit/skpaymentqueue/1505992-restorecompletedtransactionswith?language=objc)
   /// depending on whether the `applicationUserName` is set.
   Future<void> restoreTransactions({String applicationUserName}) async {
-    await channel.invokeMethod(
+    await channel.invokeMethod<void>(
         '-[InAppPurchasePlugin restoreTransactions:result:]',
         applicationUserName);
   }

--- a/packages/in_app_purchase/lib/src/store_kit_wrappers/sk_product_wrapper.dart
+++ b/packages/in_app_purchase/lib/src/store_kit_wrappers/sk_product_wrapper.dart
@@ -24,7 +24,7 @@ class SkProductResponseWrapper {
   ///
   /// This method should only be used with `map` values returned by [SKRequestMaker.startProductRequest].
   /// The `map` parameter must not be null.
-  factory SkProductResponseWrapper.fromJson(Map map) {
+  factory SkProductResponseWrapper.fromJson(Map<String, dynamic> map) {
     assert(map != null, 'Map must not be null.');
     return _$SkProductResponseWrapperFromJson(map);
   }

--- a/packages/in_app_purchase/lib/src/store_kit_wrappers/sk_receipt_manager.dart
+++ b/packages/in_app_purchase/lib/src/store_kit_wrappers/sk_receipt_manager.dart
@@ -15,7 +15,7 @@ class SKReceiptManager {
   /// For more details on how to validate the receipt data, you can refer to Apple's document about [`About Receipt Validation`](https://developer.apple.com/library/archive/releasenotes/General/ValidateAppStoreReceipt/Introduction.html#//apple_ref/doc/uid/TP40010573-CH105-SW1).
   /// If the receipt is invalid or missing, you can use [SKRequestMaker.startRefreshReceiptRequest] to request a new receipt.
   static Future<String> retrieveReceiptData() {
-    return channel
-        .invokeMethod('-[InAppPurchasePlugin retrieveReceiptData:result:]');
+    return channel.invokeMethod<String>(
+        '-[InAppPurchasePlugin retrieveReceiptData:result:]');
   }
 }

--- a/packages/in_app_purchase/lib/src/store_kit_wrappers/sk_request_maker.dart
+++ b/packages/in_app_purchase/lib/src/store_kit_wrappers/sk_request_maker.dart
@@ -24,7 +24,8 @@ class SKRequestMaker {
   /// A [PlatformException] is thrown if the platform code making the request fails.
   Future<SkProductResponseWrapper> startProductRequest(
       List<String> productIdentifiers) async {
-    final Map productResponseMap = await channel.invokeMethod(
+    final Map<String, dynamic> productResponseMap =
+        await channel.invokeMapMethod<String, dynamic>(
       '-[InAppPurchasePlugin startProductRequest:result:]',
       productIdentifiers,
     );
@@ -47,7 +48,7 @@ class SKRequestMaker {
   /// * isRevoked: whether the receipt has been revoked.
   /// * isVolumePurchase: whether the receipt is a Volume Purchase Plan receipt.
   Future<void> startRefreshReceiptRequest({Map receiptProperties}) {
-    return channel.invokeMethod(
+    return channel.invokeMethod<void>(
       '-[InAppPurchasePlugin refreshReceipt:result:]',
       receiptProperties,
     );

--- a/packages/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/pubspec.yaml
@@ -31,5 +31,5 @@ flutter:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.4.4 <2.0.0"
+  flutter: ">=1.5.0 <2.0.0"
 


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/26431