### PR TITLE
[package_info]remove AndroidX constraint

### DIFF
--- a/packages/package_info/CHANGELOG.md
+++ b/packages/package_info/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0+9
+
+* Android: Use android.arch.lifecycle instead of androidx.lifecycle:lifecycle in `build.gradle` to support apps that has not been migrated to AndroidX.
+
 ## 0.4.0+8
 
 * Support the v2 Android embedder.

--- a/packages/package_info/android/build.gradle
+++ b/packages/package_info/android/build.gradle
@@ -63,9 +63,10 @@ afterEvaluate {
     if (!containsEmbeddingDependencies) {
         android {
             dependencies {
-                def lifecycle_version = "2.1.0"
-                api "androidx.lifecycle:lifecycle-common-java8:$lifecycle_version"
-                api "androidx.lifecycle:lifecycle-runtime:$lifecycle_version"
+                def lifecycle_version = "1.1.1"
+                api "android.arch.lifecycle:runtime:$lifecycle_version"
+                api "android.arch.lifecycle:common:$lifecycle_version"
+                api "android.arch.lifecycle:common-java8:$lifecycle_version"
             }
         }
     }

--- a/packages/package_info/android/gradle.properties
+++ b/packages/package_info/android/gradle.properties
@@ -1,2 +1,1 @@
 org.gradle.jvmargs=-Xmx1536M
-android.enableJetifier=true

--- a/packages/package_info/pubspec.yaml
+++ b/packages/package_info/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for querying information about the application
   package, such as CFBundleVersion on iOS or versionCode on Android.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/package_info
-version: 0.4.0+8
+version: 0.4.0+9
 
 flutter:
   plugin:
@@ -14,7 +14,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## Description

Android: Use android.arch.lifecycle instead of androidx.lifecycle:lifecycle in build.gradle to support apps that has not been migrated to AndroidX.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
