### PR TITLE
[image_picker] fix crash when aar from 'flutter build aar'

### DIFF
--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.6.1+7
 
-* Android: Fix ImagePickerPlugin#onCreate cast context may be cause exeception.
+* Android: Fix ImagePickerPlugin#onCreate casting context which causes exception.
 
 ## 0.6.1+6
 

--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.1+6
+
+* Android: Fix ImagePickerPlugin#onCreate cast context may be cause exeception.
+
 ## 0.6.1+5
 
 * Update and migrate iOS example project.

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -98,7 +98,7 @@ public class ImagePickerPlugin implements MethodChannel.MethodCallHandler {
       ((Application) this.registrar.context().getApplicationContext())
           .registerActivityLifecycleCallbacks(
               this
-                  .activityLifecycleCallbacks); // Use getApplicationContext() to avoid casting failures
+                  .activityLifecycleCallbacks); // Use getApplicationContext() to avoid casting failures.
     }
   }
 

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -92,7 +92,9 @@ public class ImagePickerPlugin implements MethodChannel.MethodCallHandler {
           public void onActivityStopped(Activity activity) {}
         };
 
-    if (this.registrar != null) {
+    if (this.registrar != null
+        && this.registrar.context() != null
+        && this.registrar.context().getApplicationContext() != null) {
       ((Application) this.registrar.context().getApplicationContext())
           .registerActivityLifecycleCallbacks(
               this

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -82,7 +82,9 @@ public class ImagePickerPlugin implements MethodChannel.MethodCallHandler {
           @Override
           public void onActivityDestroyed(Activity activity) {
             if (activity == registrar.activity()) {
-              ((Application) registrar.context().getApplicationContext()).unregisterActivityLifecycleCallbacks(this);// Use getApplicationContext() to avoid casting failures
+              ((Application) registrar.context().getApplicationContext())
+                  .unregisterActivityLifecycleCallbacks(
+                      this); // Use getApplicationContext() to avoid casting failures
             }
           }
 
@@ -92,7 +94,9 @@ public class ImagePickerPlugin implements MethodChannel.MethodCallHandler {
 
     if (this.registrar != null) {
       ((Application) this.registrar.context().getApplicationContext())
-          .registerActivityLifecycleCallbacks(this.activityLifecycleCallbacks);// Use getApplicationContext() to avoid casting failures
+          .registerActivityLifecycleCallbacks(
+              this
+                  .activityLifecycleCallbacks); // Use getApplicationContext() to avoid casting failures
     }
   }
 

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -82,7 +82,7 @@ public class ImagePickerPlugin implements MethodChannel.MethodCallHandler {
           @Override
           public void onActivityDestroyed(Activity activity) {
             if (activity == registrar.activity()) {
-              ((Application) registrar.context()).unregisterActivityLifecycleCallbacks(this);
+              ((Application) registrar.context().getApplicationContext()).unregisterActivityLifecycleCallbacks(this);// Use getApplicationContext() to avoid casting failures
             }
           }
 
@@ -91,8 +91,8 @@ public class ImagePickerPlugin implements MethodChannel.MethodCallHandler {
         };
 
     if (this.registrar != null) {
-      ((Application) this.registrar.context())
-          .registerActivityLifecycleCallbacks(this.activityLifecycleCallbacks);
+      ((Application) this.registrar.context().getApplicationContext())
+          .registerActivityLifecycleCallbacks(this.activityLifecycleCallbacks);// Use getApplicationContext() to avoid casting failures
     }
   }
 

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -81,8 +81,9 @@ public class ImagePickerPlugin implements MethodChannel.MethodCallHandler {
 
           @Override
           public void onActivityDestroyed(Activity activity) {
-            if (activity == registrar.activity()) {
-              ((Application) registrar.context().getApplicationContext())
+            if (activity == registrar.activity()
+                && registrar.activity().getApplicationContext() != null) {
+              ((Application) registrar.activity().getApplicationContext())
                   .unregisterActivityLifecycleCallbacks(
                       this); // Use getApplicationContext() to avoid casting failures
             }

--- a/packages/image_picker/example/android/app/src/test/java/io/flutter/plugins/imagepicker/ImagePickerPluginTest.java
+++ b/packages/image_picker/example/android/app/src/test/java/io/flutter/plugins/imagepicker/ImagePickerPluginTest.java
@@ -111,7 +111,6 @@ public class ImagePickerPluginTest {
 
   @Test
   public void onConstructor_WhenContextTypeIsActivity_ShouldNotCrash() {
-    // When you use Module to dependency, the type of Context will be Application.but when you use AAR to dependency on this plugin, the type of Context will be Activity.
     when(mockRegistrar.context()).thenReturn(mockActivity);
     new ImagePickerPlugin(mockRegistrar, mockImagePickerDelegate);
     assertTrue(

--- a/packages/image_picker/example/android/app/src/test/java/io/flutter/plugins/imagepicker/ImagePickerPluginTest.java
+++ b/packages/image_picker/example/android/app/src/test/java/io/flutter/plugins/imagepicker/ImagePickerPluginTest.java
@@ -109,6 +109,15 @@ public class ImagePickerPluginTest {
         "No exception thrown when ImagePickerPlugin.registerWith ran with activity = null", true);
   }
 
+  @Test
+  public void onConstructor_WhenContextTypeIsActivity_ShouldNotCrash() {
+    // When you use Module to dependency, the type of Context will be Application.but when you use AAR to dependency on this plugin, the type of Context will be Activity.
+    when(mockRegistrar.context()).thenReturn(mockActivity);
+    new ImagePickerPlugin(mockRegistrar, mockImagePickerDelegate);
+    assertTrue(
+        "No exception thrown when ImagePickerPlugin() ran with context instanceof Activity", true);
+  }
+
   private MethodCall buildMethodCall(final int source) {
     final Map<String, Object> arguments = new HashMap<>();
     arguments.put("source", source);

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -5,7 +5,7 @@ authors:
   - Flutter Team <flutter-dev@googlegroups.com>
   - Rhodes Davis Jr. <rody.davis.jr@gmail.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.6.1+5
+version: 0.6.1+6
 
 flutter:
   plugin:

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -5,7 +5,7 @@ authors:
   - Flutter Team <flutter-dev@googlegroups.com>
   - Rhodes Davis Jr. <rody.davis.jr@gmail.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.6.1+6
+version: 0.6.1+7
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description
Use context cast application in ImagePickerPlugin#onCreate,when depend module context type is application, but depend on aar context type is acitivity, finally cause ClassCastException.

## Related Issues

[flutter/flutter#41558](https://github.com/flutter/flutter/issues/41558)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
