### PR TITLE
[google_maps_flutter] Avoid unnecessary map element updates (performance)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -52,3 +52,4 @@ Koushik Ravikumar <koushik@tengio.com>
 Nissim Dsilva <nissim@tengio.com>
 Giancarlo Rocha <giancarloiff@gmail.com>
 Ryo Miyake <ryo@miyake.id>
+Théo Champion <contact.theochampion@gmail.com>

--- a/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
@@ -1,317 +1,317 @@
 ## 0.5.25+2
 
-- Avoid unnecessary map elements updates by ignoring not platform related attributes (eg. onTap)
+* Avoid unnecessary map elements updates by ignoring not platform related attributes (eg. onTap)
 
 ## 0.5.25+1
 
-- Add takeSnapshot that takes a snapshot of the map.
+* Add takeSnapshot that takes a snapshot of the map.
 
 ## 0.5.25
 
-- Add an optional param `mipmaps` for `BitmapDescriptor.fromAssetImage`.
+* Add an optional param `mipmaps` for `BitmapDescriptor.fromAssetImage`.
 
 ## 0.5.24+1
 
-- Make the pedantic dev_dependency explicit.
+* Make the pedantic dev_dependency explicit.
 
 ## 0.5.24
 
-- Exposed `getZoomLevel` in `GoogleMapController`.
+* Exposed `getZoomLevel` in `GoogleMapController`.
 
 ## 0.5.23+1
 
-- Move core plugin to its own subdirectory, to prepare for federation.
+* Move core plugin to its own subdirectory, to prepare for federation.
 
 ## 0.5.23
 
-- Add methods to programmatically control markers info windows.
+* Add methods to programmatically control markers info windows.
 
 ## 0.5.22+3
 
-- Fix polygon and circle stroke width according to device density
+* Fix polygon and circle stroke width according to device density
 
 ## 0.5.22+2
 
-- Update README: Add steps to enable Google Map SDK in the Google Developer Console.
+* Update README: Add steps to enable Google Map SDK in the Google Developer Console.
 
 ## 0.5.22+1
 
-- Fix for toggling traffic layer on Android not working
+* Fix for toggling traffic layer on Android not working
 
 ## 0.5.22
 
-- Support Android v2 embedding.
-- Bump the min flutter version to `1.12.13+hotfix.5`.
-- Fixes some e2e tests on Android.
+* Support Android v2 embedding.
+* Bump the min flutter version to `1.12.13+hotfix.5`.
+* Fixes some e2e tests on Android.
 
 ## 0.5.21+17
 
-- Fix Swift example in README.md.
+* Fix Swift example in README.md.
 
 ## 0.5.21+16
 
-- Fixed typo in LatLng's documentation.
+* Fixed typo in LatLng's documentation.
 
 ## 0.5.21+15
 
-- Remove the deprecated `author:` field from pubspec.yaml
-- Migrate the plugin to the pubspec platforms manifest.
-- Require Flutter SDK 1.10.0 or greater.
+* Remove the deprecated `author:` field from pubspec.yaml
+* Migrate the plugin to the pubspec platforms manifest.
+* Require Flutter SDK 1.10.0 or greater.
 
 ## 0.5.21+14
 
-- Adds support for toggling 3D buildings.
+* Adds support for toggling 3D buildings.
 
 ## 0.5.21+13
 
-- Add documentation.
+* Add documentation.
 
 ## 0.5.21+12
 
-- Update driver tests in the example app to e2e tests.
+* Update driver tests in the example app to e2e tests.
 
 ## 0.5.21+11
 
-- Define clang module for iOS, fix analyzer warnings.
+* Define clang module for iOS, fix analyzer warnings.
 
 ## 0.5.21+10
 
-- Cast error.code to unsigned long to avoid using NSInteger as %ld format warnings.
+* Cast error.code to unsigned long to avoid using NSInteger as %ld format warnings.
 
 ## 0.5.21+9
 
-- Remove AndroidX warnings.
+* Remove AndroidX warnings.
 
 ## 0.5.21+8
 
-- Add NS*ASSUME_NONNULL*\* macro to reduce iOS compiler warnings.
+* Add NS*ASSUME_NONNULL*\* macro to reduce iOS compiler warnings.
 
 ## 0.5.21+7
 
-- Create a clone of cached elements in GoogleMap (Polyline, Polygon, etc.) to detect modifications
+* Create a clone of cached elements in GoogleMap (Polyline, Polygon, etc.) to detect modifications
   if these objects are mutated instead of modified by copy.
 
 ## 0.5.21+6
 
-- Override a default method to work around flutter/flutter#40126.
+* Override a default method to work around flutter/flutter#40126.
 
 ## 0.5.21+5
 
