### PR TITLE
[firebase_storage] Fix Content-Type auto-detection for Android

### DIFF
--- a/packages/firebase_storage/CHANGELOG.md
+++ b/packages/firebase_storage/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.3
+
+* Fix inconsistency of `getPath`, on Android the path returned started with a `/` but on iOS it did not
+* Fix content-type auto-detection on Android
+
 ## 3.0.2
 
 * Automatically use version from pubspec.yaml when reporting usage to Firebase.

--- a/packages/firebase_storage/android/src/main/java/io/flutter/plugins/firebase/storage/FirebaseStoragePlugin.java
+++ b/packages/firebase_storage/android/src/main/java/io/flutter/plugins/firebase/storage/FirebaseStoragePlugin.java
@@ -6,7 +6,9 @@ package io.flutter.plugins.firebase.storage;
 
 import android.net.Uri;
 import android.util.SparseArray;
+
 import androidx.annotation.NonNull;
+
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
@@ -20,16 +22,20 @@ import com.google.firebase.storage.StorageException;
 import com.google.firebase.storage.StorageMetadata;
 import com.google.firebase.storage.StorageReference;
 import com.google.firebase.storage.UploadTask;
+
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
+
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
-/** FirebaseStoragePlugin */
+/**
+ * FirebaseStoragePlugin
+ */
 public class FirebaseStoragePlugin implements MethodCallHandler {
   private FirebaseStorage firebaseStorage;
   private final MethodChannel channel;
@@ -49,7 +55,7 @@ public class FirebaseStoragePlugin implements MethodCallHandler {
   }
 
   @Override
-  public void onMethodCall(MethodCall call, final Result result) {
+  public void onMethodCall(@NonNull MethodCall call, @NonNull final Result result) {
     String app = call.argument("app");
     String storageBucket = call.argument("bucket");
     if (app == null && storageBucket == null) {

--- a/packages/firebase_storage/android/src/main/java/io/flutter/plugins/firebase/storage/FirebaseStoragePlugin.java
+++ b/packages/firebase_storage/android/src/main/java/io/flutter/plugins/firebase/storage/FirebaseStoragePlugin.java
@@ -270,7 +270,6 @@ public class FirebaseStoragePlugin implements MethodCallHandler {
     result.success(handle);
   }
 
-
   private void putData(MethodCall call, Result result) {
     byte[] bytes = call.argument("data");
     String path = call.argument("path");
@@ -394,7 +393,7 @@ public class FirebaseStoragePlugin implements MethodCallHandler {
     }
   }
 
-  private void resumeUploadTask(MethodCall call,@NonNull final Result result) {
+  private void resumeUploadTask(MethodCall call, @NonNull final Result result) {
     int handle = call.argument("handle");
     UploadTask task = uploadTasks.get(handle);
     if (task != null) {

--- a/packages/firebase_storage/example/pubspec.yaml
+++ b/packages/firebase_storage/example/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   firebase_storage:
     path: ../
   firebase_core: ^0.4.0
-  uuid: "^1.0.0"
+  uuid: ^1.0.0
   http: ^0.12.0
 
 dev_dependencies:

--- a/packages/firebase_storage/lib/src/storage_reference.dart
+++ b/packages/firebase_storage/lib/src/storage_reference.dart
@@ -88,12 +88,18 @@ class StorageReference {
   /// Returns the full path to this object, not including the Google Cloud
   /// Storage bucket.
   Future<String> getPath() async {
-    return await FirebaseStorage.channel
+    final String path = await FirebaseStorage.channel
         .invokeMethod<String>("StorageReference#getPath", <String, String>{
       'app': _firebaseStorage.app?.name,
       'bucket': _firebaseStorage.storageBucket,
       'path': _pathComponents.join("/"),
     });
+
+    if (path.startsWith('/')) {
+      return path.substring(1);
+    } else {
+      return path;
+    }
   }
 
   /// Returns the short name of this object.

--- a/packages/firebase_storage/pubspec.yaml
+++ b/packages/firebase_storage/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Cloud Storage, a powerful, simple, and
   cost-effective object storage service for Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_storage
-version: 3.0.2
+version: 3.0.3
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description
Fix auto-detection of Content-Type for Android.

## Related Issues
https://github.com/flutter/flutter/issues/32181

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.