### PR TITLE
[android alarm manager] Fix crash below API 19

### DIFF
--- a/packages/android_alarm_manager/CHANGELOG.md
+++ b/packages/android_alarm_manager/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.4.1+7
 
-* Fix possible crash on APIs below 19.
+* Fix possible crash on Android devices with APIs below 19.
 
 ## 0.4.1+6
 

--- a/packages/android_alarm_manager/CHANGELOG.md
+++ b/packages/android_alarm_manager/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1+7
+
+* Fix possible crash on APIs below 19
+
 ## 0.4.1+6
 
 * Bump the minimum Flutter version to 1.2.0.

--- a/packages/android_alarm_manager/CHANGELOG.md
+++ b/packages/android_alarm_manager/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.4.1+7
 
-* Fix possible crash on APIs below 19
+* Fix possible crash on APIs below 19.
 
 ## 0.4.1+6
 

--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AlarmService.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AlarmService.java
@@ -9,7 +9,6 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.os.Build;
 import android.os.Handler;
 import android.util.Log;
 import androidx.core.app.AlarmManagerCompat;
@@ -407,12 +406,7 @@ public class AlarmService extends JobIntentService {
               false,
               callbackHandle);
         } catch (JSONException e) {
-          Log.e(
-              TAG,
-              "Data for alarm request code "
-                  + requestCode
-                  + " is invalid: "
-                  + json);
+          Log.e(TAG, "Data for alarm request code " + requestCode + " is invalid: " + json);
         }
       }
     }

--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/RebootBroadcastReceiver.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/RebootBroadcastReceiver.java
@@ -32,7 +32,6 @@ public class RebootBroadcastReceiver extends BroadcastReceiver {
    */
   @Override
   public void onReceive(Context context, Intent intent) {
-
     if (Intent.ACTION_BOOT_COMPLETED.equals(intent.getAction())) {
       Log.i("AlarmService", "Rescheduling after boot!");
       AlarmService.reschedulePersistentAlarms(context);

--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/RebootBroadcastReceiver.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/RebootBroadcastReceiver.java
@@ -32,7 +32,8 @@ public class RebootBroadcastReceiver extends BroadcastReceiver {
    */
   @Override
   public void onReceive(Context context, Intent intent) {
-    if (intent.getAction().equals("android.intent.action.BOOT_COMPLETED")) {
+
+    if (Intent.ACTION_BOOT_COMPLETED.equals(intent.getAction())) {
       Log.i("AlarmService", "Rescheduling after boot!");
       AlarmService.reschedulePersistentAlarms(context);
     }

--- a/packages/android_alarm_manager/pubspec.yaml
+++ b/packages/android_alarm_manager/pubspec.yaml
@@ -1,7 +1,7 @@
 name: android_alarm_manager
 description: Flutter plugin for accessing the Android AlarmManager service, and
   running Dart code in the background when alarms fire.
-version: 0.4.1+6
+version: 0.4.1+7
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/android_alarm_manager
 


### PR DESCRIPTION
## Description

- This PR fixes a possible crash on APIs below 19 when requesting an exact time alarm.
- I did some clean up as the IDE was complaining about it.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [X] No, this is *not* a breaking change.