### PR TITLE
[shared_preferences] Allow getInstance() to be reentrant

### DIFF
--- a/packages/shared_preferences/lib/shared_preferences.dart
+++ b/packages/shared_preferences/lib/shared_preferences.dart
@@ -26,7 +26,7 @@ class SharedPreferences {
         final Map<String, Object> preferencesMap =
             await _getSharedPreferencesMap();
         _completer.complete(SharedPreferences._(preferencesMap));
-      } on Exception catch(e) {
+      } on Exception catch (e) {
         // If there's an error, explicitly return the future with an error.
         // then set the completer to null so we can retry.
         _completer.completeError(e);
@@ -178,7 +178,7 @@ class SharedPreferences {
 
   /// Initializes the shared preferences with mock values for testing.
   ///
-  /// If the singleton instance has been initialized already, it is automatically reloaded.
+  /// If the singleton instance has been initialized already, it is nullified.
   @visibleForTesting
   static void setMockInitialValues(Map<String, dynamic> values) {
     _kChannel.setMockMethodCallHandler((MethodCall methodCall) async {
@@ -187,6 +187,6 @@ class SharedPreferences {
       }
       return null;
     });
-    _completer?.future.then((SharedPreferences prefs) => prefs.reload());
+    _completer = null;
   }
 }

--- a/packages/shared_preferences/lib/shared_preferences.dart
+++ b/packages/shared_preferences/lib/shared_preferences.dart
@@ -18,14 +18,24 @@ class SharedPreferences {
   SharedPreferences._(this._preferenceCache);
 
   static const String _prefix = 'flutter.';
-  static SharedPreferences _instance;
+  static Completer<SharedPreferences> _completer;
   static Future<SharedPreferences> getInstance() async {
-    if (_instance == null) {
-      final Map<String, Object> preferencesMap =
-          await _getSharedPreferencesMap();
-      _instance = SharedPreferences._(preferencesMap);
+    if (_completer == null) {
+      _completer = Completer();
+      try {
+        final Map<String, Object> preferencesMap =
+            await _getSharedPreferencesMap();
+        _completer.complete(SharedPreferences._(preferencesMap));
+      } on Exception catch(e) {
+        // If there's an error, explicitly return the future with an error.
+        // then set the completer to null so we can retry.
+        _completer.completeError(e);
+        Future<SharedPreferences> sharedPrefsFuture = _completer.future;
+        _completer = null;
+        return sharedPrefsFuture;
+      }
     }
-    return _instance;
+    return _completer.future;
   }
 
   /// The cache that holds all preferences.
@@ -177,6 +187,6 @@ class SharedPreferences {
       }
       return null;
     });
-    _instance?.reload();
+    _completer?.future.then((SharedPreferences prefs) => prefs.reload());
   }
 }

--- a/packages/shared_preferences/lib/shared_preferences.dart
+++ b/packages/shared_preferences/lib/shared_preferences.dart
@@ -21,7 +21,7 @@ class SharedPreferences {
   static Completer<SharedPreferences> _completer;
   static Future<SharedPreferences> getInstance() async {
     if (_completer == null) {
-      _completer = Completer();
+      _completer = Completer<SharedPreferences>();
       try {
         final Map<String, Object> preferencesMap =
             await _getSharedPreferencesMap();
@@ -30,7 +30,7 @@ class SharedPreferences {
         // If there's an error, explicitly return the future with an error.
         // then set the completer to null so we can retry.
         _completer.completeError(e);
-        Future<SharedPreferences> sharedPrefsFuture = _completer.future;
+        final Future<SharedPreferences> sharedPrefsFuture = _completer.future;
         _completer = null;
         return sharedPrefsFuture;
       }

--- a/packages/shared_preferences/test/shared_preferences_test.dart
+++ b/packages/shared_preferences/test/shared_preferences_test.dart
@@ -155,6 +155,12 @@ void main() {
       expect(preferences.getString('String'), kTestValues2['flutter.String']);
     });
 
+    test('back to back calls should return same instance.', () async {
+      Future<SharedPreferences> first = SharedPreferences.getInstance();
+      Future<SharedPreferences> second = SharedPreferences.getInstance();
+      expect(await first, await second);
+    });
+
     group('mocking', () {
       const String _key = 'dummy';
       const String _prefixedKey = 'flutter.' + _key;

--- a/packages/shared_preferences/test/shared_preferences_test.dart
+++ b/packages/shared_preferences/test/shared_preferences_test.dart
@@ -156,8 +156,8 @@ void main() {
     });
 
     test('back to back calls should return same instance.', () async {
-      Future<SharedPreferences> first = SharedPreferences.getInstance();
-      Future<SharedPreferences> second = SharedPreferences.getInstance();
+      final Future<SharedPreferences> first = SharedPreferences.getInstance();
+      final Future<SharedPreferences> second = SharedPreferences.getInstance();
       expect(await first, await second);
     });
 


### PR DESCRIPTION
This is not a breaking change.

The rationale is that some apps call SharedPreferences.getInstance() from multiple widgets. If these calls come back to back before the map definition manages to come back from native, you end up getting different instances of SharedPreferences which is very very bad.