### PR TITLE
[script] Don't run incremental build when there are no changes in packages

### DIFF
--- a/script/incremental_build.sh
+++ b/script/incremental_build.sh
@@ -21,8 +21,7 @@ else
   check_changed_packages
 
   if [[ "$CHANGED_PACKAGES" == "" ]]; then
-    echo "Running for all packages"
-    (cd "$REPO_DIR" && pub global run flutter_plugin_tools "${ACTIONS[@]}" $PLUGIN_SHARDING)
+    echo "No changes detected in packages."
   else
     (cd "$REPO_DIR" && pub global run flutter_plugin_tools "${ACTIONS[@]}" --plugins="$CHANGED_PACKAGES" $PLUGIN_SHARDING)
   fi


### PR DESCRIPTION
## Description

This PR stops running `incremental_build.sh` script when there are no changes in `packages/'. 
Typically cirrus would run on all packages, but this often causes timeouts in PRs: 

https://github.com/flutter/plugins/pull/1764
https://github.com/flutter/plugins/pull/1725

When on `master` branch, it will still run on all packages: 
https://github.com/flutter/plugins/pull/1768/files#diff-786bf7969139ce4398c295bd601799d4L16