### PR TITLE
[image_picker]use class instead of struct for GIFInfo on iOS

### DIFF
--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.0+12
+
+* Use class instead of struct for `GIFInfo` in iOS implementation.
+
 ## 0.6.0+11
 
 * Don't use module imports.

--- a/packages/image_picker/example/ios/image_picker_exampleTests/ImageUtilTests.m
+++ b/packages/image_picker/example/ios/image_picker_exampleTests/ImageUtilTests.m
@@ -31,7 +31,7 @@
   // gif image that frame size is 3 and the duration is 1 second.
   NSData *data = [NSData dataWithContentsOfFile:[self.testBundle pathForResource:@"gifImage"
                                                                           ofType:@"gif"]];
-  GIFInfo info = [FLTImagePickerImageUtil scaledGIFImage:data maxWidth:@3 maxHeight:@2];
+  GIFInfo *info = [FLTImagePickerImageUtil scaledGIFImage:data maxWidth:@3 maxHeight:@2];
 
   NSArray<UIImage *> *images = info.images;
   NSTimeInterval duration = info.interval;

--- a/packages/image_picker/ios/Classes/FLTImagePickerImageUtil.h
+++ b/packages/image_picker/ios/Classes/FLTImagePickerImageUtil.h
@@ -7,11 +7,14 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef struct GIFInfo {
-  // frames of animation
-  NSArray<UIImage *> *images;
-  NSTimeInterval interval;
-} GIFInfo;
+@interface GIFInfo : NSObject
+
+@property(strong, nonatomic, readonly) NSArray<UIImage *> *images;
+@property(assign, nonatomic, readonly) NSTimeInterval interval;
+
+- (instancetype)initWithImages:(NSArray<UIImage *> *)images interval:(NSTimeInterval)interval;
+
+@end
 
 @interface FLTImagePickerImageUtil : NSObject
 
@@ -20,9 +23,9 @@ typedef struct GIFInfo {
                maxHeight:(NSNumber *)maxHeight;
 
 // Resize all gif animation frames.
-+ (GIFInfo)scaledGIFImage:(NSData *)data
-                 maxWidth:(NSNumber *)maxWidth
-                maxHeight:(NSNumber *)maxHeight;
++ (GIFInfo *)scaledGIFImage:(NSData *)data
+                   maxWidth:(NSNumber *)maxWidth
+                  maxHeight:(NSNumber *)maxHeight;
 
 @end
 

--- a/packages/image_picker/ios/Classes/FLTImagePickerImageUtil.m
+++ b/packages/image_picker/ios/Classes/FLTImagePickerImageUtil.m
@@ -5,6 +5,27 @@
 #import "FLTImagePickerImageUtil.h"
 #import <MobileCoreServices/MobileCoreServices.h>
 
+@interface GIFInfo ()
+
+@property(strong, nonatomic, readwrite) NSArray<UIImage *> *images;
+@property(assign, nonatomic, readwrite) NSTimeInterval interval;
+
+@end
+
+@implementation GIFInfo
+
+- (instancetype)initWithImages:(NSArray<UIImage *> *)images interval:(NSTimeInterval)interval;
+{
+  self = [super init];
+  if (self) {
+    self.images = images;
+    self.interval = interval;
+  }
+  return self;
+}
+
+@end
+
 @implementation FLTImagePickerImageUtil : NSObject
 
 + (UIImage *)scaledImage:(UIImage *)image
@@ -57,9 +78,9 @@
   return scaledImage;
 }
 
-+ (GIFInfo)scaledGIFImage:(NSData *)data
-                 maxWidth:(NSNumber *)maxWidth
-                maxHeight:(NSNumber *)maxHeight {
++ (GIFInfo *)scaledGIFImage:(NSData *)data
+                   maxWidth:(NSNumber *)maxWidth
+                  maxHeight:(NSNumber *)maxHeight {
   NSMutableDictionary<NSString *, id> *options = [NSMutableDictionary dictionary];
   options[(NSString *)kCGImageSourceShouldCache] = @(YES);
   options[(NSString *)kCGImageSourceTypeIdentifierHint] = (NSString *)kUTTypeGIF;
@@ -98,9 +119,7 @@
 
   CFRelease(imageSource);
 
-  GIFInfo info;
-  info.images = images;
-  info.interval = interval;
+  GIFInfo *info = [[GIFInfo alloc] initWithImages:images interval:interval];
 
   return info;
 }

--- a/packages/image_picker/ios/Classes/FLTImagePickerPhotoAssetUtil.m
+++ b/packages/image_picker/ios/Classes/FLTImagePickerPhotoAssetUtil.m
@@ -6,7 +6,7 @@
 #import "FLTImagePickerImageUtil.h"
 #import "FLTImagePickerMetaDataUtil.h"
 
-#import <MobileCoreServices/MobileCoreServices.h>;
+#import <MobileCoreServices/MobileCoreServices.h>
 
 @implementation FLTImagePickerPhotoAssetUtil
 
@@ -35,9 +35,9 @@
     metaData = [FLTImagePickerMetaDataUtil getMetaDataFromImageData:originalImageData];
   }
   if (type == FLTImagePickerMIMETypeGIF) {
-    GIFInfo gifInfo = [FLTImagePickerImageUtil scaledGIFImage:originalImageData
-                                                     maxWidth:maxWidth
-                                                    maxHeight:maxHeight];
+    GIFInfo *gifInfo = [FLTImagePickerImageUtil scaledGIFImage:originalImageData
+                                                      maxWidth:maxWidth
+                                                     maxHeight:maxHeight];
 
     return [self saveImageWithMetaData:metaData gifInfo:gifInfo suffix:suffix];
   } else {
@@ -54,7 +54,7 @@
 }
 
 + (NSString *)saveImageWithMetaData:(NSDictionary *)metaData
-                            gifInfo:(GIFInfo)gifInfo
+                            gifInfo:(GIFInfo *)gifInfo
                              suffix:(NSString *)suffix {
   NSString *path = [self temporaryFilePath:suffix];
   return [self saveImageWithMetaData:metaData gifInfo:gifInfo path:path];
@@ -82,7 +82,7 @@
 }
 
 + (NSString *)saveImageWithMetaData:(NSDictionary *)metaData
-                            gifInfo:(GIFInfo)gifInfo
+                            gifInfo:(GIFInfo *)gifInfo
                                path:(NSString *)path {
   CGImageDestinationRef destination = CGImageDestinationCreateWithURL(
       (CFURLRef)[NSURL fileURLWithPath:path], kUTTypeGIF, gifInfo.images.count, NULL);

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -5,7 +5,7 @@ authors:
   - Flutter Team <flutter-dev@googlegroups.com>
   - Rhodes Davis Jr. <rody.davis.jr@gmail.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.6.0+11
+version: 0.6.0+12
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

We were using struct for GIFInfo, objective-c doesn't support struct with objective-c object as a member in ARC mode. We should avoid it.
Also removed an extra `;` in the import statement.

## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
