### PR TITLE
## Description

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,7 +8,10 @@ task:
     - flutter channel master
     - flutter upgrade
     - git fetch origin master
-  activate_script: pub global activate flutter_plugin_tools
+  activate_script:
+    - // TODO(jackson): Remove this line once the flutter_plugin_tools PR lands
+    - git clone git@github.com:collinjackson/flutter_plugin_tools.git -b ftl_demo
+    - pub global activate flutter_plugin_tools -s path
   matrix:
     - name: publishable
       script: ./script/check_publish.sh

--- a/packages/package_info/example/android/app/build.gradle
+++ b/packages/package_info/example/android/app/build.gradle
@@ -54,6 +54,8 @@ flutter {
 
 dependencies {
     testImplementation 'junit:junit:4.12'
+    androidTestImplementation 'androidx.test:core:1.0.0'
     androidTestImplementation 'androidx.test:runner:1.1.1'
+    androidTestImplementation 'androidx.test:rules:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
 }

--- a/packages/package_info/example/android/app/src/androidTest/java/io/flutter/plugins/packageinfoexample/FlutterJUnitRunner.java
+++ b/packages/package_info/example/android/app/src/androidTest/java/io/flutter/plugins/packageinfoexample/FlutterJUnitRunner.java
@@ -1,0 +1,71 @@
+package io.flutter.plugins.packageinfoexample;
+
+import androidx.test.rule.ActivityTestRule;
+import io.flutter.plugin.common.MethodCall;
+import io.flutter.plugin.common.MethodChannel;
+import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
+import io.flutter.plugin.common.MethodChannel.Result;
+import io.flutter.view.FlutterView;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.junit.runner.Description;
+import org.junit.runner.Runner;
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunNotifier;
+
+public class FlutterJUnitRunner extends Runner {
+
+    private static final String CHANNEL = "dev.flutter/InstrumentationTestFlutterBinding";
+    CompletableFuture<Map<String, String>> testResults;
+
+    public FlutterJUnitRunner(Class<?> klass) {
+        ActivityTestRule<MainActivity> rule = new ActivityTestRule<>(MainActivity.class);
+        MainActivity fa = rule.launchActivity(null);
+        FlutterView fv = fa.getFlutterView();
+        MethodChannel methodChannel = new MethodChannel(fv, CHANNEL);
+        testResults = new CompletableFuture<>();
+        methodChannel.setMethodCallHandler(
+                new MethodCallHandler() {
+                    @Override
+                    public void onMethodCall(MethodCall call, Result result) {
+                        if (call.method.equals("testFinished")) {
+                            Map<String, String> results = call.argument("results");
+                            testResults.complete(results);
+                            result.success(null);
+                        } else {
+                            result.notImplemented();
+                        }
+                    }
+                });
+    }
+
+    @Override
+    public Description getDescription() {
+        return Description.createTestDescription(MainActivity.class, "foobar");
+    }
+
+    @Override
+    public void run(RunNotifier notifier) {
+        Map<String, String> results = null;
+        try {
+            results = testResults.get();
+        } catch (ExecutionException e) {
+            e.printStackTrace();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        for (String name : results.keySet()) {
+            Description d = Description.createTestDescription(MainActivity.class, name);
+            notifier.fireTestStarted(d);
+            String outcome = results.get(name);
+            if (outcome.equals("failed")) {
+                Exception dummyException = new Exception(outcome);
+                notifier.fireTestFailure(new Failure(d, dummyException));
+            }
+            notifier.fireTestFinished(d);
+        }
+    }
+}

--- a/packages/package_info/example/android/app/src/androidTest/java/io/flutter/plugins/packageinfoexample/WidgetTests.java
+++ b/packages/package_info/example/android/app/src/androidTest/java/io/flutter/plugins/packageinfoexample/WidgetTests.java
@@ -1,0 +1,12 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.plugins.packageinfoexample;
+
+import org.junit.runner.RunWith;
+
+@RunWith(FlutterJUnitRunner.class)
+public class WidgetTests {
+  // This class is intentionally left blank.
+}

--- a/packages/package_info/example/android/run_test.sh
+++ b/packages/package_info/example/android/run_test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+./gradlew \
+    -Pverbose=true \
+    -Ptarget=$(pwd)/../test_driver/adapter.dart \
+    -Ptrack-widget-creation=false \
+    -Pfilesystem-scheme=org-dartlang-root \
+    connectedAndroidTest

--- a/packages/package_info/example/test_driver/package_info.dart
+++ b/packages/package_info/example/test_driver/package_info.dart
@@ -1,31 +1,11 @@
 import 'dart:async';
-import 'dart:io';
 import 'package:flutter_driver/driver_extension.dart';
-import 'package:flutter_test/flutter_test.dart';
-import 'package:package_info/package_info.dart';
+
+import '../test_live/package_info.dart' as live_test;
 
 void main() {
   final Completer<String> completer = Completer<String>();
   enableFlutterDriverExtension(handler: (_) => completer.future);
   tearDownAll(() => completer.complete(null));
-
-  group('package_info test driver', () {
-    testWidgets('test package info result', (_) async {
-      final PackageInfo info = await PackageInfo.fromPlatform();
-      // These tests are based on the example app. The tests should be updated if any related info changes.
-      if (Platform.isAndroid) {
-        expect(info.appName, 'package_info_example');
-        expect(info.buildNumber, '1');
-        expect(info.packageName, 'io.flutter.plugins.packageinfoexample');
-        expect(info.version, '1.0');
-      } else if (Platform.isIOS) {
-        expect(info.appName, 'Package Info Example');
-        expect(info.buildNumber, '1');
-        expect(info.packageName, 'io.flutter.plugins.packageInfoExample');
-        expect(info.version, '1.0');
-      } else {
-        throw (UnsupportedError('platform not supported'));
-      }
-    });
-  });
+  live_test.main();
 }

--- a/packages/package_info/example/test_driver/package_info.dart
+++ b/packages/package_info/example/test_driver/package_info.dart
@@ -10,7 +10,7 @@ void main() {
   tearDownAll(() => completer.complete(null));
 
   group('package_info test driver', () {
-    test('test package info result', () async {
+    testWidgets('test package info result', (_) async {
       final PackageInfo info = await PackageInfo.fromPlatform();
       // These tests are based on the example app. The tests should be updated if any related info changes.
       if (Platform.isAndroid) {

--- a/packages/package_info/example/test_live/package_info.dart
+++ b/packages/package_info/example/test_live/package_info.dart
@@ -1,0 +1,32 @@
+import 'dart:async';
+import 'dart:io';
+import 'package:flutter_driver/driver_extension.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:package_info/package_info.dart';
+
+
+void main() {
+  group('package_info test driver', () {
+    testWidgets('test package info result', (_) async {
+      final PackageInfo info = await PackageInfo.fromPlatform();
+      // These tests are based on the example app. The tests should be updated if any related info changes.
+      if (Platform.isAndroid) {
+        expect(info.appName, 'package_info_example');
+        expect(info.buildNumber, '1');
+        expect(info.packageName, 'io.flutter.plugins.packageinfoexample');
+        expect(info.version, '1.0');
+      } else if (Platform.isIOS) {
+        expect(info.appName, 'Package Info Example');
+        expect(info.buildNumber, '1');
+        expect(info.packageName, 'io.flutter.plugins.packageInfoExample');
+        expect(info.version, '1.0');
+      } else {
+        throw (UnsupportedError('platform not supported'));
+      }
+    });
+  });
+
+  testWidgets("failing test example", (WidgetTester tester) async {
+    expect(2 + 2, equals(5));
+  }, skip: true);
+}


### PR DESCRIPTION
This pull request demonstrates an Android instrumentation test included in a plugin package.

Ultimately I'd like to see the "flutter create" template include these instrumentation tests automatically, but first we need to try them out a bit with plugins.

## Related Issues

flutter/flutter#11718