### PR TITLE
[image_picker] Update README example

### DIFF
--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.6.0+14
 
-* Fix typo in README
+* Fix typo in README.
 
 ## 0.6.0+13
 

--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.6.0+14
+* Example Fix: Update the example LostDataResponse type.
+
 ## 0.6.0+13
 
 * Bugfix Android: Fix a crash occurs in some scenarios when user picks up image from gallery.

--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.6.0+14
-* Example Fix: Update the example LostDataResponse type.
+
+* Fix typo in README
 
 ## 0.6.0+13
 

--- a/packages/image_picker/README.md
+++ b/packages/image_picker/README.md
@@ -71,7 +71,7 @@ Android system -- although very rarely -- sometimes kills the MainActivity after
 
 ```dart
 Future<void> retrieveLostData() async {
-  final RetrieveLostDataResponse response =
+  final LostDataResponse response =
       await ImagePicker.retrieveLostData();
   if (response == null) {
     return;

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -5,7 +5,7 @@ authors:
   - Flutter Team <flutter-dev@googlegroups.com>
   - Rhodes Davis Jr. <rody.davis.jr@gmail.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.6.0+13
+version: 0.6.0+14
 
 flutter:
   plugin:


### PR DESCRIPTION
Update `RetrieveLostDataResponse` type to correct `LostDataResponse`.

## Description

The RetrieveLostDataResponse type doesn't exist as part of the standard image_picker library

## Related Issues

None

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
