### PR TITLE
[image_picker] Don't use modules

### DIFF
--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.0+11
+
+* Don't use module imports.
+
 ## 0.6.0+10
 
 * iOS: support picking GIF from gallery.

--- a/packages/image_picker/ios/Classes/FLTImagePickerPhotoAssetUtil.m
+++ b/packages/image_picker/ios/Classes/FLTImagePickerPhotoAssetUtil.m
@@ -6,7 +6,7 @@
 #import "FLTImagePickerImageUtil.h"
 #import "FLTImagePickerMetaDataUtil.h"
 
-@import MobileCoreServices;
+#import <MobileCoreServices/MobileCoreServices.h>;
 
 @implementation FLTImagePickerPhotoAssetUtil
 

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -5,7 +5,7 @@ authors:
   - Flutter Team <flutter-dev@googlegroups.com>
   - Rhodes Davis Jr. <rody.davis.jr@gmail.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.6.0+10
+version: 0.6.0+11
 
 flutter:
   plugin:


### PR DESCRIPTION
Our internal build system is allergic to modules. We try to avoid them as much as we can and in here it seems harmless to change upstream code.