### PR TITLE
[google_maps] Set correct polyline width when building polylines.

### DIFF
--- a/packages/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.20+2
+
+* Android: Fix polyline width in building phase.
+
 ## 0.5.20+1
 
 * Android: Unregister ActivityLifecycleCallbacks on activity destroy (fixes a memory leak).

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/PolylineBuilder.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/PolylineBuilder.java
@@ -9,9 +9,11 @@ import java.util.List;
 class PolylineBuilder implements PolylineOptionsSink {
   private final PolylineOptions polylineOptions;
   private boolean consumeTapEvents;
+  private final float density;
 
-  PolylineBuilder() {
+  PolylineBuilder(float density) {
     this.polylineOptions = new PolylineOptions();
+    this.density = density;
   }
 
   PolylineOptions build() {
@@ -70,7 +72,7 @@ class PolylineBuilder implements PolylineOptionsSink {
 
   @Override
   public void setWidth(float width) {
-    polylineOptions.width(width);
+    polylineOptions.width(width * density);
   }
 
   @Override

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/PolylinesController.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/PolylinesController.java
@@ -81,7 +81,7 @@ class PolylinesController {
     if (polyline == null) {
       return;
     }
-    PolylineBuilder polylineBuilder = new PolylineBuilder();
+    PolylineBuilder polylineBuilder = new PolylineBuilder(density);
     String polylineId = Convert.interpretPolylineOptions(polyline, polylineBuilder);
     PolylineOptions options = polylineBuilder.build();
     addPolyline(polylineId, options, polylineBuilder.consumeTapEvents());

--- a/packages/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter
-version: 0.5.20+1
+version: 0.5.20+2
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Description

*Currently when you start GoogleMaps widget first time, the widget won't take device display metrics into account and only when you reload state of the widget the metrics are applied to polyline width.  **As far as I know, this issue is only on Android platform.***

## Related Issues

*flutter/flutter#36754*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

