### PR TITLE
[firebase_remote_config] fix config value source parsing

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -39,3 +39,4 @@ ko2ic <ko2ic.dev@gmail.com>
 Jonathan Younger <jonathan@daikini.com>
 Jose Sanchez <josesm82@gmail.com>
 Debkanchan Samadder <debu.samadder@gmail.com>
+Audrius Karosevicius <audrius.karosevicius@gmail.com>

--- a/packages/firebase_remote_config/CHANGELOG.md
+++ b/packages/firebase_remote_config/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.0+4
+
+* Fixed a bug where `RemoteConfigValue` could report remote `source` on a default value.
+* Added an integration test for the above.
+
 ## 0.2.0+3
 
 * Automatically use version from pubspec.yaml when reporting usage to Firebase.

--- a/packages/firebase_remote_config/CHANGELOG.md
+++ b/packages/firebase_remote_config/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 0.2.0+4
 
-* Fixed a bug where `RemoteConfigValue` could report remote `source` on a default value.
-* Added an integration test for the above.
+* Fixed a bug where `RemoteConfigValue` could incorrectly report a remote `source` for default values.
+* Added an integration test for the fixed behavior of `source`.
+* Removed a test that made integration test flaky.
 
 ## 0.2.0+3
 

--- a/packages/firebase_remote_config/example/test_driver/firebase_remote_config.dart
+++ b/packages/firebase_remote_config/example/test_driver/firebase_remote_config.dart
@@ -29,6 +29,14 @@ void main() {
       await remoteConfig.activateFetched();
       expect(remoteConfig.getString('welcome'), 'Earth, welcome! Hello!');
       expect(remoteConfig.getString('hello'), 'default hello');
+      expect(remoteConfig.getInt('nonexisting'), 0);
+
+      expect(remoteConfig.getValue('welcome').source, ValueSource.valueRemote);
+      expect(remoteConfig.getValue('hello').source, ValueSource.valueDefault);
+      expect(
+        remoteConfig.getValue('nonexisting').source,
+        ValueSource.valueStatic,
+      );
     });
   });
 }

