### PR TITLE
[cloud_functions] Hide the origin attribute of CloudFunctions constructor.

### DIFF
--- a/packages/cloud_functions/lib/src/cloud_functions.dart
+++ b/packages/cloud_functions/lib/src/cloud_functions.dart
@@ -16,10 +16,9 @@ class CloudFunctionsException implements Exception {
 ///
 /// You can get an instance by calling [CloudFunctions.instance].
 class CloudFunctions {
-  CloudFunctions({FirebaseApp app, String region, String origin})
+  CloudFunctions({FirebaseApp app, String region})
       : _app = app ?? FirebaseApp.instance,
-        _region = region,
-        _origin = origin;
+        _region = region;
 
   @visibleForTesting
   static const MethodChannel channel = MethodChannel('cloud_functions');


### PR DESCRIPTION
The `origin` attribute isn't in the constructor on other platforms, and isn't testing so let's not expose it.

Follow-on to #1887 which hasn't been released yet, hoping to get this merged in to 0.4.1 so we don't have to do a breaking change.