### PR TITLE
Recommend 4.3.0 version of google-services in READMEs/examples

### DIFF
--- a/packages/android_alarm_manager/CHANGELOG.md
+++ b/packages/android_alarm_manager/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1+8
+
+* Remove dependency on google-services in the Android example.
+
 ## 0.4.1+7
 
 * Fix possible crash on Android devices with APIs below 19.

--- a/packages/android_alarm_manager/example/android/build.gradle
+++ b/packages/android_alarm_manager/example/android/build.gradle
@@ -6,7 +6,6 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.0'
-        classpath 'com.google.gms:google-services:4.2.0'
     }
 }
 

--- a/packages/android_alarm_manager/pubspec.yaml
+++ b/packages/android_alarm_manager/pubspec.yaml
@@ -1,7 +1,7 @@
 name: android_alarm_manager
 description: Flutter plugin for accessing the Android AlarmManager service, and
   running Dart code in the background when alarms fire.
-version: 0.4.1+7
+version: 0.4.1+8
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/android_alarm_manager
 

--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.7+1
+
+* Update google-services Android gradle plugin to 4.3.0 in documentation and examples.
+
 ## 0.12.7
 
 * Methods of `Transaction` no longer require `await`.

--- a/packages/cloud_firestore/example/android/build.gradle
+++ b/packages/cloud_firestore/example/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.0'
-        classpath 'com.google.gms:google-services:4.2.0'
+        classpath 'com.google.gms:google-services:4.3.0'
     }
 }
 

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_firestore
-version: 0.12.7
+version: 0.12.7+1
 
 flutter:
   plugin:

--- a/packages/cloud_functions/CHANGELOG.md
+++ b/packages/cloud_functions/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0+3
+
+* Update google-services Android gradle plugin to 4.3.0 in documentation and examples.
+
 ## 0.4.0+2
 
 * Automatically use version from pubspec.yaml when reporting usage to Firebase.

--- a/packages/cloud_functions/example/android/build.gradle
+++ b/packages/cloud_functions/example/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.0'
-        classpath 'com.google.gms:google-services:4.2.0'
+        classpath 'com.google.gms:google-services:4.3.0'
     }
 }
 

--- a/packages/cloud_functions/pubspec.yaml
+++ b/packages/cloud_functions/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cloud_functions
 description: Flutter plugin for Cloud Functions.
-version: 0.4.0+2
+version: 0.4.0+3
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_functions
 

--- a/packages/firebase_admob/CHANGELOG.md
+++ b/packages/firebase_admob/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.0+3
+
+* Update google-services Android gradle plugin to 4.3.0 in documentation and examples.
+
 ## 0.9.0+2
 
 * On Android, no longer crashes when registering the plugin if no activity is available.

--- a/packages/firebase_admob/example/android/build.gradle
+++ b/packages/firebase_admob/example/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.0'
-        classpath 'com.google.gms:google-services:4.2.0'
+        classpath 'com.google.gms:google-services:4.3.0'
     }
 }
 

--- a/packages/firebase_admob/pubspec.yaml
+++ b/packages/firebase_admob/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase AdMob, supporting
   banner, interstitial (full-screen), and rewarded video ads
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_admob
-version: 0.9.0+2
+version: 0.9.0+3
 
 flutter:
   plugin:

--- a/packages/firebase_analytics/CHANGELOG.md
+++ b/packages/firebase_analytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.2
+
+* Update google-services Android gradle plugin to 4.3.0 in documentation and examples.
+
 ## 4.0.1
 
 * Refactor unit tests to use `setMockMethodCallHandler`.

--- a/packages/firebase_analytics/example/android/build.gradle
+++ b/packages/firebase_analytics/example/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.0'
-        classpath 'com.google.gms:google-services:4.2.0'
+        classpath 'com.google.gms:google-services:4.3.0'
     }
 }
 

--- a/packages/firebase_analytics/pubspec.yaml
+++ b/packages/firebase_analytics/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Analytics for Firebase, an app measuremen
   solution that provides insight on app usage and user engagement on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_analytics
-version: 4.0.1
+version: 4.0.2
 
 flutter:
   plugin:

--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.11.1+12
+
+* Update google-services Android gradle plugin to 4.3.0 in documentation and examples.
+
 ## 0.11.1+11
 
 * On iOS, `getIdToken()` now uses the `refresh` parameter instead of always using `true`.

