### PR TITLE
[connectivity] update the connectivity readme to include info about changes in iOS 13

### DIFF
--- a/packages/connectivity/CHANGELOG.md
+++ b/packages/connectivity/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.3+7
+
+* Update README with iOS 13 known issue information
+
 ## 0.4.3+6
 
 * [Android] Fix the invalid suppression check (it should be "deprecation" not "deprecated").

--- a/packages/connectivity/CHANGELOG.md
+++ b/packages/connectivity/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.4.3+7
 
-* Update README with iOS 13 known issue information
+* Update README with the updated information about CNCopyCurrentNetworkInfo on iOS 13.
 
 ## 0.4.3+6
 

--- a/packages/connectivity/README.md
+++ b/packages/connectivity/README.md
@@ -50,14 +50,14 @@ dispose() {
 }
 ```
 
-Additional methods available:
+You can get WIFI related information using:
 
 ```dart
 import 'package:connectivity/connectivity.dart';
 
-var wifiBSSID = await (Connectivity().getWifiBSSID()); // obtains the BSSID of the connected wifi network
-var wifiIP = await (Connectivity().getWifiIP());       // obtains the IP address of the connected wifi network
-var wifiName = await (Connectivity().getWifiName());   // obtains the wifi name (SSID) of the connected wifi network
+var wifiBSSID = await (Connectivity().getWifiBSSID());
+var wifiIP = await (Connectivity().getWifiIP());network
+var wifiName = await (Connectivity().getWifiName());wifi network
 ```
 
 ### Known Issues
@@ -66,7 +66,7 @@ var wifiName = await (Connectivity().getWifiName());   // obtains the wifi name 
 
 The methods `.getWifiBSSID()` and `.getWifiName()` utilize the [CNCopyCurrentNetworkInfo](https://developer.apple.com/documentation/systemconfiguration/1614126-cncopycurrentnetworkinfo) function on iOS.
 
-As of iOS 13, these APIs will no longer return valid information by default and will instead return the following:
+As of iOS 13, Apple announced that these APIs will no longer return valid information by default and will instead return the following:
 > SSID: "Wi-Fi" or "WLAN" ("WLAN" will be returned for the China SKU)  
 > BSSID: "00:00:00:00:00:00"
 

--- a/packages/connectivity/README.md
+++ b/packages/connectivity/README.md
@@ -69,7 +69,7 @@ initState() {
 
 The methods `.getWifiBSSID()` and `.getWifiName()` utilize the [CNCopyCurrentNetworkInfo](https://developer.apple.com/documentation/systemconfiguration/1614126-cncopycurrentnetworkinfo) function on iOS.
 
-As of iOS 13 that api will no longer return valid information by default and will instead return the following:
+As of iOS 13, these APIs will no longer return valid information by default and will instead return the following:
 > SSID: "Wi-Fi" or "WLAN" ("WLAN" will be returned for the China SKU)  
 > BSSID: "00:00:00:00:00:00"
 

--- a/packages/connectivity/README.md
+++ b/packages/connectivity/README.md
@@ -53,14 +53,11 @@ dispose() {
 Additional methods available:
 
 ```dart
-@override
-initState() {
-  super.initState();
+import 'package:connectivity/connectivity.dart';
 
-  await Connectivity().getWifiBSSID(); // obtains the BSSID of the connected wifi network
-  await Connectivity().getWifiIP();    // obtains the IP address of the connected wifi network
-  await Connectivity().getWifiName();  // obtains the wifi name (SSID) of the connected wifi network
-}
+var wifiBSSID = await (Connectivity().getWifiBSSID()); // obtains the BSSID of the connected wifi network
+var wifiIP = await (Connectivity().getWifiIP());       // obtains the IP address of the connected wifi network
+var wifiName = await (Connectivity().getWifiName());   // obtains the wifi name (SSID) of the connected wifi network
 ```
 
 ### Known Issues

--- a/packages/connectivity/README.md
+++ b/packages/connectivity/README.md
@@ -7,6 +7,8 @@ This plugin works for iOS and Android.
 > Note that on Android, this does not guarantee connection to Internet. For instance,
 the app might have wifi access but it might be a VPN or a hotel WiFi with no access.
 
+## Usage
+
 Sample usage to check current status:
 
 ```dart
@@ -47,6 +49,31 @@ dispose() {
   subscription.cancel();
 }
 ```
+
+Additional methods available:
+
+```dart
+@override
+initState() {
+  super.initState();
+
+  await Connectivity().getWifiBSSID(); // obtains the BSSID of the connected wifi network
+  await Connectivity().getWifiIP();    // obtains the IP address of the connected wifi network
+  await Connectivity().getWifiName();  // obtains the wifi name (SSID) of the connected wifi network
+}
+```
+
+### Known Issues
+
+#### iOS 13
+
+The methods `.getWifiBSSID()` and `.getWifiName()` utilize the [CNCopyCurrentNetworkInfo](https://developer.apple.com/documentation/systemconfiguration/1614126-cncopycurrentnetworkinfo) function on iOS.
+
+As of iOS 13 that api will no longer return valid information by default and will instead return the following:
+> SSID: "Wi-Fi" or "WLAN" ("WLAN" will be returned for the China SKU)  
+> BSSID: "00:00:00:00:00:00"
+
+You can follow issue [#37804](https://github.com/flutter/flutter/issues/37804) for the changes required to return valid SSID and BSSID values with iOS 13.
 
 ## Getting Started
 

--- a/packages/connectivity/pubspec.yaml
+++ b/packages/connectivity/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for discovering the state of the network (WiFi &
   mobile/cellular) connectivity on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/connectivity
-version: 0.4.3+6
+version: 0.4.3+7
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Update the Readme for the Connectivity plugin to include information about changes in iOS 13.

Specifically the tightening of security around SSID and BSSID information.

Apple's email announcing the change:
![image](https://user-images.githubusercontent.com/17821843/62652121-73cd6780-b90f-11e9-9b85-ec2d2c43dc96.png)

Apple's documentation about [CNCopyCurrentNetworkInfo](https://developer.apple.com/documentation/systemconfiguration/1614126-cncopycurrentnetworkinfo)

## Related Issues

Resolves: [#35322](https://github.com/flutter/flutter/issues/35332)

A followup issue has been created for "fixing" the iOS 13 functionality at [#37804](https://github.com/flutter/flutter/issues/37804)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ X ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ X ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ X ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ X ] I signed the [CLA].
- [ X ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ X ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
