### PR TITLE
[firebase_crashlyitcs] On Android, use actual the Dart exception name instead of "Dart error."

### DIFF
--- a/packages/firebase_crashlytics/CHANGELOG.md
+++ b/packages/firebase_crashlytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.4+6
+
+* Fix Android exception message so it include the dart exception message.
+
 ## 0.0.4+5
 
 * Fix parsing stacktrace.

--- a/packages/firebase_crashlytics/CHANGELOG.md
+++ b/packages/firebase_crashlytics/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.0.4+6
 
-* Update Android exception message to include the Dart exception message.
+* On Android, use actual the Dart exception name instead of "Dart error."
 
 ## 0.0.4+5
 

--- a/packages/firebase_crashlytics/CHANGELOG.md
+++ b/packages/firebase_crashlytics/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.0.4+6
 
-* Fix Android exception message so it include the dart exception message.
+* Update Android exception message to include the Dart exception message.
 
 ## 0.0.4+5
 

--- a/packages/firebase_crashlytics/android/src/main/java/io/flutter/plugins/firebase/crashlytics/firebasecrashlytics/FirebaseCrashlyticsPlugin.java
+++ b/packages/firebase_crashlytics/android/src/main/java/io/flutter/plugins/firebase/crashlytics/firebasecrashlytics/FirebaseCrashlyticsPlugin.java
@@ -58,7 +58,7 @@ public class FirebaseCrashlyticsPlugin implements MethodCallHandler {
 
       // Report crash.
       String dartExceptionMessage = (String) call.argument("exception");
-      Exception exception = new Exception("Dart Error: " + dartExceptionMessage);
+      Exception exception = new Exception(dartExceptionMessage);
       List<Map<String, String>> errorElements = call.argument("stackTraceElements");
       List<StackTraceElement> elements = new ArrayList<>();
       for (Map<String, String> errorElement : errorElements) {

--- a/packages/firebase_crashlytics/android/src/main/java/io/flutter/plugins/firebase/crashlytics/firebasecrashlytics/FirebaseCrashlyticsPlugin.java
+++ b/packages/firebase_crashlytics/android/src/main/java/io/flutter/plugins/firebase/crashlytics/firebasecrashlytics/FirebaseCrashlyticsPlugin.java
@@ -57,7 +57,8 @@ public class FirebaseCrashlyticsPlugin implements MethodCallHandler {
       }
 
       // Report crash.
-      Exception exception = new Exception("Dart Error");
+      String dartExceptionMessage = (String) call.argument("exception");
+      Exception exception = new Exception("Dart Error: " + dartExceptionMessage);
       List<Map<String, String>> errorElements = call.argument("stackTraceElements");
       List<StackTraceElement> elements = new ArrayList<>();
       for (Map<String, String> errorElement : errorElements) {

--- a/packages/firebase_crashlytics/pubspec.yaml
+++ b/packages/firebase_crashlytics/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_crashlytics
 description: Flutter plugin for Firebase Crashlytics. It reports uncaught errors to the
   Firebase console.
-version: 0.0.4+5
+version: 0.0.4+6
 author: Flutter Team <flutter-dev@google.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_crashlytics
 


### PR DESCRIPTION
## Description

Fixing the message of the exception used when reporting dart errors to Firebase Crashlytics. Previously all errors used the same message "Dart Error" which caused every reported error to appear as the same error in the Firebase Crashlytics console. After this change the exception message will include the message from the dart code.

## Related Issues

flutter/flutter#31370

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
