### PR TITLE
[firebase_crashlytics] Fixes exception when trying to format crash re…

### DIFF
--- a/packages/firebase_crashlytics/CHANGELOG.md
+++ b/packages/firebase_crashlytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0+2
+
+* [iOS] Fixes crash when trying to report a crash without any context
+
 ## 0.1.0+1
 
 * Added additional exception information from the Flutter framework to the reports.

--- a/packages/firebase_crashlytics/ios/Classes/FirebaseCrashlyticsPlugin.m
+++ b/packages/firebase_crashlytics/ios/Classes/FirebaseCrashlyticsPlugin.m
@@ -76,11 +76,16 @@
     for (NSDictionary *errorElement in errorElements) {
       [frames addObject:[self generateFrame:errorElement]];
     }
-    [[Crashlytics sharedInstance]
-        recordCustomExceptionName:call.arguments[@"exception"]
-                           reason:[NSString
-                                      stringWithFormat:@"thrown %s", call.arguments[@"context"]]
-                       frameArray:frames];
+
+    NSString *context = call.arguments[@"context"];
+    NSString *reason;
+    if (context != nil) {
+      reason = [NSString stringWithFormat:@"thrown %@", context];
+    }
+
+    [[Crashlytics sharedInstance] recordCustomExceptionName:call.arguments[@"exception"]
+                                                     reason:reason
+                                                 frameArray:frames];
     result(@"Error reported to Crashlytics.");
   } else if ([@"Crashlytics#isDebuggable" isEqualToString:call.method]) {
     result([NSNumber numberWithBool:[Crashlytics sharedInstance].debugMode]);

--- a/packages/firebase_crashlytics/pubspec.yaml
+++ b/packages/firebase_crashlytics/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_crashlytics
 description:
   Flutter plugin for Firebase Crashlytics. It reports uncaught errors to the
   Firebase console.
-version: 0.1.0+1
+version: 0.1.0+2
 author: Flutter Team <flutter-dev@google.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_crashlytics
 


### PR DESCRIPTION
…ason when the crash has no context

## Description

Seeing lots of crashes related to this issue.

Example crash log:

```
#0. Crashed: com.apple.main-thread
0  libsystem_platform.dylib       0x1ad46e384 _platform_strlen + 4
1  CoreFoundation                 0x1ad80b5e8 __CFStringAppendFormatCore + 6024
2  CoreFoundation                 0x1ad80d6b8 _CFStringCreateWithFormatAndArgumentsAux2 + 136
3  Foundation                     0x1ae1b6790 +[NSString stringWithFormat:] + 68
4  Runner                         0x100fa2608 -[FirebaseCrashlyticsPlugin handleMethodCall:result:] + 81 (FirebaseCrashlyticsPlugin.m:81)
```

## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
