### PR TITLE
[firebase_crashlytics] Handle case where function isn't in class for stack

### DIFF
--- a/packages/firebase_crashlytics/CHANGELOG.md
+++ b/packages/firebase_crashlytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.4+11
+
+* Fixed an issue where `Crashlytics#getStackTraceElements` didn't handle functions without classes.
+
 ## 0.0.4+10
 
 * Update README.

--- a/packages/firebase_crashlytics/android/src/main/java/io/flutter/plugins/firebase/crashlytics/firebasecrashlytics/FirebaseCrashlyticsPlugin.java
+++ b/packages/firebase_crashlytics/android/src/main/java/io/flutter/plugins/firebase/crashlytics/firebasecrashlytics/FirebaseCrashlyticsPlugin.java
@@ -104,7 +104,7 @@ public class FirebaseCrashlyticsPlugin implements MethodCallHandler {
       String methodName = errorElement.get("method");
 
       return new StackTraceElement(
-          className == null ? "" : className, methodName, fileName, Integer.parseInt(lineNumber));
+          className ?? "", methodName, fileName, Integer.parseInt(lineNumber));
     } catch (Exception e) {
       Log.e(TAG, "Unable to generate stack trace element from Dart side error.");
       return null;

--- a/packages/firebase_crashlytics/android/src/main/java/io/flutter/plugins/firebase/crashlytics/firebasecrashlytics/FirebaseCrashlyticsPlugin.java
+++ b/packages/firebase_crashlytics/android/src/main/java/io/flutter/plugins/firebase/crashlytics/firebasecrashlytics/FirebaseCrashlyticsPlugin.java
@@ -104,7 +104,7 @@ public class FirebaseCrashlyticsPlugin implements MethodCallHandler {
       String methodName = errorElement.get("method");
 
       return new StackTraceElement(
-          className ?? "", methodName, fileName, Integer.parseInt(lineNumber));
+          className == null ? "" : className, methodName, fileName, Integer.parseInt(lineNumber));
     } catch (Exception e) {
       Log.e(TAG, "Unable to generate stack trace element from Dart side error.");
       return null;

--- a/packages/firebase_crashlytics/android/src/main/java/io/flutter/plugins/firebase/crashlytics/firebasecrashlytics/FirebaseCrashlyticsPlugin.java
+++ b/packages/firebase_crashlytics/android/src/main/java/io/flutter/plugins/firebase/crashlytics/firebasecrashlytics/FirebaseCrashlyticsPlugin.java
@@ -103,7 +103,7 @@ public class FirebaseCrashlyticsPlugin implements MethodCallHandler {
       String className = errorElement.get("class");
       String methodName = errorElement.get("method");
 
-      return new StackTraceElement(className, methodName, fileName, Integer.parseInt(lineNumber));
+      return new StackTraceElement(className == null ? "" : className, methodName, fileName, Integer.parseInt(lineNumber));
     } catch (Exception e) {
       Log.e(TAG, "Unable to generate stack trace element from Dart side error.");
       return null;

--- a/packages/firebase_crashlytics/android/src/main/java/io/flutter/plugins/firebase/crashlytics/firebasecrashlytics/FirebaseCrashlyticsPlugin.java
+++ b/packages/firebase_crashlytics/android/src/main/java/io/flutter/plugins/firebase/crashlytics/firebasecrashlytics/FirebaseCrashlyticsPlugin.java
@@ -103,7 +103,8 @@ public class FirebaseCrashlyticsPlugin implements MethodCallHandler {
       String className = errorElement.get("class");
       String methodName = errorElement.get("method");
 
-      return new StackTraceElement(className == null ? "" : className, methodName, fileName, Integer.parseInt(lineNumber));
+      return new StackTraceElement(
+          className == null ? "" : className, methodName, fileName, Integer.parseInt(lineNumber));
     } catch (Exception e) {
       Log.e(TAG, "Unable to generate stack trace element from Dart side error.");
       return null;

--- a/packages/firebase_crashlytics/lib/src/firebase_crashlytics.dart
+++ b/packages/firebase_crashlytics/lib/src/firebase_crashlytics.dart
@@ -171,17 +171,25 @@ class Crashlytics {
         final String lineNumber = lineParts[1].contains(":")
             ? lineParts[1].substring(0, lineParts[1].indexOf(":")).trim()
             : lineParts[1];
-        final String className =
-            lineParts[2].substring(0, lineParts[2].indexOf(".")).trim();
-        final String methodName =
-            lineParts[2].substring(lineParts[2].indexOf(".") + 1).trim();
 
-        elements.add(<String, String>{
-          'class': className,
-          'method': methodName,
+        final Map<String, String> element = {
           'file': fileName,
           'line': lineNumber,
-        });
+        };
+
+        if (lineParts[2].contains(".")) {
+          final String className =
+              lineParts[2].substring(0, lineParts[2].indexOf(".")).trim();
+          final String methodName =
+              lineParts[2].substring(lineParts[2].indexOf(".") + 1).trim();
+
+          element['class'] = className;
+          element['method'] = methodName;
+        } else {
+          element['method'] = lineParts[2];
+        }
+
+        elements.add(element);
       } catch (e) {
         print(e.toString());
       }

--- a/packages/firebase_crashlytics/lib/src/firebase_crashlytics.dart
+++ b/packages/firebase_crashlytics/lib/src/firebase_crashlytics.dart
@@ -172,7 +172,7 @@ class Crashlytics {
             ? lineParts[1].substring(0, lineParts[1].indexOf(":")).trim()
             : lineParts[1];
 
-        final Map<String, String> element = {
+        final Map<String, String> element = <String, String>{
           'file': fileName,
           'line': lineNumber,
         };

--- a/packages/firebase_crashlytics/pubspec.yaml
+++ b/packages/firebase_crashlytics/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_crashlytics
 description: Flutter plugin for Firebase Crashlytics. It reports uncaught errors to the
   Firebase console.
-version: 0.0.4+10
+version: 0.0.4+11
 author: Flutter Team <flutter-dev@google.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_crashlytics
 

--- a/packages/firebase_crashlytics/test/firebase_crashlytics_test.dart
+++ b/packages/firebase_crashlytics/test/firebase_crashlytics_test.dart
@@ -142,5 +142,19 @@ void main() {
         'line': '3825',
       });
     });
+
+    test('getStackTraceElements without class', () async {
+      final List<String> lines = <String>[
+        'package:firebase_crashlytics/test/main.dart 12  main'
+      ];
+      final List<Map<String, String>> elements =
+          crashlytics.getStackTraceElements(lines);
+      expect(elements.length, 1);
+      expect(elements.first, <String, String>{
+        'method': 'main',
+        'file': 'package:firebase_crashlytics/test/main.dart',
+        'line': '12',
+      });
+    });
   });
 }


### PR DESCRIPTION
## Description

Currently, the stacktrace parser can't handle it when there is a method without a class in dart - it instead throws its own exception and loses the original one!

This PR handles the case where there is no class name. 

There is a slight caveat to the fix on Android - firebase reporting uses a StackTraceElement which requires a class (which makes sense in Java since you can't have Class-less methods), so on Android class-less methods are reported as `.<functionName>` whereas on iOS they are simply reported as `<className>`.

I don't think this is a big problem as there seem to be other differences between how the stacktraces are reported on Android and iOS anyways.

i.e. iOS: 
![image](https://user-images.githubusercontent.com/3103484/61001821-3926de00-a315-11e9-975b-69b9b26630bd.png)

Android:
![image](https://user-images.githubusercontent.com/3103484/61001915-5a87ca00-a315-11e9-8bfd-4f5d5a28ad9d.png)


## Related Issues

* flutter/flutter#32178

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
