### PR TITLE
[firebase_analytics] add missing named events tracking

### DIFF
--- a/packages/firebase_analytics/CHANGELOG.md
+++ b/packages/firebase_analytics/CHANGELOG.md
@@ -1,13 +1,12 @@
-## 3.1.0
+## 4.0.0
 
 * Include missing tracking events:
  - `logLevelStart`
  - `logLevelEnd`
  - `logRemoveFromCart`
  - `logSetCheckoutOption`
-
 * Update the list of reserved event names.
-* Add new required parameter to `logShare` event tracking.
+* **Breaking change**. Add new required parameter to `logShare` event tracking.
 
 ## 3.0.3
 

--- a/packages/firebase_analytics/CHANGELOG.md
+++ b/packages/firebase_analytics/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 3.1.0
+
+* Include missing tracking events:
+ - `logLevelStart`
+ - `logLevelEnd`
+ - `logRemoveFromCart`
+ - `logSetCheckoutOption`
+
+* Update the list of reserved event names.
+* Add new required parameter to `logShare` event tracking.
+
 ## 3.0.3
 
 * Automatically use version from pubspec.yaml when reporting usage to Firebase.

--- a/packages/firebase_analytics/CHANGELOG.md
+++ b/packages/firebase_analytics/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## 4.0.0
 
 * Include missing tracking events:
- - `logLevelStart`
- - `logLevelEnd`
- - `logRemoveFromCart`
- - `logSetCheckoutOption`
+  - `logLevelStart`
+  - `logLevelEnd`
+  - `logRemoveFromCart`
+  - `logSetCheckoutOption`
 * Update the list of reserved event names.
 * **Breaking change**. Add new required parameter to `logShare` event tracking.
 

--- a/packages/firebase_analytics/CHANGELOG.md
+++ b/packages/firebase_analytics/CHANGELOG.md
@@ -1,12 +1,20 @@
 ## 4.0.0
 
-* Include missing tracking events:
+* Added new tracking events:
   - `logLevelStart`
   - `logLevelEnd`
   - `logRemoveFromCart`
   - `logSetCheckoutOption`
-* Update the list of reserved event names.
-* **Breaking change**. Add new required parameter to `logShare` event tracking.
+* **Breaking change**. Add new required parameter `method` to `logShare` event tracking.
+* **Breaking change**. The following event names are reserved and cannot be used:
+  - `ad_activeview`
+  - `ad_click`
+  - `ad_exposure`
+  - `ad_impression`
+  - `ad_query`
+  - `adunit_exposure`
+  - `first_visit`
+  - `screen_view`
 
 ## 3.0.3
 

--- a/packages/firebase_analytics/example/lib/main.dart
+++ b/packages/firebase_analytics/example/lib/main.dart
@@ -227,10 +227,9 @@ class _MyHomePageState extends State<MyHomePage> {
       itemId: 'test item id',
     );
     await analytics.logShare(
-      contentType: 'test content type',
-      itemId: 'test item id',
-      method: 'facebook'
-    );
+        contentType: 'test content type',
+        itemId: 'test item id',
+        method: 'facebook');
     await analytics.logSignUp(
       signUpMethod: 'test sign up method',
     );

--- a/packages/firebase_analytics/example/lib/main.dart
+++ b/packages/firebase_analytics/example/lib/main.dart
@@ -229,6 +229,7 @@ class _MyHomePageState extends State<MyHomePage> {
     await analytics.logShare(
       contentType: 'test content type',
       itemId: 'test item id',
+      method: 'facebook'
     );
     await analytics.logSignUp(
       signUpMethod: 'test sign up method',

--- a/packages/firebase_analytics/lib/firebase_analytics.dart
+++ b/packages/firebase_analytics/lib/firebase_analytics.dart
@@ -446,6 +446,36 @@ class FirebaseAnalytics {
     );
   }
 
+  /// Logs the standard `level_start` event.
+  ///
+  /// See: https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.Event.html#LEVEL_START
+  Future<void> logLevelStart({
+    @required int levelName,
+  }) {
+    return logEvent(
+      name: 'level_start',
+      parameters: filterOutNulls(<String, dynamic>{
+        _LEVEL_NAME: levelName,
+      }),
+    );
+  }
+
+  /// Logs the standard `level_end` event.
+  ///
+  /// See: https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.Event.html#LEVEL_END
+  Future<void> logLevelEnd({
+    @required int levelName,
+    String success,
+  }) {
+    return logEvent(
+      name: 'level_end',
+      parameters: filterOutNulls(<String, dynamic>{
+        _LEVEL_NAME: levelName,
+        _SUCCESS: success,
+      }),
+    );
+  }
+
   /// Logs the standard `login` event.
   ///
   /// Apps with a login feature can report this event to signify that a user
@@ -544,6 +574,44 @@ class FirebaseAnalytics {
     );
   }
 
