### PR TITLE
Update CODEWNERS for google_maps_flutter and webview_flutter

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -21,7 +21,7 @@ packages/firebase_ml_vision/* @bparrishMines
 packages/firebase_performance/* @bparrishMines @collinjackson
 packages/firebase_remote_config/* @collinjackson @kroikie
 packages/firebase_storage/* @collinjackson @kroikie
-packages/google_maps_flutter/* @amirh @iskakaushik
+packages/google_maps_flutter/* @iskakaushik
 packages/google_sign_in/* @cyanglaz @mehmetf
 packages/image_picker/* @cyanglaz
 packages/in_app_purchase/* @mklim @cyanglaz
@@ -29,4 +29,4 @@ packages/package_info/* @cyanglaz
 packages/path_provider/* @collinjackson
 packages/shared_preferences/* @collinjackson
 packages/video_player/* @iskakaushik @cyanglaz
-packages/webview_flutter/* @amirh @iskakaushik
+packages/webview_flutter/* @amirh


### PR DESCRIPTION
As we're mainly using this to control notification updating to reflect
the current status of PR triage ownership.