### PR TITLE
[cloud_firestore] Transactions improvements

### DIFF
--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.5+3
+
+* Add an integration test for rapidly incrementing field value.
+
 ## 0.12.5+2
 
 * Automatically use version from pubspec.yaml when reporting usage to Firebase.

--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,6 +1,8 @@
-## 0.12.5+3
+## 0.12.6
 
-* Add an integration test for rapidly incrementing field value.
+* Methods of `Transaction` no longer require `await`.
+* Added documentation to methods of `Transaction`.
+* Added an integration test for rapidly incrementing field value.
 
 ## 0.12.5+2
 

--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Methods of `Transaction` no longer require `await`.
 * Added documentation to methods of `Transaction`.
+* Removed an unnecessary log on Android.
 * Added an integration test for rapidly incrementing field value.
 
 ## 0.12.6

--- a/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
+++ b/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
@@ -528,7 +528,6 @@ public class CloudFirestorePlugin implements MethodCallHandler {
                   new Runnable() {
                     @Override
                     public void run() {
-                      Log.d(TAG, "sending set success");
                       result.success(null);
                     }
                   });

--- a/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
+++ b/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
@@ -389,7 +389,7 @@ public class CloudFirestorePlugin implements MethodCallHandler {
                                         String errorMessage,
                                         Object errorDetails) {
                                       transactionTCS.trySetException(
-                                          new Exception("Do transaction failed."));
+                                          new Exception("DoTransaction failed: " + errorMessage));
                                     }
 
                                     @Override

--- a/packages/cloud_firestore/example/test_driver/cloud_firestore.dart
+++ b/packages/cloud_firestore/example/test_driver/cloud_firestore.dart
@@ -92,9 +92,9 @@ void main() {
       expect(snapshot.data['message'], 42.1);
 
       // Call several times without awaiting the result
-      await Future.wait(new List.generate(
+      await Future.wait<void>(List<Future<void>>.generate(
         100,
-        (i) => ref.updateData(<String, dynamic>{
+        (int i) => ref.updateData(<String, dynamic>{
           'message': FieldValue.increment(i),
         }),
       ));

--- a/packages/cloud_firestore/example/test_driver/cloud_firestore.dart
+++ b/packages/cloud_firestore/example/test_driver/cloud_firestore.dart
@@ -117,11 +117,12 @@ void main() {
           final Map<String, dynamic> updatedData =
               Map<String, dynamic>.from(snapshot.data);
           updatedData['message'] = 'testing2';
-          tx.update(ref, updatedData);  // calling await here is optional
+          tx.update(ref, updatedData); // calling await here is optional
           return updatedData;
         },
       );
       expect(result['message'], 'testing2');
+
       await ref.delete();
       final DocumentSnapshot nonexistentSnapshot = await ref.get();
       expect(nonexistentSnapshot.data, null);

--- a/packages/cloud_firestore/example/test_driver/cloud_firestore.dart
+++ b/packages/cloud_firestore/example/test_driver/cloud_firestore.dart
@@ -90,6 +90,16 @@ void main() {
       });
       snapshot = await ref.get();
       expect(snapshot.data['message'], 42.1);
+
+      // Call several times without awaiting the result
+      await Future.wait(new List.generate(
+        100,
+        (i) => ref.updateData(<String, dynamic>{
+          'message': FieldValue.increment(i),
+        }),
+      ));
+      snapshot = await ref.get();
+      expect(snapshot.data['message'], 4992.1);
       await ref.delete();
     });
 

--- a/packages/cloud_firestore/example/test_driver/cloud_firestore.dart
+++ b/packages/cloud_firestore/example/test_driver/cloud_firestore.dart
@@ -93,13 +93,13 @@ void main() {
 
       // Call several times without awaiting the result
       await Future.wait<void>(List<Future<void>>.generate(
-        100,
+        3,
         (int i) => ref.updateData(<String, dynamic>{
           'message': FieldValue.increment(i),
         }),
       ));
       snapshot = await ref.get();
-      expect(snapshot.data['message'], 4992.1);
+      expect(snapshot.data['message'], 45.1);
       await ref.delete();
     });
 
@@ -117,7 +117,7 @@ void main() {
           final Map<String, dynamic> updatedData =
               Map<String, dynamic>.from(snapshot.data);
           updatedData['message'] = 'testing2';
-          tx.update(ref, updatedData);  // calling await here is now optional
+          tx.update(ref, updatedData);  // calling await here is optional
           return updatedData;
         },
       );

--- a/packages/cloud_firestore/example/test_driver/cloud_firestore.dart
+++ b/packages/cloud_firestore/example/test_driver/cloud_firestore.dart
@@ -117,7 +117,7 @@ void main() {
           final Map<String, dynamic> updatedData =
               Map<String, dynamic>.from(snapshot.data);
           updatedData['message'] = 'testing2';
-          await tx.update(ref, updatedData);
+          tx.update(ref, updatedData);  // calling await here is now optional
           return updatedData;
         },
       );

--- a/packages/cloud_firestore/lib/src/firestore.dart
+++ b/packages/cloud_firestore/lib/src/firestore.dart
@@ -26,7 +26,8 @@ class Firestore {
       } else if (call.method == 'DoTransaction') {
         final int transactionId = call.arguments['transactionId'];
         final Transaction transaction = Transaction(transactionId, this);
-        final dynamic result = await _transactionHandlers[transactionId](transaction);
+        final dynamic result =
+            await _transactionHandlers[transactionId](transaction);
         await transaction._finish();
         return result;
       }

