### PR TITLE
[firebase_messaging] Separate onLaunch to a future to be able to retrieve launch message in a synchronous way

### DIFF
--- a/packages/firebase_messaging/CHANGELOG.md
+++ b/packages/firebase_messaging/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.0
+*  **Breaking Change** Separated onLaunch to an specific method to be able to retrieve launch
+   message in a synchronous way.
+
 ## 5.0.4
 
 * Automatically use version from pubspec.yaml when reporting usage to Firebase.

--- a/packages/firebase_messaging/README.md
+++ b/packages/firebase_messaging/README.md
@@ -57,12 +57,18 @@ Next, you should probably request permissions for receiving Push Notifications. 
 
 ## Receiving Messages
 
-Messages are sent to your Flutter app via the `onMessage`, `onLaunch`, and `onResume` callbacks that you configured with the plugin during setup. Here is how different message types are delivered on the supported platforms:
+Launch messages (when application is closed) are retrieved on application init so you can act based on the notification data:
+
+```dart
+ Map<String, dynamic> message = await _firebaseMessaging.getLaunchMessage();
+```
+
+Messages when the application is not in foreground are sent to your Flutter app via the `onMessage` and `onResume` callbacks that you configured with the plugin during setup. Here is how different message types are delivered on the supported platforms:
 
 |                             | App in Foreground | App in Background | App Terminated |
 | --------------------------: | ----------------- | ----------------- | -------------- |
-| **Notification on Android** | `onMessage` | Notification is delivered to system tray. When the user clicks on it to open app `onResume` fires if `click_action: FLUTTER_NOTIFICATION_CLICK` is set (see below). | Notification is delivered to system tray. When the user clicks on it to open app `onLaunch` fires if `click_action: FLUTTER_NOTIFICATION_CLICK` is set (see below). |
-| **Notification on iOS** | `onMessage` | Notification is delivered to system tray. When the user clicks on it to open app `onResume` fires. | Notification is delivered to system tray. When the user clicks on it to open app `onLaunch` fires. |
+| **Notification on Android** | `onMessage` | Notification is delivered to system tray. When the user clicks on it to open app `onResume` fires if `click_action: FLUTTER_NOTIFICATION_CLICK` is set (see below). | Notification is delivered to system tray. When the user clicks on it to open app `geLaunchMessage` fires if `click_action: FLUTTER_NOTIFICATION_CLICK` is set (see below). |
+| **Notification on iOS** | `onMessage` | Notification is delivered to system tray. When the user clicks on it to open app `onResume` fires. | Notification is delivered to system tray. When the user clicks on it to open app `getLaunchMessage` fires. |
 | **Data Message on Android** | `onMessage` | `onMessage` while app stays in the background. | *not supported by plugin, message is lost* |
 | **Data Message on iOS**     | `onMessage` | Message is stored by FCM and delivered to app via `onMessage` when the app is brought back to foreground. | Message is stored by FCM and delivered to app via `onMessage` when the app is brought back to foreground. |
 

--- a/packages/firebase_messaging/example/lib/main.dart
+++ b/packages/firebase_messaging/example/lib/main.dart
@@ -137,14 +137,21 @@ class _PushMessagingExampleState extends State<PushMessagingExample> {
   @override
   void initState() {
     super.initState();
+  }
+
+  void initPushNotifications() async {
+    final Map<String, dynamic> message =
+        await _firebaseMessaging.getLaunchMessage();
+
+    if (message != null) {
+      print("getLaunchMessage $message");
+      _navigateToItemDetail(message);
+    }
+
     _firebaseMessaging.configure(
       onMessage: (Map<String, dynamic> message) async {
         print("onMessage: $message");
         _showItemDialog(message);
-      },
-      onLaunch: (Map<String, dynamic> message) async {
-        print("onLaunch: $message");
-        _navigateToItemDetail(message);
       },
       onResume: (Map<String, dynamic> message) async {
         print("onResume: $message");

--- a/packages/firebase_messaging/ios/Classes/FirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/ios/Classes/FirebaseMessagingPlugin.m
@@ -68,12 +68,11 @@
     [[UIApplication sharedApplication] registerUserNotificationSettings:settings];
 
     result(nil);
+  } else if ([@"getLaunchMessage" isEqualToString:method]) {
+    result(_launchNotification);
   } else if ([@"configure" isEqualToString:method]) {
     [FIRMessaging messaging].shouldEstablishDirectChannel = true;
     [[UIApplication sharedApplication] registerForRemoteNotifications];
-    if (_launchNotification != nil) {
-      [_channel invokeMethod:@"onLaunch" arguments:_launchNotification];
-    }
     result(nil);
   } else if ([@"subscribeToTopic" isEqualToString:method]) {
     NSString *topic = call.arguments;

--- a/packages/firebase_messaging/lib/firebase_messaging.dart
+++ b/packages/firebase_messaging/lib/firebase_messaging.dart
@@ -30,7 +30,6 @@ class FirebaseMessaging {
   final Platform _platform;
 
   MessageHandler _onMessage;
-  MessageHandler _onLaunch;
   MessageHandler _onResume;
 
   /// On iOS, prompts the user for notification permissions the first time
@@ -59,14 +58,17 @@ class FirebaseMessaging {
   /// Sets up [MessageHandler] for incoming messages.
   void configure({
     MessageHandler onMessage,
-    MessageHandler onLaunch,
     MessageHandler onResume,
   }) {
     _onMessage = onMessage;
-    _onLaunch = onLaunch;
     _onResume = onResume;
     _channel.setMethodCallHandler(_handleMethod);
     _channel.invokeMethod<void>('configure');
+  }
+
+  Future<Map<dynamic, dynamic>> getLaunchMessage() async {
+    return await _channel
+        .invokeMethod<Map<dynamic, dynamic>>('getLaunchMessage');
   }
 
   final StreamController<String> _tokenStreamController =
@@ -126,8 +128,6 @@ class FirebaseMessaging {
         return null;
       case "onMessage":
         return _onMessage(call.arguments.cast<String, dynamic>());
-      case "onLaunch":
-        return _onLaunch(call.arguments.cast<String, dynamic>());
       case "onResume":
         return _onResume(call.arguments.cast<String, dynamic>());
       default:

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Cloud Messaging, a cross-platform
   messaging solution that lets you reliably deliver messages on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_messaging
-version: 5.0.4
+version: 6.0.0
 
 flutter:
   plugin:


### PR DESCRIPTION
Separate onLaunch to an specific method to be able to retrieve launch message in a synchronous way

## Description

When an application is closed an a user opens it by clicking a push notification we can retrieve the message in a synchronous way but the current architecture expects this to be asynchronous which may conflict with other processes run in parallel. This behaviour forces programmers to synchronize those processes and with the added problem that on of the async calls (onLaunch) is not called when the user opens the app in a normal way, so it is needed to add timeouts to limit the time we wait the callback.

Android and iOS let programmers access how the app has been opened in a synchronous way for Dynamic Links, Push notifications, etc. So this PR (and https://github.com/flutter/plugins/pull/1687) fixes this and handles this two situations in a consistent way.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [ x I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
