### PR TITLE
[webview_flutter] Workaround display listeners bug on all Android versions prior to P

### DIFF
--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.11+3
+
+* Apply the display listeners workaround that was shipped in 0.3.11+1 on
+  all Android versions prior to P.
+
 ## 0.3.11+2
 
 * Add fix for input connection being dropped after a screen resize on certain

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/DisplayListenerProxy.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/DisplayListenerProxy.java
@@ -107,9 +107,10 @@ class DisplayListenerProxy {
 
   @SuppressWarnings({"unchecked", "PrivateApi"})
   private static ArrayList<DisplayListener> yoinkDisplayListeners(DisplayManager displayManager) {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-      // We cannot use reflection on Android O, but it shouldn't matter as it shipped
-      // with a WebView version that has the bug this code is working around fixed.
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+      // We cannot use reflection on Android P, but it shouldn't matter as it shipped
+      // with WebView 66.0.3359.158 and the webview the bug this code is working around was
+      // fixed in 61.0.3116.0.
       return new ArrayList<>();
     }
     try {

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/DisplayListenerProxy.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/DisplayListenerProxy.java
@@ -109,7 +109,7 @@ class DisplayListenerProxy {
   private static ArrayList<DisplayListener> yoinkDisplayListeners(DisplayManager displayManager) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
       // We cannot use reflection on Android P, but it shouldn't matter as it shipped
-      // with WebView 66.0.3359.158 and the webview the bug this code is working around was
+      // with WebView 66.0.3359.158 and the WebView version the bug this code is working around was
       // fixed in 61.0.3116.0.
       return new ArrayList<>();
     }

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
-version: 0.3.11+2
+version: 0.3.11+3
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/webview_flutter
 


### PR DESCRIPTION
Follow up on https://github.com/flutter/plugins/pull/1964