-- Update and migrate iOS example project.
+* Update and migrate iOS example project.
 
 ## 0.5.21+4
 
-- Support projection methods to translate between screen and latlng coordinates.
+* Support projection methods to translate between screen and latlng coordinates.
 
 ## 0.5.21+3
 
-- Fix `myLocationButton` bug in `google_maps_flutter` iOS.
+* Fix `myLocationButton` bug in `google_maps_flutter` iOS.
 
 ## 0.5.21+2
 
-- Fix more `prefer_const_constructors` analyzer warnings in example app.
+* Fix more `prefer_const_constructors` analyzer warnings in example app.
 
 ## 0.5.21+1
 
-- Fix `prefer_const_constructors` analyzer warnings in example app.
+* Fix `prefer_const_constructors` analyzer warnings in example app.
 
 ## 0.5.21
 
-- Don't recreate map elements if they didn't change since last widget build.
+* Don't recreate map elements if they didn't change since last widget build.
 
 ## 0.5.20+6
 
-- Adds support for toggling the traffic layer
+* Adds support for toggling the traffic layer
 
 ## 0.5.20+5
 
-- Allow (de-)serialization of CameraPosition
+* Allow (de-)serialization of CameraPosition
 
 ## 0.5.20+4
 
-- Marker drag event
+* Marker drag event
 
 ## 0.5.20+3
 
-- Update Android play-services-maps to 17.0.0
+* Update Android play-services-maps to 17.0.0
 
 ## 0.5.20+2
 
-- Android: Fix polyline width in building phase.
+* Android: Fix polyline width in building phase.
 
 ## 0.5.20+1
 
-- Android: Unregister ActivityLifecycleCallbacks on activity destroy (fixes a memory leak).
+* Android: Unregister ActivityLifecycleCallbacks on activity destroy (fixes a memory leak).
 
 ## 0.5.20
 
-- Add map toolbar support
+* Add map toolbar support
 
 ## 0.5.19+2
 
-- Fix polygons for iOS
+* Fix polygons for iOS
 
 ## 0.5.19+1
 
-- Fix polyline width according to device density
+* Fix polyline width according to device density
 
 ## 0.5.19
 
-- Adds support for toggling Indoor View on or off.
+* Adds support for toggling Indoor View on or off.
 
-- Allow BitmapDescriptor scaling override
+* Allow BitmapDescriptor scaling override
 
 ## 0.5.18
 
-- Fixed build issue on iOS.
+* Fixed build issue on iOS.
 
 ## 0.5.17
 
-- Add support for Padding.
+* Add support for Padding.
 
 ## 0.5.16+1
 
-- Update Dart code to conform to current Dart formatter.
+* Update Dart code to conform to current Dart formatter.
 
 ## 0.5.16
 
-- Add support for custom map styling.
+* Add support for custom map styling.
 
 ## 0.5.15+1
 
-- Add missing template type parameter to `invokeMethod` calls.
-- Bump minimum Flutter version to 1.5.0.
-- Replace invokeMethod with invokeMapMethod wherever necessary.
+* Add missing template type parameter to `invokeMethod` calls.
+* Bump minimum Flutter version to 1.5.0.
+* Replace invokeMethod with invokeMapMethod wherever necessary.
 
 ## 0.5.15
 
-- Add support for Polygons.
+* Add support for Polygons.
 
 ## 0.5.14+1
 
