### PR TITLE
[url_launcher] add support for android headers

### DIFF
--- a/packages/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.6
+
+* Add `headers` field to enable headers in the Android implementation.
+
 ## 5.0.5
 
 * Add `enableDomStorage` field to `launch` to enable DOM storage in Android WebView.

--- a/packages/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 5.0.6
+## 5.1.0
 
 * Add `headers` field to enable headers in the Android implementation.
 

--- a/packages/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/UrlLauncherPlugin.java
+++ b/packages/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/UrlLauncherPlugin.java
@@ -18,13 +18,13 @@ import android.view.KeyEvent;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
-import java.util.HashMap;
-import java.util.Map;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
+import java.util.HashMap;
+import java.util.Map;
 
 /** UrlLauncherPlugin */
 public class UrlLauncherPlugin implements MethodCallHandler {
@@ -125,10 +125,8 @@ public class UrlLauncherPlugin implements MethodCallHandler {
       // Get the Intent that started this activity and extract the string
       final Intent intent = getIntent();
       final String url = intent.getStringExtra("url");
-      final boolean enableJavaScript =
-        intent.getBooleanExtra("enableJavaScript", false);
-      final boolean enableDomStorage =
-        intent.getBooleanExtra("enableDomStorage", false);
+      final boolean enableJavaScript = intent.getBooleanExtra("enableJavaScript", false);
+      final boolean enableDomStorage = intent.getBooleanExtra("enableDomStorage", false);
       final Bundle headersBundle = intent.getBundleExtra(Browser.EXTRA_HEADERS);
 
       final Map<String, String> headersMap = extractHeaders(headersBundle);
@@ -139,38 +137,38 @@ public class UrlLauncherPlugin implements MethodCallHandler {
 
       // Open new urls inside the webview itself.
       webview.setWebViewClient(
-        new WebViewClient() {
+          new WebViewClient() {
 
-          @Override
-          @SuppressWarnings("deprecation")
-          public boolean shouldOverrideUrlLoading(WebView view, String url) {
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-              view.loadUrl(url);
+            @Override
+            @SuppressWarnings("deprecation")
+            public boolean shouldOverrideUrlLoading(WebView view, String url) {
+              if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+                view.loadUrl(url);
+                return false;
+              }
+              return super.shouldOverrideUrlLoading(view, url);
+            }
+
+            @Override
+            public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
+              if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                view.loadUrl(request.getUrl().toString());
+              }
               return false;
             }
-            return super.shouldOverrideUrlLoading(view, url);
-          }
-
-          @Override
-          public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-              view.loadUrl(request.getUrl().toString());
-            }
-            return false;
-          }
-        });
+          });
 
       // Set broadcast receiver to handle calls to close the web view
       broadcastReceiver =
-        new BroadcastReceiver() {
-          @Override
-          public void onReceive(Context arg0, Intent intent) {
-            String action = intent.getAction();
-            if ("close".equals(action)) {
-              finish();
+          new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context arg0, Intent intent) {
+              String action = intent.getAction();
+              if ("close".equals(action)) {
+                finish();
+              }
             }
-          }
-        };
+          };
       registerReceiver(broadcastReceiver, new IntentFilter("close"));
     }
 

--- a/packages/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/UrlLauncherPlugin.java
+++ b/packages/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/UrlLauncherPlugin.java
@@ -11,11 +11,17 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
+import android.provider.Browser;
 import android.view.KeyEvent;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
