### PR TITLE
[cloud_firestore] Add metadata to QuerySnapshot

### DIFF
--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.12.8
 
+* Add metatdata to QuerySnapshot.
+
+## 0.12.8
+
 * Updated how document ids are generated to more closely match native implementations.
 
 ## 0.12.7+1

--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,7 +1,10 @@
+## 0.12.8+1
+
+* Add `metadata` to `QuerySnapshot`.
+
 ## 0.12.8
 
 * Updated how document ids are generated to more closely match native implementations.
-* Add `metadata` to `QuerySnapshot`.
 
 ## 0.12.7+1
 

--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.12.8
+## 0.12.8+1
 
 * Add metatdata to QuerySnapshot.
 

--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,10 +1,7 @@
-## 0.12.8+1
-
-* Add metatdata to QuerySnapshot.
-
 ## 0.12.8
 
 * Updated how document ids are generated to more closely match native implementations.
+* Add `metadata` to `QuerySnapshot`.
 
 ## 0.12.7+1
 

--- a/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
+++ b/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
@@ -192,6 +192,11 @@ public class CloudFirestorePlugin implements MethodCallHandler {
     }
     data.put("documentChanges", documentChanges);
 
+    Map<String, Object> metadata = new HashMap<>();
+    metadata.put("hasPendingWrites", querySnapshot.getMetadata().hasPendingWrites());
+    metadata.put("isFromCache", querySnapshot.getMetadata().isFromCache());
+    data.put("metadata", metadata);
+
     return data;
   }
 

