### PR TITLE
[Package_info] Add missing template type parameter to `invokeMethod` calls. Bump minimum Flutter version to 1.5.0. Replace invokeMethod with invokeMapMethod wherever necessary.

### DIFF
--- a/packages/package_info/CHANGELOG.md
+++ b/packages/package_info/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.4.0+4
+
+* Add missing template type parameter to `invokeMethod` calls.
+* Bump minimum Flutter version to 1.5.0.
+* Replace invokeMethod with invokeMapMethod wherever necessary.
+
 ## 0.4.0+3
 
 * Add integration test.

--- a/packages/package_info/lib/package_info.dart
+++ b/packages/package_info/lib/package_info.dart
@@ -32,7 +32,8 @@ class PackageInfo {
     if (_fromPlatform == null) {
       final Completer<PackageInfo> completer = Completer<PackageInfo>();
 
-      _kChannel.invokeMapMethod<String, dynamic>('getAll').then((dynamic result) {
+      _kChannel.invokeMapMethod<String, dynamic>('getAll').then(
+          (dynamic result) {
         final Map<dynamic, dynamic> map = result;
 
         completer.complete(PackageInfo(

--- a/packages/package_info/lib/package_info.dart
+++ b/packages/package_info/lib/package_info.dart
@@ -32,10 +32,7 @@ class PackageInfo {
     if (_fromPlatform == null) {
       final Completer<PackageInfo> completer = Completer<PackageInfo>();
 
-      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-      // https://github.com/flutter/flutter/issues/26431
-      // ignore: strong_mode_implicit_dynamic_method
-      _kChannel.invokeMethod('getAll').then((dynamic result) {
+      _kChannel.invokeMapMethod<String, dynamic>('getAll').then((dynamic result) {
         final Map<dynamic, dynamic> map = result;
 
         completer.complete(PackageInfo(

--- a/packages/package_info/pubspec.yaml
+++ b/packages/package_info/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for querying information about the application
   package, such as CFBundleVersion on iOS or versionCode on Android.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/package_info
-version: 0.4.0+3
+version: 0.4.0+4
 
 flutter:
   plugin:
@@ -24,4 +24,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.1.4 <2.0.0"
+  flutter: ">=1.5.0 <2.0.0"


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/26431