### PR TITLE
[quick_actions] Define clang module for iOS

### DIFF
--- a/packages/quick_actions/CHANGELOG.md
+++ b/packages/quick_actions/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.2+3
+
+* Define clang module for iOS.
+
 ## 0.3.2+2
 * Fix bug that would make the shortcut not open on Android.
 * Report shortcut used on Android.

--- a/packages/quick_actions/ios/quick_actions.podspec
+++ b/packages/quick_actions/ios/quick_actions.podspec
@@ -15,7 +15,6 @@ A new flutter plugin project.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  
-  s.ios.deployment_target = '8.0'
+  s.platform = :ios, '8.0'
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
 end
-

--- a/packages/quick_actions/pubspec.yaml
+++ b/packages/quick_actions/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for creating shortcuts on home screen, also known as
   Quick Actions on iOS and App Shortcuts on Android.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/quick_actions
-version: 0.3.2+2
+version: 0.3.2+3
 
 flutter:
   plugin:

--- a/script/lint_darwin_plugins.sh
+++ b/script/lint_darwin_plugins.sh
@@ -57,7 +57,6 @@ function lint_packages() {
     'google_maps_flutter'
     'google_sign_in'
     'path_provider'
-    'quick_actions'
     'share'
     'video_player'
     'webview_flutter'


### PR DESCRIPTION
## Description

- Limit the supported podspec platform to iOS so tests don't run (and fail) for macOS.
- Define the module by setting `DEFINES_MODULE` in the podspec.  See [CocoaPod modular headers docs](http://blog.cocoapods.org/CocoaPods-1.5.0/).
- Explicitly set `VALID_ARCHS` to x86_64 for the simulator.  See https://github.com/CocoaPods/CocoaPods/issues/9210.

Note: there are quite a few warnings in this plugin due to UIApplicationShortcutItem being introduced in iOS 9.0 but the deployment target being 8.0, which means iOS 8 devices will crash if this plugin is used.  I didn't try to fix them in this PR.
```
QuickActionsPlugin.m:44:35: 'UIApplicationShortcutItem' is only available on iOS 9.0 or newer
QuickActionsPlugin.m:67:14: 'UIApplicationShortcutIcon' is only available on iOS 9.0 or newer
```

## Related Issues

See https://github.com/flutter/flutter/issues/41007.

## Tests

- Remove quick_actions from the list of packages to skip when linting the podspec.  This will at minimum make sure quick_actions can be imported into a project without compilation errors.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.