--- a/packages/cloud_firestore/example/lib/main.dart
+++ b/packages/cloud_firestore/example/lib/main.dart
@@ -36,8 +36,6 @@ class MessageList extends StatelessWidget {
       stream: firestore.collection('messages').snapshots(),
       builder: (BuildContext context, AsyncSnapshot<QuerySnapshot> snapshot) {
         if (!snapshot.hasData) return const Text('Loading...');
-        print(snapshot.data.metadata.isFromCache);
-        print(snapshot.data.metadata.hasPendingWrites);
         final int messageCount = snapshot.data.documents.length;
         return ListView.builder(
           itemCount: messageCount,

--- a/packages/cloud_firestore/example/lib/main.dart
+++ b/packages/cloud_firestore/example/lib/main.dart
@@ -36,6 +36,8 @@ class MessageList extends StatelessWidget {
       stream: firestore.collection('messages').snapshots(),
       builder: (BuildContext context, AsyncSnapshot<QuerySnapshot> snapshot) {
         if (!snapshot.hasData) return const Text('Loading...');
+        print(snapshot.data.metadata.isFromCache);
+        print(snapshot.data.metadata.hasPendingWrites);
         final int messageCount = snapshot.data.documents.length;
         return ListView.builder(
           itemCount: messageCount,

--- a/packages/cloud_firestore/example/test_driver/cloud_firestore.dart
+++ b/packages/cloud_firestore/example/test_driver/cloud_firestore.dart
@@ -51,6 +51,7 @@ void main() {
           .where('message', isEqualTo: 'Hello world!')
           .limit(1);
       final QuerySnapshot querySnapshot = await query.getDocuments();
+      expect(querySnapshot.metadata, isNotNull);
       expect(querySnapshot.documents.first['message'], 'Hello world!');
       final DocumentReference firstDoc =
           querySnapshot.documents.first.reference;
@@ -70,6 +71,7 @@ void main() {
           .limit(1);
       final QuerySnapshot querySnapshot = await query.getDocuments();
       expect(querySnapshot.documents.first['stars'], 5);
+      expect(querySnapshot.metadata, isNotNull);
     });
 
     test('increment', () async {

--- a/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
+++ b/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
@@ -203,6 +203,10 @@ static NSDictionary *parseQuerySnapshot(FIRQuerySnapshot *snapshot) {
     @"documentChanges" : documentChanges,
     @"documents" : documents,
     @"metadatas" : metadatas,
+    @"metadata": @{
+      @"hasPendingWrites": @(snapshot.metadata.hasPendingWrites),
+      @"isFromCache": @(snapshot.metadata.isFromCache),
+    }
   };
 }
 

--- a/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
+++ b/packages/cloud_firestore/ios/Classes/CloudFirestorePlugin.m
@@ -203,9 +203,9 @@ static NSDictionary *parseQuerySnapshot(FIRQuerySnapshot *snapshot) {
     @"documentChanges" : documentChanges,
     @"documents" : documents,
     @"metadatas" : metadatas,
-    @"metadata": @{
-      @"hasPendingWrites": @(snapshot.metadata.hasPendingWrites),
-      @"isFromCache": @(snapshot.metadata.isFromCache),
+    @"metadata" : @{
+      @"hasPendingWrites" : @(snapshot.metadata.hasPendingWrites),
+      @"isFromCache" : @(snapshot.metadata.isFromCache),
     }
   };
 }

--- a/packages/cloud_firestore/lib/src/query_snapshot.dart
+++ b/packages/cloud_firestore/lib/src/query_snapshot.dart
@@ -25,7 +25,11 @@ class QuerySnapshot {
             data['documentChanges'][index],
             _firestore,
           );
-        });
+        }),
+        metadata = SnapshotMetadata._(
+          data['metadata']['hasPendingWrites'],
+          data['metadata']['isFromCache'],
+        );
 
   /// Gets a list of all the documents included in this snapshot
   final List<DocumentSnapshot> documents;
@@ -33,6 +37,8 @@ class QuerySnapshot {
   /// An array of the documents that changed since the last snapshot. If this
   /// is the first snapshot, all documents will be in the list as Added changes.
   final List<DocumentChange> documentChanges;
+
+  final SnapshotMetadata metadata;
 
   final Firestore _firestore;
 }

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_firestore
-version: 0.12.8
+version: 0.12.8+1
 
 flutter:
   plugin:

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_firestore
-version: 0.12.8+1
+version: 0.12.8
 
 flutter:
   plugin:

--- a/packages/cloud_firestore/test/cloud_firestore_test.dart
+++ b/packages/cloud_firestore/test/cloud_firestore_test.dart
@@ -9,6 +9,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test/flutter_test.dart' as prefix0;
 
 void main() {
   group('$Firestore', () {
@@ -63,6 +64,7 @@ void main() {
                     'paths': <String>["${methodCall.arguments['path']}/0"],
                     'documents': <dynamic>[kMockDocumentSnapshotData],
                     'metadatas': <Map<String, dynamic>>[kMockSnapshotMetadata],
+                    'metadata': kMockSnapshotMetadata,
                     'documentChanges': <dynamic>[
                       <String, dynamic>{
                         'oldIndex': -1,
@@ -105,6 +107,7 @@ void main() {
               'paths': <String>["${methodCall.arguments['path']}/0"],
               'documents': <dynamic>[kMockDocumentSnapshotData],
               'metadatas': <Map<String, dynamic>>[kMockSnapshotMetadata],
+              'metadata': kMockSnapshotMetadata,
               'documentChanges': <dynamic>[
                 <String, dynamic>{
                   'oldIndex': -1,
@@ -614,6 +617,8 @@ void main() {
       test('getDocumentsFromCollection', () async {
         QuerySnapshot snapshot =
             await collectionReference.getDocuments(source: Source.server);
+        expect(snapshot.metadata.hasPendingWrites, equals(kMockSnapshotMetadata['hasPendingWrites']));
+        expect(snapshot.metadata.isFromCache, equals(kMockSnapshotMetadata['isFromCache']));
         DocumentSnapshot document = snapshot.documents.first;
         expect(document.documentID, equals('0'));
         expect(document.reference.path, equals('foo/0'));
@@ -781,6 +786,10 @@ void main() {
       });
       test('getDocumentsFromCollectionGroup', () async {
         QuerySnapshot snapshot = await collectionGroupQuery.getDocuments();
+        expect(snapshot.metadata.hasPendingWrites,
+            equals(kMockSnapshotMetadata['hasPendingWrites']));
+        expect(snapshot.metadata.isFromCache,
+            equals(kMockSnapshotMetadata['isFromCache']));
         DocumentSnapshot document = snapshot.documents.first;
         expect(document.documentID, equals('0'));
         expect(document.reference.path, equals('bar/0'));

--- a/packages/cloud_firestore/test/cloud_firestore_test.dart
+++ b/packages/cloud_firestore/test/cloud_firestore_test.dart
@@ -9,7 +9,6 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:flutter_test/flutter_test.dart' as prefix0;
 
 void main() {
   group('$Firestore', () {
@@ -617,8 +616,10 @@ void main() {
       test('getDocumentsFromCollection', () async {
         QuerySnapshot snapshot =
             await collectionReference.getDocuments(source: Source.server);
-        expect(snapshot.metadata.hasPendingWrites, equals(kMockSnapshotMetadata['hasPendingWrites']));
-        expect(snapshot.metadata.isFromCache, equals(kMockSnapshotMetadata['isFromCache']));
+        expect(snapshot.metadata.hasPendingWrites,
+            equals(kMockSnapshotMetadata['hasPendingWrites']));
+        expect(snapshot.metadata.isFromCache,
+            equals(kMockSnapshotMetadata['isFromCache']));
         DocumentSnapshot document = snapshot.documents.first;
         expect(document.documentID, equals('0'));
         expect(document.reference.path, equals('foo/0'));


### PR DESCRIPTION
## Description

Bring `cloud_firestore` plugin in line with native SDKs by exposing the metadata of QuerySnapshot.

## Related Issues

Fixes: https://github.com/flutter/flutter/issues/35550