### PR TITLE
[cloud_firestore] Invoke on ui thread only

### DIFF
--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.12.2
+
+* Ensure that all channel calls to the Dart side from the Java side are done
+  on the UI thread. This change allows Transactions to work with upcoming
+  Engine restrictions, which require channel calls be made on the UI thread. 
+
 ## 0.12.1
 
 * Added support for `Source` to `Query.getDocuments()` and `DocumentReference.get()`.

--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 * Ensure that all channel calls to the Dart side from the Java side are done
   on the UI thread. This change allows Transactions to work with upcoming
-  Engine restrictions, which require channel calls be made on the UI thread. 
+  Engine restrictions, which require channel calls be made on the UI thread.
+  **Note** this is an Android only change, the iOS implementation was not impacted.
+* Updated the Firebase reporting string to `flutter-fire-fst` to be consistent
+  with other reporting libraries.
 
 ## 0.12.1
 

--- a/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
+++ b/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
@@ -10,7 +10,6 @@ import android.util.Log;
 import android.util.SparseArray;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
@@ -359,35 +358,38 @@ public class CloudFirestorePlugin implements MethodCallHandler {
                       completionTasks.append(transactionId, transactionTCS);
 
                       // Start operations on Dart side.
-                      activity.runOnUiThread(new Runnable() {
-                        @Override
-                        public void run() {
-                          channel.invokeMethod(
-                              "DoTransaction",
-                              arguments,
-                              new Result() {
-                                @SuppressWarnings("unchecked")
-                                @Override
-                                public void success(Object doTransactionResult) {
-                                  transactionTCS.trySetResult(
-                                      (Map<String, Object>) doTransactionResult);
-                                }
+                      activity.runOnUiThread(
+                          new Runnable() {
+                            @Override
+                            public void run() {
+                              channel.invokeMethod(
+                                  "DoTransaction",
+                                  arguments,
+                                  new Result() {
+                                    @SuppressWarnings("unchecked")
+                                    @Override
+                                    public void success(Object doTransactionResult) {
+                                      transactionTCS.trySetResult(
+                                          (Map<String, Object>) doTransactionResult);
+                                    }
 
-                                @Override
-                                public void error(
-                                    String errorCode, String errorMessage, Object errorDetails) {
-                                  transactionTCS.trySetException(
-                                      new Exception("Do transaction failed."));
-                                }
+                                    @Override
+                                    public void error(
+                                        String errorCode,
+                                        String errorMessage,
+                                        Object errorDetails) {
+                                      transactionTCS.trySetException(
+                                          new Exception("Do transaction failed."));
+                                    }
 
-                                @Override
-                                public void notImplemented() {
-                                  transactionTCS.trySetException(
-                                      new Exception("DoTransaction not implemented"));
-                                }
-                              });
-                        }
-                      });
+                                    @Override
+                                    public void notImplemented() {
+                                      transactionTCS.trySetException(
+                                          new Exception("DoTransaction not implemented"));
+                                    }
+                                  });
+                            }
+                          });
 
                       // Wait till transaction is complete.
                       try {
@@ -405,17 +407,18 @@ public class CloudFirestorePlugin implements MethodCallHandler {
                       return null;
                     }
                   })
-              .addOnCompleteListener(new OnCompleteListener<Map<String, Object>>() {
-                @Override
-                public void onComplete(Task<Map<String, Object>> task) {
-                  if (task.isSuccessful()) {
-                    result.success(task.getResult());
-                  } else {
-                    result.error("Error performing transaction",
-                        task.getException().getMessage(), null);
-                  }
-                }
-              });
+              .addOnCompleteListener(
+                  new OnCompleteListener<Map<String, Object>>() {
+                    @Override
+                    public void onComplete(Task<Map<String, Object>> task) {
+                      if (task.isSuccessful()) {
+                        result.success(task.getResult());
+                      } else {
+                        result.error(
+                            "Error performing transaction", task.getException().getMessage(), null);
+                      }
+                    }
+                  });
           break;
         }
       case "Transaction#get":
