### PR TITLE
[path_provider] Add support to access getApplicationSupportDirectory on Android

### DIFF
--- a/packages/path_provider/CHANGELOG.md
+++ b/packages/path_provider/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+
+* Android: `getApplicationSupportDirectory` enabled by using `getFilesDir`.
+
 ## 1.1.2
 
 * `getExternalStorageDirectory` now uses `getExternalFilesDir` on Android.

--- a/packages/path_provider/CHANGELOG.md
+++ b/packages/path_provider/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.2.0
 
-* Android: `getApplicationSupportDirectory` enabled by using `getFilesDir`.
+* On Android, `getApplicationSupportDirectory` is now supported and uses `getFilesDir`.
+* `getStorageDirectory` now returns `null` instead of throwing an exception if no external files directory is available.
 
 ## 1.1.2
 

--- a/packages/path_provider/CHANGELOG.md
+++ b/packages/path_provider/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 1.2.0
 
-* On Android, `getApplicationSupportDirectory` is now supported and uses `getFilesDir`.
-* `getStorageDirectory` now returns `null` instead of throwing an exception if no external files directory is available.
+* On Android, `getApplicationSupportDirectory` is now supported using `getFilesDir`.
+* `getExternalStorageDirectory` now returns `null` instead of throwing an
+  exception if no external files directory is available.
 
 ## 1.1.2
 

--- a/packages/path_provider/android/src/main/java/io/flutter/plugins/pathprovider/PathProviderPlugin.java
+++ b/packages/path_provider/android/src/main/java/io/flutter/plugins/pathprovider/PathProviderPlugin.java
@@ -10,13 +10,14 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
 import io.flutter.util.PathUtils;
+import java.io.File;
 
 public class PathProviderPlugin implements MethodCallHandler {
   private final Registrar mRegistrar;
 
   public static void registerWith(Registrar registrar) {
     MethodChannel channel =
-        new MethodChannel(registrar.messenger(), "plugins.flutter.io/path_provider");
+      new MethodChannel(registrar.messenger(), "plugins.flutter.io/path_provider");
     PathProviderPlugin instance = new PathProviderPlugin(registrar);
     channel.setMethodCallHandler(instance);
   }
@@ -37,6 +38,8 @@ public class PathProviderPlugin implements MethodCallHandler {
       case "getStorageDirectory":
         result.success(getPathProviderStorageDirectory());
         break;
+      case "getApplicationSupportDirectory":
+        result.success(getApplicationSupportDirectory());
       default:
         result.notImplemented();
     }
@@ -46,11 +49,19 @@ public class PathProviderPlugin implements MethodCallHandler {
     return mRegistrar.context().getCacheDir().getPath();
   }
 
+  private String getApplicationSupportDirectory() {
+    return PathUtils.getFilesDir(mRegistrar.context());
+  }
+
   private String getPathProviderApplicationDocumentsDirectory() {
     return PathUtils.getDataDirectory(mRegistrar.context());
   }
 
   private String getPathProviderStorageDirectory() {
-    return mRegistrar.context().getExternalFilesDir(null).getAbsolutePath();
+    final File dir = mRegistrar.context().getExternalFilesDir(null);
+    if(dir == null){
+      return null;
+    }
+    return dir.getAbsolutePath();
   }
 }

--- a/packages/path_provider/android/src/main/java/io/flutter/plugins/pathprovider/PathProviderPlugin.java
+++ b/packages/path_provider/android/src/main/java/io/flutter/plugins/pathprovider/PathProviderPlugin.java
@@ -17,7 +17,7 @@ public class PathProviderPlugin implements MethodCallHandler {
 
   public static void registerWith(Registrar registrar) {
     MethodChannel channel =
-      new MethodChannel(registrar.messenger(), "plugins.flutter.io/path_provider");
+        new MethodChannel(registrar.messenger(), "plugins.flutter.io/path_provider");
     PathProviderPlugin instance = new PathProviderPlugin(registrar);
     channel.setMethodCallHandler(instance);
   }
@@ -59,7 +59,7 @@ public class PathProviderPlugin implements MethodCallHandler {
 
   private String getPathProviderStorageDirectory() {
     final File dir = mRegistrar.context().getExternalFilesDir(null);
-    if(dir == null){
+    if (dir == null) {
       return null;
     }
     return dir.getAbsolutePath();

--- a/packages/path_provider/lib/path_provider.dart
+++ b/packages/path_provider/lib/path_provider.dart
@@ -57,7 +57,7 @@ Future<Directory> getApplicationSupportDirectory() async {
 /// [getApplicationSupportDirectory] instead if the data is not user-generated.
 ///
 /// On Android, this uses the `getDataDirectory` API on the context. Consider
-/// using getExternalStorageDirectory instead if data is intended to be visible
+/// using [getExternalStorageDirectory] instead if data is intended to be visible
 /// to the user.
 Future<Directory> getApplicationDocumentsDirectory() async {
   final String path =

--- a/packages/path_provider/lib/path_provider.dart
+++ b/packages/path_provider/lib/path_provider.dart
@@ -39,15 +39,14 @@ Future<Directory> getTemporaryDirectory() async {
 /// On iOS, this uses the `NSApplicationSupportDirectory` API.
 /// If this directory does not exist, it is created automatically.
 ///
-/// On Android, this function throws an [UnsupportedError].
+/// On Android, this function uses the `getFilesDir` API on the context.
 Future<Directory> getApplicationSupportDirectory() async {
-  if (!Platform.isIOS)
-    throw UnsupportedError("getApplicationSupportDirectory requires iOS");
   final String path =
       await _channel.invokeMethod<String>('getApplicationSupportDirectory');
   if (path == null) {
     return null;
   }
+
   return Directory(path);
 }
 

--- a/packages/path_provider/pubspec.yaml
+++ b/packages/path_provider/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for getting commonly used locations on the Android &
   iOS file systems, such as the temp and app data directories.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/path_provider
-version: 1.1.2
+version: 1.2.0
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description
This PR enables the plugin to use `getApplicationSupportDirectory` on android.

on iOS apple says : https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html
> Put app-created support files in the Library/Application support/ directory. In general, this directory includes files that the app uses to run but that should remain hidden from the user. This directory can also include data files, configuration files, templates and modified versions of resources loaded from the app bundle.

This is very close of the usage of `getFilesDir` on Android. It is private to the app, there is no sync and the app can use to save files that are not temporary (cache).

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
I don't know if it is a breaking change. What worked before should keep working know, but it does change the behavior of a method.

Does your PR require plugin users to manually update their apps to accommodate your change?

- [X] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.
