### PR TITLE
[flutter_webview] Migrate to the new embedding

### DIFF
--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.15
+
+* Add support for the v2 Android embedding. This shouldn't affect existing
+  functionality. Plugin authors who use the V2 embedding can now register the
+  plugin and expect that it correctly responds to app lifecycle changes.
+
 ## 0.3.14+2
 
 * Define clang module for iOS.
@@ -13,7 +19,7 @@
 ## 0.3.13
 
 * Add an optional `userAgent` property to set a custom User Agent.
-  
+
 ## 0.3.12+1
 
 * Temporarily revert getTitle (doing this as a patch bump shortly after publishing).

--- a/packages/webview_flutter/android/build.gradle
+++ b/packages/webview_flutter/android/build.gradle
@@ -50,3 +50,28 @@ android {
         implementation 'androidx.webkit:webkit:1.0.0'
     }
 }
+
+// TODO(mklim): Remove this hack once androidx.lifecycle is included on stable. https://github.com/flutter/flutter/issues/42348
+afterEvaluate {
+    def containsEmbeddingDependencies = false
+    for (def configuration : configurations.all) {
+        for (def dependency : configuration.dependencies) {
+            if (dependency.group == 'io.flutter' &&
+                dependency.name.startsWith('flutter_embedding') &&
+                dependency.isTransitive())
+            {
+                containsEmbeddingDependencies = true
+                break
+            }
+        }
+    }
+    if (!containsEmbeddingDependencies) {
+        android {
+            dependencies {
+                def lifecycle_version = "2.1.0"
+                api "androidx.lifecycle:lifecycle-common-java8:$lifecycle_version"
+                api "androidx.lifecycle:lifecycle-runtime:$lifecycle_version"
+            }
+        }
+    }
+}

--- a/packages/webview_flutter/android/gradle.properties
+++ b/packages/webview_flutter/android/gradle.properties
@@ -1,1 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
+android.enableJetifier=true
+android.useAndroidX=true

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterCookieManager.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterCookieManager.java
@@ -22,10 +22,6 @@ class FlutterCookieManager implements MethodCallHandler {
     methodChannel.setMethodCallHandler(this);
   }
 
