### PR TITLE
[in_app_purchase]fix the regression introduced in 0.2.0+1

### DIFF
--- a/packages/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0+2
+
+* Fix a google_play_connection purchase update listener regression introduced in 0.2.0+1.
+
 ## 0.2.0+1
 
 * Fix an issue the type is not casted before passing to `PurchasesResultWrapper.fromJson`.

--- a/packages/in_app_purchase/lib/src/billing_client_wrappers/billing_client_wrapper.dart
+++ b/packages/in_app_purchase/lib/src/billing_client_wrappers/billing_client_wrapper.dart
@@ -218,7 +218,6 @@ class BillingClient {
       case kOnPurchasesUpdated:
         // The purchases updated listener is a singleton.
         assert(_callbacks[kOnPurchasesUpdated].length == 1);
-        assert(call.arguments is Map<String, dynamic>);
         final PurchasesUpdatedListener listener =
             _callbacks[kOnPurchasesUpdated].first;
         listener(PurchasesResultWrapper.fromJson(

--- a/packages/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase
 description: A Flutter plugin for in-app purchases. Exposes APIs for making in-app purchases through the App Store and Google Play.
 author:  Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/in_app_purchase
-version: 0.2.0+1
+version: 0.2.0+2
 
 dependencies:
   async: ^2.0.8

--- a/packages/in_app_purchase/test/in_app_purchase_connection/google_play_connection_test.dart
+++ b/packages/in_app_purchase/test/in_app_purchase_connection/google_play_connection_test.dart
@@ -306,17 +306,6 @@ void main() {
       expect(result.purchaseID, isNull);
     });
 
-    test('test purchase updated type assertion', () async {
-      final BillingResponse sentCode = BillingResponse.error;
-
-      MethodCall call = MethodCall(kOnPurchasesUpdated, {
-        1: BillingResponseConverter().toJson(sentCode),
-        'purchasesList': []
-      });
-      expect(() => connection.billingClient.callHandler(call),
-          throwsA(TypeMatcher<AssertionError>()));
-    });
-
     test('buy consumable with auto consume, serializes and deserializes data',
         () async {
       final SkuDetailsWrapper skuDetails = dummySkuDetails;


### PR DESCRIPTION
## Description

Fix the update purchase listener regression introduced in 0.2.0+1. Also removed related tests.
The type should not be assert checked because it is always <dynamic, dynamic> coming from the platform and the assertion will always return false.

## Related Issues

https://github.com/flutter/flutter/issues/34040

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
