### PR TITLE
[image_picker] Depend on AndroidX Core instead of Legacy Support v4

### DIFF
--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.1+2
+
+* Replace dependency on `androidx.legacy:legacy-support-v4:1.0.0` with `androidx.core:core:1.0.2`
+
 ## 0.6.1+1
 
 * Add dependency on `androidx.annotation:annotation:1.0.0`.

--- a/packages/image_picker/android/build.gradle
+++ b/packages/image_picker/android/build.gradle
@@ -48,7 +48,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        api 'androidx.core:core:1.0.2'
+        implementation 'androidx.core:core:1.0.2'
         implementation 'androidx.annotation:annotation:1.0.0'
     }
 }

--- a/packages/image_picker/android/build.gradle
+++ b/packages/image_picker/android/build.gradle
@@ -48,7 +48,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        api 'androidx.legacy:legacy-support-v4:1.0.0'
+        api 'androidx.core:core:1.0.2'
         implementation 'androidx.annotation:annotation:1.0.0'
     }
 }

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -5,7 +5,7 @@ authors:
   - Flutter Team <flutter-dev@googlegroups.com>
   - Rhodes Davis Jr. <rody.davis.jr@gmail.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.6.1+1
+version: 0.6.1+2
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

It's not recommended to depend on the `legacy-support-v4` artifact any longer as we should depend on the relevant sub-artifacts instead to reduce the transitive dependencies.

The `image_picker` package only uses classes from the `androidx.core` package, so we can safely replace the `androidx.legacy:legacy-support-v4` dependency with `androidx.core:core`.

## Related Issues

This simple change is part of the PR #1878.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
