### PR TITLE
[camera] Define clang modules in for iOS

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -64,6 +64,8 @@ task:
   matrix:
     - name: build_all_plugins_ipa
       script: ./script/build_all_plugins_app.sh ios --no-codesign
+    - name: lint_darwin_plugins
+      script: ./script/lint_darwin_plugins.sh
     - name: build-ipas+drive-examples
       env:
         PATH: $PATH:/usr/local/bin

--- a/packages/camera/CHANGELOG.md
+++ b/packages/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.5
+
+* Define clang modules for iOS.
+
 ## 0.5.4+3
 
 * Update and migrate iOS example project.

--- a/packages/camera/ios/Tests/CameraPluginTests.m
+++ b/packages/camera/ios/Tests/CameraPluginTests.m
@@ -1,0 +1,16 @@
+@import camera;
+@import XCTest;
+
+@interface CameraPluginTests : XCTestCase
+@end
+
+@implementation CameraPluginTests
+
+- (void)testModuleImport {
+  // This test will fail to compile if the module cannot be imported.
+  // Make sure this plugin supports modules. See https://github.com/flutter/flutter/issues/41007.
+  // If not already present, add this line to the podspec:
+  // s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
+}
+
+@end

--- a/packages/camera/ios/camera.podspec
+++ b/packages/camera/ios/camera.podspec
@@ -15,7 +15,10 @@ A new flutter plugin project.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  
-  s.ios.deployment_target = '8.0'
-end
+  s.platform = :ios, '8.0'
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS' => 'armv7 arm64 x86_64' }
 
+  s.test_spec 'Tests' do |test_spec|
+    test_spec.source_files = 'Tests/**/*'
+  end
+end

--- a/packages/camera/pubspec.yaml
+++ b/packages/camera/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera
 description: A Flutter plugin for getting information about and controlling the
   camera on Android and iOS. Supports previewing the camera feed, capturing images, capturing video,
   and streaming image buffers to dart.
-version: 0.5.4+3
+version: 0.5.5
 
 authors:
   - Flutter Team <flutter-dev@googlegroups.com>

--- a/script/build_all_plugins_app.sh
+++ b/script/build_all_plugins_app.sh
@@ -4,8 +4,8 @@
 # sure all first party plugins can be compiled together.
 
 # So that users can run this script from anywhere and it will work as expected.
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null && pwd)"
-REPO_DIR="$(dirname "$SCRIPT_DIR")"
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null && pwd)"
+readonly REPO_DIR="$(dirname "$SCRIPT_DIR")"
 
 source "$SCRIPT_DIR/common.sh"
 check_changed_packages > /dev/null

--- a/script/check_publish.sh
+++ b/script/check_publish.sh
@@ -5,8 +5,8 @@ set -e
 # It doesn't actually publish anything.
 
 # So that users can run this script from anywhere and it will work as expected.
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
-REPO_DIR="$(dirname "$SCRIPT_DIR")"
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+readonly REPO_DIR="$(dirname "$SCRIPT_DIR")"
 
 source "$SCRIPT_DIR/common.sh"
 

--- a/script/incremental_build.sh
+++ b/script/incremental_build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
-REPO_DIR="$(dirname "$SCRIPT_DIR")"
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+readonly REPO_DIR="$(dirname "$SCRIPT_DIR")"
 
 source "$SCRIPT_DIR/common.sh"
 

--- a/script/lint_darwin_plugins.sh
+++ b/script/lint_darwin_plugins.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+# This script lints and tests iOS and macOS platform code.
+
+# So that users can run this script from anywhere and it will work as expected.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+REPO_DIR="$(dirname "$SCRIPT_DIR")"
+
+source "$SCRIPT_DIR/common.sh"
+
+function lint_package() {
+  local package_name=$1
+  local platform=$2
+  local podspec_dir="$REPO_DIR/packages/$package_name/$platform/$package_name.podspec"
+  local failure_count=0
+
+  if [[ -f "$podspec_dir" ]]; then
+    echo "Linting $platform $package_name.podspec"
+
+    # Build as frameworks.
+    # This will also run any tests set up as a test_spec. See https://blog.cocoapods.org/CocoaPods-1.3.0.
+    pod lib lint "$podspec_dir" --allow-warnings --fail-fast --silent
+    if [[ $? -ne 0 ]]; then
+      error "Package $package_name has framework issues. Run \"pod lib lint $podspec_dir\" to inspect."
+      failure_count+=1
+    fi
+
+    # Build as libraries.
+    pod lib lint "$podspec_dir" --allow-warnings --use-libraries --fail-fast --silent
+    if [[ $? -ne 0 ]]; then
+      error "Package $package_name has library issues. Run \"pod lib lint $podspec_dir --use-libraries\" to inspect."
+      failure_count+=1
+    fi
+  fi
+
+  return $failure_count
+}
+
+function lint_packages() {
+  if [[ ! $(which pod) ]]; then 
+    echo "pod not installed. Skipping."
+    return
+  fi
+
+  # TODO: These packages have linter errors. Remove plugins from this list as linter issues are fixed.
+  local skipped_packages=(
+    android_alarm_manager
+    android_intent
+    battery
+    connectivity
+    device_info
+    google_maps_flutter
+    google_sign_in
+    image_picker
+    in_app_purchase
+    instrumentation_adapter
+    local_auth
+    package_info
+    path_provider
+    quick_actions
+    sensors
+    share
+    shared_preferences
+    url_launcher
+    video_player
+    webview_flutter
+  )
+
+  local failure_count=0
+  for package_name in "$@"; do
+    if [[ ${skipped_packages[*]} =~ $package_name ]]; then
+      continue
+    fi      
+    lint_package $package_name "ios"
+    failure_count+=$?
+    lint_package $package_name "macos"
+    failure_count+=$?
+  done
+
+  return $failure_count
+}
+
+# Sets CHANGED_PACKAGE_LIST
+check_changed_packages
+
+if [[ "${#CHANGED_PACKAGE_LIST[@]}" != 0 ]]; then
+  lint_packages "${CHANGED_PACKAGE_LIST[@]}"
+fi