--- a/packages/firebase_auth/README.md
+++ b/packages/firebase_auth/README.md
@@ -27,7 +27,7 @@ dependencies {
   // Example existing classpath
   classpath 'com.android.tools.build:gradle:3.2.1'
   // Add the google services classpath
-  classpath 'com.google.gms:google-services:4.2.0'
+  classpath 'com.google.gms:google-services:4.3.0'
 }
 ```
 

--- a/packages/firebase_auth/example/android/build.gradle
+++ b/packages/firebase_auth/example/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.1'
-        classpath 'com.google.gms:google-services:4.2.0'
+        classpath 'com.google.gms:google-services:4.3.0'
     }
 }
 

--- a/packages/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Firebase Auth, enabling Android and iOS
   like Google, Facebook and Twitter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_auth
-version: "0.11.1+11"
+version: "0.11.1+12"
 
 flutter:
   plugin:

--- a/packages/firebase_core/CHANGELOG.md
+++ b/packages/firebase_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0+7
+
+* Update google-services Android gradle plugin to 4.3.0 in documentation and examples.
+
 ## 0.4.0+6
 
 * Automatically use version from pubspec.yaml when reporting usage to Firebase.

--- a/packages/firebase_core/pubspec.yaml
+++ b/packages/firebase_core/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Core, enabling connecting to multiple
   Firebase apps.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_core
-version: 0.4.0+6
+version: 0.4.0+7
 
 flutter:
   plugin:

--- a/packages/firebase_crashlytics/CHANGELOG.md
+++ b/packages/firebase_crashlytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.4+12
+
+* Update google-services Android gradle plugin to 4.3.0 in documentation and examples.
+
 ## 0.0.4+11
 
 * Fixed an issue where `Crashlytics#getStackTraceElements` didn't handle functions without classes.

--- a/packages/firebase_crashlytics/README.md
+++ b/packages/firebase_crashlytics/README.md
@@ -35,7 +35,7 @@ dependencies {
   // Example existing classpath
   classpath 'com.android.tools.build:gradle:3.2.1'
   // Add the google services classpath
-  classpath 'com.google.gms:google-services:4.2.0'
+  classpath 'com.google.gms:google-services:4.3.0'
   // Add fabric classpath
   classpath 'io.fabric.tools:gradle:1.26.1'
 }

--- a/packages/firebase_crashlytics/example/android/build.gradle
+++ b/packages/firebase_crashlytics/example/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.2'
-        classpath 'com.google.gms:google-services:4.2.0'
+        classpath 'com.google.gms:google-services:4.3.0'
         classpath 'io.fabric.tools:gradle:1.26.1'
     }
 }

--- a/packages/firebase_crashlytics/pubspec.yaml
+++ b/packages/firebase_crashlytics/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_crashlytics
 description: Flutter plugin for Firebase Crashlytics. It reports uncaught errors to the
   Firebase console.
-version: 0.0.4+11
+version: 0.0.4+12
 author: Flutter Team <flutter-dev@google.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_crashlytics
 

--- a/packages/firebase_database/CHANGELOG.md
+++ b/packages/firebase_database/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.5
+
+* Update google-services Android gradle plugin to 4.3.0 in documentation and examples.
+
 ## 3.0.4
 
 * Updated transactions implementation on Android for compatibility with

--- a/packages/firebase_database/example/android/build.gradle
+++ b/packages/firebase_database/example/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.0'
-        classpath 'com.google.gms:google-services:4.2.0'
+        classpath 'com.google.gms:google-services:4.3.0'
     }
 }
 

--- a/packages/firebase_database/pubspec.yaml
+++ b/packages/firebase_database/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Database, a cloud-hosted NoSQL database
   with realtime data syncing across Android and iOS clients, and offline access.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_database
-version: 3.0.4
+version: 3.0.5
 
 flutter:
   plugin:

--- a/packages/firebase_dynamic_links/CHANGELOG.md
+++ b/packages/firebase_dynamic_links/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0+6
+
+* Update google-services Android gradle plugin to 4.3.0 in documentation and examples.
+
 ## 0.4.0+5
 
 * Fix the bug below properly by allowing the activity to be null (but still registering the plugin). If activity is null, we don't get a latestIntent, instead we expect the intent listener to grab it.

--- a/packages/firebase_dynamic_links/example/android/build.gradle
+++ b/packages/firebase_dynamic_links/example/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.0'
-        classpath 'com.google.gms:google-services:4.2.0'
+        classpath 'com.google.gms:google-services:4.3.0'
     }
 }
 

--- a/packages/firebase_dynamic_links/pubspec.yaml
+++ b/packages/firebase_dynamic_links/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_dynamic_links
 description: Flutter plugin for Google Dynamic Links for Firebase, an app solution for creating
   and handling links across multiple platforms.
