### PR TITLE
[shared_preferences]Add missing template type parameter to `invokeMethod` calls. Bump minimum Flutter version to 1.5.0. Replace invokeMethod with invokeMapMethod wherever necessary.

### DIFF
--- a/packages/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.5.3+1
+
+* Add missing template type parameter to `invokeMethod` calls.
+* Bump minimum Flutter version to 1.5.0.
+* Replace invokeMethod with invokeMapMethod wherever necessary.
+
 ## 0.5.3
 
 * Add reload method.

--- a/packages/shared_preferences/lib/shared_preferences.dart
+++ b/packages/shared_preferences/lib/shared_preferences.dart
@@ -114,19 +114,13 @@ class SharedPreferences {
     if (value == null) {
       _preferenceCache.remove(key);
       return _kChannel
-          // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-          // https://github.com/flutter/flutter/issues/26431
-          // ignore: strong_mode_implicit_dynamic_method
-          .invokeMethod('remove', params)
+          .invokeMethod<bool>('remove', params)
           .then<bool>((dynamic result) => result);
     } else {
       _preferenceCache[key] = value;
       params['value'] = value;
       return _kChannel
-          // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-          // https://github.com/flutter/flutter/issues/26431
-          // ignore: strong_mode_implicit_dynamic_method
-          .invokeMethod('set$valueType', params)
+          .invokeMethod<bool>('set$valueType', params)
           .then<bool>((dynamic result) => result);
     }
   }
@@ -134,18 +128,12 @@ class SharedPreferences {
   /// Always returns true.
   /// On iOS, synchronize is marked deprecated. On Android, we commit every set.
   @deprecated
-  // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-  // https://github.com/flutter/flutter/issues/26431
-  // ignore: strong_mode_implicit_dynamic_method
-  Future<bool> commit() async => await _kChannel.invokeMethod('commit');
+  Future<bool> commit() async => await _kChannel.invokeMethod<bool>('commit');
 
   /// Completes with true once the user preferences for the app has been cleared.
   Future<bool> clear() async {
     _preferenceCache.clear();
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return await _kChannel.invokeMethod('clear');
+    return await _kChannel.invokeMethod<bool>('clear');
   }
 
   /// Fetches the latest values from the host platform.
@@ -160,8 +148,8 @@ class SharedPreferences {
   }
 
   static Future<Map<String, Object>> _getSharedPreferencesMap() async {
-    final Map<Object, Object> fromSystem =
-        await _kChannel.invokeMethod('getAll');
+    final Map<String, Object> fromSystem =
+        await _kChannel.invokeMapMethod<String, Object>('getAll');
     assert(fromSystem != null);
     // Strip the flutter. prefix from the returned preferences.
     final Map<String, Object> preferencesMap = <String, Object>{};

--- a/packages/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for reading and writing simple key-value pairs.
   Wraps NSUserDefaults on iOS and SharedPreferences on Android.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/shared_preferences
-version: 0.5.3
+version: 0.5.3+1
 
 flutter:
   plugin:
@@ -25,4 +25,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.1.4 <2.0.0"
+  flutter: ">=1.5.0 <2.0.0"

--- a/packages/shared_preferences/test/shared_preferences_test.dart
+++ b/packages/shared_preferences/test/shared_preferences_test.dart
@@ -156,15 +156,11 @@ void main() {
     });
 
     test('mocking', () async {
-      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-      // https://github.com/flutter/flutter/issues/26431
-      // ignore: strong_mode_implicit_dynamic_method
-      expect(await channel.invokeMethod('getAll'), kTestValues);
+      expect(
+          await channel.invokeMapMethod<String, Object>('getAll'), kTestValues);
       SharedPreferences.setMockInitialValues(kTestValues2);
-      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-      // https://github.com/flutter/flutter/issues/26431
-      // ignore: strong_mode_implicit_dynamic_method
-      expect(await channel.invokeMethod('getAll'), kTestValues2);
+      expect(await channel.invokeMapMethod<String, Object>('getAll'),
+          kTestValues2);
     });
   });
 }


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/26431