### PR TITLE
[webview_flutter] Support Flutter `TextInput`s

### DIFF
--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.10+1
+
+* Add support for simultaenous Flutter `TextInput` and WebView text fields.
+
 ## 0.3.10
 
 * Add partial WebView keyboard support for Android versions prior to N. Support

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/InputAwareWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/InputAwareWebView.java
@@ -118,12 +118,16 @@ final class InputAwareWebView extends WebView {
    * longer has focus.
    *
    * <p>The logic in {@link #checkInputConnectionProxy} forces input creation to happen on Webview's
-   * thread for all connections. We undo it here so usres will be able to go back to typing in
+   * thread for all connections. We undo it here so users will be able to go back to typing in
    * Flutter UIs as expected.
    */
   @Override
   public void clearFocus() {
     super.clearFocus();
+    if (proxyAdapterView == null) {
+      // No need to reset the InputConnection to the default thread if we've never changed it.
+      return;
+    }
     containerView.requestFocus();
     containerView.post(
         new Runnable() {

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/InputAwareWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/InputAwareWebView.java
@@ -112,4 +112,28 @@ final class InputAwareWebView extends WebView {
         });
     return super.checkInputConnectionProxy(view);
   }
+
+  /**
+   * Ensure that input creation happens back on {@link #containerView}'s thread once this view no
+   * longer has focus.
+   *
+   * <p>The logic in {@link #checkInputConnectionProxy} forces input creation to happen on Webview's
+   * thread for all connections. We undo it here so usres will be able to go back to typing in
+   * Flutter UIs as expected.
+   */
+  @Override
+  public void clearFocus() {
+    super.clearFocus();
+    containerView.requestFocus();
+    containerView.post(
+        new Runnable() {
+          @Override
+          public void run() {
+            containerView.onWindowFocusChanged(true);
+            InputMethodManager imm =
+                (InputMethodManager) getContext().getSystemService(INPUT_METHOD_SERVICE);
+            imm.isActive(containerView);
+          }
+        });
+  }
 }

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
-version: 0.3.10
+version: 0.3.10+1
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/webview_flutter
 


### PR DESCRIPTION
## Description

Adds logic to `InputAwareWebView#clearFocus` to reset input creation
back to the container view's thread whenever the WebView is unfocused.
Fixes issue where Flutter UIs could no longer receive InputConnections
because WebView was causing all connections to happen on WebView's IME
thread.

Manually tested using mklim/plugins@928c790.

## Related Issues

flutter/flutter#19718

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
