### PR TITLE
[in_app_purchase]fix the type casting issue

### DIFF
--- a/packages/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0+1
+
+* Fix an issue the type is not casted before passing to `PurchasesResultWrapper.fromJson`.
+
 ## 0.2.0
 
 * [Breaking Change] Rename 'PurchaseError' to 'IAPError'.

--- a/packages/in_app_purchase/lib/src/billing_client_wrappers/billing_client_wrapper.dart
+++ b/packages/in_app_purchase/lib/src/billing_client_wrappers/billing_client_wrapper.dart
@@ -218,9 +218,11 @@ class BillingClient {
       case kOnPurchasesUpdated:
         // The purchases updated listener is a singleton.
         assert(_callbacks[kOnPurchasesUpdated].length == 1);
+        assert(call.arguments is Map<String, dynamic>);
         final PurchasesUpdatedListener listener =
             _callbacks[kOnPurchasesUpdated].first;
-        listener(PurchasesResultWrapper.fromJson(call.arguments));
+        listener(PurchasesResultWrapper.fromJson(
+            call.arguments.cast<String, dynamic>()));
         break;
       case _kOnBillingServiceDisconnected:
         final int handle = call.arguments['handle'];

--- a/packages/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase
 description: A Flutter plugin for in-app purchases. Exposes APIs for making in-app purchases through the App Store and Google Play.
 author:  Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/in_app_purchase
-version: 0.2.0
+version: 0.2.0+1
 
 dependencies:
   async: ^2.0.8

--- a/packages/in_app_purchase/test/in_app_purchase_connection/google_play_connection_test.dart
+++ b/packages/in_app_purchase/test/in_app_purchase_connection/google_play_connection_test.dart
@@ -306,7 +306,7 @@ void main() {
       expect(result.purchaseID, isNull);
     });
 
-    test('tes purchase updated type assertion', () async {
+    test('test purchase updated type assertion', () async {
       final BillingResponse sentCode = BillingResponse.error;
 
       MethodCall call = MethodCall(kOnPurchasesUpdated, {

--- a/packages/in_app_purchase/test/in_app_purchase_connection/google_play_connection_test.dart
+++ b/packages/in_app_purchase/test/in_app_purchase_connection/google_play_connection_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter/services.dart';
 import 'package:in_app_purchase/src/in_app_purchase/purchase_details.dart';
 import 'package:test/test.dart';
 
-import 'package:flutter/widgets.dart';
+import 'package:flutter/widgets.dart' hide TypeMatcher;
 import 'package:in_app_purchase/billing_client_wrappers.dart';
 import 'package:in_app_purchase/src/billing_client_wrappers/enum_converters.dart';
 import 'package:in_app_purchase/src/in_app_purchase/google_play_connection.dart';
@@ -304,6 +304,17 @@ void main() {
       expect(result.error.source, IAPSource.GooglePlay);
       expect(result.status, PurchaseStatus.error);
       expect(result.purchaseID, isNull);
+    });
+
+    test('tes purchase updated type assertion', () async {
+      final BillingResponse sentCode = BillingResponse.error;
+
+      MethodCall call = MethodCall(kOnPurchasesUpdated, {
+        1: BillingResponseConverter().toJson(sentCode),
+        'purchasesList': []
+      });
+      expect(() => connection.billingClient.callHandler(call),
+          throwsA(TypeMatcher<AssertionError>()));
     });
 
     test('buy consumable with auto consume, serializes and deserializes data',


### PR DESCRIPTION
## Description

Fix an issue where the type is incorrectly passed to `PurchasesResultWrapper.fromJson`

## Related Issues

https://github.com/flutter/flutter/issues/34040

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
