### PR TITLE
[url_launcher] Removed reference to rootViewController during initialization

### DIFF
--- a/packages/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/CHANGELOG.md
@@ -1,3 +1,8 @@
+
+## 5.1.3
+
+* Fixed iOS app2app scenario.
+
 ## 5.1.2
 
 * Update AGP and gradle.

--- a/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
+++ b/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
@@ -61,12 +61,6 @@ API_AVAILABLE(ios(9.0))
 
 @end
 
-@interface FLTUrlLauncherPlugin ()
-
-@property(strong, nonatomic) UIViewController *viewController;
-
-@end
-
 @implementation FLTUrlLauncherPlugin
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
@@ -76,16 +70,8 @@ API_AVAILABLE(ios(9.0))
   UIViewController *viewController =
       [UIApplication sharedApplication].delegate.window.rootViewController;
   FLTUrlLauncherPlugin *plugin =
-      [[FLTUrlLauncherPlugin alloc] initWithViewController:viewController];
+      [[FLTUrlLauncherPlugin alloc] init];
   [registrar addMethodCallDelegate:plugin channel:channel];
-}
-
-- (instancetype)initWithViewController:(UIViewController *)viewController {
-  self = [super init];
-  if (self) {
-    self.viewController = viewController;
-  }
-  return self;
 }
 
 - (void)handleMethodCall:(FlutterMethodCall *)call result:(FlutterResult)result {
@@ -153,9 +139,9 @@ API_AVAILABLE(ios(9.0))
   self.currentSession.didFinish = ^(void) {
     weakSelf.currentSession = nil;
   };
-  [self.viewController presentViewController:self.currentSession.safari
-                                    animated:YES
-                                  completion:nil];
+  [self.topViewController presentViewController:self.currentSession.safari
+                                      animated:YES
+                                    completion:nil];
 }
 
 - (void)closeWebViewWithResult:(FlutterResult)result API_AVAILABLE(ios(9.0)) {
@@ -165,4 +151,23 @@ API_AVAILABLE(ios(9.0))
   result(nil);
 }
 
+- (UIViewController *)topViewController {
+  return [self topViewController:[UIApplication sharedApplication].keyWindow.rootViewController];
+}
+
+- (UIViewController *)topViewController:(UIViewController *)rootViewController
+{
+  if ([rootViewController isKindOfClass:[UINavigationController class]]) {
+    UINavigationController *navigationController = (UINavigationController *)rootViewController;
+    return [self topViewController:[navigationController.viewControllers lastObject]];
+  }
+  if ([rootViewController isKindOfClass:[UITabBarController class]]) {
+    UITabBarController *tabController = (UITabBarController *)rootViewController;
+    return [self topViewController:tabController.selectedViewController];
+  }
+  if (rootViewController.presentedViewController) {
+    return [self topViewController:rootViewController];
+  }
+  return rootViewController;
+}
 @end

--- a/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
+++ b/packages/url_launcher/ios/Classes/UrlLauncherPlugin.m
@@ -166,7 +166,7 @@ API_AVAILABLE(ios(9.0))
     return [self topViewController:tabController.selectedViewController];
   }
   if (rootViewController.presentedViewController) {
-    return [self topViewController:rootViewController];
+    return [self topViewController:rootViewController.presentedViewController];
   }
   return rootViewController;
 }

--- a/packages/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for launching a URL on Android and iOS. Supports
   web, phone, SMS, and email schemes.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher
-version: 5.1.2
+version: 5.1.3
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

The current plugin implementation stores a reference to the rootViewController during the initialisation which breaks scenarios like app2app. This PR does not store any variable to rootViewController but search through the VC hierarchy to get the top most VC in order to present the new vc.

## Related Issues

https://github.com/flutter/flutter/issues/33259

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/