+
+import java.util.HashMap;
+import java.util.Map;
+
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
@@ -60,16 +66,18 @@ public class UrlLauncherPlugin implements MethodCallHandler {
     boolean canLaunch =
         componentName != null
             && !"{com.android.fallback/com.android.fallback.Fallback}"
-                .equals(componentName.toShortString());
+            .equals(componentName.toShortString());
     result.success(canLaunch);
   }
 
   private void launch(MethodCall call, Result result, String url) {
     Intent launchIntent;
-    boolean useWebView = call.argument("useWebView");
-    boolean enableJavaScript = call.argument("enableJavaScript");
-    boolean enableDomStorage = call.argument("enableDomStorage");
-    Activity activity = mRegistrar.activity();
+    final boolean useWebView = call.argument("useWebView");
+    final boolean enableJavaScript = call.argument("enableJavaScript");
+    final boolean enableDomStorage = call.argument("enableDomStorage");
+    final Map<String, String> headersMap = call.argument("headers");
+    final Activity activity = mRegistrar.activity();
+
     if (activity == null) {
       result.error("NO_ACTIVITY", "Launching a URL requires a foreground activity.", null);
       return;
@@ -83,6 +91,10 @@ public class UrlLauncherPlugin implements MethodCallHandler {
       launchIntent = new Intent(Intent.ACTION_VIEW);
       launchIntent.setData(Uri.parse(url));
     }
+
+    final Bundle headersBundle = extractBundle(headersMap);
+    launchIntent.putExtra(Browser.EXTRA_HEADERS, headersBundle);
+
     activity.startActivity(launchIntent);
     result.success(true);
   }
@@ -91,6 +103,15 @@ public class UrlLauncherPlugin implements MethodCallHandler {
     Intent intent = new Intent("close");
     mRegistrar.context().sendBroadcast(intent);
     result.success(null);
+  }
+
+  private Bundle extractBundle(Map<String, String> headersMap) {
+    final Bundle headersBundle = new Bundle();
+    for (String key : headersMap.keySet()) {
+      final String value = headersMap.get(key);
+      headersBundle.putString(key, value);
+    }
+    return headersBundle;
   }
 
   /*  Launches WebView activity */
@@ -104,23 +125,37 @@ public class UrlLauncherPlugin implements MethodCallHandler {
       webview = new WebView(this);
       setContentView(webview);
       // Get the Intent that started this activity and extract the string
-      Intent intent = getIntent();
-      String url = intent.getStringExtra("url");
-      Boolean enableJavaScript = intent.getBooleanExtra("enableJavaScript", false);
-      Boolean enableDomStorage = intent.getBooleanExtra("enableDomStorage", false);
-      webview.loadUrl(url);
-      if (enableJavaScript) {
-        webview.getSettings().setJavaScriptEnabled(enableJavaScript);
-      }
-      if (enableDomStorage) {
-        webview.getSettings().setDomStorageEnabled(enableDomStorage);
-      }
+      final Intent intent = getIntent();
+      final String url = intent.getStringExtra("url");
+      final boolean enableJavaScript = intent.getBooleanExtra("enableJavaScript", false);
+      final boolean enableDomStorage = intent.getBooleanExtra("enableDomStorage", false);
+      final Bundle headersBundle = intent.getBundleExtra(Browser.EXTRA_HEADERS);
+
+      final Map<String, String> headersMap = extractHeaders(headersBundle);
+      webview.loadUrl(url, headersMap);
+
+      webview.getSettings().setJavaScriptEnabled(enableJavaScript);
+      webview.getSettings().setDomStorageEnabled(enableDomStorage);
+
       // Open new urls inside the webview itself.
       webview.setWebViewClient(
           new WebViewClient() {
+
+            @Override
+            @SuppressWarnings("deprecation")
+            public boolean shouldOverrideUrlLoading(WebView view, String url) {
+              if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+                view.loadUrl(url);
+                return false;
+              }
+              return super.shouldOverrideUrlLoading(view, url);
+            }
+
             @Override
             public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
-              view.loadUrl(request.getUrl().toString());
+              if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                view.loadUrl(request.getUrl().toString());
+              }
               return false;
             }
           });
@@ -137,6 +172,15 @@ public class UrlLauncherPlugin implements MethodCallHandler {
             }
           };
       registerReceiver(broadcastReceiver, new IntentFilter("close"));
