### PR TITLE
[webview_flutter] Filter onChanged events for invalid displays

### DIFF
--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.11+1
+
+* Work around a bug in old Android WebView versions that was causing a crash
+  when resizing the webview on old devices.
+
 ## 0.3.11
 
 * Add an initialAutoMediaPlaybackPolicy setting for controlling how auto media

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/DisplayListenerProxy.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/DisplayListenerProxy.java
@@ -1,0 +1,142 @@
+package io.flutter.plugins.webviewflutter;
+
+import android.annotation.TargetApi;
+import android.hardware.display.DisplayManager;
+import android.os.Build;
+import android.util.Log;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+
+import static android.hardware.display.DisplayManager.DisplayListener;
+
+/**
+ * Works around an Android WebView bug by filtering some DisplayListener invocations.
+ *
+ * <p>Older Android WebView versions had assumed that when {@link DisplayListener#onDisplayChanged}
+ * is invoked, the display ID it is provided is of a valid display. However it turns out that
+ * when a display is removed Android may call onDisplayChanged with the ID of the removed display,
+ * in this case the Android WebView code tries to fetch and use the display with this ID and crashes
+ * with an NPE.
+ *
+ * <p>This issue was fixed in the Android WebView code in
+ * https://chromium-review.googlesource.com/517913 which is available starting WebView version
+ * 58.0.3029.125 however older webviews in the wild still have this issue.
+ *
+ * <p>Since Flutter removes virtual displays whenever a platform view is resized the webview crash
+ * is more likely to happen than other apps. And users were reporting this issue see:
+ * https://github.com/flutter/flutter/issues/30420
+ *
+ * <p>This class works around the webview bug by unregistering the WebView's DisplayListener,
+ * and instead registering its own DisplayListener which delegates the callbacks to the WebView's
+ * listener unless it's a onDisplayChanged for an invalid display.
+ *
+ * <p>I did not find a clean way to get a handle of the WebView's DisplayListener so I'm using
+ * reflection to fetch all registered listeners before and after initializing a webview. In the
+ * first initialization of a webview within the process the difference between the lists is the
+ * webview's display listener.
+ */
+@TargetApi(Build.VERSION_CODES.KITKAT)
+class DisplayListenerProxy {
+    private static final String TAG = "DisplayListenerProxy";
+
+    private ArrayList<DisplayListener> listenersBeforeWebView;
+
+    /**
+     * Should be called prior to the webview's initialization.
+     */
+    void onPreWebViewInitialization(DisplayManager displayManager) {
+       listenersBeforeWebView = yoinkDisplayListeners(displayManager) ;
+    }
+
+    /**
+     * Should be called after the webview's initialization.
+     */
+    void onPostWebViewInitialization(final DisplayManager displayManager) {
+        final ArrayList<DisplayListener> listeners = yoinkDisplayListeners(displayManager);
+        // We recorded
+        listeners.removeAll(listenersBeforeWebView);
+
+        if (listeners.isEmpty()) {
+            // The Android WebView registers a single display listener per process (even if there
+            // are multiple WebView instances) so this list is expected to be non-empty only the
+            // first time a webview is initialized.
+            // Note that in an add2app scenario if the application had instantiated a non Flutter
+            // WebView prior to instantiating the Flutter WebView we are not able to get a reference
+            // to the WebView's display listener and can't work around the bug.
+            //
+            // This means that webview resizes in add2app Flutter apps with a non Flutter WebView
+            // running on a system with a webview prior to 58.0.3029.125 may crash (the Android's
+            // behavior seems to be racy so it doesn't always happen).
+            return;
+        }
+
+
+        for (DisplayListener webViewListener : listeners) {
+            // Note that while DisplayManager.unregisterDisplayListener throws when given an
+            // unregistered listener, this isn't an issue as the WebView code never calls
+            // unregisterDisplayListener.
+            displayManager.unregisterDisplayListener(webViewListener);
+
+            // We never explicitly unregister this listener as the webview's listener is never
+            // unregistered (it's released when the process is terminated).
+            displayManager.registerDisplayListener(new DisplayListener() {
+                @Override
+                public void onDisplayAdded(int displayId) {
+                    for (DisplayListener webViewListener : listeners) {
+                        webViewListener.onDisplayAdded(displayId);
+                    }
+                }
+
+                @Override
+                public void onDisplayRemoved(int displayId) {
+                    for (DisplayListener webViewListener : listeners) {
+                        webViewListener.onDisplayRemoved(displayId);
+                    }
+                }
+
+                @Override
+                public void onDisplayChanged(int displayId) {
+                    if (displayManager.getDisplay(displayId) == null) {
+                        return;
+                    }
+                    for (DisplayListener webViewListener : listeners) {
+                        webViewListener.onDisplayChanged(displayId);
+                    }
+                }
+            }, null);
+        }
+    }
+
+    @SuppressWarnings({"unchecked", "PrivateApi"})
+    private static ArrayList<DisplayListener> yoinkDisplayListeners(DisplayManager displayManager) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            // We cannot use reflection on Android O, but it shouldn't matter as it shipped
+            // with a WebView version that has the bug this code is working around fixed.
+            return new ArrayList<>();
+        }
+        try {
+            Field displayManagerGlobalField = DisplayManager.class.getDeclaredField("mGlobal");
+            displayManagerGlobalField.setAccessible(true);
+            Object displayManagerGlobal = displayManagerGlobalField.get(displayManager);
+            Field displayListenersField = displayManagerGlobal.getClass().getDeclaredField("mDisplayListeners");
+            displayListenersField.setAccessible(true);
+            ArrayList<Object> delegates = (ArrayList<Object>) displayListenersField.get(displayManagerGlobal);
+
+            Field listenerField = null;
+            ArrayList<DisplayManager.DisplayListener> listeners = new ArrayList<>();
+            for (Object delegate : delegates) {
+                if (listenerField == null) {
+                    listenerField = delegate.getClass().getField("mListener");
+                    listenerField.setAccessible(true);
+                }
+                DisplayManager.DisplayListener listener = (DisplayManager.DisplayListener) listenerField.get(delegate);
+                listeners.add(listener);
+            }
+            return listeners;
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            Log.w(TAG, "Could not extract WebView's display listeners. " + e);
+            return new ArrayList<>();
+        }
+    }
+}

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/DisplayListenerProxy.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/DisplayListenerProxy.java
@@ -1,23 +1,22 @@
 package io.flutter.plugins.webviewflutter;
 
