### PR TITLE
[firebase_auth] Register for iOS notifications to support phone auth

### DIFF
--- a/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
+++ b/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
@@ -81,11 +81,7 @@ int nextHandle = 0;
 
 - (void)application:(UIApplication *)application
     didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
-#ifdef DEBUG
-  [[FIRAuth auth] setAPNSToken:deviceToken type:FIRAuthAPNSTokenTypeSandbox];
-#else
   [[FIRAuth auth] setAPNSToken:deviceToken type:FIRAuthAPNSTokenTypeProd];
-#endif
 }
 
 - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary *)options {

--- a/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
+++ b/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
@@ -43,6 +43,7 @@ int nextHandle = 0;
   FLTFirebaseAuthPlugin *instance = [[FLTFirebaseAuthPlugin alloc] init];
   instance.channel = channel;
   instance.authStateChangeListeners = [[NSMutableDictionary alloc] init];
+  [registrar addApplicationDelegate:instance];
   [registrar addMethodCallDelegate:instance channel:channel];
 
   SEL sel = NSSelectorFromString(@"registerLibrary:withVersion:");
@@ -66,6 +67,29 @@ int nextHandle = 0;
 - (FIRAuth *_Nullable)getAuth:(NSDictionary *)args {
   NSString *appName = [args objectForKey:@"app"];
   return [FIRAuth authWithApp:[FIRApp appNamed:appName]];
+}
+
+- (bool)application:(UIApplication *)application
+    didReceiveRemoteNotification:(NSDictionary *)userInfo
+          fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler {
+  if ([[FIRAuth auth] canHandleNotification:notification]) {
+    completionHandler(UIBackgroundFetchResultNoData);
+    return;
+  }
+  return NO;
+}
+
+- (void)application:(UIApplication *)application
+    didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
+#ifdef DEBUG
+  [[FIRAuth auth] setAPNSToken:deviceToken type:FIRMessagingAPNSTokenTypeSandbox];
+#else
+  [[FIRAuth auth] setAPNSToken:deviceToken type:FIRMessagingAPNSTokenTypeProd];
+#endif
+}
+
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary *)options {
+  return [[FIRAuth auth] canHandleURL:url];
 }
 
 // TODO(jackson): We should use the renamed versions of the following methods

--- a/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
+++ b/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
@@ -70,11 +70,11 @@ int nextHandle = 0;
 }
 
 - (bool)application:(UIApplication *)application
-    didReceiveRemoteNotification:(NSDictionary *)userInfo
+    didReceiveRemoteNotification:(NSDictionary *)notification
           fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler {
   if ([[FIRAuth auth] canHandleNotification:notification]) {
     completionHandler(UIBackgroundFetchResultNoData);
-    return;
+    return YES;
   }
   return NO;
 }

--- a/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
+++ b/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
@@ -82,9 +82,9 @@ int nextHandle = 0;
 - (void)application:(UIApplication *)application
     didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
 #ifdef DEBUG
-  [[FIRAuth auth] setAPNSToken:deviceToken type:FIRMessagingAPNSTokenTypeSandbox];
+  [[FIRAuth auth] setAPNSToken:deviceToken type:FIRAuthAPNSTokenTypeSandbox];
 #else
-  [[FIRAuth auth] setAPNSToken:deviceToken type:FIRMessagingAPNSTokenTypeProd];
+  [[FIRAuth auth] setAPNSToken:deviceToken type:FIRAuthAPNSTokenTypeProd];
 #endif
 }
 


### PR DESCRIPTION
Apparently the automatic method swizzling stopped working somewhere between v1.5.4-hotfix.2 and v1.7.8+hotfix.2 (it would be great to narrow that down further)

See https://firebase.google.com/docs/auth/ios/phone-auth#enable-app-verification

Fixes flutter/flutter#35267

Unfortunately I don't have a good solution to test for this yet, but have manually tested.

The disadvantage of this change as written is that it may result in firebase_auth users getting warnings about "missing Push Notification Entitlement" even after https://github.com/flutter/flutter/issues/9984 is fixed. But since that has affected every iOS Flutter submission up to this point, it seems like a low priority.