### PR TITLE
[firebase_auth] [google_sign_in] Update consent screen docs

### DIFF
--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.11.1+9
+
+* Update README to clarify importance of filling out all fields for OAuth consent screen.
+
 ## 0.11.1+8
 
 * Automatically register for iOS notifications, ensuring that phone authentication

--- a/packages/firebase_auth/README.md
+++ b/packages/firebase_auth/README.md
@@ -12,7 +12,7 @@ For Flutter plugins for other Firebase products, see [FlutterFire.md](https://gi
 ### Configure the Google sign-in plugin
 The Google Sign-in plugin is required to use the firebase_auth plugin for Google authentication. Follow the [Google sign-in plugin installation instructions](https://pub.dartlang.org/packages/google_sign_in#pub-pkg-tab-installing).
 
-If you're using Google Sign-in with Firebase auth, be sure to include a support email in the [Firebase console](https://console.firebase.google.com/). If you don't, you may encounter `com.google.android.gms.common.api.ApiException: 12500`.
+If you're using Google Sign-in with Firebase auth, be sure to include all required fields in the [OAuth consent screen](https://console.developers.google.com/apis/credentials/consent). If you don't, you may encounter an `ApiException`.
 
 ### Import the firebase_auth plugin
 To use the firebase_auth plugin, follow the [plugin installation instructions](https://pub.dartlang.org/packages/firebase_auth#pub-pkg-tab-installing).

--- a/packages/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Firebase Auth, enabling Android and iOS
   like Google, Facebook and Twitter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_auth
-version: "0.11.1+8"
+version: "0.11.1+9"
 
 flutter:
   plugin:

--- a/packages/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.5
+
+* Update README with solution to `APIException` errors.
+
 ## 4.0.4
 
 * Revert changes in 4.0.3.

--- a/packages/google_sign_in/README.md
+++ b/packages/google_sign_in/README.md
@@ -18,6 +18,8 @@ manager](https://console.developers.google.com/). For example, if you
 want to mimic the behavior of the Google Sign-In sample app, you'll need to
 enable the [Google People API](https://developers.google.com/people/).
 
+Make sure you've filled out all required fields in the console for [OAuth consent screen](https://console.developers.google.com/apis/credentials/consent). Otherwise, you may encounter `APIException` errors.
+
 ## iOS integration
 
 1. [First register your application](https://developers.google.com/mobile/add?platform=ios).

--- a/packages/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_sign_in
-version: 4.0.4
+version: 4.0.5
 
 flutter:
   plugin:


### PR DESCRIPTION
Document the importance of the OAuth consent screen page for google_sign_in and firebase_auth.
  
Fixes flutter/flutter#36041, flutter/flutter#33393, flutter/flutter#25909