-- Example app update(comment out usage of the ImageStreamListener API which has a breaking change
+* Example app update(comment out usage of the ImageStreamListener API which has a breaking change
   that's not yet on master). See: https://github.com/flutter/flutter/issues/33438
 
 ## 0.5.14
 
-- Adds onLongPress callback for GoogleMap.
+* Adds onLongPress callback for GoogleMap.
 
 ## 0.5.13
 
-- Add support for Circle overlays.
+* Add support for Circle overlays.
 
 ## 0.5.12
 
-- Prevent calling null callbacks and callbacks on removed objects.
+* Prevent calling null callbacks and callbacks on removed objects.
 
 ## 0.5.11+1
 
-- Android: Fix an issue where myLocationButtonEnabled setting was not propagated when set to false onMapLoad.
+* Android: Fix an issue where myLocationButtonEnabled setting was not propagated when set to false onMapLoad.
 
 ## 0.5.11
 
-- Add myLocationButtonEnabled option.
+* Add myLocationButtonEnabled option.
 
 ## 0.5.10
 
-- Support Color's alpha channel when converting to UIColor on iOS.
+* Support Color's alpha channel when converting to UIColor on iOS.
 
 ## 0.5.9
 
-- BitmapDescriptor#fromBytes accounts for screen scale on ios.
+* BitmapDescriptor#fromBytes accounts for screen scale on ios.
 
 ## 0.5.8
 
-- Remove some unused variables and rename method
+* Remove some unused variables and rename method
 
 ## 0.5.7
 
-- Add a BitmapDescriptor that is aware of scale.
+* Add a BitmapDescriptor that is aware of scale.
 
 ## 0.5.6
 
-- Add support for Polylines on GoogleMap.
+* Add support for Polylines on GoogleMap.
 
 ## 0.5.5
 
-- Enable iOS accessibility.
+* Enable iOS accessibility.
 
 ## 0.5.4
 
-- Add method getVisibleRegion for get the latlng bounds of the visible map area.
+* Add method getVisibleRegion for get the latlng bounds of the visible map area.
 
 ## 0.5.3
 
-- Added support setting marker icons from bytes.
+* Added support setting marker icons from bytes.
 
 ## 0.5.2
 
-- Added onTap for callback for GoogleMap.
+* Added onTap for callback for GoogleMap.
 
 ## 0.5.1
 
-- Update Android gradle version.
-- Added infrastructure to write integration tests.
+* Update Android gradle version.
+* Added infrastructure to write integration tests.
 
 ## 0.5.0
 
-- Add a key parameter to the GoogleMap widget.
+* Add a key parameter to the GoogleMap widget.
 
 ## 0.4.0
 
-- Change events are call backs on GoogleMap widget.
-- GoogleMapController no longer handles change events.
-- trackCameraPosition is inferred from GoogleMap.onCameraMove being set.
+* Change events are call backs on GoogleMap widget.
+* GoogleMapController no longer handles change events.
+* trackCameraPosition is inferred from GoogleMap.onCameraMove being set.
 
 ## 0.3.0+3
 
-- Update Android play-services-maps to 16.1.0
+* Update Android play-services-maps to 16.1.0
 
 ## 0.3.0+2
 
-- Address an issue on iOS where icons were not loading.
-- Add apache http library required false for Android.
+* Address an issue on iOS where icons were not loading.
+* Add apache http library required false for Android.
 
 ## 0.3.0+1
 
-- Add NSNull Checks for markers controller in iOS.
-- Also address an issue where initial markers are set before initialization.
+* Add NSNull Checks for markers controller in iOS.
+* Also address an issue where initial markers are set before initialization.
 
 ## 0.3.0
 
-- **Breaking change**. Changed the Marker API to be
+* **Breaking change**. Changed the Marker API to be
   widget based, it was controller based. Also changed the
   example app to account for the same.
 
 ## 0.2.0+6
 
-- Updated the sample app in README.md.
+* Updated the sample app in README.md.
 
 ## 0.2.0+5
 
-- Skip the Gradle Android permissions lint for MyLocation (https://github.com/flutter/flutter/issues/28339)
-- Suppress unchecked cast warning for the PlatformViewFactory creation parameters.
+* Skip the Gradle Android permissions lint for MyLocation (https://github.com/flutter/flutter/issues/28339)
+* Suppress unchecked cast warning for the PlatformViewFactory creation parameters.
 
 ## 0.2.0+4
 
-- Fixed a crash when the plugin is registered by a background FlutterView.
+* Fixed a crash when the plugin is registered by a background FlutterView.
 
 ## 0.2.0+3
 
-- Fixed a memory leak on Android - the map was not properly disposed.
+* Fixed a memory leak on Android - the map was not properly disposed.
 
 ## 0.2.0+2
 
-- Log a more detailed warning at build time about the previous AndroidX
+* Log a more detailed warning at build time about the previous AndroidX
   migration.
 
 ## 0.2.0+1
 
-- Fixed a bug which the camera is not positioned correctly at map initialization(temporary workaround)(https://github.com/flutter/flutter/issues/27550).
+* Fixed a bug which the camera is not positioned correctly at map initialization(temporary workaround)(https://github.com/flutter/flutter/issues/27550).
 
 ## 0.2.0
 
-- **Breaking change**. Migrate from the deprecated original Android Support
+* **Breaking change**. Migrate from the deprecated original Android Support
   Library to AndroidX. This shouldn't result in any functional changes, but it
   requires any Android apps using this plugin to [also
   migrate](https://developer.android.com/jetpack/androidx/migrate) if they're
@@ -319,26 +319,26 @@
 
 ## 0.1.0
 
-- Move the map options from the GoogleMapOptions class to GoogleMap widget parameters.
+* Move the map options from the GoogleMapOptions class to GoogleMap widget parameters.
 
 ## 0.0.3+3
 
-- Relax Flutter version requirement to 0.11.9.
+* Relax Flutter version requirement to 0.11.9.
 
 ## 0.0.3+2
 
-- Update README to recommend using the package from pub.
+* Update README to recommend using the package from pub.
 
 ## 0.0.3+1
 
-- Bug fix: custom marker images were not working on iOS as we were not keeping
+* Bug fix: custom marker images were not working on iOS as we were not keeping
   a reference to the plugin registrar so couldn't fetch assets.
 
 ## 0.0.3
 
-- Don't export `dart:async`.
-- Update the minimal required Flutter SDK version to one that supports embedding platform views.
+* Don't export `dart:async`.
+* Update the minimal required Flutter SDK version to one that supports embedding platform views.
 
 ## 0.0.2
 
-- Initial developers preview release.
+* Initial developers preview release.

--- a/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
@@ -1,315 +1,317 @@
+## 0.5.25+2
+
+- Avoid unnecessary map elements updates by ignoring not platform related attributes (eg. onTap)
+
 ## 0.5.25+1
 
-* Add takeSnapshot that takes a snapshot of the map.
+- Add takeSnapshot that takes a snapshot of the map.
 
 ## 0.5.25
 
-* Add an optional param `mipmaps` for `BitmapDescriptor.fromAssetImage`.
+- Add an optional param `mipmaps` for `BitmapDescriptor.fromAssetImage`.
 
 ## 0.5.24+1
 
-* Make the pedantic dev_dependency explicit.
+- Make the pedantic dev_dependency explicit.
 
 ## 0.5.24
 
-* Exposed `getZoomLevel` in `GoogleMapController`.
+- Exposed `getZoomLevel` in `GoogleMapController`.
 
 ## 0.5.23+1
 
-* Move core plugin to its own subdirectory, to prepare for federation.
+- Move core plugin to its own subdirectory, to prepare for federation.
 
 ## 0.5.23
 
-* Add methods to programmatically control markers info windows.
+- Add methods to programmatically control markers info windows.
 
 ## 0.5.22+3
 
-* Fix polygon and circle stroke width according to device density
+- Fix polygon and circle stroke width according to device density
 
 ## 0.5.22+2
 
-* Update README: Add steps to enable Google Map SDK in the Google Developer Console.
+- Update README: Add steps to enable Google Map SDK in the Google Developer Console.
 
 ## 0.5.22+1
 
-* Fix for toggling traffic layer on Android not working
+- Fix for toggling traffic layer on Android not working
 
 ## 0.5.22
 
-* Support Android v2 embedding.
-* Bump the min flutter version to `1.12.13+hotfix.5`.
-* Fixes some e2e tests on Android.
+- Support Android v2 embedding.
+- Bump the min flutter version to `1.12.13+hotfix.5`.
+- Fixes some e2e tests on Android.
 
 ## 0.5.21+17
 
-* Fix Swift example in README.md.
+- Fix Swift example in README.md.
 
 ## 0.5.21+16
 
-* Fixed typo in LatLng's documentation.
+- Fixed typo in LatLng's documentation.
 
 ## 0.5.21+15
 
-* Remove the deprecated `author:` field from pubspec.yaml
-* Migrate the plugin to the pubspec platforms manifest.
-* Require Flutter SDK 1.10.0 or greater.
+- Remove the deprecated `author:` field from pubspec.yaml
+- Migrate the plugin to the pubspec platforms manifest.
+- Require Flutter SDK 1.10.0 or greater.
 
 ## 0.5.21+14
 
-* Adds support for toggling 3D buildings.
+- Adds support for toggling 3D buildings.
 
 ## 0.5.21+13
 
-* Add documentation.
+- Add documentation.
 
 ## 0.5.21+12
 
-* Update driver tests in the example app to e2e tests.
+- Update driver tests in the example app to e2e tests.
 
 ## 0.5.21+11
 
-* Define clang module for iOS, fix analyzer warnings.
+- Define clang module for iOS, fix analyzer warnings.
 
 ## 0.5.21+10
 
-* Cast error.code to unsigned long to avoid using NSInteger as %ld format warnings.
+- Cast error.code to unsigned long to avoid using NSInteger as %ld format warnings.
 
 ## 0.5.21+9
 
-* Remove AndroidX warnings.
+- Remove AndroidX warnings.
 
 ## 0.5.21+8
 
-* Add NS_ASSUME_NONNULL_* macro to reduce iOS compiler warnings.
+- Add NS*ASSUME_NONNULL*\* macro to reduce iOS compiler warnings.
 
 ## 0.5.21+7
 
-* Create a clone of cached elements in GoogleMap (Polyline, Polygon, etc.) to detect modifications
+- Create a clone of cached elements in GoogleMap (Polyline, Polygon, etc.) to detect modifications
   if these objects are mutated instead of modified by copy.
 
 ## 0.5.21+6
 
-* Override a default method to work around flutter/flutter#40126.
+- Override a default method to work around flutter/flutter#40126.
 
 ## 0.5.21+5
 
-* Update and migrate iOS example project.
+- Update and migrate iOS example project.
 
 ## 0.5.21+4
 
-* Support projection methods to translate between screen and latlng coordinates.
+- Support projection methods to translate between screen and latlng coordinates.
 
 ## 0.5.21+3
 
-* Fix `myLocationButton` bug in `google_maps_flutter` iOS.
+- Fix `myLocationButton` bug in `google_maps_flutter` iOS.
 
 ## 0.5.21+2
 
-* Fix more `prefer_const_constructors` analyzer warnings in example app.
+- Fix more `prefer_const_constructors` analyzer warnings in example app.
 
 ## 0.5.21+1
 
-* Fix `prefer_const_constructors` analyzer warnings in example app.
+- Fix `prefer_const_constructors` analyzer warnings in example app.
 
 ## 0.5.21
 
-* Don't recreate map elements if they didn't change since last widget build.
+- Don't recreate map elements if they didn't change since last widget build.
 
 ## 0.5.20+6
 
-* Adds support for toggling the traffic layer
+- Adds support for toggling the traffic layer
 
 ## 0.5.20+5
 
-* Allow (de-)serialization of CameraPosition
+- Allow (de-)serialization of CameraPosition
 
 ## 0.5.20+4
 
-* Marker drag event
+- Marker drag event
 
 ## 0.5.20+3
 
-* Update Android play-services-maps to 17.0.0
+- Update Android play-services-maps to 17.0.0
 
 ## 0.5.20+2
 
-* Android: Fix polyline width in building phase.
+- Android: Fix polyline width in building phase.
 
 ## 0.5.20+1
 
-* Android: Unregister ActivityLifecycleCallbacks on activity destroy (fixes a memory leak).
+- Android: Unregister ActivityLifecycleCallbacks on activity destroy (fixes a memory leak).
 
 ## 0.5.20
 
-* Add map toolbar support
+- Add map toolbar support
 
 ## 0.5.19+2
 
-* Fix polygons for iOS
+- Fix polygons for iOS
 
 ## 0.5.19+1
 
-* Fix polyline width according to device density
+- Fix polyline width according to device density
 
 ## 0.5.19
 
+- Adds support for toggling Indoor View on or off.
 
-* Adds support for toggling Indoor View on or off.
-
-* Allow BitmapDescriptor scaling override
-
+- Allow BitmapDescriptor scaling override
 
 ## 0.5.18
 
-* Fixed build issue on iOS.
+- Fixed build issue on iOS.
 
 ## 0.5.17
 
-* Add support for Padding.
+- Add support for Padding.
 
 ## 0.5.16+1
 
-* Update Dart code to conform to current Dart formatter.
+- Update Dart code to conform to current Dart formatter.
 
 ## 0.5.16
 
-* Add support for custom map styling.
+- Add support for custom map styling.
 
 ## 0.5.15+1
 
-* Add missing template type parameter to `invokeMethod` calls.
-* Bump minimum Flutter version to 1.5.0.
-* Replace invokeMethod with invokeMapMethod wherever necessary.
+- Add missing template type parameter to `invokeMethod` calls.
+- Bump minimum Flutter version to 1.5.0.
+- Replace invokeMethod with invokeMapMethod wherever necessary.
 
 ## 0.5.15
 
-* Add support for Polygons.
+- Add support for Polygons.
 
 ## 0.5.14+1
 
-* Example app update(comment out usage of the ImageStreamListener API which has a breaking change
+- Example app update(comment out usage of the ImageStreamListener API which has a breaking change
   that's not yet on master). See: https://github.com/flutter/flutter/issues/33438
 
 ## 0.5.14
 
-* Adds onLongPress callback for GoogleMap.
+- Adds onLongPress callback for GoogleMap.
 
 ## 0.5.13
 
-* Add support for Circle overlays.
+- Add support for Circle overlays.
 
 ## 0.5.12
 
-* Prevent calling null callbacks and callbacks on removed objects.
+- Prevent calling null callbacks and callbacks on removed objects.
 
 ## 0.5.11+1
 
-* Android: Fix an issue where myLocationButtonEnabled setting was not propagated when set to false onMapLoad.
+- Android: Fix an issue where myLocationButtonEnabled setting was not propagated when set to false onMapLoad.
 
 ## 0.5.11
 
-* Add myLocationButtonEnabled option.
+- Add myLocationButtonEnabled option.
 
 ## 0.5.10
 
-* Support Color's alpha channel when converting to UIColor on iOS.
+- Support Color's alpha channel when converting to UIColor on iOS.
 
 ## 0.5.9
 
-* BitmapDescriptor#fromBytes accounts for screen scale on ios.
+- BitmapDescriptor#fromBytes accounts for screen scale on ios.
 
 ## 0.5.8
 
-* Remove some unused variables and rename method
+- Remove some unused variables and rename method
 
 ## 0.5.7
 
-* Add a BitmapDescriptor that is aware of scale.
+- Add a BitmapDescriptor that is aware of scale.
 
 ## 0.5.6
 
-* Add support for Polylines on GoogleMap.
+- Add support for Polylines on GoogleMap.
 
 ## 0.5.5
 
-* Enable iOS accessibility.
+- Enable iOS accessibility.
 
 ## 0.5.4
 
-* Add method getVisibleRegion for get the latlng bounds of the visible map area.
+- Add method getVisibleRegion for get the latlng bounds of the visible map area.
 
 ## 0.5.3
 
-* Added support setting marker icons from bytes.
+- Added support setting marker icons from bytes.
 
 ## 0.5.2
 
-* Added onTap for callback for GoogleMap.
+- Added onTap for callback for GoogleMap.
 
 ## 0.5.1
 
-* Update Android gradle version.
-* Added infrastructure to write integration tests.
+- Update Android gradle version.
+- Added infrastructure to write integration tests.
 
 ## 0.5.0
 
-* Add a key parameter to the GoogleMap widget.
+- Add a key parameter to the GoogleMap widget.
 
 ## 0.4.0
 
-* Change events are call backs on GoogleMap widget.
-* GoogleMapController no longer handles change events.
-* trackCameraPosition is inferred from GoogleMap.onCameraMove being set.
+- Change events are call backs on GoogleMap widget.
+- GoogleMapController no longer handles change events.
+- trackCameraPosition is inferred from GoogleMap.onCameraMove being set.
 
 ## 0.3.0+3
 
-* Update Android play-services-maps to 16.1.0
+- Update Android play-services-maps to 16.1.0
 
 ## 0.3.0+2
 
-* Address an issue on iOS where icons were not loading.
-* Add apache http library required false for Android.
+- Address an issue on iOS where icons were not loading.
+- Add apache http library required false for Android.
 
 ## 0.3.0+1
 
-* Add NSNull Checks for markers controller in iOS.
-* Also address an issue where initial markers are set before initialization.
+- Add NSNull Checks for markers controller in iOS.
+- Also address an issue where initial markers are set before initialization.
 
 ## 0.3.0
 
-* **Breaking change**. Changed the Marker API to be
+- **Breaking change**. Changed the Marker API to be
   widget based, it was controller based. Also changed the
   example app to account for the same.
 
 ## 0.2.0+6
 
-* Updated the sample app in README.md.
+- Updated the sample app in README.md.
 
 ## 0.2.0+5
 
-* Skip the Gradle Android permissions lint for MyLocation (https://github.com/flutter/flutter/issues/28339)
-* Suppress unchecked cast warning for the PlatformViewFactory creation parameters.
+- Skip the Gradle Android permissions lint for MyLocation (https://github.com/flutter/flutter/issues/28339)
+- Suppress unchecked cast warning for the PlatformViewFactory creation parameters.
 
 ## 0.2.0+4
 
-* Fixed a crash when the plugin is registered by a background FlutterView.
+- Fixed a crash when the plugin is registered by a background FlutterView.
 
 ## 0.2.0+3
 
-* Fixed a memory leak on Android - the map was not properly disposed.
+- Fixed a memory leak on Android - the map was not properly disposed.
 
 ## 0.2.0+2
 
-* Log a more detailed warning at build time about the previous AndroidX
+- Log a more detailed warning at build time about the previous AndroidX
   migration.
 
 ## 0.2.0+1
 
-* Fixed a bug which the camera is not positioned correctly at map initialization(temporary workaround)(https://github.com/flutter/flutter/issues/27550).
+- Fixed a bug which the camera is not positioned correctly at map initialization(temporary workaround)(https://github.com/flutter/flutter/issues/27550).
 
 ## 0.2.0
 
-* **Breaking change**. Migrate from the deprecated original Android Support
+- **Breaking change**. Migrate from the deprecated original Android Support
   Library to AndroidX. This shouldn't result in any functional changes, but it
   requires any Android apps using this plugin to [also
   migrate](https://developer.android.com/jetpack/androidx/migrate) if they're
@@ -317,26 +319,26 @@
 
 ## 0.1.0
 
-* Move the map options from the GoogleMapOptions class to GoogleMap widget parameters.
+- Move the map options from the GoogleMapOptions class to GoogleMap widget parameters.
 
 ## 0.0.3+3
 
-* Relax Flutter version requirement to 0.11.9.
+- Relax Flutter version requirement to 0.11.9.
 
 ## 0.0.3+2
 
-* Update README to recommend using the package from pub.
+- Update README to recommend using the package from pub.
 
 ## 0.0.3+1
 
-* Bug fix: custom marker images were not working on iOS as we were not keeping
+- Bug fix: custom marker images were not working on iOS as we were not keeping
   a reference to the plugin registrar so couldn't fetch assets.
 
 ## 0.0.3
 
-* Don't export `dart:async`.
-* Update the minimal required Flutter SDK version to one that supports embedding platform views.
+- Don't export `dart:async`.
+- Update the minimal required Flutter SDK version to one that supports embedding platform views.
 
 ## 0.0.2
 
-* Initial developers preview release.
+- Initial developers preview release.

--- a/packages/google_maps_flutter/google_maps_flutter/lib/src/circle.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/lib/src/circle.dart
@@ -154,8 +154,7 @@ class Circle {
         strokeColor == typedOther.strokeColor &&
         strokeWidth == typedOther.strokeWidth &&
         visible == typedOther.visible &&
-        zIndex == typedOther.zIndex &&
-        onTap == typedOther.onTap;
+        zIndex == typedOther.zIndex;
   }
 
   @override

--- a/packages/google_maps_flutter/google_maps_flutter/lib/src/marker.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/lib/src/marker.dart
@@ -302,8 +302,7 @@ class Marker {
         position == typedOther.position &&
         rotation == typedOther.rotation &&
         visible == typedOther.visible &&
-        zIndex == typedOther.zIndex &&
-        onTap == typedOther.onTap;
+        zIndex == typedOther.zIndex;
   }
 
   @override

--- a/packages/google_maps_flutter/google_maps_flutter/lib/src/polygon.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/lib/src/polygon.dart
@@ -165,8 +165,7 @@ class Polygon {
         visible == typedOther.visible &&
         strokeColor == typedOther.strokeColor &&
         strokeWidth == typedOther.strokeWidth &&
-        zIndex == typedOther.zIndex &&
-        onTap == typedOther.onTap;
+        zIndex == typedOther.zIndex;
   }
 
   @override

--- a/packages/google_maps_flutter/google_maps_flutter/lib/src/polyline.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/lib/src/polyline.dart
@@ -216,8 +216,7 @@ class Polyline {
         endCap == typedOther.endCap &&
         visible == typedOther.visible &&
         width == typedOther.width &&
-        zIndex == typedOther.zIndex &&
-        onTap == typedOther.onTap;
+        zIndex == typedOther.zIndex;
   }
 
   @override

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -29,5 +29,5 @@ flutter:
         pluginClass: FLTGoogleMapsPlugin
 
 environment:
-  sdk: '>=2.0.0-dev.47.0 <3.0.0'
-  flutter: '>=1.12.13+hotfix.5 <2.0.0'
+  sdk: ">=2.0.0-dev.47.0 <3.0.0"
+  flutter: ">=1.12.13+hotfix.5 <2.0.0"

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -28,7 +28,6 @@ flutter:
       ios:
         pluginClass: FLTGoogleMapsPlugin
 
-
 environment:
-  sdk: ">=2.0.0-dev.47.0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.5 <2.0.0"
+  sdk: '>=2.0.0-dev.47.0 <3.0.0'
+  flutter: '>=1.12.13+hotfix.5 <2.0.0'

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter/google_maps_flutter
-version: 0.5.25+1
+version: 0.5.25+2
 
 dependencies:
   flutter:

--- a/packages/google_maps_flutter/google_maps_flutter/test/circle_updates_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/test/circle_updates_test.dart
@@ -190,4 +190,21 @@ void main() {
     expect(platformGoogleMap.circleIdsToRemove.isEmpty, true);
     expect(platformGoogleMap.circlesToAdd.isEmpty, true);
   });
+
+  testWidgets("Update non platform related attr", (WidgetTester tester) async {
+    Circle c1 = Circle(circleId: CircleId("circle_1"));
+    final Set<Circle> prev = _toSet(c1: c1);
+    c1 = Circle(circleId: CircleId("circle_1"), onTap: () => print("hello"));
+    final Set<Circle> cur = _toSet(c1: c1);
+
+    await tester.pumpWidget(_mapWithCircles(prev));
+    await tester.pumpWidget(_mapWithCircles(cur));
+
+    final FakePlatformGoogleMap platformGoogleMap =
+        fakePlatformViewsController.lastCreatedView;
+
+    expect(platformGoogleMap.circlesToChange.isEmpty, true);
+    expect(platformGoogleMap.circleIdsToRemove.isEmpty, true);
+    expect(platformGoogleMap.circlesToAdd.isEmpty, true);
+  });
 }

--- a/packages/google_maps_flutter/google_maps_flutter/test/marker_updates_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/test/marker_updates_test.dart
@@ -193,4 +193,24 @@ void main() {
     expect(platformGoogleMap.markerIdsToRemove.isEmpty, true);
     expect(platformGoogleMap.markersToAdd.isEmpty, true);
   });
+
+  testWidgets("Update non platform related attr", (WidgetTester tester) async {
+    Marker m1 = Marker(markerId: MarkerId("marker_1"));
+    final Set<Marker> prev = _toSet(m1: m1);
+    m1 = Marker(
+        markerId: MarkerId("marker_1"),
+        onTap: () => print("hello"),
+        onDragEnd: (LatLng latLng) => print(latLng));
+    final Set<Marker> cur = _toSet(m1: m1);
+
+    await tester.pumpWidget(_mapWithMarkers(prev));
+    await tester.pumpWidget(_mapWithMarkers(cur));
+
+    final FakePlatformGoogleMap platformGoogleMap =
+        fakePlatformViewsController.lastCreatedView;
+
+    expect(platformGoogleMap.markersToChange.isEmpty, true);
+    expect(platformGoogleMap.markerIdsToRemove.isEmpty, true);
+    expect(platformGoogleMap.markersToAdd.isEmpty, true);
+  });
 }

--- a/packages/google_maps_flutter/google_maps_flutter/test/polygon_updates_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/test/polygon_updates_test.dart
@@ -211,4 +211,21 @@ void main() {
     expect(platformGoogleMap.polygonIdsToRemove.isEmpty, true);
     expect(platformGoogleMap.polygonsToAdd.isEmpty, true);
   });
+
+  testWidgets("Update non platform related attr", (WidgetTester tester) async {
+    Polygon p1 = Polygon(polygonId: PolygonId("polygon_1"));
+    final Set<Polygon> prev = _toSet(p1: p1);
+    p1 = Polygon(polygonId: PolygonId("polygon_1"), onTap: () => print(2 + 2));
+    final Set<Polygon> cur = _toSet(p1: p1);
+
+    await tester.pumpWidget(_mapWithPolygons(prev));
+    await tester.pumpWidget(_mapWithPolygons(cur));
+
+    final FakePlatformGoogleMap platformGoogleMap =
+        fakePlatformViewsController.lastCreatedView;
+
+    expect(platformGoogleMap.polygonsToChange.isEmpty, true);
+    expect(platformGoogleMap.polygonIdsToRemove.isEmpty, true);
+    expect(platformGoogleMap.polygonsToAdd.isEmpty, true);
+  });
 }

--- a/packages/google_maps_flutter/google_maps_flutter/test/polyline_updates_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/test/polyline_updates_test.dart
@@ -211,4 +211,26 @@ void main() {
     expect(platformGoogleMap.polylineIdsToRemove.isEmpty, true);
     expect(platformGoogleMap.polylinesToAdd.isEmpty, true);
   });
+
+  testWidgets("Update non platform related attr", (WidgetTester tester) async {
+    Polyline p1 = Polyline(polylineId: PolylineId("polyline_1"), onTap: null);
+    final Set<Polyline> prev = _toSet(
+      p1: p1,
+    );
+    p1 = Polyline(
+        polylineId: PolylineId("polyline_1"), onTap: () => print(2 + 2));
+    final Set<Polyline> cur = _toSet(
+      p1: p1,
+    );
+
+    await tester.pumpWidget(_mapWithPolylines(prev));
+    await tester.pumpWidget(_mapWithPolylines(cur));
+
+    final FakePlatformGoogleMap platformGoogleMap =
+        fakePlatformViewsController.lastCreatedView;
+
+    expect(platformGoogleMap.polylinesToChange.isEmpty, true);
+    expect(platformGoogleMap.polylineIdsToRemove.isEmpty, true);
+    expect(platformGoogleMap.polylinesToAdd.isEmpty, true);
+  });
 }


### PR DESCRIPTION
## Description

Currently, all attributes of map elements are taken into account when computing which one have changed and needs to be rebuilt. This causes changes in attributes that are not related to the platform (like `onTap` or `onDragEnd`) to trigger an unnecessary rebuild of the element. This is especially problematic as new instances of closures are often used in those handlers resulting in lots of unnecessary rebuilds.

This PR address that problem by ensuring attributes not related to the platform are ignored when comparing elements for change.

## Related Issues

This PR reduces drastically performance problems explained in this issue:
https://github.com/flutter/flutter/issues/41731

However, this is only one part of the problem, so this issue still needs some love <3

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