+import static android.hardware.display.DisplayManager.DisplayListener;
+
 import android.annotation.TargetApi;
 import android.hardware.display.DisplayManager;
 import android.os.Build;
 import android.util.Log;
-
 import java.lang.reflect.Field;
 import java.util.ArrayList;
-
-import static android.hardware.display.DisplayManager.DisplayListener;
 
 /**
  * Works around an Android WebView bug by filtering some DisplayListener invocations.
  *
  * <p>Older Android WebView versions had assumed that when {@link DisplayListener#onDisplayChanged}
- * is invoked, the display ID it is provided is of a valid display. However it turns out that
- * when a display is removed Android may call onDisplayChanged with the ID of the removed display,
- * in this case the Android WebView code tries to fetch and use the display with this ID and crashes
- * with an NPE.
+ * is invoked, the display ID it is provided is of a valid display. However it turns out that when a
+ * display is removed Android may call onDisplayChanged with the ID of the removed display, in this
+ * case the Android WebView code tries to fetch and use the display with this ID and crashes with an
+ * NPE.
  *
  * <p>This issue was fixed in the Android WebView code in
  * https://chromium-review.googlesource.com/517913 which is available starting WebView version
@@ -27,8 +26,8 @@ import static android.hardware.display.DisplayManager.DisplayListener;
  * is more likely to happen than other apps. And users were reporting this issue see:
  * https://github.com/flutter/flutter/issues/30420
  *
- * <p>This class works around the webview bug by unregistering the WebView's DisplayListener,
- * and instead registering its own DisplayListener which delegates the callbacks to the WebView's
+ * <p>This class works around the webview bug by unregistering the WebView's DisplayListener, and
+ * instead registering its own DisplayListener which delegates the callbacks to the WebView's
  * listener unless it's a onDisplayChanged for an invalid display.
  *
  * <p>I did not find a clean way to get a handle of the WebView's DisplayListener so I'm using
@@ -38,105 +37,105 @@ import static android.hardware.display.DisplayManager.DisplayListener;
  */
 @TargetApi(Build.VERSION_CODES.KITKAT)
 class DisplayListenerProxy {
-    private static final String TAG = "DisplayListenerProxy";
+  private static final String TAG = "DisplayListenerProxy";
 
-    private ArrayList<DisplayListener> listenersBeforeWebView;
+  private ArrayList<DisplayListener> listenersBeforeWebView;
 
-    /**
-     * Should be called prior to the webview's initialization.
-     */
-    void onPreWebViewInitialization(DisplayManager displayManager) {
-       listenersBeforeWebView = yoinkDisplayListeners(displayManager) ;
+  /** Should be called prior to the webview's initialization. */
+  void onPreWebViewInitialization(DisplayManager displayManager) {
+    listenersBeforeWebView = yoinkDisplayListeners(displayManager);
+  }
+
+  /** Should be called after the webview's initialization. */
+  void onPostWebViewInitialization(final DisplayManager displayManager) {
+    final ArrayList<DisplayListener> listeners = yoinkDisplayListeners(displayManager);
+    // We recorded
+    listeners.removeAll(listenersBeforeWebView);
+
+    if (listeners.isEmpty()) {
+      // The Android WebView registers a single display listener per process (even if there
+      // are multiple WebView instances) so this list is expected to be non-empty only the
+      // first time a webview is initialized.
+      // Note that in an add2app scenario if the application had instantiated a non Flutter
+      // WebView prior to instantiating the Flutter WebView we are not able to get a reference
+      // to the WebView's display listener and can't work around the bug.
+      //
+      // This means that webview resizes in add2app Flutter apps with a non Flutter WebView
+      // running on a system with a webview prior to 58.0.3029.125 may crash (the Android's
+      // behavior seems to be racy so it doesn't always happen).
+      return;
     }
 
-    /**
-     * Should be called after the webview's initialization.
-     */
-    void onPostWebViewInitialization(final DisplayManager displayManager) {
-        final ArrayList<DisplayListener> listeners = yoinkDisplayListeners(displayManager);
-        // We recorded
-        listeners.removeAll(listenersBeforeWebView);
+    for (DisplayListener webViewListener : listeners) {
+      // Note that while DisplayManager.unregisterDisplayListener throws when given an
+      // unregistered listener, this isn't an issue as the WebView code never calls
+      // unregisterDisplayListener.
+      displayManager.unregisterDisplayListener(webViewListener);
 
-        if (listeners.isEmpty()) {
-            // The Android WebView registers a single display listener per process (even if there
-            // are multiple WebView instances) so this list is expected to be non-empty only the
-            // first time a webview is initialized.
-            // Note that in an add2app scenario if the application had instantiated a non Flutter
-            // WebView prior to instantiating the Flutter WebView we are not able to get a reference
-            // to the WebView's display listener and can't work around the bug.
-            //
-            // This means that webview resizes in add2app Flutter apps with a non Flutter WebView
-            // running on a system with a webview prior to 58.0.3029.125 may crash (the Android's
-            // behavior seems to be racy so it doesn't always happen).
-            return;
-        }
-
-
-        for (DisplayListener webViewListener : listeners) {
-            // Note that while DisplayManager.unregisterDisplayListener throws when given an
-            // unregistered listener, this isn't an issue as the WebView code never calls
-            // unregisterDisplayListener.
-            displayManager.unregisterDisplayListener(webViewListener);
-
-            // We never explicitly unregister this listener as the webview's listener is never
-            // unregistered (it's released when the process is terminated).
-            displayManager.registerDisplayListener(new DisplayListener() {
-                @Override
-                public void onDisplayAdded(int displayId) {
-                    for (DisplayListener webViewListener : listeners) {
-                        webViewListener.onDisplayAdded(displayId);
-                    }
-                }
-
-                @Override
-                public void onDisplayRemoved(int displayId) {
-                    for (DisplayListener webViewListener : listeners) {
-                        webViewListener.onDisplayRemoved(displayId);
-                    }
-                }
-
-                @Override
-                public void onDisplayChanged(int displayId) {
-                    if (displayManager.getDisplay(displayId) == null) {
-                        return;
-                    }
-                    for (DisplayListener webViewListener : listeners) {
-                        webViewListener.onDisplayChanged(displayId);
-                    }
-                }
-            }, null);
-        }
-    }
-
-    @SuppressWarnings({"unchecked", "PrivateApi"})
-    private static ArrayList<DisplayListener> yoinkDisplayListeners(DisplayManager displayManager) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-            // We cannot use reflection on Android O, but it shouldn't matter as it shipped
-            // with a WebView version that has the bug this code is working around fixed.
-            return new ArrayList<>();
-        }
-        try {
-            Field displayManagerGlobalField = DisplayManager.class.getDeclaredField("mGlobal");
-            displayManagerGlobalField.setAccessible(true);
-            Object displayManagerGlobal = displayManagerGlobalField.get(displayManager);
-            Field displayListenersField = displayManagerGlobal.getClass().getDeclaredField("mDisplayListeners");
-            displayListenersField.setAccessible(true);
-            ArrayList<Object> delegates = (ArrayList<Object>) displayListenersField.get(displayManagerGlobal);
-
-            Field listenerField = null;
-            ArrayList<DisplayManager.DisplayListener> listeners = new ArrayList<>();
-            for (Object delegate : delegates) {
-                if (listenerField == null) {
-                    listenerField = delegate.getClass().getField("mListener");
-                    listenerField.setAccessible(true);
-                }
-                DisplayManager.DisplayListener listener = (DisplayManager.DisplayListener) listenerField.get(delegate);
-                listeners.add(listener);
+      // We never explicitly unregister this listener as the webview's listener is never
+      // unregistered (it's released when the process is terminated).
+      displayManager.registerDisplayListener(
+          new DisplayListener() {
+            @Override
+            public void onDisplayAdded(int displayId) {
+              for (DisplayListener webViewListener : listeners) {
+                webViewListener.onDisplayAdded(displayId);
+              }
             }
-            return listeners;
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            Log.w(TAG, "Could not extract WebView's display listeners. " + e);
-            return new ArrayList<>();
-        }
+
+            @Override
+            public void onDisplayRemoved(int displayId) {
+              for (DisplayListener webViewListener : listeners) {
+                webViewListener.onDisplayRemoved(displayId);
+              }
+            }
+
+            @Override
+            public void onDisplayChanged(int displayId) {
+              if (displayManager.getDisplay(displayId) == null) {
+                return;
+              }
+              for (DisplayListener webViewListener : listeners) {
+                webViewListener.onDisplayChanged(displayId);
+              }
+            }
+          },
+          null);
     }
+  }
+
+  @SuppressWarnings({"unchecked", "PrivateApi"})
+  private static ArrayList<DisplayListener> yoinkDisplayListeners(DisplayManager displayManager) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+      // We cannot use reflection on Android O, but it shouldn't matter as it shipped
+      // with a WebView version that has the bug this code is working around fixed.
+      return new ArrayList<>();
+    }
+    try {
+      Field displayManagerGlobalField = DisplayManager.class.getDeclaredField("mGlobal");
+      displayManagerGlobalField.setAccessible(true);
+      Object displayManagerGlobal = displayManagerGlobalField.get(displayManager);
+      Field displayListenersField =
+          displayManagerGlobal.getClass().getDeclaredField("mDisplayListeners");
+      displayListenersField.setAccessible(true);
+      ArrayList<Object> delegates =
+          (ArrayList<Object>) displayListenersField.get(displayManagerGlobal);
+
+      Field listenerField = null;
+      ArrayList<DisplayManager.DisplayListener> listeners = new ArrayList<>();
+      for (Object delegate : delegates) {
+        if (listenerField == null) {
+          listenerField = delegate.getClass().getField("mListener");
+          listenerField.setAccessible(true);
+        }
+        DisplayManager.DisplayListener listener =
+            (DisplayManager.DisplayListener) listenerField.get(delegate);
+        listeners.add(listener);
+      }
+      return listeners;
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      Log.w(TAG, "Could not extract WebView's display listeners. " + e);
+      return new ArrayList<>();
+    }
+  }
 }

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/DisplayListenerProxy.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/DisplayListenerProxy.java
@@ -48,11 +48,12 @@ class DisplayListenerProxy {
 
   /** Should be called after the webview's initialization. */
   void onPostWebViewInitialization(final DisplayManager displayManager) {
-    final ArrayList<DisplayListener> listeners = yoinkDisplayListeners(displayManager);
-    // We recorded
-    listeners.removeAll(listenersBeforeWebView);
+    final ArrayList<DisplayListener> webViewListeners = yoinkDisplayListeners(displayManager);
+    // We recorded the list of listeners prior to initializing webview, any new listeners we see
+    // after initializing the webview are listeners added by the webview.
+    webViewListeners.removeAll(listenersBeforeWebView);
 
-    if (listeners.isEmpty()) {
+    if (webViewListeners.isEmpty()) {
       // The Android WebView registers a single display listener per process (even if there
       // are multiple WebView instances) so this list is expected to be non-empty only the
       // first time a webview is initialized.
@@ -66,7 +67,7 @@ class DisplayListenerProxy {
       return;
     }
 
-    for (DisplayListener webViewListener : listeners) {
+    for (DisplayListener webViewListener : webViewListeners) {
       // Note that while DisplayManager.unregisterDisplayListener throws when given an
       // unregistered listener, this isn't an issue as the WebView code never calls
       // unregisterDisplayListener.
@@ -78,14 +79,14 @@ class DisplayListenerProxy {
           new DisplayListener() {
             @Override
             public void onDisplayAdded(int displayId) {
-              for (DisplayListener webViewListener : listeners) {
+              for (DisplayListener webViewListener : webViewListeners) {
                 webViewListener.onDisplayAdded(displayId);
               }
             }
 
             @Override
             public void onDisplayRemoved(int displayId) {
-              for (DisplayListener webViewListener : listeners) {
+              for (DisplayListener webViewListener : webViewListeners) {
                 webViewListener.onDisplayRemoved(displayId);
               }
             }
@@ -95,7 +96,7 @@ class DisplayListenerProxy {
               if (displayManager.getDisplay(displayId) == null) {
                 return;
               }
-              for (DisplayListener webViewListener : listeners) {
+              for (DisplayListener webViewListener : webViewListeners) {
                 webViewListener.onDisplayChanged(displayId);
               }
             }

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -6,20 +6,23 @@ package io.flutter.plugins.webviewflutter;
 
 import android.annotation.TargetApi;
 import android.content.Context;
+import android.hardware.display.DisplayManager;
 import android.os.Build;
 import android.os.Handler;
 import android.view.View;
 import android.webkit.WebStorage;
 import android.webkit.WebViewClient;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.platform.PlatformView;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 
 public class FlutterWebView implements PlatformView, MethodCallHandler {
   private static final String JS_CHANNEL_NAMES_FIELD = "javascriptChannelNames";
@@ -28,14 +31,20 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
   private final FlutterWebViewClient flutterWebViewClient;
   private final Handler platformThreadHandler;
 
+  @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
   @SuppressWarnings("unchecked")
   FlutterWebView(
-      Context context,
+      final Context context,
       BinaryMessenger messenger,
       int id,
       Map<String, Object> params,
       final View containerView) {
+
+    DisplayListenerProxy displayListenerProxy = new DisplayListenerProxy();
+    DisplayManager displayManager = (DisplayManager) context.getSystemService(Context.DISPLAY_SERVICE);
+    displayListenerProxy.onPreWebViewInitialization(displayManager);
     webView = new InputAwareWebView(context, containerView);
+    displayListenerProxy.onPostWebViewInitialization(displayManager);
 
     platformThreadHandler = new Handler(context.getMainLooper());
     // Allow local storage.

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -12,17 +12,15 @@ import android.os.Handler;
 import android.view.View;
 import android.webkit.WebStorage;
 import android.webkit.WebViewClient;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.platform.PlatformView;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 public class FlutterWebView implements PlatformView, MethodCallHandler {
   private static final String JS_CHANNEL_NAMES_FIELD = "javascriptChannelNames";
@@ -41,7 +39,8 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
       final View containerView) {
 
     DisplayListenerProxy displayListenerProxy = new DisplayListenerProxy();
-    DisplayManager displayManager = (DisplayManager) context.getSystemService(Context.DISPLAY_SERVICE);
+    DisplayManager displayManager =
+        (DisplayManager) context.getSystemService(Context.DISPLAY_SERVICE);
     displayListenerProxy.onPreWebViewInitialization(displayManager);
     webView = new InputAwareWebView(context, containerView);
     displayListenerProxy.onPostWebViewInitialization(displayManager);

--- a/packages/webview_flutter/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/webview_flutter/example/ios/Runner.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		127772EEA7782174BE0D74B5 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
@@ -55,6 +56,7 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		C475C484BD510DD9CB2E403C /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -138,6 +140,8 @@
 		C6FFB52F5C2B8A41A7E39DE2 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
+				127772EEA7782174BE0D74B5 /* Pods-Runner.debug.xcconfig */,
+				C475C484BD510DD9CB2E403C /* Pods-Runner.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -249,7 +253,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
 				"${PODS_ROOT}/../.symlinks/flutter/ios/Flutter.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -258,7 +262,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		B71376B4FB8384EF9D5F3F84 /* [CP] Check Pods Manifest.lock */ = {

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
-version: 0.3.11
+version: 0.3.11+1
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/webview_flutter
 


### PR DESCRIPTION
## Description

Works around an Android WebView bug that was causing a crash by filtering some DisplayListener invocations.

Older Android WebView versions had assumed that when `DisplayListener#onDisplayChanged` is invoked, the display ID it is provided is of a valid display. However it turns out that when a display is removed Android may call onDisplayChanged with the ID of the removed display, in this case the Android WebView code tries to fetch and use the display with this ID and crashes with an NPE.

The issue was fixed in the Android WebView code in https://chromium-review.googlesource.com/517913 which is available starting WebView version 58.0.3029.125 however older webviews in the wild still have this issue.

Since Flutter removes virtual displays whenever a platform view is resized the webview crash is more likely to happen than other apps. And users were reporting this issue see: https://github.com/flutter/flutter/issues/30420

This change works around the webview bug by unregistering the WebView's DisplayListener, and instead registering our own DisplayListener which delegates the callbacks to the WebView's listener unless it's a onDisplayChanged for an invalid display.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/30420

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.