### PR TITLE
[firebase_dynamic_links] Allow FDL plugin to be registered without an activity

### DIFF
--- a/packages/firebase_dynamic_links/CHANGELOG.md
+++ b/packages/firebase_dynamic_links/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0+5
+
+* Fix the bug below properly by allowing the activity to be null (but still registering the plugin). If activity is null, we don't get a latestIntent, instead we expect the intent listener to grab it.
+
 ## 0.4.0+4
 
 * Fixed bug on Android when a headless plugin tries to register this plugin causing a crash due no activity from the registrar.

--- a/packages/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebasedynamiclinks/FirebaseDynamicLinksPlugin.java
+++ b/packages/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebasedynamiclinks/FirebaseDynamicLinksPlugin.java
@@ -28,7 +28,9 @@ public class FirebaseDynamicLinksPlugin implements MethodCallHandler {
 
   private FirebaseDynamicLinksPlugin(Registrar registrar) {
     this.registrar = registrar;
-    latestIntent = registrar.activity().getIntent();
+    if (registrar.activity() != null) {
+      latestIntent = registrar.activity().getIntent();
+    }
 
     registrar.addNewIntentListener(
         new PluginRegistry.NewIntentListener() {
@@ -41,9 +43,6 @@ public class FirebaseDynamicLinksPlugin implements MethodCallHandler {
   }
 
   public static void registerWith(Registrar registrar) {
-    if (registrar.activity() == null) {
-      return;
-    }
     final MethodChannel channel =
         new MethodChannel(registrar.messenger(), "plugins.flutter.io/firebase_dynamic_links");
     channel.setMethodCallHandler(new FirebaseDynamicLinksPlugin(registrar));

--- a/packages/firebase_dynamic_links/pubspec.yaml
+++ b/packages/firebase_dynamic_links/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_dynamic_links
 description: Flutter plugin for Google Dynamic Links for Firebase, an app solution for creating
   and handling links across multiple platforms.
-version: 0.4.0+4
+version: 0.4.0+5
 
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_dynamic_links


### PR DESCRIPTION
Some apps do not have an activity available when they register plugins. We should still register the plugin and leave it up to the intent listener to grab the latest intent.