### PR TITLE
[share] Add subject support when sharing text

### DIFF
--- a/packages/firebase_dynamic_links/ios/Classes/FirebaseDynamicLinksPlugin.m
+++ b/packages/firebase_dynamic_links/ios/Classes/FirebaseDynamicLinksPlugin.m
@@ -81,6 +81,7 @@ static FlutterError *getFlutterError(NSError *error) {
 - (BOOL)application:(UIApplication *)application
             openURL:(NSURL *)url
             options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options {
+  NSLog(@"DynamicLinks! options");
   return [self checkForDynamicLink:url];
 }
 
@@ -88,6 +89,7 @@ static FlutterError *getFlutterError(NSError *error) {
               openURL:(NSURL *)url
     sourceApplication:(NSString *)sourceApplication
            annotation:(id)annotation {
+  NSLog(@"DynamicLinks! annotation");
   return [self checkForDynamicLink:url];
 }
 
@@ -103,6 +105,7 @@ static FlutterError *getFlutterError(NSError *error) {
 - (BOOL)application:(UIApplication *)application
     continueUserActivity:(NSUserActivity *)userActivity
       restorationHandler:(void (^)(NSArray *))restorationHandler {
+  NSLog(@"DynamicLinks! restorationHandler");
   usleep(50000);
   BOOL handled = [[FIRDynamicLinks dynamicLinks]
       handleUniversalLink:userActivity.webpageURL

--- a/packages/share/CHANGELOG.md
+++ b/packages/share/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.2
+
+* Add optional subject to fill email subject in case user selects email app.
+
 ## 0.6.1+1
 
 * Fix analyzer warnings about `const Rect` in tests.

--- a/packages/share/android/src/main/java/io/flutter/plugins/share/SharePlugin.java
+++ b/packages/share/android/src/main/java/io/flutter/plugins/share/SharePlugin.java
@@ -34,14 +34,14 @@ public class SharePlugin implements MethodChannel.MethodCallHandler {
         throw new IllegalArgumentException("Map argument expected");
       }
       // Android does not support showing the share sheet at a particular point on screen.
-      share((String) call.argument("text"));
+      share((String) call.argument("text"),(String) call.argument("subject"));
       result.success(null);
     } else {
       result.notImplemented();
     }
   }
 
-  private void share(String text) {
+  private void share(String text, String subject) {
     if (text == null || text.isEmpty()) {
       throw new IllegalArgumentException("Non-empty text expected");
     }
@@ -49,6 +49,7 @@ public class SharePlugin implements MethodChannel.MethodCallHandler {
     Intent shareIntent = new Intent();
     shareIntent.setAction(Intent.ACTION_SEND);
     shareIntent.putExtra(Intent.EXTRA_TEXT, text);
+    shareIntent.putExtra(Intent.EXTRA_SUBJECT, subject);
     shareIntent.setType("text/plain");
     Intent chooserIntent = Intent.createChooser(shareIntent, null /* dialog title optional */);
     if (mRegistrar.activity() != null) {

--- a/packages/share/example/lib/main.dart
+++ b/packages/share/example/lib/main.dart
@@ -16,6 +16,7 @@ class DemoApp extends StatefulWidget {
 
 class DemoAppState extends State<DemoApp> {
   String text = '';
+  String subject = '';
 
   @override
   Widget build(BuildContext context) {
@@ -32,12 +33,22 @@ class DemoAppState extends State<DemoApp> {
               children: <Widget>[
                 TextField(
                   decoration: const InputDecoration(
-                    labelText: 'Share:',
+                    labelText: 'Share text:',
                     hintText: 'Enter some text and/or link to share',
                   ),
                   maxLines: 2,
                   onChanged: (String value) => setState(() {
                         text = value;
+                      }),
+                ),
+                TextField(
+                  decoration: const InputDecoration(
+                    labelText: 'Share subject:',
+                    hintText: 'Enter subject to share (Optional)',
+                  ),
+                  maxLines: 2,
+                  onChanged: (String value) => setState(() {
+                        subject = value;
                       }),
                 ),
                 const Padding(padding: EdgeInsets.only(top: 24.0)),
@@ -57,9 +68,7 @@ class DemoAppState extends State<DemoApp> {
                               // has its position and size after it's built.
                               final RenderBox box = context.findRenderObject();
                               Share.share(text,
-                                  sharePositionOrigin:
-                                      box.localToGlobal(Offset.zero) &
-                                          box.size);
+                                  subject: subject, sharePositionOrigin: box.localToGlobal(Offset.zero) & box.size);
                             },
                     );
                   },

--- a/packages/share/ios/Classes/SharePlugin.m
+++ b/packages/share/ios/Classes/SharePlugin.m
@@ -17,6 +17,7 @@ static NSString *const PLATFORM_CHANNEL = @"plugins.flutter.io/share";
     if ([@"share" isEqualToString:call.method]) {
       NSDictionary *arguments = [call arguments];
       NSString *shareText = arguments[@"text"];
+      NSString *shareSubject = arguments[@"subject"];
 
       if (shareText.length == 0) {
         result([FlutterError errorWithCode:@"error"
@@ -37,6 +38,7 @@ static NSString *const PLATFORM_CHANNEL = @"plugins.flutter.io/share";
       }
 
       [self share:shareText
+          subject: shareSubject
           withController:[UIApplication sharedApplication].keyWindow.rootViewController
                 atSource:originRect];
       result(nil);
@@ -47,11 +49,13 @@ static NSString *const PLATFORM_CHANNEL = @"plugins.flutter.io/share";
 }
 
 + (void)share:(id)sharedItems
+    subject:(NSString *) subject
     withController:(UIViewController *)controller
           atSource:(CGRect)origin {
   UIActivityViewController *activityViewController =
       [[UIActivityViewController alloc] initWithActivityItems:@[ sharedItems ]
                                         applicationActivities:nil];
+  [activityViewController setValue:subject forKey:@"subject"];
   activityViewController.popoverPresentationController.sourceView = controller.view;
   if (!CGRectIsEmpty(origin)) {
     activityViewController.popoverPresentationController.sourceRect = origin;

--- a/packages/share/lib/share.dart
+++ b/packages/share/lib/share.dart
@@ -12,10 +12,10 @@ import 'package:meta/meta.dart' show visibleForTesting;
 class Share {
   /// [MethodChannel] used to communicate with the platform side.
   @visibleForTesting
-  static const MethodChannel channel =
-      MethodChannel('plugins.flutter.io/share');
+  static const MethodChannel channel = MethodChannel('plugins.flutter.io/share');
 
-  /// Summons the platform's share sheet to share text.
+  /// Summons the platform's share sheet to share text. Adding an optional subject
+  /// in case customer selects email.
   ///
   /// Wraps the platform's native share dialog. Can share a text and/or a URL.
   /// It uses the ACTION_SEND Intent on Android and UIActivityViewController
@@ -27,12 +27,10 @@ class Share {
   ///
   /// May throw [PlatformException] or [FormatException]
   /// from [MethodChannel].
-  static Future<void> share(String text, {Rect sharePositionOrigin}) {
+  static Future<void> share(String text, {String subject, Rect sharePositionOrigin}) {
     assert(text != null);
     assert(text.isNotEmpty);
-    final Map<String, dynamic> params = <String, dynamic>{
-      'text': text,
-    };
+    final Map<String, dynamic> params = <String, dynamic>{'text': text, 'subject': subject};
 
     if (sharePositionOrigin != null) {
       params['originX'] = sharePositionOrigin.left;

--- a/packages/share/pubspec.yaml
+++ b/packages/share/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for sharing content via the platform share UI, using
   the ACTION_SEND intent on Android and UIActivityViewController on iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/share
-version: 0.6.1+1
+version: 0.6.2
 
 flutter:
   plugin:

--- a/packages/share/test/share_test.dart
+++ b/packages/share/test/share_test.dart
@@ -43,6 +43,7 @@ void main() {
   test('sharing origin sets the right params', () async {
     await Share.share(
       'some text to share',
+      subject: 'some subject to share',
       // TODO(jackson): Use const Rect when available in minimum Flutter SDK
       // ignore: prefer_const_constructors
       sharePositionOrigin: Rect.fromLTWH(1.0, 2.0, 3.0, 4.0),
@@ -52,6 +53,7 @@ void main() {
     // ignore: strong_mode_implicit_dynamic_method
     verify(mockChannel.invokeMethod('share', <String, dynamic>{
       'text': 'some text to share',
+      'subject': 'some subject to share',
       'originX': 1.0,
       'originY': 2.0,
       'originWidth': 3.0,


### PR DESCRIPTION
## Description

This PR adds an optional parameter to share plugin to accept `subject` in case user selects email client as sharing app.

## Related Issues

No issues found regarding this functionality.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [ ] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
