### PR TITLE
[firebase_admob] Adding async await for rewarded video ad

### DIFF
--- a/packages/firebase_admob/android/src/main/java/io/flutter/plugins/firebaseadmob/FirebaseAdMobPlugin.java
+++ b/packages/firebase_admob/android/src/main/java/io/flutter/plugins/firebaseadmob/FirebaseAdMobPlugin.java
@@ -113,11 +113,11 @@ public class FirebaseAdMobPlugin implements MethodCallHandler {
   }
 
   private void callLoadRewardedVideoAd(MethodCall call, Result result) {
-    if (rewardedWrapper.getStatus() != RewardedVideoAdWrapper.Status.CREATED
+    /*if (rewardedWrapper.getStatus() != RewardedVideoAdWrapper.Status.CREATED
         && rewardedWrapper.getStatus() != RewardedVideoAdWrapper.Status.FAILED) {
       result.success(Boolean.TRUE); // The ad was already loading or loaded.
       return;
-    }
+    }*/
 
     String adUnitId = call.argument("adUnitId");
     if (adUnitId == null || adUnitId.isEmpty()) {

--- a/packages/firebase_admob/lib/firebase_admob.dart
+++ b/packages/firebase_admob/lib/firebase_admob.dart
@@ -394,9 +394,9 @@ class RewardedVideoAd {
 
   /// Loads a rewarded video ad using the provided ad unit ID.
   Future<bool> load(
-      {@required String adUnitId, MobileAdTargetingInfo targetingInfo}) {
+      {@required String adUnitId, MobileAdTargetingInfo targetingInfo}) async {
     assert(adUnitId.isNotEmpty);
-    return _invokeBooleanMethod("loadRewardedVideoAd", <String, dynamic>{
+    return await _invokeBooleanMethod("loadRewardedVideoAd", <String, dynamic>{
       'adUnitId': adUnitId,
       'targetingInfo': targetingInfo?.toJson(),
     });


### PR DESCRIPTION
## Description


Adding async and await do much more better for me. And works good without any errors

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
