### PR TITLE
[in_app_purchase] (fix): readme typo

### DIFF
--- a/packages/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0+1
+
+* Corrected a typo in the README.
+
 ## 0.2.0
 
 * [Breaking Change] Rename 'PurchaseError' to 'IAPError'.

--- a/packages/in_app_purchase/README.md
+++ b/packages/in_app_purchase/README.md
@@ -102,7 +102,7 @@ final QueryPurchaseDetailsResponse response = await InAppPurchaseConnection.inst
 if (response.error != null) {
     // Handle the error.
 }
-for (PurchaseDetails purchase : repsonse.pastPurchases) {
+for (PurchaseDetails purchase : response.pastPurchases) {
     _verifyPurchase(purchase);  // Verify the purchase following the best practices for each storefront.
     _deliverPurchase(purchase); // Deliver the purchase to the user in your app.
     if (Platform.isIOS) {

--- a/packages/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase
 description: A Flutter plugin for in-app purchases. Exposes APIs for making in-app purchases through the App Store and Google Play.
 author:  Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/in_app_purchase
-version: 0.2.0
+version: 0.2.0+1
 
 dependencies:
   async: ^2.0.8


### PR DESCRIPTION
Simple typo fix. changed 'reponse' to 'response' in code snippet.