### PR TITLE
[share] Fixed email sharing on IOS w/o filled subject

### DIFF
--- a/packages/share/lib/share.dart
+++ b/packages/share/lib/share.dart
@@ -39,7 +39,7 @@ class Share {
     assert(text.isNotEmpty);
     final Map<String, dynamic> params = <String, dynamic>{
       'text': text,
-      'subject': subject,
+      'subject': subject ?? '',
     };
 
     if (sharePositionOrigin != null) {


### PR DESCRIPTION
## Description

When i share content by email on IOS app crashes and throws `NSInvalidArgumentException` due to the fact that subject cannot be null