### PR TITLE
[firebase_ml_vision] Add getter for closing state of detector

### DIFF
--- a/packages/firebase_ml_vision/lib/src/barcode_detector.dart
+++ b/packages/firebase_ml_vision/lib/src/barcode_detector.dart
@@ -191,6 +191,8 @@ class BarcodeDetector {
   bool _hasBeenOpened = false;
   bool _isClosed = false;
 
+  bool get isClosed => _isClosed;
+
   /// Detects barcodes in the input image.
   Future<List<Barcode>> detectInImage(FirebaseVisionImage visionImage) async {
     assert(!_isClosed);

--- a/packages/firebase_ml_vision/lib/src/face_detector.dart
+++ b/packages/firebase_ml_vision/lib/src/face_detector.dart
@@ -46,6 +46,8 @@ class FaceDetector {
   bool _hasBeenOpened = false;
   bool _isClosed = false;
 
+  bool get isClosed => _isClosed;
+
   /// Detects faces in the input image.
   Future<List<Face>> processImage(FirebaseVisionImage visionImage) async {
     assert(!_isClosed);

--- a/packages/firebase_ml_vision/lib/src/image_labeler.dart
+++ b/packages/firebase_ml_vision/lib/src/image_labeler.dart
@@ -44,6 +44,8 @@ class ImageLabeler {
   bool _hasBeenOpened = false;
   bool _isClosed = false;
 
+  bool get isClosed => _isClosed;
+
   /// Finds entities in the input image.
   Future<List<ImageLabel>> processImage(FirebaseVisionImage visionImage) async {
     assert(!_isClosed);

--- a/packages/firebase_ml_vision/lib/src/text_recognizer.dart
+++ b/packages/firebase_ml_vision/lib/src/text_recognizer.dart
@@ -31,6 +31,8 @@ class TextRecognizer {
   bool _hasBeenOpened = false;
   bool _isClosed = false;
 
+  bool get isClosed => _isClosed;
+
   /// Detects [VisionText] from a [FirebaseVisionImage].
   Future<VisionText> processImage(FirebaseVisionImage visionImage) async {
     assert(!_isClosed);

--- a/packages/firebase_ml_vision/test/firebase_ml_vision_close_state_test.dart
+++ b/packages/firebase_ml_vision/test/firebase_ml_vision_close_state_test.dart
@@ -1,0 +1,39 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:firebase_ml_vision/firebase_ml_vision.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('$FirebaseVision', () {
+    test('Barcode Detector', () async {
+      final BarcodeDetector detector =
+          FirebaseVision.instance.barcodeDetector();
+      expect(detector.isClosed, isFalse);
+      await detector.close();
+      expect(detector.isClosed, isTrue);
+    });
+
+    test('Face Detector', () async {
+      final FaceDetector detector = FirebaseVision.instance.faceDetector();
+      expect(detector.isClosed, isFalse);
+      await detector.close();
+      expect(detector.isClosed, isTrue);
+    });
+
+    test('Text Recognizer', () async {
+      final TextRecognizer detector = FirebaseVision.instance.textRecognizer();
+      expect(detector.isClosed, isFalse);
+      await detector.close();
+      expect(detector.isClosed, isTrue);
+    });
+
+    test('Image Labeler', () async {
+      final ImageLabeler detector = FirebaseVision.instance.imageLabeler();
+      expect(detector.isClosed, isFalse);
+      await detector.close();
+      expect(detector.isClosed, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Description

Add a getter for each detector to get the _isClosed state, to enable control over when to call detectInImage/processImage. 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
