### PR TITLE
[cloud_functions] Remove unused header reference

### DIFF
--- a/packages/cloud_functions/CHANGELOG.md
+++ b/packages/cloud_functions/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0+1
+
+* Remove reference to unused header file.
+
 ## 0.4.0
 
 * Removed unused `parameters` param from `getHttpsCallable`.

--- a/packages/cloud_functions/ios/Classes/CloudFunctionsPlugin.m
+++ b/packages/cloud_functions/ios/Classes/CloudFunctionsPlugin.m
@@ -4,7 +4,6 @@
 
 #import "CloudFunctionsPlugin.h"
 
-#import "FIRFunctions+Internal.h"
 #import "Firebase/Firebase.h"
 
 @interface CloudFunctionsPlugin ()

--- a/packages/cloud_functions/pubspec.yaml
+++ b/packages/cloud_functions/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cloud_functions
 description: Flutter plugin for Cloud Functions.
-version: 0.4.0
+version: 0.4.0+1
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_functions
 


### PR DESCRIPTION
As suggested in #1070 this removes a reference to an internal header file.