-  static void registerWith(BinaryMessenger messenger) {
-    new FlutterCookieManager(messenger);
-  }
-
   @Override
   public void onMethodCall(MethodCall methodCall, Result result) {
     switch (methodCall.method) {

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterCookieManager.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterCookieManager.java
@@ -15,17 +15,15 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 
 class FlutterCookieManager implements MethodCallHandler {
+  private final MethodChannel methodChannel;
 
-  private FlutterCookieManager() {
-    // Do not instantiate.
-    // This class should only be used in context of a BinaryMessenger.
-    // Use FlutterCookieManager#registerWith instead.
+  FlutterCookieManager(BinaryMessenger messenger) {
+    methodChannel = new MethodChannel(messenger, "plugins.flutter.io/cookie_manager");
+    methodChannel.setMethodCallHandler(this);
   }
 
   static void registerWith(BinaryMessenger messenger) {
-    MethodChannel methodChannel = new MethodChannel(messenger, "plugins.flutter.io/cookie_manager");
-    FlutterCookieManager cookieManager = new FlutterCookieManager();
-    methodChannel.setMethodCallHandler(cookieManager);
+    new FlutterCookieManager(messenger);
   }
 
   @Override
@@ -37,6 +35,10 @@ class FlutterCookieManager implements MethodCallHandler {
       default:
         result.notImplemented();
     }
+  }
+
+  void dispose() {
+    methodChannel.setMethodCallHandler(null);
   }
 
   private static void clearCookies(final Result result) {

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -12,6 +12,8 @@ import android.os.Handler;
 import android.view.View;
 import android.webkit.WebStorage;
 import android.webkit.WebViewClient;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
@@ -36,7 +38,7 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
       BinaryMessenger messenger,
       int id,
       Map<String, Object> params,
-      final View containerView) {
+      @Nullable View containerView) {
 
     DisplayListenerProxy displayListenerProxy = new DisplayListenerProxy();
     DisplayManager displayManager =
@@ -93,6 +95,16 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
   // TODO(mklim): Add the @Override annotation once flutter/engine#9727 rolls to stable.
   public void onInputConnectionLocked() {
     webView.lockInputConnection();
+  }
+
+  @Override
+  public void onFlutterViewAttached(@NonNull View flutterView) {
+    webView.setContainerView(flutterView);
+  }
+
+  @Override
+  public void onFlutterViewDetached() {
+    webView.setContainerView(null);
   }
 
   @Override

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/InputAwareWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/InputAwareWebView.java
@@ -7,9 +7,11 @@ package io.flutter.plugins.webviewflutter;
 import static android.content.Context.INPUT_METHOD_SERVICE;
 
 import android.content.Context;
+import android.util.Log;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
 import android.webkit.WebView;
+import androidx.annotation.Nullable;
 
 /**
  * A WebView subclass that mirrors the same implementation hacks that the system WebView does in
@@ -22,14 +24,27 @@ import android.webkit.WebView;
  * <p>See also {@link ThreadedInputConnectionProxyAdapterView}.
  */
 final class InputAwareWebView extends WebView {
-  private final View containerView;
-
+  private static final String TAG = "InputAwareWebView";
   private View threadedInputConnectionProxyView;
   private ThreadedInputConnectionProxyAdapterView proxyAdapterView;
+  private @Nullable View containerView;
 
-  InputAwareWebView(Context context, View containerView) {
+  InputAwareWebView(Context context, @Nullable View containerView) {
     super(context);
     this.containerView = containerView;
+  }
+
+  void setContainerView(@Nullable View containerView) {
+    this.containerView = containerView;
+
+    if (proxyAdapterView == null) {
+      return;
+    }
+
+    Log.e(TAG, "The containerView has changed while the proxyAdapterView exists.");
+    if (containerView != null) {
+      setInputConnectionTarget(proxyAdapterView);
+    }
   }
 
   /**
@@ -81,6 +96,12 @@ final class InputAwareWebView extends WebView {
       // This isn't a new ThreadedInputConnectionProxyView. Ignore it.
       return super.checkInputConnectionProxy(view);
     }
+    if (containerView == null) {
+      Log.e(
+          TAG,
+          "Can't create a proxy view because there's no container view. Text input may not work.");
+      return super.checkInputConnectionProxy(view);
+    }
 
     // We've never seen this before, so we make the assumption that this is WebView's
     // ThreadedInputConnectionProxyView. We are making the assumption that the only view that could
@@ -120,6 +141,10 @@ final class InputAwareWebView extends WebView {
       // No need to reset the InputConnection to the default thread if we've never changed it.
       return;
     }
+    if (containerView == null) {
+      Log.e(TAG, "Can't reset the input connection to the container view because there is none.");
+      return;
+    }
     setInputConnectionTarget(/*targetView=*/ containerView);
   }
 
@@ -132,6 +157,13 @@ final class InputAwareWebView extends WebView {
    * InputConnections should be created on.
    */
   private void setInputConnectionTarget(final View targetView) {
+    if (containerView == null) {
+      Log.e(
+          TAG,
+          "Can't set the input connection target because there is no containerView to use as a handler.");
+      return;
+    }
+
     targetView.requestFocus();
     containerView.post(
         new Runnable() {

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/InputAwareWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/InputAwareWebView.java
@@ -41,7 +41,7 @@ final class InputAwareWebView extends WebView {
       return;
     }
 
-    Log.e(TAG, "The containerView has changed while the proxyAdapterView exists.");
+    Log.w(TAG, "The containerView has changed while the proxyAdapterView exists.");
     if (containerView != null) {
       setInputConnectionTarget(proxyAdapterView);
     }

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/WebViewFactory.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/WebViewFactory.java
@@ -6,6 +6,7 @@ package io.flutter.plugins.webviewflutter;
 
 import android.content.Context;
 import android.view.View;
+import androidx.annotation.Nullable;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.StandardMessageCodec;
 import io.flutter.plugin.platform.PlatformView;
@@ -14,9 +15,9 @@ import java.util.Map;
 
 public final class WebViewFactory extends PlatformViewFactory {
   private final BinaryMessenger messenger;
-  private final View containerView;
+  private @Nullable final View containerView;
 
-  WebViewFactory(BinaryMessenger messenger, View containerView) {
+  WebViewFactory(BinaryMessenger messenger, @Nullable View containerView) {
     super(StandardMessageCodec.INSTANCE);
     this.messenger = messenger;
     this.containerView = containerView;

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/WebViewFlutterPlugin.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/WebViewFlutterPlugin.java
@@ -4,11 +4,36 @@
 
 package io.flutter.plugins.webviewflutter;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import io.flutter.embedding.engine.plugins.FlutterPlugin;
+import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
 
-/** WebViewFlutterPlugin */
-public class WebViewFlutterPlugin {
-  /** Plugin registration. */
+/**
+ * Java platform implementation of the webview_flutter plugin.
+ *
+ * <p>Instantiate this in an add to app scenario to gracefully handle activity and context changes.
+ *
+ * <p>Call registerWith to use the stable {@code io.flutter.plugin.common} package instead.
+ */
+public class WebViewFlutterPlugin implements FlutterPlugin {
+  private @Nullable FlutterCookieManager flutterCookieManager;
+
+  /**
+   * Initialize this within the {@code #configureFlutterEngine} of a Flutter activity or fragment.
+   *
+   * <p>See {@code io.flutter.plugins.webviewflutterexample.MainActivity} for an example.
+   */
+  public WebViewFlutterPlugin() {}
+
+  /**
+   * Registers a plugin implementation that uses the stable {@code io.flutter.plugin.common}
+   * package.
+   *
+   * <p>Calling this automatically initializes the plugin. However plugins initialized this way
+   * won't react to changes in activity or context, unlike {@link CameraPlugin}.
+   */
   public static void registerWith(Registrar registrar) {
     registrar
         .platformViewRegistry()
@@ -16,5 +41,27 @@ public class WebViewFlutterPlugin {
             "plugins.flutter.io/webview",
             new WebViewFactory(registrar.messenger(), registrar.view()));
     FlutterCookieManager.registerWith(registrar.messenger());
+  }
+
+  @Override
+  public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
+    BinaryMessenger messenger = binding.getFlutterEngine().getDartExecutor();
+    binding
+        .getFlutterEngine()
+        .getPlatformViewsController()
+        .getRegistry()
+        .registerViewFactory(
+            "plugins.flutter.io/webview", new WebViewFactory(messenger, /*containerView=*/ null));
+    flutterCookieManager = new FlutterCookieManager(messenger);
+  }
+
+  @Override
+  public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
+    if (flutterCookieManager == null) {
+      return;
+    }
+
+    flutterCookieManager.dispose();
+    flutterCookieManager = null;
   }
 }

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/WebViewFlutterPlugin.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/WebViewFlutterPlugin.java
@@ -13,17 +13,21 @@ import io.flutter.plugin.common.PluginRegistry.Registrar;
 /**
  * Java platform implementation of the webview_flutter plugin.
  *
- * <p>Instantiate this in an add to app scenario to gracefully handle activity and context changes.
+ * <p>Register this in an add to app scenario to gracefully handle activity and context changes.
  *
- * <p>Call registerWith to use the stable {@code io.flutter.plugin.common} package instead.
+ * <p>Call {@link #registerWith(Registrar)} to use the stable {@code io.flutter.plugin.common}
+ * package instead.
  */
 public class WebViewFlutterPlugin implements FlutterPlugin {
+
   private @Nullable FlutterCookieManager flutterCookieManager;
 
   /**
-   * Initialize this within the {@code #configureFlutterEngine} of a Flutter activity or fragment.
+   * Add an instance of this to {@link io.flutter.embedding.engine.plugins.PluginRegistry} to
+   * register it.
    *
-   * <p>See {@code io.flutter.plugins.webviewflutterexample.MainActivity} for an example.
+   * <p>Registration should eventually be handled automatically by v2 of the
+   * GeneratedPluginRegistrant. https://github.com/flutter/flutter/issues/42694
    */
   public WebViewFlutterPlugin() {}
 
@@ -40,7 +44,7 @@ public class WebViewFlutterPlugin implements FlutterPlugin {
         .registerViewFactory(
             "plugins.flutter.io/webview",
             new WebViewFactory(registrar.messenger(), registrar.view()));
-    FlutterCookieManager.registerWith(registrar.messenger());
+    new FlutterCookieManager(registrar.messenger());
   }
 
   @Override

--- a/packages/webview_flutter/example/android/app/build.gradle
+++ b/packages/webview_flutter/example/android/app/build.gradle
@@ -55,6 +55,8 @@ flutter {
 }
 
 dependencies {
+    implementation 'androidx.lifecycle:lifecycle-runtime:2.1.0'
+    implementation 'androidx.lifecycle:lifecycle-common-java8:2.1.0'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'

--- a/packages/webview_flutter/example/android/app/build.gradle
+++ b/packages/webview_flutter/example/android/app/build.gradle
@@ -55,9 +55,8 @@ flutter {
 }
 
 dependencies {
-    implementation 'androidx.lifecycle:lifecycle-runtime:2.1.0'
-    implementation 'androidx.lifecycle:lifecycle-common-java8:2.1.0'
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test:runner:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
+    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation 'androidx.test:rules:1.2.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }

--- a/packages/webview_flutter/example/android/app/src/androidTestDebug/java/io/flutter/plugins/webviewflutterexample/EmbeddingV1ActivityTest.java
+++ b/packages/webview_flutter/example/android/app/src/androidTestDebug/java/io/flutter/plugins/webviewflutterexample/EmbeddingV1ActivityTest.java
@@ -1,0 +1,13 @@
+package io.flutter.plugins.webviewflutterexample;
+
+import androidx.test.rule.ActivityTestRule;
+import dev.flutter.plugins.e2e.FlutterRunner;
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+
+@RunWith(FlutterRunner.class)
+public class EmbeddingV1ActivityTest {
+  @Rule
+  public ActivityTestRule<EmbeddingV1Activity> rule =
+      new ActivityTestRule<>(EmbeddingV1Activity.class);
+}

--- a/packages/webview_flutter/example/android/app/src/androidTestDebug/java/io/flutter/plugins/webviewflutterexample/MainActivityTest.java
+++ b/packages/webview_flutter/example/android/app/src/androidTestDebug/java/io/flutter/plugins/webviewflutterexample/MainActivityTest.java
@@ -1,0 +1,11 @@
+package io.flutter.plugins.webviewflutterexample;
+
+import androidx.test.rule.ActivityTestRule;
+import dev.flutter.plugins.e2e.FlutterRunner;
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+
+@RunWith(FlutterRunner.class)
+public class MainActivityTest {
+  @Rule public ActivityTestRule<MainActivity> rule = new ActivityTestRule<>(MainActivity.class);
+}

--- a/packages/webview_flutter/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/webview_flutter/example/android/app/src/main/AndroidManifest.xml
@@ -1,39 +1,48 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.flutter.plugins.webviewflutterexample">
+  package="io.flutter.plugins.webviewflutterexample">
 
-    <!-- The INTERNET permission is required for development. Specifically,
-         flutter needs it to communicate with the running application
-         to allow setting breakpoints, to provide hot reload, etc.
-    -->
-    <uses-permission android:name="android.permission.INTERNET"/>
+  <!-- io.flutter.app.FlutterApplication is an android.app.Application that
+       calls FlutterMain.startInitialization(this); in its onCreate method.
+       In most cases you can leave this as-is, but you if you want to provide
+       additional functionality it is fine to subclass or reimplement
+       FlutterApplication and put your custom class here. -->
+  <application
+    android:icon="@mipmap/ic_launcher"
+    android:label="webview_flutter_example"
+    android:name="io.flutter.app.FlutterApplication">
+    <activity
+      android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density"
+      android:exported="true"
+      android:hardwareAccelerated="true"
+      android:launchMode="singleTop"
+      android:name=".EmbeddingV1Activity"
+      android:theme="@style/LaunchTheme"
+      android:windowSoftInputMode="adjustResize">
+      <!-- This keeps the window background of the activity showing
+           until Flutter renders its first frame. It can be removed if
+           there is no splash screen (such as the default splash screen
+           defined in @style/LaunchTheme). -->
+      <meta-data
+        android:name="io.flutter.app.android.SplashScreenUntilFirstFrame"
+        android:value="true"/>
+    </activity>
+    <activity
+      android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density"
+      android:hardwareAccelerated="true"
+      android:launchMode="singleTop"
+      android:name=".MainActivity"
+      android:theme="@style/LaunchTheme"
+      android:windowSoftInputMode="adjustResize">
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN"/>
+        <category android:name="android.intent.category.LAUNCHER"/>
+      </intent-filter>
+    </activity>
+  </application>
 
-    <!-- io.flutter.app.FlutterApplication is an android.app.Application that
-         calls FlutterMain.startInitialization(this); in its onCreate method.
-         In most cases you can leave this as-is, but you if you want to provide
-         additional functionality it is fine to subclass or reimplement
-         FlutterApplication and put your custom class here. -->
-    <application
-        android:name="io.flutter.app.FlutterApplication"
-        android:label="webview_flutter_example"
-        android:icon="@mipmap/ic_launcher">
-        <activity
-            android:name=".MainActivity"
-            android:launchMode="singleTop"
-            android:theme="@style/LaunchTheme"
-            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density"
-            android:hardwareAccelerated="true"
-            android:windowSoftInputMode="adjustResize">
-            <!-- This keeps the window background of the activity showing
-                 until Flutter renders its first frame. It can be removed if
-                 there is no splash screen (such as the default splash screen
-                 defined in @style/LaunchTheme). -->
-            <meta-data
-                android:name="io.flutter.app.android.SplashScreenUntilFirstFrame"
-                android:value="true" />
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.LAUNCHER"/>
-            </intent-filter>
-        </activity>
-    </application>
+  <!-- The INTERNET permission is required for development. Specifically,
+       flutter needs it to communicate with the running application
+       to allow setting breakpoints, to provide hot reload, etc.
+  -->
+  <uses-permission android:name="android.permission.INTERNET"/>
 </manifest>

--- a/packages/webview_flutter/example/android/app/src/main/java/io/flutter/plugins/webviewflutterexample/EmbeddingV1Activity.java
+++ b/packages/webview_flutter/example/android/app/src/main/java/io/flutter/plugins/webviewflutterexample/EmbeddingV1Activity.java
@@ -1,4 +1,4 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
+// Copyright 2019 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/webview_flutter/example/android/app/src/main/java/io/flutter/plugins/webviewflutterexample/EmbeddingV1Activity.java
+++ b/packages/webview_flutter/example/android/app/src/main/java/io/flutter/plugins/webviewflutterexample/EmbeddingV1Activity.java
@@ -1,0 +1,17 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.plugins.webviewflutterexample;
+
+import android.os.Bundle;
+import io.flutter.app.FlutterActivity;
+import io.flutter.plugins.GeneratedPluginRegistrant;
+
+public class EmbeddingV1Activity extends FlutterActivity {
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    GeneratedPluginRegistrant.registerWith(this);
+  }
+}

--- a/packages/webview_flutter/example/android/app/src/main/java/io/flutter/plugins/webviewflutterexample/MainActivity.java
+++ b/packages/webview_flutter/example/android/app/src/main/java/io/flutter/plugins/webviewflutterexample/MainActivity.java
@@ -1,17 +1,12 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 package io.flutter.plugins.webviewflutterexample;
 
-import android.os.Bundle;
-import io.flutter.app.FlutterActivity;
-import io.flutter.plugins.GeneratedPluginRegistrant;
+import io.flutter.embedding.android.FlutterActivity;
+import io.flutter.embedding.engine.FlutterEngine;
+import io.flutter.plugins.webviewflutter.WebViewFlutterPlugin;
 
 public class MainActivity extends FlutterActivity {
   @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    GeneratedPluginRegistrant.registerWith(this);
+  public void configureFlutterEngine(FlutterEngine flutterEngine) {
+    flutterEngine.getPlugins().add(new WebViewFlutterPlugin());
   }
 }

--- a/packages/webview_flutter/example/android/app/src/main/java/io/flutter/plugins/webviewflutterexample/MainActivity.java
+++ b/packages/webview_flutter/example/android/app/src/main/java/io/flutter/plugins/webviewflutterexample/MainActivity.java
@@ -1,3 +1,7 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package io.flutter.plugins.webviewflutterexample;
 
 import io.flutter.embedding.android.FlutterActivity;
@@ -5,6 +9,7 @@ import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.plugins.webviewflutter.WebViewFlutterPlugin;
 
 public class MainActivity extends FlutterActivity {
+  // TODO(mklim): Remove this once v2 of GeneratedPluginRegistrant rolls to stable. https://github.com/flutter/flutter/issues/42694
   @Override
   public void configureFlutterEngine(FlutterEngine flutterEngine) {
     flutterEngine.getPlugins().add(new WebViewFlutterPlugin());

--- a/packages/webview_flutter/example/android/gradle.properties
+++ b/packages/webview_flutter/example/android/gradle.properties
@@ -1,2 +1,4 @@
 org.gradle.jvmargs=-Xmx1536M
-android.useAndroidX=trueandroid.enableR8=true
+android.useAndroidX=true
+android.enableJetifier=true
+android.enableR8=true

--- a/packages/webview_flutter/example/android/gradle.properties
+++ b/packages/webview_flutter/example/android/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.jvmargs=-Xmx1536M
-android.useAndroidX=true
+android.useAndroidX=trueandroid.enableR8=true

--- a/packages/webview_flutter/example/android/settings_aar.gradle
+++ b/packages/webview_flutter/example/android/settings_aar.gradle
@@ -1,0 +1,1 @@
+include ':app'

--- a/packages/webview_flutter/example/android/settings_aar.gradle
+++ b/packages/webview_flutter/example/android/settings_aar.gradle
@@ -1,1 +1,0 @@
-include ':app'

--- a/packages/webview_flutter/example/pubspec.yaml
+++ b/packages/webview_flutter/example/pubspec.yaml
@@ -5,7 +5,7 @@ version: 1.0.1
 
 environment:
   sdk: ">=2.0.0-dev.68.0 <3.0.0"
-  flutter: ">=1.9.1+hotfix.2 <2.0.0"
+  flutter: ">=1.9.1+hotfix.4 <2.0.0"
 
 dependencies:
   flutter:

--- a/packages/webview_flutter/example/pubspec.yaml
+++ b/packages/webview_flutter/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: webview_flutter_example
 description: Demonstrates how to use the webview_flutter plugin.
 
-version: 1.0.1
+version: 1.0.2
 
 environment:
   sdk: ">=2.0.0-dev.68.0 <3.0.0"

--- a/packages/webview_flutter/example/pubspec.yaml
+++ b/packages/webview_flutter/example/pubspec.yaml
@@ -5,6 +5,7 @@ version: 1.0.1
 
 environment:
   sdk: ">=2.0.0-dev.68.0 <3.0.0"
+  flutter: ">=1.9.1+hotfix.2 <2.0.0"
 
 dependencies:
   flutter:
@@ -17,6 +18,7 @@ dev_dependencies:
     sdk: flutter
   flutter_driver:
     sdk: flutter
+  e2e: "^0.2.0"
 
 flutter:
   uses-material-design: true

--- a/packages/webview_flutter/example/test_driver/webview_flutter_e2e.dart
+++ b/packages/webview_flutter/example/test_driver/webview_flutter_e2e.dart
@@ -9,19 +9,17 @@ import 'dart:typed_data';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
-import 'package:flutter_driver/driver_extension.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:webview_flutter/webview_flutter.dart';
+import 'package:e2e/e2e.dart';
 
 void main() {
-  final Completer<String> allTestsCompleter = Completer<String>();
-  enableFlutterDriverExtension(handler: (_) => allTestsCompleter.future);
-  tearDownAll(() => allTestsCompleter.complete(null));
+  E2EWidgetsFlutterBinding.ensureInitialized();
 
-  test('initalUrl', () async {
+  testWidgets('initalUrl', (WidgetTester tester) async {
     final Completer<WebViewController> controllerCompleter =
         Completer<WebViewController>();
-    await pumpWidget(
+    await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
         child: WebView(
@@ -38,10 +36,10 @@ void main() {
     expect(currentUrl, 'https://flutter.dev/');
   });
 
-  test('loadUrl', () async {
+  testWidgets('loadUrl', (WidgetTester tester) async {
     final Completer<WebViewController> controllerCompleter =
         Completer<WebViewController>();
-    await pumpWidget(
+    await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
         child: WebView(
@@ -61,11 +59,11 @@ void main() {
 
   // enable this once https://github.com/flutter/flutter/issues/31510
   // is resolved.
-  test('loadUrl with headers', () async {
+  testWidgets('loadUrl with headers', (WidgetTester tester) async {
     final Completer<WebViewController> controllerCompleter =
         Completer<WebViewController>();
     final StreamController<String> pageLoads = StreamController<String>();
-    await pumpWidget(
+    await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
         child: WebView(
@@ -96,12 +94,12 @@ void main() {
     expect(content.contains('flutter_test_header'), isTrue);
   });
 
-  test('JavaScriptChannel', () async {
+  testWidgets('JavaScriptChannel', (WidgetTester tester) async {
     final Completer<WebViewController> controllerCompleter =
         Completer<WebViewController>();
     final Completer<void> pageLoaded = Completer<void>();
     final List<String> messagesReceived = <String>[];
-    await pumpWidget(
+    await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
         child: WebView(
@@ -137,7 +135,7 @@ void main() {
     expect(messagesReceived, equals(<String>['hello']));
   });
 
-  test('resize webview', () async {
+  testWidgets('resize webview', (WidgetTester tester) async {
     final String resizeTest = '''
         <!DOCTYPE html><html>
         <head><title>Resize test</title>
@@ -184,7 +182,7 @@ void main() {
       javascriptMode: JavascriptMode.unrestricted,
     );
 
-    await pumpWidget(
+    await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
         child: Column(
@@ -204,7 +202,7 @@ void main() {
 
     expect(resizeCompleter.isCompleted, false);
 
-    await pumpWidget(
+    await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
         child: Column(
@@ -222,11 +220,11 @@ void main() {
     await resizeCompleter.future;
   });
 
-  test('set custom userAgent', () async {
+  testWidgets('set custom userAgent', (WidgetTester tester) async {
     final Completer<WebViewController> controllerCompleter1 =
         Completer<WebViewController>();
     final GlobalKey _globalKey = GlobalKey();
-    await pumpWidget(
+    await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
         child: WebView(
@@ -244,7 +242,7 @@ void main() {
     final String customUserAgent1 = await _getUserAgent(controller1);
     expect(customUserAgent1, 'Custom_User_Agent1');
     // rebuild the WebView with a different user agent.
-    await pumpWidget(
+    await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
         child: WebView(
@@ -260,12 +258,13 @@ void main() {
     expect(customUserAgent2, 'Custom_User_Agent2');
   });
 
-  test('use default platform userAgent after webView is rebuilt', () async {
+  testWidgets('use default platform userAgent after webView is rebuilt',
+      (WidgetTester tester) async {
     final Completer<WebViewController> controllerCompleter =
         Completer<WebViewController>();
     final GlobalKey _globalKey = GlobalKey();
     // Build the webView with no user agent to get the default platform user agent.
-    await pumpWidget(
+    await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
         child: WebView(
@@ -281,7 +280,7 @@ void main() {
     final WebViewController controller = await controllerCompleter.future;
     final String defaultPlatformUserAgent = await _getUserAgent(controller);
     // rebuild the WebView with a custom user agent.
-    await pumpWidget(
+    await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
         child: WebView(
@@ -295,7 +294,7 @@ void main() {
     final String customUserAgent = await _getUserAgent(controller);
     expect(customUserAgent, 'Custom_User_Agent');
     // rebuilds the WebView with no user agent.
-    await pumpWidget(
+    await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
         child: WebView(
@@ -341,12 +340,12 @@ void main() {
       audioTestBase64 = base64Encode(const Utf8Encoder().convert(audioTest));
     });
 
-    test('Auto media playback', () async {
+    testWidgets('Auto media playback', (WidgetTester tester) async {
       Completer<WebViewController> controllerCompleter =
           Completer<WebViewController>();
       Completer<void> pageLoaded = Completer<void>();
 
-      await pumpWidget(
+      await tester.pumpWidget(
         Directionality(
           textDirection: TextDirection.ltr,
           child: WebView(
@@ -373,7 +372,7 @@ void main() {
       pageLoaded = Completer<void>();
 
       // We change the key to re-create a new webview as we change the initialMediaPlaybackPolicy
-      await pumpWidget(
+      await tester.pumpWidget(
         Directionality(
           textDirection: TextDirection.ltr,
           child: WebView(
@@ -399,13 +398,14 @@ void main() {
       expect(isPaused, _webviewBool(true));
     });
 
-    test('Changes to initialMediaPlaybackPolocy are ignored', () async {
+    testWidgets('Changes to initialMediaPlaybackPolocy are ignored',
+        (WidgetTester tester) async {
       final Completer<WebViewController> controllerCompleter =
           Completer<WebViewController>();
       Completer<void> pageLoaded = Completer<void>();
 
       final GlobalKey key = GlobalKey();
-      await pumpWidget(
+      await tester.pumpWidget(
         Directionality(
           textDirection: TextDirection.ltr,
           child: WebView(
@@ -430,7 +430,7 @@ void main() {
 
       pageLoaded = Completer<void>();
 
-      await pumpWidget(
+      await tester.pumpWidget(
         Directionality(
           textDirection: TextDirection.ltr,
           child: WebView(
@@ -458,7 +458,7 @@ void main() {
     });
   });
 
-  test('getTitle', () async {
+  testWidgets('getTitle', (WidgetTester tester) async {
     final String getTitleTest = '''
         <!DOCTYPE html><html>
         <head><title>Some title</title>
@@ -473,7 +473,7 @@ void main() {
     final Completer<WebViewController> controllerCompleter =
         Completer<WebViewController>();
 
-    await pumpWidget(
+    await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
         child: WebView(
@@ -494,11 +494,6 @@ void main() {
     final String title = await controller.getTitle();
     expect(title, 'Some title');
   });
-}
-
-Future<void> pumpWidget(Widget widget) {
-  runApp(widget);
-  return WidgetsBinding.instance.endOfFrame;
 }
 
 // JavaScript booleans evaluate to different string values on Android and iOS.

--- a/packages/webview_flutter/example/test_driver/webview_flutter_e2e_test.dart
+++ b/packages/webview_flutter/example/test_driver/webview_flutter_e2e_test.dart
@@ -3,11 +3,14 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter_driver/flutter_driver.dart';
 
 Future<void> main() async {
   final FlutterDriver driver = await FlutterDriver.connect();
-  await driver.requestData(null, timeout: const Duration(minutes: 1));
+  final String result =
+      await driver.requestData(null, timeout: const Duration(minutes: 1));
   driver.close();
+  exit(result == 'pass' ? 0 : 1);
 }

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
-version: 0.3.14+2
+version: 0.3.15
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/webview_flutter
 

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://github.com/flutter/plugins/tree/master/packages/webview_flutte
 
 environment:
   sdk: ">=2.0.0-dev.68.0 <3.0.0"
-  flutter: ">=1.5.0 <2.0.0"
+  flutter: ">=1.6.7 <2.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Description

This depends on a new bugfix on the engine for text input to work with
the new embedding (flutter/engine#13015).

This also introduces some interesting and strange new failure cases.
With the new embedding, a FlutterView can be attached and detached from
the plugin at any point. It "should never" but technically can happen
that the plugin gets into a state where there is an active proxy adapter
view but no valid FlutterView to use for input proxying. For now I've
mostly added error logs and guards against NPEs detecting whenever we've
gotten into one of this situations. But I think we should probably
rigorously test this in an a2a specific situation to truly vet for a2a
support.

## Related Issues

Fixes flutter/flutter#41851.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x]  I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
