### PR TITLE
[firebase_crashlytics] Fix parsing stacktrace

### DIFF
--- a/packages/firebase_crashlytics/CHANGELOG.md
+++ b/packages/firebase_crashlytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.4+5
+
+* Fix parsing stacktrace.
+
 ## 0.0.4+4
 
 * Add missing template type parameter to `invokeMethod` calls.

--- a/packages/firebase_crashlytics/lib/src/firebase_crashlytics.dart
+++ b/packages/firebase_crashlytics/lib/src/firebase_crashlytics.dart
@@ -40,7 +40,7 @@ class Crashlytics {
       final List<String> stackTraceLines =
           Trace.format(details.stack).trimRight().split('\n');
       final List<Map<String, String>> stackTraceElements =
-          _getStackTraceElements(stackTraceLines);
+          getStackTraceElements(stackTraceLines);
       final dynamic result = await channel
           .invokeMethod<dynamic>('Crashlytics#onError', <String, dynamic>{
         'exception': details.exceptionAsString(),
@@ -161,14 +161,16 @@ class Crashlytics {
     return crashlyticsKeys;
   }
 
-  List<Map<String, String>> _getStackTraceElements(List<String> lines) {
+  @visibleForTesting
+  List<Map<String, String>> getStackTraceElements(List<String> lines) {
     final List<Map<String, String>> elements = <Map<String, String>>[];
     for (String line in lines) {
       final List<String> lineParts = line.split(RegExp('\\s+'));
       try {
         final String fileName = lineParts[0];
-        final String lineNumber =
-            lineParts[1].substring(0, lineParts[1].indexOf(":")).trim();
+        final String lineNumber = lineParts[1].contains(":")
+            ? lineParts[1].substring(0, lineParts[1].indexOf(":")).trim()
+            : lineParts[1];
         final String className =
             lineParts[2].substring(0, lineParts[2].indexOf(".")).trim();
         final String methodName =

--- a/packages/firebase_crashlytics/pubspec.yaml
+++ b/packages/firebase_crashlytics/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_crashlytics
 description: Flutter plugin for Firebase Crashlytics. It reports uncaught errors to the
   Firebase console.
-version: 0.0.4+4
+version: 0.0.4+5
 author: Flutter Team <flutter-dev@google.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_crashlytics
 

--- a/packages/firebase_crashlytics/test/firebase_crashlytics_test.dart
+++ b/packages/firebase_crashlytics/test/firebase_crashlytics_test.dart
@@ -97,5 +97,35 @@ void main() {
             arguments: <String, dynamic>{'name': 'foo'})
       ]);
     });
+
+    test('getStackTraceElements with character index', () async {
+      final List<String> lines = <String>[
+        'package:flutter/src/widgets/framework.dart 3825:27  StatefulElement.build'
+      ];
+      final List<Map<String, String>> elements =
+          crashlytics.getStackTraceElements(lines);
+      expect(elements.length, 1);
+      expect(elements.first, <String, String>{
+        'class': 'StatefulElement',
+        'method': 'build',
+        'file': 'package:flutter/src/widgets/framework.dart',
+        'line': '3825',
+      });
+    });
+
+    test('getStackTraceElements without character index', () async {
+      final List<String> lines = <String>[
+        'package:flutter/src/widgets/framework.dart 3825  StatefulElement.build'
+      ];
+      final List<Map<String, String>> elements =
+          crashlytics.getStackTraceElements(lines);
+      expect(elements.length, 1);
+      expect(elements.first, <String, String>{
+        'class': 'StatefulElement',
+        'method': 'build',
+        'file': 'package:flutter/src/widgets/framework.dart',
+        'line': '3825',
+      });
+    });
   });
 }

--- a/packages/firebase_crashlytics/test/firebase_crashlytics_test.dart
+++ b/packages/firebase_crashlytics/test/firebase_crashlytics_test.dart
@@ -1,6 +1,7 @@
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -37,7 +38,7 @@ void main() {
         exception: 'foo exception',
         stack: StackTrace.current,
         library: 'foo library',
-        context: 'foo context',
+        context: ErrorDescription('foo context'),
       );
       crashlytics.enableInDevMode = true;
       crashlytics.log('foo');

--- a/packages/firebase_crashlytics/test/firebase_crashlytics_test.dart
+++ b/packages/firebase_crashlytics/test/firebase_crashlytics_test.dart
@@ -1,7 +1,6 @@
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -38,7 +37,7 @@ void main() {
         exception: 'foo exception',
         stack: StackTrace.current,
         library: 'foo library',
-        context: ErrorDescription('foo context'),
+        context: 'foo context',
       );
       crashlytics.enableInDevMode = true;
       crashlytics.log('foo');


### PR DESCRIPTION
## Description

This change is support for parsing stacktrace without character index.

On debug build stacktrace like

```
package:flutter/src/widgets/framework.dart 3825:27  StatefulElement.build
```

but, on release build stacktrace like

```
package:flutter/src/widgets/framework.dart 3825  StatefulElement.build
```

## Related Issues

Nothing.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
