### PR TITLE
[firebase_auth] fetchSignInMethodsForEmail returns null on iOS, empty array on Android

### DIFF
--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.14.0+3
+
+* Handle incorrect response from native iOS SDK. 
+
 ## 0.14.0+2
 
 * Reduce compiler warnings on iOS port by replacing `int` with `long` backing in returned timestamps.

--- a/packages/firebase_auth/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/lib/src/firebase_auth.dart
@@ -119,7 +119,7 @@ class FirebaseAuth {
     return await channel.invokeListMethod<String>(
       'fetchSignInMethodsForEmail',
       <String, String>{'email': email, 'app': app.name},
-    );
+    ) ?? <List<String>>[];
   }
 
   /// Triggers the Firebase Authentication backend to send a password-reset

--- a/packages/firebase_auth/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/lib/src/firebase_auth.dart
@@ -117,9 +117,10 @@ class FirebaseAuth {
   }) async {
     assert(email != null);
     return await channel.invokeListMethod<String>(
-      'fetchSignInMethodsForEmail',
-      <String, String>{'email': email, 'app': app.name},
-    ) ?? <List<String>>[];
+          'fetchSignInMethodsForEmail',
+          <String, String>{'email': email, 'app': app.name},
+        ) ??
+        <List<String>>[];
   }
 
   /// Triggers the Firebase Authentication backend to send a password-reset

--- a/packages/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Firebase Auth, enabling Android and iOS
   like Google, Facebook and Twitter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/firebase_auth
-version: 0.14.0+2
+version: 0.14.0+3
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

[As the issue I opened in the firebase sdk repo](https://github.com/firebase/firebase-ios-sdk/issues/3655) explains, a call to `fetchProvidersForEmail()` in the native Firebase Auth SDKs for an unregistered user returns null on iOS, and an empty array on Android-so the plugin returns _different results_ for the same line of Dart code depending on the platform.
The best option would be to standardize the native SDKs, but until that happens I'm proposing a slight change that returns an empty array on iOS if the SDK returns null.

This can't be tested without an integration test, and the firebase_auth library doesn't have any yet.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
