### PR TITLE
[instrumentation_adapter] update for release

### DIFF
--- a/packages/instrumentation_adapter/pubspec.yaml
+++ b/packages/instrumentation_adapter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: instrumentation_adapter
 description: Runs tests that use the flutter_test API as platform native instrumentation tests.
-version: 0.1.1
+version: 0.1.2
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/instrumentation_adapter
 


### PR DESCRIPTION
This pubspec.yaml didn't get updated due to a merge conflict.

Updates the version to match the CHANGELOG