### PR TITLE
[image_picker] Removed cursor and added MimeTypeMap.getFileExtensionFromUrl to handle app crash

### DIFF
--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
@@ -141,7 +141,7 @@ class FileUtils {
     OutputStream outputStream = null;
     boolean success = false;
     try {
-      String extension = getImageExtension(context, uri);
+      String extension = getImageExtension(uri);
       inputStream = context.getContentResolver().openInputStream(uri);
       file = File.createTempFile("image_picker", extension, context.getCacheDir());
       outputStream = new FileOutputStream(file);
@@ -168,31 +168,18 @@ class FileUtils {
   }
 
   /** @return extension of image with dot, or default .jpg if it none. */
-  private static String getImageExtension(Context context, Uri uriImage) {
+  private static String getImageExtension(Uri uriImage) {
     String extension = null;
-    Cursor cursor = null;
-
     try {
-      cursor =
-          context
-              .getContentResolver()
-              .query(uriImage, new String[] {MediaStore.MediaColumns.MIME_TYPE}, null, null, null);
-
-      if (cursor != null && cursor.moveToNext()) {
-        String mimeType = cursor.getString(0);
-
-        extension = MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType);
-      }
-    } finally {
-      if (cursor != null) {
-        cursor.close();
-      }
+        extension = MimeTypeMap.getFileExtensionFromUrl(uriImage.getPath());
+    } catch (Exception e) {
+        extension = null;
     }
 
     if (extension == null) {
-      //default extension for matches the previous behavior of the plugin
-      extension = "jpg";
-    }
+        //default extension for matches the previous behavior of the plugin
+        extension = "jpg";
+    }      
     return "." + extension;
   }
 


### PR DESCRIPTION
## Description

*App is crashing in some scenarios while image picked from the file manager or other sources. In a line:182 while getting the mimeType for an image it was causing the app to crash as sometimes there is no mime type available for image. Now, to get image extension cursor is removed and now extension will be taken from MimeTypeMap.getFileExtensionFromUrl*

## Related Issues

*Fixes #35632*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
