### PR TITLE
fix android crash when pausing or resuming video on APIs lower than 24.

### DIFF
--- a/packages/camera/CHANGELOG.md
+++ b/packages/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.4+1
+
+* Fix Android pause and resume video crash when executing in APIs below 24.
+
 ## 0.5.4
 
 * Add feature to pause and resume video recording.

--- a/packages/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
+++ b/packages/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
@@ -21,6 +21,7 @@ import android.media.CamcorderProfile;
 import android.media.Image;
 import android.media.ImageReader;
 import android.media.MediaRecorder;
+import android.os.Build;
 import android.util.Size;
 import android.view.OrientationEventListener;
 import android.view.Surface;
@@ -395,7 +396,12 @@ public class Camera {
     }
 
     try {
-      mediaRecorder.pause();
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+        mediaRecorder.pause();
+      } else {
+        result.error("videoRecordingFailed", "pauseVideoRecording requires Android API +24.", null);
+        return;
+      }
     } catch (IllegalStateException e) {
       result.error("videoRecordingFailed", e.getMessage(), null);
       return;
@@ -411,7 +417,13 @@ public class Camera {
     }
 
     try {
-      mediaRecorder.resume();
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+        mediaRecorder.resume();
+      } else {
+        result.error(
+            "videoRecordingFailed", "resumeVideoRecording requires Android API +24.", null);
+        return;
+      }
     } catch (IllegalStateException e) {
       result.error("videoRecordingFailed", e.getMessage(), null);
       return;

--- a/packages/camera/example/lib/main.dart
+++ b/packages/camera/example/lib/main.dart
@@ -393,7 +393,7 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
       await controller.pauseVideoRecording();
     } on CameraException catch (e) {
       _showCameraException(e);
-      return null;
+      rethrow;
     }
   }
 
@@ -406,7 +406,7 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
       await controller.resumeVideoRecording();
     } on CameraException catch (e) {
       _showCameraException(e);
-      return null;
+      rethrow;
     }
   }
 
@@ -477,6 +477,7 @@ List<CameraDescription> cameras;
 Future<void> main() async {
   // Fetch the available cameras before initializing the app.
   try {
+    WidgetsFlutterBinding.ensureInitialized();
     cameras = await availableCameras();
   } on CameraException catch (e) {
     logError(e.code, e.description);

--- a/packages/camera/pubspec.yaml
+++ b/packages/camera/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera
 description: A Flutter plugin for getting information about and controlling the
   camera on Android and iOS. Supports previewing the camera feed, capturing images, capturing video,
   and streaming image buffers to dart.
-version: 0.5.4
+version: 0.5.4+1
 
 authors:
   - Flutter Team <flutter-dev@googlegroups.com>


### PR DESCRIPTION
## Description

This PR fixes a crash when pause/resume methods are called in APIs lower than 24 on Android.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [X] No, this is *not* a breaking change.