-version: 0.4.0+5
+version: 0.4.0+6
 
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_dynamic_links

--- a/packages/firebase_in_app_messaging/CHANGELOG.md
+++ b/packages/firebase_in_app_messaging/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.1+1
+
+* Update google-services Android gradle plugin to 4.3.0 in documentation and examples.
+
 ## 0.0.1
 
 * Initial release.

--- a/packages/firebase_in_app_messaging/README.md
+++ b/packages/firebase_in_app_messaging/README.md
@@ -21,7 +21,7 @@ dependencies {
   // Example existing classpath
   classpath 'com.android.tools.build:gradle:3.3.0'
   // Add the google services classpath
-  classpath 'com.google.gms:google-services:4.2.0'
+  classpath 'com.google.gms:google-services:4.3.0'
 }
 ```
 

--- a/packages/firebase_in_app_messaging/example/android/build.gradle
+++ b/packages/firebase_in_app_messaging/example/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.0'
-        classpath 'com.google.gms:google-services:4.2.0'
+        classpath 'com.google.gms:google-services:4.3.0'
 
     }
 }

--- a/packages/firebase_in_app_messaging/pubspec.yaml
+++ b/packages/firebase_in_app_messaging/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_in_app_messaging
 description: Flutter plugin for Firebase In-App Messaging.
-version: 0.0.1
+version: 0.0.1+1
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_in_app_messaging
 

--- a/packages/firebase_messaging/CHANGELOG.md
+++ b/packages/firebase_messaging/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.1.3
+
+* Update google-services Android gradle plugin to 4.3.0 in documentation and examples.
+
 ## 5.1.2
 
 * Updates to README and example with explanations of differences in data format.

--- a/packages/firebase_messaging/README.md
+++ b/packages/firebase_messaging/README.md
@@ -29,7 +29,7 @@ dependencies {
   // Example existing classpath
   classpath 'com.android.tools.build:gradle:3.2.1'
   // Add the google services classpath
-  classpath 'com.google.gms:google-services:4.2.0'
+  classpath 'com.google.gms:google-services:4.3.0'
 }
 ```
 3. Add the apply plugin to the `[project]/android/app/build.gradle` file.

--- a/packages/firebase_messaging/example/android/build.gradle
+++ b/packages/firebase_messaging/example/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.0'
-        classpath 'com.google.gms:google-services:4.2.0'
+        classpath 'com.google.gms:google-services:4.3.0'
     }
 }
 

--- a/packages/firebase_messaging/example/pubspec.yaml
+++ b/packages/firebase_messaging/example/pubspec.yaml
@@ -2,6 +2,7 @@ name: firebase_messaging_example
 description: Demonstrates how to use the firebase_messaging plugin.
 
 dependencies:
+  firebase_analytics: any
   flutter:
     sdk: flutter
   firebase_messaging:

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -3,8 +3,7 @@ description: Flutter plugin for Firebase Cloud Messaging, a cross-platform
   messaging solution that lets you reliably deliver messages on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_messaging
-
-version: 5.1.2
+version: 5.1.3
 
 flutter:
   plugin:

--- a/packages/firebase_ml_vision/CHANGELOG.md
+++ b/packages/firebase_ml_vision/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.1+1
+
+* Update google-services Android gradle plugin to 4.3.0 in documentation and examples.
+
 ## 0.9.1
 
 * Add support for cloud text recognizer.

--- a/packages/firebase_ml_vision/example/android/build.gradle
+++ b/packages/firebase_ml_vision/example/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.0'
-        classpath 'com.google.gms:google-services:4.2.0'
+        classpath 'com.google.gms:google-services:4.3.0'
     }
 }
 

--- a/packages/firebase_ml_vision/pubspec.yaml
+++ b/packages/firebase_ml_vision/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_ml_vision
 description: Flutter plugin for Firebase machine learning vision services.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_ml_vision
-version: 0.9.1
+version: 0.9.1+1
 
 dependencies:
   flutter:

--- a/packages/firebase_performance/CHANGELOG.md
+++ b/packages/firebase_performance/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0+4
+
+* Update google-services Android gradle plugin to 4.3.0 in documentation and examples.
+
 ## 0.3.0+3
 
 * Fix bug that caused `invokeMethod` to fail with Dart code obfuscation

--- a/packages/firebase_performance/example/android/build.gradle
+++ b/packages/firebase_performance/example/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.0'
-        classpath 'com.google.gms:google-services:4.2.0'
+        classpath 'com.google.gms:google-services:4.3.0'
     }
 }
 

