### PR TITLE
[cloud_firestore] Support for map fields in document pagination

### DIFF
--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.12.6+1
+## 0.12.5+3
 
 * Support for `orderBy` on map fields (e.g. `orderBy('cake.flavor')`) for
   `startAtDocument`, `startAfterDocument`, `endAtDocument`, and `endBeforeDocument` added.

--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.12.6+1
+
+* Support for `orderBy` on map fields (e.g. `orderBy('cake.flavor')`) for
+  `startAtDocument`, `startAfterDocument`, `endAtDocument`, and `endBeforeDocument` added.
+
 ## 0.12.5+2
 
 * Automatically use version from pubspec.yaml when reporting usage to Firebase.

--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.12.5+3
+## 0.12.6
 
 * Support for `orderBy` on map fields (e.g. `orderBy('cake.flavor')`) for
   `startAtDocument`, `startAfterDocument`, `endAtDocument`, and `endBeforeDocument` added.

--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.12.6
+## 0.12.5+3
 
 * Support for `orderBy` on map fields (e.g. `orderBy('cake.flavor')`) for
   `startAtDocument`, `startAfterDocument`, `endAtDocument`, and `endBeforeDocument` added.

--- a/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
+++ b/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
@@ -129,6 +129,14 @@ public class CloudFirestorePlugin implements MethodCallHandler {
     if (orderBy != null) {
       for (List<Object> order : orderBy) {
         String orderByFieldName = (String) order.get(0);
+        if (orderByFieldName.contains(".")) {
+          String[] fieldNameParts = orderByFieldName.split("\\.");
+          Map<String, Object> current = (Map<String, Object>) documentData.get(fieldNameParts[0]);
+          for (int i = 1; i < fieldNameParts.length - 1; i++) {
+            current = (Map<String, Object>) current.get(fieldNameParts[i]);
+          }
+          orderByFieldName = fieldNameParts[fieldNameParts.length - 1];
+        }
         data.add(documentData.get(orderByFieldName));
       }
     }

--- a/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
+++ b/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
@@ -135,9 +135,10 @@ public class CloudFirestorePlugin implements MethodCallHandler {
           for (int i = 1; i < fieldNameParts.length - 1; i++) {
             current = (Map<String, Object>) current.get(fieldNameParts[i]);
           }
-          orderByFieldName = fieldNameParts[fieldNameParts.length - 1];
+          data.add(current.get(fieldNameParts[fieldNameParts.length - 1]));
+        } else {
+          data.add(documentData.get(orderByFieldName));
         }
-        data.add(documentData.get(orderByFieldName));
       }
     }
     data.add((boolean) arguments.get("isCollectionGroup") ? document.get("path") : documentId);

