### PR TITLE
[shared_preferences] Updated to use platform interface

### DIFF
--- a/packages/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.5.3+5
+
+* Allow replacing the platform-specific implementation of SharedPreferences in
+Dart in addition to the existing ability to do so in native code by implementing
+the method channel contract.
+
 ## 0.5.3+4
 
 * Copy `List` instances when reading and writing values to prevent mutations from propagating.

--- a/packages/shared_preferences/README.md
+++ b/packages/shared_preferences/README.md
@@ -50,3 +50,24 @@ const MethodChannel('plugins.flutter.io/shared_preferences')
     return null;
   });
 ```
+
+### Replacing platform-specific implementation
+
+You can manually set the platform-specific implementation of the ```SharedPreferences```
+protocol by implementing the interface defined by the abstract ```SharedPreferencesPlatform```
+class and setting it via the ```platform``` property:
+
+```dart
+class MySharedPreferences extends SharedPreferencesPlatform {...}
+...
+SharedPreferences.platform = MySharedPreferences();
+```
+
+This allows for replacing the platform-specific implementation of ```SharedPreferences```
+in Dart in addition to the existing ability to do so in native code by implementing
+the method channel contract.
+
+The ```platform``` property must be set before calling ```getInstance```.
+
+By default, if the ```platform``` property isn't set, it will use the method channel
+protocol implementation for iOS and Android (no other platform is currently supported).

--- a/packages/shared_preferences/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/shared_preferences/example/ios/Runner.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		2D5378261FAA1A9400D5DBA9 /* flutter_assets in Resources */ = {isa = PBXBuildFile; fileRef = 2D5378251FAA1A9400D5DBA9 /* flutter_assets */; };
 		2D92224B1EC342E7007564B0 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D92224A1EC342E7007564B0 /* GeneratedPluginRegistrant.m */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		3B80C3941E831B6300D905FE /* App.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B80C3931E831B6300D905FE /* App.framework */; };
@@ -41,7 +40,6 @@
 
 /* Begin PBXFileReference section */
 		12E03CD14DABAA3AD3923183 /* libPods-Runner.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Runner.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		2D5378251FAA1A9400D5DBA9 /* flutter_assets */ = {isa = PBXFileReference; lastKnownFileType = folder; name = flutter_assets; path = Flutter/flutter_assets; sourceTree = SOURCE_ROOT; };
 		2D9222491EC342E7007564B0 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		2D92224A1EC342E7007564B0 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
@@ -49,6 +47,7 @@
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		7AFFD8ED1D35381100E5BB4D /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		7AFFD8EE1D35381100E5BB4D /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		91DC8E16C9EB141517160AA7 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		9740EEBA1CF902C7004384FC /* Flutter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Flutter.framework; path = Flutter/Flutter.framework; sourceTree = "<group>"; };
@@ -58,6 +57,7 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B24EED9488CC16C5050BA785 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -77,6 +77,8 @@
 		840012C8B5EDBCF56B0E4AC1 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
+				91DC8E16C9EB141517160AA7 /* Pods-Runner.debug.xcconfig */,
+				B24EED9488CC16C5050BA785 /* Pods-Runner.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -86,7 +88,6 @@
 			children = (
 				3B80C3931E831B6300D905FE /* App.framework */,
 				3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */,
-				2D5378251FAA1A9400D5DBA9 /* flutter_assets */,
 				9740EEBA1CF902C7004384FC /* Flutter.framework */,
 				9740EEB21CF90195004384FC /* Debug.xcconfig */,
 				7AFA3C8E1D35360C0083082E /* Release.xcconfig */,
@@ -160,7 +161,6 @@
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				95BB15E9E1769C0D146AA592 /* [CP] Embed Pods Frameworks */,
-				532EA9D341340B1DCD08293D /* [CP] Copy Pods Resources */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 			);
 			buildRules = (
@@ -212,7 +212,6 @@
 				97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */,
 				9740EEB51CF90195004384FC /* Generated.xcconfig in Resources */,
 				3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */,
-				2D5378261FAA1A9400D5DBA9 /* flutter_assets in Resources */,
 				9740EEB41CF90195004384FC /* Debug.xcconfig in Resources */,
 				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
 				97C146FC1CF9000F007C117D /* Main.storyboard in Resources */,
@@ -236,37 +235,19 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" thin";
 		};
-		532EA9D341340B1DCD08293D /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		95BB15E9E1769C0D146AA592 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
-				"${PODS_ROOT}/.symlinks/flutter/ios/Flutter.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Flutter.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {

--- a/packages/shared_preferences/lib/method_channel_shared_preferences.dart
+++ b/packages/shared_preferences/lib/method_channel_shared_preferences.dart
@@ -1,0 +1,44 @@
+import 'dart:async';
+import 'package:flutter/services.dart';
+import 'shared_preferences_platform_interface.dart';
+
+const MethodChannel _kChannel =
+    MethodChannel('plugins.flutter.io/shared_preferences');
+
+/// Wraps NSUserDefaults (on iOS) and SharedPreferences (on Android), providing
+/// a persistent store for simple data.
+class MethodChannelSharedPreferences extends SharedPreferencesPlatform {
+  @override
+  Future<Map<String, Object>> getAll() =>
+      _kChannel.invokeMapMethod<String, Object>('getAll');
+
+  @override
+  Future<bool> remove(String key) =>
+      _kChannel.invokeMethod<bool>('remove', <String, dynamic>{'key': key});
+
+  @override
+  Future<bool> clear() => _kChannel.invokeMethod<bool>('clear');
+
+  @override
+  Future<bool> setBool(String key, bool value) => _kChannel.invokeMethod<bool>(
+      'setBool', <String, dynamic>{'key': key, 'value': value});
+
+  @override
+  Future<bool> setInt(String key, int value) => _kChannel.invokeMethod<bool>(
+      'setInt', <String, dynamic>{'key': key, 'value': value});
+
+  @override
+  Future<bool> setDouble(String key, double value) =>
+      _kChannel.invokeMethod<bool>(
+          'setDouble', <String, dynamic>{'key': key, 'value': value});
+
+  @override
+  Future<bool> setString(String key, String value) =>
+      _kChannel.invokeMethod<bool>(
+          'setString', <String, dynamic>{'key': key, 'value': value});
+
+  @override
+  Future<bool> setStringList(String key, List<String> value) =>
+      _kChannel.invokeMethod<bool>(
+          'setStringList', <String, dynamic>{'key': key, 'value': value});
+}

--- a/packages/shared_preferences/lib/shared_preferences.dart
+++ b/packages/shared_preferences/lib/shared_preferences.dart
@@ -52,15 +52,7 @@ class SharedPreferences {
   /// The default value is [MethodChannelSharedPreferences] on Android or iOS.
   static SharedPreferencesPlatform get platform {
     if (_platform == null) {
-      switch (defaultTargetPlatform) {
-        case TargetPlatform.android:
-        case TargetPlatform.iOS:
           _platform = MethodChannelSharedPreferences();
-          break;
-        default:
-          throw UnsupportedError(
-              "Trying to use the default shared preferences implementation for $defaultTargetPlatform but there isn't a default one");
-      }
     }
     return _platform;
   }

--- a/packages/shared_preferences/lib/shared_preferences_platform_interface.dart
+++ b/packages/shared_preferences/lib/shared_preferences_platform_interface.dart
@@ -1,0 +1,16 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+abstract class SharedPreferencesPlatform {
+  Future<Map<String, Object>> getAll();
+  Future<bool> setBool(String key, bool value);
+  Future<bool> setInt(String key, int value);
+  Future<bool> setDouble(String key, double value);
+  Future<bool> setString(String key, String value);
+  Future<bool> setStringList(String key, List<String> value);
+  Future<bool> remove(String key);
+  Future<bool> clear();
+}

--- a/packages/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for reading and writing simple key-value pairs.
   Wraps NSUserDefaults on iOS and SharedPreferences on Android.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/shared_preferences
-version: 0.5.3+4
+version: 0.5.3+5
 
 flutter:
   plugin:

--- a/packages/shared_preferences/test/platform_shared_preferences_test.dart
+++ b/packages/shared_preferences/test/platform_shared_preferences_test.dart
@@ -1,0 +1,105 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences/shared_preferences_platform_interface.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const Map<String, dynamic> kTestValues = <String, dynamic>{
+    'flutter.String': 'hello world',
+    'flutter.bool': true,
+    'flutter.int': 42,
+    'flutter.double': 3.14159,
+    'flutter.List': <String>['foo', 'bar'],
+  };
+
+  group('SharedPreferences: setting the platform', () {
+    final Map<String, Object> values = <String, Object>{};
+    SharedPreferences.platform = MockSharedPreferences(values);
+
+    test('mock shared preferences', () async {
+      SharedPreferences.setMockInitialValues(
+          <String, Object>{'flutter.String': kTestValues['flutter.String']});
+      final SharedPreferences preferences =
+          await SharedPreferences.getInstance();
+
+      expect(preferences.getString('String'), kTestValues['flutter.String']);
+      expect((await SharedPreferences.platform.getAll()).isEmpty, true);
+
+      SharedPreferences.setMockInitialValues(null);
+      await preferences.reload();
+      expect(preferences.getString('String'), null);
+    });
+
+    test('some basics', () async {
+      final SharedPreferences preferences =
+          await SharedPreferences.getInstance();
+
+      preferences.setString('String', kTestValues['flutter.String']);
+      preferences.setBool('bool', kTestValues['flutter.bool']);
+      preferences.setInt('int', kTestValues['flutter.int']);
+      preferences.setDouble('double', kTestValues['flutter.double']);
+      preferences.setStringList('List', kTestValues['flutter.List']);
+
+      expect(values['flutter.String'], kTestValues['flutter.String']);
+      expect(values['flutter.bool'], kTestValues['flutter.bool']);
+      expect(values['flutter.int'], kTestValues['flutter.int']);
+      expect(values['flutter.double'], kTestValues['flutter.double']);
+      expect(values['flutter.List'], kTestValues['flutter.List']);
+
+      preferences.clear();
+      expect(values['flutter.String'], null);
+      expect(values['flutter.bool'], null);
+      expect(values['flutter.int'], null);
+      expect(values['flutter.double'], null);
+      expect(values['flutter.List'], null);
+    });
+  });
+}
+
+class MockSharedPreferences extends SharedPreferencesPlatform {
+  MockSharedPreferences(this.values);
+  final Map<String, Object> values;
+
+  @override
+  Future<Map<String, Object>> getAll() =>
+      Future<Map<String, Object>>.value(values);
+
+  @override
+  Future<bool> remove(String key) {
+    return Future<bool>.value(values.remove(key) != null);
+  }
+
+  @override
+  Future<bool> clear() {
+    values.clear();
+    return Future<bool>.value(true);
+  }
+
+  @override
+  Future<bool> setBool(String key, bool value) => _setValue(key, value);
+
+  @override
+  Future<bool> setDouble(String key, double value) => _setValue(key, value);
+
+  @override
+  Future<bool> setInt(String key, int value) => _setValue(key, value);
+
+  @override
+  Future<bool> setString(String key, String value) => _setValue(key, value);
+
+  @override
+  Future<bool> setStringList(String key, List<String> value) =>
+      _setValue(key, value);
+
+  Future<bool> _setValue(String key, Object value) {
+    if (value == null) return remove(key);
+
+    values[key] = value;
+    return Future<bool>.value(true);
+  }
+}

--- a/packages/shared_preferences/test/shared_preferences_test.dart
+++ b/packages/shared_preferences/test/shared_preferences_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/method_channel_shared_preferences.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
@@ -32,6 +33,7 @@ void main() {
 
     final List<MethodCall> log = <MethodCall>[];
     SharedPreferences preferences;
+    SharedPreferences.platform = MethodChannelSharedPreferences();
 
     setUp(() async {
       channel.setMockMethodCallHandler((MethodCall methodCall) async {


### PR DESCRIPTION
## Description
Allows replacing the platform-specific implementation of SharedPreferences in Dart in addition to the existing ability to do so in native code by implementing the method channel contract.

This is a required step to allowing other platform implementations that don't need to implement the same method channel protocol implemented for Android and iOS, e.g. a Windows implementation could use Dart:FFI instead of method channels.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

## Notes
- I'm not sure I exported the new SharedPreferencesPlatform type correctly for implementation outside of the plugin

- I'm not sure I added my tests correctly -- I created a new test file so I'd get a new instance of the test runner, as the implementation (properly) only allows setting the ```platform``` once; the original tests depended on a method channel implementation whereas the new tests needed to test a custom implementation.