### PR TITLE
 [url_launcher] Adds macOS support

### DIFF
--- a/packages/url_launcher/url_launcher_macos/LICENSE
+++ b/packages/url_launcher/url_launcher_macos/LICENSE
@@ -1,0 +1,27 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/url_launcher/url_launcher_macos/README.md
+++ b/packages/url_launcher/url_launcher_macos/README.md
@@ -4,7 +4,7 @@ The macOS implementation of [`url_launcher`][1].
 
 ## Usage
 
-To use this plugin in your Flutter Web app, simply add it as a dependency in
+To use this plugin in your macOS Flutter app, simply add it as a dependency in
 your pubspec using a `git` dependency. This is only temporary: in the future
 we hope to make this package an "endorsed" implementation of `url_launcher`,
 so that it is automatically included in your macOS Flutter app when you depend

--- a/packages/url_launcher/url_launcher_macos/README.md
+++ b/packages/url_launcher/url_launcher_macos/README.md
@@ -1,0 +1,25 @@
+# url\_launcher\_macos
+
+The macOS implementation of [`url_launcher`][1].
+
+## Usage
+
+To use this plugin in your Flutter Web app, simply add it as a dependency in
+your pubspec using a `git` dependency. This is only temporary: in the future
+we hope to make this package an "endorsed" implementation of `url_launcher`,
+so that it is automatically included in your macOS Flutter app when you depend
+on `package:url_launcher`.
+
+```yaml
+dependencies:
+  url_launcher: ^5.1.4
+  url_launcher_macos:
+    git:
+      url: git://github.com/flutter/plugins.git
+      path: packages/url_launcher/url_launcher_macos
+```
+
+Once you have the `url_launcher_macos` dependency in your pubspec, you should
+be able to use `package:url_launcher` as normal.
+
+[1]: ../url_launcher

--- a/packages/url_launcher/url_launcher_macos/ios/url_launcher_macos.podspec
+++ b/packages/url_launcher/url_launcher_macos/ios/url_launcher_macos.podspec
@@ -1,0 +1,21 @@
+#
+# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
+#
+Pod::Spec.new do |s|
+  s.name             = 'url_launcher_fde'
+  s.version          = '0.0.1'
+  s.summary          = 'No-op implementation of url_launcher_macos to avoid build issues on iOS'
+  s.description      = <<-DESC
+  No-op implementation of url_launcher_macos to avoid build issues on iOS.
+  See https://github.com/flutter/flutter/issues/39659
+                       DESC
+  s.homepage         = 'https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher_macos'
+  s.license          = { :file => '../LICENSE' }
+  s.author           = { 'Flutter Team' => 'flutter-dev@googlegroups.com' }
+  s.source           = { :path => '.' }
+  s.source_files = 'Classes/**/*'
+  s.public_header_files = 'Classes/**/*.h'
+  s.dependency 'Flutter'
+
+  s.ios.deployment_target = '8.0'
+end

--- a/packages/url_launcher/url_launcher_macos/macos/Classes/UrlLauncherPlugin.swift
+++ b/packages/url_launcher/url_launcher_macos/macos/Classes/UrlLauncherPlugin.swift
@@ -1,0 +1,48 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import FlutterMacOS
+import Foundation
+
+public class UrlLauncherPlugin: NSObject, FlutterPlugin {
+  public static func register(with registrar: FlutterPluginRegistrar) {
+    let channel = FlutterMethodChannel(
+      name: "plugins.flutter.io/url_launcher",
+      binaryMessenger: registrar.messenger)
+    let instance = UrlLauncherPlugin()
+    registrar.addMethodCallDelegate(instance, channel: channel)
+  }
+
+  public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    let urlString: String? = (call.arguments as? [String: Any])?["url"] as? String
+    switch call.method {
+    case "canLaunch":
+      guard let unwrappedURLString = urlString,
+        let url = URL.init(string: unwrappedURLString)
+      else {
+        result(invalidURLError(urlString))
+        return
+      }
+      result(NSWorkspace.shared.urlForApplication(toOpen: url) != nil)
+    case "launch":
+      guard let unwrappedURLString = urlString,
+        let url = URL.init(string: unwrappedURLString)
+      else {
+        result(invalidURLError(urlString))
+        return
+      }
+      result(NSWorkspace.shared.open(url))
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+}
+
+/// Returns an error for the case where a URL string can't be parsed as a URL.
+private func invalidURLError(_ url: String?) -> FlutterError {
+  return FlutterError(
+    code: "argument_error",
+    message: "Unable to parse URL",
+    details: "Provided URL: \(String(describing: url))")
+}

--- a/packages/url_launcher/url_launcher_macos/macos/url_launcher_fde.podspec
+++ b/packages/url_launcher/url_launcher_macos/macos/url_launcher_fde.podspec
@@ -1,0 +1,20 @@
+#
+# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
+#
+Pod::Spec.new do |s|
+  s.name             = 'url_launcher_macos'
+  s.version          = '0.0.1'
+  s.summary          = 'Flutter plugin for launching a URL.'
+  s.description      = <<-DESC
+  A macOS implmentation of the url_launcher plugin.
+                       DESC
+  s.homepage         = 'https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher_macos'
+  s.license          = { :file => '../LICENSE' }
+  s.author           = { 'Flutter Team' => 'flutter-dev@googlegroups.com' }
+  s.source           = { :path => '.' }
+  s.source_files = 'Classes/**/*'
+  s.dependency 'FlutterMacOS'
+
+  s.platform = :osx
+  s.osx.deployment_target = '10.11'
+end

--- a/packages/url_launcher/url_launcher_macos/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_macos/pubspec.yaml
@@ -1,0 +1,23 @@
+name: url_launcher_macos
+description: macOS platform implementation of url_launcher
+version: 0.9.0
+author: Flutter Team <flutter-dev@googlegroups.com>
+homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher_macos
+
+flutter:
+  plugin:
+    platforms:
+      macos:
+        pluginClass: UrlLauncherPlugin
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+environment:
+  sdk: ">=2.0.0-dev.28.0 <3.0.0"
+  flutter: ">=1.5.0 <2.0.0"


### PR DESCRIPTION
## Description

Follows the structure established in #2119 to add a federated macOS implementation of the url_launcher plugin.

## Related Issues

Fixes macOS portion of https://github.com/flutter/flutter/issues/41721

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
