### PR TITLE
[android_alarm_manager] Define clang module for iOS

### DIFF
--- a/packages/android_alarm_manager/CHANGELOG.md
+++ b/packages/android_alarm_manager/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.4.4+1
 
 * Update and migrate iOS example project.
+* Define clang module for iOS.
 
 ## 0.4.4
 

--- a/packages/android_alarm_manager/ios/Classes/AndroidAlarmManagerPlugin.m
+++ b/packages/android_alarm_manager/ios/Classes/AndroidAlarmManagerPlugin.m
@@ -9,7 +9,7 @@
   FlutterMethodChannel* channel =
       [FlutterMethodChannel methodChannelWithName:@"plugins.flutter.io/android_alarm_manager"
                                   binaryMessenger:[registrar messenger]
-                                            codec:[FlutterJSONMessageCodec sharedInstance]];
+                                            codec:[FlutterJSONMethodCodec sharedInstance]];
   FLTAndroidAlarmManagerPlugin* instance = [[FLTAndroidAlarmManagerPlugin alloc] init];
   [registrar addMethodCallDelegate:instance channel:channel];
 }

--- a/packages/android_alarm_manager/ios/android_alarm_manager.podspec
+++ b/packages/android_alarm_manager/ios/android_alarm_manager.podspec
@@ -15,7 +15,6 @@ A new flutter plugin project.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  
-  s.ios.deployment_target = '8.0'
+  s.platform = :ios, '8.0'
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
 end
-

--- a/script/lint_darwin_plugins.sh
+++ b/script/lint_darwin_plugins.sh
@@ -45,7 +45,6 @@ function lint_packages() {
 
   # TODO: These packages have linter errors. Remove plugins from this list as linter issues are fixed.
   local skipped_packages=(
-    'android_alarm_manager'
     'android_intent'
     'battery'
     'connectivity'


### PR DESCRIPTION
## Description

- Limit the supported podspec platform to iOS so tests don't run (and fail) for macOS.
- Define the module by setting `DEFINES_MODULE` in the podspec.  See [CocoaPod modular headers docs](http://blog.cocoapods.org/CocoaPods-1.5.0/).
- Explicitly set `VALID_ARCHS` to x86_64 for the simulator.  See https://github.com/CocoaPods/CocoaPods/issues/9210.
- Fix incompatible-pointer-types build warning where FlutterJSON**Message**Codec was passed into a parameter wanting a Flutter**Method**Codec.
```
AndroidAlarmManagerPlugin.m:12:51: warning: incompatible pointer types sending 'FlutterJSONMessageCodec * _Nonnull' to parameter of type 'NSObject<FlutterMethodCodec> * _Nonnull' [-Wincompatible-pointer-types]
```

## Related Issues

Fixes https://github.com/flutter/flutter/issues/41855.
See also https://github.com/flutter/flutter/issues/41007.

## Tests

- Remove android_alarm_manager from the list of packages to skip when linting the podspec.  This will at minimum make sure android_alarm_manager can be imported into a project without compilation errors.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.