### PR TITLE
[Firebase Auth] Fix user creation example on README

### DIFF
--- a/packages/firebase_auth/README.md
+++ b/packages/firebase_auth/README.md
@@ -88,10 +88,10 @@ _handleSignIn()
 ### Register a user
 
 ```dart
-final FirebaseUser user = await _auth.createUserWithEmailAndPassword(
+final FirebaseUser user = (await _auth.createUserWithEmailAndPassword(
       email: 'an email',
       password: 'a password',
-    );
+    )).user;
 ```
 
 ### Supported Firebase authentication methods


### PR DESCRIPTION

## Description

Properly assign user to the FirebaseUser from the Auth Result on creating a new user from email and password on README.md
