### PR TITLE
[android_alarm_manager] Added oneShotAt method to schedule a alarm at a given time

### DIFF
--- a/packages/android_alarm_manager/CHANGELOG.md
+++ b/packages/android_alarm_manager/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 0.4.2+1
+## 0.4.3
 
-* Added oneShotAt method to run `callback` at a given DateTime `time`.
+* Added `oneShotAt` method to run `callback` at a given DateTime `time`.
 
 ## 0.4.2
 

--- a/packages/android_alarm_manager/CHANGELOG.md
+++ b/packages/android_alarm_manager/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.4.2+1
 
-* Added oneShotAt method to run `callback` at given DateTime `time`.
+* Added oneShotAt method to run `callback` at a given DateTime `time`.
 
 ## 0.4.2
 

--- a/packages/android_alarm_manager/CHANGELOG.md
+++ b/packages/android_alarm_manager/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.2+1
+
+* Added oneShotAt method to run `callback` at given DateTime `time`.
+
 ## 0.4.2
 
 * Added support for setting alarms which work when the phone is in doze mode.

--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AndroidAlarmManagerPlugin.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AndroidAlarmManagerPlugin.java
@@ -50,7 +50,7 @@ public class AndroidAlarmManagerPlugin implements MethodCallHandler, ViewDestroy
     // alarmManagerPluginChannel is the channel responsible for receiving the following messages
     // from the main Flutter app:
     // - "AlarmService.start"
-    // - "Alarm.oneShot"
+    // - "Alarm.oneShotAt"
     // - "Alarm.periodic"
     // - "Alarm.cancel"
     final MethodChannel alarmManagerPluginChannel =
@@ -125,7 +125,7 @@ public class AndroidAlarmManagerPlugin implements MethodCallHandler, ViewDestroy
         PeriodicRequest periodicRequest = PeriodicRequest.fromJson((JSONArray) arguments);
         AlarmService.setPeriodic(mContext, periodicRequest);
         result.success(true);
-      } else if (method.equals("Alarm.oneShot")) {
+      } else if (method.equals("Alarm.oneShotAt")) {
         // This message indicates that the Flutter app would like to schedule a one-time
         // task.
         OneShotRequest oneShotRequest = OneShotRequest.fromJson((JSONArray) arguments);

--- a/packages/android_alarm_manager/lib/android_alarm_manager.dart
+++ b/packages/android_alarm_manager/lib/android_alarm_manager.dart
@@ -113,24 +113,19 @@ class AndroidAlarmManager {
     bool exact = false,
     bool wakeup = false,
     bool rescheduleOnReboot = false,
-  }) async {
-    final int now = DateTime.now().millisecondsSinceEpoch;
-    final int first = now + delay.inMilliseconds;
-    final CallbackHandle handle = PluginUtilities.getCallbackHandle(callback);
-    if (handle == null) {
-      return false;
-    }
-    final bool r = await _channel.invokeMethod<bool>('Alarm.oneShot', <dynamic>[
+  }) {
+    final DateTime now = DateTime.now();
+    final DateTime time = now.add(delay);
+    return oneShotAt(
+      time,
       id,
-      alarmClock,
-      allowWhileIdle,
-      exact,
-      wakeup,
-      first,
-      rescheduleOnReboot,
-      handle.toRawHandle(),
-    ]);
-    return (r == null) ? false : r;
+      callback,
+      alarmClock: alarmClock,
+      allowWhileIdle: allowWhileIdle,
+      exact: exact,
+      wakeup: wakeup,
+      rescheduleOnReboot: rescheduleOnReboot,
+    );
   }
 
   /// Schedules a one-shot timer to run `callback` at `time`.

