### PR TITLE
[shared_preferences] Unhardcode Flutter prefix in platform code

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -43,3 +43,4 @@ Audrius Karosevicius <audrius.karosevicius@gmail.com>
 Lukasz Piliszczuk <lukasz@intheloup.io>
 SoundReply Solutions GmbH <ch@soundreply.com>
 Rafal Wachol <rwachol@gmail.com>
+Nino Uzelac <uzelac.nino@gmail.com>

--- a/packages/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.4
+
+* Remove hardcoded prefix from internal platform calls
+
 ## 0.5.3+4
 
 * Copy `List` instances when reading and writing values to prevent mutations from propagating.

--- a/packages/shared_preferences/android/src/main/java/io/flutter/plugins/sharedpreferences/SharedPreferencesPlugin.java
+++ b/packages/shared_preferences/android/src/main/java/io/flutter/plugins/sharedpreferences/SharedPreferencesPlugin.java
@@ -77,11 +77,11 @@ public class SharedPreferencesPlugin implements MethodCallHandler {
   }
 
   // Filter preferences to only those set by the flutter app.
-  private Map<String, Object> getAllPrefs() throws IOException {
+  private Map<String, Object> getAllPrefs(String prefix) throws IOException {
     Map<String, ?> allPrefs = preferences.getAll();
     Map<String, Object> filteredPrefs = new HashMap<>();
     for (String key : allPrefs.keySet()) {
-      if (key.startsWith("flutter.")) {
+      if (key.startsWith(prefix)) {
         Object value = allPrefs.get(key);
         if (value instanceof String) {
           String stringValue = (String) value;
@@ -179,13 +179,13 @@ public class SharedPreferencesPlugin implements MethodCallHandler {
           result.success(true);
           break;
         case "getAll":
-          result.success(getAllPrefs());
+          result.success(getAllPrefs((String) call.argument("prefix")));
           return;
         case "remove":
           commitAsync(preferences.edit().remove(key), result);
           break;
         case "clear":
-          Set<String> keySet = getAllPrefs().keySet();
+          Set<String> keySet = getAllPrefs((String) call.argument("prefix")).keySet();
           Editor clearEditor = preferences.edit();
           for (String keyToDelete : keySet) {
             clearEditor.remove(keyToDelete);

--- a/packages/shared_preferences/ios/Classes/SharedPreferencesPlugin.m
+++ b/packages/shared_preferences/ios/Classes/SharedPreferencesPlugin.m
@@ -16,7 +16,8 @@ static NSString *const CHANNEL_NAME = @"plugins.flutter.io/shared_preferences";
     NSDictionary *arguments = [call arguments];
 
     if ([method isEqualToString:@"getAll"]) {
-      result(getAllPrefs());
+      NSString *prefix = arguments[@"prefix"];
+      result(getAllPrefs(prefix));
     } else if ([method isEqualToString:@"setBool"]) {
       NSString *key = arguments[@"key"];
       NSNumber *value = arguments[@"value"];
@@ -54,7 +55,8 @@ static NSString *const CHANNEL_NAME = @"plugins.flutter.io/shared_preferences";
       result(@YES);
     } else if ([method isEqualToString:@"clear"]) {
       NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-      for (NSString *key in getAllPrefs()) {
+      NSString *prefix = arguments[@"prefix"];
+      for (NSString *key in getAllPrefs(prefix)) {
         [defaults removeObjectForKey:key];
       }
       result(@YES);
@@ -66,13 +68,13 @@ static NSString *const CHANNEL_NAME = @"plugins.flutter.io/shared_preferences";
 
 #pragma mark - Private
 
-static NSMutableDictionary *getAllPrefs() {
+static NSMutableDictionary *getAllPrefs(NSString *prefix) {
   NSString *appDomain = [[NSBundle mainBundle] bundleIdentifier];
   NSDictionary *prefs = [[NSUserDefaults standardUserDefaults] persistentDomainForName:appDomain];
   NSMutableDictionary *filteredPrefs = [NSMutableDictionary dictionary];
   if (prefs != nil) {
     for (NSString *candidateKey in prefs) {
-      if ([candidateKey hasPrefix:@"flutter."]) {
+      if ([candidateKey hasPrefix:prefix]) {
         [filteredPrefs setObject:prefs[candidateKey] forKey:candidateKey];
       }
     }

--- a/packages/shared_preferences/lib/shared_preferences.dart
+++ b/packages/shared_preferences/lib/shared_preferences.dart
@@ -148,8 +148,11 @@ class SharedPreferences {
 
   /// Completes with true once the user preferences for the app has been cleared.
   Future<bool> clear() async {
+    final Map<String, dynamic> params = <String, dynamic>{
+      'prefix': '$_prefix',
+    };
     _preferenceCache.clear();
-    return await _kChannel.invokeMethod<bool>('clear');
+    return await _kChannel.invokeMethod<bool>('clear', params);
   }
 
   /// Fetches the latest values from the host platform.
@@ -164,8 +167,11 @@ class SharedPreferences {
   }
 
   static Future<Map<String, Object>> _getSharedPreferencesMap() async {
+    final Map<String, dynamic> params = <String, dynamic>{
+      'prefix': '$_prefix',
+    };
     final Map<String, Object> fromSystem =
-        await _kChannel.invokeMapMethod<String, Object>('getAll');
+        await _kChannel.invokeMapMethod<String, Object>('getAll', params);
     assert(fromSystem != null);
     // Strip the flutter. prefix from the returned preferences.
     final Map<String, Object> preferencesMap = <String, Object>{};

--- a/packages/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for reading and writing simple key-value pairs.
   Wraps NSUserDefaults on iOS and SharedPreferences on Android.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/shared_preferences
-version: 0.5.3+4
+version: 0.5.4
 
 flutter:
   plugin:

--- a/packages/shared_preferences/test/shared_preferences_test.dart
+++ b/packages/shared_preferences/test/shared_preferences_test.dart
@@ -143,7 +143,11 @@ void main() {
       expect(preferences.getInt('int'), null);
       expect(preferences.getDouble('double'), null);
       expect(preferences.getStringList('List'), null);
-      expect(log, <Matcher>[isMethodCall('clear', arguments: null)]);
+      expect(log, <Matcher>[
+        isMethodCall('clear', arguments: <String, dynamic>{
+          'prefix': 'flutter.',
+        })
+      ]);
     });
 
     test('reloading', () async {


### PR DESCRIPTION
## Description

This is a first step towards resolving the linked issue and being able to access all shared prefs stored in the system. I'm not sure what's the best way to proceed after removing the hardcoded prefix in ios/android. Since prefs is a singleton, maybe adding a new method in Dart that returns all unfiltered prefs, e.g. by calling `getAll("")`?

## Related Issues

flutter/flutter#38769

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
