### PR TITLE
[firebase_crashlytics] Fix Printing, README, Changelog & log FlutterErrorDetails.informationCollector

### DIFF
--- a/packages/firebase_crashlytics/CHANGELOG.md
+++ b/packages/firebase_crashlytics/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.1.1
 
+* Added additional exception information from the Flutter framework to the reports.
+* Reformatted debug printing of exceptions to be human-readable.
 * Updated `README.md` to include both the breaking change from `0.1.0` and the newly added
   `recordError` function in the setup section.
 * Made the `_recordError` function safe for missing stack traces (`null`).

--- a/packages/firebase_crashlytics/CHANGELOG.md
+++ b/packages/firebase_crashlytics/CHANGELOG.md
@@ -7,10 +7,11 @@
 * Made the `_recordError` function safe for missing stack traces (`null`).
 * Added the "Error reported to Crashlytics." print statement that was previously missing.
 * Adjusted `README.md` formatting.
+* Fixed `recordFlutterError` method name in the `0.1.0` changelog entry.
 
 ## 0.1.0
 
-* **Breaking Change** Renamed `onError` to `reportFlutterError`.
+* **Breaking Change** Renamed `onError` to `recordFlutterError`.
 * Added `recordError` method for errors caught using `runZoned`'s `onError`.
 
 ## 0.0.4+12

--- a/packages/firebase_crashlytics/CHANGELOG.md
+++ b/packages/firebase_crashlytics/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.1.1
+
+* Updated `README.md` to include both the breaking change from `0.1.0` and the newly added
+  `recordError` function in the setup section.
+* Made the `_recordError` function safe for missing stack traces (`null`).
+* Added the "Error reported to Crashlytics." print statement that was previously missing.
+* Adjusted `README.md` formatting.
+
 ## 0.1.0
 
 * **Breaking Change** Renamed `onError` to `reportFlutterError`.

--- a/packages/firebase_crashlytics/CHANGELOG.md
+++ b/packages/firebase_crashlytics/CHANGELOG.md
@@ -1,11 +1,11 @@
-## 0.1.1
+## 0.1.0+1
 
 * Added additional exception information from the Flutter framework to the reports.
-* Reformatted debug printing of exceptions to be human-readable.
+* Refactored debug printing of exceptions to be human-readable.
+* Passing `null` stack traces is now supported.
+* Added the "Error reported to Crashlytics." print statement that was previously missing.
 * Updated `README.md` to include both the breaking change from `0.1.0` and the newly added
   `recordError` function in the setup section.
-* Made the `_recordError` function safe for missing stack traces (`null`).
-* Added the "Error reported to Crashlytics." print statement that was previously missing.
 * Adjusted `README.md` formatting.
 * Fixed `recordFlutterError` method name in the `0.1.0` changelog entry.
 

--- a/packages/firebase_crashlytics/README.md
+++ b/packages/firebase_crashlytics/README.md
@@ -110,7 +110,7 @@ If an error is caught, you should see the following messages in your logs:
 flutter: Flutter error caught by Crashlytics plugin:
 // OR if you use recordError for runZoned:
 flutter: Error caught by Crashlytics plugin <recordError>:
