### PR TITLE
Ensure that CocoaPods on Cirrus is always the latest version.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -72,8 +72,7 @@ task:
     - brew install libimobiledevice
     - brew install ideviceinstaller
     - brew install ios-deploy
-    - brew install cocoapods
-    - brew link --overwrite cocoapods
+    - brew upgrade cocoapods || echo No upgrade necessary
     - pod repo update
     - git clone https://github.com/flutter/flutter.git
     - git fetch origin master

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -69,6 +69,7 @@ task:
     SIMCTL_CHILD_MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
   setup_script:
     - brew update
+    - brew upgrade cocoapods
     - brew install libimobiledevice
     - brew install ideviceinstaller
     - brew install ios-deploy

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -69,10 +69,10 @@ task:
     SIMCTL_CHILD_MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
   setup_script:
     - brew update
-    - brew upgrade cocoapods
     - brew install libimobiledevice
     - brew install ideviceinstaller
     - brew install ios-deploy
+    - brew install cocoapods
     - pod repo update
     - git clone https://github.com/flutter/flutter.git
     - git fetch origin master

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -73,6 +73,7 @@ task:
     - brew install ideviceinstaller
     - brew install ios-deploy
     - brew install cocoapods
+    - brew link --overwrite cocoapods
     - pod repo update
     - git clone https://github.com/flutter/flutter.git
     - git fetch origin master


### PR DESCRIPTION
Fixes test failures on the plugins iOS builder

```
Warning: CocoaPods minimum required version 1.6.0 or greater not installed. Skipping pod install.
  CocoaPods is used to retrieve the iOS and macOS platform side's plugin code that responds to your plugin usage on the Dart side.
  Without CocoaPods, plugins will not work on iOS or macOS.
  For more info, see https://flutter.dev/platform-plugins
To upgrade:
  brew upgrade cocoapods
  pod setup

```
