### PR TITLE
[android_intent] Cleanup the V2 migration

### DIFF
--- a/packages/android_intent/CHANGELOG.md
+++ b/packages/android_intent/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.4+1
+
+* Fix minor lints in the Java platform code.
+* Add smoke e2e tests for the V2 embedding.
+* Fully migrate the example app to AndroidX.
+
 ## 0.3.4
 
 * Migrate the plugin to use the V2 Android engine embedding. This shouldn't

--- a/packages/android_intent/android/src/main/java/io/flutter/plugins/androidintent/AndroidIntentPlugin.java
+++ b/packages/android_intent/android/src/main/java/io/flutter/plugins/androidintent/AndroidIntentPlugin.java
@@ -21,7 +21,7 @@ public final class AndroidIntentPlugin implements FlutterPlugin, ActivityAware {
    * <p>See {@code io.flutter.plugins.androidintentexample.MainActivity} for an example.
    */
   public AndroidIntentPlugin() {
-    sender = new IntentSender(/*activity=*/ null, /*context=*/ null);
+    sender = new IntentSender(/*activity=*/ null, /*applicationContext=*/ null);
     impl = new MethodCallHandlerImpl(sender);
   }
 

--- a/packages/android_intent/android/src/main/java/io/flutter/plugins/androidintent/IntentSender.java
+++ b/packages/android_intent/android/src/main/java/io/flutter/plugins/androidintent/IntentSender.java
@@ -14,8 +14,8 @@ import androidx.annotation.Nullable;
 public final class IntentSender {
   private static final String TAG = "IntentSender";
 
-  private @Nullable Activity activity;
-  private @Nullable Context applicationContext;
+  @Nullable private Activity activity;
+  @Nullable private Context applicationContext;
 
   /**
    * Caches the given {@code activity} and {@code applicationContext} to use for sending intents

--- a/packages/android_intent/android/src/main/java/io/flutter/plugins/androidintent/MethodCallHandlerImpl.java
+++ b/packages/android_intent/android/src/main/java/io/flutter/plugins/androidintent/MethodCallHandlerImpl.java
@@ -21,7 +21,7 @@ import java.util.Map;
 public final class MethodCallHandlerImpl implements MethodCallHandler {
   private static final String TAG = "MethodCallHandlerImpl";
   private final IntentSender sender;
-  private @Nullable MethodChannel methodChannel;
+  @Nullable private MethodChannel methodChannel;
 
   /**
    * Uses the given {@code sender} for all incoming calls.

--- a/packages/android_intent/example/android/app/src/androidTestDebug/java/io/flutter/plugins/androidintentexample/EmbeddingV1ActivityTest.java
+++ b/packages/android_intent/example/android/app/src/androidTestDebug/java/io/flutter/plugins/androidintentexample/EmbeddingV1ActivityTest.java
@@ -1,0 +1,13 @@
+package io.flutter.plugins.androidintentexample;
+
+import androidx.test.rule.ActivityTestRule;
+import dev.flutter.plugins.e2e.FlutterRunner;
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+
+@RunWith(FlutterRunner.class)
+public class EmbeddingV1ActivityTest {
+  @Rule
+  public ActivityTestRule<EmbeddingV1Activity> rule =
+      new ActivityTestRule<>(EmbeddingV1Activity.class);
+}

--- a/packages/android_intent/example/android/app/src/androidTestDebug/java/io/flutter/plugins/androidintentexample/MainActivityTest.java
+++ b/packages/android_intent/example/android/app/src/androidTestDebug/java/io/flutter/plugins/androidintentexample/MainActivityTest.java
@@ -1,0 +1,11 @@
+package io.flutter.plugins.androidintentexample;
+
+import androidx.test.rule.ActivityTestRule;
+import dev.flutter.plugins.e2e.FlutterRunner;
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+
+@RunWith(FlutterRunner.class)
+public class MainActivityTest {
+  @Rule public ActivityTestRule<MainActivity> rule = new ActivityTestRule<>(MainActivity.class);
+}

--- a/packages/android_intent/example/android/gradle.properties
+++ b/packages/android_intent/example/android/gradle.properties
@@ -1,2 +1,4 @@
 org.gradle.jvmargs=-Xmx1536M
+android.enableJetifier=true
+android.useAndroidX=true
 android.enableR8=true

--- a/packages/android_intent/example/pubspec.yaml
+++ b/packages/android_intent/example/pubspec.yaml
@@ -7,6 +7,11 @@ dependencies:
   android_intent:
     path: ../
 
+dev_dependencies:
+  e2e: "^0.2.1"
+  flutter_driver:
+    sdk: flutter
+
 # The following section is specific to Flutter.
 flutter:
   uses-material-design: true

--- a/packages/android_intent/example/test_driver/android_intent_e2e.dart
+++ b/packages/android_intent/example/test_driver/android_intent_e2e.dart
@@ -19,12 +19,24 @@ void main() {
     await tester.pumpWidget(MyApp());
 
     // Verify that the new embedding example app builds
-    expect(
-      find.byWidgetPredicate(
-        (Widget widget) => widget is Text && widget.data.startsWith('Tap here'),
-      ),
-      findsNWidgets(2),
-    );
+    if (Platform.isAndroid) {
+      expect(
+        find.byWidgetPredicate(
+          (Widget widget) =>
+              widget is Text && widget.data.startsWith('Tap here'),
+        ),
+        findsNWidgets(2),
+      );
+    } else {
+      expect(
+        find.byWidgetPredicate(
+          (Widget widget) =>
+              widget is Text &&
+              widget.data.startsWith('This plugin only works with Android'),
+        ),
+        findsOneWidget,
+      );
+    }
   });
 
   testWidgets('#launch throws when no Activity is found',

--- a/packages/android_intent/example/test_driver/android_intent_e2e.dart
+++ b/packages/android_intent/example/test_driver/android_intent_e2e.dart
@@ -1,8 +1,12 @@
-import 'package:flutter/material.dart';
-import 'package:flutter_test/flutter_test.dart';
-import 'package:e2e/e2e.dart';
+import 'dart:io';
 
 import 'package:android_intent_example/main.dart';
+import 'package:e2e/e2e.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../lib/android_intent.dart';
 
 /// This is a smoke test that verifies that the example app builds and loads.
 /// Because this plugin works by launching Android platform UIs it's not
@@ -22,4 +26,16 @@ void main() {
       findsNWidgets(2),
     );
   });
+
+  testWidgets('#launch throws when no Activity is found',
+      (WidgetTester tester) async {
+    // We can't test that any of this is really working, this is mostly just
+    // checking that the plugin API is registered. Only works on Android.
+    const AndroidIntent intent =
+        AndroidIntent(action: 'LAUNCH', package: 'foobar');
+    await expectLater(() async => await intent.launch(), throwsA((Exception e) {
+      return e is PlatformException &&
+          e.message.contains('No Activity found to handle Intent');
+    }));
+  }, skip: !Platform.isAndroid);
 }

--- a/packages/android_intent/example/test_driver/android_intent_e2e.dart
+++ b/packages/android_intent/example/test_driver/android_intent_e2e.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:e2e/e2e.dart';
+
+import 'package:android_intent_example/main.dart';
+
+/// This is a smoke test that verifies that the example app builds and loads.
+/// Because this plugin works by launching Android platform UIs it's not
+/// possible to meaningfully test it through its Dart interface currently. There
+/// are more useful unit tests for the platform logic under android/src/test/.
+void main() {
+  E2EWidgetsFlutterBinding.ensureInitialized();
+  testWidgets('Embedding example app loads', (WidgetTester tester) async {
+    // Build our app and trigger a frame.
+    await tester.pumpWidget(MyApp());
+
+    // Verify that the new embedding example app builds
+    expect(
+      find.byWidgetPredicate(
+        (Widget widget) => widget is Text && widget.data.startsWith('Tap here'),
+      ),
+      findsNWidgets(2),
+    );
+  });
+}

--- a/packages/android_intent/example/test_driver/android_intent_e2e_test.dart
+++ b/packages/android_intent/example/test_driver/android_intent_e2e_test.dart
@@ -1,0 +1,12 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_driver/flutter_driver.dart';
+
+Future<void> main() async {
+  final FlutterDriver driver = await FlutterDriver.connect();
+  final String result =
+      await driver.requestData(null, timeout: const Duration(minutes: 1));
+  driver.close();
+  exit(result == 'pass' ? 0 : 1);
+}

--- a/packages/android_intent/pubspec.yaml
+++ b/packages/android_intent/pubspec.yaml
@@ -2,7 +2,7 @@ name: android_intent
 description: Flutter plugin for launching Android Intents. Not supported on iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/android_intent
-version: 0.3.4
+version: 0.3.4+1
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

- Fix minor lint errors in the Java platform code.
- Add a smoke e2e test for the V2 embedding.
- Fully migrate the example app to AndroidX.

## Related Issues

flutter/flutter#41831

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
