### PR TITLE
[firebase_auth] Fixes exceptions when signing in on iOS

### DIFF
--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.12.0+1
 
 * Fixes iOS sign-in exceptions when `additionalUserInfo` is `nil` or has `nil` fields.
+* Additional integration testing.
 
 ## 0.12.0
 

--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.0+1
+
+* Fixes iOS sign-in exceptions when `additionalUserInfo` is `nil`.
+
 ## 0.12.0
 
 * Added new `AuthResult` and `AdditionalUserInfo` classes.

--- a/packages/firebase_auth/example/test/firebase_auth.dart
+++ b/packages/firebase_auth/example/test/firebase_auth.dart
@@ -26,12 +26,14 @@ void main() {
       expect(user.uid, isNotNull);
       expect(user.isAnonymous, isTrue);
       final AdditionalUserInfo additionalUserInfo = result.additionalUserInfo;
+      expect(additionalUserInfo.username, isNull);
+      expect(additionalUserInfo.isNewUser, isNotNull);
+      expect(additionalUserInfo.profile, isNull);
       if (Platform.isIOS) {
-        expect(additionalUserInfo, isNull);
+        // TODO(jackson): Fix behavior to be consistent across platforms
+        // https://github.com/firebase/firebase-ios-sdk/issues/3450
+        expect(additionalUserInfo.providerId, 'password');
       } else if (Platform.isAndroid) {
-        expect(additionalUserInfo.username, isNull);
-        expect(additionalUserInfo.isNewUser, isNotNull);
-        expect(additionalUserInfo.profile, isNull);
         expect(additionalUserInfo.providerId, isNull);
       }
     });

--- a/packages/firebase_auth/example/test/firebase_auth.dart
+++ b/packages/firebase_auth/example/test/firebase_auth.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io';
 import 'package:flutter_driver/driver_extension.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:firebase_auth/firebase_auth.dart';
@@ -21,10 +22,14 @@ void main() {
       expect(user.uid, isNotNull);
       expect(user.isAnonymous, isTrue);
       final AdditionalUserInfo additionalUserInfo = result.additionalUserInfo;
-      expect(additionalUserInfo.username, isNull);
-      expect(additionalUserInfo.isNewUser, isNotNull);
-      expect(additionalUserInfo.profile, isNull);
-      expect(additionalUserInfo.providerId, isNull);
+      if (Platform.isIOS) {
+        expect(additionalUserInfo, isNull);
+      } else if (Platform.isAndroid) {
+        expect(additionalUserInfo.username, isNull);
+        expect(additionalUserInfo.isNewUser, isNotNull);
+        expect(additionalUserInfo.profile, isNull);
+        expect(additionalUserInfo.providerId, isNull);
+      }
     });
 
     test('isSignInWithEmailLink', () async {

--- a/packages/firebase_auth/example/test/firebase_auth.dart
+++ b/packages/firebase_auth/example/test/firebase_auth.dart
@@ -16,6 +16,10 @@ void main() {
   group('$FirebaseAuth', () {
     final FirebaseAuth auth = FirebaseAuth.instance;
 
+    setUp(() async {
+      await auth.signOut();
+    });
+
     test('signInAnonymously', () async {
       final AuthResult result = await auth.signInAnonymously();
       final FirebaseUser user = result.user;

--- a/packages/firebase_auth/example/test/firebase_auth.dart
+++ b/packages/firebase_auth/example/test/firebase_auth.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 import 'package:flutter_driver/driver_extension.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:firebase_auth/firebase_auth.dart';
@@ -29,13 +28,12 @@ void main() {
       expect(additionalUserInfo.username, isNull);
       expect(additionalUserInfo.isNewUser, isNotNull);
       expect(additionalUserInfo.profile, isNull);
-      if (Platform.isIOS) {
-        // TODO(jackson): Fix behavior to be consistent across platforms
-        // https://github.com/firebase/firebase-ios-sdk/issues/3450
-        expect(additionalUserInfo.providerId, 'password');
-      } else if (Platform.isAndroid) {
-        expect(additionalUserInfo.providerId, isNull);
-      }
+      // TODO(jackson): Fix behavior to be consistent across platforms
+      // https://github.com/firebase/firebase-ios-sdk/issues/3450
+      expect(
+          additionalUserInfo.providerId == null ||
+              additionalUserInfo.providerId == 'password',
+          isTrue);
     });
 
     test('isSignInWithEmailLink', () async {

--- a/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
+++ b/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
@@ -379,7 +379,8 @@ int nextHandle = 0;
              @"username" : additionalUserInfo.username ?: [NSNull null],
              @"providerId" : additionalUserInfo.providerID ?: [NSNull null],
              @"profile" : additionalUserInfo.profile ?: [NSNull null],
-           } : [NSNull null],
+           }
+                                                      : [NSNull null],
          }
              error:error];
 }

--- a/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
+++ b/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
@@ -376,9 +376,9 @@ int nextHandle = 0;
            @"user" : (user != nil ? [self dictionaryFromUser:user] : nil),
            @"additionalUserInfo" : additionalUserInfo ? @{
              @"isNewUser" : [NSNumber numberWithBool:additionalUserInfo.isNewUser],
-             @"username" : additionalUserInfo.username,
-             @"providerId" : additionalUserInfo.providerID,
-             @"profile" : additionalUserInfo.profile,
+             @"username" : additionalUserInfo.username ?: [NSNull null],
+             @"providerId" : additionalUserInfo.providerID ?: [NSNull null],
+             @"profile" : additionalUserInfo.profile ?: [NSNull null],
            } : [NSNull null],
          }
              error:error];

--- a/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
+++ b/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
@@ -374,12 +374,12 @@ int nextHandle = 0;
   [self sendResult:result
          forObject:@{
            @"user" : (user != nil ? [self dictionaryFromUser:user] : nil),
-           @"additionalUserInfo" : @{
+           @"additionalUserInfo" : additionalUserInfo ? @{
              @"isNewUser" : [NSNumber numberWithBool:additionalUserInfo.isNewUser],
              @"username" : additionalUserInfo.username,
              @"providerId" : additionalUserInfo.providerID,
              @"profile" : additionalUserInfo.profile,
-           }
+           } : [NSNull null],
          }
              error:error];
 }

--- a/packages/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Firebase Auth, enabling Android and iOS
   like Google, Facebook and Twitter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_auth
-version: "0.12.0"
+version: "0.12.0+1"
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Avoids an exception when `additionalProviderInfo` is `nil` or has `nil` fields.

## Related Issues

Fixes flutter/flutter#37133

This is already tested by our integration tests, but our test CI isn't failing on exceptions that kill the app on iOS, which is how this slipped through. Once that is fixed, test failures like this will prevent PRs from being merged. (flutter/flutter#37141, https://github.com/flutter/plugin_tools/pull/50)

For the moment we can confirm that the test failure is fixed by just looking at the test logs.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.