### PR TITLE
Run clang analyzer on iOS and macOS code in CI test when packages change

### DIFF
--- a/script/lint_darwin_plugins.sh
+++ b/script/lint_darwin_plugins.sh
@@ -13,31 +13,52 @@ function lint_package() {
   local package_dir="${REPO_DIR}/packages/$package_name/"
   local failure_count=0
 
+  # These podspecs are temporary multi-platform adoption dummy files.
   local skipped_podspecs=(
-    'url_launcher_web.podspec'
+    "url_launcher_web.podspec"
   )
-  find "${package_dir}" -type f -name '*\.podspec' | while read podspec; do
-    # These podspecs are temporary multi-platform adoption dummy files.
-    if [[ "${skipped_podspecs[*]}" =~ "$(basename ${podspec})" ]]; then
+  
+  # TODO: These packages have analyzer warnings. Remove plugins from this list as issues are fixed.
+  local skip_analysis_packages=(
+    "camera.podspec"
+    "image_picker.podspec"
+    "in_app_purchase.podspec"
+  )
+  find "${package_dir}" -type f -name "*\.podspec" | while read podspec; do
+    local podspecBasename=$(basename "${podspec}")
+    if [[ "${skipped_podspecs[*]}" =~ "${podspecBasename}" ]]; then
       continue
     fi
 
-    echo "Linting $(basename ${podspec})"
+    # TODO: Remove --allow-warnings flag https://github.com/flutter/flutter/issues/41444
+    local lint_args=(
+      lib
+      lint
+      "${podspec}"
+      --allow-warnings
+      --fail-fast
+      --silent
+    )
+    if [[ ! "${skip_analysis_packages[*]}" =~ "${podspecBasename}" ]]; then
+      lint_args+=(--analyze)
+      echo "Linting and analyzing ${podspecBasename}"
+    else
+      echo "Linting ${podspecBasename}"
+    fi
 
     # Build as frameworks.
     # This will also run any tests set up as a test_spec. See https://blog.cocoapods.org/CocoaPods-1.3.0.
-    # TODO: Add --analyze flag https://github.com/flutter/flutter/issues/41443
-    # TODO: Remove --allow-warnings flag https://github.com/flutter/flutter/issues/41444
-    pod lib lint "${podspec}" --allow-warnings --fail-fast --silent
+    pod "${lint_args[@]}"
     if [[ "$?" -ne 0 ]]; then
-      error "Package ${package_name} has framework issues. Run \"pod lib lint $podspec\" to inspect."
+      error "Package ${package_name} has framework issues. Run \"pod lib lint ${podspec} --analyze\" to inspect."
       failure_count+=1
     fi
 
     # Build as libraries.
-    pod lib lint "${podspec}" --allow-warnings --use-libraries --fail-fast --silent
+    lint_args+=(--use-libraries)
+    pod "${lint_args[@]}"
     if [[ "$?" -ne 0 ]]; then
-      error "Package ${package_name} has library issues. Run \"pod lib lint $podspec --use-libraries\" to inspect."
+      error "Package ${package_name} has library issues. Run \"pod lib lint ${podspec} --use-libraries --analyze\" to inspect."
       failure_count+=1
     fi
   done

--- a/script/lint_darwin_plugins.sh
+++ b/script/lint_darwin_plugins.sh
@@ -20,9 +20,9 @@ function lint_package() {
   
   # TODO: These packages have analyzer warnings. Remove plugins from this list as issues are fixed.
   local skip_analysis_packages=(
-    "camera.podspec"
-    "image_picker.podspec"
-    "in_app_purchase.podspec"
+    "camera.podspec" # https://github.com/flutter/flutter/issues/42673
+    "image_picker.podspec" # https://github.com/flutter/flutter/issues/42678
+    "in_app_purchase.podspec" # https://github.com/flutter/flutter/issues/42679
   )
   find "${package_dir}" -type f -name "*\.podspec" | while read podspec; do
     local podspecBasename=$(basename "${podspec}")


### PR DESCRIPTION
## Description

Add the `--analyzer` flag during linting to run clang analyzer.
Skip packages with known analyzer warnings.
I tested this by faking out a change in every package locally and confirmed this script still passes.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/41443.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.