### PR TITLE
Bump cloud_firestore version for release

### DIFF
--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/cloud_firestore
-version: 0.12.7+1
+version: 0.12.8
 
 flutter:
   plugin:


### PR DESCRIPTION
Left out of https://github.com/flutter/plugins/pull/1907

Adding tests to prevent this in the future: https://github.com/flutter/plugin_tools/pull/49