### PR TITLE
[webview_flutter] Add setter and getter for cookies

### DIFF
--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.20
+
+* Add support to set and get cookies fo iOS and Android. For iOS, the cookies
+  are now also shared across WebViews with a ProcessPool
+
 ## 0.3.19+5
 
 * On iOS, always keep contentInsets of the WebView to be 0.
@@ -50,7 +55,7 @@
 ## 0.3.15+3
 
 * Re-land support for the v2 Android embedding. This correctly sets the minimum
-  SDK to the latest stable and avoid any compile errors. *WARNING:* the V2
+  SDK to the latest stable and avoid any compile errors. _WARNING:_ the V2
   embedding itself still requires the current Flutter master channel
   (flutter/flutter@1d4d63a) for text input to work properly on all Android
   versions.
@@ -188,7 +193,7 @@
 
 ## 0.3.6+1
 
-* Remove un-used method params in webview\_flutter
+* Remove un-used method params in webview_flutter
 
 ## 0.3.6
 

--- a/packages/webview_flutter/ios/Classes/FLTCookieManager.m
+++ b/packages/webview_flutter/ios/Classes/FLTCookieManager.m
@@ -19,6 +19,10 @@
 - (void)handleMethodCall:(FlutterMethodCall *)call result:(FlutterResult)result {
   if ([[call method] isEqualToString:@"clearCookies"]) {
     [self clearCookies:result];
+  } else if ([[call method] isEqualToString:@"setCookies"]) {
+    [self setCookies:call result:result];
+  } else if ([[call method] isEqualToString:@"getCookies"]) {
+    [self getCookies:call result:result];
   } else {
     result(FlutterMethodNotImplemented);
   }
@@ -43,7 +47,111 @@
   } else {
     // support for iOS8 tracked in https://github.com/flutter/flutter/issues/27624.
     NSLog(@"Clearing cookies is not supported for Flutter WebViews prior to iOS 9.");
+    result([FlutterError
+        errorWithCode:@"not supported"
+              message:@"Clearing cookies is not supported for Flutter WebViews prior to iOS 9."
+              details:nil]);
   }
+}
+
+- (void)setCookies:(FlutterMethodCall *)call result:(FlutterResult)result {
+  if (@available(iOS 11.0, *)) {
+    NSMutableArray<NSHTTPCookie *> *cookies = [[NSMutableArray<NSHTTPCookie *> alloc] init];
+    for (NSDictionary *input in call.arguments) {
+      [cookies addObject:[self dictionaryToCookie:input]];
+    }
+    WKWebsiteDataStore *dataStore = [WKWebsiteDataStore defaultDataStore];
+    WKHTTPCookieStore *cookieStore = [dataStore httpCookieStore];
+    __block int counter = 0;
+
+    for (NSHTTPCookie *cookie in cookies) {
+      [cookieStore setCookie:cookie
+           completionHandler:^{
+             counter += 1;
+             if (counter == cookies.count) {
+               result(nil);
+             }
+           }];
+    }
+  } else {
+    NSLog(@"Setting cookies is not supported for Flutter WebViews prior to iOS 11.");
+    result([FlutterError
+        errorWithCode:@"not supported"
+              message:@"Setting cookies is not supported for Flutter WebViews prior to iOS 11."
+              details:nil]);
+  }
+}
+
+- (void)getCookies:(FlutterMethodCall *)call result:(FlutterResult)result {
+  if (@available(iOS 11.0, *)) {
+    WKWebsiteDataStore *dataStore = [WKWebsiteDataStore defaultDataStore];
+    [[dataStore httpCookieStore] getAllCookies:^(NSArray<NSHTTPCookie *> *cookies) {
+      NSMutableArray<NSDictionary *> *allCookies = [[NSMutableArray<NSDictionary *> alloc] init];
+      for (NSHTTPCookie *cookie in cookies) {
+        [allCookies addObject:[self cookieToDictionary:cookie]];
+      }
+      result(allCookies);
+    }];
+  } else {
+    NSLog(@"Getting cookies is not supported for Flutter WebViews prior to iOS 11.");
+    result([FlutterError
+        errorWithCode:@"not supported"
+              message:@"Getting cookies is not supported for Flutter WebViews prior to iOS 11."
+              details:nil]);
+  }
+}
+
+- (NSDictionary *)cookieToDictionary:(NSHTTPCookie *)cookie {
+  NSMutableDictionary *result = [[NSMutableDictionary alloc] init];
+  [result addEntriesFromDictionary:@{
+    @"name" : cookie.name,
+    @"value" : cookie.value,
+    @"domain" : cookie.domain,
+    @"path" : cookie.path,
+    @"secure" : [NSNumber numberWithBool:cookie.isSecure],
+    @"httpOnly" : [NSNumber numberWithBool:cookie.isHTTPOnly],
+  }];
+  if ([cookie expiresDate] != nil) {
+    [result setValue:[NSNumber numberWithDouble:[[cookie expiresDate] timeIntervalSince1970]]
+              forKey:@"expires"];
+  }
+
+  return result;
+}
+
+- (NSHTTPCookie *)dictionaryToCookie:(NSDictionary *)input {
+  NSMutableDictionary *properties = [[NSMutableDictionary alloc] init];
+  [properties setValue:input[@"value"] forKey:NSHTTPCookieValue];
+  [properties setValue:input[@"name"] forKey:NSHTTPCookieName];
+
+  if (input[@"domain"] != nil) {
+    [properties setValue:input[@"domain"] forKey:NSHTTPCookieDomain];
+  }
+
+  if (input[@"path"] != nil) {
+    [properties setValue:input[@"path"] forKey:NSHTTPCookiePath];
+  } else {
+    [properties setValue:@"/" forKey:NSHTTPCookiePath];
+  }
+
+  if (input[@"expires"] != nil) {
+    NSNumber *expires = [input valueForKey:@"expires"];
+    [properties setValue:[NSDate dateWithTimeIntervalSince1970:[expires doubleValue]]
+                  forKey:NSHTTPCookieExpires];
+  }
+
+  NSNumber *secure = input[@"secure"];
+  if ([secure isEqualToNumber:@1]) {
+    [properties setValue:@true forKey:NSHTTPCookieSecure];
+  }
+
+  // seems to be an undocumented property 🤷‍♂️
+  NSNumber *httpOnly = input[@"httpOnly"];
+  if ([httpOnly isEqualToNumber:@1]) {
+    [properties setValue:@true forKey:@"HttpOnly"];
+  }
+  NSHTTPCookie *cookie = [NSHTTPCookie cookieWithProperties:properties];
+  return cookie;
 }
 
 @end