--- a/packages/android_alarm_manager/lib/android_alarm_manager.dart
+++ b/packages/android_alarm_manager/lib/android_alarm_manager.dart
@@ -176,7 +176,7 @@ class AndroidAlarmManager {
     bool wakeup = false,
     bool rescheduleOnReboot = false,
   }) async {
-    final int first = time.millisecondsSinceEpoch;
+    final int startMillis = time.millisecondsSinceEpoch;
     final CallbackHandle handle = PluginUtilities.getCallbackHandle(callback);
     if (handle == null) {
       return false;
@@ -187,7 +187,7 @@ class AndroidAlarmManager {
       allowWhileIdle,
       exact,
       wakeup,
-      first,
+      startMillis,
       rescheduleOnReboot,
       handle.toRawHandle(),
     ]);

--- a/packages/android_alarm_manager/lib/android_alarm_manager.dart
+++ b/packages/android_alarm_manager/lib/android_alarm_manager.dart
@@ -173,7 +173,8 @@ class AndroidAlarmManager {
     if (handle == null) {
       return false;
     }
-    final bool r = await _channel.invokeMethod<bool>('Alarm.oneShotAt', <dynamic>[
+    final bool r =
+        await _channel.invokeMethod<bool>('Alarm.oneShotAt', <dynamic>[
       id,
       alarmClock,
       allowWhileIdle,

--- a/packages/android_alarm_manager/lib/android_alarm_manager.dart
+++ b/packages/android_alarm_manager/lib/android_alarm_manager.dart
@@ -133,6 +133,67 @@ class AndroidAlarmManager {
     return (r == null) ? false : r;
   }
 
+  /// Schedules a one-shot timer to run `callback` at `time`.
+  ///
+  /// The `callback` will run whether or not the main application is running or
+  /// in the foreground. It will run in the Isolate owned by the
+  /// AndroidAlarmManager service.
+  ///
+  /// `callback` must be either a top-level function or a static method from a
+  /// class.
+  ///
+  /// The timer is uniquely identified by `id`. Calling this function again
+  /// again with the same `id` will cancel and replace the existing timer.
+  ///
+  /// If `alarmClock` is passed as `true`, the timer will be created with
+  /// Android's `AlarmManagerCompat.setAlarmClock`.
+  ///
+  /// If `allowWhileIdle` is passed as `true`, the timer will be created with
+  /// Android's `AlarmManagerCompat.setExactAndAllowWhileIdle` or
+  /// `AlarmManagerCompat.setAndAllowWhileIdle`.
+  ///
+  /// If `exact` is passed as `true`, the timer will be created with Android's
+  /// `AlarmManagerCompat.setExact`. When `exact` is `false` (the default), the
+  /// timer will be created with `AlarmManager.set`.
+  ///
+  /// If `wakeup` is passed as `true`, the device will be woken up when the
+  /// alarm fires. If `wakeup` is false (the default), the device will not be
+  /// woken up to service the alarm.
+  ///
+  /// If `rescheduleOnReboot` is passed as `true`, the alarm will be persisted
+  /// across reboots. If `rescheduleOnReboot` is false (the default), the alarm
+  /// will not be rescheduled after a reboot and will not be executed.
+  ///
+  /// Returns a [Future] that resolves to `true` on success and `false` on
+  /// failure.
+  static Future<bool> oneShotAt(
+    DateTime time,
+    int id,
+    dynamic Function() callback, {
+    bool alarmClock = false,
+    bool allowWhileIdle = false,
+    bool exact = false,
+    bool wakeup = false,
+    bool rescheduleOnReboot = false,
+  }) async {
+    final int first = time.millisecondsSinceEpoch;
+    final CallbackHandle handle = PluginUtilities.getCallbackHandle(callback);
+    if (handle == null) {
+      return false;
+    }
+    final bool r = await _channel.invokeMethod<bool>('Alarm.oneShot', <dynamic>[
+      id,
+      alarmClock,
+      allowWhileIdle,
+      exact,
+      wakeup,
+      first,
+      rescheduleOnReboot,
+      handle.toRawHandle(),
+    ]);
+    return (r == null) ? false : r;
+  }
+
   /// Schedules a repeating timer to run `callback` with period `duration`.
   ///
   /// The `callback` will run whether or not the main application is running or

--- a/packages/android_alarm_manager/lib/android_alarm_manager.dart
+++ b/packages/android_alarm_manager/lib/android_alarm_manager.dart
@@ -113,20 +113,17 @@ class AndroidAlarmManager {
     bool exact = false,
     bool wakeup = false,
     bool rescheduleOnReboot = false,
-  }) {
-    final DateTime now = DateTime.now();
-    final DateTime time = now.add(delay);
-    return oneShotAt(
-      time,
-      id,
-      callback,
-      alarmClock: alarmClock,
-      allowWhileIdle: allowWhileIdle,
-      exact: exact,
-      wakeup: wakeup,
-      rescheduleOnReboot: rescheduleOnReboot,
-    );
-  }
+  }) =>
+      oneShotAt(
+        DateTime.now().add(delay),
+        id,
+        callback,
+        alarmClock: alarmClock,
+        allowWhileIdle: allowWhileIdle,
+        exact: exact,
+        wakeup: wakeup,
+        rescheduleOnReboot: rescheduleOnReboot,
+      );
 
   /// Schedules a one-shot timer to run `callback` at `time`.
   ///
@@ -176,7 +173,7 @@ class AndroidAlarmManager {
     if (handle == null) {
       return false;
     }
-    final bool r = await _channel.invokeMethod<bool>('Alarm.oneShot', <dynamic>[
+    final bool r = await _channel.invokeMethod<bool>('Alarm.oneShotAt', <dynamic>[
       id,
       alarmClock,
       allowWhileIdle,

--- a/packages/android_alarm_manager/pubspec.yaml
+++ b/packages/android_alarm_manager/pubspec.yaml
@@ -1,7 +1,7 @@
 name: android_alarm_manager
 description: Flutter plugin for accessing the Android AlarmManager service, and
   running Dart code in the background when alarms fire.
-version: 0.4.2+1
+version: 0.4.3
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/android_alarm_manager
 

--- a/packages/android_alarm_manager/pubspec.yaml
+++ b/packages/android_alarm_manager/pubspec.yaml
@@ -1,7 +1,7 @@
 name: android_alarm_manager
 description: Flutter plugin for accessing the Android AlarmManager service, and
   running Dart code in the background when alarms fire.
-version: 0.4.2
+version: 0.4.2+1
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/android_alarm_manager
 


### PR DESCRIPTION
## Description

Added  a static `oneShotAt` method to AndroidAlarmManager to run `callback` at a given DateTime `time`.

## Related Issues
None

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
