### PR TITLE
Fix firebase_admob issues caused by un-handled exception situations

### DIFF
--- a/packages/firebase_admob/lib/firebase_admob.dart
+++ b/packages/firebase_admob/lib/firebase_admob.dart
@@ -233,7 +233,11 @@ abstract class MobileAd {
   /// Disposing a banner ad that's been shown removes it from the screen.
   /// Interstitial ads can't be programmatically removed from view.
   Future<bool> dispose() {
-    assert(_allAds[id] != null);
+    // When dispose is called, following assert prevents graceful cleanup of resources
+    // and occationally causes exception in the plugin which results in dangling
+    // BannerAd in the app. Hence commenting it for now till better way of handling is
+    // added by the plugin maintainer.
+    // assert(_allAds[id] != null);
     _allAds[id] = null;
     return _invokeBooleanMethod("disposeAd", <String, dynamic>{'id': id});
   }

--- a/packages/firebase_admob/lib/firebase_admob.dart
+++ b/packages/firebase_admob/lib/firebase_admob.dart
@@ -518,10 +518,26 @@ class FirebaseAdMob {
   }
 }
 
+// Future<bool> _invokeBooleanMethod(String method, [dynamic arguments]) async {
+//   final bool result = await FirebaseAdMob.instance._channel.invokeMethod<bool>(
+//     method,
+//     arguments,
+//   );
+//   return result;
+// }
 Future<bool> _invokeBooleanMethod(String method, [dynamic arguments]) async {
-  final bool result = await FirebaseAdMob.instance._channel.invokeMethod<bool>(
-    method,
-    arguments,
-  );
+  bool result = false;
+  try {
+    result = await FirebaseAdMob.instance._channel.invokeMethod<bool>(
+      method,
+      arguments,
+    );
+  } catch (e) {
+    // In case of "no_ad_for_id" error return result as false. Don't expect app code
+    // to deal with the exception condition because app code does not know about
+    // platform implementation.
+    result = false;
+  }
+
   return result;
 }


### PR DESCRIPTION
## Description

While using BannerAd from fairly complex application which expects BannerAd to be disposed gracefully there are multiple un-handled exception situations in the plugin which are addressed in following commits in https://github.com/archanpaul/flutter-plugins/commits/fix-firebase_admob

commit 7dfeeac4f43e781cff1f7d5c548cce166a5f32f9 (HEAD -> fix-firebase_admob, origin/fix-firebase_admob)
Author: Archan Paul <archan.paul@arputer.com>
Date:   Sat Jul 6 18:36:29 2019 +0530

    Handle exception in _invokeBooleanMethod(...) and return false in case of exception.

commit a2b1eac1408b9457ae8889629f0f15c5a60ff0ea
Author: Archan Paul <archan.paul@arputer.com>
Date:   Sat Jul 6 17:51:34 2019 +0530

    Interim fix for dangling BannerAd during dispose call.

## Related code and log references

```
  BannerAd _adbmobBanner = BannerAd(
      adUnitId: BannerAd.testAdUnitId,
      size: AdSize.smartBanner,
      targetingInfo: _targetingInfo,
      listener: (MobileAdEvent event) {
        _subjectAdEvent.sink.add(event);
        switch (event) {
          case MobileAdEvent.clicked:
            break;
          case MobileAdEvent.closed:
            break;
          case MobileAdEvent.failedToLoad:
            break;
          case MobileAdEvent.impression:
            break;
          case MobileAdEvent.leftApplication:
            break;
          case MobileAdEvent.loaded:
            break;
          case MobileAdEvent.opened:
            break;
          default:
            break;
        }
      },
    );
  ...
  Future dispose() async {
    await _adbmobBanner?.dispose();
  }

```