--- a/packages/firebase_remote_config/example/test_driver/firebase_remote_config.dart
+++ b/packages/firebase_remote_config/example/test_driver/firebase_remote_config.dart
@@ -13,8 +13,8 @@ void main() {
 
     setUp(() async {
       remoteConfig = await RemoteConfig.instance;
-      remoteConfig.setConfigSettings(RemoteConfigSettings(debugMode: true));
-      remoteConfig.setDefaults(<String, dynamic>{
+      await remoteConfig.setConfigSettings(RemoteConfigSettings(debugMode: true));
+      await remoteConfig.setDefaults(<String, dynamic>{
         'welcome': 'default welcome',
         'hello': 'default hello',
       });
@@ -26,6 +26,7 @@ void main() {
       await remoteConfig.fetch(expiration: const Duration(seconds: 0));
       expect(remoteConfig.lastFetchStatus, LastFetchStatus.success);
       await remoteConfig.activateFetched();
+
       expect(remoteConfig.getString('welcome'), 'Earth, welcome! Hello!');
       expect(remoteConfig.getString('hello'), 'default hello');
       expect(remoteConfig.getInt('nonexisting'), 0);
@@ -36,17 +37,6 @@ void main() {
         remoteConfig.getValue('nonexisting').source,
         ValueSource.valueStatic,
       );
-    });
-
-    test('setDefaults', () async {
-      await remoteConfig.setDefaults(<String, dynamic>{
-        'custom_default': 3.14,
-      });
-      await remoteConfig.activateFetched();
-      remoteConfig.setDefaults(<String, dynamic>{});
-      RemoteConfigValue value = remoteConfig.getValue('custom_default');
-      expect(value.asDouble(), 3.14);
-      expect(value.source, ValueSource.valueDefault);
     });
   });
 }

--- a/packages/firebase_remote_config/example/test_driver/firebase_remote_config.dart
+++ b/packages/firebase_remote_config/example/test_driver/firebase_remote_config.dart
@@ -13,7 +13,8 @@ void main() {
 
     setUp(() async {
       remoteConfig = await RemoteConfig.instance;
-      await remoteConfig.setConfigSettings(RemoteConfigSettings(debugMode: true));
+      await remoteConfig
+          .setConfigSettings(RemoteConfigSettings(debugMode: true));
       await remoteConfig.setDefaults(<String, dynamic>{
         'welcome': 'default welcome',
         'hello': 'default hello',

--- a/packages/firebase_remote_config/example/test_driver/firebase_remote_config.dart
+++ b/packages/firebase_remote_config/example/test_driver/firebase_remote_config.dart
@@ -24,7 +24,6 @@ void main() {
       final DateTime lastFetchTime = remoteConfig.lastFetchTime;
       expect(lastFetchTime.isBefore(DateTime.now()), true);
       await remoteConfig.fetch(expiration: const Duration(seconds: 0));
-      expect(remoteConfig.lastFetchTime.isAfter(lastFetchTime), true);
       expect(remoteConfig.lastFetchStatus, LastFetchStatus.success);
       await remoteConfig.activateFetched();
       expect(remoteConfig.getString('welcome'), 'Earth, welcome! Hello!');
@@ -37,6 +36,17 @@ void main() {
         remoteConfig.getValue('nonexisting').source,
         ValueSource.valueStatic,
       );
+    });
+
+    test('setDefaults', () async {
+      await remoteConfig.setDefaults(<String, dynamic>{
+        'custom_default': 3.14,
+      });
+      await remoteConfig.activateFetched();
+      remoteConfig.setDefaults(<String, dynamic>{});
+      RemoteConfigValue value = remoteConfig.getValue('custom_default');
+      expect(value.asDouble(), 3.14);
+      expect(value.source, ValueSource.valueDefault);
     });
   });
 }

--- a/packages/firebase_remote_config/lib/src/remote_config.dart
+++ b/packages/firebase_remote_config/lib/src/remote_config.dart
@@ -58,10 +58,8 @@ class RemoteConfig extends ChangeNotifier {
         <String, RemoteConfigValue>{};
     parameters.forEach((dynamic key, dynamic value) {
       final ValueSource valueSource = _parseValueSource(value['source']);
-      final List<int> origValue =
-          value['value'] == null ? null : value['value'].cast<int>();
       final RemoteConfigValue remoteConfigValue =
-          RemoteConfigValue._(origValue, valueSource);
+          RemoteConfigValue._(value['value']?.cast<int>(), valueSource);
       parsedParameters[key] = remoteConfigValue;
     });
     return parsedParameters;

--- a/packages/firebase_remote_config/lib/src/remote_config.dart
+++ b/packages/firebase_remote_config/lib/src/remote_config.dart
@@ -74,7 +74,7 @@ class RemoteConfig extends ChangeNotifier {
       case 'remote':
         return ValueSource.valueRemote;
       default:
-        return ValueSource.valueStatic;
+        return null;
     }
   }
 

--- a/packages/firebase_remote_config/lib/src/remote_config.dart
+++ b/packages/firebase_remote_config/lib/src/remote_config.dart
@@ -153,6 +153,7 @@ class RemoteConfig extends ChangeNotifier {
   /// Default config parameters should be set then when changes are needed the
   /// parameters should be updated in the Firebase console.
   Future<void> setDefaults(Map<String, dynamic> defaults) async {
+    assert(defaults != null);
     // Make defaults available even if fetch fails.
     defaults.forEach((String key, dynamic value) {
       if (!_parameters.containsKey(key)) {

--- a/packages/firebase_remote_config/lib/src/remote_config.dart
+++ b/packages/firebase_remote_config/lib/src/remote_config.dart
@@ -58,8 +58,10 @@ class RemoteConfig extends ChangeNotifier {
         <String, RemoteConfigValue>{};
     parameters.forEach((dynamic key, dynamic value) {
       final ValueSource valueSource = _parseValueSource(value['source']);
+      final List<int> origValue =
+          value['value'] == null ? null : value['value'].cast<int>();
       final RemoteConfigValue remoteConfigValue =
-          RemoteConfigValue._(value['value'].cast<int>(), valueSource);
+          RemoteConfigValue._(origValue, valueSource);
       parsedParameters[key] = remoteConfigValue;
     });
     return parsedParameters;
@@ -67,11 +69,11 @@ class RemoteConfig extends ChangeNotifier {
 
   static ValueSource _parseValueSource(String sourceStr) {
     switch (sourceStr) {
-      case 'valueStatic':
+      case 'static':
         return ValueSource.valueStatic;
-      case 'valueDefault':
+      case 'default':
         return ValueSource.valueDefault;
-      case 'valueRemote':
+      case 'remote':
         return ValueSource.valueRemote;
       default:
         return ValueSource.valueStatic;
@@ -226,5 +228,12 @@ class RemoteConfig extends ChangeNotifier {
     } else {
       return RemoteConfigValue._(null, ValueSource.valueStatic);
     }
+  }
+
+  /// Gets all [RemoteConfigValue].
+  ///
+  /// This includes all remote and default values
+  Map<String, RemoteConfigValue> getAll() {
+    return Map<String, RemoteConfigValue>.unmodifiable(_parameters);
   }
 }

--- a/packages/firebase_remote_config/lib/src/remote_config.dart
+++ b/packages/firebase_remote_config/lib/src/remote_config.dart
@@ -156,10 +156,9 @@ class RemoteConfig extends ChangeNotifier {
     // Make defaults available even if fetch fails.
     defaults.forEach((String key, dynamic value) {
       if (!_parameters.containsKey(key)) {
-        final ValueSource valueSource = ValueSource.valueDefault;
         final RemoteConfigValue remoteConfigValue = RemoteConfigValue._(
           const Utf8Codec().encode(value.toString()),
-          valueSource,
+          ValueSource.valueDefault,
         );
         _parameters[key] = remoteConfigValue;
       }

--- a/packages/firebase_remote_config/lib/src/remote_config_value.dart
+++ b/packages/firebase_remote_config/lib/src/remote_config_value.dart
@@ -6,13 +6,12 @@ enum ValueSource { valueStatic, valueDefault, valueRemote }
 /// RemoteConfigValue encapsulates the value and source of a Remote Config
 /// parameter.
 class RemoteConfigValue {
-  RemoteConfigValue._(this._value, this._source);
+  RemoteConfigValue._(this._value, this.source) : assert(source != null);
 
   List<int> _value;
-  ValueSource _source;
 
   /// Indicates at which source this value came from.
-  ValueSource get source => _source ?? ValueSource.valueRemote;
+  final ValueSource source;
 
   /// Decode value to string.
   String asString() {

--- a/packages/firebase_remote_config/lib/src/remote_config_value.dart
+++ b/packages/firebase_remote_config/lib/src/remote_config_value.dart
@@ -12,9 +12,7 @@ class RemoteConfigValue {
   ValueSource _source;
 
   /// Indicates at which source this value came from.
-  ValueSource get source => _source == ValueSource.valueDefault
-      ? ValueSource.valueDefault
-      : ValueSource.valueRemote;
+  ValueSource get source => _source ?? ValueSource.valueRemote;
 
   /// Decode value to string.
   String asString() {

--- a/packages/firebase_remote_config/pubspec.yaml
+++ b/packages/firebase_remote_config/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Remote Config. Update your application 
   re-releasing.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_remote_config
-version: 0.2.0+3
+version: 0.2.0+4
 
 dependencies:
   flutter:

--- a/packages/firebase_remote_config/test/firebase_remote_config_test.dart
+++ b/packages/firebase_remote_config/test/firebase_remote_config_test.dart
@@ -100,7 +100,7 @@ void main() {
                   'value': <int>[116, 114, 117, 101], // UTF-8 encoded 'true'
                 },
                 'param5': <String, dynamic>{
-                  'source': 'static',
+                  'source': 'default',
                   'value': <int>[
                     102,
                     97,
@@ -109,7 +109,7 @@ void main() {
                     101
                   ], // UTF-8 encoded 'false'
                 },
-                'param6': <String, dynamic>{'source': 'static', 'value': null}
+                'param6': <String, dynamic>{'source': 'default', 'value': null}
               },
               'newConfig': true,
             };
@@ -206,8 +206,8 @@ void main() {
         'param2': ValueSource.valueRemote,
         'param3': ValueSource.valueDefault,
         'param4': ValueSource.valueRemote,
-        'param5': ValueSource.valueStatic,
-        'param6': ValueSource.valueStatic,
+        'param5': ValueSource.valueDefault,
+        'param6': ValueSource.valueDefault,
       });
     });
 

--- a/packages/firebase_remote_config/test/firebase_remote_config_test.dart
+++ b/packages/firebase_remote_config/test/firebase_remote_config_test.dart
@@ -84,11 +84,11 @@ void main() {
             return <String, dynamic>{
               'parameters': <String, dynamic>{
                 'param1': <String, dynamic>{
-                  'source': 'static',
+                  'source': 'remote',
                   'value': <int>[118, 97, 108, 49], // UTF-8 encoded 'val1'
                 },
                 'param2': <String, dynamic>{
-                  'source': 'static',
+                  'source': 'remote',
                   'value': <int>[49, 50, 51, 52, 53], // UTF-8 encoded '12345'
                 },
                 'param3': <String, dynamic>{
@@ -96,9 +96,20 @@ void main() {
                   'value': <int>[51, 46, 49, 52], // UTF-8 encoded '3.14'
                 },
                 'param4': <String, dynamic>{
+                  'source': 'remote',
+                  'value': <int>[116, 114, 117, 101], // UTF-8 encoded 'true'
+                },
+                'param5': <String, dynamic>{
                   'source': 'static',
-                  'value': <int>[116, 114, 117, 101] // UTF-8 encoded 'true'
-                }
+                  'value': <int>[
+                    102,
+                    97,
+                    108,
+                    115,
+                    101
+                  ], // UTF-8 encoded 'false'
+                },
+                'param6': <String, dynamic>{'source': 'static', 'value': null}
               },
               'newConfig': true,
             };
@@ -159,6 +170,45 @@ void main() {
       expect(remoteConfig.getInt('param2'), 12345);
       expect(remoteConfig.getDouble('param3'), 3.14);
       expect(remoteConfig.getBool('param4'), true);
+      expect(remoteConfig.getBool('param5'), false);
+      expect(remoteConfig.getInt('param6'), 0);
+
+      remoteConfig.getAll().forEach((String key, RemoteConfigValue value) {
+        switch (key) {
+          case 'param1':
+            expect(value.asString(), 'val1');
+            break;
+          case 'param2':
+            expect(value.asInt(), 12345);
+            break;
+          case 'param3':
+            expect(value.asDouble(), 3.14);
+            break;
+          case 'param4':
+            expect(value.asBool(), true);
+            break;
+          case 'param5':
+            expect(value.asBool(), false);
+            break;
+          case 'param6':
+            expect(value.asInt(), 0);
+            break;
+          default:
+        }
+      });
+
+      final Map<String, ValueSource> resultAllSources = remoteConfig
+          .getAll()
+          .map((String key, RemoteConfigValue value) =>
+              MapEntry<String, ValueSource>(key, value.source));
+      expect(resultAllSources, <String, ValueSource>{
+        'param1': ValueSource.valueRemote,
+        'param2': ValueSource.valueRemote,
+        'param3': ValueSource.valueDefault,
+        'param4': ValueSource.valueRemote,
+        'param5': ValueSource.valueStatic,
+        'param6': ValueSource.valueStatic,
+      });
     });
 
     test('setConfigSettings', () async {


### PR DESCRIPTION
## Description

Value source is parsed incorrectly
- Source enum names mismatch when transferred via MethodChannel. 
- For some reason `ValueSource.valueStatic` was omitted in this getter https://github.com/flutter/plugins/blob/master/packages/firebase_remote_config/lib/src/remote_config_value.dart#L15

## Related Issues

--

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
