### PR TITLE
[google_sign_in] Define clang module for iOS

### DIFF
--- a/packages/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 4.0.9
 
 * Update and migrate iOS example project.
+* Define clang module for iOS.
 
 ## 4.0.8
 

--- a/packages/google_sign_in/ios/google_sign_in.podspec
+++ b/packages/google_sign_in/ios/google_sign_in.podspec
@@ -17,4 +17,7 @@ Enables Google Sign-In in Flutter apps.
   s.dependency 'Flutter'
   s.dependency 'GoogleSignIn', '~> 4.0'
   s.static_framework = true
+
+  s.platform = :ios, '8.0'
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
 end

--- a/script/lint_darwin_plugins.sh
+++ b/script/lint_darwin_plugins.sh
@@ -55,7 +55,6 @@ function lint_packages() {
   local skipped_packages=(
     'battery'
     'google_maps_flutter'
-    'google_sign_in'
     'share'
     'video_player'
     'webview_flutter'


### PR DESCRIPTION
## Description

- Limit the supported podspec platform to iOS so tests don't run (and fail) for macOS.
- Define the module by setting `DEFINES_MODULE` in the podspec.  See [CocoaPod modular headers docs](http://blog.cocoapods.org/CocoaPods-1.5.0/).
- Explicitly set `VALID_ARCHS` to x86_64 for the simulator.  See https://github.com/CocoaPods/CocoaPods/issues/9210.

## Related Issues

See https://github.com/flutter/flutter/issues/41007.

## Tests

- Remove google_sign_in from the list of packages to skip when linting the podspec.  This will at minimum make sure google_sign_in can be imported into a project without compilation errors.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.