### PR TITLE
[image_picker] fix crash on Android when selecting photo from OneDrive

### DIFF
--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.1+5
+
+* Android: Fix a crash when selecting photo from OneDrive provider
+
 ## 0.6.1+4
 
 * Android: Fix a regression where the `retrieveLostImage` does not work anymore.

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
@@ -33,7 +33,6 @@ import android.os.Environment;
 import android.provider.DocumentsContract;
 import android.provider.MediaStore;
 import android.text.TextUtils;
-
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -92,23 +91,16 @@ class FileUtils {
                 }
 
                 final String selection = "_id=?";
-                final String[] selectionArgs = new String[]{split[1]};
+                final String[] selectionArgs = new String[] {split[1]};
 
                 return getDataColumn(context, contentUri, selection, selectionArgs);
             }
         } else if ("content".equalsIgnoreCase(uri.getScheme())) {
 
             // Return the remote address
-            if (isGooglePhotosUri(uri)) {
+            if (isGooglePhotosUri(uri) || isOneDriveUri(uri)) {
                 return null;
             }
-
-            // OneDrive stores files in the local storage, we can't get path
-            // Return the remote address
-            if (isOneDriveUri(uri)) {
-                return null;
-            }
-
 
             return getDataColumn(context, uri, null, null);
         } else if ("file".equalsIgnoreCase(uri.getScheme())) {
@@ -178,9 +170,7 @@ class FileUtils {
         return success ? file.getPath() : null;
     }
 
-    /**
-     * @return extension of image with dot, or default .jpg if it none.
-     */
+    /** @return extension of image with dot, or default .jpg if it none. */
     private static String getImageExtension(Uri uriImage) {
         String extension = null;
 

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
@@ -33,6 +33,7 @@ import android.os.Environment;
 import android.provider.DocumentsContract;
 import android.provider.MediaStore;
 import android.text.TextUtils;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -41,178 +42,192 @@ import java.io.OutputStream;
 
 class FileUtils {
 
-  String getPathFromUri(final Context context, final Uri uri) {
-    String path = getPathFromLocalUri(context, uri);
-    if (path == null) {
-      path = getPathFromRemoteUri(context, uri);
+    String getPathFromUri(final Context context, final Uri uri) {
+        String path = getPathFromLocalUri(context, uri);
+        if (path == null) {
+            path = getPathFromRemoteUri(context, uri);
+        }
+        return path;
     }
-    return path;
-  }
 
-  @SuppressLint("NewApi")
-  private String getPathFromLocalUri(final Context context, final Uri uri) {
-    final boolean isKitKat = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
+    @SuppressLint("NewApi")
+    private String getPathFromLocalUri(final Context context, final Uri uri) {
+        final boolean isKitKat = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
 
-    if (isKitKat && DocumentsContract.isDocumentUri(context, uri)) {
-      if (isExternalStorageDocument(uri)) {
-        final String docId = DocumentsContract.getDocumentId(uri);
-        final String[] split = docId.split(":");
-        final String type = split[0];
+        if (isKitKat && DocumentsContract.isDocumentUri(context, uri)) {
+            if (isExternalStorageDocument(uri)) {
+                final String docId = DocumentsContract.getDocumentId(uri);
+                final String[] split = docId.split(":");
+                final String type = split[0];
 
-        if ("primary".equalsIgnoreCase(type)) {
-          return Environment.getExternalStorageDirectory() + "/" + split[1];
+                if ("primary".equalsIgnoreCase(type)) {
+                    return Environment.getExternalStorageDirectory() + "/" + split[1];
+                }
+            } else if (isDownloadsDocument(uri)) {
+                final String id = DocumentsContract.getDocumentId(uri);
+
+                if (!TextUtils.isEmpty(id)) {
+                    try {
+                        final Uri contentUri =
+                                ContentUris.withAppendedId(
+                                        Uri.parse(Environment.DIRECTORY_DOWNLOADS), Long.valueOf(id));
+                        return getDataColumn(context, contentUri, null, null);
+                    } catch (NumberFormatException e) {
+                        return null;
+                    }
+                }
+
+            } else if (isMediaDocument(uri)) {
+                final String docId = DocumentsContract.getDocumentId(uri);
+                final String[] split = docId.split(":");
+                final String type = split[0];
+
+                Uri contentUri = null;
+                if ("image".equals(type)) {
+                    contentUri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
+                } else if ("video".equals(type)) {
+                    contentUri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI;
+                } else if ("audio".equals(type)) {
+                    contentUri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI;
+                }
+
+                final String selection = "_id=?";
+                final String[] selectionArgs = new String[]{split[1]};
+
+                return getDataColumn(context, contentUri, selection, selectionArgs);
+            }
+        } else if ("content".equalsIgnoreCase(uri.getScheme())) {
+
+            // Return the remote address
+            if (isGooglePhotosUri(uri)) {
+                return null;
+            }
+
+            // OneDrive stores files in the local storage, we can't get path
+            // Return the remote address
+            if (isOneDriveUri(uri)) {
+                return null;
+            }
+
+
+            return getDataColumn(context, uri, null, null);
+        } else if ("file".equalsIgnoreCase(uri.getScheme())) {
+            return uri.getPath();
         }
-      } else if (isDownloadsDocument(uri)) {
-        final String id = DocumentsContract.getDocumentId(uri);
 
-        if (!TextUtils.isEmpty(id)) {
-          try {
-            final Uri contentUri =
-                ContentUris.withAppendedId(
-                    Uri.parse(Environment.DIRECTORY_DOWNLOADS), Long.valueOf(id));
-            return getDataColumn(context, contentUri, null, null);
-          } catch (NumberFormatException e) {
-            return null;
-          }
-        }
-
-      } else if (isMediaDocument(uri)) {
-        final String docId = DocumentsContract.getDocumentId(uri);
-        final String[] split = docId.split(":");
-        final String type = split[0];
-
-        Uri contentUri = null;
-        if ("image".equals(type)) {
-          contentUri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
-        } else if ("video".equals(type)) {
-          contentUri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI;
-        } else if ("audio".equals(type)) {
-          contentUri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI;
-        }
-
-        final String selection = "_id=?";
-        final String[] selectionArgs = new String[] {split[1]};
-
-        return getDataColumn(context, contentUri, selection, selectionArgs);
-      }
-    } else if ("content".equalsIgnoreCase(uri.getScheme())) {
-
-      // Return the remote address
-      if (isGooglePhotosUri(uri)) {
         return null;
-      }
-
-      return getDataColumn(context, uri, null, null);
-    } else if ("file".equalsIgnoreCase(uri.getScheme())) {
-      return uri.getPath();
     }
 
-    return null;
-  }
+    private static String getDataColumn(
+            Context context, Uri uri, String selection, String[] selectionArgs) {
+        Cursor cursor = null;
 
-  private static String getDataColumn(
-      Context context, Uri uri, String selection, String[] selectionArgs) {
-    Cursor cursor = null;
+        final String column = "_data";
+        final String[] projection = {column};
 
-    final String column = "_data";
-    final String[] projection = {column};
+        try {
+            cursor = context.getContentResolver().query(uri, projection, selection, selectionArgs, null);
+            if (cursor != null && cursor.moveToFirst()) {
+                final int column_index = cursor.getColumnIndex(column);
 
-    try {
-      cursor = context.getContentResolver().query(uri, projection, selection, selectionArgs, null);
-      if (cursor != null && cursor.moveToFirst()) {
-        final int column_index = cursor.getColumnIndex(column);
+                //yandex.disk and dropbox do not have _data column
+                if (column_index == -1) {
+                    return null;
+                }
 
-        //yandex.disk and dropbox do not have _data column
-        if (column_index == -1) {
-          return null;
+                return cursor.getString(column_index);
+            }
+        } finally {
+            if (cursor != null) {
+                cursor.close();
+            }
+        }
+        return null;
+    }
+
+    private static String getPathFromRemoteUri(final Context context, final Uri uri) {
+        // The code below is why Java now has try-with-resources and the Files utility.
+        File file = null;
+        InputStream inputStream = null;
+        OutputStream outputStream = null;
+        boolean success = false;
+        try {
+            String extension = getImageExtension(uri);
+            inputStream = context.getContentResolver().openInputStream(uri);
+            file = File.createTempFile("image_picker", extension, context.getCacheDir());
+            outputStream = new FileOutputStream(file);
+            if (inputStream != null) {
+                copy(inputStream, outputStream);
+                success = true;
+            }
+        } catch (IOException ignored) {
+        } finally {
+            try {
+                if (inputStream != null) inputStream.close();
+            } catch (IOException ignored) {
+            }
+            try {
+                if (outputStream != null) outputStream.close();
+            } catch (IOException ignored) {
+                // If closing the output stream fails, we cannot be sure that the
+                // target file was written in full. Flushing the stream merely moves
+                // the bytes into the OS, not necessarily to the file.
+                success = false;
+            }
+        }
+        return success ? file.getPath() : null;
+    }
+
+    /**
+     * @return extension of image with dot, or default .jpg if it none.
+     */
+    private static String getImageExtension(Uri uriImage) {
+        String extension = null;
+
+        try {
+            String imagePath = uriImage.getPath();
+            if (imagePath != null && imagePath.lastIndexOf(".") != -1) {
+                extension = imagePath.substring(imagePath.lastIndexOf(".") + 1);
+            }
+        } catch (Exception e) {
+            extension = null;
         }
 
-        return cursor.getString(column_index);
-      }
-    } finally {
-      if (cursor != null) {
-        cursor.close();
-      }
-    }
-    return null;
-  }
+        if (extension == null || extension.isEmpty()) {
+            //default extension for matches the previous behavior of the plugin
+            extension = "jpg";
+        }
 
-  private static String getPathFromRemoteUri(final Context context, final Uri uri) {
-    // The code below is why Java now has try-with-resources and the Files utility.
-    File file = null;
-    InputStream inputStream = null;
-    OutputStream outputStream = null;
-    boolean success = false;
-    try {
-      String extension = getImageExtension(uri);
-      inputStream = context.getContentResolver().openInputStream(uri);
-      file = File.createTempFile("image_picker", extension, context.getCacheDir());
-      outputStream = new FileOutputStream(file);
-      if (inputStream != null) {
-        copy(inputStream, outputStream);
-        success = true;
-      }
-    } catch (IOException ignored) {
-    } finally {
-      try {
-        if (inputStream != null) inputStream.close();
-      } catch (IOException ignored) {
-      }
-      try {
-        if (outputStream != null) outputStream.close();
-      } catch (IOException ignored) {
-        // If closing the output stream fails, we cannot be sure that the
-        // target file was written in full. Flushing the stream merely moves
-        // the bytes into the OS, not necessarily to the file.
-        success = false;
-      }
-    }
-    return success ? file.getPath() : null;
-  }
-
-  /** @return extension of image with dot, or default .jpg if it none. */
-  private static String getImageExtension(Uri uriImage) {
-    String extension = null;
-
-    try {
-      String imagePath = uriImage.getPath();
-      if (imagePath != null && imagePath.lastIndexOf(".") != -1) {
-        extension = imagePath.substring(imagePath.lastIndexOf(".") + 1);
-      }
-    } catch (Exception e) {
-      extension = null;
+        return "." + extension;
     }
 
-    if (extension == null || extension.isEmpty()) {
-      //default extension for matches the previous behavior of the plugin
-      extension = "jpg";
+    private static void copy(InputStream in, OutputStream out) throws IOException {
+        final byte[] buffer = new byte[4 * 1024];
+        int bytesRead;
+        while ((bytesRead = in.read(buffer)) != -1) {
+            out.write(buffer, 0, bytesRead);
+        }
+        out.flush();
     }
 
-    return "." + extension;
-  }
-
-  private static void copy(InputStream in, OutputStream out) throws IOException {
-    final byte[] buffer = new byte[4 * 1024];
-    int bytesRead;
-    while ((bytesRead = in.read(buffer)) != -1) {
-      out.write(buffer, 0, bytesRead);
+    private static boolean isExternalStorageDocument(Uri uri) {
+        return "com.android.externalstorage.documents".equals(uri.getAuthority());
     }
-    out.flush();
-  }
 
-  private static boolean isExternalStorageDocument(Uri uri) {
-    return "com.android.externalstorage.documents".equals(uri.getAuthority());
-  }
+    private static boolean isDownloadsDocument(Uri uri) {
+        return "com.android.providers.downloads.documents".equals(uri.getAuthority());
+    }
 
-  private static boolean isDownloadsDocument(Uri uri) {
-    return "com.android.providers.downloads.documents".equals(uri.getAuthority());
-  }
+    private static boolean isMediaDocument(Uri uri) {
+        return "com.android.providers.media.documents".equals(uri.getAuthority());
+    }
 
-  private static boolean isMediaDocument(Uri uri) {
-    return "com.android.providers.media.documents".equals(uri.getAuthority());
-  }
+    private static boolean isGooglePhotosUri(Uri uri) {
+        return "com.google.android.apps.photos.contentprovider".equals(uri.getAuthority());
+    }
 
-  private static boolean isGooglePhotosUri(Uri uri) {
-    return "com.google.android.apps.photos.contentprovider".equals(uri.getAuthority());
-  }
+    private static boolean isOneDriveUri(Uri uri) {
+        return "com.microsoft.skydrive.content.external".equals(uri.getAuthority());
+    }
+
 }

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
@@ -219,5 +219,4 @@ class FileUtils {
   private static boolean isOneDriveUri(Uri uri) {
     return "com.microsoft.skydrive.content.external".equals(uri.getAuthority());
   }
-
 }

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
@@ -41,183 +41,183 @@ import java.io.OutputStream;
 
 class FileUtils {
 
-    String getPathFromUri(final Context context, final Uri uri) {
-        String path = getPathFromLocalUri(context, uri);
-        if (path == null) {
-            path = getPathFromRemoteUri(context, uri);
-        }
-        return path;
+  String getPathFromUri(final Context context, final Uri uri) {
+    String path = getPathFromLocalUri(context, uri);
+    if (path == null) {
+      path = getPathFromRemoteUri(context, uri);
     }
+    return path;
+  }
 
-    @SuppressLint("NewApi")
-    private String getPathFromLocalUri(final Context context, final Uri uri) {
-        final boolean isKitKat = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
+  @SuppressLint("NewApi")
+  private String getPathFromLocalUri(final Context context, final Uri uri) {
+    final boolean isKitKat = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
 
-        if (isKitKat && DocumentsContract.isDocumentUri(context, uri)) {
-            if (isExternalStorageDocument(uri)) {
-                final String docId = DocumentsContract.getDocumentId(uri);
-                final String[] split = docId.split(":");
-                final String type = split[0];
+    if (isKitKat && DocumentsContract.isDocumentUri(context, uri)) {
+      if (isExternalStorageDocument(uri)) {
+        final String docId = DocumentsContract.getDocumentId(uri);
+        final String[] split = docId.split(":");
+        final String type = split[0];
 
-                if ("primary".equalsIgnoreCase(type)) {
-                    return Environment.getExternalStorageDirectory() + "/" + split[1];
-                }
-            } else if (isDownloadsDocument(uri)) {
-                final String id = DocumentsContract.getDocumentId(uri);
+        if ("primary".equalsIgnoreCase(type)) {
+          return Environment.getExternalStorageDirectory() + "/" + split[1];
+        }
+      } else if (isDownloadsDocument(uri)) {
+        final String id = DocumentsContract.getDocumentId(uri);
 
-                if (!TextUtils.isEmpty(id)) {
-                    try {
-                        final Uri contentUri =
-                                ContentUris.withAppendedId(
-                                        Uri.parse(Environment.DIRECTORY_DOWNLOADS), Long.valueOf(id));
-                        return getDataColumn(context, contentUri, null, null);
-                    } catch (NumberFormatException e) {
-                        return null;
-                    }
-                }
-
-            } else if (isMediaDocument(uri)) {
-                final String docId = DocumentsContract.getDocumentId(uri);
-                final String[] split = docId.split(":");
-                final String type = split[0];
-
-                Uri contentUri = null;
-                if ("image".equals(type)) {
-                    contentUri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
-                } else if ("video".equals(type)) {
-                    contentUri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI;
-                } else if ("audio".equals(type)) {
-                    contentUri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI;
-                }
-
-                final String selection = "_id=?";
-                final String[] selectionArgs = new String[] {split[1]};
-
-                return getDataColumn(context, contentUri, selection, selectionArgs);
-            }
-        } else if ("content".equalsIgnoreCase(uri.getScheme())) {
-
-            // Return the remote address
-            if (isGooglePhotosUri(uri) || isOneDriveUri(uri)) {
-                return null;
-            }
-
-            return getDataColumn(context, uri, null, null);
-        } else if ("file".equalsIgnoreCase(uri.getScheme())) {
-            return uri.getPath();
+        if (!TextUtils.isEmpty(id)) {
+          try {
+            final Uri contentUri =
+                ContentUris.withAppendedId(
+                    Uri.parse(Environment.DIRECTORY_DOWNLOADS), Long.valueOf(id));
+            return getDataColumn(context, contentUri, null, null);
+          } catch (NumberFormatException e) {
+            return null;
+          }
         }
 
+      } else if (isMediaDocument(uri)) {
+        final String docId = DocumentsContract.getDocumentId(uri);
+        final String[] split = docId.split(":");
+        final String type = split[0];
+
+        Uri contentUri = null;
+        if ("image".equals(type)) {
+          contentUri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
+        } else if ("video".equals(type)) {
+          contentUri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI;
+        } else if ("audio".equals(type)) {
+          contentUri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI;
+        }
+
+        final String selection = "_id=?";
+        final String[] selectionArgs = new String[] {split[1]};
+
+        return getDataColumn(context, contentUri, selection, selectionArgs);
+      }
+    } else if ("content".equalsIgnoreCase(uri.getScheme())) {
+
+      // Return the remote address
+      if (isGooglePhotosUri(uri) || isOneDriveUri(uri)) {
         return null;
+      }
+
+      return getDataColumn(context, uri, null, null);
+    } else if ("file".equalsIgnoreCase(uri.getScheme())) {
+      return uri.getPath();
     }
 
-    private static String getDataColumn(
-            Context context, Uri uri, String selection, String[] selectionArgs) {
-        Cursor cursor = null;
+    return null;
+  }
 
-        final String column = "_data";
-        final String[] projection = {column};
+  private static String getDataColumn(
+      Context context, Uri uri, String selection, String[] selectionArgs) {
+    Cursor cursor = null;
 
-        try {
-            cursor = context.getContentResolver().query(uri, projection, selection, selectionArgs, null);
-            if (cursor != null && cursor.moveToFirst()) {
-                final int column_index = cursor.getColumnIndex(column);
+    final String column = "_data";
+    final String[] projection = {column};
 
-                //yandex.disk and dropbox do not have _data column
-                if (column_index == -1) {
-                    return null;
-                }
+    try {
+      cursor = context.getContentResolver().query(uri, projection, selection, selectionArgs, null);
+      if (cursor != null && cursor.moveToFirst()) {
+        final int column_index = cursor.getColumnIndex(column);
 
-                return cursor.getString(column_index);
-            }
-        } finally {
-            if (cursor != null) {
-                cursor.close();
-            }
-        }
-        return null;
-    }
-
-    private static String getPathFromRemoteUri(final Context context, final Uri uri) {
-        // The code below is why Java now has try-with-resources and the Files utility.
-        File file = null;
-        InputStream inputStream = null;
-        OutputStream outputStream = null;
-        boolean success = false;
-        try {
-            String extension = getImageExtension(uri);
-            inputStream = context.getContentResolver().openInputStream(uri);
-            file = File.createTempFile("image_picker", extension, context.getCacheDir());
-            outputStream = new FileOutputStream(file);
-            if (inputStream != null) {
-                copy(inputStream, outputStream);
-                success = true;
-            }
-        } catch (IOException ignored) {
-        } finally {
-            try {
-                if (inputStream != null) inputStream.close();
-            } catch (IOException ignored) {
-            }
-            try {
-                if (outputStream != null) outputStream.close();
-            } catch (IOException ignored) {
-                // If closing the output stream fails, we cannot be sure that the
-                // target file was written in full. Flushing the stream merely moves
-                // the bytes into the OS, not necessarily to the file.
-                success = false;
-            }
-        }
-        return success ? file.getPath() : null;
-    }
-
-    /** @return extension of image with dot, or default .jpg if it none. */
-    private static String getImageExtension(Uri uriImage) {
-        String extension = null;
-
-        try {
-            String imagePath = uriImage.getPath();
-            if (imagePath != null && imagePath.lastIndexOf(".") != -1) {
-                extension = imagePath.substring(imagePath.lastIndexOf(".") + 1);
-            }
-        } catch (Exception e) {
-            extension = null;
+        //yandex.disk and dropbox do not have _data column
+        if (column_index == -1) {
+          return null;
         }
 
-        if (extension == null || extension.isEmpty()) {
-            //default extension for matches the previous behavior of the plugin
-            extension = "jpg";
-        }
+        return cursor.getString(column_index);
+      }
+    } finally {
+      if (cursor != null) {
+        cursor.close();
+      }
+    }
+    return null;
+  }
 
-        return "." + extension;
+  private static String getPathFromRemoteUri(final Context context, final Uri uri) {
+    // The code below is why Java now has try-with-resources and the Files utility.
+    File file = null;
+    InputStream inputStream = null;
+    OutputStream outputStream = null;
+    boolean success = false;
+    try {
+      String extension = getImageExtension(uri);
+      inputStream = context.getContentResolver().openInputStream(uri);
+      file = File.createTempFile("image_picker", extension, context.getCacheDir());
+      outputStream = new FileOutputStream(file);
+      if (inputStream != null) {
+        copy(inputStream, outputStream);
+        success = true;
+      }
+    } catch (IOException ignored) {
+    } finally {
+      try {
+        if (inputStream != null) inputStream.close();
+      } catch (IOException ignored) {
+      }
+      try {
+        if (outputStream != null) outputStream.close();
+      } catch (IOException ignored) {
+        // If closing the output stream fails, we cannot be sure that the
+        // target file was written in full. Flushing the stream merely moves
+        // the bytes into the OS, not necessarily to the file.
+        success = false;
+      }
+    }
+    return success ? file.getPath() : null;
+  }
+
+  /** @return extension of image with dot, or default .jpg if it none. */
+  private static String getImageExtension(Uri uriImage) {
+    String extension = null;
+
+    try {
+      String imagePath = uriImage.getPath();
+      if (imagePath != null && imagePath.lastIndexOf(".") != -1) {
+        extension = imagePath.substring(imagePath.lastIndexOf(".") + 1);
+      }
+    } catch (Exception e) {
+      extension = null;
     }
 
-    private static void copy(InputStream in, OutputStream out) throws IOException {
-        final byte[] buffer = new byte[4 * 1024];
-        int bytesRead;
-        while ((bytesRead = in.read(buffer)) != -1) {
-            out.write(buffer, 0, bytesRead);
-        }
-        out.flush();
+    if (extension == null || extension.isEmpty()) {
+      //default extension for matches the previous behavior of the plugin
+      extension = "jpg";
     }
 
-    private static boolean isExternalStorageDocument(Uri uri) {
-        return "com.android.externalstorage.documents".equals(uri.getAuthority());
-    }
+    return "." + extension;
+  }
 
-    private static boolean isDownloadsDocument(Uri uri) {
-        return "com.android.providers.downloads.documents".equals(uri.getAuthority());
+  private static void copy(InputStream in, OutputStream out) throws IOException {
+    final byte[] buffer = new byte[4 * 1024];
+    int bytesRead;
+    while ((bytesRead = in.read(buffer)) != -1) {
+      out.write(buffer, 0, bytesRead);
     }
+    out.flush();
+  }
 
-    private static boolean isMediaDocument(Uri uri) {
-        return "com.android.providers.media.documents".equals(uri.getAuthority());
-    }
+  private static boolean isExternalStorageDocument(Uri uri) {
+    return "com.android.externalstorage.documents".equals(uri.getAuthority());
+  }
 
-    private static boolean isGooglePhotosUri(Uri uri) {
-        return "com.google.android.apps.photos.contentprovider".equals(uri.getAuthority());
-    }
+  private static boolean isDownloadsDocument(Uri uri) {
+    return "com.android.providers.downloads.documents".equals(uri.getAuthority());
+  }
 
-    private static boolean isOneDriveUri(Uri uri) {
-        return "com.microsoft.skydrive.content.external".equals(uri.getAuthority());
-    }
+  private static boolean isMediaDocument(Uri uri) {
+    return "com.android.providers.media.documents".equals(uri.getAuthority());
+  }
+
+  private static boolean isGooglePhotosUri(Uri uri) {
+    return "com.google.android.apps.photos.contentprovider".equals(uri.getAuthority());
+  }
+
+  private static boolean isOneDriveUri(Uri uri) {
+    return "com.microsoft.skydrive.content.external".equals(uri.getAuthority());
+  }
 
 }

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -5,7 +5,7 @@ authors:
   - Flutter Team <flutter-dev@googlegroups.com>
   - Rhodes Davis Jr. <rody.davis.jr@gmail.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.6.1+4
+version: 0.6.1+5
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description
Fixed crash on Android when selecting photos from OneDrive. It stores files in the local storage, we can't get path and should work with it's URIs as remote, same like with GooglePhotos

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.