### PR TITLE
[google_maps_flutter] Fix circle and polygon stroke width

### DIFF
--- a/packages/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.22+3
+
+* Fix polygon and circle stroke width according to device density
+
 ## 0.5.22+2
 
 * Update README: Add steps to enable Google Map SDK in the Google Developer Console.

--- a/packages/google_maps_flutter/android/build.gradle
+++ b/packages/google_maps_flutter/android/build.gradle
@@ -39,3 +39,8 @@ android {
         androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     }
 }
+
+dependencies {
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-core:3.2.4'
+}

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/CircleBuilder.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/CircleBuilder.java
@@ -9,10 +9,12 @@ import com.google.android.gms.maps.model.LatLng;
 
 class CircleBuilder implements CircleOptionsSink {
   private final CircleOptions circleOptions;
+  private final float density;
   private boolean consumeTapEvents;
 
-  CircleBuilder() {
+  CircleBuilder(float density) {
     this.circleOptions = new CircleOptions();
+    this.density = density;
   }
 
   CircleOptions build() {
@@ -56,7 +58,7 @@ class CircleBuilder implements CircleOptionsSink {
 
   @Override
   public void setStrokeWidth(float strokeWidth) {
-    circleOptions.strokeWidth(strokeWidth);
+    circleOptions.strokeWidth(strokeWidth * density);
   }
 
   @Override

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/CircleController.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/CircleController.java
@@ -11,11 +11,13 @@ import com.google.android.gms.maps.model.LatLng;
 class CircleController implements CircleOptionsSink {
   private final Circle circle;
   private final String googleMapsCircleId;
+  private final float density;
   private boolean consumeTapEvents;
 
-  CircleController(Circle circle, boolean consumeTapEvents) {
+  CircleController(Circle circle, boolean consumeTapEvents, float density) {
     this.circle = circle;
     this.consumeTapEvents = consumeTapEvents;
+    this.density = density;
     this.googleMapsCircleId = circle.getId();
   }
 
@@ -56,7 +58,7 @@ class CircleController implements CircleOptionsSink {
 
   @Override
   public void setStrokeWidth(float strokeWidth) {
-    circle.setStrokeWidth(strokeWidth);
+    circle.setStrokeWidth(strokeWidth * density);
   }
 
   @Override

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/CirclesController.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/CirclesController.java
@@ -81,7 +81,7 @@ class CirclesController {
     if (circle == null) {
       return;
     }
-    CircleBuilder circleBuilder = new CircleBuilder();
+    CircleBuilder circleBuilder = new CircleBuilder(density);
     String circleId = Convert.interpretCircleOptions(circle, circleBuilder);
     CircleOptions options = circleBuilder.build();
     addCircle(circleId, options, circleBuilder.consumeTapEvents());

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/CirclesController.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/CirclesController.java
@@ -17,12 +17,14 @@ class CirclesController {
   private final Map<String, CircleController> circleIdToController;
   private final Map<String, String> googleMapsCircleIdToDartCircleId;
   private final MethodChannel methodChannel;
+  private final float density;
   private GoogleMap googleMap;
 
-  CirclesController(MethodChannel methodChannel) {
+  CirclesController(MethodChannel methodChannel, float density) {
     this.circleIdToController = new HashMap<>();
     this.googleMapsCircleIdToDartCircleId = new HashMap<>();
     this.methodChannel = methodChannel;
+    this.density = density;
   }
 
   void setGoogleMap(GoogleMap googleMap) {
@@ -87,7 +89,7 @@ class CirclesController {
 
   private void addCircle(String circleId, CircleOptions circleOptions, boolean consumeTapEvents) {
     final Circle circle = googleMap.addCircle(circleOptions);
-    CircleController controller = new CircleController(circle, consumeTapEvents);
+    CircleController controller = new CircleController(circle, consumeTapEvents, density);
     circleIdToController.put(circleId, controller);
     googleMapsCircleIdToDartCircleId.put(circle.getId(), circleId);
   }

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
@@ -125,9 +125,9 @@ final class GoogleMapController
     this.registrar = registrar;
     this.activityHashCode = registrarActivityHashCode;
     this.markersController = new MarkersController(methodChannel);
-    this.polygonsController = new PolygonsController(methodChannel);
+    this.polygonsController = new PolygonsController(methodChannel, density);
     this.polylinesController = new PolylinesController(methodChannel, density);
-    this.circlesController = new CirclesController(methodChannel);
+    this.circlesController = new CirclesController(methodChannel, density);
   }
 
   @Override

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/PolygonBuilder.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/PolygonBuilder.java
@@ -10,10 +10,12 @@ import java.util.List;
 
 class PolygonBuilder implements PolygonOptionsSink {
   private final PolygonOptions polygonOptions;
+  private final float density;
   private boolean consumeTapEvents;
 
-  PolygonBuilder() {
+  PolygonBuilder(float density) {
     this.polygonOptions = new PolygonOptions();
+    this.density = density;
   }
 
   PolygonOptions build() {
@@ -57,7 +59,7 @@ class PolygonBuilder implements PolygonOptionsSink {
 
   @Override
   public void setStrokeWidth(float width) {
-    polygonOptions.strokeWidth(width);
+    polygonOptions.strokeWidth(width * density);
   }
 
   @Override

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/PolygonController.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/PolygonController.java
@@ -12,10 +12,12 @@ import java.util.List;
 class PolygonController implements PolygonOptionsSink {
   private final Polygon polygon;
   private final String googleMapsPolygonId;
+  private final float density;
   private boolean consumeTapEvents;
 
-  PolygonController(Polygon polygon, boolean consumeTapEvents) {
+  PolygonController(Polygon polygon, boolean consumeTapEvents, float density) {
     this.polygon = polygon;
+    this.density = density;
     this.consumeTapEvents = consumeTapEvents;
     this.googleMapsPolygonId = polygon.getId();
   }
@@ -57,7 +59,7 @@ class PolygonController implements PolygonOptionsSink {
 
   @Override
   public void setStrokeWidth(float width) {
-    polygon.setStrokeWidth(width);
+    polygon.setStrokeWidth(width * density);
   }
 
   @Override

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/PolygonsController.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/PolygonsController.java
@@ -81,7 +81,7 @@ class PolygonsController {
     if (polygon == null) {
       return;
     }
-    PolygonBuilder polygonBuilder = new PolygonBuilder();
+    PolygonBuilder polygonBuilder = new PolygonBuilder(density);
     String polygonId = Convert.interpretPolygonOptions(polygon, polygonBuilder);
     PolygonOptions options = polygonBuilder.build();
     addPolygon(polygonId, options, polygonBuilder.consumeTapEvents());

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/PolygonsController.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/PolygonsController.java
@@ -17,12 +17,14 @@ class PolygonsController {
   private final Map<String, PolygonController> polygonIdToController;
   private final Map<String, String> googleMapsPolygonIdToDartPolygonId;
   private final MethodChannel methodChannel;
+  private final float density;
   private GoogleMap googleMap;
 
-  PolygonsController(MethodChannel methodChannel) {
+  PolygonsController(MethodChannel methodChannel, float density) {
     this.polygonIdToController = new HashMap<>();
     this.googleMapsPolygonIdToDartPolygonId = new HashMap<>();
     this.methodChannel = methodChannel;
+    this.density = density;
   }
 
   void setGoogleMap(GoogleMap googleMap) {
@@ -88,7 +90,7 @@ class PolygonsController {
   private void addPolygon(
       String polygonId, PolygonOptions polygonOptions, boolean consumeTapEvents) {
     final Polygon polygon = googleMap.addPolygon(polygonOptions);
-    PolygonController controller = new PolygonController(polygon, consumeTapEvents);
+    PolygonController controller = new PolygonController(polygon, consumeTapEvents, density);
     polygonIdToController.put(polygonId, controller);
     googleMapsPolygonIdToDartPolygonId.put(polygon.getId(), polygonId);
   }

--- a/packages/google_maps_flutter/android/src/test/java/io/flutter/plugins/googlemaps/CircleBuilderTest.java
+++ b/packages/google_maps_flutter/android/src/test/java/io/flutter/plugins/googlemaps/CircleBuilderTest.java
@@ -1,0 +1,22 @@
+package io.flutter.plugins.googlemaps;
+
+import static junit.framework.TestCase.assertEquals;
+
+import com.google.android.gms.maps.model.CircleOptions;
+import org.junit.Test;
+
+public class CircleBuilderTest {
+
+  @Test
+  public void density_AppliesToStrokeWidth() {
+    final float density = 5;
+    final float strokeWidth = 3;
+    final CircleBuilder builder = new CircleBuilder(density);
+    builder.setStrokeWidth(strokeWidth);
+
+    final CircleOptions options = builder.build();
+    final float width = options.getStrokeWidth();
+
+    assertEquals(density * strokeWidth, width);
+  }
+}

--- a/packages/google_maps_flutter/android/src/test/java/io/flutter/plugins/googlemaps/CircleControllerTest.java
+++ b/packages/google_maps_flutter/android/src/test/java/io/flutter/plugins/googlemaps/CircleControllerTest.java
@@ -1,0 +1,25 @@
+package io.flutter.plugins.googlemaps;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+import com.google.android.gms.internal.maps.zzh;
+import com.google.android.gms.maps.model.Circle;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class CircleControllerTest {
+
+  @Test
+  public void controller_SetsStrokeDensity() {
+    final zzh z = mock(zzh.class);
+    final Circle circle = spy(new Circle(z));
+
+    final float density = 5;
+    final float strokeWidth = 3;
+    final CircleController controller = new CircleController(circle, false, density);
+    controller.setStrokeWidth(strokeWidth);
+
+    Mockito.verify(circle).setStrokeWidth(density * strokeWidth);
+  }
+}

--- a/packages/google_maps_flutter/android/src/test/java/io/flutter/plugins/googlemaps/PolygonBuilderTest.java
+++ b/packages/google_maps_flutter/android/src/test/java/io/flutter/plugins/googlemaps/PolygonBuilderTest.java
@@ -1,0 +1,23 @@
+package io.flutter.plugins.googlemaps;
+
+import static junit.framework.TestCase.assertEquals;
+
+import com.google.android.gms.maps.model.PolygonOptions;
+import org.junit.Test;
+
+public class PolygonBuilderTest {
+
+  @Test
+  public void density_AppliesToStrokeWidth() {
+    final float density = 5;
+    final float strokeWidth = 3;
+
+    final PolygonBuilder builder = new PolygonBuilder(density);
+    builder.setStrokeWidth(strokeWidth);
+
+    final PolygonOptions options = builder.build();
+    final float width = options.getStrokeWidth();
+
+    assertEquals(density * strokeWidth, width);
+  }
+}

--- a/packages/google_maps_flutter/android/src/test/java/io/flutter/plugins/googlemaps/PolygonControllerTest.java
+++ b/packages/google_maps_flutter/android/src/test/java/io/flutter/plugins/googlemaps/PolygonControllerTest.java
@@ -1,0 +1,25 @@
+package io.flutter.plugins.googlemaps;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+import com.google.android.gms.internal.maps.zzw;
+import com.google.android.gms.maps.model.Polygon;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class PolygonControllerTest {
+
+  @Test
+  public void controller_SetsStrokeDensity() {
+    final zzw z = mock(zzw.class);
+    final Polygon polygon = spy(new Polygon(z));
+
+    final float density = 5;
+    final float strokeWidth = 3;
+    final PolygonController controller = new PolygonController(polygon, false, density);
+    controller.setStrokeWidth(strokeWidth);
+
+    Mockito.verify(polygon).setStrokeWidth(density * strokeWidth);
+  }
+}

--- a/packages/google_maps_flutter/android/src/test/java/io/flutter/plugins/googlemaps/PolylineBuilderTest.java
+++ b/packages/google_maps_flutter/android/src/test/java/io/flutter/plugins/googlemaps/PolylineBuilderTest.java
@@ -1,0 +1,23 @@
+package io.flutter.plugins.googlemaps;
+
+import static junit.framework.TestCase.assertEquals;
+
+import com.google.android.gms.maps.model.PolylineOptions;
+import org.junit.Test;
+
+public class PolylineBuilderTest {
+
+  @Test
+  public void density_AppliesToStrokeWidth() {
+    final float density = 5;
+    final float strokeWidth = 3;
+
+    final PolylineBuilder builder = new PolylineBuilder(density);
+    builder.setWidth(strokeWidth);
+
+    final PolylineOptions options = builder.build();
+    final float width = options.getWidth();
+
+    assertEquals(density * strokeWidth, width);
+  }
+}

--- a/packages/google_maps_flutter/android/src/test/java/io/flutter/plugins/googlemaps/PolylineControllerTest.java
+++ b/packages/google_maps_flutter/android/src/test/java/io/flutter/plugins/googlemaps/PolylineControllerTest.java
@@ -1,0 +1,25 @@
+package io.flutter.plugins.googlemaps;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+import com.google.android.gms.internal.maps.zzz;
+import com.google.android.gms.maps.model.Polyline;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class PolylineControllerTest {
+
+  @Test
+  public void controller_SetsStrokeDensity() {
+    final zzz z = mock(zzz.class);
+    final Polyline polyline = spy(new Polyline(z));
+
+    final float density = 5;
+    final float strokeWidth = 3;
+    final PolylineController controller = new PolylineController(polyline, false, density);
+    controller.setWidth(strokeWidth);
+
+    Mockito.verify(polyline).setWidth(density * strokeWidth);
+  }
+}

--- a/packages/google_maps_flutter/android/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/packages/google_maps_flutter/android/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/packages/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter
-version: 0.5.22+2
+version: 0.5.22+3
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Description

Stroke width of Polygon and Circles on Android is not independent of the screen density

## Related Issues

flutter/flutter#39476

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [-] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.


