### PR TITLE
[firebase_admob] Fixes memory leak by removing static reference for Activities

### DIFF
--- a/packages/firebase_admob/CHANGELOG.md
+++ b/packages/firebase_admob/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.1
+
+* Android: Fixes memory leak.
+
 ## 0.9.0+3
 
 * Update google-services Android gradle plugin to 4.3.0 in documentation and examples.

--- a/packages/firebase_admob/android/src/main/java/io/flutter/plugins/firebaseadmob/MobileAdRegistrar.java
+++ b/packages/firebase_admob/android/src/main/java/io/flutter/plugins/firebaseadmob/MobileAdRegistrar.java
@@ -1,0 +1,48 @@
+package io.flutter.plugins.firebaseadmob;
+
+import android.app.Activity;
+import android.util.SparseArray;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.google.android.gms.ads.AdSize;
+import io.flutter.plugin.common.MethodChannel;
+
+/* Class that acts as Factory and registry for MobileAds. */
+class MobileAdRegistrar {
+  private SparseArray<MobileAd> allAds = new SparseArray<>();
+
+  /* Returns a MobileAd if it is registered in this Registrar. */
+  @Nullable
+  MobileAd getAdForId(Integer id) {
+    return allAds.get(id);
+  }
+
+  /* Registers a new MobileAd with the given id. */
+  void register(int id, MobileAd ad) {
+    allAds.put(id, ad);
+  }
+
+  /* Returns an already registered Banner with the given id or creates a new Banner. */
+  @NonNull
+  MobileAd.Banner createBanner(
+      Integer id, AdSize adSize, Activity activity, MethodChannel channel) {
+    MobileAd ad = getAdForId(id);
+    return (ad != null)
+        ? (MobileAd.Banner) ad
+        : new MobileAd.Banner(this, id, adSize, activity, channel);
+  }
+
+  /* Returns an already registered Interstitial with the given id or creates a new Interstitial. */
+  @NonNull
+  MobileAd.Interstitial createInterstitial(Integer id, Activity activity, MethodChannel channel) {
+    MobileAd ad = getAdForId(id);
+    return (ad != null)
+        ? (MobileAd.Interstitial) ad
+        : new MobileAd.Interstitial(this, id, activity, channel);
+  }
+
+  /* Unregisters a MobileAd with the given id. */
+  void unregister(Integer id) {
+    allAds.remove(id);
+  }
+}

--- a/packages/firebase_admob/pubspec.yaml
+++ b/packages/firebase_admob/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase AdMob, supporting
   banner, interstitial (full-screen), and rewarded video ads
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_admob
-version: 0.9.0+3
+version: 0.9.1
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description
This PR tries to fix a memory leak on Android caused by `MobileAd.allAds` variable being `static`.
Each ad has a reference to the current Activity and the static reference kept the Activity in memory even after it was destroyed be the platform. 

To solve this, `allAds` was moved to another class, called `ModileAdRegistrar` that handles the interaction with this variable in a non static way.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [X] No, this is *not* a breaking change.