--- a/packages/cloud_firestore/example/test_driver/cloud_firestore.dart
+++ b/packages/cloud_firestore/example/test_driver/cloud_firestore.dart
@@ -214,21 +214,15 @@ void main() {
     test('pagination with map', () async {
       // Populate the database with two test documents.
       final CollectionReference messages = firestore.collection('messages');
-      final DocumentReference doc1 = await messages.add(<String, dynamic> {
+      final DocumentReference doc1 = await messages.add(<String, dynamic>{
         'cake': <String, dynamic>{
-          'flavor': <String, dynamic>{
-            'type': 1,
-            'name': 'test'
-          }
+          'flavor': <String, dynamic>{'type': 1, 'name': 'test'}
         }
       });
       final DocumentSnapshot snapshot1 = await doc1.get();
       final DocumentReference doc2 = await messages.add(<String, dynamic>{
         'cake': <String, dynamic>{
-          'flavor': <String, dynamic>{
-            'type': 2,
-            'name': 'test'
-          }
+          'flavor': <String, dynamic>{'type': 2, 'name': 'test'}
         }
       });
 

--- a/packages/cloud_firestore/example/test_driver/cloud_firestore.dart
+++ b/packages/cloud_firestore/example/test_driver/cloud_firestore.dart
@@ -210,5 +210,45 @@ void main() {
       await doc1.delete();
       await doc2.delete();
     });
+
+    test('pagination with map', () async {
+      // Populate the database with two test documents.
+      final CollectionReference messages = firestore.collection('messages');
+      final DocumentReference doc1 = await messages.add(<String, dynamic> {
+        'cake': <String, dynamic>{
+          'flavor': <String, dynamic>{
+            'type': 1,
+            'name': 'test'
+          }
+        }
+      });
+      final DocumentSnapshot snapshot1 = await doc1.get();
+      final DocumentReference doc2 = await messages.add(<String, dynamic>{
+        'cake': <String, dynamic>{
+          'flavor': <String, dynamic>{
+            'type': 2,
+            'name': 'test'
+          }
+        }
+      });
+
+      QuerySnapshot snapshot;
+      List<DocumentSnapshot> results;
+
+      // startAtDocument - one is enough as all of the pagination methods use the same method to get data internally
+      snapshot = await messages
+          .orderBy('cake.flavor.type')
+          .startAtDocument(snapshot1)
+          .getDocuments();
+      results = snapshot.documents;
+
+      // Clean up - before expect in case the test fails
+      await doc1.delete();
+      await doc2.delete();
+
+      expect(results.length, 2);
+      expect(results[0].data['cake']['flavor']['type'], 1);
+      expect(results[1].data['cake']['flavor']['type'], 2);
+    });
   });
 }

--- a/packages/cloud_firestore/example/test_driver/cloud_firestore.dart
+++ b/packages/cloud_firestore/example/test_driver/cloud_firestore.dart
@@ -214,35 +214,40 @@ void main() {
     test('pagination with map', () async {
       // Populate the database with two test documents.
       final CollectionReference messages = firestore.collection('messages');
-      final DocumentReference doc1 = await messages.add(<String, dynamic>{
+      final DocumentReference doc1 = messages.document();
+      // Use document ID as a unique identifier to ensure that we don't
+      // collide with other tests running against this database.
+      final String testRun = doc1.documentID;
+      await doc1.setData(<String, dynamic>{
         'cake': <String, dynamic>{
-          'flavor': <String, dynamic>{'type': 1, 'name': 'test'}
+          'flavor': <String, dynamic>{'type': 1, 'test_run': testRun}
         }
       });
+
       final DocumentSnapshot snapshot1 = await doc1.get();
       final DocumentReference doc2 = await messages.add(<String, dynamic>{
         'cake': <String, dynamic>{
-          'flavor': <String, dynamic>{'type': 2, 'name': 'test'}
+          'flavor': <String, dynamic>{'type': 2, 'test_run': testRun}
         }
       });
 
       QuerySnapshot snapshot;
       List<DocumentSnapshot> results;
 
-      // startAtDocument - one is enough as all of the pagination methods use the same method to get data internally
+      // One pagination call is enough as all of the pagination methods use the same method to get data internally.
       snapshot = await messages
           .orderBy('cake.flavor.type')
+          .where('cake.flavor.test_run', isEqualTo: testRun)
           .startAtDocument(snapshot1)
           .getDocuments();
       results = snapshot.documents;
 
-      // Clean up - before expect in case the test fails
-      await doc1.delete();
-      await doc2.delete();
-
       expect(results.length, 2);
       expect(results[0].data['cake']['flavor']['type'], 1);
       expect(results[1].data['cake']['flavor']['type'], 2);
+
+      await doc1.delete();
+      await doc2.delete();
     });
   });
 }

--- a/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
+++ b/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
@@ -38,8 +38,8 @@ static NSArray *getDocumentValues(NSDictionary *document, NSArray *orderBy,
         for (int i = 1; i < [fieldNameParts count] - 1; i++) {
           currentMap = [currentMap objectForKey:[fieldNameParts objectAtIndex:i]];
         }
-        [values addObject:[currentMap
-            objectForKey:[fieldNameParts objectAtIndex:[fieldNameParts count] - 1]]];
+        [values addObject:[currentMap objectForKey:[fieldNameParts
+                                                       objectAtIndex:[fieldNameParts count] - 1]]];
       } else {
         [values addObject:[documentData objectForKey:fieldName]];
       }

--- a/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
+++ b/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
@@ -32,6 +32,14 @@ static NSArray *getDocumentValues(NSDictionary *document, NSArray *orderBy,
     for (id item in orderBy) {
       NSArray *orderByParameters = item;
       NSString *fieldName = orderByParameters[0];
+      if ([fieldName rangeOfString:@"."].location != NSNotFound) {
+        NSArray *fieldNameParts = [fieldName componentsSeparatedByString:@"."];
+        NSDictionary *currentMap = [documentData objectForKey:[fieldNameParts objectAtIndex:0]];
+        for (int i = 1; i < [fieldNameParts count] - 1; i++) {
+          currentMap = [currentMap objectForKey:[fieldNameParts objectAtIndex:i]];
+        }
+        fieldName = [currentMap objectForKey:[fieldNameParts objectAtIndex:[fieldNameParts count] - 1]];
+      }
       [values addObject:[documentData objectForKey:fieldName]];
     }
   }

--- a/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
+++ b/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
@@ -38,7 +38,8 @@ static NSArray *getDocumentValues(NSDictionary *document, NSArray *orderBy,
         for (int i = 1; i < [fieldNameParts count] - 1; i++) {
           currentMap = [currentMap objectForKey:[fieldNameParts objectAtIndex:i]];
         }
-        fieldName = [currentMap objectForKey:[fieldNameParts objectAtIndex:[fieldNameParts count] - 1]];
+        fieldName =
+            [currentMap objectForKey:[fieldNameParts objectAtIndex:[fieldNameParts count] - 1]];
       }
       [values addObject:[documentData objectForKey:fieldName]];
     }

