### PR TITLE
[image_picker] Fix a crash when user takes a photo using devices under iOS 11.

### DIFF
--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.0+17
+
+* iOS: Fix a crash when user captures image from the camera with devices under iOS 11.
+
 ## 0.6.0+16
 
 * iOS Simulator: fix hang after trying to take an image from the non-existent camera.

--- a/packages/image_picker/example/ios/image_picker_exampleTests/PhotoAssetUtilTests.m
+++ b/packages/image_picker/example/ios/image_picker_exampleTests/PhotoAssetUtilTests.m
@@ -18,6 +18,11 @@
   self.testBundle = [NSBundle bundleForClass:self.class];
 }
 
+- (void)getAssetFromImagePickerInfoShouldReturnNilIfNotAvailable {
+  NSDictionary *mockData = @{};
+  XCTAssertNil([FLTImagePickerPhotoAssetUtil getAssetFromImagePickerInfo:mockData]);
+}
+
 - (void)testSaveImageWithOriginalImageData_ShouldSaveWithTheCorrectExtentionAndMetaData {
   // test jpg
   NSData *dataJPG = [NSData dataWithContentsOfFile:[self.testBundle pathForResource:@"jpgImage"

--- a/packages/image_picker/ios/Classes/FLTImagePickerPhotoAssetUtil.h
+++ b/packages/image_picker/ios/Classes/FLTImagePickerPhotoAssetUtil.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface FLTImagePickerPhotoAssetUtil : NSObject
 
-+ (PHAsset *)getAssetFromImagePickerInfo:(NSDictionary *)info;
++ (nullable PHAsset *)getAssetFromImagePickerInfo:(NSDictionary *)info;
 
 // Save image with correct meta data and extention copied from the original asset.
 // maxWidth and maxHeight are used only for GIF images.

--- a/packages/image_picker/ios/Classes/FLTImagePickerPhotoAssetUtil.m
+++ b/packages/image_picker/ios/Classes/FLTImagePickerPhotoAssetUtil.m
@@ -15,6 +15,9 @@
     return [info objectForKey:UIImagePickerControllerPHAsset];
   }
   NSURL *referenceURL = [info objectForKey:UIImagePickerControllerReferenceURL];
+  if (!referenceURL) {
+    return nil;
+  }
   PHFetchResult<PHAsset *> *result = [PHAsset fetchAssetsWithALAssetURLs:@[ referenceURL ]
                                                                  options:nil];
   return result.firstObject;

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -6,7 +6,7 @@ authors:
   - Rhodes Davis Jr. <rody.davis.jr@gmail.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
 
-version: 0.6.0+16
+version: 0.6.0+17
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

When the ` [info objectForKey:UIImagePickerControllerReferenceURL];` returns nil and adding the nil result to the asset array causes null pointer exception.

## Related Issues

https://github.com/flutter/flutter/issues/34691

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
