### PR TITLE
[instrumentation_adapter] Fix Java import path and warnings about API checking.

### DIFF
--- a/packages/instrumentation_adapter/android/src/main/java/dev/flutter/plugins/instrumentationadapter/FlutterRunner.java
+++ b/packages/instrumentation_adapter/android/src/main/java/dev/flutter/plugins/instrumentationadapter/FlutterRunner.java
@@ -5,6 +5,8 @@
 package dev.flutter.plugins.instrumentationadapter;
 
 import android.app.Activity;
+import android.os.Build;
+import androidx.annotation.RequiresApi;
 import androidx.test.rule.ActivityTestRule;
 import java.lang.reflect.Field;
 import java.util.Map;
@@ -15,6 +17,7 @@ import org.junit.runner.Runner;
 import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunNotifier;
 
+@RequiresApi(api = Build.VERSION_CODES.N)
 public class FlutterRunner extends Runner {
 
   final Class testClass;
@@ -44,6 +47,7 @@ public class FlutterRunner extends Runner {
   public Description getDescription() {
     return Description.createTestDescription(testClass, "Flutter Tests");
   }
+
 
   @Override
   public void run(RunNotifier notifier) {

--- a/packages/instrumentation_adapter/android/src/main/java/dev/flutter/plugins/instrumentationadapter/InstrumentationAdapterPlugin.java
+++ b/packages/instrumentation_adapter/android/src/main/java/dev/flutter/plugins/instrumentationadapter/InstrumentationAdapterPlugin.java
@@ -4,6 +4,8 @@
 
 package dev.flutter.plugins.instrumentationadapter;
 
+import android.os.Build;
+import androidx.annotation.RequiresApi;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
@@ -13,6 +15,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 /** InstrumentationAdapterPlugin */
+@RequiresApi(api = Build.VERSION_CODES.N)
 public class InstrumentationAdapterPlugin implements MethodCallHandler {
 
   public static CompletableFuture<Map<String, String>> testResults = new CompletableFuture<>();


### PR DESCRIPTION
## Description

A no-op refactor to make the code follows Android convention.

## Related Issues

flutter/flutter#38824

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
