### PR TITLE
[android_intent] Adds mapping to "Intent.ACTION_CALL"

### DIFF
--- a/packages/android_intent/android/src/main/java/io/flutter/plugins/androidintent/AndroidIntentPlugin.java
+++ b/packages/android_intent/android/src/main/java/io/flutter/plugins/androidintent/AndroidIntentPlugin.java
@@ -40,6 +40,8 @@ public class AndroidIntentPlugin implements MethodCallHandler {
     switch (action) {
       case "action_view":
         return Intent.ACTION_VIEW;
+      case "action_call":
+        return Intent.ACTION_CALL;
       case "action_voice":
         return Intent.ACTION_VOICE_COMMAND;
       case "settings":


### PR DESCRIPTION
Sorry if this is the wrong way of proposing a PR, I am a web developer and don't know how things are done in Flutter / Android.

## Description

This PR only adds support for the action : `Intent.ACTION_CALL` from the `android_intent` plugin. The proposed name is "action_call".

## Related

Is there a plan to map all android intents to counterpart names in this flutter plugin? I am guessing that other users could need other actions which are unavailable for now.