### PR TITLE
[google_sign_in] Fixes PlataformException leaking in debug mode (#37343)

### DIFF
--- a/packages/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 4.0.5+1
+## 4.0.6
 
 * Fixed the `PlatformException` leaking from `catchError()` in debug mode.
 

--- a/packages/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.5+1
+
+* Fixed the `PlatformException` leaking from `catchError()` in debug mode.
+
 ## 4.0.5
 
 * Update README with solution to `APIException` errors.
@@ -6,7 +10,7 @@
 
 * Revert changes in 4.0.3.
 
-## 4.0.3	
+## 4.0.3
 
 * Update guava to `27.0.1-android`.	
 * Add correct @NonNull annotations to reduce compiler warnings.	

--- a/packages/google_sign_in/lib/google_sign_in.dart
+++ b/packages/google_sign_in/lib/google_sign_in.dart
@@ -342,9 +342,13 @@ class _MethodCompleter {
   final Completer<GoogleSignInAccount> _completer =
       Completer<GoogleSignInAccount>();
 
-  void complete(FutureOr<GoogleSignInAccount> value) {
+  Future<void> complete(FutureOr<GoogleSignInAccount> value) async {
     if (value is Future<GoogleSignInAccount>) {
-      value.then(_completer.complete, onError: _completer.completeError);
+      try {
+        _completer.complete(await value);
+      } catch (e, stacktrace) {
+        _completer.completeError(e, stacktrace);
+      }
     } else {
       _completer.complete(value);
     }

--- a/packages/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_sign_in
-version: 4.0.5
+version: 4.0.5+1
 
 flutter:
   plugin:

--- a/packages/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_sign_in
-version: 4.0.5+1
+version: 4.0.6
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Prevents `PlatformException` from leaking in debug mode, as Dart is not able to support an exception thrown in a future because the event loop that handles the future is not able to see the caller's stack trace.

## Related Issues

flutter/flutter#37343
flutter/flutter#26705
dart-lang/sdk#37268

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
