### PR TITLE
[url_launcher] Define clang module for iOS

### DIFF
--- a/packages/url_launcher/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.1.7
+
+* Define clang module for iOS.
+
 ## 5.1.6
 
 * Fixes bug where androidx app won't build with this plugin by enabling androidx and jetifier in the android `gradle.properties`.

--- a/packages/url_launcher/url_launcher/ios/url_launcher.podspec
+++ b/packages/url_launcher/url_launcher/ios/url_launcher.podspec
@@ -16,6 +16,7 @@ A Flutter plugin for making the underlying platform (Android or iOS) launch a UR
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   
-  s.ios.deployment_target = '8.0'
+  s.platform = :ios, '8.0'
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
 end
 

--- a/packages/url_launcher/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for launching a URL on Android and iOS. Supports
   web, phone, SMS, and email schemes.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher
-version: 5.1.6
+version: 5.1.7
 
 flutter:
   plugin:

--- a/script/lint_darwin_plugins.sh
+++ b/script/lint_darwin_plugins.sh
@@ -13,8 +13,16 @@ function lint_package() {
   local package_dir="${REPO_DIR}/packages/$package_name/"
   local failure_count=0
 
-  for podspec in "$(find "${package_dir}" -name '*\.podspec')"; do
-    echo "Linting $package_name.podspec"
+  local skipped_podspecs=(
+    'url_launcher_web.podspec'
+  )
+  find "${package_dir}" -type f -name '*\.podspec' | while read podspec; do
+    # These podspecs are temporary multi-platform adoption dummy files.
+    if [[ "${skipped_podspecs[*]}" =~ "$(basename ${podspec})" ]]; then
+      continue
+    fi
+
+    echo "Linting $(basename ${podspec})"
 
     # Build as frameworks.
     # This will also run any tests set up as a test_spec. See https://blog.cocoapods.org/CocoaPods-1.3.0.
@@ -54,7 +62,6 @@ function lint_packages() {
     'sensors'
     'share'
     'shared_preferences'
-    'url_launcher'
     'video_player'
     'webview_flutter'
   )


### PR DESCRIPTION
## Description

- Limit the supported podspec platform to iOS so tests don't run (and fail) for macOS.
- Define the module by setting `DEFINES_MODULE` in the podspec.  See [CocoaPod modular headers docs](http://blog.cocoapods.org/CocoaPods-1.5.0/).
- Explicitly set `VALID_ARCHS` to x86_64 for the simulator.  See https://github.com/CocoaPods/CocoaPods/issues/9210.
- Add mechanism to skip dummy multi-platform podspecs so url_launcher_web could be skipped during lint script.

## Related Issues

See https://github.com/flutter/flutter/issues/41007.

## Tests

- Fix bug in lint script that was separating files by spaces instead of newlines, so wasn't running the podspecs individually.
- Remove url_launcher from the list of packages to skip when linting the podspec.  This will at minimum make sure url_launcher can be imported into a project without compilation errors.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.