### PR TITLE
[webview_flutter] Fix input bug on route changes

### DIFF
--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.10+2
+
+* Fix InputConnection being lost when combined with route transitions.
+
 ## 0.3.10+1
 
 * Add support for simultaenous Flutter `TextInput` and WebView text fields.

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -261,5 +261,6 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
   @Override
   public void dispose() {
     methodChannel.setMethodCallHandler(null);
+    webView.dispose();
   }
 }

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/InputAwareWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/InputAwareWebView.java
@@ -89,31 +89,7 @@ final class InputAwareWebView extends WebView {
             /*containerView=*/ containerView,
             /*targetView=*/ view,
             /*imeHandler=*/ view.getHandler());
-    proxyAdapterView.requestFocus();
-    // This is the crucial trick that gets the InputConnection creation to happen on the correct
-    // thread.
-    // https://cs.chromium.org/chromium/src/content/public/android/java/src/org/chromium/content/browser/input/ThreadedInputConnectionFactory.java?l=169&rcl=f0698ee3e4483fad5b0c34159276f71cfaf81f3a
-    post(
-        new Runnable() {
-          @Override
-          public void run() {
-            InputMethodManager imm =
-                (InputMethodManager) getContext().getSystemService(INPUT_METHOD_SERVICE);
-            // This is a hack to make InputMethodManager believe that the proxy view now has focus.
-            // As a result, InputMethodManager will think that proxyAdapterView is focused, and will
-            // call getHandler() of the view when creating input connection.
-
-            // Step 1: Set proxyAdapterView as InputMethodManager#mNextServedView. This does not
-            // affect the real window focus.
-            proxyAdapterView.onWindowFocusChanged(true);
-
-            // Step 2: Have InputMethodManager focus in on proxyAdapterView. As a result, IMM will
-            // call onCreateInputConnection() on proxyAdapterView on the same thread as
-            // proxyAdapterView.getHandler(). It will also call subsequent InputConnection methods
-            // on this IME thread.
-            imm.isActive(containerView);
-          }
-        });
+    setInputConnectionThread(/*targetView=*/ proxyAdapterView);
     return super.checkInputConnectionProxy(view);
   }
 
@@ -135,7 +111,7 @@ final class InputAwareWebView extends WebView {
    * Ensure that input creation happens back on {@link #containerView}'s thread.
    *
    * <p>The logic in {@link #checkInputConnectionProxy} forces input creation to happen on Webview's
-   * thread for all connections. We undo it here so usres will be able to go back to typing in
+   * thread for all connections. We undo it here so users will be able to go back to typing in
    * Flutter UIs as expected.
    */
   private void resetInputConnection() {
@@ -143,14 +119,37 @@ final class InputAwareWebView extends WebView {
       // No need to reset the InputConnection to the default thread if we've never changed it.
       return;
     }
-    containerView.requestFocus();
+    setInputConnectionThread(/*targetView=*/ containerView);
+  }
+
+  /**
+   * This is the crucial trick that gets the InputConnection creation to happen on the correct
+   * thread.
+   * https://cs.chromium.org/chromium/src/content/public/android/java/src/org/chromium/content/browser/input/ThreadedInputConnectionFactory.java?l=169&rcl=f0698ee3e4483fad5b0c34159276f71cfaf81f3a
+   *
+   * <p>{@code targetView} should have a {@link View#getHandler} method with the thread that future
+   * InputConnections should be created on.
+   */
+  private void setInputConnectionThread(final View targetView) {
+    targetView.requestFocus();
     containerView.post(
         new Runnable() {
           @Override
           public void run() {
-            containerView.onWindowFocusChanged(true);
             InputMethodManager imm =
                 (InputMethodManager) getContext().getSystemService(INPUT_METHOD_SERVICE);
+            // This is a hack to make InputMethodManager believe that the proxy view now has focus.
+            // As a result, InputMethodManager will think that proxyAdapterView is focused, and will
+            // call getHandler() of the view when creating input connection.
+
+            // Step 1: Set proxyAdapterView as InputMethodManager#mNextServedView. This does not
+            // affect the real window focus.
+            targetView.onWindowFocusChanged(true);
+
+            // Step 2: Have InputMethodManager focus in on proxyAdapterView. As a result, IMM will
+            // call onCreateInputConnection() on proxyAdapterView on the same thread as
+            // proxyAdapterView.getHandler(). It will also call subsequent InputConnection methods
+            // on this IME thread.
             imm.isActive(containerView);
           }
         });

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
-version: 0.3.10+1
+version: 0.3.10+2
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/webview_flutter
 


### PR DESCRIPTION
## Description

Fixes bug where the InputConnection proxy view was persisting across
multiple WebView creation calls.

Manually tested with mklim/plugins@3e033be.

## Related Issues

flutter/flutter#19718

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
