### PR TITLE
[in_app_purchase] remove AndroidX constraint

### DIFF
--- a/packages/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 * Android: Use android.arch.lifecycle instead of androidx.lifecycle:lifecycle in `build.gradle` to support apps that has not been migrated to AndroidX.
 
-
 ## 0.2.2
 
 * Support the v2 Android embedder.

--- a/packages/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.2+1
+
+* Fix a regression in 0.2.2 that requires the app to migrate to AndroidX to use the plugin.
+
 ## 0.2.2
 
 * Support the v2 Android embedder.

--- a/packages/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.2.2+1
 
-* Fix a regression in 0.2.2 that requires the app to migrate to AndroidX to use the plugin.
+* Android: Use android.arch.lifecycle instead of androidx.lifecycle:lifecycle in `build.gradle` to support apps that has not been migrated to AndroidX.
+
 
 ## 0.2.2
 

--- a/packages/in_app_purchase/android/build.gradle
+++ b/packages/in_app_purchase/android/build.gradle
@@ -73,9 +73,9 @@ afterEvaluate {
         android {
             dependencies {
                 def lifecycle_version = "1.1.1"
-                api 'android.arch.lifecycle:runtime:$lifecycle_version'
-                api 'android.arch.lifecycle:common:$lifecycle_version'
-                api 'android.arch.lifecycle:common-java8:$lifecycle_version'
+                api "android.arch.lifecycle:runtime:$lifecycle_version"
+                api "android.arch.lifecycle:common:$lifecycle_version"
+                api "android.arch.lifecycle:common-java8:$lifecycle_version"
             }
         }
     }

--- a/packages/in_app_purchase/android/build.gradle
+++ b/packages/in_app_purchase/android/build.gradle
@@ -72,9 +72,10 @@ afterEvaluate {
     if (!containsEmbeddingDependencies) {
         android {
             dependencies {
-                def lifecycle_version = "2.1.0"
-                api "androidx.lifecycle:lifecycle-common-java8:$lifecycle_version"
-                api "androidx.lifecycle:lifecycle-runtime:$lifecycle_version"
+                def lifecycle_version = "1.1.1"
+                api 'android.arch.lifecycle:runtime:$lifecycle_version'
+                api 'android.arch.lifecycle:common:$lifecycle_version'
+                api 'android.arch.lifecycle:common-java8:$lifecycle_version'
             }
         }
     }

--- a/packages/in_app_purchase/android/gradle.properties
+++ b/packages/in_app_purchase/android/gradle.properties
@@ -1,3 +1,1 @@
 org.gradle.jvmargs=-Xmx1536M
-android.useAndroidX=true
-android.enableJetifier=true

--- a/packages/in_app_purchase/android/gradle.properties
+++ b/packages/in_app_purchase/android/gradle.properties
@@ -1,1 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
+android.useAndroidX=true
+android.enableJetifier=true

--- a/packages/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase
 description: A Flutter plugin for in-app purchases. Exposes APIs for making in-app purchases through the App Store and Google Play.
 author:  Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/in_app_purchase
-version: 0.2.2
+version: 0.2.2+1
 
 
 dependencies:


### PR DESCRIPTION
## Description

After 0.2.2, we introduced a constraint that the app uses the plugin has to be migrated to androidx.
This patch removes the constraint.

## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