--- a/packages/firebase_performance/pubspec.yaml
+++ b/packages/firebase_performance/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Google Performance Monitoring for Firebase, an a
   iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_performance
-version: 0.3.0+3
+version: 0.3.0+4
 
 dependencies:
   flutter:

--- a/packages/firebase_remote_config/CHANGELOG.md
+++ b/packages/firebase_remote_config/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0+5
+
+* Update google-services Android gradle plugin to 4.3.0 in documentation and examples.
+
 ## 0.2.0+4
 
 * Fixed a bug where `RemoteConfigValue` could incorrectly report a remote `source` for default values.

--- a/packages/firebase_remote_config/README.md
+++ b/packages/firebase_remote_config/README.md
@@ -23,7 +23,7 @@ dependencies {
   // Example existing classpath
   classpath 'com.android.tools.build:gradle:3.2.1'
   // Add the google services classpath
-  classpath 'com.google.gms:google-services:4.2.0'
+  classpath 'com.google.gms:google-services:4.3.0'
 }
 ```
 

--- a/packages/firebase_remote_config/example/android/build.gradle
+++ b/packages/firebase_remote_config/example/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.0'
-        classpath 'com.google.gms:google-services:4.2.0'
+        classpath 'com.google.gms:google-services:4.3.0'
     }
 }
 

--- a/packages/firebase_remote_config/pubspec.yaml
+++ b/packages/firebase_remote_config/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Remote Config. Update your application 
   re-releasing.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_remote_config
-version: 0.2.0+4
+version: 0.2.0+5
 
 dependencies:
   flutter:

--- a/packages/firebase_storage/CHANGELOG.md
+++ b/packages/firebase_storage/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.4
+
+* Update google-services Android gradle plugin to 4.3.0 in documentation and examples.
+
 ## 3.0.3
 
 * Fix inconsistency of `getPath`, on Android the path returned started with a `/` but on iOS it did not

--- a/packages/firebase_storage/example/android/build.gradle
+++ b/packages/firebase_storage/example/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.0'
-        classpath 'com.google.gms:google-services:4.2.0'
+        classpath 'com.google.gms:google-services:4.3.0'
     }
 }
 

--- a/packages/firebase_storage/pubspec.yaml
+++ b/packages/firebase_storage/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Cloud Storage, a powerful, simple, and
   cost-effective object storage service for Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_storage
-version: 3.0.3
+version: 3.0.4
 
 flutter:
   plugin:

--- a/packages/package_info/android/build.gradle
+++ b/packages/package_info/android/build.gradle
@@ -30,11 +30,6 @@ rootProject.allprojects {
         google()
         jcenter()
     }
-    gradle.projectsEvaluated {
-        tasks.withType(JavaCompile) {
-            options.compilerArgs << "-Xlint:deprecation"
-        }
-    }
 }
 
 apply plugin: 'com.android.library'

--- a/packages/package_info/android/build.gradle
+++ b/packages/package_info/android/build.gradle
@@ -30,6 +30,11 @@ rootProject.allprojects {
         google()
         jcenter()
     }
+    gradle.projectsEvaluated {
+        tasks.withType(JavaCompile) {
+            options.compilerArgs << "-Xlint:deprecation"
+        }
+    }
 }
 
 apply plugin: 'com.android.library'


### PR DESCRIPTION
Per discussion https://github.com/flutter/flutter/issues/28770#issuecomment-512519916

We can prevent these deprecation warnings by updating to a newer version of google-services gradle plugin.

```
flutter run                                                                                                     11:32:05
Launching lib/main.dart on Pixel 2 in debug mode...
Initializing gradle...                                              1.9s
Resolving dependencies...                                           5.2s
registerResGeneratingTask is deprecated, use registerGeneratedResFolders(FileCollection)
registerResGeneratingTask is deprecated, use registerGeneratedResFolders(FileCollection)
registerResGeneratingTask is deprecated, use registerGeneratedResFolders(FileCollection)
Note: /Users/deg/.pub-cache/hosted/pub.dartlang.org/firebase_core-0.4.0+6/android/src/main/java/io/flutter/plugins/firebase/core/FirebaseCorePlugin.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.                      
Running Gradle task 'assembleDebug'...                                  
Running Gradle task 'assembleDebug'... Done                        45.0s
Built build/app/outputs/apk/debug/app-debug.apk.
...
```

This change will cause warnings to be emitted to the console the first time building after upgrading an app's google-services.

```
ERROR: [TAG] Failed to resolve variable '${junit.version}'              
ERROR: [TAG] Failed to resolve variable '${animal.sniffer.version}'     
```

Subsequent builds will not have the error.

Fixes fluttere/flutter#28982