### PR TITLE
[location_background] Add missing template type parameter to `invokeMethod` calls. Bump minimum Flutter version to 1.5.0. Replace invokeMethod with invokeMapMethod wherever necessary.

### DIFF
--- a/packages/location_background/CHANGELOG.md
+++ b/packages/location_background/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.1.0+2
+
+* Add missing template type parameter to `invokeMethod` calls.
+* Bump minimum Flutter version to 1.5.0.
+* Replace invokeMethod with invokeMapMethod wherever necessary.
+
 ## 0.1.0+1
 
 * Log a more detailed warning at build time about the previous AndroidX

--- a/packages/location_background/lib/location_background_plugin.dart
+++ b/packages/location_background/lib/location_background_plugin.dart
@@ -117,11 +117,8 @@ class LocationBackgroundPlugin {
     final CallbackHandle handle =
         PluginUtilities.getCallbackHandle(_backgroundCallbackDispatcher);
     assert(handle != null, 'Unable to lookup callback.');
-    _channel
-        // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-        // https://github.com/flutter/flutter/issues/26431
-        // ignore: strong_mode_implicit_dynamic_method
-        .invokeMethod(_kStartHeadlessService, <dynamic>[handle.toRawHandle()]);
+    _channel.invokeMethod<void>(
+        _kStartHeadlessService, <dynamic>[handle.toRawHandle()]);
   }
 
   // The method channel we'll use to communicate with the native portion of our
@@ -147,10 +144,7 @@ class LocationBackgroundPlugin {
       throw ArgumentError.notNull('callback');
     }
     final CallbackHandle handle = PluginUtilities.getCallbackHandle(callback);
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return _channel.invokeMethod(_kMonitorLocationChanges, <dynamic>[
+    return _channel.invokeMethod<bool>(_kMonitorLocationChanges, <dynamic>[
       handle.toRawHandle(),
       pauseLocationUpdatesAutomatically,
       showsBackgroundLocationIndicator,
@@ -160,8 +154,5 @@ class LocationBackgroundPlugin {
 
   /// Stop all location updates.
   Future<void> cancelLocationUpdates() =>
-      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-      // https://github.com/flutter/flutter/issues/26431
-      // ignore: strong_mode_implicit_dynamic_method
-      _channel.invokeMethod(_kCancelLocationUpdates);
+      _channel.invokeMethod<void>(_kCancelLocationUpdates);
 }

--- a/packages/location_background/pubspec.yaml
+++ b/packages/location_background/pubspec.yaml
@@ -2,7 +2,7 @@ name: location_background_plugin
 description: A new flutter plugin project.
 author:  Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/location_background
-version: 0.1.0+1
+version: 0.1.0+2
 publish_to: none
 
 dependencies:
@@ -20,4 +20,4 @@ flutter:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.4.4 <2.0.0"
+  flutter: ">=1.5.0 <2.0.0"


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/26431