### PR TITLE
[android_alarm_manager] Added ability to get id in the callback

### DIFF
--- a/packages/android_alarm_manager/CHANGELOG.md
+++ b/packages/android_alarm_manager/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.4
+
+* Now `id` will passed to `callback` if it is of type `Function(int)`
+
 ## 0.4.3
 
 * Added `oneShotAt` method to run `callback` at a given DateTime `time`.

--- a/packages/android_alarm_manager/CHANGELOG.md
+++ b/packages/android_alarm_manager/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.4.4
 
-* Now `id` will passed to `callback` if it is of type `Function(int)`
+* Add `id` to `callback` if it is of type `Function(int)`
 
 ## 0.4.3
 

--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AlarmService.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AlarmService.java
@@ -211,7 +211,8 @@ public class AlarmService extends JobIntentService {
     // provided.
     // TODO(mattcarroll): consider giving a method name anyway for the purpose of developer discoverability
     //                    when reading the source code. Especially on the Dart side.
-    sBackgroundChannel.invokeMethod("", new Object[] {callbackHandle, intent.getIntExtra("id", -1)}, result);
+    sBackgroundChannel.invokeMethod(
+        "", new Object[] {callbackHandle, intent.getIntExtra("id", -1)}, result);
   }
 
   private static void scheduleAlarm(

--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AlarmService.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AlarmService.java
@@ -211,7 +211,7 @@ public class AlarmService extends JobIntentService {
     // provided.
     // TODO(mattcarroll): consider giving a method name anyway for the purpose of developer discoverability
     //                    when reading the source code. Especially on the Dart side.
-    sBackgroundChannel.invokeMethod("", new Object[] {callbackHandle}, result);
+    sBackgroundChannel.invokeMethod("", new Object[] {callbackHandle, intent.getIntExtra("id", -1)}, result);
   }
 
   private static void scheduleAlarm(
@@ -242,6 +242,7 @@ public class AlarmService extends JobIntentService {
 
     // Create an Intent for the alarm and set the desired Dart callback handle.
     Intent alarm = new Intent(context, AlarmBroadcastReceiver.class);
+    alarm.putExtra("id", requestCode);
     alarm.putExtra("callbackHandle", callbackHandle);
     PendingIntent pendingIntent =
         PendingIntent.getBroadcast(context, requestCode, alarm, PendingIntent.FLAG_UPDATE_CURRENT);

--- a/packages/android_alarm_manager/lib/android_alarm_manager.dart
+++ b/packages/android_alarm_manager/lib/android_alarm_manager.dart
@@ -89,7 +89,7 @@ class AndroidAlarmManager {
   /// `callback` can be `Function()` or `Function(int)`
   ///
   /// The timer is uniquely identified by `id`. Calling this function again
-  /// again with the same `id` will cancel and replace the existing timer.
+  /// with the same `id` will cancel and replace the existing timer.
   ///
   /// `id` will passed to `callback` if it is of type `Function(int)`
   ///
@@ -147,7 +147,7 @@ class AndroidAlarmManager {
   /// `callback` can be `Function()` or `Function(int)`
   ///
   /// The timer is uniquely identified by `id`. Calling this function again
-  /// again with the same `id` will cancel and replace the existing timer.
+  /// with the same `id` will cancel and replace the existing timer.
   ///
   /// `id` will passed to `callback` if it is of type `Function(int)`
   ///
@@ -214,7 +214,7 @@ class AndroidAlarmManager {
   ///
   /// `callback` can be `Function()` or `Function(int)`
   ///
-  /// The timer is uniquely identified by `id`. Calling this function again
+  /// The repeating timer is uniquely identified by `id`. Calling this function
   /// again with the same `id` will cancel and replace the existing timer.
   ///
   /// `id` will passed to `callback` if it is of type `Function(int)`

--- a/packages/android_alarm_manager/lib/android_alarm_manager.dart
+++ b/packages/android_alarm_manager/lib/android_alarm_manager.dart
@@ -38,7 +38,13 @@ void _alarmManagerCallbackDispatcher() {
       print('Fatal: could not find callback');
       exit(-1);
     }
-    closure();
+
+    if (closure is Function()) {
+      closure();
+    } else if (closure is Function(int)) {
+      final int id = args[1];
+      closure(id);
+    }
   });
 
   // Once we've finished initializing, let the native portion of the plugin
@@ -80,8 +86,12 @@ class AndroidAlarmManager {
   /// `callback` must be either a top-level function or a static method from a
   /// class.
   ///
+  /// `callback` can be `Function()` or `Function(int)`
+  ///
   /// The timer is uniquely identified by `id`. Calling this function again
   /// again with the same `id` will cancel and replace the existing timer.
+  ///
+  /// `id` will passed to `callback` if it is of type `Function(int)`
   ///
   /// If `alarmClock` is passed as `true`, the timer will be created with
   /// Android's `AlarmManagerCompat.setAlarmClock`.
@@ -107,7 +117,7 @@ class AndroidAlarmManager {
   static Future<bool> oneShot(
     Duration delay,
     int id,
-    dynamic Function() callback, {
+    Function callback, {
     bool alarmClock = false,
     bool allowWhileIdle = false,
     bool exact = false,
@@ -134,8 +144,12 @@ class AndroidAlarmManager {
   /// `callback` must be either a top-level function or a static method from a
   /// class.
   ///
+  /// `callback` can be `Function()` or `Function(int)`
+  ///
   /// The timer is uniquely identified by `id`. Calling this function again
   /// again with the same `id` will cancel and replace the existing timer.
+  ///
+  /// `id` will passed to `callback` if it is of type `Function(int)`
   ///
   /// If `alarmClock` is passed as `true`, the timer will be created with
   /// Android's `AlarmManagerCompat.setAlarmClock`.
@@ -161,13 +175,15 @@ class AndroidAlarmManager {
   static Future<bool> oneShotAt(
     DateTime time,
     int id,
-    dynamic Function() callback, {
+    Function callback, {
     bool alarmClock = false,
     bool allowWhileIdle = false,
     bool exact = false,
     bool wakeup = false,
     bool rescheduleOnReboot = false,
   }) async {
+    assert(callback is Function() || callback is Function(int));
+    assert(id.bitLength < 32);
     final int startMillis = time.millisecondsSinceEpoch;
     final CallbackHandle handle = PluginUtilities.getCallbackHandle(callback);
     if (handle == null) {
@@ -196,8 +212,12 @@ class AndroidAlarmManager {
   /// `callback` must be either a top-level function or a static method from a
   /// class.
   ///
-  /// The repeating timer is uniquely identified by `id`. Calling this function
+  /// `callback` can be `Function()` or `Function(int)`
+  ///
+  /// The timer is uniquely identified by `id`. Calling this function again
   /// again with the same `id` will cancel and replace the existing timer.
+  ///
+  /// `id` will passed to `callback` if it is of type `Function(int)`
   ///
   /// If `startAt` is passed, the timer will first go off at that time and
   /// subsequently run with period `duration`.
@@ -219,12 +239,14 @@ class AndroidAlarmManager {
   static Future<bool> periodic(
     Duration duration,
     int id,
-    dynamic Function() callback, {
+    Function callback, {
     DateTime startAt,
     bool exact = false,
     bool wakeup = false,
     bool rescheduleOnReboot = false,
   }) async {
+    assert(callback is Function() || callback is Function(int));
+    assert(id.bitLength < 32);
     final int now = DateTime.now().millisecondsSinceEpoch;
     final int period = duration.inMilliseconds;
     final int first =

--- a/packages/android_alarm_manager/pubspec.yaml
+++ b/packages/android_alarm_manager/pubspec.yaml
@@ -1,7 +1,7 @@
 name: android_alarm_manager
 description: Flutter plugin for accessing the Android AlarmManager service, and
   running Dart code in the background when alarms fire.
-version: 0.4.3
+version: 0.4.4
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/android_alarm_manager
 


### PR DESCRIPTION
## Description

Added ability to get `id` in the `callback`.

## Related Issues
[#31658 Getting alarm ID in callback ](https://github.com/flutter/flutter/issues/31658)

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.