### PR TITLE
[firebase_auth] Fix getIdToken refresh param on iOS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -40,3 +40,4 @@ Jonathan Younger <jonathan@daikini.com>
 Jose Sanchez <josesm82@gmail.com>
 Debkanchan Samadder <debu.samadder@gmail.com>
 Audrius Karosevicius <audrius.karosevicius@gmail.com>
+Lukasz Piliszczuk <lukasz@intheloup.io>

--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.11.1+11
+
+* On iOS, `getIdToken()` now properly takes in account the refresh parameter. It was previously ignored, and always set to `true`.
+
 ## 0.11.1+10
 
 * On Android, `providerData` now includes `UserInfo` for the phone authentication provider.

--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.11.1+11
 
-* On iOS, `getIdToken()` now properly takes in account the refresh parameter. It was previously ignored, and always set to `true`.
+* On iOS, `getIdToken()` now uses the `refresh` parameter instead of always using `true`.
 
 ## 0.11.1+10
 

--- a/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
+++ b/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
@@ -198,8 +198,10 @@ int nextHandle = 0;
       [self sendResult:result forObject:nil error:nil];
     }
   } else if ([@"getIdToken" isEqualToString:call.method]) {
+    NSDictionary *args = call.arguments;
+    BOOL refresh = [args objectForKey:@"refresh"];
     [[self getAuth:call.arguments].currentUser
-        getIDTokenForcingRefresh:YES
+        getIDTokenForcingRefresh:refresh
                       completion:^(NSString *_Nullable token, NSError *_Nullable error) {
                         [self sendResult:result forObject:token error:error];
                       }];

--- a/packages/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Firebase Auth, enabling Android and iOS
   like Google, Facebook and Twitter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_auth
-version: "0.11.1+10"
+version: "0.11.1+11"
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

The function `getIdToken()` takes a refresh parameter. 
This parameter is ignored on iOS, and hardcoded refresh = true is used. This PR fixes that.
No changes required on Android, the refresh parameter is properly taken in account.

## Related Issues


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