@@ -439,19 +442,21 @@ public class CloudFirestorePlugin implements MethodCallHandler {
                 metadata.put("hasPendingWrites", documentSnapshot.getMetadata().hasPendingWrites());
                 metadata.put("isFromCache", documentSnapshot.getMetadata().isFromCache());
                 snapshotMap.put("metadata", metadata);
-                activity.runOnUiThread(new Runnable() {
-                  @Override
-                  public void run() {
-                    result.success(snapshotMap);
-                  }
-                });
+                activity.runOnUiThread(
+                    new Runnable() {
+                      @Override
+                      public void run() {
+                        result.success(snapshotMap);
+                      }
+                    });
               } catch (final FirebaseFirestoreException e) {
-                activity.runOnUiThread(new Runnable() {
-                  @Override
-                  public void run() {
-                    result.error("Error performing Transaction#get", e.getMessage(), null);
-                  }
-                });
+                activity.runOnUiThread(
+                    new Runnable() {
+                      @Override
+                      public void run() {
+                        result.error("Error performing Transaction#get", e.getMessage(), null);
+                      }
+                    });
               }
               return null;
             }
@@ -469,19 +474,21 @@ public class CloudFirestorePlugin implements MethodCallHandler {
               Map<String, Object> data = (Map<String, Object>) arguments.get("data");
               try {
                 transaction.update(getDocumentReference(arguments), data);
-                activity.runOnUiThread(new Runnable() {
-                  @Override
-                  public void run() {
-                    result.success(null);
-                  }
-                });
+                activity.runOnUiThread(
+                    new Runnable() {
+                      @Override
+                      public void run() {
+                        result.success(null);
+                      }
+                    });
               } catch (final IllegalStateException e) {
-                activity.runOnUiThread(new Runnable() {
-                  @Override
-                  public void run() {
-                    result.error("Error performing Transaction#update", e.getMessage(), null);
-                  }
-                });
+                activity.runOnUiThread(
+                    new Runnable() {
+                      @Override
+                      public void run() {
+                        result.error("Error performing Transaction#update", e.getMessage(), null);
+                      }
+                    });
               }
               return null;
             }
@@ -498,13 +505,14 @@ public class CloudFirestorePlugin implements MethodCallHandler {
             protected Void doInBackground(Void... voids) {
               Map<String, Object> data = (Map<String, Object>) arguments.get("data");
               transaction.set(getDocumentReference(arguments), data);
-              activity.runOnUiThread(new Runnable() {
-                @Override
-                public void run() {
-                  Log.d(TAG, "sending set success");
-                  result.success(null);
-                }
-              });
+              activity.runOnUiThread(
+                  new Runnable() {
+                    @Override
+                    public void run() {
+                      Log.d(TAG, "sending set success");
+                      result.success(null);
+                    }
+                  });
               return null;
             }
           }.execute();
@@ -518,12 +526,13 @@ public class CloudFirestorePlugin implements MethodCallHandler {
             @Override
             protected Void doInBackground(Void... voids) {
               transaction.delete(getDocumentReference(arguments));
-              activity.runOnUiThread(new Runnable() {
-                  @Override
-                  public void run() {
+              activity.runOnUiThread(
+                  new Runnable() {
+                    @Override
+                    public void run() {
                       result.success(null);
-                  }
-              });
+                    }
+                  });
               return null;
             }
           }.execute();

--- a/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
+++ b/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
@@ -4,10 +4,14 @@
 
 package io.flutter.plugins.firebase.cloudfirestore;
 
+import android.app.Activity;
 import android.os.AsyncTask;
+import android.util.Log;
 import android.util.SparseArray;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.android.gms.tasks.Task;
@@ -53,8 +57,9 @@ import java.util.concurrent.TimeUnit;
 
 public class CloudFirestorePlugin implements MethodCallHandler {
 
-  public static final String TAG = "CloudFirestorePlugin";
+  private static final String TAG = "CloudFirestorePlugin";
   private final MethodChannel channel;
+  private final Activity activity;
 
   // Handles are ints used as indexes into the sparse array of active observers
   private int nextListenerHandle = 0;
@@ -72,11 +77,12 @@ public class CloudFirestorePlugin implements MethodCallHandler {
             registrar.messenger(),
             "plugins.flutter.io/cloud_firestore",
             new StandardMethodCodec(FirestoreMessageCodec.INSTANCE));
-    channel.setMethodCallHandler(new CloudFirestorePlugin(channel));
+    channel.setMethodCallHandler(new CloudFirestorePlugin(channel, registrar.activity()));
   }
 