+    }
+
+    private Map<String, String> extractHeaders(Bundle headersBundle) {
+      final Map<String, String> headersMap = new HashMap<>();
+      for (String key : headersBundle.keySet()) {
+        final String value = headersBundle.getString(key);
+        headersMap.put(key, value);
+      }
+      return headersMap;
     }
 
     @Override

--- a/packages/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/UrlLauncherPlugin.java
+++ b/packages/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/UrlLauncherPlugin.java
@@ -18,10 +18,8 @@ import android.view.KeyEvent;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
-
 import java.util.HashMap;
 import java.util.Map;
-
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
@@ -66,7 +64,7 @@ public class UrlLauncherPlugin implements MethodCallHandler {
     boolean canLaunch =
         componentName != null
             && !"{com.android.fallback/com.android.fallback.Fallback}"
-            .equals(componentName.toShortString());
+                .equals(componentName.toShortString());
     result.success(canLaunch);
   }
 
@@ -127,8 +125,10 @@ public class UrlLauncherPlugin implements MethodCallHandler {
       // Get the Intent that started this activity and extract the string
       final Intent intent = getIntent();
       final String url = intent.getStringExtra("url");
-      final boolean enableJavaScript = intent.getBooleanExtra("enableJavaScript", false);
-      final boolean enableDomStorage = intent.getBooleanExtra("enableDomStorage", false);
+      final boolean enableJavaScript =
+        intent.getBooleanExtra("enableJavaScript", false);
+      final boolean enableDomStorage =
+        intent.getBooleanExtra("enableDomStorage", false);
       final Bundle headersBundle = intent.getBundleExtra(Browser.EXTRA_HEADERS);
 
       final Map<String, String> headersMap = extractHeaders(headersBundle);
@@ -139,38 +139,38 @@ public class UrlLauncherPlugin implements MethodCallHandler {
 
       // Open new urls inside the webview itself.
       webview.setWebViewClient(
-          new WebViewClient() {
+        new WebViewClient() {
 
-            @Override
-            @SuppressWarnings("deprecation")
-            public boolean shouldOverrideUrlLoading(WebView view, String url) {
-              if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-                view.loadUrl(url);
-                return false;
-              }
-              return super.shouldOverrideUrlLoading(view, url);
-            }
-
-            @Override
-            public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
-              if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                view.loadUrl(request.getUrl().toString());
-              }
+          @Override
+          @SuppressWarnings("deprecation")
+          public boolean shouldOverrideUrlLoading(WebView view, String url) {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+              view.loadUrl(url);
               return false;
             }
-          });
+            return super.shouldOverrideUrlLoading(view, url);
+          }
+
+          @Override
+          public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+              view.loadUrl(request.getUrl().toString());
+            }
+            return false;
+          }
+        });
 
       // Set broadcast receiver to handle calls to close the web view
       broadcastReceiver =
-          new BroadcastReceiver() {
-            @Override
-            public void onReceive(Context arg0, Intent intent) {
-              String action = intent.getAction();
-              if ("close".equals(action)) {
-                finish();
-              }
+        new BroadcastReceiver() {
+          @Override
+          public void onReceive(Context arg0, Intent intent) {
+            String action = intent.getAction();
+            if ("close".equals(action)) {
+              finish();
             }
-          };
+          }
+        };
       registerReceiver(broadcastReceiver, new IntentFilter("close"));
     }
 