--- a/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
+++ b/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
@@ -38,10 +38,11 @@ static NSArray *getDocumentValues(NSDictionary *document, NSArray *orderBy,
         for (int i = 1; i < [fieldNameParts count] - 1; i++) {
           currentMap = [currentMap objectForKey:[fieldNameParts objectAtIndex:i]];
         }
-        fieldName =
-            [currentMap objectForKey:[fieldNameParts objectAtIndex:[fieldNameParts count] - 1]];
+        [values addObject:[currentMap
+            objectForKey:[fieldNameParts objectAtIndex:[fieldNameParts count] - 1]]];
+      } else {
+        [values addObject:[documentData objectForKey:fieldName]];
       }
-      [values addObject:[documentData objectForKey:fieldName]];
     }
   }
   if (isCollectionGroup) {

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_firestore
-version: 0.12.5+3
+version: 0.12.6
 
 flutter:
   plugin:

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_firestore
-version: 0.12.5+2
+version: 0.12.6+1
 
 flutter:
   plugin:

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_firestore
-version: 0.12.6+1
+version: 0.12.5+3
 
 flutter:
   plugin:

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_firestore
-version: 0.12.6
+version: 0.12.5+3
 
 flutter:
   plugin:


### PR DESCRIPTION
Currently, a query with `orderBy('cake.flavor')` will return no documents when using any document pagination method (`startAtDocument` etc.).  
This happens because the internal method, which gets the data from the documents to fill in the `startAt` methods, will try to do something like `map['cake.flavor']`, which will return nothing.  
It should really be retrieving the field's value using `map['cake']['flavor']`, which this pull request adds.

I am not sure about the iOS implementation, however, CI should tell me as I added an integration test (after the index is added).

@collinjackson The query in the integration test [requires an index](https://console.firebase.google.com/project/flutter-firestore/database/firestore/indexes?create_composite=ClJwcm9qZWN0cy9mbHV0dGVyLWZpcmVzdG9yZS9kYXRhYmFzZXMvKGRlZmF1bHQpL2NvbGxlY3Rpb25Hcm91cHMvbWVzc2FnZXMvaW5kZXhlcy9fEAEaGAoUY2FrZS5mbGF2b3IudGVzdF9ydW4QARoUChBjYWtlLmZsYXZvci50eXBlEAEaDAoIX19uYW1lX18QAQ). It would be great if that could be added to test the iOS implementation as well.