### PR TITLE
[camera] Fix permissions bug in sample code.

### DIFF
--- a/packages/camera/example/lib/main.dart
+++ b/packages/camera/example/lib/main.dart
@@ -52,6 +52,10 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
+    // App state changed before we got the chance to initialize.
+    if (controller == null || !controller.value.isInitialized) {
+      return;
+    }
     if (state == AppLifecycleState.inactive) {
       controller?.dispose();
     } else if (state == AppLifecycleState.resumed) {


### PR DESCRIPTION
Permission requests force app to go into background triggering a controller.dispose() before the controller is even initialized. After the permission is granted, you end up with an exception.

We should not dispose or reinit a controller if it is not inited yet.