### PR TITLE
Bump google_maps_flutter pubspec version to match CHANGELOG

### DIFF
--- a/packages/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter
-version: 0.5.21+9
+version: 0.5.21+10
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Description

https://github.com/flutter/plugins/pull/2242 added a new CHANGELOG version but did not bump the pubspec version.

Update to 0.5.21+10.