### PR TITLE
Request code needs to be below 2^16 for FragmentActivity

### DIFF
--- a/packages/camera/CHANGELOG.md
+++ b/packages/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.3+1
+
+* Fix too large request code for FragmentActivity users.
+
 ## 0.5.3
 
 * Added new quality presets.

--- a/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPermissions.java
+++ b/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPermissions.java
@@ -10,7 +10,7 @@ import io.flutter.plugin.common.PluginRegistry;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 public class CameraPermissions {
-  private static final int CAMERA_REQUEST_ID = 513469796;
+  private static final int CAMERA_REQUEST_ID = 9796;
   private boolean ongoing = false;
 
   public void requestPermissions(

--- a/packages/camera/pubspec.yaml
+++ b/packages/camera/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera
 description: A Flutter plugin for getting information about and controlling the
   camera on Android and iOS. Supports previewing the camera feed, capturing images, capturing video,
   and streaming image buffers to dart.
-version: 0.5.3
+version: 0.5.3+1
 
 authors:
   - Flutter Team <flutter-dev@googlegroups.com>


### PR DESCRIPTION
If using FragmentActivity, the requestCode used for startActivityForResult needs to be below 65536. See https://stackoverflow.com/questions/25529865/java-lang-illegalargumentexception-can-only-use-lower-16-bits-for-requestcode.