### PR TITLE
[quick_ actions] Add missing template type parameter to `invokeMethod` calls. Bump minimum Flutter version to 1.5.0. Replace invokeMethod with invokeMapMethod wherever necessary.

### DIFF
--- a/packages/quick_actions/CHANGELOG.md
+++ b/packages/quick_actions/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.0+2
+
+* Add missing template type parameter to `invokeMethod` calls.
+* Bump minimum Flutter version to 1.5.0.
+* Replace invokeMethod with invokeMapMethod wherever necessary.
+
 ## 0.3.0+1
 
 * Log a more detailed warning at build time about the previous AndroidX

--- a/packages/quick_actions/lib/quick_actions.dart
+++ b/packages/quick_actions/lib/quick_actions.dart
@@ -52,18 +52,12 @@ class QuickActions {
   Future<void> setShortcutItems(List<ShortcutItem> items) async {
     final List<Map<String, String>> itemsList =
         items.map(_serializeItem).toList();
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    await _kChannel.invokeMethod('setShortcutItems', itemsList);
+    await _kChannel.invokeMethod<void>('setShortcutItems', itemsList);
   }
 
   /// Removes all [ShortcutItem]s registered for the app.
   Future<void> clearShortcutItems() =>
-      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-      // https://github.com/flutter/flutter/issues/26431
-      // ignore: strong_mode_implicit_dynamic_method
-      _kChannel.invokeMethod('clearShortcutItems');
+      _kChannel.invokeMethod<void>('clearShortcutItems');
 
   Map<String, String> _serializeItem(ShortcutItem item) {
     return <String, String>{

--- a/packages/quick_actions/pubspec.yaml
+++ b/packages/quick_actions/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for creating shortcuts on home screen, also known as
   Quick Actions on iOS and App Shortcuts on Android.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/quick_actions
-version: 0.3.0+1
+version: 0.3.0+2
 
 flutter:
   plugin:
@@ -18,4 +18,4 @@ dependencies:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.1.4 <2.0.0"
+  flutter: ">=1.5.0 <2.0.0"


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/26431