### PR TITLE
[in_app_purchase] Fix iOS build warning

### DIFF
--- a/packages/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.2.1+5
 
 * Define clang module for iOS.
+* Fix iOS build warning
 
 ## 0.2.1+4
 

--- a/packages/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.2.1+5
 
 * Define clang module for iOS.
-* Fix iOS build warning
+* Fix iOS build warning.
 
 ## 0.2.1+4
 

--- a/packages/in_app_purchase/ios/Classes/InAppPurchasePlugin.h
+++ b/packages/in_app_purchase/ios/Classes/InAppPurchasePlugin.h
@@ -10,6 +10,7 @@
 
 @property(strong, nonatomic) FIAPaymentQueueHandler *paymentQueueHandler;
 
-- (instancetype)initWithReceiptManager:(FIAPReceiptManager *)receiptManager;
+- (instancetype)initWithReceiptManager:(FIAPReceiptManager *)receiptManager NS_DESIGNATED_INITIALIZER;
+- (instancetype)init NS_UNAVAILABLE;
 
 @end

--- a/packages/in_app_purchase/ios/Classes/InAppPurchasePlugin.h
+++ b/packages/in_app_purchase/ios/Classes/InAppPurchasePlugin.h
@@ -10,7 +10,8 @@
 
 @property(strong, nonatomic) FIAPaymentQueueHandler *paymentQueueHandler;
 
-- (instancetype)initWithReceiptManager:(FIAPReceiptManager *)receiptManager NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithReceiptManager:(FIAPReceiptManager *)receiptManager
+    NS_DESIGNATED_INITIALIZER;
 - (instancetype)init NS_UNAVAILABLE;
 
 @end

--- a/packages/in_app_purchase/ios/Classes/InAppPurchasePlugin.m
+++ b/packages/in_app_purchase/ios/Classes/InAppPurchasePlugin.m
@@ -54,26 +54,25 @@
   _messenger = [registrar messenger];
 
   __weak typeof(self) weakSelf = self;
-  _paymentQueueHandler =
-      [[FIAPaymentQueueHandler alloc] initWithQueue:[SKPaymentQueue defaultQueue]
-          transactionsUpdated:^(NSArray<SKPaymentTransaction *> *_Nonnull transactions) {
-            [weakSelf handleTransactionsUpdated:transactions];
-          }
-          transactionRemoved:^(NSArray<SKPaymentTransaction *> *_Nonnull transactions) {
-            [weakSelf handleTransactionsRemoved:transactions];
-          }
-          restoreTransactionFailed:^(NSError *_Nonnull error) {
-            [weakSelf handleTransactionRestoreFailed:error];
-          }
-          restoreCompletedTransactionsFinished:^{
-            [weakSelf restoreCompletedTransactionsFinished];
-          }
-          shouldAddStorePayment:^BOOL(SKPayment *payment, SKProduct *product) {
-            return [weakSelf shouldAddStorePayment:payment product:product];
-          }
-          updatedDownloads:^void(NSArray<SKDownload *> *_Nonnull downloads) {
-            [weakSelf updatedDownloads:downloads];
-          }];
+  _paymentQueueHandler = [[FIAPaymentQueueHandler alloc] initWithQueue:[SKPaymentQueue defaultQueue]
+      transactionsUpdated:^(NSArray<SKPaymentTransaction *> *_Nonnull transactions) {
+        [weakSelf handleTransactionsUpdated:transactions];
+      }
+      transactionRemoved:^(NSArray<SKPaymentTransaction *> *_Nonnull transactions) {
+        [weakSelf handleTransactionsRemoved:transactions];
+      }
+      restoreTransactionFailed:^(NSError *_Nonnull error) {
+        [weakSelf handleTransactionRestoreFailed:error];
+      }
+      restoreCompletedTransactionsFinished:^{
+        [weakSelf restoreCompletedTransactionsFinished];
+      }
+      shouldAddStorePayment:^BOOL(SKPayment *payment, SKProduct *product) {
+        return [weakSelf shouldAddStorePayment:payment product:product];
+      }
+      updatedDownloads:^void(NSArray<SKDownload *> *_Nonnull downloads) {
+        [weakSelf updatedDownloads:downloads];
+      }];
   _callbackChannel =
       [FlutterMethodChannel methodChannelWithName:@"plugins.flutter.io/in_app_purchase_callback"
                                   binaryMessenger:[registrar messenger]];

--- a/packages/in_app_purchase/ios/Classes/InAppPurchasePlugin.m
+++ b/packages/in_app_purchase/ios/Classes/InAppPurchasePlugin.m
@@ -13,19 +13,19 @@
 
 // Holding strong references to FIAPRequestHandlers. Remove the handlers from the set after
 // the request is finished.
