### PR TITLE
Add some more CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,6 +5,8 @@
 # reviewed by someone else.
 
 packages/android_alarm_manager/* @bkonyi
+packages/android_intent/* @mklim
+packages/battery/* @amirh
 packages/camera/* @bparrishMines @mklim
 packages/cloud_firestore/* @collinjackson @kroikie
 packages/cloud_functions/* @collinjackson @kroikie
@@ -27,6 +29,8 @@ packages/image_picker/* @cyanglaz
 packages/in_app_purchase/* @mklim @cyanglaz
 packages/package_info/* @cyanglaz
 packages/path_provider/* @collinjackson
+packages/quick_actions/* @collinjackson
 packages/shared_preferences/* @collinjackson
+packages/url_launcher/* @mklim
 packages/video_player/* @iskakaushik @cyanglaz
 packages/webview_flutter/* @amirh


### PR DESCRIPTION
After this change, the only plugins that lack CODEOWNERS are device_info, local_auth, sensors, and share
