### PR TITLE
[url_launcher] Make open URLs has "intent://" scheme for Android Chrome

### DIFF
--- a/packages/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.5
+
+* Fix `launch` to open `intent:` URL scheme on Android.
+
 ## 5.0.4
 
 * Update Dart code to conform to current Dart formatter.

--- a/packages/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/UrlLauncherPlugin.java
+++ b/packages/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/UrlLauncherPlugin.java
@@ -21,6 +21,7 @@ import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
+import java.net.URISyntaxException;
 
 /** UrlLauncherPlugin */
 public class UrlLauncherPlugin implements MethodCallHandler {
@@ -52,8 +53,19 @@ public class UrlLauncherPlugin implements MethodCallHandler {
   }
 
   private void canLaunch(String url, Result result) {
-    Intent launchIntent = new Intent(Intent.ACTION_VIEW);
-    launchIntent.setData(Uri.parse(url));
+    Intent launchIntent;
+    Uri uri = Uri.parse(url);
+    if (uri.getScheme().equals("intent")) {
+      try {
+        launchIntent = Intent.parseUri(url, Intent.URI_INTENT_SCHEME);
+      } catch (URISyntaxException e) {
+        result.error("ILLEGAL_URL", "Can't parse the URL " + url, e);
+        return;
+      }
+    } else {
+      launchIntent = new Intent(Intent.ACTION_VIEW);
+      launchIntent.setData(uri);
+    }
     ComponentName componentName =
         launchIntent.resolveActivity(mRegistrar.context().getPackageManager());
 
@@ -78,8 +90,18 @@ public class UrlLauncherPlugin implements MethodCallHandler {
       launchIntent.putExtra("url", url);
       launchIntent.putExtra("enableJavaScript", enableJavaScript);
     } else {
-      launchIntent = new Intent(Intent.ACTION_VIEW);
-      launchIntent.setData(Uri.parse(url));
+      Uri uri = Uri.parse(url);
+      if (uri.getScheme().equals("intent")) {
+        try {
+          launchIntent = Intent.parseUri(url, Intent.URI_INTENT_SCHEME);
+        } catch (URISyntaxException e) {
+          result.error("ILLEGAL_URL", "Can't parse the URL " + url, e);
+          return;
+        }
+      } else {
+        launchIntent = new Intent(Intent.ACTION_VIEW);
+        launchIntent.setData(uri);
+      }
     }
     activity.startActivity(launchIntent);
     result.success(true);

--- a/packages/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for launching a URL on Android and iOS. Supports
   web, phone, SMS, and email schemes.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher
-version: 5.0.4
+version: 5.0.5
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

I make url_launcher can open URLs has "intent://" scheme for Chrome on Android.
https://developer.chrome.com/multidevice/android/intents

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).  <- Android/iOS part has no tests. How test it?
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
