### PR TITLE
Revert "[google_sign_in] Added NonNull annotations, reduce Guava usage (#844)

### DIFF
--- a/packages/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.4
+
+* Revert changes in 4.0.3.
+
 ## 4.0.3	
 
 * Update guava to `27.0.1-android`.	

--- a/packages/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/CHANGELOG.md
@@ -1,8 +1,3 @@
-## 4.0.3
-
-* Update guava to `27.0.1-android`.
-* Add correct @NonNull annotations to reduce compiler warnings.
-
 ## 4.0.2
 
 * Add missing template type parameter to `invokeMethod` calls.

--- a/packages/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.0.3	
+
+* Update guava to `27.0.1-android`.	
+* Add correct @NonNull annotations to reduce compiler warnings.	
+
 ## 4.0.2
 
 * Add missing template type parameter to `invokeMethod` calls.

--- a/packages/google_sign_in/android/build.gradle
+++ b/packages/google_sign_in/android/build.gradle
@@ -48,5 +48,5 @@ android {
 
 dependencies {
     api 'com.google.android.gms:play-services-auth:16.0.1'
-    implementation 'com.google.guava:guava:27.0.1-android'
+    implementation 'com.google.guava:guava:20.0'
 }

--- a/packages/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
+++ b/packages/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
@@ -7,8 +7,6 @@ package io.flutter.plugins.googlesignin;
 import android.accounts.Account;
 import android.app.Activity;
 import android.content.Intent;
-import android.text.TextUtils;
-import androidx.annotation.NonNull;
 import com.google.android.gms.auth.GoogleAuthUtil;
 import com.google.android.gms.auth.UserRecoverableAuthException;
 import com.google.android.gms.auth.api.signin.GoogleSignIn;
@@ -22,6 +20,8 @@ import com.google.android.gms.common.api.Scope;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.RuntimeExecutionException;
 import com.google.android.gms.tasks.Task;
+import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
@@ -107,7 +107,7 @@ public class GoogleSignInPlugin implements MethodCallHandler {
 
   /**
    * A delegate interface that exposes all of the sign-in functionality for other plugins to use.
-   * The below {@link Delegate} implementation should be used by any clients unless they need to
+   * The below {@link #Delegate} implementation should be used by any clients unless they need to
    * override some of these functions, such as for testing.
    */
   public interface IDelegate {
@@ -243,7 +243,7 @@ public class GoogleSignInPlugin implements MethodCallHandler {
         for (String scope : requestedScopes) {
           optionsBuilder.requestScopes(new Scope(scope));
         }
-        if (!TextUtils.isEmpty(hostedDomain)) {
+        if (!Strings.isNullOrEmpty(hostedDomain)) {
           optionsBuilder.setHostedDomain(hostedDomain);
         }
 
@@ -270,7 +270,7 @@ public class GoogleSignInPlugin implements MethodCallHandler {
         task.addOnCompleteListener(
             new OnCompleteListener<GoogleSignInAccount>() {
               @Override
-              public void onComplete(@NonNull Task<GoogleSignInAccount> task) {
+              public void onComplete(Task<GoogleSignInAccount> task) {
                 onSignInResult(task);
               }
             });
@@ -305,7 +305,7 @@ public class GoogleSignInPlugin implements MethodCallHandler {
           .addOnCompleteListener(
               new OnCompleteListener<Void>() {
                 @Override
-                public void onComplete(@NonNull Task<Void> task) {
+                public void onComplete(Task<Void> task) {
                   if (task.isSuccessful()) {
                     finishWithSuccess(null);
                   } else {
@@ -325,7 +325,7 @@ public class GoogleSignInPlugin implements MethodCallHandler {
           .addOnCompleteListener(
               new OnCompleteListener<Void>() {
                 @Override
-                public void onComplete(@NonNull Task<Void> task) {
+                public void onComplete(Task<Void> task) {
                   if (task.isSuccessful()) {
                     finishWithSuccess(null);
                   } else {
@@ -448,7 +448,7 @@ public class GoogleSignInPlugin implements MethodCallHandler {
             @Override
             public String call() throws Exception {
               Account account = new Account(email, "com.google");
-              String scopesStr = "oauth2:" + TextUtils.join(" ", requestedScopes);
+              String scopesStr = "oauth2:" + Joiner.on(' ').join(requestedScopes);
               return GoogleAuthUtil.getToken(registrar.context(), account, scopesStr);
             }
           };

--- a/packages/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_sign_in
-version: 4.0.2
+version: 4.0.4
 
 flutter:
   plugin:

--- a/packages/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_sign_in
-version: 4.0.3
+version: 4.0.2
 
 flutter:
   plugin:


### PR DESCRIPTION
This reverts commit 19bdccee76eb1063063fa5300b885d3cc70c9019.

PR https://github.com/flutter/plugins/pull/844

@ened The previous PR broke some example apps in the repo because they have not been migrated to AndroidX yet. We have to keep this commit reverted until we migrate example apps to androidX