--- a/packages/webview_flutter/ios/Classes/FLTWebViewFlutterPlugin.m
+++ b/packages/webview_flutter/ios/Classes/FLTWebViewFlutterPlugin.m
@@ -9,8 +9,9 @@
 @implementation FLTWebViewFlutterPlugin
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
+  WKProcessPool* processPool = [[WKProcessPool alloc] init];
   FLTWebViewFactory* webviewFactory =
-      [[FLTWebViewFactory alloc] initWithMessenger:registrar.messenger];
+      [[FLTWebViewFactory alloc] initWithMessenger:registrar.messenger processPool:processPool];
   [registrar registerViewFactory:webviewFactory withId:@"plugins.flutter.io/webview"];
   [FLTCookieManager registerWithRegistrar:registrar];
 }

--- a/packages/webview_flutter/ios/Classes/FlutterWebView.h
+++ b/packages/webview_flutter/ios/Classes/FlutterWebView.h
@@ -12,13 +12,15 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithFrame:(CGRect)frame
                viewIdentifier:(int64_t)viewId
                     arguments:(id _Nullable)args
-              binaryMessenger:(NSObject<FlutterBinaryMessenger>*)messenger;
+              binaryMessenger:(NSObject<FlutterBinaryMessenger>*)messenger
+                  processPool:(WKProcessPool*)processPool;
 
 - (UIView*)view;
 @end
 
 @interface FLTWebViewFactory : NSObject <FlutterPlatformViewFactory>
