### PR TITLE
[instrumentation_adapter] update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,6 +13,7 @@ packages/google_maps_flutter/* @iskakaushik
 packages/google_sign_in/* @cyanglaz @mehmetf
 packages/image_picker/* @cyanglaz
 packages/in_app_purchase/* @mklim @cyanglaz
+packages/instrumentation_adapter/* @collinjackson @digiter
 packages/package_info/* @cyanglaz
 packages/path_provider/* @collinjackson
 packages/quick_actions/* @collinjackson


### PR DESCRIPTION
Adds @collinjackson and @digiter to the CODEOWNERS for the instrumentation_adapter plugin.