### PR TITLE
Revert "[webview_flutter] Add a getTitle method to WebViewController"

### DIFF
--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 0.3.12
-
-* Added a getTitle getter to WebViewController.
-
 ## 0.3.11+6
 
 * Calling destroy on Android webview when flutter webview is getting disposed.

--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.3.12+1
+
+* Temporarily revert getTitle (doing this as a patch bump shortly after publishing).
+
+## 0.3.12
+
+* Added a getTitle getter to WebViewController.
+
 ## 0.3.11+6
 
 * Calling destroy on Android webview when flutter webview is getting disposed.

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -130,9 +130,6 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
       case "clearCache":
         clearCache(result);
         break;
-      case "getTitle":
-        getTitle(result);
-        break;
       default:
         result.notImplemented();
     }
@@ -223,10 +220,6 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
     webView.clearCache(true);
     WebStorage.getInstance().deleteAllData();
     result.success(null);
-  }
-
-  private void getTitle(Result result) {
-    result.success(webView.getTitle());
   }
 
   private void applySettings(Map<String, Object> settings) {

--- a/packages/webview_flutter/example/test_driver/webview.dart
+++ b/packages/webview_flutter/example/test_driver/webview.dart
@@ -369,43 +369,6 @@ void main() {
       expect(isPaused, _webviewBool(false));
     });
   });
-
-  test('getTitle', () async {
-    final String getTitleTest = '''
-        <!DOCTYPE html><html>
-        <head><title>Some title</title>
-        </head>
-        <body>
-        </body>
-        </html>
-      ''';
-    final String getTitleTestBase64 =
-        base64Encode(const Utf8Encoder().convert(getTitleTest));
-    final Completer<void> pageLoaded = Completer<void>();
-    final Completer<WebViewController> controllerCompleter =
-        Completer<WebViewController>();
-
-    await pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: WebView(
-          initialUrl: 'data:text/html;charset=utf-8;base64,$getTitleTestBase64',
-          onWebViewCreated: (WebViewController controller) {
-            controllerCompleter.complete(controller);
-          },
-          onPageFinished: (String url) {
-            pageLoaded.complete(null);
-          },
-        ),
-      ),
-    );
-
-    final WebViewController controller = await controllerCompleter.future;
-    await pageLoaded.future;
-
-    final String title = await controller.getTitle();
-    expect(title, 'Some title');
-  });
 }
 
 Future<void> pumpWidget(Widget widget) {

--- a/packages/webview_flutter/ios/Classes/FlutterWebView.m
+++ b/packages/webview_flutter/ios/Classes/FlutterWebView.m
@@ -118,8 +118,6 @@
     [self onRemoveJavaScriptChannels:call result:result];
   } else if ([[call method] isEqualToString:@"clearCache"]) {
     [self clearCache:result];
-  } else if ([[call method] isEqualToString:@"getTitle"]) {
-    [self onGetTitle:result];
   } else {
     result(FlutterMethodNotImplemented);
   }
@@ -238,11 +236,6 @@
     // support for iOS8 tracked in https://github.com/flutter/flutter/issues/27624.
     NSLog(@"Clearing cache is not supported for Flutter WebViews prior to iOS 9.");
   }
-}
-
-- (void)onGetTitle:(FlutterResult)result {
-  NSString* title = _webView.title;
-  result(title);
 }
 
 // Returns nil when successful, or an error message when one or more keys are unknown.

--- a/packages/webview_flutter/lib/platform_interface.dart
+++ b/packages/webview_flutter/lib/platform_interface.dart
@@ -152,12 +152,6 @@ abstract class WebViewPlatformController {
     throw UnimplementedError(
         "WebView removeJavascriptChannels is not implemented on the current platform");
   }
-
-  /// Returns the title of the currently loaded page.
-  Future<String> getTitle() {
-    throw UnimplementedError(
-        "WebView getTitle is not implemented on the current platform");
-  }
 }
 
 /// Settings for configuring a WebViewPlatform.

--- a/packages/webview_flutter/lib/src/webview_method_channel.dart
+++ b/packages/webview_flutter/lib/src/webview_method_channel.dart
@@ -103,9 +103,6 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
         'removeJavascriptChannels', javascriptChannelNames.toList());
   }
 
-  @override
-  Future<String> getTitle() => _channel.invokeMethod<String>("getTitle");
-
   /// Method channel implementation for [WebViewPlatform.clearCookies].
   static Future<bool> clearCookies() {
     return _cookieManagerChannel

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -600,11 +600,6 @@ class WebViewController {
     // ignore: strong_mode_implicit_dynamic_method
     return _webViewPlatformController.evaluateJavascript(javascriptString);
   }
-
-  /// Returns the title of the currently loaded page.
-  Future<String> getTitle() {
-    return _webViewPlatformController.getTitle();
-  }
 }
 
 /// Manages cookies pertaining to all [WebView]s.

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
-version: 0.3.11+6
+version: 0.3.12+1
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/webview_flutter
 

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
-version: 0.3.12
+version: 0.3.11+6
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/webview_flutter
 


### PR DESCRIPTION
Reverts flutter/plugins#1979

The change broke Fuchsia, as [FuchsiaWebViewController](https://fuchsia.googlesource.com/topaz/+/refs/heads/master/public/dart/fuchsia_webview_flutter/lib/src/fuchsia_webview_platform_controller.dart#20) implements WebViewPlatformController so it doesn't get the no-op implementation of getTitle. We could change the FuchsiaWebViewController implementation to extend WebViewPlatformController so we can add new methods without requiring roll coordination.

I'm reverting temporarily until we resolve the roll issue.