### PR TITLE
[firebase_auth] use long datatype for timestamps (iOS)

### DIFF
--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.14.0+2
+
+* Reduce compiler warnings on iOS port by replacing `int` with `long` backing in returned timestamps.
+
 ## 0.14.0+1
 
 * Add dependency on `androidx.annotation:annotation:1.0.0`.

--- a/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
+++ b/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
@@ -217,9 +217,10 @@ int nextHandle = 0;
                                 tokenData = [[NSMutableDictionary alloc] initWithDictionary:@{
                                   @"token" : tokenResult.token,
                                   @"expirationTimestamp" :
-                                      [NSNumber numberWithInt:expirationTimestamp],
-                                  @"authTimestamp" : [NSNumber numberWithInt:authTimestamp],
-                                  @"issuedAtTimestamp" : [NSNumber numberWithInt:issuedAtTimestamp],
+                                      [NSNumber numberWithLong:expirationTimestamp],
+                                  @"authTimestamp" : [NSNumber numberWithLong:authTimestamp],
+                                  @"issuedAtTimestamp" :
+                                      [NSNumber numberWithLong:issuedAtTimestamp],
                                   @"claims" : tokenResult.claims,
                                 }];
 

--- a/packages/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Firebase Auth, enabling Android and iOS
   like Google, Facebook and Twitter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_auth
-version: 0.14.0+1
+version: 0.14.0+2
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Reduces a few compiler warnings in the firebase_auth plugin that were caused by using `[NSNumber numberWithInt]` when `numberWithLong` would have worked as well.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
