### PR TITLE
[webview_flutter] Basic fix for input pre N

### DIFF
--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.9+3
+
+* Add partial fix for webview keyboard input on Android versions prior to N.
+
 ## 0.3.9+2
 
 * Update Dart code to conform to current Dart formatter.

--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## 0.3.10
 
-* Add partial WebView keyboard support for Android versions prior to N.
+* Add partial WebView keyboard support for Android versions prior to N. Support
+  for UIs that also have Flutter `TextInput` fields is still pending. This basic
+  support currently only works with Flutter `master`. The keyboard will still
+  appear when it previously did not when run with older versions of Flutter. But
+  if the WebView is resized while showing the keyboard the text field will need
+  to be focused multiple times for any input to be registered.
 
 ## 0.3.9+2
 

--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 0.3.9+3
+## 0.3.10
 
-* Add partial fix for webview keyboard input on Android versions prior to N.
+* Add partial WebView keyboard support for Android versions prior to N.
 
 ## 0.3.9+2
 

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -4,19 +4,12 @@
 
 package io.flutter.plugins.webviewflutter;
 
-import static android.content.Context.INPUT_METHOD_SERVICE;
-
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.os.Build;
 import android.os.Handler;
-import android.util.Log;
 import android.view.View;
-import android.view.inputmethod.EditorInfo;
-import android.view.inputmethod.InputConnection;
-import android.view.inputmethod.InputMethodManager;
 import android.webkit.WebStorage;
-import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
@@ -34,93 +27,6 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
   private final MethodChannel methodChannel;
   private final FlutterWebViewClient flutterWebViewClient;
   private final Handler platformThreadHandler;
