### PR TITLE
Point opensource site at new location

### DIFF
--- a/.opensource/project.json
+++ b/.opensource/project.json
@@ -1,24 +1,11 @@
 {
-  "name": "FlutterFire",
+  "name": "FlutterFire - MOVED",
   "platforms": [
     "Android",
     "iOS"
   ],
   "content": "FlutterFire.md",
-  "pages": {
-    "packages/cloud_firestore/README.md": "Cloud Firestore",
-    "packages/cloud_functions/README.md": "Cloud Functions",
-    "packages/firebase_admob/README.md": "Admob",
-    "packages/firebase_analytics/README.md": "Analytics",
-    "packages/firebase_auth/README.md": "Authentication",
-    "packages/firebase_core/README.md": "Core",
-    "packages/firebase_crashlytics/README.md": "Crashlytics",
-    "packages/firebase_database/README.md": "Realtime Database",
-    "packages/firebase_dynamic_links/README.md": "Dynamic Links",
-    "packages/firebase_messaging/README.md": "Cloud Messaging",
-    "packages/firebase_ml_vision/README.md": "ML Kit: Vision",
-    "packages/firebase_performance/README.md": "Performance Monitoring",
-    "packages/firebase_remote_config/README.md": "Remote Config",
-    "packages/firebase_storage/README.md": "Cloud Storage"
-  }
+  "related": [
+    "FirebaseExtended/flutterfire"
+  ]
 }

--- a/FlutterFire.md
+++ b/FlutterFire.md
@@ -1,0 +1,6 @@
+# FlutterFire - MOVED
+
+The FlutterFire family of plugins has moved to the FirebaseExtended organization on GitHub. This makes it easier for us to collaborate with the Firebase team. We want to build the best integration we can!
+
+Visit FlutterFire at its new home:
+https://github.com/FirebaseExtended/flutterfire


### PR DESCRIPTION
## Description

This page currently gets about 1000 views/week:
https://firebaseopensource.com/projects/flutter/plugins/

While I am removing it from the firebaseopensource.com home page, I expect there will be some lingering direct traffic to the page.  Rather than having it 404, I'd like it to send people to the new location.

## Related Issues

https://github.com/FirebaseExtended/flutterfire/pull/127

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ x] All existing and new tests are passing.
- [ x] I updated/added relevant documentation (doc comments with `///`).
- [ x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [ x] I read and followed the [Flutter Style Guide].
- [ x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [ x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ x] I updated CHANGELOG.md to add a description of the change.
- [ x] I signed the [CLA].
- [ x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