-- (instancetype)initWithMessenger:(NSObject<FlutterBinaryMessenger>*)messenger;
+- (instancetype)initWithMessenger:(NSObject<FlutterBinaryMessenger>*)messenger
+                      processPool:(WKProcessPool*)processPool;
 @end
 
 /**

--- a/packages/webview_flutter/lib/platform_interface.dart
+++ b/packages/webview_flutter/lib/platform_interface.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -368,5 +369,24 @@ abstract class WebViewPlatform {
   Future<bool> clearCookies() {
     throw UnimplementedError(
         "WebView clearCookies is not implemented on the current platform");
+  }
+
+  /// Gets the current cookies.
+  ///
+  /// On iOS, returns all cookies from the [WebView] instance.
+  /// On Android, only returns the cookies for the current URL from the [WebView] instance.
+  Future<List<Cookie>> getCookies() {
+    throw UnimplementedError(
+        "WebView getCookies is not implemented on the current platform");
+  }
+
+  /// Sets the specified cookies.
+  ///
+  /// `cookies` must not be null.
+  Future<void> setCookies(
+    List<Cookie> cookies,
+  ) {
+    throw UnimplementedError(
+        "WebView setCookies is not implemented on the current platform");
   }
 }

--- a/packages/webview_flutter/lib/src/webview_android.dart
+++ b/packages/webview_flutter/lib/src/webview_android.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -60,4 +61,16 @@ class AndroidWebView implements WebViewPlatform {
 
   @override
   Future<bool> clearCookies() => MethodChannelWebViewPlatform.clearCookies();
+
+  @override
+  Future<List<Cookie>> getCookies() {
+    // TODO: implement getCookies
+    return null;
+  }
+
+  @override
+  Future<void> setCookies(List<Cookie> cookies) {
+    // TODO: implement setCookies
+    return null;
+  }
 }

--- a/packages/webview_flutter/lib/src/webview_android.dart
+++ b/packages/webview_flutter/lib/src/webview_android.dart
@@ -19,6 +19,9 @@ import 'webview_method_channel.dart';
 /// an [AndroidView] to embed the webview in the widget hierarchy, and uses a method channel to
 /// communicate with the platform code.
 class AndroidWebView implements WebViewPlatform {
+  /// The platform controller
+  MethodChannelWebViewPlatform platformController;
+
   @override
   Widget build({
     BuildContext context,
@@ -44,8 +47,9 @@ class AndroidWebView implements WebViewPlatform {
           if (onWebViewPlatformCreated == null) {
             return;
           }
-          onWebViewPlatformCreated(MethodChannelWebViewPlatform(
-              id, webViewPlatformCallbacksHandler));
+          platformController =
+              MethodChannelWebViewPlatform(id, webViewPlatformCallbacksHandler);
+          onWebViewPlatformCreated(platformController);
         },
         gestureRecognizers: gestureRecognizers,
         // WebView content is not affected by the Android view's layout direction,
@@ -63,14 +67,12 @@ class AndroidWebView implements WebViewPlatform {
   Future<bool> clearCookies() => MethodChannelWebViewPlatform.clearCookies();
 
   @override
-  Future<List<Cookie>> getCookies() {
-    // TODO: implement getCookies
-    return null;
+  Future<List<Cookie>> getCookies() async {
+    final String currentUrl = await platformController.currentUrl();
+    return MethodChannelWebViewPlatform.getCookies(currentUrl);
   }
 
   @override
-  Future<void> setCookies(List<Cookie> cookies) {
-    // TODO: implement setCookies
-    return null;
-  }
+  Future<void> setCookies(List<Cookie> cookies) =>
+      MethodChannelWebViewPlatform.setCookies(cookies);
 }

--- a/packages/webview_flutter/lib/src/webview_cupertino.dart
+++ b/packages/webview_flutter/lib/src/webview_cupertino.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -44,4 +45,12 @@ class CupertinoWebView implements WebViewPlatform {
 
   @override
   Future<bool> clearCookies() => MethodChannelWebViewPlatform.clearCookies();
+
+  @override
+  Future<List<Cookie>> getCookies() =>
+      MethodChannelWebViewPlatform.getCookies();
+
+  @override
+  Future<void> setCookies(List<Cookie> cookies) =>
+      MethodChannelWebViewPlatform.setCookies(cookies);
 }

--- a/packages/webview_flutter/lib/src/webview_method_channel.dart
+++ b/packages/webview_flutter/lib/src/webview_method_channel.dart
@@ -119,10 +119,12 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
         .then<bool>((dynamic result) => result);
   }
 
-  static Future<List<Cookie>> getCookies() {
-    return _cookieManagerChannel
-        .invokeListMethod<Map<dynamic, dynamic>>('getCookies')
-        .then<List<Cookie>>((List<Map<dynamic, dynamic>> results) {
+  /// Read out all cookies, or all cookies for a url when provided
+  static Future<List<Cookie>> getCookies([String currentUrl]) {
+    return _cookieManagerChannel.invokeListMethod<Map<dynamic, dynamic>>(
+        'getCookies', <dynamic, dynamic>{
+      'url': currentUrl
+    }).then<List<Cookie>>((List<Map<dynamic, dynamic>> results) {
       return results.map((Map<dynamic, dynamic> result) {
         final Cookie c = Cookie(result['name'], result['value']);
         // following values optionally work on iOS only
@@ -141,6 +143,7 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
     });
   }
 
+  /// Set cookies into the web view
   static Future<void> setCookies(List<Cookie> cookies) {
     final List<Map<String, dynamic>> transferCookies = cookies.map((Cookie c) {
       final Map<String, dynamic> output = <String, dynamic>{
@@ -150,6 +153,7 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
         'domain': c.domain,
         'secure': c.secure,
         'httpOnly': c.httpOnly,
+        'asString': c.toString(),
       };
 
       if (c.expires != null) {

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -678,6 +679,22 @@ class CookieManager {
   ///
   /// Returns true if cookies were present before clearing, else false.
   Future<bool> clearCookies() => WebView.platform.clearCookies();
+
+  /// Gets the current cookies.
+  ///
+  /// This is a no op on iOS versions smaller than 11.
+  ///
+  /// On iOS, returns all cookies from the [WebView] instance.
+  /// On Android, only returns the cookies for the current URL from the [WebView] instance.
+  Future<List<Cookie>> getCookies() => WebView.platform.getCookies();
+
+  /// Sets the specified cookies.
+  ///
+  /// This is a no op on iOS versions smaller than 11.
+  ///
+  /// `cookies` must not be null.
+  Future<void> setCookies(List<Cookie> cookies) =>
+      WebView.platform.setCookies(cookies);
 }
 
 // Throws an ArgumentError if `url` is not a valid URL string.

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
-version: 0.3.19+5
+version: 0.3.20
 homepage: https://github.com/flutter/plugins/tree/master/packages/webview_flutter
 
 environment:

--- a/packages/webview_flutter/test/webview_flutter_test.dart
+++ b/packages/webview_flutter/test/webview_flutter_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
 import 'dart:math';
 import 'dart:typed_data';
 
@@ -1145,6 +1146,16 @@ class MyWebViewPlatform implements WebViewPlatform {
   @override
   Future<bool> clearCookies() {
     return Future<bool>.sync(() => null);
+  }
+
+  @override
+  Future<List<Cookie>> getCookies() {
+    return Future<List<Cookie>>.value(<Cookie>[]);
+  }
+
+  @override
+  Future<void> setCookies(List<Cookie> cookies) {
+    return Future<void>.value();
   }
 }
 

--- a/packages/webview_flutter/test/webview_flutter_test.dart
+++ b/packages/webview_flutter/test/webview_flutter_test.dart
@@ -429,6 +429,33 @@ void main() {
     expect(hasCookiesSecond, false);
   });
 
+  testWidgets('Set and get Cookies', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const WebView(
+        initialUrl: 'https://flutter.io',
+      ),
+    );
+    final Cookie testCookie = Cookie('test', 'value')
+      ..path = '/'
+      ..domain = 'flutter.io'
+      ..secure = true
+      ..expires = DateTime.now()
+      ..httpOnly = true;
+    final CookieManager cookieManager = CookieManager();
+    final List<Cookie> cookies = <Cookie>[testCookie];
+    await cookieManager.setCookies(cookies);
+    final List<Cookie> receivedCookies = await cookieManager.getCookies();
+    final Cookie receivedCookie = receivedCookies.first;
+    expect(receivedCookie.name, testCookie.name);
+    expect(receivedCookie.value, testCookie.value);
+    expect(receivedCookie.path, testCookie.path);
+    expect(receivedCookie.domain, testCookie.domain);
+    expect(receivedCookie.secure, testCookie.secure);
+    expect(receivedCookie.expires.millisecondsSinceEpoch ~/ 1000,
+        testCookie.expires.millisecondsSinceEpoch ~/ 1000);
+    expect(receivedCookie.httpOnly, testCookie.httpOnly);
+  });
+
   testWidgets('Initial JavaScript channels', (WidgetTester tester) async {
     await tester.pumpWidget(
       WebView(
@@ -1103,8 +1130,9 @@ class _FakeCookieManager {
   }
 
   bool hasCookies = true;
+  List<Map<dynamic, dynamic>> cookies = <Map<dynamic, dynamic>>[];
 
-  Future<bool> onMethodCall(MethodCall call) {
+  Future<dynamic> onMethodCall(MethodCall call) {
     switch (call.method) {
       case 'clearCookies':
         bool hadCookies = false;
@@ -1115,7 +1143,14 @@ class _FakeCookieManager {
         return Future<bool>.sync(() {
           return hadCookies;
         });
-        break;
+      case 'setCookies':
+        final List<dynamic> newCookies = call.arguments;
+        for (final Map<dynamic, dynamic> cookie in newCookies) {
+          cookies.add(cookie);
+        }
+        return Future<dynamic>.value(null);
+      case 'getCookies':
+        return Future<dynamic>.value(cookies);
     }
     return Future<bool>.sync(() => null);
   }


### PR DESCRIPTION
## Description

This is adding cookie setter/getter methods to set cookies inside the Web View.

## Related Issues

There already is this #1880  where I based my work on. But a lot of other cookie properties for iOS needed to be supported and I also added tests, formatted everything, so this is ready to merge.

Fixes flutter/flutter#27597

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

For iOS I am using a WKProcessPool now which is syncing the cookies between all instances of WebViews. Is that a breaking change? Was anybody relying on the behavior of having some more or less randomized isolated environments?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