-@property(strong, nonatomic) NSMutableSet *requestHandlers;
+@property(strong, nonatomic, readonly) NSMutableSet *requestHandlers;
 
 // After querying the product, the available products will be saved in the map to be used
 // for purchase.
-@property(copy, nonatomic) NSMutableDictionary *productsCache;
+@property(strong, nonatomic, readonly) NSMutableDictionary *productsCache;
 
 // Call back channel to dart used for when a listener function is triggered.
-@property(strong, nonatomic) FlutterMethodChannel *callbackChannel;
-@property(strong, nonatomic) NSObject<FlutterTextureRegistry> *registry;
-@property(strong, nonatomic) NSObject<FlutterBinaryMessenger> *messenger;
-@property(strong, nonatomic) NSObject<FlutterPluginRegistrar> *registrar;
+@property(strong, nonatomic, readonly) FlutterMethodChannel *callbackChannel;
+@property(strong, nonatomic, readonly) NSObject<FlutterTextureRegistry> *registry;
+@property(strong, nonatomic, readonly) NSObject<FlutterBinaryMessenger> *messenger;
+@property(strong, nonatomic, readonly) NSObject<FlutterPluginRegistrar> *registrar;
 
-@property(strong, nonatomic) FIAPReceiptManager *receiptManager;
+@property(strong, nonatomic, readonly) FIAPReceiptManager *receiptManager;
 
 @end
 
@@ -40,19 +40,21 @@
 }
 
 - (instancetype)initWithReceiptManager:(FIAPReceiptManager *)receiptManager {
-  self = [self init];
-  self.receiptManager = receiptManager;
+  self = [super init];
+  _receiptManager = receiptManager;
+  _requestHandlers = [NSMutableSet new];
+  _productsCache = [NSMutableDictionary new];
   return self;
 }
 
 - (instancetype)initWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
   self = [self initWithReceiptManager:[FIAPReceiptManager new]];
-  self.registrar = registrar;
-  self.registry = [registrar textures];
-  self.messenger = [registrar messenger];
+  _registrar = registrar;
+  _registry = [registrar textures];
+  _messenger = [registrar messenger];
 
   __weak typeof(self) weakSelf = self;
-  self.paymentQueueHandler =
+  _paymentQueueHandler =
       [[FIAPaymentQueueHandler alloc] initWithQueue:[SKPaymentQueue defaultQueue]
           transactionsUpdated:^(NSArray<SKPaymentTransaction *> *_Nonnull transactions) {
             [weakSelf handleTransactionsUpdated:transactions];
@@ -72,7 +74,7 @@
           updatedDownloads:^void(NSArray<SKDownload *> *_Nonnull downloads) {
             [weakSelf updatedDownloads:downloads];
           }];
-  self.callbackChannel =
+  _callbackChannel =
       [FlutterMethodChannel methodChannelWithName:@"plugins.flutter.io/in_app_purchase_callback"
                                   binaryMessenger:[registrar messenger]];
   return self;
@@ -318,22 +320,6 @@
 
 - (SKReceiptRefreshRequest *)getRefreshReceiptRequest:(NSDictionary *)properties {
   return [[SKReceiptRefreshRequest alloc] initWithReceiptProperties:properties];
-}
-
-#pragma mark - getter
-
-- (NSSet *)requestHandlers {
-  if (!_requestHandlers) {
-    _requestHandlers = [NSMutableSet new];
-  }
-  return _requestHandlers;
-}
-
-- (NSMutableDictionary *)productsCache {
-  if (!_productsCache) {
-    _productsCache = [NSMutableDictionary new];
-  }
-  return _productsCache;
 }
 
 @end

--- a/script/lint_darwin_plugins.sh
+++ b/script/lint_darwin_plugins.sh
@@ -21,7 +21,6 @@ function lint_package() {
   # TODO: These packages have analyzer warnings. Remove plugins from this list as issues are fixed.
   local skip_analysis_packages=(
     "camera.podspec" # https://github.com/flutter/flutter/issues/42673
-    "in_app_purchase.podspec" # https://github.com/flutter/flutter/issues/42679
   )
   find "${package_dir}" -type f -name "*\.podspec" | while read podspec; do
     local podspecBasename=$(basename "${podspec}")


### PR DESCRIPTION
## Description

- Fix mutable collection being stored immutably.

Slight cleanup of InAppPurchasePlugin since I was editing it anyway:
- Decorated designated initializer to initialize mutable collection ivars on init, then remove (unthreadsafe) getters in favor of synthesized property getters.
- Set ivars instead of properties in initializers.
- Make category properties readonly.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/42679.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.