### PR TITLE
[Image_picker] fix `retrieveImage` breakage, added tests.

### DIFF
--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.1+4
+
+* Android: Fix a regression where the `retrieveLostImage` does not work anymore.
+* Set up Android unit test to test `ImagePickerCache` and added image quality caching tests.
+
 ## 0.6.1+3
 
 * Bugfix iOS: Fix orientation of the picked image after scaling.

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerCache.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerCache.java
@@ -29,14 +29,12 @@ class ImagePickerCache {
   private static final String SHARED_PREFERENCE_ERROR_MESSAGE_KEY =
       "flutter_image_picker_error_message";
 
-  @VisibleForTesting
-  static final String SHARED_PREFERENCE_MAX_WIDTH_KEY = "flutter_image_picker_max_width";
+  private static final String SHARED_PREFERENCE_MAX_WIDTH_KEY = "flutter_image_picker_max_width";
 
-  @VisibleForTesting
-  static final String SHARED_PREFERENCE_MAX_HEIGHT_KEY = "flutter_image_picker_max_height";
+  private static final String SHARED_PREFERENCE_MAX_HEIGHT_KEY = "flutter_image_picker_max_height";
 
-  @VisibleForTesting
-  static final String SHARED_PREFERENCE_IMAGE_QUALITY_KEY = "flutter_image_picker_image_quality";
+  private static final String SHARED_PREFERENCE_IMAGE_QUALITY_KEY =
+      "flutter_image_picker_image_quality";
 
   private static final String SHARED_PREFERENCE_TYPE_KEY = "flutter_image_picker_type";
   private static final String SHARED_PREFERENCE_PENDING_IMAGE_URI_PATH_KEY =

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerCache.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerCache.java
@@ -8,6 +8,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.net.Uri;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 import io.flutter.plugin.common.MethodCall;
 import java.util.HashMap;
 import java.util.Map;
@@ -27,14 +28,22 @@ class ImagePickerCache {
   private static final String SHARED_PREFERENCE_ERROR_CODE_KEY = "flutter_image_picker_error_code";
   private static final String SHARED_PREFERENCE_ERROR_MESSAGE_KEY =
       "flutter_image_picker_error_message";
-  private static final String SHARED_PREFERENCE_MAX_WIDTH_KEY = "flutter_image_picker_max_width";
-  private static final String SHARED_PREFERENCE_MAX_HEIGHT_KEY = "flutter_image_picker_max_height";
-  private static final String SHARED_PREFERENCE_IMAGE_QUALITY_KEY =
-      "flutter_image_picker_image_quality";
+
+  @VisibleForTesting
+  static final String SHARED_PREFERENCE_MAX_WIDTH_KEY = "flutter_image_picker_max_width";
+
+  @VisibleForTesting
+  static final String SHARED_PREFERENCE_MAX_HEIGHT_KEY = "flutter_image_picker_max_height";
+
+  @VisibleForTesting
+  static final String SHARED_PREFERENCE_IMAGE_QUALITY_KEY = "flutter_image_picker_image_quality";
+
   private static final String SHARED_PREFERENCE_TYPE_KEY = "flutter_image_picker_type";
   private static final String SHARED_PREFERENCE_PENDING_IMAGE_URI_PATH_KEY =
       "flutter_image_picker_pending_image_uri";
-  private static final String SHARED_PREFERENCES_NAME = "flutter_image_picker_shared_preference";
+
+  @VisibleForTesting
+  static final String SHARED_PREFERENCES_NAME = "flutter_image_picker_shared_preference";
 
   private SharedPreferences prefs;
 
@@ -147,9 +156,9 @@ class ImagePickerCache {
       }
       if (prefs.contains(SHARED_PREFERENCE_IMAGE_QUALITY_KEY)) {
         final int imageQuality = prefs.getInt(SHARED_PREFERENCE_IMAGE_QUALITY_KEY, 100);
-        resultMap.put(MAP_KEY_MAX_HEIGHT, imageQuality);
+        resultMap.put(MAP_KEY_IMAGE_QUALITY, imageQuality);
       } else {
-        resultMap.put(MAP_KEY_MAX_HEIGHT, 100);
+        resultMap.put(MAP_KEY_IMAGE_QUALITY, 100);
       }
     }
 

--- a/packages/image_picker/example/android/app/src/test/java/io/flutter/plugins/imagepicker/ImagePickerCacheTest.java
+++ b/packages/image_picker/example/android/app/src/test/java/io/flutter/plugins/imagepicker/ImagePickerCacheTest.java
@@ -1,0 +1,118 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.plugins.imagepicker;
+
+import static io.flutter.plugins.imagepicker.ImagePickerCache.MAP_KEY_IMAGE_QUALITY;
+import static io.flutter.plugins.imagepicker.ImagePickerCache.SHARED_PREFERENCES_NAME;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
+import io.flutter.plugin.common.MethodCall;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class ImagePickerCacheTest {
+  private static final double WIDTH = 10.0;
+  private static final double HEIGHT = 10.0;
+  private static final int IMAGE_QUALITY = 90;
+  private static final String PATH = "a_mock_path";
+
+  @Mock Activity mockActivity;
+  @Mock SharedPreferences mockPreference;
+  @Mock SharedPreferences.Editor mockEditor;
+  @Mock MethodCall mockMethodCall;
+
+  static Map<String, Object> preferenceStorage;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+
+    preferenceStorage = new HashMap();
+    when(mockActivity.getPackageName()).thenReturn("com.example.test");
+    when(mockActivity.getPackageManager()).thenReturn(mock(PackageManager.class));
+    when(mockActivity.getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE))
+        .thenReturn(mockPreference);
+    when(mockPreference.edit()).thenReturn(mockEditor);
+    when(mockEditor.putInt(any(String.class), any(int.class)))
+        .then(
+            i -> {
+              preferenceStorage.put(i.getArgument(0), i.getArgument(1));
+              return mockEditor;
+            });
+    when(mockEditor.putLong(any(String.class), any(long.class)))
+        .then(
+            i -> {
+              preferenceStorage.put(i.getArgument(0), i.getArgument(1));
+              return mockEditor;
+            });
+    when(mockEditor.putString(any(String.class), any(String.class)))
+        .then(
+            i -> {
+              preferenceStorage.put(i.getArgument(0), i.getArgument(1));
+              return mockEditor;
+            });
+
+    when(mockPreference.getInt(any(String.class), any(int.class)))
+        .then(
+            i -> {
+              int result =
+                  (int)
+                      ((preferenceStorage.get(i.getArgument(0)) != null)
+                          ? preferenceStorage.get(i.getArgument(0))
+                          : i.getArgument(1));
+              return result;
+            });
+    when(mockPreference.getLong(any(String.class), any(long.class)))
+        .then(
+            i -> {
+              long result =
+                  (long)
+                      ((preferenceStorage.get(i.getArgument(0)) != null)
+                          ? preferenceStorage.get(i.getArgument(0))
+                          : i.getArgument(1));
+              return result;
+            });
+    when(mockPreference.getString(any(String.class), any(String.class)))
+        .then(
+            i -> {
+              String result =
+                  (String)
+                      ((preferenceStorage.get(i.getArgument(0)) != null)
+                          ? preferenceStorage.get(i.getArgument(0))
+                          : i.getArgument(1));
+              return result;
+            });
+
+    when(mockPreference.contains(any(String.class))).thenReturn(true);
+  }
+
+  @Test
+  public void ImageCache_ShouldBeAbleToSetAndGetQuality() {
+    when(mockMethodCall.argument(MAP_KEY_IMAGE_QUALITY)).thenReturn(IMAGE_QUALITY);
+    ImagePickerCache cache = new ImagePickerCache(mockActivity);
+    cache.saveDimensionWithMethodCall(mockMethodCall);
+    Map<String, Object> resultMap = cache.getCacheMap();
+    int imageQuality = (int) resultMap.get(cache.MAP_KEY_IMAGE_QUALITY);
+    assertThat(imageQuality, equalTo(IMAGE_QUALITY));
+
+    when(mockMethodCall.argument(MAP_KEY_IMAGE_QUALITY)).thenReturn(null);
+    cache.saveDimensionWithMethodCall(mockMethodCall);
+    Map<String, Object> resultMapWithDefaultQuality = cache.getCacheMap();
+    int defaultImageQuality = (int) resultMapWithDefaultQuality.get(cache.MAP_KEY_IMAGE_QUALITY);
+    assertThat(defaultImageQuality, equalTo(100));
+  }
+}

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -5,7 +5,7 @@ authors:
   - Flutter Team <flutter-dev@googlegroups.com>
   - Rhodes Davis Jr. <rody.davis.jr@gmail.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.6.1+3
+version: 0.6.1+4
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Image picker retrieveImage broke after https://github.com/flutter/plugins/pull/1877
This PR is to fix the crash.
Also added tests for the fix.

## Related Issues

https://github.com/flutter/flutter/issues/38025

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
