### PR TITLE
[google_maps_flutter] iOS: add a cache for defaultMarker(WithHue) and fromBytes icons...

### DIFF
--- a/packages/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.22+13
+
+* iOS: add a cache for defaultMarker(WithHue) and fromBytes icons.
+
 ## 0.5.21+12
 
 * Update driver tests in the example app to e2e tests.

--- a/packages/google_maps_flutter/example/lib/main.dart
+++ b/packages/google_maps_flutter/example/lib/main.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/material.dart';
 import 'animate_camera.dart';
+import 'many_markers.dart';
 import 'map_click.dart';
 import 'map_coordinates.dart';
 import 'map_ui.dart';
@@ -30,6 +31,7 @@ final List<Page> _allPages = <Page>[
   PlacePolygonPage(),
   PlaceCirclePage(),
   PaddingPage(),
+  ManyMarkersPage(),
 ];
 
 class MapsDemo extends StatelessWidget {
@@ -48,6 +50,7 @@ class MapsDemo extends StatelessWidget {
       body: ListView.builder(
         itemCount: _allPages.length,
         itemBuilder: (_, int index) => ListTile(
+          key: Key(_allPages[index].title),
           leading: _allPages[index].leading,
           title: Text(_allPages[index].title),
           onTap: () => _pushPage(context, _allPages[index]),

--- a/packages/google_maps_flutter/example/lib/many_markers.dart
+++ b/packages/google_maps_flutter/example/lib/many_markers.dart
@@ -1,0 +1,132 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:math';
+import 'dart:typed_data';
+import 'dart:ui';
+import 'package:flutter/material.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'page.dart';
+
+const int _kNbPins = 2450;
+final int _kNbPinLon = (sqrt(_kNbPins / 2)).round();
+final int _kNbPinLat = 2 * _kNbPinLon;
+const LatLng _kMapCenter = LatLng(56, -3.5402);
+enum MarkerType {
+  defaultMarker,
+  defaultMarkerWithHue,
+  fromAssetImage,
+  fromBytes
+}
+const MarkerType _kMarkerType = MarkerType.defaultMarkerWithHue;
+
+class ManyMarkersPage extends Page {
+  ManyMarkersPage()
+      : super(const Icon(Icons.place), 'Many markers (wait few seconds...)');
+
+  @override
+  Widget build(BuildContext context) {
+    return const ManyMarkersBody();
+  }
+}
+
+class ManyMarkersBody extends StatefulWidget {
+  const ManyMarkersBody();
+
+  @override
+  State<StatefulWidget> createState() => ManyMarkersBodyState();
+}
+
+class ManyMarkersBodyState extends State<ManyMarkersBody> {
+  BitmapDescriptor _markerIconFrom;
+
+  @override
+  Widget build(BuildContext context) {
+    if (_kMarkerType == MarkerType.fromAssetImage) {
+      _createMarkerImageFromAsset(context);
+    } else if (_kMarkerType == MarkerType.fromBytes) {
+      _createMarkerImageFromBytes(context);
+    }
+    return GoogleMap(
+      key: const Key('GoogleMap'),
+      initialCameraPosition: const CameraPosition(
+        target: _kMapCenter,
+        zoom: 5.0,
+      ),
+      markers: _createMarkers(),
+    );
+  }
+
+  Set<Marker> _createMarkers() {
+    return <Marker>{
+      for (int y = 0; y < _kNbPinLat; y++)
+        for (int x = 1; x <= _kNbPinLon; x++)
+          Marker(
+            markerId: MarkerId('marker_${y * _kNbPinLon + x}'),
+            position: LatLng(47 + y / 5, -6 + x / 5),
+            icon: _getMarkerIcon(x),
+            infoWindow: InfoWindow(
+                title: 'marker_${y * _kNbPinLon + x}',
+                snippet: 'marker_${y * _kNbPinLon + x}',
+                onTap: () => print('marker_${y * _kNbPinLon + x}')),
+          ),
+    };
+  }
+
+  BitmapDescriptor _getMarkerIcon(int x) {
+    switch (_kMarkerType) {
+      case MarkerType.defaultMarker:
+        return BitmapDescriptor.defaultMarker;
+      case MarkerType.defaultMarkerWithHue:
+        return BitmapDescriptor.defaultMarkerWithHue((x % 11) * 30.0);
+      case MarkerType.fromAssetImage:
+      case MarkerType.fromBytes:
+        return _markerIconFrom;
+    }
+    assert(false);
+    return null;
+  }
+
+  Future<void> _createMarkerImageFromAsset(BuildContext context) async {
+    if (_markerIconFrom == null) {
+      final ImageConfiguration imageConfiguration =
+          createLocalImageConfiguration(context);
+      BitmapDescriptor.fromAssetImage(
+              imageConfiguration, 'assets/red_square.png')
+          .then(_updateBitmap);
+    }
+  }
+
+  void _updateBitmap(BitmapDescriptor bitmap) {
+    setState(() {
+      _markerIconFrom = bitmap;
+    });
+  }
+
+  Future<void> _createMarkerImageFromBytes(BuildContext context) async {
+    if (_markerIconFrom == null) {
+      _getAssetIcon(context).then(_updateBitmap);
+    }
+  }
+
+  Future<BitmapDescriptor> _getAssetIcon(BuildContext context) async {
+    final Completer<BitmapDescriptor> bitmapIcon =
+        Completer<BitmapDescriptor>();
+    final ImageConfiguration config = createLocalImageConfiguration(context);
+
+    const AssetImage('assets/red_square.png')
+        .resolve(config)
+        .addListener(ImageStreamListener((ImageInfo image, bool sync) async {
+      final ByteData bytes =
+          await image.image.toByteData(format: ImageByteFormat.png);
+      final BitmapDescriptor bitmap = BitmapDescriptor.fromBytes(
+          bytes.buffer.asUint8List(),
+          tag: 'red_square as bytes');
+      bitmapIcon.complete(bitmap);
+    }));
+
+    return await bitmapIcon.future;
+  }
+}

--- a/packages/google_maps_flutter/lib/src/bitmap.dart
+++ b/packages/google_maps_flutter/lib/src/bitmap.dart
@@ -79,8 +79,13 @@ class BitmapDescriptor {
 
   /// Creates a BitmapDescriptor using an array of bytes that must be encoded
   /// as PNG.
-  static BitmapDescriptor fromBytes(Uint8List byteData) {
-    return BitmapDescriptor._(<dynamic>['fromBytes', byteData]);
+  /// iOS only: Set `tag` to cache the image with this tag.
+  static BitmapDescriptor fromBytes(Uint8List byteData, {String tag}) {
+    if (tag == null) {
+      return BitmapDescriptor._(<dynamic>['fromBytes', byteData]);
+    } else {
+      return BitmapDescriptor._(<dynamic>['fromBytes', byteData, tag]);
+    }
   }
 
   final dynamic _json;

--- a/packages/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter
-version: 0.5.21+12
+version: 0.5.22+13
 
 dependencies:
   flutter:


### PR DESCRIPTION
... to avoid following errors :
> ((null)) was false: Reached the max number of texture atlases, can not allocate more.
> ((null)) was false: Failed to allocate texture space for marker

Markers are created but the icon images are missing into the map.

## Description
iOS only: This PR adds a cache system to keep references on the icons images created for each marker.
When there are more than about 1250 markers using the same icon = BitmapDescriptor.defaultMarker(WithHue) or BitmapDescriptor.fromBytes, then the plugin creates 1250 UIImage in memory.
It writes some error messages while debugging and crashes on a release app.

## Related Issues
This PR fixes this issue:
https://github.com/flutter/flutter/issues/45508

I don't know how an integration test could test this... I've started one but I'm stuck on it...

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
