### PR TITLE
Update cirrus to create IOS simulator on 13.2 an xCode 11

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -82,7 +82,7 @@ task:
 task:
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   osx_instance:
-    image: mojave-xcode-10.2-flutter
+    image: mojave-xcode-11.2.1-flutter
   setup_script:
     - pod repo update
   upgrade_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -82,7 +82,7 @@ task:
 task:
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   osx_instance:
-    image: mojave-xcode-11.2.1-flutter
+    image: mojave-flutter
   setup_script:
     - pod repo update
   upgrade_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -82,7 +82,7 @@ task:
 task:
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   osx_instance:
-    image: mojave-flutter
+    image: mojave-xcode-11.2.1-flutter
   setup_script:
     - pod repo update
   upgrade_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -94,7 +94,7 @@ task:
   activate_script: pub global activate flutter_plugin_tools
   create_simulator_script:
     - xcrun simctl list
-    - xcrun simctl create Flutter-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-X com.apple.CoreSimulator.SimRuntime.iOS-12-2 | xargs xcrun simctl boot
+    - xcrun simctl create Flutter-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-X com.apple.CoreSimulator.SimRuntime.iOS-13-2 | xargs xcrun simctl boot
   matrix:
     - name: build_all_plugins_ipa
       script:

--- a/packages/e2e/example/pubspec.yaml
+++ b/packages/e2e/example/pubspec.yaml
@@ -1,5 +1,6 @@
 name: e2e_example
 description: Demonstrates how to use the e2e plugin.
+version: 0.0.1
 publish_to: 'none'
 
 environment:


### PR DESCRIPTION
Also fixed a complier failure after upgrading to xcode11

PRs in plugin repo are failing CIs at the step of creating iOS simulator like https://github.com/flutter/plugins/pull/2083

cirrus console link: https://cirrus-ci.com/task/5575560322875392