### PR TITLE
[image_picker] Fix iOS build and analyzer warnings

### DIFF
--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.1+8
+
+* Fix iOS build and analyzer warnings.
+
 ## 0.6.1+7
 
 * Android: Fix ImagePickerPlugin#onCreate casting context which causes exception.

--- a/packages/image_picker/ios/Classes/FLTImagePickerMetaDataUtil.m
+++ b/packages/image_picker/ios/Classes/FLTImagePickerMetaDataUtil.m
@@ -45,6 +45,7 @@ const FLTImagePickerMIMEType kFLTImagePickerMIMETypeDefault = FLTImagePickerMIME
   CGImageSourceRef source = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
   NSDictionary *metadata =
       (NSDictionary *)CFBridgingRelease(CGImageSourceCopyPropertiesAtIndex(source, 0, NULL));
+  CFRelease(source);
   return metadata;
 }
 

--- a/packages/image_picker/ios/Classes/FLTImagePickerPhotoAssetUtil.h
+++ b/packages/image_picker/ios/Classes/FLTImagePickerPhotoAssetUtil.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 // Save image with correct meta data and extention copied from image picker result info.
 + (NSString *)saveImageWithPickerInfo:(nullable NSDictionary *)info
                                 image:(UIImage *)image
-                         imageQuality:(NSNumber *)imageQuality;
+                         imageQuality:(nullable NSNumber *)imageQuality;
 
 @end
 

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -5,7 +5,7 @@ authors:
   - Flutter Team <flutter-dev@googlegroups.com>
   - Rhodes Davis Jr. <rody.davis.jr@gmail.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.6.1+7
+version: 0.6.1+8
 
 flutter:
   plugin:

--- a/script/lint_darwin_plugins.sh
+++ b/script/lint_darwin_plugins.sh
@@ -21,7 +21,6 @@ function lint_package() {
   # TODO: These packages have analyzer warnings. Remove plugins from this list as issues are fixed.
   local skip_analysis_packages=(
     "camera.podspec" # https://github.com/flutter/flutter/issues/42673
-    "image_picker.podspec" # https://github.com/flutter/flutter/issues/42678
     "in_app_purchase.podspec" # https://github.com/flutter/flutter/issues/42679
   )
   find "${package_dir}" -type f -name "*\.podspec" | while read podspec; do


### PR DESCRIPTION
## Description

Fix build and analyzer issues.
- Leak
- Nullability

## Related Issues

Fixes https://github.com/flutter/flutter/issues/42678.
Fixes https://github.com/flutter/flutter/issues/30556.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.