### PR TITLE
[firebase_storage] Remove StorageTaskEvent prints

### DIFF
--- a/packages/firebase_storage/CHANGELOG.md
+++ b/packages/firebase_storage/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.0.5
+* Removed automatic print statements for `StorageTaskEvent`'s.
+  If you want to see the event status in your logs now, you will have to use the following:
+  `storageReference.put{File/Data}(..).events.listen((event) => print('EVENT ${event.type}'));`
+* Updated `README.md` to explain the above.
+
 ## 3.0.4
 
 * Update google-services Android gradle plugin to 4.3.0 in documentation and examples.

--- a/packages/firebase_storage/README.md
+++ b/packages/firebase_storage/README.md
@@ -27,7 +27,8 @@ final StreamSubscription<StorageTaskEvent> streamSubscription = uploadTask.event
   // For example: you could use the uploadTask.events stream in a StreamBuilder instead
   // to show your user what the current status is. In that case, you would not need to cancel any
   // subscription as StreamBuilder handles this automatically.
-  // In this case, every StorageTaskEvent concerning the upload is printed to the logs.
+
+  // Here, every StorageTaskEvent concerning the upload is printed to the logs.
   print('EVENT ${event.type}');
 });
 

--- a/packages/firebase_storage/README.md
+++ b/packages/firebase_storage/README.md
@@ -9,7 +9,27 @@ For Flutter plugins for other Firebase products, see [FlutterFire.md](https://gi
 *Note*: This plugin is still under development, and some APIs might not be available yet. [Feedback](https://github.com/flutter/flutter/issues) and [Pull Requests](https://github.com/flutter/plugins/pulls) are most welcome!
 
 ## Usage
+
 To use this plugin, add `firebase_storage` as a [dependency in your pubspec.yaml file](https://flutter.io/platform-plugins/).
+
+### Logging
+
+If you wish to see status events for your upload tasks in your logs, you should listen to the `StorageUploadTask.events` stream.  
+This could look like the following if you are using `StorageReference.putData`:
+
+```dart
+final StorageReference storageReference = FirebaseStorage().ref().child(path);
+
+final StorageUploadTask uploadTask = storageReference.putData(data);
+
+final StreamSubscription<StorageTaskEvent> streamSubscription = uploadTask.events.listen((event) {
+  print('EVENT ${event.type}');
+});
+
+// Cancel your subscription when done.
+await uploadTask.onComplete;
+streamSubscription.cancel();
+```
 
 ## Getting Started
 

--- a/packages/firebase_storage/README.md
+++ b/packages/firebase_storage/README.md
@@ -23,6 +23,11 @@ final StorageReference storageReference = FirebaseStorage().ref().child(path);
 final StorageUploadTask uploadTask = storageReference.putData(data);
 
 final StreamSubscription<StorageTaskEvent> streamSubscription = uploadTask.events.listen((event) {
+  // You can use this to notify yourself or your user in any kind of way.
+  // For example: you could use the uploadTask.events stream in a StreamBuilder instead
+  // to show your user what the current status is. In that case, you would not need to cancel any
+  // subscription as StreamBuilder handles this automatically.
+  // In this case, every StorageTaskEvent concerning the upload is printed to the logs.
   print('EVENT ${event.type}');
 });
 

--- a/packages/firebase_storage/lib/src/upload_task.dart
+++ b/packages/firebase_storage/lib/src/upload_task.dart
@@ -56,7 +56,6 @@ abstract class StorageUploadTask {
 
   void _changeState(StorageTaskEvent event) {
     _resetState();
-    print('EVENT ${event.type}');
     switch (event.type) {
       case StorageTaskEventType.progress:
         isInProgress = true;

--- a/packages/firebase_storage/pubspec.yaml
+++ b/packages/firebase_storage/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Cloud Storage, a powerful, simple, and
   cost-effective object storage service for Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_storage
-version: 3.0.4
+version: 3.0.5
 
 flutter:
   plugin:


### PR DESCRIPTION
## Reason

It is generally pretty annoying to see prints in your logs from sources you do not control and in this case, any user could manually add print statements (or even better, other kinds of notifications) very easily.  
More importantly, this actually becomes *a problem* when running multiple uploads simultaneously. Here is a list of issues I encountered:

 1. There is no indication as to which upload the print statement is referring to, it is just a continuous stream of `EVENT StorageTaskEventType.progress` and `EVENT StorageTaskEventType.success`.

 1. There is no way to disable these prints if I do not want them to clutter my logs.

 1. This does impact performance and that is a problem when considering the previous point.

 1. They seem to be delayed? I am not entirely sure about this, but I added an element to my UI that waited for `Future.wait(futures)`, where `futures` was a list of `onComplete`'s and that element showed that all uploads did complete long before the logging stopped.

## Implementation

I decided to essentially do nothing for the implementation (only remove the `print` call) and here is why:

 * There already is a way to manually print the upload status. I simply added explanation of how to do this both to `README.md` and `CHANGELOG.md`.

 * I would need to add an implementation to the plugin to make this behavior optional out of the box, which seems redundant to me as there already is a stream that is meant to handle cases like this.

## Conclusion

I feel like there is no good answer to the question "Why do we need to print the upload status out of the box in the first place?".  
If the developer wants to know about their upload status, they should listen to the stream and this even encourages to find different, possibly better ways, to notify about the upload status than simply printing to the logs.