### PR TITLE
[google_maps_flutter] Define clang module for iOS, fix analyzer warnings

### DIFF
--- a/packages/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.5.21+10
 
 * Cast error.code to unsigned long to avoid using NSInteger as %ld format warnings.
+* Define clang module for iOS, fix analyzer warnings.
 
 ## 0.5.21+9
 

--- a/packages/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/CHANGELOG.md
@@ -1,7 +1,10 @@
+## 0.5.21+11
+
+* Define clang module for iOS, fix analyzer warnings.
+
 ## 0.5.21+10
 
 * Cast error.code to unsigned long to avoid using NSInteger as %ld format warnings.
-* Define clang module for iOS, fix analyzer warnings.
 
 ## 0.5.21+9
 

--- a/packages/google_maps_flutter/example/ios/Runner/AppDelegate.m
+++ b/packages/google_maps_flutter/example/ios/Runner/AppDelegate.m
@@ -1,6 +1,7 @@
-#include "AppDelegate.h"
-#include "GeneratedPluginRegistrant.h"
-#import "GoogleMaps/GoogleMaps.h"
+#import "AppDelegate.h"
+#import "GeneratedPluginRegistrant.h"
+
+@import GoogleMaps;
 
 @implementation AppDelegate
 

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapCircleController.m
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapCircleController.m
@@ -73,17 +73,17 @@ static UIColor* ToColor(NSNumber* data) { return [FLTGoogleMapJsonConversions to
 static void InterpretCircleOptions(NSDictionary* data, id<FLTGoogleMapCircleOptionsSink> sink,
                                    NSObject<FlutterPluginRegistrar>* registrar) {
   NSNumber* consumeTapEvents = data[@"consumeTapEvents"];
-  if (consumeTapEvents) {
+  if (consumeTapEvents != nil) {
     [sink setConsumeTapEvents:ToBool(consumeTapEvents)];
   }
 
   NSNumber* visible = data[@"visible"];
-  if (visible) {
+  if (visible != nil) {
     [sink setVisible:ToBool(visible)];
   }
 
   NSNumber* zIndex = data[@"zIndex"];
-  if (zIndex) {
+  if (zIndex != nil) {
     [sink setZIndex:ToInt(zIndex)];
   }
 
@@ -93,22 +93,22 @@ static void InterpretCircleOptions(NSDictionary* data, id<FLTGoogleMapCircleOpti
   }
 
   NSNumber* radius = data[@"radius"];
-  if (radius) {
+  if (radius != nil) {
     [sink setRadius:ToDistance(radius)];
   }
 
   NSNumber* strokeColor = data[@"strokeColor"];
-  if (strokeColor) {
+  if (strokeColor != nil) {
     [sink setStrokeColor:ToColor(strokeColor)];
   }
 
   NSNumber* strokeWidth = data[@"strokeWidth"];
-  if (strokeWidth) {
+  if (strokeWidth != nil) {
     [sink setStrokeWidth:ToInt(strokeWidth)];
   }
 
   NSNumber* fillColor = data[@"fillColor"];
-  if (fillColor) {
+  if (fillColor != nil) {
     [sink setFillColor:ToColor(fillColor)];
   }
 }

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapController.h
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapController.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 // Defines map UI options writable from Flutter.
 @protocol FLTGoogleMapOptionsSink
-- (void)setCameraTargetBounds:(GMSCoordinateBounds *)bounds;
+- (void)setCameraTargetBounds:(nullable GMSCoordinateBounds *)bounds;
 - (void)setCompassEnabled:(BOOL)enabled;
 - (void)setIndoorEnabled:(BOOL)enabled;
 - (void)setTrafficEnabled:(BOOL)enabled;
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setZoomGesturesEnabled:(BOOL)enabled;
 - (void)setMyLocationEnabled:(BOOL)enabled;
 - (void)setMyLocationButtonEnabled:(BOOL)enabled;
-- (NSString *)setMapStyle:(NSString *)mapStyle;
+- (nullable NSString *)setMapStyle:(NSString *)mapStyle;
 @end
 
 // Defines map overlay controllable from Flutter.
@@ -35,13 +35,13 @@ NS_ASSUME_NONNULL_BEGIN
     : NSObject <GMSMapViewDelegate, FLTGoogleMapOptionsSink, FlutterPlatformView>
 - (instancetype)initWithFrame:(CGRect)frame
                viewIdentifier:(int64_t)viewId
-                    arguments:(id _Nullable)args
+                    arguments:(nullable id)args
                     registrar:(NSObject<FlutterPluginRegistrar> *)registrar;
 - (void)showAtX:(CGFloat)x Y:(CGFloat)y;
 - (void)hide;
 - (void)animateWithCameraUpdate:(GMSCameraUpdate *)cameraUpdate;
 - (void)moveWithCameraUpdate:(GMSCameraUpdate *)cameraUpdate;
-- (GMSCameraPosition *)cameraPosition;
+- (nullable GMSCameraPosition *)cameraPosition;
 @end
 
 // Allows the engine to create new Google Map instances.

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapController.m
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapController.m
@@ -65,7 +65,7 @@ static double ToDouble(NSNumber* data) { return [FLTGoogleMapJsonConversions toD
                viewIdentifier:(int64_t)viewId
                     arguments:(id _Nullable)args
                     registrar:(NSObject<FlutterPluginRegistrar>*)registrar {
-  if ([super init]) {
+  if (self = [super init]) {
     _viewId = viewId;
 
     GMSCameraPosition* camera = ToOptionalCameraPosition(args[@"initialCameraPosition"]);
@@ -543,7 +543,7 @@ static void InterpretMapOptions(NSDictionary* data, id<FLTGoogleMapOptionsSink> 
     [sink setCameraTargetBounds:ToOptionalBounds(cameraTargetBounds)];
   }
   NSNumber* compassEnabled = data[@"compassEnabled"];
-  if (compassEnabled) {
+  if (compassEnabled != nil) {
     [sink setCompassEnabled:ToBool(compassEnabled)];
   }
   id indoorEnabled = data[@"indoorEnabled"];
@@ -574,31 +574,31 @@ static void InterpretMapOptions(NSDictionary* data, id<FLTGoogleMapOptionsSink> 
   }
 
   NSNumber* rotateGesturesEnabled = data[@"rotateGesturesEnabled"];
-  if (rotateGesturesEnabled) {
+  if (rotateGesturesEnabled != nil) {
     [sink setRotateGesturesEnabled:ToBool(rotateGesturesEnabled)];
   }
   NSNumber* scrollGesturesEnabled = data[@"scrollGesturesEnabled"];
-  if (scrollGesturesEnabled) {
+  if (scrollGesturesEnabled != nil) {
     [sink setScrollGesturesEnabled:ToBool(scrollGesturesEnabled)];
   }
   NSNumber* tiltGesturesEnabled = data[@"tiltGesturesEnabled"];
-  if (tiltGesturesEnabled) {
+  if (tiltGesturesEnabled != nil) {
     [sink setTiltGesturesEnabled:ToBool(tiltGesturesEnabled)];
   }
   NSNumber* trackCameraPosition = data[@"trackCameraPosition"];
-  if (trackCameraPosition) {
+  if (trackCameraPosition != nil) {
     [sink setTrackCameraPosition:ToBool(trackCameraPosition)];
   }
   NSNumber* zoomGesturesEnabled = data[@"zoomGesturesEnabled"];
-  if (zoomGesturesEnabled) {
+  if (zoomGesturesEnabled != nil) {
     [sink setZoomGesturesEnabled:ToBool(zoomGesturesEnabled)];
   }
   NSNumber* myLocationEnabled = data[@"myLocationEnabled"];
-  if (myLocationEnabled) {
+  if (myLocationEnabled != nil) {
     [sink setMyLocationEnabled:ToBool(myLocationEnabled)];
   }
   NSNumber* myLocationButtonEnabled = data[@"myLocationButtonEnabled"];
-  if (myLocationButtonEnabled) {
+  if (myLocationButtonEnabled != nil) {
     [sink setMyLocationButtonEnabled:ToBool(myLocationButtonEnabled)];
   }
 }

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapMarkerController.m
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapMarkerController.m
@@ -95,7 +95,7 @@ static NSArray* PositionToJson(CLLocationCoordinate2D data) {
 static void InterpretMarkerOptions(NSDictionary* data, id<FLTGoogleMapMarkerOptionsSink> sink,
                                    NSObject<FlutterPluginRegistrar>* registrar) {
   NSNumber* alpha = data[@"alpha"];
-  if (alpha) {
+  if (alpha != nil) {
     [sink setAlpha:ToFloat(alpha)];
   }
   NSArray* anchor = data[@"anchor"];
@@ -103,7 +103,7 @@ static void InterpretMarkerOptions(NSDictionary* data, id<FLTGoogleMapMarkerOpti
     [sink setAnchor:ToPoint(anchor)];
   }
   NSNumber* draggable = data[@"draggable"];
-  if (draggable) {
+  if (draggable != nil) {
     [sink setDraggable:ToBool(draggable)];
   }
   NSArray* icon = data[@"icon"];
@@ -112,11 +112,11 @@ static void InterpretMarkerOptions(NSDictionary* data, id<FLTGoogleMapMarkerOpti
     [sink setIcon:image];
   }
   NSNumber* flat = data[@"flat"];
-  if (flat) {
+  if (flat != nil) {
     [sink setFlat:ToBool(flat)];
   }
   NSNumber* consumeTapEvents = data[@"consumeTapEvents"];
-  if (consumeTapEvents) {
+  if (consumeTapEvents != nil) {
     [sink setConsumeTapEvents:ToBool(consumeTapEvents)];
   }
   InterpretInfoWindow(sink, data);
@@ -125,15 +125,15 @@ static void InterpretMarkerOptions(NSDictionary* data, id<FLTGoogleMapMarkerOpti
     [sink setPosition:ToLocation(position)];
   }
   NSNumber* rotation = data[@"rotation"];
-  if (rotation) {
+  if (rotation != nil) {
     [sink setRotation:ToDouble(rotation)];
   }
   NSNumber* visible = data[@"visible"];
-  if (visible) {
+  if (visible != nil) {
     [sink setVisible:ToBool(visible)];
   }
   NSNumber* zIndex = data[@"zIndex"];
-  if (zIndex) {
+  if (zIndex != nil) {
     [sink setZIndex:ToInt(zIndex)];
   }
 }

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapPolygonController.m
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapPolygonController.m
@@ -70,17 +70,17 @@ static UIColor* ToColor(NSNumber* data) { return [FLTGoogleMapJsonConversions to
 static void InterpretPolygonOptions(NSDictionary* data, id<FLTGoogleMapPolygonOptionsSink> sink,
                                     NSObject<FlutterPluginRegistrar>* registrar) {
   NSNumber* consumeTapEvents = data[@"consumeTapEvents"];
-  if (consumeTapEvents) {
+  if (consumeTapEvents != nil) {
     [sink setConsumeTapEvents:ToBool(consumeTapEvents)];
   }
 
   NSNumber* visible = data[@"visible"];
-  if (visible) {
+  if (visible != nil) {
     [sink setVisible:ToBool(visible)];
   }
 
   NSNumber* zIndex = data[@"zIndex"];
-  if (zIndex) {
+  if (zIndex != nil) {
     [sink setZIndex:ToInt(zIndex)];
   }
 
@@ -90,17 +90,17 @@ static void InterpretPolygonOptions(NSDictionary* data, id<FLTGoogleMapPolygonOp
   }
 
   NSNumber* fillColor = data[@"fillColor"];
-  if (fillColor) {
+  if (fillColor != nil) {
     [sink setFillColor:ToColor(fillColor)];
   }
 
   NSNumber* strokeColor = data[@"strokeColor"];
-  if (strokeColor) {
+  if (strokeColor != nil) {
     [sink setStrokeColor:ToColor(strokeColor)];
   }
 
   NSNumber* strokeWidth = data[@"strokeWidth"];
-  if (strokeWidth) {
+  if (strokeWidth != nil) {
     [sink setStrokeWidth:ToInt(strokeWidth)];
   }
 }

--- a/packages/google_maps_flutter/ios/Classes/GoogleMapPolylineController.m
+++ b/packages/google_maps_flutter/ios/Classes/GoogleMapPolylineController.m
@@ -67,17 +67,17 @@ static UIColor* ToColor(NSNumber* data) { return [FLTGoogleMapJsonConversions to
 static void InterpretPolylineOptions(NSDictionary* data, id<FLTGoogleMapPolylineOptionsSink> sink,
                                      NSObject<FlutterPluginRegistrar>* registrar) {
   NSNumber* consumeTapEvents = data[@"consumeTapEvents"];
-  if (consumeTapEvents) {
+  if (consumeTapEvents != nil) {
     [sink setConsumeTapEvents:ToBool(consumeTapEvents)];
   }
 
   NSNumber* visible = data[@"visible"];
-  if (visible) {
+  if (visible != nil) {
     [sink setVisible:ToBool(visible)];
   }
 
   NSNumber* zIndex = data[@"zIndex"];
-  if (zIndex) {
+  if (zIndex != nil) {
     [sink setZIndex:ToInt(zIndex)];
   }
 
@@ -87,12 +87,12 @@ static void InterpretPolylineOptions(NSDictionary* data, id<FLTGoogleMapPolyline
   }
 
   NSNumber* strokeColor = data[@"color"];
-  if (strokeColor) {
+  if (strokeColor != nil) {
     [sink setColor:ToColor(strokeColor)];
   }
 
   NSNumber* strokeWidth = data[@"width"];
-  if (strokeWidth) {
+  if (strokeWidth != nil) {
     [sink setStrokeWidth:ToInt(strokeWidth)];
   }
 }

--- a/packages/google_maps_flutter/ios/google_maps_flutter.podspec
+++ b/packages/google_maps_flutter/ios/google_maps_flutter.podspec
@@ -16,7 +16,7 @@ A new flutter plugin project.
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.dependency 'GoogleMaps'
-  s.compiler_flags = '-fno-modules'
   s.static_framework = true
-  s.ios.deployment_target = '8.0'
+  s.platform = :ios, '8.0'
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
 end

--- a/packages/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter
-version: 0.5.21+10
+version: 0.5.21+11
 
 dependencies:
   flutter:

--- a/script/lint_darwin_plugins.sh
+++ b/script/lint_darwin_plugins.sh
@@ -70,16 +70,8 @@ function lint_packages() {
     return
   fi
 
-  # TODO: These packages have linter errors. Remove plugins from this list as linter issues are fixed.
-  local skipped_packages=(
-    'google_maps_flutter'
-  )
-
   local failure_count=0
-  for package_name in "$@"; do
-    if [[ "${skipped_packages[*]}" =~ "${package_name}" ]]; then
-      continue
-    fi      
+  for package_name in "$@"; do   
     lint_package "${package_name}"
     failure_count+="$?"
   done


### PR DESCRIPTION
## Description

- Limit the supported podspec platform to iOS so tests don't run (and fail) for macOS.
- Define the module by setting `DEFINES_MODULE` in the podspec.  See [CocoaPod modular headers docs](http://blog.cocoapods.org/CocoaPods-1.5.0/).
- Explicitly set `VALID_ARCHS` to x86_64 for the simulator.  See https://github.com/CocoaPods/CocoaPods/issues/9210.
- Revert https://github.com/flutter/plugins/pull/1734 to support modules.
- Fix 35 analyzer warnings:
```
GoogleMapMarkerController.m:98:7: Converting a pointer value of type 'NSNumber *' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue
GoogleMapMarkerController.m:106:7: Converting a pointer value of type 'NSNumber *' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue
GoogleMapMarkerController.m:115:7: Converting a pointer value of type 'NSNumber *' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue
GoogleMapMarkerController.m:119:7: Converting a pointer value of type 'NSNumber *' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue
GoogleMapMarkerController.m:128:7: Converting a pointer value of type 'NSNumber *' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue
GoogleMapMarkerController.m:132:7: Converting a pointer value of type 'NSNumber *' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue
GoogleMapMarkerController.m:136:7: Converting a pointer value of type 'NSNumber *' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue
GoogleMapPolylineController.m:70:7: warning: Converting a pointer value of type 'NSNumber *' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue
  if (consumeTapEvents) {
  ~~~~^~~~~~~~~~~~~~~~~~~
GoogleMapPolylineController.m:75:7: warning: Converting a pointer value of type 'NSNumber *' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue
  if (visible) {
  ~~~~^~~~~~~~~~
GoogleMapPolylineController.m:80:7: warning: Converting a pointer value of type 'NSNumber *' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue
  if (zIndex) {
  ~~~~^~~~~~~~~
GoogleMapPolylineController.m:90:7: warning: Converting a pointer value of type 'NSNumber *' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue
  if (strokeColor) {
  ~~~~^~~~~~~~~~~~~~
GoogleMapPolylineController.m:95:7: warning: Converting a pointer value of type 'NSNumber *' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue
  if (strokeWidth) {
  ~~~~^~~~~~~~~~~~~~

GoogleMapPolygonController.m:73:7: warning: Converting a pointer value of type 'NSNumber *' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue
  if (consumeTapEvents) {
  ~~~~^~~~~~~~~~~~~~~~~~~
GoogleMapPolygonController.m:78:7: warning: Converting a pointer value of type 'NSNumber *' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue
  if (visible) {
  ~~~~^~~~~~~~~~
GoogleMapPolygonController.m:83:7: warning: Converting a pointer value of type 'NSNumber *' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue
  if (zIndex) {
  ~~~~^~~~~~~~~
GoogleMapPolygonController.m:93:7: warning: Converting a pointer value of type 'NSNumber *' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue
  if (fillColor) {
  ~~~~^~~~~~~~~~~~
GoogleMapPolygonController.m:98:7: warning: Converting a pointer value of type 'NSNumber *' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue
  if (strokeColor) {
  ~~~~^~~~~~~~~~~~~~
GoogleMapPolygonController.m:103:7: warning: Converting a pointer value of type 'NSNumber *' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue
  if (strokeWidth) {
  ~~~~^~~~~~~~~~~~~~
GoogleMapCircleController.m:76:7: warning: Converting a pointer value of type 'NSNumber *' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue
  if (consumeTapEvents) {
  ~~~~^~~~~~~~~~~~~~~~~~~
GoogleMapCircleController.m:81:7: warning: Converting a pointer value of type 'NSNumber *' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue
  if (visible) {
  ~~~~^~~~~~~~~~
GoogleMapCircleController.m:86:7: warning: Converting a pointer value of type 'NSNumber *' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue
  if (zIndex) {
  ~~~~^~~~~~~~~
GoogleMapCircleController.m:96:7: warning: Converting a pointer value of type 'NSNumber *' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue
  if (radius) {
  ~~~~^~~~~~~~~
GoogleMapCircleController.m:101:7: warning: Converting a pointer value of type 'NSNumber *' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue
  if (strokeColor) {
  ~~~~^~~~~~~~~~~~~~
GoogleMapCircleController.m:106:7: warning: Converting a pointer value of type 'NSNumber *' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue
  if (strokeWidth) {
  ~~~~^~~~~~~~~~~~~~
GoogleMapCircleController.m:111:7: warning: Converting a pointer value of type 'NSNumber *' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue
  if (fillColor) {
  ~~~~^~~~~~~~~~~~
GoogleMapController.m:69:5: warning: Instance variable used while 'self' is not set to the result of '[(super or self) init...]'
    _viewId = viewId;
    ^~~~~~~
GoogleMapController.m:118:3: warning: Returning 'self' while it is not set to the result of '[(super or self) init...]'
  return self;
  ^~~~~~~~~~~
GoogleMapController.m:546:7: warning: Converting a pointer value of type 'NSNumber *' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue
  if (compassEnabled) {
  ~~~~^~~~~~~~~~~~~~~~~
GoogleMapController.m:577:7: warning: Converting a pointer value of type 'NSNumber *' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue
  if (rotateGesturesEnabled) {
  ~~~~^~~~~~~~~~~~~~~~~~~~~~~~
GoogleMapController.m:581:7: warning: Converting a pointer value of type 'NSNumber *' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue
  if (scrollGesturesEnabled) {
  ~~~~^~~~~~~~~~~~~~~~~~~~~~~~
GoogleMapController.m:585:7: warning: Converting a pointer value of type 'NSNumber *' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue
  if (tiltGesturesEnabled) {
  ~~~~^~~~~~~~~~~~~~~~~~~~~~
GoogleMapController.m:589:7: warning: Converting a pointer value of type 'NSNumber *' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue
  if (trackCameraPosition) {
  ~~~~^~~~~~~~~~~~~~~~~~~~~~
GoogleMapController.m:593:7: warning: Converting a pointer value of type 'NSNumber *' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue
  if (zoomGesturesEnabled) {
  ~~~~^~~~~~~~~~~~~~~~~~~~~~
GoogleMapController.m:597:7: warning: Converting a pointer value of type 'NSNumber *' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue
  if (myLocationEnabled) {
  ~~~~^~~~~~~~~~~~~~~~~~~~
GoogleMapController.m:601:7: warning: Converting a pointer value of type 'NSNumber *' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue
  if (myLocationButtonEnabled) {
  ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
```

## Related Issues

See https://github.com/flutter/flutter/issues/41007.
Might fix https://github.com/flutter/flutter/issues/34042 (though I can't reproduce it)

## Tests

- Remove google_maps_flutter from the list of packages to skip when linting the podspec.  This will at minimum make sure google_maps_flutter can be imported into a project without compilation errors.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.