--- a/script/lint_darwin_plugins.sh
+++ b/script/lint_darwin_plugins.sh
@@ -10,12 +10,11 @@ source "$SCRIPT_DIR/common.sh"
 
 function lint_package() {
   local package_name=$1
-  local platform=$2
-  local podspec="$REPO_DIR/packages/$package_name/$platform/$package_name.podspec"
+  local package_dir="$REPO_DIR/packages/$package_name/"
   local failure_count=0
 
-  if [[ -f "$podspec" ]]; then
-    echo "Linting $platform $package_name.podspec"
+  for podspec in $(find "$package_dir" -name "*\.podspec"); do
+    echo "Linting $package_name.podspec"
 
     # Build as frameworks.
     # This will also run any tests set up as a test_spec. See https://blog.cocoapods.org/CocoaPods-1.3.0.
@@ -33,7 +32,7 @@ function lint_package() {
       error "Package $package_name has library issues. Run \"pod lib lint $podspec --use-libraries\" to inspect."
       failure_count+=1
     fi
-  fi
+  done
 
   return $failure_count
 }
@@ -73,9 +72,7 @@ function lint_packages() {
     if [[ ${skipped_packages[*]} =~ $package_name ]]; then
       continue
     fi      
-    lint_package $package_name "ios"
-    failure_count+=$?
-    lint_package $package_name "macos"
+    lint_package $package_name
     failure_count+=$?
   done
 

--- a/script/lint_darwin_plugins.sh
+++ b/script/lint_darwin_plugins.sh
@@ -3,32 +3,34 @@
 # This script lints and tests iOS and macOS platform code.
 
 # So that users can run this script from anywhere and it will work as expected.
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
-REPO_DIR="$(dirname "$SCRIPT_DIR")"
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+readonly REPO_DIR="$(dirname "$SCRIPT_DIR")"
 
 source "$SCRIPT_DIR/common.sh"
 
 function lint_package() {
   local package_name=$1
   local platform=$2
-  local podspec_dir="$REPO_DIR/packages/$package_name/$platform/$package_name.podspec"
+  local podspec="$REPO_DIR/packages/$package_name/$platform/$package_name.podspec"
   local failure_count=0
 
-  if [[ -f "$podspec_dir" ]]; then
+  if [[ -f "$podspec" ]]; then
     echo "Linting $platform $package_name.podspec"
 
     # Build as frameworks.
     # This will also run any tests set up as a test_spec. See https://blog.cocoapods.org/CocoaPods-1.3.0.
-    pod lib lint "$podspec_dir" --allow-warnings --fail-fast --silent
+    # TODO: Add --analyze flag https://github.com/flutter/flutter/issues/41443
+    # TODO: Remove --allow-warnings flag https://github.com/flutter/flutter/issues/41444
+    pod lib lint "$podspec" --allow-warnings --fail-fast --silent
     if [[ $? -ne 0 ]]; then
-      error "Package $package_name has framework issues. Run \"pod lib lint $podspec_dir\" to inspect."
+      error "Package $package_name has framework issues. Run \"pod lib lint $podspec\" to inspect."
       failure_count+=1
     fi
 
     # Build as libraries.
-    pod lib lint "$podspec_dir" --allow-warnings --use-libraries --fail-fast --silent
+    pod lib lint "$podspec" --allow-warnings --use-libraries --fail-fast --silent
     if [[ $? -ne 0 ]]; then
-      error "Package $package_name has library issues. Run \"pod lib lint $podspec_dir --use-libraries\" to inspect."
+      error "Package $package_name has library issues. Run \"pod lib lint $podspec --use-libraries\" to inspect."
       failure_count+=1
     fi
   fi

--- a/script/lint_darwin_plugins.sh
+++ b/script/lint_darwin_plugins.sh
@@ -9,74 +9,74 @@ readonly REPO_DIR="$(dirname "$SCRIPT_DIR")"
 source "$SCRIPT_DIR/common.sh"
 
 function lint_package() {
-  local package_name=$1
-  local package_dir="$REPO_DIR/packages/$package_name/"
+  local package_name="$1"
+  local package_dir="${REPO_DIR}/packages/$package_name/"
   local failure_count=0
 
-  for podspec in $(find "$package_dir" -name "*\.podspec"); do
+  for podspec in "$(find "${package_dir}" -name '*\.podspec')"; do
     echo "Linting $package_name.podspec"
 
     # Build as frameworks.
     # This will also run any tests set up as a test_spec. See https://blog.cocoapods.org/CocoaPods-1.3.0.
     # TODO: Add --analyze flag https://github.com/flutter/flutter/issues/41443
     # TODO: Remove --allow-warnings flag https://github.com/flutter/flutter/issues/41444
-    pod lib lint "$podspec" --allow-warnings --fail-fast --silent
-    if [[ $? -ne 0 ]]; then
-      error "Package $package_name has framework issues. Run \"pod lib lint $podspec\" to inspect."
+    pod lib lint "${podspec}" --allow-warnings --fail-fast --silent
+    if [[ "$?" -ne 0 ]]; then
+      error "Package ${package_name} has framework issues. Run \"pod lib lint $podspec\" to inspect."
       failure_count+=1
     fi
 
     # Build as libraries.
-    pod lib lint "$podspec" --allow-warnings --use-libraries --fail-fast --silent
-    if [[ $? -ne 0 ]]; then
-      error "Package $package_name has library issues. Run \"pod lib lint $podspec --use-libraries\" to inspect."
+    pod lib lint "${podspec}" --allow-warnings --use-libraries --fail-fast --silent
+    if [[ "$?" -ne 0 ]]; then
+      error "Package ${package_name} has library issues. Run \"pod lib lint $podspec --use-libraries\" to inspect."
       failure_count+=1
     fi
   done
 
-  return $failure_count
+  return "${failure_count}"
 }
 
 function lint_packages() {
-  if [[ ! $(which pod) ]]; then 
+  if [[ ! "$(which pod)" ]]; then 
     echo "pod not installed. Skipping."
     return
   fi
 
   # TODO: These packages have linter errors. Remove plugins from this list as linter issues are fixed.
   local skipped_packages=(
-    android_alarm_manager
-    android_intent
-    battery
-    connectivity
-    device_info
-    google_maps_flutter
-    google_sign_in
-    image_picker
-    in_app_purchase
-    instrumentation_adapter
-    local_auth
-    package_info
-    path_provider
-    quick_actions
-    sensors
-    share
-    shared_preferences
-    url_launcher
-    video_player
-    webview_flutter
+    'android_alarm_manager'
+    'android_intent'
+    'battery'
+    'connectivity'
+    'device_info'
+    'google_maps_flutter'
+    'google_sign_in'
+    'image_picker'
+    'in_app_purchase'
+    'instrumentation_adapter'
+    'local_auth'
+    'package_info'
+    'path_provider'
+    'quick_actions'
+    'sensors'
+    'share'
+    'shared_preferences'
+    'url_launcher'
+    'video_player'
+    'webview_flutter'
   )
 
   local failure_count=0
   for package_name in "$@"; do
-    if [[ ${skipped_packages[*]} =~ $package_name ]]; then
+    if [[ "${skipped_packages[*]}" =~ "${package_name}" ]]; then
       continue
     fi      
-    lint_package $package_name
-    failure_count+=$?
+    lint_package "${package_name}"
+    failure_count+="$?"
   done
 
-  return $failure_count
+  return "${failure_count}"
 }
 
 # Sets CHANGED_PACKAGE_LIST


### PR DESCRIPTION
## Description

- Limit the supported podspec platform to iOS so tests don't run (and fail) for macOS.
- Define the module by setting `DEFINES_MODULE` in the podspec.  See [CocoaPod modular headers docs](http://blog.cocoapods.org/CocoaPods-1.5.0/).
- Explicitly set `VALID_ARCHS` to architectures included in the Flutter universal binary.  This is the CocoaPods-suggested workaround to prevent tests from running on the i386 simulator.  See https://github.com/CocoaPods/CocoaPods/pull/8159.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/41439.
See also https://github.com/flutter/flutter/issues/41007.

## Tests

- Add a test_spec to the podspec so the CocoaPods linter will test them.  These tests fail before the `s.platform` and `s.pod_target_xcconfig` changes.
- Add Cirrus script to lint and test plugins with iOS platform code. This uses CocoaPods's built-in [test_specs](https://guides.cocoapods.org/using/test-specs.html) and lints and tests via `pod lib lint`.
- Exclude every iOS plugin except for camera from this script until they can be migrated.  Linter errors/warnings for all plugins:
```shell
find . -name "*\.podspec" -exec pod lib lint {} --analyze --verbose  \;
```

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.