### PR TITLE
[share] Specify explicit type for invokeMethod & const for Rect

### DIFF
--- a/packages/share/CHANGELOG.md
+++ b/packages/share/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.6.2+1
 
 * Specify explicit type for `invokeMethod`.
+* Use `const` for `Rect`.
 
 ## 0.6.2
 

--- a/packages/share/CHANGELOG.md
+++ b/packages/share/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Specify explicit type for `invokeMethod`.
 * Use `const` for `Rect`.
+* Updated minimum Flutter SDK to 1.6.0.
 
 ## 0.6.2
 

--- a/packages/share/CHANGELOG.md
+++ b/packages/share/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.2+1
+
+* Specify explicit type for `invokeMethod`.
+
 ## 0.6.2
 
 * Add optional subject to fill email subject in case user selects email app.

--- a/packages/share/lib/share.dart
+++ b/packages/share/lib/share.dart
@@ -49,9 +49,6 @@ class Share {
       params['originHeight'] = sharePositionOrigin.height;
     }
 
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return channel.invokeMethod('share', params);
+    return channel.invokeMethod<void>('share', params);
   }
 }

--- a/packages/share/pubspec.yaml
+++ b/packages/share/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for sharing content via the platform share UI, using
   the ACTION_SEND intent on Android and UIActivityViewController on iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/share
-version: 0.6.2
+version: 0.6.2+1
 
 flutter:
   plugin:

--- a/packages/share/pubspec.yaml
+++ b/packages/share/pubspec.yaml
@@ -24,4 +24,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=0.1.4 <2.0.0"
+  flutter: ">=1.6.0 <2.0.0"

--- a/packages/share/test/share_test.dart
+++ b/packages/share/test/share_test.dart
@@ -17,10 +17,8 @@ void main() {
     mockChannel = MockMethodChannel();
     // Re-pipe to mockito for easier verifies.
     Share.channel.setMockMethodCallHandler((MethodCall call) async {
-      // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-      // https://github.com/flutter/flutter/issues/26431
-      // ignore: strong_mode_implicit_dynamic_method
-      mockChannel.invokeMethod(call.method, call.arguments);
+      // The explicit type can be void as the only method call has a return type of void.
+      mockChannel.invokeMethod<void>(call.method, call.arguments);
     });
   });
 
@@ -44,14 +42,9 @@ void main() {
     await Share.share(
       'some text to share',
       subject: 'some subject to share',
-      // TODO(jackson): Use const Rect when available in minimum Flutter SDK
-      // ignore: prefer_const_constructors
-      sharePositionOrigin: Rect.fromLTWH(1.0, 2.0, 3.0, 4.0),
+      sharePositionOrigin: const Rect.fromLTWH(1.0, 2.0, 3.0, 4.0),
     );
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    verify(mockChannel.invokeMethod('share', <String, dynamic>{
+    verify(mockChannel.invokeMethod<void>('share', <String, dynamic>{
       'text': 'some text to share',
       'subject': 'some subject to share',
       'originX': 1.0,


### PR DESCRIPTION
I was also wondering if there are plans to upgrade to Dart `2.2.2`. That would allow for putting the `sharePositionOrigin` parameters inside the map literal.