### PR TITLE
Add explicit initialization of TestWidgets binding to all breaking unit tests

### DIFF
--- a/packages/camera/test/camera_test.dart
+++ b/packages/camera/test/camera_test.dart
@@ -9,6 +9,8 @@ import 'package:camera/new/src/camera_testing.dart';
 import 'package:camera/new/src/common/native_texture.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   group('Camera', () {
     final List<MethodCall> log = <MethodCall>[];
 

--- a/packages/camera/test/support_android/support_android_test.dart
+++ b/packages/camera/test/support_android/support_android_test.dart
@@ -9,6 +9,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:camera/new/src/camera_testing.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   group('Support Android Camera', () {
     group('$Camera', () {
       final List<MethodCall> log = <MethodCall>[];

--- a/packages/connectivity/test/connectivity_test.dart
+++ b/packages/connectivity/test/connectivity_test.dart
@@ -7,6 +7,8 @@ import 'package:connectivity/connectivity.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   group('$Connectivity', () {
     final List<MethodCall> log = <MethodCall>[];
 

--- a/packages/google_maps_flutter/test/circle_updates_test.dart
+++ b/packages/google_maps_flutter/test/circle_updates_test.dart
@@ -34,6 +34,8 @@ Widget _mapWithCircles(Set<Circle> circles) {
 }
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   final FakePlatformViewsController fakePlatformViewsController =
       FakePlatformViewsController();
 

--- a/packages/google_maps_flutter/test/google_map_test.dart
+++ b/packages/google_maps_flutter/test/google_map_test.dart
@@ -10,6 +10,8 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'fake_maps_controllers.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   final FakePlatformViewsController fakePlatformViewsController =
       FakePlatformViewsController();
 

--- a/packages/google_maps_flutter/test/marker_updates_test.dart
+++ b/packages/google_maps_flutter/test/marker_updates_test.dart
@@ -34,6 +34,8 @@ Widget _mapWithMarkers(Set<Marker> markers) {
 }
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   final FakePlatformViewsController fakePlatformViewsController =
       FakePlatformViewsController();
 

--- a/packages/google_maps_flutter/test/polygon_updates_test.dart
+++ b/packages/google_maps_flutter/test/polygon_updates_test.dart
@@ -34,6 +34,8 @@ Widget _mapWithPolygons(Set<Polygon> polygons) {
 }
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   final FakePlatformViewsController fakePlatformViewsController =
       FakePlatformViewsController();
 

--- a/packages/google_maps_flutter/test/polyline_updates_test.dart
+++ b/packages/google_maps_flutter/test/polyline_updates_test.dart
@@ -34,6 +34,8 @@ Widget _mapWithPolylines(Set<Polyline> polylines) {
 }
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   final FakePlatformViewsController fakePlatformViewsController =
       FakePlatformViewsController();
 

--- a/packages/google_sign_in/test/google_sign_in_test.dart
+++ b/packages/google_sign_in/test/google_sign_in_test.dart
@@ -10,6 +10,8 @@ import 'package:google_sign_in/google_sign_in.dart';
 import 'package:google_sign_in/testing.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   group('GoogleSignIn', () {
     const MethodChannel channel = MethodChannel(
       'plugins.flutter.io/google_sign_in',

--- a/packages/image_picker/test/image_picker_test.dart
+++ b/packages/image_picker/test/image_picker_test.dart
@@ -7,6 +7,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:image_picker/image_picker.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   group('$ImagePicker', () {
     const MethodChannel channel =
         MethodChannel('plugins.flutter.io/image_picker');

--- a/packages/in_app_purchase/test/billing_client_wrappers/billing_client_wrapper_test.dart
+++ b/packages/in_app_purchase/test/billing_client_wrappers/billing_client_wrapper_test.dart
@@ -13,6 +13,8 @@ import 'sku_details_wrapper_test.dart';
 import 'purchase_wrapper_test.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   final StubInAppPurchasePlatform stubPlatform = StubInAppPurchasePlatform();
   BillingClient billingClient;
 

--- a/packages/in_app_purchase/test/in_app_purchase_connection/app_store_connection_test.dart
+++ b/packages/in_app_purchase/test/in_app_purchase_connection/app_store_connection_test.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart' show TestWidgetsFlutterBinding;
 import 'package:in_app_purchase/src/in_app_purchase/purchase_details.dart';
 import 'package:test/test.dart';
 
@@ -17,6 +18,8 @@ import 'package:in_app_purchase/store_kit_wrappers.dart';
 import '../store_kit_wrappers/sk_test_stub_objects.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   final FakeIOSPlatform fakeIOSPlatform = FakeIOSPlatform();
 
   setUpAll(() {

--- a/packages/in_app_purchase/test/in_app_purchase_connection/google_play_connection_test.dart
+++ b/packages/in_app_purchase/test/in_app_purchase_connection/google_play_connection_test.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart' show TestWidgetsFlutterBinding;
 import 'package:in_app_purchase/src/in_app_purchase/purchase_details.dart';
 import 'package:test/test.dart';
 
@@ -20,6 +21,8 @@ import '../billing_client_wrappers/sku_details_wrapper_test.dart';
 import '../billing_client_wrappers/purchase_wrapper_test.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   final StubInAppPurchasePlatform stubPlatform = StubInAppPurchasePlatform();
   GooglePlayConnection connection;
   const String startConnectionCall =

--- a/packages/in_app_purchase/test/store_kit_wrappers/sk_methodchannel_apis_test.dart
+++ b/packages/in_app_purchase/test/store_kit_wrappers/sk_methodchannel_apis_test.dart
@@ -9,6 +9,8 @@ import 'package:in_app_purchase/store_kit_wrappers.dart';
 import 'sk_test_stub_objects.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   final FakeIOSPlatform fakeIOSPlatform = FakeIOSPlatform();
 
   setUpAll(() {

--- a/packages/path_provider/test/path_provider_test.dart
+++ b/packages/path_provider/test/path_provider_test.dart
@@ -9,6 +9,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:path_provider/path_provider.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   const MethodChannel channel =
       MethodChannel('plugins.flutter.io/path_provider');
   final List<MethodCall> log = <MethodCall>[];

--- a/packages/quick_actions/test/quick_actions_test.dart
+++ b/packages/quick_actions/test/quick_actions_test.dart
@@ -6,6 +6,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:quick_actions/quick_actions.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   QuickActions quickActions;
   final List<MethodCall> log = <MethodCall>[];
 

--- a/packages/share/test/share_test.dart
+++ b/packages/share/test/share_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:ui';
 
+import 'package:flutter_test/flutter_test.dart' show TestWidgetsFlutterBinding;
 import 'package:mockito/mockito.dart';
 import 'package:share/share.dart';
 import 'package:test/test.dart';
@@ -11,6 +12,8 @@ import 'package:test/test.dart';
 import 'package:flutter/services.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   MockMethodChannel mockChannel;
 
   setUp(() {

--- a/packages/shared_preferences/test/shared_preferences_test.dart
+++ b/packages/shared_preferences/test/shared_preferences_test.dart
@@ -7,6 +7,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   group('$SharedPreferences', () {
     const MethodChannel channel = MethodChannel(
       'plugins.flutter.io/shared_preferences',

--- a/packages/url_launcher/test/url_launcher_test.dart
+++ b/packages/url_launcher/test/url_launcher_test.dart
@@ -7,6 +7,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   const MethodChannel channel =
       MethodChannel('plugins.flutter.io/url_launcher');
   final List<MethodCall> log = <MethodCall>[];

--- a/packages/webview_flutter/test/webview_flutter_test.dart
+++ b/packages/webview_flutter/test/webview_flutter_test.dart
@@ -16,6 +16,8 @@ import 'package:webview_flutter/webview_flutter.dart';
 typedef void VoidCallback();
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   final _FakePlatformViewsController fakePlatformViewsController =
       _FakePlatformViewsController();
 


### PR DESCRIPTION
This is a tests only change so I did not increment versions.