### PR TITLE
[path_provider] Implement for macOS

### DIFF
--- a/packages/path_provider/lib/path_provider.dart
+++ b/packages/path_provider/lib/path_provider.dart
@@ -41,8 +41,8 @@ Future<Directory> getTemporaryDirectory() async {
 ///
 /// On Android, this function throws an [UnsupportedError].
 Future<Directory> getApplicationSupportDirectory() async {
-  if (!Platform.isIOS)
-    throw UnsupportedError("getApplicationSupportDirectory requires iOS");
+  if (!(Platform.isIOS || Platform.isMacOS))
+    throw UnsupportedError("getApplicationSupportDirectory requires iOS or macOS");
   final String path =
       await _channel.invokeMethod<String>('getApplicationSupportDirectory');
   if (path == null) {
@@ -80,6 +80,8 @@ Future<Directory> getApplicationDocumentsDirectory() async {
 Future<Directory> getExternalStorageDirectory() async {
   if (Platform.isIOS)
     throw UnsupportedError("Functionality not available on iOS");
+  if (Platform.isMacOS)
+    throw UnsupportedError("Functionality not implemented on macOS");
   final String path =
       await _channel.invokeMethod<String>('getStorageDirectory');
   if (path == null) {

--- a/packages/path_provider/macos/Classes/PathProviderPlugin.swift
+++ b/packages/path_provider/macos/Classes/PathProviderPlugin.swift
@@ -1,0 +1,51 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import FlutterMacOS
+import Foundation
+
+public class PathProviderPlugin: NSObject, FlutterPlugin {
+  public static func register(with registrar: FlutterPluginRegistrar) {
+    let channel = FlutterMethodChannel(
+      name: "plugins.flutter.io/path_provider",
+      binaryMessenger: registrar.messenger)
+    let instance = PathProviderPlugin()
+    registrar.addMethodCallDelegate(instance, channel: channel)
+  }
+
+  public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    let method = call.method
+    if method == "getTemporaryDirectory" {
+      result(getDirectory(ofType: FileManager.SearchPathDirectory.cachesDirectory))
+    } else if method == "getApplicationDocumentsDirectory" {
+      result(getDirectory(ofType: FileManager.SearchPathDirectory.documentDirectory))
+    } else if (method == "getApplicationSupportDirectory") {
+      var path = getDirectory(ofType: FileManager.SearchPathDirectory.applicationSupportDirectory)
+      if let basePath = path {
+        let basePathURL = URL.init(fileURLWithPath: basePath)
+        path = basePathURL.appendingPathComponent(Bundle.main.bundleIdentifier!).path
+        do {
+          try FileManager.default.createDirectory(atPath: path!, withIntermediateDirectories: true)
+        } catch {
+          result(FlutterError(
+            code:"directory_creation_failure",
+            message: error.localizedDescription,
+            details: "\(error)"))
+          return
+        }
+      }
+      result(path)
+    } else {
+      result(FlutterMethodNotImplemented)
+    }
+  }
+}
+
+private func getDirectory(ofType directory: FileManager.SearchPathDirectory) -> String? {
+  let paths = NSSearchPathForDirectoriesInDomains(
+    directory,
+    FileManager.SearchPathDomainMask.userDomainMask,
+    true)
+  return paths.first
+}

--- a/packages/path_provider/macos/path_provider.podspec
+++ b/packages/path_provider/macos/path_provider.podspec
@@ -1,0 +1,21 @@
+#
+# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
+#
+Pod::Spec.new do |s|
+  s.name             = 'path_provider'
+  s.version          = '0.0.1'
+  s.summary          = 'A Flutter plugin for getting commonly used locations on the filesystem.'
+  s.description      = <<-DESC
+A Flutter plugin for getting commonly used locations on the filesystem.
+                       DESC
+  s.homepage         = 'https://github.com/flutter/plugins/tree/master/packages/path_provider'
+  s.license          = { :file => '../LICENSE' }
+  s.author           = { 'Flutter Team' => 'flutter-dev@googlegroups.com' }
+  s.source           = { :path => '.' }
+  s.source_files = 'Classes/**/*'
+  s.dependency 'FlutterMacOS'
+
+  s.platform = :osx
+  s.osx.deployment_target = '10.12'
+end
+

--- a/packages/path_provider/pubspec.yaml
+++ b/packages/path_provider/pubspec.yaml
@@ -9,6 +9,7 @@ flutter:
   plugin:
     androidPackage: io.flutter.plugins.pathprovider
     iosPrefix: FLT
+    macosPrefix: FLT
     pluginClass: PathProviderPlugin
 
 dependencies:


### PR DESCRIPTION
## Description

Adds an initial path_provider implementation for macOS.

Top-level storage is currently unimplemented since decisions around
default behavior of macOS runner with respect to file system access
have not been finalized.

## Related Issues

None

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