--- a/packages/url_launcher/example/lib/main.dart
+++ b/packages/url_launcher/example/lib/main.dart
@@ -38,9 +38,12 @@ class _MyHomePageState extends State<MyHomePage> {
 
   Future<void> _launchInBrowser(String url) async {
     if (await canLaunch(url)) {
-      await launch(url, forceSafariVC: false, forceWebView: false, headers: <String, String>{
-        'my_header_key': 'my_header_value'
-      });
+      await launch(
+        url,
+        forceSafariVC: false,
+        forceWebView: false,
+        headers: <String, String>{'my_header_key': 'my_header_value'},
+      );
     } else {
       throw 'Could not launch $url';
     }
@@ -48,9 +51,12 @@ class _MyHomePageState extends State<MyHomePage> {
 
   Future<void> _launchInWebViewOrVC(String url) async {
     if (await canLaunch(url)) {
-      await launch(url, forceSafariVC: true, forceWebView: true, headers: <String, String>{
-        'my_header_key': 'my_header_value'
-      });
+      await launch(
+        url,
+        forceSafariVC: true,
+        forceWebView: true,
+        headers: <String, String>{'my_header_key': 'my_header_value'},
+      );
     } else {
       throw 'Could not launch $url';
     }

--- a/packages/url_launcher/example/lib/main.dart
+++ b/packages/url_launcher/example/lib/main.dart
@@ -38,7 +38,7 @@ class _MyHomePageState extends State<MyHomePage> {
 
   Future<void> _launchInBrowser(String url) async {
     if (await canLaunch(url)) {
-      await launch(url, forceSafariVC: false, forceWebView: false, headers: {
+      await launch(url, forceSafariVC: false, forceWebView: false, headers: <String, String>{
         'my_header_key': 'my_header_value'
       });
     } else {
@@ -48,7 +48,7 @@ class _MyHomePageState extends State<MyHomePage> {
 
   Future<void> _launchInWebViewOrVC(String url) async {
     if (await canLaunch(url)) {
-      await launch(url, forceSafariVC: true, forceWebView: true, headers: {
+      await launch(url, forceSafariVC: true, forceWebView: true, headers: <String, String>{
         'my_header_key': 'my_header_value'
       });
     } else {

--- a/packages/url_launcher/example/lib/main.dart
+++ b/packages/url_launcher/example/lib/main.dart
@@ -38,7 +38,9 @@ class _MyHomePageState extends State<MyHomePage> {
 
   Future<void> _launchInBrowser(String url) async {
     if (await canLaunch(url)) {
-      await launch(url, forceSafariVC: false, forceWebView: false);
+      await launch(url, forceSafariVC: false, forceWebView: false, headers: {
+        'my_header_key': 'my_header_value'
+      });
     } else {
       throw 'Could not launch $url';
     }
@@ -46,7 +48,9 @@ class _MyHomePageState extends State<MyHomePage> {
 
   Future<void> _launchInWebViewOrVC(String url) async {
     if (await canLaunch(url)) {
-      await launch(url, forceSafariVC: true, forceWebView: true);
+      await launch(url, forceSafariVC: true, forceWebView: true, headers: {
+        'my_header_key': 'my_header_value'
+      });
     } else {
       throw 'Could not launch $url';
     }
@@ -112,7 +116,7 @@ class _MyHomePageState extends State<MyHomePage> {
 
   @override
   Widget build(BuildContext context) {
-    const String toLaunch = 'https://flutter.io';
+    const String toLaunch = 'https://www.cylog.org/headers/';
     return Scaffold(
       appBar: AppBar(
         title: Text(widget.title),

--- a/packages/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/lib/url_launcher.dart
@@ -44,6 +44,7 @@ const MethodChannel _channel = MethodChannel('plugins.flutter.io/url_launcher');
 /// javascript.
 /// [enableDomStorage] is an Android only setting. If true, WebView enable
 /// DOM storage.
+/// [headers] is an Android only setting that adds headers to the WebView.
 ///
 /// Note that if any of the above are set to true but the URL is not a web URL,
 /// this will throw a [PlatformException].

--- a/packages/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/lib/url_launcher.dart
@@ -61,6 +61,7 @@ Future<bool> launch(
   bool enableJavaScript,
   bool enableDomStorage,
   bool universalLinksOnly,
+  Map<String, String> headers,
   Brightness statusBarBrightness,
 }) async {
   assert(urlString != null);
@@ -91,6 +92,7 @@ Future<bool> launch(
       'enableJavaScript': enableJavaScript ?? false,
       'enableDomStorage': enableDomStorage ?? false,
       'universalLinksOnly': universalLinksOnly ?? false,
+      'headers': headers ?? <String, String>{},
     },
   );
   if (statusBarBrightness != null) {

--- a/packages/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for launching a URL on Android and iOS. Supports
   web, phone, SMS, and email schemes.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher
-version: 5.0.5
+version: 5.0.6
 
 flutter:
   plugin:

--- a/packages/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for launching a URL on Android and iOS. Supports
   web, phone, SMS, and email schemes.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher
-version: 5.0.6
+version: 5.1.0
 
 flutter:
   plugin:

--- a/packages/url_launcher/test/url_launcher_test.dart
+++ b/packages/url_launcher/test/url_launcher_test.dart
@@ -42,6 +42,26 @@ void main() {
           'enableJavaScript': false,
           'enableDomStorage': false,
           'universalLinksOnly': false,
+          'headers': <String, String>{},
+        })
+      ],
+    );
+  });
+
+  test('launch with headers', () async {
+    await launch('http://example.com/',
+      headers: <String, String>{ 'key': 'value' },);
+    expect(
+      log,
+      <Matcher>[
+        isMethodCall('launch', arguments: <String, Object>{
+          'url': 'http://example.com/',
+          'useSafariVC': true,
+          'useWebView': false,
+          'enableJavaScript': false,
+          'enableDomStorage': false,
+          'universalLinksOnly': false,
+          'headers': <String, String>{ 'key': 'value' },
         })
       ],
     );
@@ -59,6 +79,7 @@ void main() {
           'enableJavaScript': false,
           'enableDomStorage': false,
           'universalLinksOnly': false,
+          'headers': <String, String>{},
         })
       ],
     );
@@ -77,6 +98,7 @@ void main() {
           'enableJavaScript': false,
           'enableDomStorage': false,
           'universalLinksOnly': true,
+          'headers': <String, String>{},
         })
       ],
     );
@@ -94,6 +116,7 @@ void main() {
           'enableJavaScript': false,
           'enableDomStorage': false,
           'universalLinksOnly': false,
+          'headers': <String, String>{},
         })
       ],
     );
@@ -112,6 +135,7 @@ void main() {
           'enableJavaScript': true,
           'enableDomStorage': false,
           'universalLinksOnly': false,
+          'headers': <String, String>{},
         })
       ],
     );
@@ -130,6 +154,7 @@ void main() {
           'enableJavaScript': false,
           'enableDomStorage': true,
           'universalLinksOnly': false,
+          'headers': <String, String>{},
         })
       ],
     );
@@ -147,6 +172,7 @@ void main() {
           'enableJavaScript': false,
           'enableDomStorage': false,
           'universalLinksOnly': false,
+          'headers': <String, String>{},
         })
       ],
     );

--- a/packages/url_launcher/test/url_launcher_test.dart
+++ b/packages/url_launcher/test/url_launcher_test.dart
@@ -49,8 +49,10 @@ void main() {
   });
 
   test('launch with headers', () async {
-    await launch('http://example.com/',
-      headers: <String, String>{ 'key': 'value' },);
+    await launch(
+      'http://example.com/',
+      headers: <String, String>{'key': 'value'},
+    );
     expect(
       log,
       <Matcher>[
@@ -61,7 +63,7 @@ void main() {
           'enableJavaScript': false,
           'enableDomStorage': false,
           'universalLinksOnly': false,
-          'headers': <String, String>{ 'key': 'value' },
+          'headers': <String, String>{'key': 'value'},
         })
       ],
     );


### PR DESCRIPTION
## Description
This PR enables the developer to send headers to the Android browser.
This enables the developer to keep the app session in the browser when the same authentication header is used in the app http requests and the in the web site.

## Checklist

- [ X I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [X] No, this is *not* a breaking change.