--- a/packages/cloud_firestore/lib/src/firestore.dart
+++ b/packages/cloud_firestore/lib/src/firestore.dart
@@ -26,7 +26,7 @@ class Firestore {
       } else if (call.method == 'DoTransaction') {
         final int transactionId = call.arguments['transactionId'];
         final Transaction transaction = Transaction(transactionId, this);
-        dynamic result = await _transactionHandlers[transactionId](transaction);
+        final dynamic result = await _transactionHandlers[transactionId](transaction);
         await transaction._finish();
         return result;
       }

--- a/packages/cloud_firestore/lib/src/firestore.dart
+++ b/packages/cloud_firestore/lib/src/firestore.dart
@@ -25,9 +25,10 @@ class Firestore {
         _documentObservers[call.arguments['handle']].add(snapshot);
       } else if (call.method == 'DoTransaction') {
         final int transactionId = call.arguments['transactionId'];
-        return _transactionHandlers[transactionId](
-          Transaction(transactionId, this),
-        );
+        final Transaction transaction = Transaction(transactionId, this);
+        dynamic result = await _transactionHandlers[transactionId](transaction);
+        await transaction._finish();
+        return result;
       }
     });
     _initialized = true;

--- a/packages/cloud_firestore/lib/src/transaction.dart
+++ b/packages/cloud_firestore/lib/src/transaction.dart
@@ -12,7 +12,7 @@ class Transaction {
 
   int _transactionId;
   Firestore _firestore;
-  List<Future<dynamic>> _pendingResults = [];
+  List<Future<dynamic>> _pendingResults = <Future<dynamic>>[];
   Future<void> _finish() => Future.wait<void>(_pendingResults);
 
   /// Reads the document referenced by the provided DocumentReference.

--- a/packages/cloud_firestore/lib/src/transaction.dart
+++ b/packages/cloud_firestore/lib/src/transaction.dart
@@ -12,8 +12,17 @@ class Transaction {
 
   int _transactionId;
   Firestore _firestore;
+  List<Future<dynamic>> _pendingResults = [];
+  Future<void> _finish() => Future.wait<void>(_pendingResults);
 
-  Future<DocumentSnapshot> get(DocumentReference documentReference) async {
+  /// Reads the document referenced by the provided DocumentReference.
+  Future<DocumentSnapshot> get(DocumentReference documentReference) {
+    final Future<DocumentSnapshot> result = _get(documentReference);
+    _pendingResults.add(result);
+    return result;
+  }
+
+  Future<DocumentSnapshot> _get(DocumentReference documentReference) async {
     final Map<String, dynamic> result = await Firestore.channel
         .invokeMapMethod<String, dynamic>('Transaction#get', <String, dynamic>{
       'app': _firestore.app.name,
@@ -32,7 +41,17 @@ class Transaction {
     }
   }
 
-  Future<void> delete(DocumentReference documentReference) async {
+  /// Deletes the document referred to by the provided [documentReference].
+  ///
+  /// Awaiting the returned [Future] is optional and will be done automatically
+  /// when the transaction handler completes.
+  Future<void> delete(DocumentReference documentReference) {
+    final Future<void> result = _delete(documentReference);
+    _pendingResults.add(result);
+    return result;
+  }
+
+  Future<void> _delete(DocumentReference documentReference) async {
     return Firestore.channel
         .invokeMethod<void>('Transaction#delete', <String, dynamic>{
       'app': _firestore.app.name,
@@ -41,7 +60,19 @@ class Transaction {
     });
   }
 
+  /// Updates fields in the document referred to by [documentReference].
+  /// The update will fail if applied to a document that does not exist.
+  ///
+  /// Awaiting the returned [Future] is optional and will be done automatically
+  /// when the transaction handler completes.
   Future<void> update(
+      DocumentReference documentReference, Map<String, dynamic> data) async {
+    final Future<void> result = _update(documentReference, data);
+    _pendingResults.add(result);
+    return result;
+  }
+
+  Future<void> _update(
       DocumentReference documentReference, Map<String, dynamic> data) async {
     return Firestore.channel
         .invokeMethod<void>('Transaction#update', <String, dynamic>{
@@ -52,7 +83,20 @@ class Transaction {
     });
   }
 
+  /// Writes to the document referred to by the provided [DocumentReference].
+  /// If the document does not exist yet, it will be created. If you pass
+  /// SetOptions, the provided data can be merged into the existing document.
+  ///
+  /// Awaiting the returned [Future] is optional and will be done automatically
+  /// when the transaction handler completes.
   Future<void> set(
+      DocumentReference documentReference, Map<String, dynamic> data) {
+    final Future<void> result = _set(documentReference, data);
+    _pendingResults.add(result);
+    return result;
+  }
+
+  Future<void> _set(
       DocumentReference documentReference, Map<String, dynamic> data) async {
     return Firestore.channel
         .invokeMethod<void>('Transaction#set', <String, dynamic>{

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_firestore
-version: 0.12.5+2
+version: 0.12.5+3
 
 flutter:
   plugin:

--- a/packages/firebase_database/CHANGELOG.md
+++ b/packages/firebase_database/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.4
+
+* Fix transactions on 
+
 ## 3.0.3
 
 * Automatically use version from pubspec.yaml when reporting usage to Firebase.


### PR DESCRIPTION
Several improvements to transactions

1. `Transaction` methods no longer cause errors when you fail to `await`. Fixes flutter/flutter#34747
1. Add an integration test for rapid calls to `FieldValue.increment`. We also seen reports of FieldValue.increment causing crashes (flutter/flutter#35269) so I'm checking in a test for this. Test is passing for me, so I'm curious what devices it fails on.