### PR TITLE
BugFix: `formatHint` was meant for network streams.

### DIFF
--- a/packages/video_player/CHANGELOG.md
+++ b/packages/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.2+3
+
+* Fix bug where formatHint was not being pass down to network sources.
+
 ## 0.10.2+2
 
 * Update and migrate iOS example project.

--- a/packages/video_player/lib/video_player.dart
+++ b/packages/video_player/lib/video_player.dart
@@ -207,13 +207,14 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
         };
         break;
       case DataSourceType.network:
-        dataSourceDescription = <String, dynamic>{'uri': dataSource};
-        break;
-      case DataSourceType.file:
         dataSourceDescription = <String, dynamic>{
           'uri': dataSource,
           'formatHint': _videoFormatStringMap[formatHint]
         };
+        break;
+      case DataSourceType.file:
+        dataSourceDescription = <String, dynamic>{'uri': dataSource};
+        break;
     }
     final Map<String, dynamic> response =
         await _channel.invokeMapMethod<String, dynamic>(

--- a/packages/video_player/pubspec.yaml
+++ b/packages/video_player/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player
 description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
-version: 0.10.2+2
+version: 0.10.2+3
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player
 
 flutter:

--- a/packages/video_player/test/video_player_test.dart
+++ b/packages/video_player/test/video_player_test.dart
@@ -112,6 +112,20 @@ void main() {
       expect(
           fakeVideoPlayerPlatform.dataSourceDescriptions[0], <String, dynamic>{
         'uri': 'https://127.0.0.1',
+        'formatHint': null,
+      });
+    });
+
+    test('initialize network with hint', () async {
+      final VideoPlayerController controller = VideoPlayerController.network(
+          'https://127.0.0.1',
+          formatHint: VideoFormat.dash);
+      await controller.initialize();
+
+      expect(
+          fakeVideoPlayerPlatform.dataSourceDescriptions[0], <String, dynamic>{
+        'uri': 'https://127.0.0.1',
+        'formatHint': 'dash',
       });
     });
 
@@ -123,7 +137,6 @@ void main() {
       expect(
           fakeVideoPlayerPlatform.dataSourceDescriptions[0], <String, dynamic>{
         'uri': 'file://a.avi',
-        'formatHint': null,
       });
     });
   });


### PR DESCRIPTION
This hint is only valid in the network path.
