### PR TITLE
iOS build error - pod spec update for google maps

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -72,7 +72,6 @@ task:
     - brew install libimobiledevice
     - brew install ideviceinstaller
     - brew install ios-deploy
-    - brew upgrade cocoapods || echo No upgrade necessary
     - pod repo update
     - git clone https://github.com/flutter/flutter.git
     - git fetch origin master

--- a/packages/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.17
+
+* Fixed build issue on iOS
+
 ## 0.5.16
 
 * Add support for custom map styling.

--- a/packages/google_maps_flutter/ios/google_maps_flutter.podspec
+++ b/packages/google_maps_flutter/ios/google_maps_flutter.podspec
@@ -16,6 +16,7 @@ A new flutter plugin project.
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.dependency 'GoogleMaps'
+  s.compiler_flags = '-fno-modules'
   s.static_framework = true
   s.ios.deployment_target = '8.0'
 end

--- a/packages/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter
-version: 0.5.16
+version: 0.5.17
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Description

- Create a new Flutter project with "flutter create"
- Add the latest google maps flutter plugin in pubspec.yaml
- build for iOS fails with latest version of XCode / Flutter SDK with error "GoogleMapsBase not found"

This is a known issue, it has been solved for React Native : https://github.com/googlemaps/google-maps-ios-utils/pull/20/files

## Related Issues

This stems from the includes in GoogleMaps.framework headers:

#if __has_feature(modules)
@import GoogleMapsBase; <--- this is taken by default with a non-modified Flutter project
#else
#import <GoogleMapsBase/GoogleMapsBase.h>
#endif

## Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
