### PR TITLE
[flutter_webview] Prevent universal app links from opening the app

### DIFF
--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.10
+
+* Added support for preventing universal app links in iOS from opening in the relevant app and continue navigation inside the WebView.
+
 ## 0.3.9+2
 
 * Update Dart code to conform to current Dart formatter.

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewClient.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewClient.java
@@ -146,9 +146,14 @@ class FlutterWebViewClient {
 
     @Override
     public void success(Object shouldLoad) {
-      Boolean typedShouldLoad = (Boolean) shouldLoad;
-      if (typedShouldLoad) {
-        loadUrl();
+      Number typedShouldLoad = (Number) shouldLoad;
+      switch(typedShouldLoad.intValue()){
+        case 0: // cancel
+          break;
+        case 1: // navigate
+        case 2: // navigateWithoutAppLink
+          loadUrl();
+          break;
       }
     }
 

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewClient.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewClient.java
@@ -147,7 +147,7 @@ class FlutterWebViewClient {
     @Override
     public void success(Object shouldLoad) {
       Number typedShouldLoad = (Number) shouldLoad;
-      switch(typedShouldLoad.intValue()){
+      switch (typedShouldLoad.intValue()) {
         case 0: // cancel
           break;
         case 1: // navigate

--- a/packages/webview_flutter/ios/Classes/FLTWKNavigationDelegate.m
+++ b/packages/webview_flutter/ios/Classes/FLTWKNavigationDelegate.m
@@ -27,7 +27,8 @@
     @"url" : navigationAction.request.URL.absoluteString,
     @"isForMainFrame" : @(navigationAction.targetFrame.isMainFrame)
   };
-  [_methodChannel invokeMethod:@"navigationRequest"
+  [_methodChannel
+    invokeMethod:@"navigationRequest"
      arguments:arguments
         result:^(id _Nullable result) {
           if ([result isKindOfClass:[FlutterError class]]) {
@@ -51,24 +52,24 @@
             return;
           }
           NSNumber* typedResult = result;
-            switch ([typedResult intValue]) {
-                case 0:
-                    decisionHandler(WKNavigationActionPolicyCancel);
-                    break;
-                case 1:
-                    decisionHandler(WKNavigationActionPolicyAllow);
-                    break;
-                case 2:
-                    decisionHandler((WKNavigationActionPolicy)(WKNavigationActionPolicyAllow + 2));
-                    break;
-                default:
-                    NSLog(@"navigationRequest unexpectedly returned a invalid value: "
-                          @"%@, allowing navigation.",
-                          result);
-                    decisionHandler(WKNavigationActionPolicyAllow);
-                    break;
-            }
-        }];
+          switch ([typedResult intValue]) {
+            case 0:
+                decisionHandler(WKNavigationActionPolicyCancel);
+                break;
+            case 1:
+                decisionHandler(WKNavigationActionPolicyAllow);
+                break;
+            case 2:
+                decisionHandler((WKNavigationActionPolicy)(WKNavigationActionPolicyAllow + 2));
+                break;
+            default:
+                NSLog(@"navigationRequest unexpectedly returned a invalid value: "
+                      @"%@, allowing navigation.",
+                      result);
+                decisionHandler(WKNavigationActionPolicyAllow);
+                break;
+        }
+      }];
 }
 
 - (void)webView:(WKWebView*)webView didFinishNavigation:(WKNavigation*)navigation {

--- a/packages/webview_flutter/ios/Classes/FLTWKNavigationDelegate.m
+++ b/packages/webview_flutter/ios/Classes/FLTWKNavigationDelegate.m
@@ -44,15 +44,30 @@
                             return;
                           }
                           if (![result isKindOfClass:[NSNumber class]]) {
-                            NSLog(@"navigationRequest unexpectedly returned a non boolean value: "
+                            NSLog(@"navigationRequest unexpectedly returned a non numeric value: "
                                   @"%@, allowing navigation.",
                                   result);
                             decisionHandler(WKNavigationActionPolicyAllow);
                             return;
                           }
                           NSNumber* typedResult = result;
-                          decisionHandler([typedResult boolValue] ? WKNavigationActionPolicyAllow
-                                                                  : WKNavigationActionPolicyCancel);
+                            switch ([typedResult intValue]) {
+                                case 0:
+                                    decisionHandler(WKNavigationActionPolicyCancel);
+                                    break;
+                                case 1:
+                                    decisionHandler(WKNavigationActionPolicyAllow);
+                                    break;
+                                case 2:
+                                    decisionHandler((WKNavigationActionPolicy)(WKNavigationActionPolicyAllow + 2));
+                                    break;
+                                default:
+                                    NSLog(@"navigationRequest unexpectedly returned a invalid value: "
+                                          @"%@, allowing navigation.",
+                                          result);
+                                    decisionHandler(WKNavigationActionPolicyAllow);
+                                    break;
+                            }
                         }];
 }
 

--- a/packages/webview_flutter/ios/Classes/FLTWKNavigationDelegate.m
+++ b/packages/webview_flutter/ios/Classes/FLTWKNavigationDelegate.m
@@ -28,47 +28,47 @@
     @"isForMainFrame" : @(navigationAction.targetFrame.isMainFrame)
   };
   [_methodChannel invokeMethod:@"navigationRequest"
-                     arguments:arguments
-                        result:^(id _Nullable result) {
-                          if ([result isKindOfClass:[FlutterError class]]) {
-                            NSLog(@"navigationRequest has unexpectedly completed with an error, "
-                                  @"allowing navigation.");
-                            decisionHandler(WKNavigationActionPolicyAllow);
-                            return;
-                          }
-                          if (result == FlutterMethodNotImplemented) {
-                            NSLog(@"navigationRequest was unexepectedly not implemented: %@, "
-                                  @"allowing navigation.",
-                                  result);
-                            decisionHandler(WKNavigationActionPolicyAllow);
-                            return;
-                          }
-                          if (![result isKindOfClass:[NSNumber class]]) {
-                            NSLog(@"navigationRequest unexpectedly returned a non numeric value: "
-                                  @"%@, allowing navigation.",
-                                  result);
-                            decisionHandler(WKNavigationActionPolicyAllow);
-                            return;
-                          }
-                          NSNumber* typedResult = result;
-                            switch ([typedResult intValue]) {
-                                case 0:
-                                    decisionHandler(WKNavigationActionPolicyCancel);
-                                    break;
-                                case 1:
-                                    decisionHandler(WKNavigationActionPolicyAllow);
-                                    break;
-                                case 2:
-                                    decisionHandler((WKNavigationActionPolicy)(WKNavigationActionPolicyAllow + 2));
-                                    break;
-                                default:
-                                    NSLog(@"navigationRequest unexpectedly returned a invalid value: "
-                                          @"%@, allowing navigation.",
-                                          result);
-                                    decisionHandler(WKNavigationActionPolicyAllow);
-                                    break;
-                            }
-                        }];
+     arguments:arguments
+        result:^(id _Nullable result) {
+          if ([result isKindOfClass:[FlutterError class]]) {
+            NSLog(@"navigationRequest has unexpectedly completed with an error, "
+                  @"allowing navigation.");
+            decisionHandler(WKNavigationActionPolicyAllow);
+            return;
+          }
+          if (result == FlutterMethodNotImplemented) {
+            NSLog(@"navigationRequest was unexepectedly not implemented: %@, "
+                  @"allowing navigation.",
+                  result);
+            decisionHandler(WKNavigationActionPolicyAllow);
+            return;
+          }
+          if (![result isKindOfClass:[NSNumber class]]) {
+            NSLog(@"navigationRequest unexpectedly returned a non numeric value: "
+                  @"%@, allowing navigation.",
+                  result);
+            decisionHandler(WKNavigationActionPolicyAllow);
+            return;
+          }
+          NSNumber* typedResult = result;
+            switch ([typedResult intValue]) {
+                case 0:
+                    decisionHandler(WKNavigationActionPolicyCancel);
+                    break;
+                case 1:
+                    decisionHandler(WKNavigationActionPolicyAllow);
+                    break;
+                case 2:
+                    decisionHandler((WKNavigationActionPolicy)(WKNavigationActionPolicyAllow + 2));
+                    break;
+                default:
+                    NSLog(@"navigationRequest unexpectedly returned a invalid value: "
+                          @"%@, allowing navigation.",
+                          result);
+                    decisionHandler(WKNavigationActionPolicyAllow);
+                    break;
+            }
+        }];
 }
 
 - (void)webView:(WKWebView*)webView didFinishNavigation:(WKNavigation*)navigation {

--- a/packages/webview_flutter/lib/platform_interface.dart
+++ b/packages/webview_flutter/lib/platform_interface.dart
@@ -19,9 +19,7 @@ abstract class WebViewPlatformCallbacksHandler {
   void onJavaScriptChannelMessage(String channel, String message);
 
   /// Invoked by [WebViewPlatformController] when a navigation request is pending.
-  ///
-  /// If true is returned the navigation is allowed, otherwise it is blocked.
-  bool onNavigationRequest({String url, bool isForMainFrame});
+  NavigationDecision onNavigationRequest({String url, bool isForMainFrame});
 
   /// Invoked by [WebViewPlatformController] when a page has finished loading.
   void onPageFinished(String url);

--- a/packages/webview_flutter/lib/src/webview_method_channel.dart
+++ b/packages/webview_flutter/lib/src/webview_method_channel.dart
@@ -23,7 +23,7 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
   static const MethodChannel _cookieManagerChannel =
       MethodChannel('plugins.flutter.io/cookie_manager');
 
-  Future<bool> _onMethodCall(MethodCall call) async {
+  Future<dynamic> _onMethodCall(MethodCall call) async {
     switch (call.method) {
       case 'javascriptChannelMessage':
         final String channel = call.arguments['channel'];
@@ -34,7 +34,7 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
         return _platformCallbacksHandler.onNavigationRequest(
           url: call.arguments['url'],
           isForMainFrame: call.arguments['isForMainFrame'],
-        );
+        ).index;
       case 'onPageFinished':
         _platformCallbacksHandler.onPageFinished(call.arguments['url']);
         return null;

--- a/packages/webview_flutter/lib/src/webview_method_channel.dart
+++ b/packages/webview_flutter/lib/src/webview_method_channel.dart
@@ -31,10 +31,12 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
         _platformCallbacksHandler.onJavaScriptChannelMessage(channel, message);
         return true;
       case 'navigationRequest':
-        return _platformCallbacksHandler.onNavigationRequest(
-          url: call.arguments['url'],
-          isForMainFrame: call.arguments['isForMainFrame'],
-        ).index;
+        return _platformCallbacksHandler
+            .onNavigationRequest(
+              url: call.arguments['url'],
+              isForMainFrame: call.arguments['isForMainFrame'],
+            )
+            .index;
       case 'onPageFinished':
         _platformCallbacksHandler.onPageFinished(call.arguments['url']);
         return null;

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -60,7 +60,8 @@ enum NavigationDecision {
   /// Allow the navigation to take place.
   navigate,
 
-  /// Allow the navigation to take place but without trying App Link on iOS.
+  /// Allow the navigation to take place but without trying App Link on iOS
+  /// This works the same as [navigate] on Android.
   navigateWithoutTryingAppLink,
 }
 

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -389,7 +389,8 @@ class _PlatformCallbacksHandler implements WebViewPlatformCallbacksHandler {
   NavigationDecision onNavigationRequest({String url, bool isForMainFrame}) {
     final NavigationRequest request =
         NavigationRequest._(url: url, isForMainFrame: isForMainFrame);
-    return _widget?.navigationDelegate?.call(request) ?? NavigationDecision.navigate;
+    return _widget?.navigationDelegate?.call(request) ??
+        NavigationDecision.navigate;
   }
 
   @override

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -59,6 +59,9 @@ enum NavigationDecision {
 
   /// Allow the navigation to take place.
   navigate,
+
+  /// Allow the navigation to take place but without trying App Link on iOS.
+  navigateWithoutTryingAppLink,
 }
 
 /// Decides how to handle a specific navigation request.
@@ -382,12 +385,10 @@ class _PlatformCallbacksHandler implements WebViewPlatformCallbacksHandler {
   }
 
   @override
-  bool onNavigationRequest({String url, bool isForMainFrame}) {
+  NavigationDecision onNavigationRequest({String url, bool isForMainFrame}) {
     final NavigationRequest request =
         NavigationRequest._(url: url, isForMainFrame: isForMainFrame);
-    final bool allowNavigation = _widget.navigationDelegate == null ||
-        _widget.navigationDelegate(request) == NavigationDecision.navigate;
-    return allowNavigation;
+    return _widget?.navigationDelegate?.call(request) ?? NavigationDecision.navigate;
   }
 
   @override

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
-version: 0.3.9+2
+version: 0.3.10
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/webview_flutter
 

--- a/packages/webview_flutter/test/webview_flutter_test.dart
+++ b/packages/webview_flutter/test/webview_flutter_test.dart
@@ -681,9 +681,9 @@ void main() {
         initialUrl: 'https://youtube.com',
         navigationDelegate: (NavigationRequest request) {
           navigationRequests.add(request);
-          if(request.url == 'https://flutter.dev') {
+          if (request.url == 'https://flutter.dev') {
             return NavigationDecision.navigate;
-          } else if(request.url == 'custom://applink') {
+          } else if (request.url == 'custom://applink') {
             return NavigationDecision.navigateWithoutTryingAppLink;
           }
           return NavigationDecision.prevent;
@@ -711,7 +711,6 @@ void main() {
       await tester.pump();
       expect(platformWebView.currentUrl, 'custom://applink');
     });
-
 
     testWidgets('App link navigation', (WidgetTester tester) async {
       final List<NavigationRequest> navigationRequests = <NavigationRequest>[];
@@ -945,7 +944,7 @@ class FakePlatformWebView {
         .encodeMethodCall(MethodCall('javascriptChannelMessage', arguments));
     // TODO(hterkelsen): Remove this when defaultBinaryMessages is in stable.
     // https://github.com/flutter/flutter/issues/33446
-      // ignore: deprecated_member_use
+    // ignore: deprecated_member_use
     BinaryMessages.handlePlatformMessage(
         channel.name, data, (ByteData data) {});
   }


### PR DESCRIPTION
## Description

When the user taps on a universal link in WKWebView, the corresponding app will be opened (if installed). In some cases, we want to prevent this and continue loading the URLs inside the WKWebView. There is a hidden flag that allows this behaviour, which is `WKNavigationActionPolicyAllow + 2`, as seen [in the WebKit source code](https://github.com/WebKit/webkit/blob/master/Source/WebKit/UIProcess/API/Cocoa/WKNavigationDelegatePrivate.h#L58).

Please see the relevant [StackOverflow discussion](https://stackoverflow.com/questions/38450586/prevent-universal-links-from-opening-in-wkwebview-uiwebview) for reference.

Thanks to @slightfoot for his help to open this PR (basically his code) 🎉.


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviours (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
