### PR TITLE
[url_launcher] Add missing template type parameter to `invokeMethod` calls. Bump minimum Flutter version to 1.5.0. Replace invokeMethod with invokeMapMethod wherever necessary.

### DIFF
--- a/packages/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 5.0.3
+
+* Add missing template type parameter to `invokeMethod` calls.
+* Bump minimum Flutter version to 1.5.0.
+* Replace invokeMethod with invokeMapMethod wherever necessary.
+
 ## 5.0.2
 * Fixes `closeWebView` failure on iOS.
 

--- a/packages/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/lib/url_launcher.dart
@@ -79,10 +79,7 @@ Future<bool> launch(
         ? SystemUiOverlayStyle.dark
         : SystemUiOverlayStyle.light);
   }
-  // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-  // https://github.com/flutter/flutter/issues/26431
-  // ignore: strong_mode_implicit_dynamic_method
-  final bool result = await _channel.invokeMethod(
+  final bool result = await _channel.invokeMethod<bool>(
     'launch',
     <String, Object>{
       'url': urlString,
@@ -105,10 +102,7 @@ Future<bool> canLaunch(String urlString) async {
   if (urlString == null) {
     return false;
   }
-  // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-  // https://github.com/flutter/flutter/issues/26431
-  // ignore: strong_mode_implicit_dynamic_method
-  return await _channel.invokeMethod(
+  return await _channel.invokeMethod<bool>(
     'canLaunch',
     <String, Object>{'url': urlString},
   );
@@ -126,8 +120,5 @@ Future<bool> canLaunch(String urlString) async {
 /// SafariViewController is only available on IOS version >= 9.0, this method does not do anything
 /// on IOS version below 9.0
 Future<void> closeWebView() async {
-  // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-  // https://github.com/flutter/flutter/issues/26431
-  // ignore: strong_mode_implicit_dynamic_method
-  return await _channel.invokeMethod('closeWebView');
+  return await _channel.invokeMethod<void>('closeWebView');
 }

--- a/packages/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for launching a URL on Android and iOS. Supports
   web, phone, SMS, and email schemes.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher
-version: 5.0.2
+version: 5.0.3
 
 flutter:
   plugin:
@@ -21,4 +21,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.5.6 <2.0.0"
+  flutter: ">=1.5.0 <2.0.0"


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/26431