### PR TITLE
[firebase_crashlytics] Update README with advice on testing installation

### DIFF
--- a/packages/firebase_crashlytics/CHANGELOG.md
+++ b/packages/firebase_crashlytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.4+10
+
+* Update README.
+
 ## 0.0.4+9
 
 * Fixed custom keys implementation.

--- a/packages/firebase_crashlytics/README.md
+++ b/packages/firebase_crashlytics/README.md
@@ -95,13 +95,14 @@ void main() {
 
 ## Result
 
-If an error is catched correctly, you should see this log:
+If an error is caught, you should see the following messages in your logs:
 ```
 flutter: Error caught by Crashlytics plugin:
+...
 flutter: Error reported to Crashlytics.
 ```
 
-*Note:* It will takes a while (up to 24h) before you will be able to see your logs in your firebase console.
+*Note:* It may take awhile (up to 24 hours) before you will be able to see the logs appear in your Firebase console.
 
 ## Example
 

--- a/packages/firebase_crashlytics/README.md
+++ b/packages/firebase_crashlytics/README.md
@@ -93,6 +93,16 @@ void main() {
 }
 ```
 
+## Result
+
+If an error is catched correctly, you should see this log:
+```
+flutter: Error caught by Crashlytics plugin:
+flutter: Error reported to Crashlytics.
+```
+
+*Note:* It will takes a while (up to 24h) before you will be able to see your logs in your firebase console.
+
 ## Example
 
 See the [example application](https://github.com/flutter/plugins/tree/master/packages/firebase_crashlytics/example) source

--- a/packages/firebase_crashlytics/pubspec.yaml
+++ b/packages/firebase_crashlytics/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_crashlytics
 description: Flutter plugin for Firebase Crashlytics. It reports uncaught errors to the
   Firebase console.
-version: 0.0.4+9
+version: 0.0.4+10
 author: Flutter Team <flutter-dev@google.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_crashlytics
 


### PR DESCRIPTION
## Description

This section will give feedback on when the installation goes fine, plus informing user that `firebase` takes a while to display the collected crashes into the Firebase Console, since the time is quite long (almost a day) i think it's better to give a feedback here.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