```
E/flutter (29705): [ERROR:flutter/lib/ui/ui_dart_state.cc(148)] Unhandled Exception: PlatformException(no_ad_for_id, dispose failed, no add exists for id=663181399, null)
E/flutter (29705): #0      StandardMethodCodec.decodeEnvelope 
package:flutter/…/services/message_codecs.dart:564
E/flutter (29705): #1      MethodChannel.invokeMethod 
package:flutter/…/services/platform_channel.dart:316
E/flutter (29705): <asynchronous suspension>
E/flutter (29705): #2      _invokeBooleanMethod 
package:firebase_admob/firebase_admob.dart:524
E/flutter (29705): <asynchronous suspension>
E/flutter (29705): #3      MobileAd.dispose 
package:firebase_admob/firebase_admob.dart:242
E/flutter (29705): #4      AdmobProvider.dispose 
package:fitzy_20190415/…/controllers/AdmobProvider.dart:39
E/flutter (29705): <asynchronous suspension>
E/flutter (29705): #5      _WidgetPromoState.dispose 
package:fitzy_20190415/…/widgets/widgetPromo.dart:36
E/flutter (29705): <asynchronous suspension>
E/flutter (29705): #6      StatefulElement.unmount 
package:flutter/…/widgets/framework.dart:4107
E/flutter (29705): #7      _InactiveElements._unmount 
package:flutter/…/widgets/framework.dart:1737
E/flutter (29705): #8      _InactiveElements._unmount.<anonymous closure> 
package:flutter/…/widgets/framework.dart:1735
E/flutter (29705): #9      MultiChildRenderObjectElement.visitChildren 
package:flutter/…/widgets/framework.dart:5181
E/flutter (29705): #10     _InactiveElements._unmount 
package:flutter/…/widgets/framework.dart:1733
E/flutter (29705): #11     ListIterable.forEach  (dart:_internal/iterable.dart:39:13)
E/flutter (29705): #12     _InactiveElements._unmountAll 
package:flutter/…/widgets/framework.dart:1746
E/flutter (29705): #13     BuildOwner.finalizeTree.<anonymous closure> 
package:flutter/…/widgets/framework.dart:2426
E/flutter (29705): #14     BuildOwner.lockState 
package:flutter/…/widgets/framework.dart:2258
E/flutter (29705): #15     BuildOwner.finalizeTree 
package:flutter/…/widgets/framework.dart:2425
E/flutter (29705): #16     _WidgetsFlutterBinding&BindingBase&GestureBinding&ServicesBinding&SchedulerBinding&PaintingBinding&SemanticsBinding&RendererBinding&WidgetsBinding.drawFrame 
package:flutter/…/widgets/binding.dart:702
E/flutter (29705): #17     _WidgetsFlutterBinding&BindingBase&GestureBinding&ServicesBinding&SchedulerBinding&PaintingBinding&SemanticsBinding&RendererBinding._handlePersistentFrameCallback 
package:flutter/…/rendering/binding.dart:285
E/flutter (29705): #18     _WidgetsFlutterBinding&BindingBase&GestureBinding&ServicesBinding&SchedulerBinding._invokeFrameCallback 
package:flutter/…/scheduler/binding.dart:1016
E/flutter (29705): #19     _WidgetsFlutterBinding&BindingBase&GestureBinding&ServicesBinding&SchedulerBinding.handleDrawFrame 
package:flutter/…/scheduler/binding.dart:958
E/flutter (29705): #20     _WidgetsFlutterBinding&BindingBase&GestureBinding&ServicesBinding&SchedulerBinding._handleDrawFrame 
package:flutter/…/scheduler/binding.dart:874
E/flutter (29705): #21     _rootRun  (dart:async/zone.dart:1124:13)
E/flutter (29705): #22     _CustomZone.run  (dart:async/zone.dart:1021:19)
E/flutter (29705): #23     _CustomZone.runGuarded  (dart:async/zone.dart:923:7)
E/flutter (29705): #24     _invoke  (dart:ui/hooks.dart:236:10)
E/flutter (29705): #25     _drawFrame  (dart:ui/hooks.dart:194:3)
E/flutter (29705):
```
