### PR TITLE
[firebase_dynamic_links] Don't crash if activity is missing

### DIFF
--- a/packages/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebasedynamiclinks/FirebaseDynamicLinksPlugin.java
+++ b/packages/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebasedynamiclinks/FirebaseDynamicLinksPlugin.java
@@ -41,7 +41,6 @@ public class FirebaseDynamicLinksPlugin implements MethodCallHandler, NewIntentL
     FirebaseDynamicLinks.getInstance()
         .getDynamicLink(intent)
         .addOnSuccessListener(
-            registrar.activity(),
             new OnSuccessListener<PendingDynamicLinkData>() {
               @Override
               public void onSuccess(PendingDynamicLinkData pendingDynamicLinkData) {
@@ -53,7 +52,6 @@ public class FirebaseDynamicLinksPlugin implements MethodCallHandler, NewIntentL
               }
             })
         .addOnFailureListener(
-            registrar.activity(),
             new OnFailureListener() {
               @Override
               public void onFailure(@NonNull Exception e) {
@@ -117,6 +115,11 @@ public class FirebaseDynamicLinksPlugin implements MethodCallHandler, NewIntentL
   }
 
   private void handleGetInitialDynamicLink(final Result result) {
+    if (registrar.activity() == null) {
+      result.success(null);
+      return;
+    }
+
     FirebaseDynamicLinks.getInstance()
         .getDynamicLink(registrar.activity().getIntent())
         .addOnSuccessListener(


### PR DESCRIPTION
`registrar.activity` can be null with dynamic links since it is possible to open the app and execute this code before the activity is ready.