### PR TITLE
[url_launcher] Implement for macOS (minimal)

### DIFF
--- a/packages/url_launcher/macos/Classes/UrlLauncherPlugin.swift
+++ b/packages/url_launcher/macos/Classes/UrlLauncherPlugin.swift
@@ -1,0 +1,45 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import FlutterMacOS
+import Foundation
+
+public class UrlLauncherPlugin: NSObject, FlutterPlugin {
+  public static func register(with registrar: FlutterPluginRegistrar) {
+    let channel = FlutterMethodChannel(
+      name: "plugins.flutter.io/url_launcher",
+      binaryMessenger: registrar.messenger)
+    let instance = UrlLauncherPlugin()
+    registrar.addMethodCallDelegate(instance, channel: channel)
+  }
+
+  public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    let method = call.method
+    let urlString: String? = (call.arguments as? Dictionary<String, Any>)?["url"] as? String
+    if method == "canLaunch" {
+      guard let unwrappedURLString = urlString,
+            let url = URL.init(string: unwrappedURLString) else {
+        result(invalidURLError(urlString))
+        return
+      }
+      result(NSWorkspace.shared.urlForApplication(toOpen: url) != nil)
+    } else if method == "launch" {
+      guard let unwrappedURLString = urlString,
+            let url = URL.init(string: unwrappedURLString) else {
+        result(invalidURLError(urlString))
+        return
+      }
+      result(NSWorkspace.shared.open(url))
+    } else {
+      result(FlutterMethodNotImplemented)
+    }
+  }
+}
+
+private func invalidURLError(_ url: String?) -> FlutterError {
+  return FlutterError(
+    code:"argument_error",
+    message: "Unable to parse URL",
+    details: "Provided URL: \(String(describing: url))")
+}

--- a/packages/url_launcher/macos/url_launcher.podspec
+++ b/packages/url_launcher/macos/url_launcher.podspec
@@ -1,0 +1,21 @@
+#
+# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
+#
+Pod::Spec.new do |s|
+  s.name             = 'url_launcher'
+  s.version          = '0.0.1'
+  s.summary          = 'Flutter plugin for launching a URL.'
+  s.description      = <<-DESC
+A Flutter plugin for making the underlying platform (Android or iOS) launch a URL.
+                       DESC
+  s.homepage         = 'https://github.com/flutter/plugins/tree/master/packages/url_launcher'
+  s.license          = { :file => '../LICENSE' }
+  s.author           = { 'Flutter Team' => 'flutter-dev@googlegroups.com' }
+  s.source           = { :path => '.' }
+  s.source_files = 'Classes/**/*'
+  s.dependency 'FlutterMacOS'
+
+  s.platform = :osx
+  s.osx.deployment_target = '10.12'
+end
+

--- a/packages/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/pubspec.yaml
@@ -9,6 +9,7 @@ flutter:
   plugin:
     androidPackage: io.flutter.plugins.urllauncher
     iosPrefix: FLT
+    macosPrefix: FLT
     pluginClass: UrlLauncherPlugin
 
 dependencies:


### PR DESCRIPTION
## Description

Adds a minimal macOS implementation of url_launcher.

Currently it doesn't support any of the options for opening web URLs
within the application. Theoretically they could be implemented by
opening a new window containing a WKWebView, but in practice the
standard desktop flow for opening a web page is to open it in the
browser, so it's not clear that the substantial added complexity would
be useful.

## Related Issues

None

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
