### PR TITLE
[local_auth] Added value none to BiometricsType

### DIFF
--- a/packages/local_auth/lib/local_auth.dart
+++ b/packages/local_auth/lib/local_auth.dart
@@ -11,7 +11,7 @@ import 'package:meta/meta.dart';
 import 'auth_strings.dart';
 import 'error_codes.dart';
 
-enum BiometricType { face, fingerprint, iris }
+enum BiometricType { face, fingerprint, iris, none }
 
 const MethodChannel _channel = MethodChannel('plugins.flutter.io/local_auth');
 


### PR DESCRIPTION

## Description

Added the value none to the enum BiometricType.
Sometimes it is useful to have a null type in the enum BiometricsType.
It is definetly no breaking change.

## Related Issues


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ x] All existing and new tests are passing.
- [ x] I updated/added relevant documentation (doc comments with `///`).
- [ x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [ x] I read and followed the [Flutter Style Guide].
- [ x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [ x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ x] I updated CHANGELOG.md to add a description of the change.
- [ x] I signed the [CLA].
- [ x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
