### PR TITLE
[image_picker]fix ios aspect ratio inversion

### DIFF
--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.6.1+5
 
-* Fix aspect ratio inversion on portrait pictures.
+* Fix aspect ratio inversion on images that was rotated side ways(Left, Right, etc.).
 
 ## 0.6.1+4
 

--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.1+5
+
+* Fix aspect ratio inversion on portrait pictures.
+
 ## 0.6.1+4
 
 * Android: Fix a regression where the `retrieveLostImage` does not work anymore.

--- a/packages/image_picker/ios/Classes/FLTImagePickerImageUtil.m
+++ b/packages/image_picker/ios/Classes/FLTImagePickerImageUtil.m
@@ -68,10 +68,18 @@
       }
     }
   }
-
+  NSLog(@"orientation %@", @(image.imageOrientation));
   // Scaling the image always rotate itself based on the current imageOrientation of the original
   // Image. Set to orientationUp for the orignal image before scaling, so the scaled image doesn't
   // mess up with the pixels.
+  if (image.imageOrientation == UIImageOrientationRight ||
+      image.imageOrientation == UIImageOrientationLeft ||
+      image.imageOrientation == UIImageOrientationLeftMirrored ||
+      image.imageOrientation == UIImageOrientationRightMirrored) {
+    double heightCopy = height;
+    height = width;
+    width = heightCopy;
+  }
   UIImage *imageToScale = [UIImage imageWithCGImage:image.CGImage
                                               scale:1
                                         orientation:UIImageOrientationUp];

--- a/packages/image_picker/ios/Classes/FLTImagePickerImageUtil.m
+++ b/packages/image_picker/ios/Classes/FLTImagePickerImageUtil.m
@@ -68,7 +68,6 @@
       }
     }
   }
-  NSLog(@"orientation %@", @(image.imageOrientation));
   // Scaling the image always rotate itself based on the current imageOrientation of the original
   // Image. Set to orientationUp for the orignal image before scaling, so the scaled image doesn't
   // mess up with the pixels.

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -5,7 +5,7 @@ authors:
   - Flutter Team <flutter-dev@googlegroups.com>
   - Rhodes Davis Jr. <rody.davis.jr@gmail.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.6.1+4
+version: 0.6.1+5
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Image picked on iOS has its aspect ratio inverted if the maxWidth or maxHeight is set when the image was originally rotated side ways. 

## Related Issues

https://github.com/flutter/flutter/issues/40334

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
