### PR TITLE
WIP Remove pod repo update from Cirrus script

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -51,6 +51,7 @@ task:
   osx_instance:
     image: mojave-xcode-10.2-flutter
   setup_script:
+    - sudo gem install cocoapods --no-document
     - pod --version
   upgrade_script:
     - flutter channel master

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -51,7 +51,7 @@ task:
   osx_instance:
     image: mojave-xcode-10.2-flutter
   setup_script:
-    - pod repo update
+    - pod --version
   upgrade_script:
     - flutter channel master
     - flutter upgrade


### PR DESCRIPTION
## Description

CocoaPods 1.8 uses a CDN instead of a local spec repository.  `pod repo update` adds a full minute to Cirrus tests.  Remove.