### PR TITLE
[video_player][IOS]Adds support for specify the mime type of asset when the asset's path has no file extension

### DIFF
--- a/packages/video_player/ios/Classes/VideoPlayerPlugin.m
+++ b/packages/video_player/ios/Classes/VideoPlayerPlugin.m
@@ -211,7 +211,8 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     
     // Error may occur during loading the tracks.
     NSError* loadTracksError;
-    AVKeyValueStatus tracksValueStatus = [asset statusOfValueForKey:@"tracks" error:&loadTracksError];
+    AVKeyValueStatus tracksValueStatus = [asset statusOfValueForKey:@"tracks"
+                                                              error:&loadTracksError];
     if (![loadTracksError isEqual:[NSNull null]]) {
       NSLog(@"Failed to load tracks : %@", [loadTracksError localizedDescription]);
     } else if (tracksValueStatus == AVKeyValueStatusLoaded) {
@@ -223,9 +224,9 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
           
           // Error may occur during loading the preferredTransform.
           NSError* loadPreferredTransformError;
-          AVKeyValueStatus preferredTransformValueState = [videoTrack
-                                                           statusOfValueForKey:@"preferredTransform"
-                                                           error:&loadPreferredTransformError];
+          AVKeyValueStatus preferredTransformValueState =
+              [videoTrack statusOfValueForKey:@"preferredTransform"
+                                        error:&loadPreferredTransformError];
           if (![loadPreferredTransformError isEqual:[NSNull null]]) {
             NSLog(@"Failed to load preferredTransform : %@",
                   [loadPreferredTransformError localizedDescription]);

--- a/packages/video_player/ios/Classes/VideoPlayerPlugin.m
+++ b/packages/video_player/ios/Classes/VideoPlayerPlugin.m
@@ -212,7 +212,7 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     NSError* loadTracksError;
     AVKeyValueStatus tracksValueStatus = [asset statusOfValueForKey:@"tracks"
                                                               error:&loadTracksError];
-    if (![loadTracksError isEqual:[NSNull null]]) {
+    if (![loadTracksError isEqual:[NSNull null]] && loadTracksError != nil) {
       NSLog(@"Failed to load tracks : %@", [loadTracksError localizedDescription]);
     } else if (tracksValueStatus == AVKeyValueStatusLoaded) {
       NSArray* tracks = [asset tracksWithMediaType:AVMediaTypeVideo];
@@ -225,7 +225,8 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
           AVKeyValueStatus preferredTransformValueState =
               [videoTrack statusOfValueForKey:@"preferredTransform"
                                         error:&loadPreferredTransformError];
-          if (![loadPreferredTransformError isEqual:[NSNull null]]) {
+          if (![loadPreferredTransformError isEqual:[NSNull null]] &&
+              loadPreferredTransformError != nil) {
             NSLog(@"Failed to load preferredTransform : %@",
                   [loadPreferredTransformError localizedDescription]);
           } else if (preferredTransformValueState == AVKeyValueStatusLoaded) {

--- a/packages/video_player/ios/Classes/VideoPlayerPlugin.m
+++ b/packages/video_player/ios/Classes/VideoPlayerPlugin.m
@@ -41,7 +41,9 @@ int64_t FLTCMTimeToMillis(CMTime time) {
 @property(nonatomic, readonly) bool isPlaying;
 @property(nonatomic) bool isLooping;
 @property(nonatomic, readonly) bool isInitialized;
-- (instancetype)initWithURL:(NSURL*)url frameUpdater:(FLTFrameUpdater*)frameUpdater mimeType:(NSString*)mimeType;
+- (instancetype)initWithURL:(NSURL*)url
+               frameUpdater:(FLTFrameUpdater*)frameUpdater
+                   mimeType:(NSString*)mimeType;
 - (void)play;
 - (void)pause;
 - (void)setIsLooping:(bool)isLooping;
@@ -55,9 +57,13 @@ static void* playbackBufferEmptyContext = &playbackBufferEmptyContext;
 static void* playbackBufferFullContext = &playbackBufferFullContext;
 
 @implementation FLTVideoPlayer
-- (instancetype)initWithAsset:(NSString*)asset frameUpdater:(FLTFrameUpdater*)frameUpdater mimeType:(NSString*)mimeType {
+- (instancetype)initWithAsset:(NSString*)asset
+                 frameUpdater:(FLTFrameUpdater*)frameUpdater
+                     mimeType:(NSString*)mimeType {
   NSString* path = [[NSBundle mainBundle] pathForResource:asset ofType:nil];
-  return [self initWithURL:[NSURL fileURLWithPath:path] frameUpdater:frameUpdater mimeType:mimeType];
+  return [self initWithURL:[NSURL fileURLWithPath:path]
+              frameUpdater:frameUpdater
+                  mimeType:mimeType];
 }
 
 - (void)addObservers:(AVPlayerItem*)item {
@@ -155,11 +161,14 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
   _displayLink.paused = YES;
 }
 
-- (instancetype)initWithURL:(NSURL*)url frameUpdater:(FLTFrameUpdater*)frameUpdater mimeType:(NSString*)mimeType {
+- (instancetype)initWithURL:(NSURL*)url
+               frameUpdater:(FLTFrameUpdater*)frameUpdater
+                   mimeType:(NSString*)mimeType {
   NSString* fileExtention = [[url absoluteString] pathExtension];
   AVURLAsset* asset;
   if ([fileExtention length] == 0) {
-    asset = [[AVURLAsset alloc] initWithURL:url options:@{@"AVURLAssetOutOfBandMIMETypeKey": mimeType}];
+    asset = [[AVURLAsset alloc] initWithURL:url
+                                    options:@{@"AVURLAssetOutOfBandMIMETypeKey" : mimeType}];
   } else {
     asset = [[AVURLAsset alloc] initWithURL:url options:nil];
   }
@@ -476,11 +485,14 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
       } else {
         assetPath = [_registrar lookupKeyForAsset:assetArg];
       }
-      player = [[FLTVideoPlayer alloc] initWithAsset:assetPath frameUpdater:frameUpdater mimeType:mimeType];
+      player = [[FLTVideoPlayer alloc] initWithAsset:assetPath
+                                        frameUpdater:frameUpdater
+                                            mimeType:mimeType];
       [self onPlayerSetup:player frameUpdater:frameUpdater result:result];
     } else if (uriArg) {
       player = [[FLTVideoPlayer alloc] initWithURL:[NSURL URLWithString:uriArg]
-                                      frameUpdater:frameUpdater mimeType:mimeType];
+                                      frameUpdater:frameUpdater
+                                          mimeType:mimeType];
       [self onPlayerSetup:player frameUpdater:frameUpdater result:result];
     } else {
       result(FlutterMethodNotImplemented);

--- a/packages/video_player/ios/Classes/VideoPlayerPlugin.m
+++ b/packages/video_player/ios/Classes/VideoPlayerPlugin.m
@@ -208,7 +208,6 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 
   AVAsset* asset = [item asset];
   void (^assetCompletionHandler)(void) = ^{
-    
     // Error may occur during loading the tracks.
     NSError* loadTracksError;
     AVKeyValueStatus tracksValueStatus = [asset statusOfValueForKey:@"tracks"
@@ -221,7 +220,6 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
         AVAssetTrack* videoTrack = tracks[0];
         void (^trackCompletionHandler)(void) = ^{
           if (self->_disposed) return;
-          
           // Error may occur during loading the preferredTransform.
           NSError* loadPreferredTransformError;
           AVKeyValueStatus preferredTransformValueState =

--- a/packages/video_player/lib/video_player.dart
+++ b/packages/video_player/lib/video_player.dart
@@ -149,7 +149,8 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   ///
   /// If the asset's path doesn't have a file extension, you can provide the [mimeType]
   /// argument to specify the asset's mime type.The default value is 'video/mp4'.
-  VideoPlayerController.asset(this.dataSource, {this.package, this.mimeType = 'video/mp4'})
+  VideoPlayerController.asset(this.dataSource,
+      {this.package, this.mimeType = 'video/mp4'})
       : dataSourceType = DataSourceType.asset,
         super(VideoPlayerValue(duration: null));
 

--- a/packages/video_player/lib/video_player.dart
+++ b/packages/video_player/lib/video_player.dart
@@ -146,7 +146,10 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   /// The name of the asset is given by the [dataSource] argument and must not be
   /// null. The [package] argument must be non-null when the asset comes from a
   /// package and null otherwise.
-  VideoPlayerController.asset(this.dataSource, {this.package})
+  ///
+  /// If the asset's path doesn't have a file extension, you can provide the [mimeType]
+  /// argument to specify the asset's mime type.The default value is 'video/mp4'.
+  VideoPlayerController.asset(this.dataSource, {this.package, this.mimeType = 'video/mp4'})
       : dataSourceType = DataSourceType.asset,
         super(VideoPlayerValue(duration: null));
 
@@ -155,7 +158,10 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   ///
   /// The URI for the video is given by the [dataSource] argument and must not be
   /// null.
-  VideoPlayerController.network(this.dataSource)
+  ///
+  /// If the url doesn't have a file extension, you can provide the [mimeType]
+  /// argument to specify the asset's mime type.The default value is 'video/mp4'.
+  VideoPlayerController.network(this.dataSource, {this.mimeType = 'video/mp4'})
       : dataSourceType = DataSourceType.network,
         package = null,
         super(VideoPlayerValue(duration: null));
@@ -164,7 +170,10 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   ///
   /// This will load the file from the file-URI given by:
   /// `'file://${file.path}'`.
-  VideoPlayerController.file(File file)
+  ///
+  /// If the file's path doesn't have a file extension, you can provide the [mimeType]
+  /// argument to specify the asset's mime type.The default value is 'video/mp4'.
+  VideoPlayerController.file(File file, {this.mimeType = 'video/mp4'})
       : dataSource = 'file://${file.path}',
         dataSourceType = DataSourceType.file,
         package = null,
@@ -178,6 +187,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   final DataSourceType dataSourceType;
 
   final String package;
+  final String mimeType;
   Timer _timer;
   bool _isDisposed = false;
   Completer<void> _creatingCompleter;
@@ -196,14 +206,21 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
       case DataSourceType.asset:
         dataSourceDescription = <String, dynamic>{
           'asset': dataSource,
-          'package': package
+          'package': package,
+          'mimeType': mimeType
         };
         break;
       case DataSourceType.network:
-        dataSourceDescription = <String, dynamic>{'uri': dataSource};
+        dataSourceDescription = <String, dynamic>{
+          'uri': dataSource,
+          'mimeType': mimeType
+        };
         break;
       case DataSourceType.file:
-        dataSourceDescription = <String, dynamic>{'uri': dataSource};
+        dataSourceDescription = <String, dynamic>{
+          'uri': dataSource,
+          'mimeType': mimeType
+        };
     }
     final Map<String, dynamic> response =
         await _channel.invokeMapMethod<String, dynamic>(

--- a/packages/video_player/test/video_player_test.dart
+++ b/packages/video_player/test/video_player_test.dart
@@ -37,6 +37,8 @@ class FakeController extends ValueNotifier<VideoPlayerValue>
   Future<void> play() async {}
   @override
   Future<void> setLooping(bool looping) async {}
+  @override
+  String get mimeType => null;
 }
 
 void main() {


### PR DESCRIPTION
[video_player][IOS]Adds support for specify the mime type of asset when the asset's path has no file extension

## Description

### What i have done?

- Add an optional parameter called `mimeType` to all the `VideoPlayerController` 's named constructors. And if the video provided doesn't contain a file extension, use the `mimeType` to specify the video's mime type in IOS native.

- Catch the potential errors occur during loading video's `tracks` and `preferredTransform`, and print them out.
### Why did i do it?

I met this issue: When the videoPlayerController tries to load a video from a url without file extension, this following line of code cannot work properly:
``` objective-c
[asset loadValuesAsynchronouslyForKeys:@[ @"tracks" ] completionHandler:assetCompletionHandler];
```
That's because the IOS native doesn't know the asset's mime type without the file extension.So this command `[asset statusOfValueForKey:@"tracks" error:nil];`will return `AVKeyValueStatusFailed` and an error will occur silently.You can get the error's information if passing error a parameter instead of nil. 

The solution is to specify the mine type manually.

## Related Issues

flutter/flutter#32029

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
