### PR TITLE
[Share] default the subject to '' to prevent iOS crash.

### DIFF
--- a/packages/share/CHANGELOG.md
+++ b/packages/share/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.2+2
+
+* Default the `subject` to an empty String if null is passed.
+
 ## 0.6.2+1
 
 * Specify explicit type for `invokeMethod`.

--- a/packages/share/lib/share.dart
+++ b/packages/share/lib/share.dart
@@ -39,7 +39,7 @@ class Share {
     assert(text.isNotEmpty);
     final Map<String, dynamic> params = <String, dynamic>{
       'text': text,
-      'subject': subject,
+      'subject': subject ?? '',
     };
 
     if (sharePositionOrigin != null) {

--- a/packages/share/pubspec.yaml
+++ b/packages/share/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for sharing content via the platform share UI, using
   the ACTION_SEND intent on Android and UIActivityViewController on iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/share
-version: 0.6.2+1
+version: 0.6.2+2
 
 flutter:
   plugin:

--- a/packages/share/test/share_test.dart
+++ b/packages/share/test/share_test.dart
@@ -56,6 +56,24 @@ void main() {
       'originHeight': 4.0,
     }));
   });
+
+  test(
+      'if subject is null, an empty string should be sent to the method channel',
+      () async {
+    await Share.share(
+      'some text to share',
+      subject: null,
+      sharePositionOrigin: const Rect.fromLTWH(1.0, 2.0, 3.0, 4.0),
+    );
+    verify(mockChannel.invokeMethod<void>('share', <String, dynamic>{
+      'text': 'some text to share',
+      'subject': '',
+      'originX': 1.0,
+      'originY': 2.0,
+      'originWidth': 3.0,
+      'originHeight': 4.0,
+    }));
+  });
 }
 
 class MockMethodChannel extends Mock implements MethodChannel {}


### PR DESCRIPTION
## Description

iOS crashes when the subject is null. Default the subject to '' from dart will prevent the crash. Ultimately, we should add similar prevention on the iOS side, and add XC Tests for it. 
I have tested that setting subject to null doesn't affect Android.

## Related Issues

https://github.com/flutter/flutter/issues/39740

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