-  private CloudFirestorePlugin(MethodChannel channel) {
+  private CloudFirestorePlugin(MethodChannel channel, Activity activity) {
     this.channel = channel;
+    this.activity = activity;
   }
 
   private FirebaseFirestore getFirestore(Map<String, Object> arguments) {
@@ -343,59 +349,73 @@ public class CloudFirestorePlugin implements MethodCallHandler {
           final Map<String, Object> arguments = call.arguments();
           getFirestore(arguments)
               .runTransaction(
-                  new Transaction.Function<Void>() {
+                  new Transaction.Function<Map<String, Object>>() {
                     @Nullable
                     @Override
-                    public Void apply(@NonNull Transaction transaction)
-                        throws FirebaseFirestoreException {
+                    public Map<String, Object> apply(@NonNull Transaction transaction) {
                       // Store transaction.
                       int transactionId = (Integer) arguments.get("transactionId");
                       transactions.append(transactionId, transaction);
                       completionTasks.append(transactionId, transactionTCS);
 
                       // Start operations on Dart side.
-                      channel.invokeMethod(
-                          "DoTransaction",
-                          arguments,
-                          new Result() {
-                            @SuppressWarnings("unchecked")
-                            @Override
-                            public void success(Object doTransactionResult) {
-                              transactionTCS.trySetResult(
-                                  (Map<String, Object>) doTransactionResult);
-                            }
+                      activity.runOnUiThread(new Runnable() {
+                        @Override
+                        public void run() {
+                          channel.invokeMethod(
+                              "DoTransaction",
+                              arguments,
+                              new Result() {
+                                @SuppressWarnings("unchecked")
+                                @Override
+                                public void success(Object doTransactionResult) {
+                                  transactionTCS.trySetResult(
+                                      (Map<String, Object>) doTransactionResult);
+                                }
 
-                            @Override
-                            public void error(
-                                String errorCode, String errorMessage, Object errorDetails) {
-                              // result.error(errorCode, errorMessage, errorDetails);
-                              transactionTCS.trySetException(
-                                  new Exception("Do transaction failed."));
-                            }
+                                @Override
+                                public void error(
+                                    String errorCode, String errorMessage, Object errorDetails) {
+                                  transactionTCS.trySetException(
+                                      new Exception("Do transaction failed."));
+                                }
 
-                            @Override
-                            public void notImplemented() {
-                              // result.error("DoTransaction not implemented", null, null);
-                              transactionTCS.setException(
-                                  new Exception("DoTransaction not implemented"));
-                            }
-                          });
+                                @Override
+                                public void notImplemented() {
+                                  transactionTCS.trySetException(
+                                      new Exception("DoTransaction not implemented"));
+                                }
+                              });
+                        }
+                      });
 
                       // Wait till transaction is complete.
                       try {
                         String timeoutKey = "transactionTimeout";
                         long timeout = ((Number) arguments.get(timeoutKey)).longValue();
-                        Map<String, Object> transactionResult =
+                        final Map<String, Object> transactionResult =
                             Tasks.await(transactionTCSTask, timeout, TimeUnit.MILLISECONDS);
 
                         // Once transaction completes return the result to the Dart side.
-                        result.success(transactionResult);
+                        return transactionResult;
                       } catch (Exception e) {
+                        Log.e(TAG, e.getMessage(), e);
                         result.error("Error performing transaction", e.getMessage(), null);
                       }
                       return null;
                     }
-                  });
+                  })
+              .addOnCompleteListener(new OnCompleteListener<Map<String, Object>>() {
+                @Override
+                public void onComplete(Task<Map<String, Object>> task) {
+                  if (task.isSuccessful()) {
+                    result.success(task.getResult());
+                  } else {
+                    result.error("Error performing transaction",
+                        task.getException().getMessage(), null);
+                  }
+                }
+              });
           break;
         }
       case "Transaction#get":
@@ -408,7 +428,7 @@ public class CloudFirestorePlugin implements MethodCallHandler {
               try {
                 DocumentSnapshot documentSnapshot =
                     transaction.get(getDocumentReference(arguments));
-                Map<String, Object> snapshotMap = new HashMap<>();
+                final Map<String, Object> snapshotMap = new HashMap<>();
                 snapshotMap.put("path", documentSnapshot.getReference().getPath());
                 if (documentSnapshot.exists()) {
                   snapshotMap.put("data", documentSnapshot.getData());
@@ -419,9 +439,19 @@ public class CloudFirestorePlugin implements MethodCallHandler {
                 metadata.put("hasPendingWrites", documentSnapshot.getMetadata().hasPendingWrites());
                 metadata.put("isFromCache", documentSnapshot.getMetadata().isFromCache());
                 snapshotMap.put("metadata", metadata);
-                result.success(snapshotMap);
-              } catch (FirebaseFirestoreException e) {
-                result.error("Error performing Transaction#get", e.getMessage(), null);
+                activity.runOnUiThread(new Runnable() {
+                  @Override
+                  public void run() {
+                    result.success(snapshotMap);
+                  }
+                });
+              } catch (final FirebaseFirestoreException e) {
+                activity.runOnUiThread(new Runnable() {
+                  @Override
+                  public void run() {
+                    result.error("Error performing Transaction#get", e.getMessage(), null);
+                  }
+                });
               }
               return null;
             }
@@ -439,9 +469,19 @@ public class CloudFirestorePlugin implements MethodCallHandler {
               Map<String, Object> data = (Map<String, Object>) arguments.get("data");
               try {
                 transaction.update(getDocumentReference(arguments), data);
-                result.success(null);
-              } catch (IllegalStateException e) {
-                result.error("Error performing Transaction#update", e.getMessage(), null);
+                activity.runOnUiThread(new Runnable() {
+                  @Override
+                  public void run() {
+                    result.success(null);
+                  }
+                });
+              } catch (final IllegalStateException e) {
+                activity.runOnUiThread(new Runnable() {
+                  @Override
+                  public void run() {
+                    result.error("Error performing Transaction#update", e.getMessage(), null);
+                  }
+                });
               }
               return null;
             }
@@ -458,7 +498,13 @@ public class CloudFirestorePlugin implements MethodCallHandler {
             protected Void doInBackground(Void... voids) {
               Map<String, Object> data = (Map<String, Object>) arguments.get("data");
               transaction.set(getDocumentReference(arguments), data);
-              result.success(null);
+              activity.runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                  Log.d(TAG, "sending set success");
+                  result.success(null);
+                }
+              });
               return null;
             }
           }.execute();
@@ -472,7 +518,12 @@ public class CloudFirestorePlugin implements MethodCallHandler {
             @Override
             protected Void doInBackground(Void... voids) {
               transaction.delete(getDocumentReference(arguments));
-              result.success(null);
+              activity.runOnUiThread(new Runnable() {
+                  @Override
+                  public void run() {
+                      result.success(null);
+                  }
+              });
               return null;
             }
           }.execute();

--- a/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/FlutterFirebaseAppRegistrar.java
+++ b/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/FlutterFirebaseAppRegistrar.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public class FlutterFirebaseAppRegistrar implements ComponentRegistrar {
   private static final String LIBRARY_NAME = "flutter-firebase_cloud_firestore";
-  private static final String LIBRARY_VERSION = "0.12.1";
+  private static final String LIBRARY_VERSION = "0.12.2";
 
   @Override
   public List<Component<?>> getComponents() {

--- a/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/FlutterFirebaseAppRegistrar.java
+++ b/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/FlutterFirebaseAppRegistrar.java
@@ -7,7 +7,7 @@ import java.util.Collections;
 import java.util.List;
 
 public class FlutterFirebaseAppRegistrar implements ComponentRegistrar {
-  private static final String LIBRARY_NAME = "flutter-firebase_cloud_firestore";
+  private static final String LIBRARY_NAME = "flutter-fire-fst";
   private static final String LIBRARY_VERSION = "0.12.2";
 
   @Override

--- a/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
+++ b/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
@@ -7,7 +7,7 @@
 #import <Firebase/Firebase.h>
 
 #define LIBRARY_NAME @"flutter-firebase_cloud_firestore"
-#define LIBRARY_VERSION @"0.12.1"
+#define LIBRARY_VERSION @"0.12.2"
 
 static FlutterError *getFlutterError(NSError *error) {
   if (error == nil) return nil;

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_firestore
-version: 0.12.1
+version: 0.12.2
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

In coming versions of the Flutter engine calls to the Dart side from the Java side must be done on the UI thread. The Firestore plugin implements transactions by making calls to the Dart side from the Java side. This change ensures that those calls are made on the UI thread.

## Related Issues

Resolves: https://github.com/flutter/flutter/issues/32657
