### PR TITLE
[battery] Define clang module for iOS

### DIFF
--- a/packages/battery/CHANGELOG.md
+++ b/packages/battery/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0+6
+
+* Define clang module for iOS.
+
 ## 0.3.0+5
 
 * Fix Gradle version.

--- a/packages/battery/ios/battery.podspec
+++ b/packages/battery/ios/battery.podspec
@@ -15,6 +15,7 @@ Flutter plugin for accessing information about the battery.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  
-  s.ios.deployment_target = '8.0'
+
+  s.platform = :ios, '8.0'
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
 end

--- a/packages/battery/pubspec.yaml
+++ b/packages/battery/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for accessing information about the battery state
   (full, charging, discharging) on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/battery
-version: 0.3.0+5
+version: 0.3.0+6
 
 flutter:
   plugin:

--- a/script/lint_darwin_plugins.sh
+++ b/script/lint_darwin_plugins.sh
@@ -53,7 +53,6 @@ function lint_packages() {
 
   # TODO: These packages have linter errors. Remove plugins from this list as linter issues are fixed.
   local skipped_packages=(
-    'battery'
     'google_maps_flutter'
     'google_sign_in'
     'share'


### PR DESCRIPTION
## Description

- Limit the supported podspec platform to iOS so tests don't run (and fail) for macOS.
- Define the module by setting `DEFINES_MODULE` in the podspec.  See [CocoaPod modular headers docs](http://blog.cocoapods.org/CocoaPods-1.5.0/).
- Explicitly set `VALID_ARCHS` to x86_64 for the simulator.  See https://github.com/CocoaPods/CocoaPods/issues/9210.

## Related Issues

See https://github.com/flutter/flutter/issues/41007.

## Tests

- Remove battery from the list of packages to skip when linting the podspec.  This will at minimum make sure battery can be imported into a project without compilation errors.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.