### PR TITLE
[firebase_core] roll back to 0.4.0+3

### DIFF
--- a/packages/firebase_core/CHANGELOG.md
+++ b/packages/firebase_core/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.4.0+5
+
+* Rollback of automatic plugin version retrieval.
+
+## 0.4.0+4
+
+* Automate the retrieval of the plugin's version when reporting usage to Firebase.
+
 ## 0.4.0+3
 
 * Add missing template type parameter to `invokeMethod` calls.

--- a/packages/firebase_core/CHANGELOG.md
+++ b/packages/firebase_core/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 0.4.0+4
-
-* Automate the retrieval of the plugin's version when reporting usage to Firebase.
-
 ## 0.4.0+3
 
 * Add missing template type parameter to `invokeMethod` calls.

--- a/packages/firebase_core/android/build.gradle
+++ b/packages/firebase_core/android/build.gradle
@@ -34,29 +34,12 @@ rootProject.allprojects {
 
 apply plugin: 'com.android.library'
 
-/**
- * Get the current version of the plugin from the plugin's pubspec.yaml file.
- *
- * @return String representing version of the plugin.
- */
-def flutterFireVersion() {
-    File pubspec = new File('../../pubspec.yaml')
-    def lines = pubspec.readLines()
-    for (line in lines) {
-        if (line.contains('version: ')) {
-            return "${line}".substring(9).trim()
-        }
-    }
-    throw new Exception('Version not found in pubspec.yaml file.')
-}
-
 android {
     compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 16
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        versionName flutterFireVersion()
     }
     lintOptions {
         disable 'InvalidPackage'

--- a/packages/firebase_core/android/src/main/java/io/flutter/plugins/firebase/core/FlutterFirebaseAppRegistrar.java
+++ b/packages/firebase_core/android/src/main/java/io/flutter/plugins/firebase/core/FlutterFirebaseAppRegistrar.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public class FlutterFirebaseAppRegistrar implements ComponentRegistrar {
   private static final String LIBRARY_NAME = "flutter-fire-core";
-  private static final String LIBRARY_VERSION = "0.4.0+3";
+  private static final String LIBRARY_VERSION = "0.4.0+5";
 
   @Override
   public List<Component<?>> getComponents() {

--- a/packages/firebase_core/android/src/main/java/io/flutter/plugins/firebase/core/FlutterFirebaseAppRegistrar.java
+++ b/packages/firebase_core/android/src/main/java/io/flutter/plugins/firebase/core/FlutterFirebaseAppRegistrar.java
@@ -7,10 +7,12 @@ import java.util.Collections;
 import java.util.List;
 
 public class FlutterFirebaseAppRegistrar implements ComponentRegistrar {
+  private static final String LIBRARY_NAME = "flutter-fire-core";
+  private static final String LIBRARY_VERSION = "0.4.0+3";
+
   @Override
   public List<Component<?>> getComponents() {
     return Collections.<Component<?>>singletonList(
-        LibraryVersionComponent.create(
-            "flutter-fire-core", BuildConfig.VERSION_NAME.replaceAll("\\+", "-")));
+        LibraryVersionComponent.create(LIBRARY_NAME, LIBRARY_VERSION));
   }
 }

--- a/packages/firebase_core/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/firebase_core/example/ios/Runner.xcodeproj/project.pbxproj
@@ -9,7 +9,6 @@
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		2AE3C69805AB6FB8C037C7BA /* libPods-Runner.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 39D23D0C629B8A857DE66538 /* libPods-Runner.a */; };
-		2D5378261FAA1A9400D5DBA9 /* flutter_assets in Resources */ = {isa = PBXBuildFile; fileRef = 2D5378251FAA1A9400D5DBA9 /* flutter_assets */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		3B80C3941E831B6300D905FE /* App.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B80C3931E831B6300D905FE /* App.framework */; };
 		3B80C3951E831B6300D905FE /* App.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3B80C3931E831B6300D905FE /* App.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -42,13 +41,13 @@
 /* Begin PBXFileReference section */
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
-		2D5378251FAA1A9400D5DBA9 /* flutter_assets */ = {isa = PBXFileReference; lastKnownFileType = folder; name = flutter_assets; path = Flutter/flutter_assets; sourceTree = SOURCE_ROOT; };
 		39D23D0C629B8A857DE66538 /* libPods-Runner.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Runner.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		3B80C3931E831B6300D905FE /* App.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = App.framework; path = Flutter/App.framework; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		7AFFD8ED1D35381100E5BB4D /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		7AFFD8EE1D35381100E5BB4D /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		8C05BEBBACF658542A507F21 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		9740EEBA1CF902C7004384FC /* Flutter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Flutter.framework; path = Flutter/Flutter.framework; sourceTree = "<group>"; };
@@ -58,6 +57,7 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		BBD18D8969E712FE54BB6E20 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -77,6 +77,8 @@
 		39F1FF2B4D76A033C08A8FD9 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
+				8C05BEBBACF658542A507F21 /* Pods-Runner.debug.xcconfig */,
+				BBD18D8969E712FE54BB6E20 /* Pods-Runner.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -86,7 +88,6 @@
 			children = (
 				3B80C3931E831B6300D905FE /* App.framework */,
 				3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */,
-				2D5378251FAA1A9400D5DBA9 /* flutter_assets */,
 				9740EEBA1CF902C7004384FC /* Flutter.framework */,
 				9740EEB21CF90195004384FC /* Debug.xcconfig */,
 				7AFA3C8E1D35360C0083082E /* Release.xcconfig */,
@@ -161,7 +162,6 @@
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				531483E699D87EBBC063AF7F /* [CP] Embed Pods Frameworks */,
-				177D2DB1F56033C34D20320F /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -212,7 +212,6 @@
 				97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */,
 				9740EEB51CF90195004384FC /* Generated.xcconfig in Resources */,
 				3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */,
-				2D5378261FAA1A9400D5DBA9 /* flutter_assets in Resources */,
 				9740EEB41CF90195004384FC /* Debug.xcconfig in Resources */,
 				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
 				97C146FC1CF9000F007C117D /* Main.storyboard in Resources */,
@@ -222,21 +221,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		177D2DB1F56033C34D20320F /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -275,16 +259,13 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
-				"${PODS_ROOT}/.symlinks/flutter/ios/Flutter.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Flutter.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
@@ -299,7 +280,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/packages/firebase_core/ios/Classes/.gitignore
+++ b/packages/firebase_core/ios/Classes/.gitignore
@@ -1,1 +1,0 @@
-version.h

--- a/packages/firebase_core/ios/Classes/FirebaseCorePlugin.m
+++ b/packages/firebase_core/ios/Classes/FirebaseCorePlugin.m
@@ -7,7 +7,7 @@
 #import <Firebase/Firebase.h>
 
 #define LIBRARY_NAME @"flutter-fire-core"
-#define LIBRARY_VERSION @"0.4.0+3"
+#define LIBRARY_VERSION @"0.4.0+5"
 
 static NSDictionary *getDictionaryFromFIROptions(FIROptions *options) {
   if (!options) {

--- a/packages/firebase_core/ios/Classes/FirebaseCorePlugin.m
+++ b/packages/firebase_core/ios/Classes/FirebaseCorePlugin.m
@@ -3,11 +3,11 @@
 // found in the LICENSE file.
 
 #import "FirebaseCorePlugin.h"
-#import "version.h"
 
 #import <Firebase/Firebase.h>
 
 #define LIBRARY_NAME @"flutter-fire-core"
+#define LIBRARY_VERSION @"0.4.0+3"
 
 static NSDictionary *getDictionaryFromFIROptions(FIROptions *options) {
   if (!options) {
@@ -45,8 +45,7 @@ static NSDictionary *getDictionaryFromFIRApp(FIRApp *app) {
 
   SEL sel = NSSelectorFromString(@"registerLibrary:withVersion:");
   if ([FIRApp respondsToSelector:sel]) {
-    NSString *version = [LIBRARY_VERSION stringByReplacingOccurrencesOfString:@"+" withString:@"-"];
-    [FIRApp performSelector:sel withObject:LIBRARY_NAME withObject:version];
+    [FIRApp performSelector:sel withObject:LIBRARY_NAME withObject:LIBRARY_VERSION];
   }
 }
 

--- a/packages/firebase_core/ios/firebase_core.podspec
+++ b/packages/firebase_core/ios/firebase_core.podspec
@@ -18,11 +18,4 @@ A new flutter plugin project.
   s.dependency 'Firebase/Core'
   s.ios.deployment_target = '8.0'
   s.static_framework = true
-
-  s.prepare_command = <<-CMD
-    PUBSPEC_VERSION=`cat ../pubspec.yaml | grep version: | sed 's/version: //g'`
-    echo // Generated file, do not edit > Classes/version.h
-    echo "#define LIBRARY_VERSION @\\"$PUBSPEC_VERSION\\"" >> Classes/version.h
-  CMD
-
 end

--- a/packages/firebase_core/pubspec.yaml
+++ b/packages/firebase_core/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Core, enabling connecting to multiple
   Firebase apps.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_core
-version: 0.4.0+3
+version: 0.4.0+5
 
 flutter:
   plugin:

--- a/packages/firebase_core/pubspec.yaml
+++ b/packages/firebase_core/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Core, enabling connecting to multiple
   Firebase apps.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_core
-version: 0.4.0+4
+version: 0.4.0+3
 
 flutter:
   plugin:


### PR DESCRIPTION
This PR reverts firebase_core to the 0.4.0+3 release due to a build issue with the 0.4.0+4 release that was not caught by our CI.

The automatic version checking feature will be re-landed once the build issue is resolved.

Fixes flutter/flutter#34410 flutter/flutter#34385 flutter/flutter#34393

See also https://github.com/flutter/plugins/pull/1736 which has some suggestions for additional improvements to automatic version checking.