### PR TITLE
Set device density to polylines

### DIFF
--- a/packages/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.19+1
+
+* Fix polyline width according to device density
+
+
 ## 0.5.19
 
 

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
@@ -105,7 +105,7 @@ final class GoogleMapController
     this.registrarActivityHashCode = registrar.activity().hashCode();
     this.markersController = new MarkersController(methodChannel);
     this.polygonsController = new PolygonsController(methodChannel);
-    this.polylinesController = new PolylinesController(methodChannel);
+    this.polylinesController = new PolylinesController(methodChannel, density);
     this.circlesController = new CirclesController(methodChannel);
   }
 

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/PolylineController.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/PolylineController.java
@@ -11,10 +11,12 @@ class PolylineController implements PolylineOptionsSink {
   private final Polyline polyline;
   private final String googleMapsPolylineId;
   private boolean consumeTapEvents;
+  private final float density;
 
-  PolylineController(Polyline polyline, boolean consumeTapEvents) {
+  PolylineController(Polyline polyline, boolean consumeTapEvents, float density) {
     this.polyline = polyline;
     this.consumeTapEvents = consumeTapEvents;
+    this.density = density;
     this.googleMapsPolylineId = polyline.getId();
   }
 
@@ -70,7 +72,7 @@ class PolylineController implements PolylineOptionsSink {
 
   @Override
   public void setWidth(float width) {
-    polyline.setWidth(width);
+    polyline.setWidth(width * density);
   }
 
   @Override

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/PolylinesController.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/PolylinesController.java
@@ -18,11 +18,13 @@ class PolylinesController {
   private final Map<String, String> googleMapsPolylineIdToDartPolylineId;
   private final MethodChannel methodChannel;
   private GoogleMap googleMap;
+  private final float density;
 
-  PolylinesController(MethodChannel methodChannel) {
+  PolylinesController(MethodChannel methodChannel, float density) {
     this.polylineIdToController = new HashMap<>();
     this.googleMapsPolylineIdToDartPolylineId = new HashMap<>();
     this.methodChannel = methodChannel;
+    this.density = density;
   }
 
   void setGoogleMap(GoogleMap googleMap) {
@@ -88,7 +90,7 @@ class PolylinesController {
   private void addPolyline(
       String polylineId, PolylineOptions polylineOptions, boolean consumeTapEvents) {
     final Polyline polyline = googleMap.addPolyline(polylineOptions);
-    PolylineController controller = new PolylineController(polyline, consumeTapEvents);
+    PolylineController controller = new PolylineController(polyline, consumeTapEvents, density);
     polylineIdToController.put(polylineId, controller);
     googleMapsPolylineIdToDartPolylineId.put(polyline.getId(), polylineId);
   }

--- a/packages/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter
-version: 0.5.19
+version: 0.5.19+1
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Description

This PR sets the width of the polyline properly according to the device density. 

## Related Issues

The polyline width on Android devices does not respect the device density 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/