### PR TITLE
[image_picker] Fix a crash when picking video on iOS 13 and above.

### DIFF
--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.2
+
+* iOS: Fixes an issue where picking conent from Gallery would result in a crash on iOS 13.
+
 ## 0.6.1+11
 
 * Stability and Maintainability: update documentations, add unit tests.

--- a/packages/image_picker/ios/Classes/ImagePickerPlugin.m
+++ b/packages/image_picker/ios/Classes/ImagePickerPlugin.m
@@ -241,6 +241,16 @@ static const int SOURCE_GALLERY = 1;
     return;
   }
   if (videoURL != nil) {
+    if (@available(iOS 13.0, *)) {
+      NSString *fileName = [videoURL lastPathComponent];
+      NSURL *destination =
+          [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:fileName]];
+
+      if ([[NSFileManager defaultManager] isReadableFileAtPath:[videoURL path]]) {
+        [[NSFileManager defaultManager] copyItemAtURL:videoURL toURL:destination error:nil];
+        videoURL = destination;
+      }
+    }
     self.result(videoURL.path);
     self.result = nil;
   } else {

--- a/packages/image_picker/ios/Classes/ImagePickerPlugin.m
+++ b/packages/image_picker/ios/Classes/ImagePickerPlugin.m
@@ -247,12 +247,24 @@ static const int SOURCE_GALLERY = 1;
           [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:fileName]];
 
       if ([[NSFileManager defaultManager] isReadableFileAtPath:[videoURL path]]) {
-        [[NSFileManager defaultManager] copyItemAtURL:videoURL toURL:destination error:nil];
+        NSError *error;
+        if (![[videoURL path] isEqualToString:[destination path]]) {
+          [[NSFileManager defaultManager] copyItemAtURL:videoURL toURL:destination error:&error];
+
+          if (error) {
+            self.result([FlutterError errorWithCode:@"flutter_image_picker_copy_video_error"
+                                            message:@"Could not cache the video file."
+                                            details:nil]);
+            self.result = nil;
+            return;
+          }
+        }
         videoURL = destination;
       }
     }
     self.result(videoURL.path);
     self.result = nil;
+
   } else {
     UIImage *image = [info objectForKey:UIImagePickerControllerEditedImage];
     if (image == nil) {

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -5,7 +5,7 @@ authors:
   - Flutter Team <flutter-dev@googlegroups.com>
   - Rhodes Davis Jr. <rody.davis.jr@gmail.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.6.1+11
+version: 0.6.2
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description
Fixes an issue that could result in a crash when picking videos from gallery on iOS 13 or above. 

## Related Issues
[#41046](https://github.com/flutter/flutter/issues/41046)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