+  /// Logs the standard `remove_from_cart` event.
+  /// See: https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.Event.html#REMOVE_FROM_CART
+  Future<void> logRemoveFromCart({
+    @required String itemId,
+    @required String itemName,
+    @required String itemCategory,
+    @required int quantity,
+    double price,
+    double value,
+    String currency,
+    String origin,
+    String itemLocationId,
+    String destination,
+    String startDate,
+    String endDate,
+  }) {
+    _requireValueAndCurrencyTogether(value, currency);
+
+    return logEvent(
+      name: 'remove_from_cart',
+      parameters: filterOutNulls(<String, dynamic>{
+        _QUANTITY: quantity,
+        _ITEM_CATEGORY: itemCategory,
+        _ITEM_NAME: itemName,
+        _ITEM_ID: itemId,
+        _VALUE: value,
+        _PRICE: price,
+        _CURRENCY: currency,
+        _ITEM_LOCATION_ID: itemLocationId,
+        _ORIGIN: origin,
+        _START_DATE: startDate,
+        _END_DATE: endDate,
+        _DESTINATION: destination,
+      }),
+    );
+  }
+
+
   /// Logs the standard `search` event.
   ///
   /// Apps that support search features can use this event to contextualize
@@ -599,6 +667,21 @@ class FirebaseAnalytics {
     );
   }
 
+  /// Logs the standard `set_checkout_option` event.
+  /// See: https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.Event.html#SET_CHECKOUT_OPTION
+  Future<void> logSetCheckoutOption({
+    @required int checkoutStep,
+    @required String checkoutOption,
+  }) {
+    return logEvent(
+      name: 'set_checkout_option',
+      parameters: filterOutNulls(<String, dynamic>{
+        _CHECKOUT_STEP: checkoutStep,
+        _CHECKOUT_OPTION: checkoutOption,
+      }),
+    );
+  }
+
   /// Logs the standard `share` event.
   ///
   /// Apps with social features can log the Share event to identify the most
