### PR TITLE
WIP maps plugin migration attempt as embedding sanity check.

### DIFF
--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapBuilder.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapBuilder.java
@@ -6,10 +6,11 @@ package io.flutter.plugins.googlemaps;
 
 import android.content.Context;
 import android.graphics.Rect;
+import androidx.lifecycle.Lifecycle;
 import com.google.android.gms.maps.GoogleMapOptions;
 import com.google.android.gms.maps.model.CameraPosition;
 import com.google.android.gms.maps.model.LatLngBounds;
-import io.flutter.plugin.common.PluginRegistry;
+import io.flutter.plugin.common.BinaryMessenger;
 import java.util.concurrent.atomic.AtomicInteger;
 
 class GoogleMapBuilder implements GoogleMapOptionsSink {
@@ -26,9 +27,9 @@ class GoogleMapBuilder implements GoogleMapOptionsSink {
   private Rect padding = new Rect(0, 0, 0, 0);
 
   GoogleMapController build(
-      int id, Context context, AtomicInteger state, PluginRegistry.Registrar registrar) {
+      int id, Context context, Lifecycle lifecycle, BinaryMessenger binaryMessenger) {
     final GoogleMapController controller =
-        new GoogleMapController(id, context, state, registrar, options);
+        new GoogleMapController(id, context, lifecycle, binaryMessenger, options);
     controller.init();
     controller.setMyLocationEnabled(myLocationEnabled);
     controller.setMyLocationButtonEnabled(myLocationButtonEnabled);

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapFactory.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapFactory.java
@@ -7,7 +7,9 @@ package io.flutter.plugins.googlemaps;
 import static io.flutter.plugin.common.PluginRegistry.Registrar;
 
 import android.content.Context;
+import androidx.lifecycle.Lifecycle;
 import com.google.android.gms.maps.model.CameraPosition;
+import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.StandardMessageCodec;
 import io.flutter.plugin.platform.PlatformView;
 import io.flutter.plugin.platform.PlatformViewFactory;
@@ -16,13 +18,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class GoogleMapFactory extends PlatformViewFactory {
 
-  private final AtomicInteger mActivityState;
-  private final Registrar mPluginRegistrar;
+  private final Lifecycle mLifecycle;
+  private final BinaryMessenger binaryMessenger;
 
-  GoogleMapFactory(AtomicInteger state, Registrar registrar) {
+  GoogleMapFactory(Lifecycle lifecycle, BinaryMessenger binaryMessenger) {
     super(StandardMessageCodec.INSTANCE);
-    mActivityState = state;
-    mPluginRegistrar = registrar;
+    mLifecycle = lifecycle;
+    this.binaryMessenger = binaryMessenger;
   }
 
   @SuppressWarnings("unchecked")
@@ -48,6 +50,6 @@ public class GoogleMapFactory extends PlatformViewFactory {
     if (params.containsKey("circlesToAdd")) {
       builder.setInitialCircles(params.get("circlesToAdd"));
     }
-    return builder.build(id, context, mActivityState, mPluginRegistrar);
+    return builder.build(id, context, mLifecycle, binaryMessenger);
   }
 }

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapsPlugin.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapsPlugin.java
@@ -7,7 +7,19 @@ package io.flutter.plugins.googlemaps;
 import android.app.Activity;
 import android.app.Application;
 import android.os.Bundle;
+import androidx.lifecycle.DefaultLifecycleObserver;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleOwner;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
+import io.flutter.embedding.engine.plugins.activity.ActivityAware;
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding.OnSaveInstanceStateListener;
+import io.flutter.embedding.engine.plugins.FlutterPlugin;
+import io.flutter.embedding.engine.plugins.FlutterPlugin.FlutterPluginBinding;
+//import io.flutter.embedding.engine.plugins.lifecycle.FlutterLifecycleAdapter;
+import io.flutter.Log;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -16,15 +28,19 @@ import java.util.concurrent.atomic.AtomicInteger;
  * the map. A Texture drawn using GoogleMap bitmap snapshots can then be shown instead of the
  * overlay.
  */
-public class GoogleMapsPlugin implements Application.ActivityLifecycleCallbacks {
+public class GoogleMapsPlugin implements FlutterPlugin, ActivityAware {
+  private static final String TAG = "GoogleMapsPlugin";
+
   static final int CREATED = 1;
   static final int STARTED = 2;
   static final int RESUMED = 3;
   static final int PAUSED = 4;
   static final int STOPPED = 5;
   static final int DESTROYED = 6;
+
   private final AtomicInteger state = new AtomicInteger(0);
-  private final int registrarActivityHashCode;
+  private FlutterPluginBinding pluginBinding;
+//  private final int registrarActivityHashCode;
 
   public static void registerWith(Registrar registrar) {
     if (registrar.activity() == null) {
@@ -32,67 +48,127 @@ public class GoogleMapsPlugin implements Application.ActivityLifecycleCallbacks 
       // We stop the registration process as this plugin is foreground only.
       return;
     }
-    final GoogleMapsPlugin plugin = new GoogleMapsPlugin(registrar);
-    registrar.activity().getApplication().registerActivityLifecycleCallbacks(plugin);
-    registrar
-        .platformViewRegistry()
-        .registerViewFactory(
-            "plugins.flutter.io/google_maps", new GoogleMapFactory(plugin.state, registrar));
+//    final GoogleMapsPlugin plugin = new GoogleMapsPlugin(registrar);
+//    registrar.activity().getApplication().registerActivityLifecycleCallbacks(plugin);
+//    registrar
+//        .platformViewRegistry()
+//        .registerViewFactory(
+//            "plugins.flutter.io/google_maps", new GoogleMapFactory(plugin.state, registrar));
   }
 
-  @Override
-  public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
-    if (activity.hashCode() != registrarActivityHashCode) {
-      return;
+  private DefaultLifecycleObserver lifecycleObserver = new DefaultLifecycleObserver() {
+    public void onCreate(LifecycleOwner owner) {
+      Log.w(TAG, "onCreate()");
+      state.set(CREATED);
     }
-    state.set(CREATED);
-  }
 
-  @Override
-  public void onActivityStarted(Activity activity) {
-    if (activity.hashCode() != registrarActivityHashCode) {
-      return;
+    public void onStart(LifecycleOwner owner) {
+      Log.w(TAG, "onStart()");
+      state.set(STARTED);
     }
-    state.set(STARTED);
-  }
 
-  @Override
-  public void onActivityResumed(Activity activity) {
-    if (activity.hashCode() != registrarActivityHashCode) {
-      return;
+    public void onResume(LifecycleOwner owner) {
+      Log.w(TAG, "onResume()");
+      state.set(RESUMED);
     }
-    state.set(RESUMED);
-  }
 
-  @Override
-  public void onActivityPaused(Activity activity) {
-    if (activity.hashCode() != registrarActivityHashCode) {
-      return;
+    public void onPause(LifecycleOwner owner) {
+      Log.w(TAG, "onPause()");
+      state.set(PAUSED);
     }
-    state.set(PAUSED);
-  }
 
-  @Override
-  public void onActivityStopped(Activity activity) {
-    if (activity.hashCode() != registrarActivityHashCode) {
-      return;
+    public void onStop(LifecycleOwner owner) {
+      Log.w(TAG, "onStop()");
+      state.set(STOPPED);
     }
-    state.set(STOPPED);
-  }
 
-  @Override
-  public void onActivitySaveInstanceState(Activity activity, Bundle outState) {}
-
-  @Override
-  public void onActivityDestroyed(Activity activity) {
-    if (activity.hashCode() != registrarActivityHashCode) {
-      return;
+    public void onDestroy(LifecycleOwner owner) {
+      Log.w(TAG, "onDestroy()");
+      state.set(DESTROYED);
     }
-    activity.getApplication().unregisterActivityLifecycleCallbacks(this);
-    state.set(DESTROYED);
+  };
+
+//  private GoogleMapsPlugin(Registrar registrar) {
+//    this.registrarActivityHashCode = registrar.activity().hashCode();
+//  }
+
+  private Lifecycle lifecycle;
+
+  public GoogleMapsPlugin() {}
+
+  @Override
+  public void onAttachedToEngine(FlutterPluginBinding binding) {
+    pluginBinding = binding;
   }
 
-  private GoogleMapsPlugin(Registrar registrar) {
-    this.registrarActivityHashCode = registrar.activity().hashCode();
+  @Override
+  public void onDetachedFromEngine(FlutterPluginBinding binding) {
+    pluginBinding = null;
+    // TODO(amirh): should the view registry allow deregistration?
+  }
+
+  @Override
+  public void onAttachedToActivity(ActivityPluginBinding binding) {
+    try {
+      binding.addOnSaveStateListener(new OnSaveInstanceStateListener() {
+        public void onSaveInstanceState(Bundle bundle) {
+          Log.w(TAG, "onSaveInstanceState()");
+        }
+
+        public void onRestoreInstanceState(Bundle bundle) {
+          Log.w(TAG, "onRestoreInstanceState(): " + bundle);
+        }
+      });
+
+      lifecycle = getLifecycle(binding);
+      lifecycle.addObserver(lifecycleObserver);
+
+      pluginBinding.getPlatformViewRegistry().registerViewFactory(
+          "plugins.flutter.io/google_maps",
+          new GoogleMapFactory(lifecycle, pluginBinding.getBinaryMessenger())
+      );
+    } catch (ClassNotFoundException
+        | NoSuchMethodException
+        | IllegalAccessException
+        | InvocationTargetException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void onDetachedFromActivityForConfigChanges() {
+    lifecycle.removeObserver(lifecycleObserver);
+  }
+
+  @Override
+  public void onReattachedToActivityForConfigChanges(ActivityPluginBinding binding) {
+    try {
+      // TODO(amirh): how should we handle config changes? The GoogleMapController takes
+      // a Lifecycle in its constructor, so it's currently configured to work with only
+      // one Activity in its life span.
+      lifecycle = getLifecycle(binding);
+      lifecycle.addObserver(lifecycleObserver);
+    } catch (ClassNotFoundException
+        | NoSuchMethodException
+        | IllegalAccessException
+        | InvocationTargetException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void onDetachedFromActivity() {
+    lifecycle.removeObserver(lifecycleObserver);
+  }
+
+  private Lifecycle getLifecycle(ActivityPluginBinding binding)
+      throws ClassNotFoundException,
+      NoSuchMethodException,
+      IllegalAccessException,
+      InvocationTargetException {
+    Class lifecycleAdapter =
+        Class.forName("io.flutter.embedding.engine.plugins.lifecycle.FlutterLifecycleAdapter");
+    Method getLifecycle = lifecycleAdapter.getMethod("getActivityLifecycle", ActivityPluginBinding.class);
+    return (Lifecycle) getLifecycle.invoke(null, binding);
   }
 }

--- a/packages/google_maps_flutter/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/google_maps_flutter/example/android/app/src/main/AndroidManifest.xml
@@ -5,7 +5,6 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
 
     <application
-        android:name="io.flutter.app.FlutterApplication"
         android:label="google_maps_flutter_example"
         android:icon="@mipmap/ic_launcher">
       <meta-data
@@ -14,7 +13,7 @@
         <!-- Update this value to your google maps api key. -->
         <meta-data
             android:name="com.google.android.geo.API_KEY"
-            android:value="${mapsApiKey}" />
+            android:value="AIzaSyCuts_LieGfhT7Mok9VZq2U9WXbNiaenyo" />
         <activity
             android:name=".MainActivity"
             android:launchMode="singleTop"

--- a/packages/google_maps_flutter/example/android/app/src/main/java/io/flutter/plugins/googlemapsexample/MainActivity.java
+++ b/packages/google_maps_flutter/example/android/app/src/main/java/io/flutter/plugins/googlemapsexample/MainActivity.java
@@ -1,13 +1,16 @@
 package io.flutter.plugins.googlemapsexample;
 
-import android.os.Bundle;
-import io.flutter.app.FlutterActivity;
+import io.flutter.embedding.android.FlutterActivity;
+import io.flutter.embedding.engine.FlutterEngine;
+import io.flutter.embedding.engine.plugins.shim.ShimPluginRegistry;
 import io.flutter.plugins.GeneratedPluginRegistrant;
+import io.flutter.plugins.googlemaps.GoogleMapsPlugin;
 
 public class MainActivity extends FlutterActivity {
   @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    GeneratedPluginRegistrant.registerWith(this);
+  public void configureFlutterEngine(FlutterEngine flutterEngine) {
+//    ShimPluginRegistry shimPluginRegistry = new ShimPluginRegistry(flutterEngine);
+//    GeneratedPluginRegistrant.registerWith(shimPluginRegistry);
+    flutterEngine.getPlugins().add(new GoogleMapsPlugin());
   }
 }

--- a/packages/google_maps_flutter/example/pubspec.yaml
+++ b/packages/google_maps_flutter/example/pubspec.yaml
@@ -9,6 +9,12 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.0
 
+  flutter_plugin_android_lifecycle:
+    git:
+      url: git://github.com/flutter/plugins.git
+      path: packages/flutter_plugin_android_lifecycle
+      ref: master
+
 dev_dependencies:
   google_maps_flutter:
     path: ../

--- a/packages/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/pubspec.yaml
@@ -8,6 +8,12 @@ dependencies:
   flutter:
     sdk: flutter
 
+  flutter_plugin_android_lifecycle:
+    git:
+      url: git://github.com/flutter/plugins.git
+      path: packages/flutter_plugin_android_lifecycle
+      ref: master
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
This is a draft PR to demonstrate the progress I've been able to make in technically migrating the maps plugin to the new Android embedding.

The approach taken is probably not ideal. I was going for the most direct changes possible.

I left the state restoration for the `MapView` unresolved in this PR because, while we should be able to hook up the appropriate callbacks, it is unclear to me how such state restoration could be made to work with the current lifespan of objects in the maps plugin.

The `GoogleMapController` appears to treat its `Activity` reference as permanent. But the nature of state restoration is that such an `Activity` has been destroyed, the state saved, and then upon recreation of that `Activity`, that state is restored. Since `GoogleMapController` expects its `Activity` to never change, it implies that a new `GoogleMapController` must be created to deal with a new `Activity`. The foundational object structure for the maps plugin looks like it probably needs to change to accommodate the possibility of a cached `FlutterEngine` that does not get destroyed with its `Activity`. I'm not sure the best refactor for that purpose, nor am I sure it's worth the time right now.

There is, however, one possible point of concern in the embedding implementation. The timing of state restoration is a tricky issue.

In `FlutterActivity`, a call to its delegate's `onAttach()` method is responsible for setting up the `FlutterEngine` and attaching plugins vis the `GeneratedPluginRegistrant`. The very next line invokes `onActivityCreated()` where the delegate can restore the previous state.

https://github.com/flutter/engine/blob/master/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java#L418

Assuming all relevant plugins are registered in `onConfigureFlutterEngine()` or before, they should receive an opportunity to restore instance state. However, if a dev registers any other plugins at any point after that, those plugins will miss the opportunity. So, even if a developer, for some reason, needs to wait for `onStart()` or `onResume()` to register a plugin, they'll miss that opportunity.

I'm not sure that there is a good way around this or not, but I can imagine that any dev that runs into this situation could find it very difficult to deal with the inability to restore plugin state. I'm mentioning this for all PR reviewers to be aware and have an opportunity to offer thoughts. I don't have any particular recommendation.