### PR TITLE
[Connectivity][Android] Updated check network info logic

### DIFF
--- a/packages/connectivity/CHANGELOG.md
+++ b/packages/connectivity/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.3+4
+
+* [Android] Updated logic to retrieve network info.
+
 ## 0.4.3+3
 
 * Support for TYPE_MOBILE_HIPRI on Android.

--- a/packages/connectivity/android/src/main/java/io/flutter/plugins/connectivity/ConnectivityPlugin.java
+++ b/packages/connectivity/android/src/main/java/io/flutter/plugins/connectivity/ConnectivityPlugin.java
@@ -99,11 +99,15 @@ public class ConnectivityPlugin implements MethodCallHandler, StreamHandler {
   }
 
   private void handleCheck(MethodCall call, final Result result) {
+    result.success(checkNetworkType());
+  }
+
+  private String checkNetworkType() {
     NetworkInfo info = manager.getActiveNetworkInfo();
     if (info != null && info.isConnected()) {
-      result.success(getNetworkType(info.getType()));
+      return getNetworkType(info.getType());
     } else {
-      result.success("none");
+      return "none";
     }
   }
 
@@ -154,14 +158,7 @@ public class ConnectivityPlugin implements MethodCallHandler, StreamHandler {
     return new BroadcastReceiver() {
       @Override
       public void onReceive(Context context, Intent intent) {
-        boolean isLost = intent.getBooleanExtra(ConnectivityManager.EXTRA_NO_CONNECTIVITY, false);
-        if (isLost) {
-          events.success("none");
-          return;
-        }
-
-        int type = intent.getIntExtra(ConnectivityManager.EXTRA_NETWORK_TYPE, -1);
-        events.success(getNetworkType(type));
+        events.success(checkNetworkType());
       }
     };
   }

--- a/packages/connectivity/pubspec.yaml
+++ b/packages/connectivity/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for discovering the state of the network (WiFi &
   mobile/cellular) connectivity on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/connectivity
-version: 0.4.3+3
+version: 0.4.3+4
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Regards to the issue https://issuetracker.google.com/issues/37137911 this PR do not use ConnectivityManager.EXTRA_NETWORK_INFO to determine current network state.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.