### PR TITLE
[image_picker] Fix image_picker Hanging After Attempting to Open Unavailable Camera on iOS Simulator

### DIFF
--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.0+16
+
+* iOS Simulator: fix hang after trying to take an image from the non-existent camera.
+
 ## 0.6.0+15
 
 * Android: throws an exception when permissions denied instead of ignoring.

--- a/packages/image_picker/ios/Classes/ImagePickerPlugin.m
+++ b/packages/image_picker/ios/Classes/ImagePickerPlugin.m
@@ -128,7 +128,9 @@ static const int SOURCE_GALLERY = 1;
                                delegate:nil
                       cancelButtonTitle:@"OK"
                       otherButtonTitles:nil] show];
-    [self imagePickerControllerDidCancel:_imagePickerController];              
+    self.result(nil);
+    self.result = nil;
+    _arguments = nil;          
   }
 }
 

--- a/packages/image_picker/ios/Classes/ImagePickerPlugin.m
+++ b/packages/image_picker/ios/Classes/ImagePickerPlugin.m
@@ -130,7 +130,7 @@ static const int SOURCE_GALLERY = 1;
                       otherButtonTitles:nil] show];
     self.result(nil);
     self.result = nil;
-    _arguments = nil;          
+    _arguments = nil;
   }
 }
 

--- a/packages/image_picker/ios/Classes/ImagePickerPlugin.m
+++ b/packages/image_picker/ios/Classes/ImagePickerPlugin.m
@@ -128,6 +128,7 @@ static const int SOURCE_GALLERY = 1;
                                delegate:nil
                       cancelButtonTitle:@"OK"
                       otherButtonTitles:nil] show];
+    [self imagePickerControllerDidCancel:_imagePickerController];              
   }
 }
 

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -6,7 +6,7 @@ authors:
   - Rhodes Davis Jr. <rody.davis.jr@gmail.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
 
-version: 0.6.0+15
+version: 0.6.0+16
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

This PR resolves the description given in the title. image_picker hangs on iOS simulator after being rejected for the camera being unavailable.

## Related Issues
[flutter/flutter #18095](https://github.com/flutter/flutter/issues/18095) describes very similar behaviour, except with respect to the gallery and video picker.
[flutter/plugins #595](https://github.com/flutter/plugins/pull/595) introduced the `FLTImagePickerPlugin#imagePickerControllerDidCancel` method, however it is never actually called anywhere in the code base. This PR simply makes use of it.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
