### PR TITLE
[webview_flutter] Don't log unknown setting key for debuggingEnabled …

### DIFF
--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.10+3
+
+* Don't log an unknown setting key error for 'debuggingEnabled' on iOS.
+
 ## 0.3.10+2
 
 * Fix InputConnection being lost when combined with route transitions.

--- a/packages/webview_flutter/ios/Classes/FlutterWebView.m
+++ b/packages/webview_flutter/ios/Classes/FlutterWebView.m
@@ -74,6 +74,8 @@
     }];
     NSDictionary<NSString*, id>* settings = args[@"settings"];
     [self applySettings:settings];
+    // TODO(amirh): return an error if apply settings failed once it's possible to do so.
+    // https://github.com/flutter/flutter/issues/36228
 
     NSString* initialUrl = args[@"initialUrl"];
     if ([initialUrl isKindOfClass:[NSString class]]) {
@@ -118,8 +120,14 @@
 }
 
 - (void)onUpdateSettings:(FlutterMethodCall*)call result:(FlutterResult)result {
-  [self applySettings:[call arguments]];
-  result(nil);
+  NSString* error = [self applySettings:[call arguments]];
+  if (error == nil) {
+    result(nil);
+    return;
+  }
+  result([FlutterError errorWithCode:@"updateSettings_failed"
+                             message:error
+                             details:nil]);
 }
 
 - (void)onLoadUrl:(FlutterMethodCall*)call result:(FlutterResult)result {
@@ -228,7 +236,9 @@
   }
 }
 
-- (void)applySettings:(NSDictionary<NSString*, id>*)settings {
+// Returns nil when succesfull, or an error message when one or more keys are unknown.
+- (NSString*)applySettings:(NSDictionary<NSString*, id>*)settings {
+  NSMutableArray<NSString*>* unknownKeys = [[NSMutableArray alloc] init];
   for (NSString* key in settings) {
     if ([key isEqualToString:@"jsMode"]) {
       NSNumber* mode = settings[key];
@@ -236,10 +246,16 @@
     } else if ([key isEqualToString:@"hasNavigationDelegate"]) {
       NSNumber* hasDartNavigationDelegate = settings[key];
       _navigationDelegate.hasDartNavigationDelegate = [hasDartNavigationDelegate boolValue];
+    } else if ([key isEqualToString:@"debuggingEnabled"]) {
+      // no-op debugging is always enabled on iOS.
     } else {
-      NSLog(@"webview_flutter: unknown setting key: %@", key);
+      [unknownKeys addObject:key];
     }
   }
+  if ([unknownKeys count] == 0) {
+    return nil;
+  }
+  return [NSString stringWithFormat:@"webview_flutter: unknown setting keys: {%@}", [unknownKeys componentsJoinedByString:@", "]];
 }
 
 - (void)updateJsMode:(NSNumber*)mode {

--- a/packages/webview_flutter/ios/Classes/FlutterWebView.m
+++ b/packages/webview_flutter/ios/Classes/FlutterWebView.m
@@ -125,9 +125,7 @@
     result(nil);
     return;
   }
-  result([FlutterError errorWithCode:@"updateSettings_failed"
-                             message:error
-                             details:nil]);
+  result([FlutterError errorWithCode:@"updateSettings_failed" message:error details:nil]);
 }
 
 - (void)onLoadUrl:(FlutterMethodCall*)call result:(FlutterResult)result {
@@ -255,7 +253,8 @@
   if ([unknownKeys count] == 0) {
     return nil;
   }
-  return [NSString stringWithFormat:@"webview_flutter: unknown setting keys: {%@}", [unknownKeys componentsJoinedByString:@", "]];
+  return [NSString stringWithFormat:@"webview_flutter: unknown setting keys: {%@}",
+                                    [unknownKeys componentsJoinedByString:@", "]];
 }
 
 - (void)updateJsMode:(NSNumber*)mode {

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
-version: 0.3.10+2
+version: 0.3.10+3
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/webview_flutter
 


### PR DESCRIPTION
…on iOS

## Description

The debuggingEnabled setting key is not used by the iOS implementation, and was logging an error.
Updated the iOS code to explicitly ignore that key.

## Related Issues

https://github.com/flutter/flutter/issues/34620

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