-// Exception and stack trace in debug mode
+// Exception, context, information and stack trace in debug mode
 // OR if not in debug mode:
 flutter: Error reported to Crashlytics.
 ```

--- a/packages/firebase_crashlytics/README.md
+++ b/packages/firebase_crashlytics/README.md
@@ -11,13 +11,13 @@ For Flutter plugins for other Firebase products, see [FlutterFire.md](https://gi
 ## Usage
 
 ### Import the firebase_crashlytics plugin
-To use the firebase_crashlytics plugin, follow the [plugin installation instructions](https://pub.dartlang.org/packages/firebase_crashlytics#pub-pkg-tab-installing).
+To use the `firebase_crashlytics` plugin, follow the [plugin installation instructions](https://pub.dartlang.org/packages/firebase_crashlytics#pub-pkg-tab-installing).
 
 ### Android integration
 
-Enable the Google services by configuring the Gradle scripts as such.
+Enable the Google services by configuring the Gradle scripts as such:
 
-1. Add Fabric repository to the `[project]/android/build.gradle` file.
+1. Add the Fabric repository to the `[project]/android/build.gradle` file.
 ```
 repositories {
   google()
@@ -29,7 +29,7 @@ repositories {
 }
 ```
 
-2. Add the classpaths to the `[project]/android/build.gradle` file.
+2. Add the following classpaths to the `[project]/android/build.gradle` file.
 ```gradle
 dependencies {
   // Example existing classpath
@@ -41,14 +41,14 @@ dependencies {
 }
 ```
 
-2. Add the apply plugins to the `[project]/android/app/build.gradle` file.
+2. Apply the following plugins in the `[project]/android/app/build.gradle` file.
 ```gradle
 // ADD THIS AT THE BOTTOM
 apply plugin: 'io.fabric'
 apply plugin: 'com.google.gms.google-services'
 ```
 
-*Note:* If this section is not completed you will get an error like this:
+*Note:* If this section is not completed, you will get an error like this:
 ```
 java.lang.IllegalStateException:
 Default FirebaseApp is not initialized in this process [package name].
@@ -56,18 +56,18 @@ Make sure to call FirebaseApp.initializeApp(Context) first.
 ```
 
 *Note:* When you are debugging on Android, use a device or AVD with Google Play services.
-Otherwise you will not be able to use Firebase Crashlytics.
+Otherwise, you will not be able to use Firebase Crashlytics.
 
 ### iOS Integration
 
-Add the Crashlytics run scripts
+Add the Crashlytics run scripts:
 
-1. From Xcode select Runner from the project navigation.
-1. Select the Build Phases tab.
-1. Click + Add a new build phase, and select New Run Script Phase.
+1. From Xcode select `Runner` from the project navigation.
+1. Select the `Build Phases` tab.
+1. Click `+ Add a new build phase`, and select `New Run Script Phase`.
 1. Add `${PODS_ROOT}/Fabric/run` to the `Type a script...` text box.
-1. If on Xcode 10 Add your app's built Info.plist location to the Build Phase's Input Files field.
-Eg: `$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)`
+1. If you are using Xcode 10, add the location of `Info.plist`, built by your app, to the `Build Phase's Input Files` field.  
+   E.g.: `$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)`
 
 ### Use the plugin
 
@@ -85,20 +85,32 @@ void main() {
   // development.
   Crashlytics.instance.enableInDevMode = true;
 
-  // Pass all uncaught errors to Crashlytics.
-  FlutterError.onError = (FlutterErrorDetails details) {
-    Crashlytics.instance.onError(details);
-  };
+  // Pass all uncaught errors from the framework to Crashlytics.
+  FlutterError.onError = Crashlytics.instance.recordFlutterError;
+  
   runApp(MyApp());
 }
 ```
+
+Overriding the `FlutterError.onError` with `Crashlytics.instance.recordFlutterError`  will automatically catch all 
+errors that are thrown from within the Flutter framework.  
+If you want to catch errors that occur in `runZoned`, 
+you can supply `Crashlytics.instance.recordError` to the `onError` parameter:
+```dart
+runZoned<Future<void>>(() async {
+    // ...
+  }, onError: Crashlytics.instance.recordError);
+``` 
 
 ## Result
 
 If an error is caught, you should see the following messages in your logs:
 ```
-flutter: Error caught by Crashlytics plugin:
-...
+flutter: Flutter error caught by Crashlytics plugin:
+// OR if you use recordError for runZoned:
+flutter: Error caught by Crashlytics plugin <recordError>:
+// Exception and stack trace in debug mode
+// OR if not in debug mode:
 flutter: Error reported to Crashlytics.
 ```
 
@@ -107,7 +119,7 @@ flutter: Error reported to Crashlytics.
 ## Example
 
 See the [example application](https://github.com/flutter/plugins/tree/master/packages/firebase_crashlytics/example) source
-for a complete sample app using the Firebase Crashlytics.
+for a complete sample app using `firebase_crashlytics`.
 
 ## Issues and feedback
 

--- a/packages/firebase_crashlytics/README.md
+++ b/packages/firebase_crashlytics/README.md
@@ -110,7 +110,7 @@ If an error is caught, you should see the following messages in your logs:
 flutter: Flutter error caught by Crashlytics plugin:
 // OR if you use recordError for runZoned:
 flutter: Error caught by Crashlytics plugin <recordError>:
-// Exception, context, information and stack trace in debug mode
+// Exception, context, information, and stack trace in debug mode
 // OR if not in debug mode:
 flutter: Error reported to Crashlytics.
 ```

--- a/packages/firebase_crashlytics/README.md
+++ b/packages/firebase_crashlytics/README.md
@@ -11,6 +11,7 @@ For Flutter plugins for other Firebase products, see [FlutterFire.md](https://gi
 ## Usage
 
 ### Import the firebase_crashlytics plugin
+
 To use the `firebase_crashlytics` plugin, follow the [plugin installation instructions](https://pub.dartlang.org/packages/firebase_crashlytics#pub-pkg-tab-installing).
 
 ### Android integration

--- a/packages/firebase_crashlytics/README.md
+++ b/packages/firebase_crashlytics/README.md
@@ -93,7 +93,7 @@ void main() {
 }
 ```
 
-Overriding the `FlutterError.onError` with `Crashlytics.instance.recordFlutterError`  will automatically catch all 
+Overriding `FlutterError.onError` with `Crashlytics.instance.recordFlutterError`  will automatically catch all 
 errors that are thrown from within the Flutter framework.  
 If you want to catch errors that occur in `runZoned`, 
 you can supply `Crashlytics.instance.recordError` to the `onError` parameter:

--- a/packages/firebase_crashlytics/android/src/main/java/io/flutter/plugins/firebase/crashlytics/firebasecrashlytics/FirebaseCrashlyticsPlugin.java
+++ b/packages/firebase_crashlytics/android/src/main/java/io/flutter/plugins/firebase/crashlytics/firebasecrashlytics/FirebaseCrashlyticsPlugin.java
@@ -71,7 +71,7 @@ public class FirebaseCrashlyticsPlugin implements MethodCallHandler {
 
       Crashlytics.setString("exception", (String) call.argument("exception"));
 
-      // Set context to show when the exception was thrown.
+      // Set a "reason" (to match iOS) to show where the exception was thrown.
       final String context = call.argument("context");
       if (context != null) Crashlytics.setString("reason", "thrown " + context);
 

--- a/packages/firebase_crashlytics/android/src/main/java/io/flutter/plugins/firebase/crashlytics/firebasecrashlytics/FirebaseCrashlyticsPlugin.java
+++ b/packages/firebase_crashlytics/android/src/main/java/io/flutter/plugins/firebase/crashlytics/firebasecrashlytics/FirebaseCrashlyticsPlugin.java
@@ -75,10 +75,9 @@ public class FirebaseCrashlyticsPlugin implements MethodCallHandler {
       final String context = call.argument("context");
       if (context != null) Crashlytics.setString("context", "thrown " + context);
 
-      // Log information
+      // Log information.
       final String information = call.argument("information");
-      if (information != null && !information.isEmpty())
-        Crashlytics.log(information);
+      if (information != null && !information.isEmpty()) Crashlytics.log(information);
 
       Crashlytics.logException(exception);
       result.success("Error reported to Crashlytics.");

--- a/packages/firebase_crashlytics/android/src/main/java/io/flutter/plugins/firebase/crashlytics/firebasecrashlytics/FirebaseCrashlyticsPlugin.java
+++ b/packages/firebase_crashlytics/android/src/main/java/io/flutter/plugins/firebase/crashlytics/firebasecrashlytics/FirebaseCrashlyticsPlugin.java
@@ -70,6 +70,16 @@ public class FirebaseCrashlyticsPlugin implements MethodCallHandler {
       exception.setStackTrace(elements.toArray(new StackTraceElement[elements.size()]));
 
       Crashlytics.setString("exception", (String) call.argument("exception"));
+
+      // Set context to show when the exception was thrown.
+      final String context = call.argument("context");
+      if (context != null) Crashlytics.setString("context", "thrown " + context);
+
+      // Log information
+      final String information = call.argument("information");
+      if (information != null && !information.isEmpty())
+        Crashlytics.log(information);
+
       Crashlytics.logException(exception);
       result.success("Error reported to Crashlytics.");
     } else if (call.method.equals("Crashlytics#isDebuggable")) {

--- a/packages/firebase_crashlytics/android/src/main/java/io/flutter/plugins/firebase/crashlytics/firebasecrashlytics/FirebaseCrashlyticsPlugin.java
+++ b/packages/firebase_crashlytics/android/src/main/java/io/flutter/plugins/firebase/crashlytics/firebasecrashlytics/FirebaseCrashlyticsPlugin.java
@@ -73,7 +73,7 @@ public class FirebaseCrashlyticsPlugin implements MethodCallHandler {
 
       // Set context to show when the exception was thrown.
       final String context = call.argument("context");
-      if (context != null) Crashlytics.setString("context", "thrown " + context);
+      if (context != null) Crashlytics.setString("reason", "thrown " + context);
 
       // Log information.
       final String information = call.argument("information");

--- a/packages/firebase_crashlytics/example/test_driver/crashlytics.dart
+++ b/packages/firebase_crashlytics/example/test_driver/crashlytics.dart
@@ -26,14 +26,13 @@ void main() {
     Crashlytics.instance.log('testing');
     await crashlytics.recordFlutterError(
       FlutterErrorDetails(
-        exception: 'testing',
-        stack: StackTrace.fromString(''),
-        context: DiagnosticsNode.message('during testing'),
-        informationCollector: () => <DiagnosticsNode>[
-          DiagnosticsNode.message('testing'),
-          DiagnosticsNode.message('information'),
-        ]
-      ),
+          exception: 'testing',
+          stack: StackTrace.fromString(''),
+          context: DiagnosticsNode.message('during testing'),
+          informationCollector: () => <DiagnosticsNode>[
+                DiagnosticsNode.message('testing'),
+                DiagnosticsNode.message('information'),
+              ])
     );
   });
 }

--- a/packages/firebase_crashlytics/example/test_driver/crashlytics.dart
+++ b/packages/firebase_crashlytics/example/test_driver/crashlytics.dart
@@ -28,6 +28,11 @@ void main() {
       FlutterErrorDetails(
         exception: 'testing',
         stack: StackTrace.fromString(''),
+        context: DiagnosticsNode.message('during testing'),
+        informationCollector: () => <DiagnosticsNode>[
+          DiagnosticsNode.message('testing'),
+          DiagnosticsNode.message('information'),
+        ]
       ),
     );
   });

--- a/packages/firebase_crashlytics/example/test_driver/crashlytics.dart
+++ b/packages/firebase_crashlytics/example/test_driver/crashlytics.dart
@@ -24,15 +24,13 @@ void main() {
     crashlytics.setDouble('testDouble', 42.0);
     crashlytics.setString('testString', 'bar');
     Crashlytics.instance.log('testing');
-    await crashlytics.recordFlutterError(
-      FlutterErrorDetails(
-          exception: 'testing',
-          stack: StackTrace.fromString(''),
-          context: DiagnosticsNode.message('during testing'),
-          informationCollector: () => <DiagnosticsNode>[
-                DiagnosticsNode.message('testing'),
-                DiagnosticsNode.message('information'),
-              ])
-    );
+    await crashlytics.recordFlutterError(FlutterErrorDetails(
+        exception: 'testing',
+        stack: StackTrace.fromString(''),
+        context: DiagnosticsNode.message('during testing'),
+        informationCollector: () => <DiagnosticsNode>[
+              DiagnosticsNode.message('testing'),
+              DiagnosticsNode.message('information'),
+            ]));
   });
 }

--- a/packages/firebase_crashlytics/ios/Classes/FirebaseCrashlyticsPlugin.m
+++ b/packages/firebase_crashlytics/ios/Classes/FirebaseCrashlyticsPlugin.m
@@ -63,6 +63,7 @@
     // Using CLSLog instead of CLS_LOG to try to avoid the automatic inclusion of the line number.
     // It also ensures that the log is only written to Crashlytics and not also to the offline log
     // as explained here: https://support.crashlytics.com/knowledgebase/articles/92519-how-do-i-use-logging
+    // Although, that would only happen in debug mode, which this method call is never called in.
     NSString *information = call.arguments[@"information"];
     if ([information length] != 0) {
       CLSLog(information);

--- a/packages/firebase_crashlytics/ios/Classes/FirebaseCrashlyticsPlugin.m
+++ b/packages/firebase_crashlytics/ios/Classes/FirebaseCrashlyticsPlugin.m
@@ -59,6 +59,15 @@
       }
     }
 
+    // Add additional information from the Flutter framework to the exception reported in Crashlytics.
+    // CLS_LOG would also print to the log if it were called in debug mode, however, the
+    // "onError" method call only occurs in release mode, which is why this is fine.
+    // Otherwise, this should use CLSLog as explained here: https://support.crashlytics.com/knowledgebase/articles/92519-how-do-i-use-logging
+    NSString *information = call.arguments[@"information"];
+    if ([information length] != 0) {
+      CLS_LOG(information);
+    }
+
     // Report crash.
     NSArray *errorElements = call.arguments[@"stackTraceElements"];
     NSMutableArray *frames = [NSMutableArray array];

--- a/packages/firebase_crashlytics/ios/Classes/FirebaseCrashlyticsPlugin.m
+++ b/packages/firebase_crashlytics/ios/Classes/FirebaseCrashlyticsPlugin.m
@@ -76,9 +76,11 @@
     for (NSDictionary *errorElement in errorElements) {
       [frames addObject:[self generateFrame:errorElement]];
     }
-    [[Crashlytics sharedInstance] recordCustomExceptionName:call.arguments[@"exception"]
-                                                     reason:[NSString stringWithFormat:@"thrown %s", call.arguments[@"context"]]
-                                                 frameArray:frames];
+    [[Crashlytics sharedInstance]
+        recordCustomExceptionName:call.arguments[@"exception"]
+                           reason:[NSString
+                                      stringWithFormat:@"thrown %s", call.arguments[@"context"]]
+                       frameArray:frames];
     result(@"Error reported to Crashlytics.");
   } else if ([@"Crashlytics#isDebuggable" isEqualToString:call.method]) {
     result([NSNumber numberWithBool:[Crashlytics sharedInstance].debugMode]);

--- a/packages/firebase_crashlytics/ios/Classes/FirebaseCrashlyticsPlugin.m
+++ b/packages/firebase_crashlytics/ios/Classes/FirebaseCrashlyticsPlugin.m
@@ -59,10 +59,10 @@
       }
     }
 
-    // Add additional information from the Flutter framework to the exception reported in Crashlytics.
-    // Using CLSLog instead of CLS_LOG to try to avoid the automatic inclusion of the line number.
-    // It also ensures that the log is only written to Crashlytics and not also to the offline log
-    // as explained here:
+    // Add additional information from the Flutter framework to the exception reported in
+    // Crashlytics. Using CLSLog instead of CLS_LOG to try to avoid the automatic inclusion of the
+    // line number. It also ensures that the log is only written to Crashlytics and not also to the
+    // offline log as explained here:
     // https://support.crashlytics.com/knowledgebase/articles/92519-how-do-i-use-logging
     // Although, that would only happen in debug mode, which this method call is never called in.
     NSString *information = call.arguments[@"information"];

--- a/packages/firebase_crashlytics/ios/Classes/FirebaseCrashlyticsPlugin.m
+++ b/packages/firebase_crashlytics/ios/Classes/FirebaseCrashlyticsPlugin.m
@@ -62,7 +62,8 @@
     // Add additional information from the Flutter framework to the exception reported in Crashlytics.
     // Using CLSLog instead of CLS_LOG to try to avoid the automatic inclusion of the line number.
     // It also ensures that the log is only written to Crashlytics and not also to the offline log
-    // as explained here: https://support.crashlytics.com/knowledgebase/articles/92519-how-do-i-use-logging
+    // as explained here:
+    // https://support.crashlytics.com/knowledgebase/articles/92519-how-do-i-use-logging
     // Although, that would only happen in debug mode, which this method call is never called in.
     NSString *information = call.arguments[@"information"];
     if ([information length] != 0) {

--- a/packages/firebase_crashlytics/ios/Classes/FirebaseCrashlyticsPlugin.m
+++ b/packages/firebase_crashlytics/ios/Classes/FirebaseCrashlyticsPlugin.m
@@ -60,7 +60,7 @@
     }
 
     // Add additional information from the Flutter framework to the exception reported in Crashlytics.
-    // CLS_LOG would also print to the log if it were called in debug mode, however, the
+    // CLS_LOG would also print to the log if it was called in debug mode, however, the
     // "onError" method call only occurs in release mode, which is why this is fine.
     // Otherwise, this should use CLSLog as explained here: https://support.crashlytics.com/knowledgebase/articles/92519-how-do-i-use-logging
     NSString *information = call.arguments[@"information"];

--- a/packages/firebase_crashlytics/ios/Classes/FirebaseCrashlyticsPlugin.m
+++ b/packages/firebase_crashlytics/ios/Classes/FirebaseCrashlyticsPlugin.m
@@ -77,7 +77,7 @@
       [frames addObject:[self generateFrame:errorElement]];
     }
     [[Crashlytics sharedInstance] recordCustomExceptionName:call.arguments[@"exception"]
-                                                     reason:call.arguments[@"context"]
+                                                     reason:[NSString stringWithFormat:@"thrown %s", call.arguments[@"context"]]
                                                  frameArray:frames];
     result(@"Error reported to Crashlytics.");
   } else if ([@"Crashlytics#isDebuggable" isEqualToString:call.method]) {

--- a/packages/firebase_crashlytics/ios/Classes/FirebaseCrashlyticsPlugin.m
+++ b/packages/firebase_crashlytics/ios/Classes/FirebaseCrashlyticsPlugin.m
@@ -60,12 +60,12 @@
     }
 
     // Add additional information from the Flutter framework to the exception reported in Crashlytics.
-    // CLS_LOG would also print to the log if it was called in debug mode, however, the
-    // "onError" method call only occurs in release mode, which is why this is fine.
-    // Otherwise, this should use CLSLog as explained here: https://support.crashlytics.com/knowledgebase/articles/92519-how-do-i-use-logging
+    // Using CLSLog instead of CLS_LOG to try to avoid the automatic inclusion of the line number.
+    // It also ensures that the log is only written to Crashlytics and not also to the offline log
+    // as explained here: https://support.crashlytics.com/knowledgebase/articles/92519-how-do-i-use-logging
     NSString *information = call.arguments[@"information"];
     if ([information length] != 0) {
-      CLS_LOG(information);
+      CLSLog(information);
     }
 
     // Report crash.

--- a/packages/firebase_crashlytics/lib/src/firebase_crashlytics.dart
+++ b/packages/firebase_crashlytics/lib/src/firebase_crashlytics.dart
@@ -194,12 +194,12 @@ class Crashlytics {
     return elements;
   }
 
-  /// On top of the default exception components, [information] can be passed as well.
-  /// This allows the developer to get a better understanding of exceptions thrown
-  /// by the Flutter framework. [FlutterErrorDetails] often explain why an exception
-  /// occurred and give useful background information in [FlutterErrorDetails.informationCollector].
-  /// Crashlytics will log this information in addition to the stack trace.
-  /// If [information] is `null` or empty, it will be ignored.
+  // On top of the default exception components, [information] can be passed as well.
+  // This allows the developer to get a better understanding of exceptions thrown
+  // by the Flutter framework. [FlutterErrorDetails] often explain why an exception
+  // occurred and give useful background information in [FlutterErrorDetails.informationCollector].
+  // Crashlytics will log this information in addition to the stack trace.
+  // If [information] is `null` or empty, it will be ignored.
   Future<void> _recordError(dynamic exception, StackTrace stack,
       {dynamic context, Iterable<DiagnosticsNode> information}) async {
     bool inDebugMode = false;
@@ -229,7 +229,7 @@ class Crashlytics {
       // The stack trace can be null. To avoid the following exception:
       // Invalid argument(s): Cannot create a Trace from null.
       // To avoid that exception, we can check for null and provide an empty stack trace.
-      if (stack == null) stack = StackTrace.fromString('');
+      stack ??= StackTrace.fromString('');
 
       // Report error.
       final List<String> stackTraceLines =

--- a/packages/firebase_crashlytics/lib/src/firebase_crashlytics.dart
+++ b/packages/firebase_crashlytics/lib/src/firebase_crashlytics.dart
@@ -31,7 +31,9 @@ class Crashlytics {
 
     _recordError(details.exceptionAsString(), details.stack,
         context: details.context,
-        information: details.informationCollector == null ? null : details.informationCollector());
+        information: details.informationCollector == null
+            ? null
+            : details.informationCollector());
   }
 
   /// Submits a report of a non-fatal error.
@@ -205,13 +207,14 @@ class Crashlytics {
       assert(inDebugMode = true);
     }
 
-    final String _information =
-      (information == null || information.isEmpty) ? '' :
-      (StringBuffer()..writeAll(information, '\n')).toString();
+    final String _information = (information == null || information.isEmpty)
+        ? ''
+        : (StringBuffer()..writeAll(information, '\n')).toString();
 
     if (inDebugMode && !enableInDevMode) {
       // If available, give context to the exception.
-      if (context != null) print('The following exception was thrown $context:');
+      if (context != null)
+        print('The following exception was thrown $context:');
 
       // Need to print the exception to explain why the exception was thrown.
       print(exception);
@@ -228,9 +231,11 @@ class Crashlytics {
       // To avoid that exception, we can check for null and provide an empty stack trace.
       if (stack == null) stack = StackTrace.fromString('');
 
-      // Report error. 
-      final List<String> stackTraceLines = Trace.format(stack).trimRight().split('\n');
-      final List<Map<String, String>> stackTraceElements = getStackTraceElements(stackTraceLines);
+      // Report error.
+      final List<String> stackTraceLines =
+          Trace.format(stack).trimRight().split('\n');
+      final List<Map<String, String>> stackTraceElements =
+          getStackTraceElements(stackTraceLines);
       final String result = await channel
           .invokeMethod<String>('Crashlytics#onError', <String, dynamic>{
         'exception': "${exception.toString()}",

--- a/packages/firebase_crashlytics/lib/src/firebase_crashlytics.dart
+++ b/packages/firebase_crashlytics/lib/src/firebase_crashlytics.dart
@@ -194,7 +194,7 @@ class Crashlytics {
 
   /// On top of the default exception components, [information] can be passed as well.
   /// This allows the developer to get a better understanding of exceptions thrown
-  /// by the Flutter frame. [FlutterErrorDetails] often explain why an exception
+  /// by the Flutter framework. [FlutterErrorDetails] often explain why an exception
   /// occurred and give useful background information in [FlutterErrorDetails.informationCollector].
   /// Crashlytics will log this information in addition to the stack trace.
   /// If [information] is `null` or empty, it will be ignored.

--- a/packages/firebase_crashlytics/lib/src/firebase_crashlytics.dart
+++ b/packages/firebase_crashlytics/lib/src/firebase_crashlytics.dart
@@ -236,6 +236,11 @@ class Crashlytics {
           Trace.format(stack).trimRight().split('\n');
       final List<Map<String, String>> stackTraceElements =
           getStackTraceElements(stackTraceLines);
+
+      // The context is a string that "should be in a form that will make sense in
+      // English when following the word 'thrown'" according to the documentation for
+      // [FlutterErrorDetails.context]. It is displayed to the user on Crashlytics
+      // as the "reason", which is forced by iOS, with the "thrown" prefix added.
       final String result = await channel
           .invokeMethod<String>('Crashlytics#onError', <String, dynamic>{
         'exception': "${exception.toString()}",

--- a/packages/firebase_crashlytics/lib/src/firebase_crashlytics.dart
+++ b/packages/firebase_crashlytics/lib/src/firebase_crashlytics.dart
@@ -223,11 +223,12 @@ class Crashlytics {
       // that Flutter developers are used to seeing.
       if (stack != null) print('\n$stack');
     } else {
-      // Report error. The stack trace can be null. To avoid the following exception:
+      // The stack trace can be null. To avoid the following exception:
       // Invalid argument(s): Cannot create a Trace from null.
       // To avoid that exception, we can check for null and provide an empty stack trace.
       if (stack == null) stack = StackTrace.fromString('');
 
+      // Report error. 
       final List<String> stackTraceLines = Trace.format(stack).trimRight().split('\n');
       final List<Map<String, String>> stackTraceElements = getStackTraceElements(stackTraceLines);
       final String result = await channel

--- a/packages/firebase_crashlytics/lib/src/firebase_crashlytics.dart
+++ b/packages/firebase_crashlytics/lib/src/firebase_crashlytics.dart
@@ -166,7 +166,7 @@ class Crashlytics {
           'line': lineNumber,
         };
 
-        // The next section would throw an exception if there was no stop here.
+        // The next section would throw an exception in some cases if there was no stop here.
         if (lineParts.length < 3) {
           elements.add(element);
           continue;

--- a/packages/firebase_crashlytics/pubspec.yaml
+++ b/packages/firebase_crashlytics/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_crashlytics
 description:
   Flutter plugin for Firebase Crashlytics. It reports uncaught errors to the
   Firebase console.
-version: 0.1.1
+version: 0.1.0+1
 author: Flutter Team <flutter-dev@google.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_crashlytics
 

--- a/packages/firebase_crashlytics/pubspec.yaml
+++ b/packages/firebase_crashlytics/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_crashlytics
 description:
   Flutter plugin for Firebase Crashlytics. It reports uncaught errors to the
   Firebase console.
-version: 0.1.0
+version: 0.1.1
 author: Flutter Team <flutter-dev@google.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_crashlytics
 

--- a/packages/firebase_crashlytics/test/firebase_crashlytics_test.dart
+++ b/packages/firebase_crashlytics/test/firebase_crashlytics_test.dart
@@ -16,6 +16,8 @@ void main() {
           .setMockMethodCallHandler((MethodCall methodCall) async {
         log.add(methodCall);
         switch (methodCall.method) {
+          case 'Crashlytics#onError':
+            return 'Error reported to Crashlytics.';
           case 'Crashlytics#isDebuggable':
             return true;
           case 'Crashlytics#setUserEmail':
@@ -38,6 +40,11 @@ void main() {
         exception: 'foo exception',
         stack: StackTrace.current,
         library: 'foo library',
+        informationCollector:
+            () => <DiagnosticsNode>[
+              DiagnosticsNode.message('test message'),
+              DiagnosticsNode.message('second message'),
+            ],
         context: ErrorDescription('foo context'),
       );
       crashlytics.enableInDevMode = true;
@@ -50,6 +57,7 @@ void main() {
       expect(log[0].method, 'Crashlytics#onError');
       expect(log[0].arguments['exception'], 'foo exception');
       expect(log[0].arguments['context'], 'foo context');
+      expect(log[0].arguments['information'], 'test message\nsecond message');
       expect(log[0].arguments['logs'], isNotEmpty);
       expect(log[0].arguments['logs'], contains('foo'));
       expect(log[0].arguments['keys'][0]['key'], 'testBool');

--- a/packages/firebase_crashlytics/test/firebase_crashlytics_test.dart
+++ b/packages/firebase_crashlytics/test/firebase_crashlytics_test.dart
@@ -40,11 +40,10 @@ void main() {
         exception: 'foo exception',
         stack: StackTrace.current,
         library: 'foo library',
-        informationCollector:
-            () => <DiagnosticsNode>[
-              DiagnosticsNode.message('test message'),
-              DiagnosticsNode.message('second message'),
-            ],
+        informationCollector: () => <DiagnosticsNode>[
+          DiagnosticsNode.message('test message'),
+          DiagnosticsNode.message('second message'),
+        ],
         context: ErrorDescription('foo context'),
       );
       crashlytics.enableInDevMode = true;


### PR DESCRIPTION
The initial issue I was facing was that `firebase_crashlytics` would throw an unhandled exception on e.g. `RenderFlex` exceptions without a stack trace (and the stack trace formatting was unreadable + the exceptions was missing information):

```
Error caught by Crashlytics plugin:
[ERROR:flutter/lib/ui/ui_dart_state.cc(148)] Unhandled Exception: Invalid argument(s): Cannot create a Trace from null.
#0      new Trace.from (package:stack_trace/src/trace.dart:105:7)
#1      Trace.format (package:stack_trace/src/trace.dart:71:21)
#2      Crashlytics.onError (package:firebase_crashlytics/src/firebase_crashlytics.dart:37:19)
<asynchronous suspension>
```

Along the way of fixing this behavior, I noticed that the `README.md` file was outdated and did not even contain the [**breaking change** from `0.1.0`](https://pub.dev/packages/firebase_crashlytics#010). Consequently, I fixed my original issue, added what was missing to the README and also adjusted some inconsistent formatting I found in the README.

I also noticed that `Error reported to Crashlytics.` was not even being printed and added that and also made the `Result` section more clear.

## Notes

I found myself adding `print(details)` to the [old `onError` implementation](https://pub.dev/documentation/firebase_crashlytics/0.0.4+6/#use-the-plugin) because the formatting from `Trace.format` is terrible for reading it in the console and it was also missing what the actual exception is, which I also added in this PR. This is the reason I averted from using `Trace.format` in the debug implementation.  

I noticed that `context` was not being used in the native Android implementation, so I thought that I would add it as a string as it is a very short term describing when the exception was thrown.  
Additionally, I added **`information`** and logged that using [`Crashlytics.log`](https://firebase.google.com/docs/crashlytics/customize-crash-reports?platform=android) and [`CS_LOG`](https://firebase.google.com/docs/crashlytics/customize-crash-reports?platform=ios#add_custom_log_messages). For me, this is a very crucial part for working with Flutter exceptions as it gives information about the tree, the specific widget and also some background information on why the exception occurred.

Furthermore, I noticed that the tests were printing errors when trying to access `lineParts[2]`, which was distracting. Hence, I added a check to prevent that from happening.

If the PR itself is fine but there are minor issues like comments being abundant, then please just fix them to speed things up.

I hope that my comments also help to understand my changes.

## Testing

It seems like driving examples was added for both Android and iOS now. Thus, I would assume that the tests run by CI should confirm whether the changes are implemented correctly or not as I added `informationCollector` and `context` to the test call.  
The logging part I could only confirm locally by trying it out. I am not sure how I would write a test for that.

## Question

After going through the code and reading the README, I am wondering if the error is also supposed to be printed locally in either of the following two scenarios because it was not printed before my change and I did not adjust that (only clarified in the README):

 1. App is in release mode.

 1. App is in debug mode but `enableInDevMode` is `true`.

### Changelog

I fixed the changelog typo that was pointed out in #1913 by @lsaudon in here as well.