-  private final View flutterView;
-
-  private static class InputAwareWebView extends WebView {
-    private static final String TAG = "InputAwareWebView";
-    private final View flutterView;
-
-    InputAwareWebView(Context context, View flutterView) {
-      super(context);
-      this.flutterView = flutterView;
-    }
-
-    private View threadedInputConnectionProxyView;
-
-    private ThreadedInputConnectionProxyAdapterView proxyAdapterView;
-
-    @Override
-    public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
-      if (proxyAdapterView == null) {
-        // No proxy adapter set, so we use the default implementation.
-        return super.onCreateInputConnection(outAttrs);
-      }
-
-      if (!proxyAdapterView.isTriggerDelayed()) {
-        // Currently on the IME thread. Delegate to the superclass.
-        return super.onCreateInputConnection(outAttrs);
-      }
-
-      InputConnection result = super.onCreateInputConnection(outAttrs);
-      if (result != null) {
-        // This should never happen.
-        Log.wtf(TAG, "Failed unexpectedly creating a webview input connection.");
-      }
-
-      final InputMethodManager imm =
-          (InputMethodManager) getContext().getSystemService(INPUT_METHOD_SERVICE);
-      proxyAdapterView.requestFocus();
-      final View containerView = this;
-
-      // This is the crucial trick that gets the InputConnection creation to happen on the correct
-      // thread. https://cs.chromium.org/chromium/src/content/public/android/java/src/org/chromium/content/browser/input/ThreadedInputConnectionFactory.java?l=169.
-      this.post(
-          new Runnable() {
-            @Override
-            public void run() {
-              // This is a hack to make InputMethodManager believe that the proxy view now has a focus.
-              // As a result, InputMethodManager will think that mProxyView is focused, and will call
-              // getHandler() of the view when creating input connection.
-
-              // Step 1: Set proxyAdapterView as InputMethodManager#mNextServedView. This does not
-              // affect the real window focus.
-              proxyAdapterView.onWindowFocusChanged(true);
-
-              // Step 2: Have InputMethodManager focus in on containerView. As a result, IMM will call
-              // onCreateInputConnection() on proxyAdapterView on the same thread as
-              // proxyAdapterView.getHandler(). It will also call subsequent InputConnection methods on
-              // this IME thread.
-              imm.isActive(containerView);
-            }
-          });
-      return null;
-    }
-
-    @Override
-    public boolean checkInputConnectionProxy(final View view) {
-      View previousProxy = threadedInputConnectionProxyView;
-      threadedInputConnectionProxyView = view;
-      if (previousProxy != view) {
-        proxyAdapterView =
-            new ThreadedInputConnectionProxyAdapterView(
-                /*containerView=*/ flutterView,
-                /*targetView=*/ view,
-                /*imeHandler=*/ view.getHandler());
-        final View container = this;
-        proxyAdapterView.requestFocus();
-        post(
-            new Runnable() {
-              @Override
-              public void run() {
-                InputMethodManager imm =
-                    (InputMethodManager) getContext().getSystemService(INPUT_METHOD_SERVICE);
-                imm.restartInput(container);
-              }
-            });
-      }
-      return super.checkInputConnectionProxy(view);
-    }
-  }
 
   @SuppressWarnings("unchecked")
   FlutterWebView(
@@ -128,9 +34,8 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
       BinaryMessenger messenger,
       int id,
       Map<String, Object> params,
-      final View flutterView) {
-    this.flutterView = flutterView;
-    webView = new InputAwareWebView(context, flutterView);
+      final View containerView) {
+    webView = new InputAwareWebView(context, containerView);
 
     platformThreadHandler = new Handler(context.getMainLooper());
     // Allow local storage.
@@ -164,14 +69,7 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
   // of Flutter but used as an override anyway wherever it's actually defined.
   // TODO(mklim): Add the @Override annotation once flutter/engine#9727 rolls to stable.
   public void onInputConnectionUnlocked() {
-    if (webView.proxyAdapterView == null) {
-      return;
-    }
-
-    webView.proxyAdapterView.setLocked(false);
-    InputMethodManager imm =
-        (InputMethodManager) flutterView.getContext().getSystemService(INPUT_METHOD_SERVICE);
-    imm.restartInput(flutterView);
+    webView.unlockInputConnection();
   }
 
   // @Override
@@ -181,11 +79,7 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
   // of Flutter but used as an override anyway wherever it's actually defined.
   // TODO(mklim): Add the @Override annotation once flutter/engine#9727 rolls to stable.
   public void onInputConnectionLocked() {
-    if (webView.proxyAdapterView == null) {
-      return;
-    }
-
-    webView.proxyAdapterView.setLocked(true);
+    webView.lockInputConnection();
   }
 
   @Override

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -4,11 +4,17 @@
 
 package io.flutter.plugins.webviewflutter;
 
+import static android.content.Context.INPUT_METHOD_SERVICE;
+
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.os.Build;
 import android.os.Handler;
+import android.util.Log;
 import android.view.View;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputConnection;
+import android.view.inputmethod.InputMethodManager;
 import android.webkit.WebStorage;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
@@ -24,14 +30,108 @@ import java.util.Map;
 
 public class FlutterWebView implements PlatformView, MethodCallHandler {
   private static final String JS_CHANNEL_NAMES_FIELD = "javascriptChannelNames";
-  private final WebView webView;
+  private final InputAwareWebView webView;
   private final MethodChannel methodChannel;
   private final FlutterWebViewClient flutterWebViewClient;
   private final Handler platformThreadHandler;
+  private final View flutterView;
+
+  private static class InputAwareWebView extends WebView {
+    private static final String TAG = "InputAwareWebView";
+    private final View flutterView;
+
+    InputAwareWebView(Context context, View flutterView) {
+      super(context);
+      this.flutterView = flutterView;
+    }
+
+    private View threadedInputConnectionProxyView;
+
+    private ThreadedInputConnectionProxyAdapterView proxyAdapterView;
+
+    @Override
+    public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
+      if (proxyAdapterView == null) {
+        // No proxy adapter set, so we use the default implementation.
+        return super.onCreateInputConnection(outAttrs);
+      }
+
+      if (!proxyAdapterView.isTriggerDelayed()) {
+        // Currently on the IME thread. Delegate to the superclass.
+        return super.onCreateInputConnection(outAttrs);
+      }
+
+      InputConnection result = super.onCreateInputConnection(outAttrs);
+      if (result != null) {
+        // This should never happen.
+        Log.wtf(TAG, "Failed unexpectedly creating a webview input connection.");
+      }
+
+      final InputMethodManager imm =
+          (InputMethodManager) getContext().getSystemService(INPUT_METHOD_SERVICE);
+      proxyAdapterView.requestFocus();
+      final View containerView = this;
+
+      // This is the crucial trick that gets the InputConnection creation to happen on the correct
+      // thread. https://cs.chromium.org/chromium/src/content/public/android/java/src/org/chromium/content/browser/input/ThreadedInputConnectionFactory.java?l=169.
+      this.post(
+          new Runnable() {
+            @Override
+            public void run() {
+              // This is a hack to make InputMethodManager believe that the proxy view now has a focus.
+              // As a result, InputMethodManager will think that mProxyView is focused, and will call
+              // getHandler() of the view when creating input connection.
+
+              // Step 1: Set proxyAdapterView as InputMethodManager#mNextServedView. This does not
+              // affect the real window focus.
+              proxyAdapterView.onWindowFocusChanged(true);
+
+              // Step 2: Have InputMethodManager focus in on containerView. As a result, IMM will call
+              // onCreateInputConnection() on proxyAdapterView on the same thread as
+              // proxyAdapterView.getHandler(). It will also call subsequent InputConnection methods on
+              // this IME thread.
+              imm.isActive(containerView);
+            }
+          });
+      return null;
+    }
+
+    @Override
+    public boolean checkInputConnectionProxy(final View view) {
+      View previousProxy = threadedInputConnectionProxyView;
+      threadedInputConnectionProxyView = view;
+      if (previousProxy != view) {
+        proxyAdapterView =
+            new ThreadedInputConnectionProxyAdapterView(
+                /*containerView=*/ flutterView,
+                /*targetView=*/ view,
+                /*imeHandler=*/ view.getHandler());
+        final View container = this;
+        proxyAdapterView.requestFocus();
+        post(
+            new Runnable() {
+              @Override
+              public void run() {
+                InputMethodManager imm =
+                    (InputMethodManager) getContext().getSystemService(INPUT_METHOD_SERVICE);
+                imm.restartInput(container);
+              }
+            });
+      }
+      return super.checkInputConnectionProxy(view);
+    }
+  }
 
   @SuppressWarnings("unchecked")
-  FlutterWebView(Context context, BinaryMessenger messenger, int id, Map<String, Object> params) {
-    webView = new WebView(context);
+  FlutterWebView(
+      Context context,
+      BinaryMessenger messenger,
+      int id,
+      Map<String, Object> params,
+      final View flutterView) {
+    this.flutterView = flutterView;
+    webView = new InputAwareWebView(context, flutterView);
+
     platformThreadHandler = new Handler(context.getMainLooper());
     // Allow local storage.
     webView.getSettings().setDomStorageEnabled(true);
@@ -55,6 +155,37 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
   @Override
   public View getView() {
     return webView;
+  }
+
+  // @Override
+  // This is overriding a method that hasn't rolled into stable Flutter yet. Including the
+  // annotation would cause compile time failures in versions of Flutter too old to include the new
+  // method. However leaving it raw like this means that the method will be ignored in old versions
+  // of Flutter but used as an override anyway wherever it's actually defined.
+  // TODO(mklim): Add the @Override annotation once flutter/engine#9727 rolls to stable.
+  public void onInputConnectionUnlocked() {
+    if (webView.proxyAdapterView == null) {
+      return;
+    }
+
+    webView.proxyAdapterView.setLocked(false);
+    InputMethodManager imm =
+        (InputMethodManager) flutterView.getContext().getSystemService(INPUT_METHOD_SERVICE);
+    imm.restartInput(flutterView);
+  }
+
+  // @Override
+  // This is overriding a method that hasn't rolled into stable Flutter yet. Including the
+  // annotation would cause compile time failures in versions of Flutter too old to include the new
+  // method. However leaving it raw like this means that the method will be ignored in old versions
+  // of Flutter but used as an override anyway wherever it's actually defined.
+  // TODO(mklim): Add the @Override annotation once flutter/engine#9727 rolls to stable.
+  public void onInputConnectionLocked() {
+    if (webView.proxyAdapterView == null) {
+      return;
+    }
+
+    webView.proxyAdapterView.setLocked(true);
   }
 
   @Override

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/InputAwareWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/InputAwareWebView.java
@@ -9,9 +9,11 @@ import android.webkit.WebView;
 
 /**
  * A WebView subclass that mirrors the same implementation hacks that the system WebView does in
- * Android versions below N in order to correctly create an InputConnection on the IME thread.
+ * order to correctly create an InputConnection.
  *
- * <p>The majority of this proxying logic is in {@link #checkInputConnectionProxy}.
+ * <p>These hacks are only needed in Android versions below N and exist to create an InputConnection
+ * on the WebView's dedicated input, or IME, thread. The majority of this proxying logic is in
+ * {@link #checkInputConnectionProxy}.
  *
  * <p>See also {@link ThreadedInputConnectionProxyAdapterView}.
  */
@@ -70,7 +72,7 @@ final class InputAwareWebView extends WebView {
     View previousProxy = threadedInputConnectionProxyView;
     threadedInputConnectionProxyView = view;
     if (previousProxy == view) {
-      // This isn't ThreadedInputConnectionProxyView. Ignore it.
+      // This isn't a new ThreadedInputConnectionProxyView. Ignore it.
       return super.checkInputConnectionProxy(view);
     }
 

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/InputAwareWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/InputAwareWebView.java
@@ -1,0 +1,102 @@
+package io.flutter.plugins.webviewflutter;
+
+import static android.content.Context.INPUT_METHOD_SERVICE;
+
+import android.content.Context;
+import android.view.View;
+import android.view.inputmethod.InputMethodManager;
+import android.webkit.WebView;
+
+/**
+ * A WebView subclass that mirrors the same implementation hacks that the system WebView does in
+ * order to correctly create an InputConnection.
+ *
+ * <p>The majority of this proxying logic is in {@link #checkInputConnectionProxy}.
+ *
+ * <p>See also {@link ThreadedInputConnectionProxyAdapterView}.
+ */
+final class InputAwareWebView extends WebView {
+  private final View containerView;
+
+  private View threadedInputConnectionProxyView;
+  private ThreadedInputConnectionProxyAdapterView proxyAdapterView;
+
+  InputAwareWebView(Context context, View containerView) {
+    super(context);
+    this.containerView = containerView;
+  }
+
+  /**
+   * Set our proxy adapter view to use its cached input connection instead of creating new ones.
+   *
+   * <p>This is used to avoid losing our input connection when the virtual display is resized.
+   */
+  void lockInputConnection() {
+    if (proxyAdapterView == null) {
+      return;
+    }
+
+    proxyAdapterView.setLocked(true);
+  }
+
+  /** Sets the proxy adapter view back to its default behavior. */
+  void unlockInputConnection() {
+    if (proxyAdapterView == null) {
+      return;
+    }
+
+    proxyAdapterView.setLocked(false);
+
+    // Restart the input connection to avoid ViewRootImpl assuming an incorrect window state.
+    InputMethodManager imm =
+        (InputMethodManager) containerView.getContext().getSystemService(INPUT_METHOD_SERVICE);
+    imm.restartInput(containerView);
+  }
+
+  /** Creates an InputConnection from the IME thread when needed. */
+  @Override
+  public boolean checkInputConnectionProxy(final View view) {
+    View previousProxy = threadedInputConnectionProxyView;
+    threadedInputConnectionProxyView = view;
+    if (previousProxy == view) {
+      return super.checkInputConnectionProxy(view);
+    }
+
+    proxyAdapterView =
+        new ThreadedInputConnectionProxyAdapterView(
+            /*containerView=*/ containerView,
+            /*targetView=*/ view,
+            /*imeHandler=*/ view.getHandler());
+    final View container = this;
+    proxyAdapterView.requestFocus();
+    // This is the crucial trick that gets the InputConnection creation to happen on the correct
+    // thread.
+    // https://cs.chromium.org/chromium/src/content/public/android/java/src/org/chromium/content/browser/input/ThreadedInputConnectionFactory.java?l=169&rcl=f0698ee3e4483fad5b0c34159276f71cfaf81f3a
+    post(
+        new Runnable() {
+          @Override
+          public void run() {
+            InputMethodManager imm =
+                (InputMethodManager) getContext().getSystemService(INPUT_METHOD_SERVICE);
+            // This is a hack to make InputMethodManager believe that the proxy view now has focus.
+            // As a result, InputMethodManager will think that proxyAdapterView is focused, and will
+            // call getHandler() of the view when creating input connection.
+
+            // Step 1: Set proxyAdapterView as InputMethodManager#mNextServedView. This does not
+            // affect the real window focus.
+            proxyAdapterView.onWindowFocusChanged(true);
+
+            // Step 2: Have InputMethodManager focus in on proxyAdapterView. As a result, IMM will
+            // call onCreateInputConnection() on proxyAdapterView on the same thread as
+            // proxyAdapterView.getHandler(). It will also call subsequent InputConnection methods
+            // on this IME thread.
+            imm.isActive(containerView);
+          }
+        });
+    return super.checkInputConnectionProxy(view);
+  }
+
+  protected ThreadedInputConnectionProxyAdapterView getProxyAdapterView() {
+    return proxyAdapterView;
+  }
+}

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/ThreadedInputConnectionProxyAdapterView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/ThreadedInputConnectionProxyAdapterView.java
@@ -1,0 +1,100 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.plugins.webviewflutter;
+
+import android.os.Handler;
+import android.os.IBinder;
+import android.view.View;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputConnection;
+
+/**
+ * A fake View only exposed to InputMethodManager.
+ *
+ * <p>This follows a similar flow to Chromium's WebView (see
+ * https://cs.chromium.org/chromium/src/content/public/android/java/src/org/chromium/content/browser/input/ThreadedInputConnectionProxyView.java).
+ * WebView itself bounces its InputConnection around several different threads. We follow its logic
+ * here to get the same working connection.
+ */
+final class ThreadedInputConnectionProxyAdapterView extends View {
+  final Handler imeHandler;
+  final IBinder windowToken;
+  final View containerView;
+  final View rootView;
+  final View targetView;
+
+  private boolean triggerDelayed = true;
+  private boolean isLocked = false;
+  private InputConnection cachedConnection;
+
+  ThreadedInputConnectionProxyAdapterView(View containerView, View targetView, Handler imeHandler) {
+    super(containerView.getContext());
+    this.imeHandler = imeHandler;
+    this.containerView = containerView;
+    this.targetView = targetView;
+    windowToken = containerView.getWindowToken();
+    rootView = containerView.getRootView();
+    setFocusable(true);
+    setFocusableInTouchMode(true);
+    setVisibility(VISIBLE);
+  }
+
+  /** Returns whether or not this is currently asynchronously acquiring an input connection. */
+  boolean isTriggerDelayed() {
+    return triggerDelayed;
+  }
+
+  /** Sets whether or not this should use its previously cached input connection. */
+  void setLocked(boolean locked) {
+    isLocked = locked;
+  }
+
+  @Override
+  public InputConnection onCreateInputConnection(final EditorInfo outAttrs) {
+    triggerDelayed = false;
+    InputConnection inputConnection =
+        (isLocked) ? cachedConnection : targetView.onCreateInputConnection(outAttrs);
+    triggerDelayed = true;
+    cachedConnection = inputConnection;
+    return inputConnection;
+  }
+
+  @Override
+  public boolean checkInputConnectionProxy(View view) {
+    return true;
+  }
+
+  @Override
+  public boolean hasWindowFocus() {
+    // None of our views here correctly report they have window focus because of how we're embedding
+    // the platform view inside of a virtual display.
+    return true;
+  }
+
+  @Override
+  public View getRootView() {
+    return rootView;
+  }
+
+  @Override
+  public boolean onCheckIsTextEditor() {
+    return true;
+  }
+
+  @Override
+  public boolean isFocused() {
+    return true;
+  }
+
+  @Override
+  public IBinder getWindowToken() {
+    return windowToken;
+  }
+
+  @Override
+  public Handler getHandler() {
+    return imeHandler;
+  }
+}

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/ThreadedInputConnectionProxyAdapterView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/ThreadedInputConnectionProxyAdapterView.java
@@ -17,6 +17,12 @@ import android.view.inputmethod.InputConnection;
  * https://cs.chromium.org/chromium/src/content/public/android/java/src/org/chromium/content/browser/input/ThreadedInputConnectionProxyView.java).
  * WebView itself bounces its InputConnection around several different threads. We follow its logic
  * here to get the same working connection.
+ *
+ * <p>This exists solely to forward input creation to WebView's ThreadedInputConnectionProxyView on
+ * the IME thread. The way that this is created in {@link
+ * InputAwareWebView#checkInputConnectionProxy} guarantees that we have a handle to
+ * ThreadedInputConnectionProxyView and {@link #onCreateInputConnection} is always called on the IME
+ * thread. We delegate to ThreadedInputConnectionProxyView there to get WebView's input connection.
  */
 final class ThreadedInputConnectionProxyAdapterView extends View {
   final Handler imeHandler;
@@ -51,6 +57,12 @@ final class ThreadedInputConnectionProxyAdapterView extends View {
     isLocked = locked;
   }
 
+  /**
+   * This is expected to be called on the IME thread. See the setup required for this in {@link
+   * InputAwareWebView#checkInputConnectionProxy(View)}.
+   *
+   * <p>Delegates to ThreadedInputConnectionProxyView to get WebView's input connection.
+   */
   @Override
   public InputConnection onCreateInputConnection(final EditorInfo outAttrs) {
     triggerDelayed = false;

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/WebViewFactory.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/WebViewFactory.java
@@ -14,18 +14,18 @@ import java.util.Map;
 
 public final class WebViewFactory extends PlatformViewFactory {
   private final BinaryMessenger messenger;
-  private final View flutterView;
+  private final View containerView;
 
-  WebViewFactory(BinaryMessenger messenger, View flutterView) {
+  WebViewFactory(BinaryMessenger messenger, View containerView) {
     super(StandardMessageCodec.INSTANCE);
     this.messenger = messenger;
-    this.flutterView = flutterView;
+    this.containerView = containerView;
   }
 
   @SuppressWarnings("unchecked")
   @Override
   public PlatformView create(Context context, int id, Object args) {
     Map<String, Object> params = (Map<String, Object>) args;
-    return new FlutterWebView(context, messenger, id, params, flutterView);
+    return new FlutterWebView(context, messenger, id, params, containerView);
   }
 }

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/WebViewFactory.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/WebViewFactory.java
@@ -5,24 +5,27 @@
 package io.flutter.plugins.webviewflutter;
 
 import android.content.Context;
+import android.view.View;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.StandardMessageCodec;
 import io.flutter.plugin.platform.PlatformView;
 import io.flutter.plugin.platform.PlatformViewFactory;
 import java.util.Map;
 
-public class WebViewFactory extends PlatformViewFactory {
+public final class WebViewFactory extends PlatformViewFactory {
   private final BinaryMessenger messenger;
+  private final View flutterView;
 
-  public WebViewFactory(BinaryMessenger messenger) {
+  WebViewFactory(BinaryMessenger messenger, View flutterView) {
     super(StandardMessageCodec.INSTANCE);
     this.messenger = messenger;
+    this.flutterView = flutterView;
   }
 
   @SuppressWarnings("unchecked")
   @Override
   public PlatformView create(Context context, int id, Object args) {
     Map<String, Object> params = (Map<String, Object>) args;
-    return new FlutterWebView(context, messenger, id, params);
+    return new FlutterWebView(context, messenger, id, params, flutterView);
   }
 }

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/WebViewFlutterPlugin.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/WebViewFlutterPlugin.java
@@ -14,7 +14,8 @@ public class WebViewFlutterPlugin {
     registrar
         .platformViewRegistry()
         .registerViewFactory(
-            "plugins.flutter.io/webview", new WebViewFactory(registrar.messenger()));
+            "plugins.flutter.io/webview",
+            new WebViewFactory(registrar.messenger(), registrar.view()));
     FlutterCookieManager.registerWith(registrar.messenger());
   }
 }

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
-version: 0.3.9+3
+version: 0.3.10
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/webview_flutter
 

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
-version: 0.3.9+2
+version: 0.3.9+3
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/webview_flutter
 


### PR DESCRIPTION
## Description

This patch follows the same hacks that WebView does on Android<N to set
up an InputConnection in onCreateInputConnection on the IME thread.
Previously WebView was asserting that the InputConnection code was being
run on the IME thread and then failing.

Of some extra and specific concern to this is that our webviews are
rendered inside of virtual displays. There is some extra logic in the
plugin to handle restarting the input connection and using the correct
cached connection on resize events because of this. It relies on
engine changes contained in flutter/flutter@b1a8637 (currently only on
master) in order to be called for the resize logic. When used on dev
this still brings up the keyboard when the webview isn't resized by the
keyboard pre N, but fails to fix the issue when bringing up the keyboard
would resize the webview UI.

This patch is forked from the proof of concept at amirh/plugins@64fe811,
plus refactoring and bug fixes to handle the resizing.

This still has an ongoing issue with switching between text inputs
inside of the webview UI and Flutter UI.

## Related Issues

flutter/flutter#19718

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
