### PR TITLE
[Camera] Fixes NullPointerException

### DIFF
--- a/packages/camera/CHANGELOG.md
+++ b/packages/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.4+2
+
+* Fix Android NullPointerException on devices with only front-facing camera.
+
 ## 0.5.4+1
 
 * Fix Android pause and resume video crash when executing in APIs below 24.

--- a/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraUtils.java
+++ b/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraUtils.java
@@ -77,32 +77,31 @@ public final class CameraUtils {
         // All of these cases deliberately fall through to get the best available profile.
       case max:
         if (CamcorderProfile.hasProfile(cameraId, CamcorderProfile.QUALITY_HIGH)) {
-          return CamcorderProfile.get(CamcorderProfile.QUALITY_HIGH);
+          return CamcorderProfile.get(cameraId, CamcorderProfile.QUALITY_HIGH);
         }
       case ultraHigh:
         if (CamcorderProfile.hasProfile(cameraId, CamcorderProfile.QUALITY_2160P)) {
-          return CamcorderProfile.get(CamcorderProfile.QUALITY_2160P);
+          return CamcorderProfile.get(cameraId, CamcorderProfile.QUALITY_2160P);
         }
       case veryHigh:
         if (CamcorderProfile.hasProfile(cameraId, CamcorderProfile.QUALITY_1080P)) {
-          return CamcorderProfile.get(CamcorderProfile.QUALITY_1080P);
+          return CamcorderProfile.get(cameraId, CamcorderProfile.QUALITY_1080P);
         }
       case high:
         if (CamcorderProfile.hasProfile(cameraId, CamcorderProfile.QUALITY_720P)) {
-          return CamcorderProfile.get(CamcorderProfile.QUALITY_720P);
+          return CamcorderProfile.get(cameraId, CamcorderProfile.QUALITY_720P);
         }
       case medium:
         if (CamcorderProfile.hasProfile(cameraId, CamcorderProfile.QUALITY_480P)) {
-          return CamcorderProfile.get(CamcorderProfile.QUALITY_480P);
+          return CamcorderProfile.get(cameraId, CamcorderProfile.QUALITY_480P);
         }
       case low:
         if (CamcorderProfile.hasProfile(cameraId, CamcorderProfile.QUALITY_QVGA)) {
-          return CamcorderProfile.get(CamcorderProfile.QUALITY_QVGA);
+          return CamcorderProfile.get(cameraId, CamcorderProfile.QUALITY_QVGA);
         }
       default:
-        if (CamcorderProfile.hasProfile(
-            Integer.parseInt(cameraName), CamcorderProfile.QUALITY_LOW)) {
-          return CamcorderProfile.get(CamcorderProfile.QUALITY_LOW);
+        if (CamcorderProfile.hasProfile(cameraId, CamcorderProfile.QUALITY_LOW)) {
+          return CamcorderProfile.get(cameraId, CamcorderProfile.QUALITY_LOW);
         } else {
           throw new IllegalArgumentException(
               "No capture session available for current capture session.");

--- a/packages/camera/pubspec.yaml
+++ b/packages/camera/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera
 description: A Flutter plugin for getting information about and controlling the
   camera on Android and iOS. Supports previewing the camera feed, capturing images, capturing video,
   and streaming image buffers to dart.
-version: 0.5.4+1
+version: 0.5.4+2
 
 authors:
   - Flutter Team <flutter-dev@googlegroups.com>


### PR DESCRIPTION
## Description
This PR fixes a possible NullPointerException when the device has only front-facing cameras.
There are two versions of `CamcorderProfile.get`, the one currently in use will return null in case there is no back-facing camera. The second version uses the `cameraId` to avoid returning null.
More: https://developer.android.com/reference/android/media/CamcorderProfile.html#get(int,%20int)

## Related Issues

https://github.com/flutter/flutter/issues/40164

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [X] No, this is *not* a breaking change.



## How to test:
1) Create an android emulator with only a front-facing camera 
2) Run the current version
You should see something like the image below.
<img src="https://user-images.githubusercontent.com/70573/64671597-5a07ce80-d43f-11e9-8e13-dc6e833eb64c.png" width="50%"/>

3) Run with the fix in this PR and you should see the camera working.
