### PR TITLE
[in_app_purchase] add missing `hashCode` implementation

### DIFF
--- a/packages/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0+6
+
+* Add missing `hashCode` implementations.
+
 ## 0.2.0+5
 
 * iOS: Support unsupported UserInfo value types on NSError.

--- a/packages/in_app_purchase/lib/src/store_kit_wrappers/sk_payment_queue_wrapper.dart
+++ b/packages/in_app_purchase/lib/src/store_kit_wrappers/sk_payment_queue_wrapper.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:ui' show hashValues;
 import 'dart:async';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
@@ -236,6 +237,9 @@ class SKError {
         DeepCollectionEquality.unordered()
             .equals(typedOther.userInfo, userInfo);
   }
+
+  @override
+  int get hashCode => hashValues(this.code, this.domain, this.userInfo);
 }
 
 /// Dart wrapper around StoreKit's
@@ -326,6 +330,14 @@ class SKPaymentWrapper {
         typedOther.simulatesAskToBuyInSandbox == simulatesAskToBuyInSandbox &&
         typedOther.requestData == requestData;
   }
+
+  @override
+  int get hashCode => hashValues(
+      this.productIdentifier,
+      this.applicationUsername,
+      this.quantity,
+      this.simulatesAskToBuyInSandbox,
+      this.requestData);
 
   @override
   String toString() => _$SKPaymentWrapperToJson(this).toString();

--- a/packages/in_app_purchase/lib/src/store_kit_wrappers/sk_payment_transaction_wrappers.dart
+++ b/packages/in_app_purchase/lib/src/store_kit_wrappers/sk_payment_transaction_wrappers.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:ui' show hashValues;
 import 'package:flutter/foundation.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'sk_product_wrapper.dart';
@@ -172,6 +173,15 @@ class SKPaymentTransactionWrapper {
         typedOther.transactionIdentifier == transactionIdentifier &&
         typedOther.error == error;
   }
+
+  @override
+  int get hashCode => hashValues(
+      this.payment,
+      this.transactionState,
+      this.originalTransaction,
+      this.transactionTimeStamp,
+      this.transactionIdentifier,
+      this.error);
 
   @override
   String toString() => _$SKPaymentTransactionWrapperToJson(this).toString();

--- a/packages/in_app_purchase/lib/src/store_kit_wrappers/sk_product_wrapper.dart
+++ b/packages/in_app_purchase/lib/src/store_kit_wrappers/sk_product_wrapper.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:ui' show hashValues;
 import 'package:flutter/foundation.dart';
 import 'package:collection/collection.dart';
 import 'package:json_annotation/json_annotation.dart';
@@ -55,6 +56,9 @@ class SkProductResponseWrapper {
         DeepCollectionEquality().equals(
             typedOther.invalidProductIdentifiers, invalidProductIdentifiers);
   }
+
+  @override
+  int get hashCode => hashValues(this.products, this.invalidProductIdentifiers);
 }
 
 /// Dart wrapper around StoreKit's [SKProductPeriodUnit](https://developer.apple.com/documentation/storekit/skproductperiodunit?language=objc).
@@ -110,6 +114,9 @@ class SKProductSubscriptionPeriodWrapper {
     final SKProductSubscriptionPeriodWrapper typedOther = other;
     return typedOther.numberOfUnits == numberOfUnits && typedOther.unit == unit;
   }
+
+  @override
+  int get hashCode => hashValues(this.numberOfUnits, this.unit);
 }
 
 /// Dart wrapper around StoreKit's [SKProductDiscountPaymentMode](https://developer.apple.com/documentation/storekit/skproductdiscountpaymentmode?language=objc).
@@ -187,6 +194,10 @@ class SKProductDiscountWrapper {
         typedOther.paymentMode == paymentMode &&
         typedOther.subscriptionPeriod == subscriptionPeriod;
   }
+
+  @override
+  int get hashCode => hashValues(this.price, this.priceLocale,
+      this.numberOfPeriods, this.paymentMode, this.subscriptionPeriod);
 }
 
 /// Dart wrapper around StoreKit's [SKProduct](https://developer.apple.com/documentation/storekit/skproduct?language=objc).
@@ -272,6 +283,17 @@ class SKProductWrapper {
         typedOther.subscriptionPeriod == subscriptionPeriod &&
         typedOther.introductoryPrice == introductoryPrice;
   }
+
+  @override
+  int get hashCode => hashValues(
+      this.productIdentifier,
+      this.localizedTitle,
+      this.localizedDescription,
+      this.priceLocale,
+      this.subscriptionGroupIdentifier,
+      this.price,
+      this.subscriptionPeriod,
+      this.introductoryPrice);
 }
 
 /// Object that indicates the locale of the price
@@ -307,4 +329,7 @@ class SKPriceLocaleWrapper {
     final SKPriceLocaleWrapper typedOther = other;
     return typedOther.currencySymbol == currencySymbol;
   }
+
+  @override
+  int get hashCode => this.currencySymbol.hashCode;
 }

--- a/packages/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase
 description: A Flutter plugin for in-app purchases. Exposes APIs for making in-app purchases through the App Store and Google Play.
 author:  Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/in_app_purchase
-version: 0.2.0+5
+version: 0.2.0+6
 
 dependencies:
   async: ^2.0.8


### PR DESCRIPTION
## Description

We need to override `hashCode` if overriding ==, some of the classes are missing this override.