@@ -608,12 +691,14 @@ class FirebaseAnalytics {
   Future<void> logShare({
     @required String contentType,
     @required String itemId,
+    @required String method,
   }) {
     return logEvent(
       name: 'share',
       parameters: filterOutNulls(<String, dynamic>{
         _CONTENT_TYPE: contentType,
         _ITEM_ID: itemId,
+        _METHOD: method,
       }),
     );
   }
@@ -861,17 +946,25 @@ void _requireValueAndCurrencyTogether(double value, String currency) {
 ///
 /// See: https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.Event.html
 const List<String> _reservedEventNames = <String>[
+  'ad_activeview',
+  'ad_click',
+  'ad_exposure',
+  'ad_impression',
+  'ad_query',
+  'adunit_exposure',
   'app_clear_data',
   'app_uninstall',
   'app_update',
   'error',
   'first_open',
+  'first_visit',
   'in_app_purchase',
   'notification_dismiss',
   'notification_foreground',
   'notification_open',
   'notification_receive',
   'os_update',
+  'screen_view',
   'session_start',
   'user_engagement',
 ];
@@ -915,6 +1008,11 @@ const String _DESTINATION = 'destination';
 /// The arrival date, check-out date, or rental end date for the item.
 const String _END_DATE = 'end_date';
 
+/// Indicates that the associated event should either
+/// extend the current session or start a new session
+/// if no session was active when the event was logged.
+// const String _EXTENDED_SESSION = 'extend_session';
+
 /// Flight number for travel events.
 const String _FLIGHT_NUMBER = 'flight_number';
 
@@ -930,14 +1028,49 @@ const String _ITEM_ID = 'item_id';
 /// The Google Place ID that corresponds to the associated item.
 const String _ITEM_LOCATION_ID = 'item_location_id';
 
-/// Item name.
+/// Item Brand.
+// const String _ITEM_BRAND = 'item_brand';
+
+/// Item Variant.
+// const String _ITEM_VARIANT = 'item_variant';
+
+/// The list in which the item was presented to the user.
+// const String _ITEM_LIST = 'item_list';
+
+/// The checkout step (1..N).
+const String _CHECKOUT_STEP = 'checkout_step';
+
+/// Some option on a step in an ecommerce flow.
+const String _CHECKOUT_OPTION = 'checkout_option';
+
+/// The name of a creative used in a promotional spot.
+// const String _CREATIVE_NAME = 'creative_name';
+
+/// The name of a creative slot.
+// const String _CREATIVE_SLOT = 'creative_slot';
+
+/// The store or affiliation from which this transaction occurred.
+// const String _AFFILIATION = 'affiliation';
+
+/// The index of an item in a list.
+// const String _INDEX = 'index';
+
+/// Item name (String).
 const String _ITEM_NAME = 'item_name';
 
 /// Level in game (long).
 const String _LEVEL = 'level';
 
+/// The name of a level in a game (String).
+const String _LEVEL_NAME = 'level_name';
+
+/// The result of an operation (long).
+const String _SUCCESS = 'success';
+
 /// Location.
 const String _LOCATION = 'location';
+
+
 
 /// `CAMPAIGN_DETAILS` medium; used to identify a medium such as email or
 /// cost-per-click (cpc).

--- a/packages/firebase_analytics/lib/firebase_analytics.dart
+++ b/packages/firebase_analytics/lib/firebase_analytics.dart
@@ -450,7 +450,7 @@ class FirebaseAnalytics {
   ///
   /// See: https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.Event.html#LEVEL_START
   Future<void> logLevelStart({
-    @required int levelName,
+    @required String levelName,
   }) {
     return logEvent(
       name: 'level_start',
@@ -464,8 +464,8 @@ class FirebaseAnalytics {
   ///
   /// See: https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.Event.html#LEVEL_END
   Future<void> logLevelEnd({
-    @required int levelName,
-    String success,
+    @required String levelName,
+    int success,
   }) {
     return logEvent(
       name: 'level_end',
@@ -610,7 +610,6 @@ class FirebaseAnalytics {
       }),
     );
   }
-
 
   /// Logs the standard `search` event.
   ///
@@ -1069,8 +1068,6 @@ const String _SUCCESS = 'success';
 
 /// Location.
 const String _LOCATION = 'location';
-
-
 
 /// `CAMPAIGN_DETAILS` medium; used to identify a medium such as email or
 /// cost-per-click (cpc).

--- a/packages/firebase_analytics/pubspec.yaml
+++ b/packages/firebase_analytics/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Analytics for Firebase, an app measuremen
   solution that provides insight on app usage and user engagement on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_analytics
-version: 3.1.0
+version: 4.0.0
 
 flutter:
   plugin:

--- a/packages/firebase_analytics/pubspec.yaml
+++ b/packages/firebase_analytics/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Analytics for Firebase, an app measuremen
   solution that provides insight on app usage and user engagement on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_analytics
-version: 3.0.3
+version: 3.1.0
 
 flutter:
   plugin:

--- a/packages/firebase_analytics/test/firebase_analytics_test.dart
+++ b/packages/firebase_analytics/test/firebase_analytics_test.dart
@@ -220,6 +220,19 @@ void main() {
               level: 56,
             ));
 
+    smokeTest(
+        'level_start',
+        () => analytics.logLevelStart(
+              levelName: 'level-name',
+            ));
+
+    smokeTest(
+        'level_end',
+        () => analytics.logLevelEnd(
+              levelName: 'level-name',
+              success: 1,
+            ));
+
     smokeTest('login', () => analytics.logLogin());
 
     smokeTest(
@@ -263,6 +276,7 @@ void main() {
         () => analytics.logShare(
               contentType: 'test content type',
               itemId: 'test item id',
+              method: 'test method',
             ));
 
     smokeTest(
@@ -331,6 +345,16 @@ void main() {
       );
     });
 
+    testRequiresValueAndCurrencyTogether('logRemoveFromCart', () {
+      return analytics.logRemoveFromCart(
+        itemId: 'test-id',
+        itemName: 'test-name',
+        itemCategory: 'test-category',
+        quantity: 5,
+        value: 123.90,
+      );
+    });
+
     testRequiresValueAndCurrencyTogether('logAddToWishlist', () {
       return analytics.logAddToWishlist(
         itemId: 'test-id',
@@ -339,6 +363,11 @@ void main() {
         quantity: 5,
         value: 123.90,
       );
+    });
+
+    testRequiresValueAndCurrencyTogether('logSetCheckoutOption', () {
+      return analytics.logSetCheckoutOption(
+          checkoutOption: 'some option', checkoutStep: 1);
     });
 
     testRequiresValueAndCurrencyTogether('logBeginCheckout', () {

--- a/packages/firebase_analytics/test/firebase_analytics_test.dart
+++ b/packages/firebase_analytics/test/firebase_analytics_test.dart
@@ -323,6 +323,11 @@ void main() {
               searchTerm: 'test search term',
             ));
 
+    smokeTest('set_checkout_option', () {
+      return analytics.logSetCheckoutOption(
+          checkoutStep: 1, checkoutOption: 'some credit card');
+    });
+
     void testRequiresValueAndCurrencyTogether(
         String methodName, Future<void> testFn()) {
       test('$methodName requires value and currency together', () async {
@@ -363,11 +368,6 @@ void main() {
         quantity: 5,
         value: 123.90,
       );
-    });
-
-    testRequiresValueAndCurrencyTogether('logSetCheckoutOption', () {
-      return analytics.logSetCheckoutOption(
-          checkoutOption: 'some option', checkoutStep: 1);
     });
 
     testRequiresValueAndCurrencyTogether('logBeginCheckout', () {


### PR DESCRIPTION
## Description
This PR:
- add some named events for firebase analytics.
- updated `logShare` to require a third parameter.
- update the list of reserved event names.
- include some constants that are in the documentation, but are not used. (yet?)

## NOTE:  Should a new parameter in the `logShare` force major version update?

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [X] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.
