### PR TITLE
[firebase_performance] Fix bug that prevented plugin to work with hot restart

### DIFF
--- a/packages/firebase_performance/CHANGELOG.md
+++ b/packages/firebase_performance/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0+2
+
+* Fix bug preventing this plugin to work with hot restart.
+
 ## 0.3.0+1
 
 * Automatically use version from pubspec.yaml when reporting usage to Firebase.

--- a/packages/firebase_performance/CHANGELOG.md
+++ b/packages/firebase_performance/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.3.0+2
 
-* Fix bug preventing this plugin to work with hot restart.
+* Fix bug preventing this plugin from working with hot restart.
 
 ## 0.3.0+1
 

--- a/packages/firebase_performance/android/src/main/java/io/flutter/plugins/firebaseperformance/FirebasePerformancePlugin.java
+++ b/packages/firebase_performance/android/src/main/java/io/flutter/plugins/firebaseperformance/FirebasePerformancePlugin.java
@@ -23,6 +23,7 @@ public class FirebasePerformancePlugin implements MethodChannel.MethodCallHandle
   @Override
   public void onMethodCall(MethodCall call, MethodChannel.Result result) {
     if (call.method.equals("FirebasePerformance#instance")) {
+      handlers.clear();
       FlutterFirebasePerformance.getInstance(call, result);
     } else {
       final MethodChannel.MethodCallHandler handler = getHandler(call);

--- a/packages/firebase_performance/ios/Classes/FirebasePerformancePlugin.m
+++ b/packages/firebase_performance/ios/Classes/FirebasePerformancePlugin.m
@@ -39,6 +39,8 @@ static NSMutableDictionary<NSNumber *, id<MethodCallHandler>> *methodHandlers;
 
 - (void)handleMethodCall:(FlutterMethodCall *)call result:(FlutterResult)result {
   if ([@"FirebasePerformance#instance" isEqualToString:call.method]) {
+    [methodHandlers removeAllObjects];
+
     NSNumber *handle = call.arguments[@"handle"];
     FLTFirebasePerformance *performance = [FLTFirebasePerformance sharedInstance];
 

--- a/packages/firebase_performance/pubspec.yaml
+++ b/packages/firebase_performance/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Google Performance Monitoring for Firebase, an a
   iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_performance
-version: 0.3.0+1
+version: 0.3.0+2
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Description

This clears the maps that hold all the `Trace`s and `HttpMetric`s when the `FirebasePerformance` object is created.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/34165

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
