### PR TITLE
[android_intent] Added 'action_app' action and getIntentExtras, getIntentData

### DIFF
--- a/packages/android_intent/android/src/main/java/io/flutter/plugins/androidintent/IntentSender.java
+++ b/packages/android_intent/android/src/main/java/io/flutter/plugins/androidintent/IntentSender.java
@@ -64,7 +64,27 @@ public final class IntentSender {
       return;
     }
 
-    Intent intent = new Intent(action);
+    Intent intent = null;
+
+    if (action.equals("action_app")) {
+      try {
+        intent =
+            applicationContext
+                .getPackageManager()
+                .getLeanbackLaunchIntentForPackage(applicationContext.getPackageName());
+      } catch (java.lang.NoSuchMethodError e) {
+      }
+
+      if (intent == null)
+        intent =
+            applicationContext
+                .getPackageManager()
+                .getLaunchIntentForPackage(applicationContext.getPackageName());
+
+      intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+    } else {
+      intent = new Intent(action);
+    }
 
     if (flags != null) {
       intent.addFlags(flags);
@@ -98,9 +118,17 @@ public final class IntentSender {
     }
   }
 
+  Activity getActivity() {
+    return this.activity;
+  }
+
   /** Caches the given {@code activity} to use for {@link #send}. */
   void setActivity(@Nullable Activity activity) {
     this.activity = activity;
+  }
+
+  Context getApplicationContext() {
+    return this.applicationContext;
   }
 
   /** Caches the given {@code applicationContext} to use for {@link #send}. */

--- a/packages/android_intent/lib/android_intent.dart
+++ b/packages/android_intent/lib/android_intent.dart
@@ -37,7 +37,7 @@ class AndroidIntent {
     this.componentName,
     Platform platform,
   })  : assert(action != null),
-        _channel = const MethodChannel(_kChannelName),
+        _instanceChannel = const MethodChannel(_kChannelName),
         _platform = platform ?? const LocalPlatform();
 
   /// This constructor is only exposed for unit testing. Do not rely on this in
@@ -53,7 +53,7 @@ class AndroidIntent {
     this.arguments,
     this.package,
     this.componentName,
-  })  : _channel = channel,
+  })  : _instanceChannel = channel,
         _platform = platform;
 
   /// This is the general verb that the intent should attempt to do. This
@@ -94,7 +94,8 @@ class AndroidIntent {
   ///
   /// See https://developer.android.com/reference/android/content/Intent.html#setComponent(android.content.ComponentName).
   final String componentName;
-  final MethodChannel _channel;
+  static final MethodChannel _channel = const MethodChannel(_kChannelName);
+  final MethodChannel _instanceChannel;
   final Platform _platform;
 
   bool _isPowerOfTwo(int x) {
@@ -142,6 +143,28 @@ class AndroidIntent {
         args['componentName'] = componentName;
       }
     }
-    await _channel.invokeMethod<void>('launch', args);
+    await _instanceChannel.invokeMethod<void>('launch', args);
+  }
+
+  /// Obtain the Intent's extras
+  static Future<Map<dynamic, dynamic>> getIntentExtras() async {
+    final Map<dynamic, dynamic> extras =
+        await _channel.invokeMethod('getIntentExtras');
+    return extras;
+  }
+
+  /// Set the Intent's extras
+  static Future<void> setIntentExtra(String name, dynamic value) async {
+    final Map<String, dynamic> args = <String, dynamic>{
+      'name': name,
+      'value': value
+    };
+    await _channel.invokeMethod<void>('setIntentExtra', args);
+  }
+
+  /// Obtain the Intent's data
+  static Future<String> getIntentData() async {
+    final String data = await _channel.invokeMethod('getIntentData');
+    return data;
   }
 }


### PR DESCRIPTION
**Note**: re-implemented version of https://github.com/flutter/plugins/pull/1101

The "action_app" special action allows to create an Intent that launches the app's launcher activity (which for most Flutter apps, it's the Activity handling the Flutter app itself).

Also added methods `getIntentExtras` and `getIntentData` which respectively let you retrieve the current Intent's extras [arguments] and data.

These two features combined are useful when your app is divided between a foreground component (the main app running the Flutter view) and a background component (a service that runs in the background).

With these features the background component can easily trigger the main app to open (whether it was running or not) and pass extra arguments to the Intent. The main app can then load up and use these extra arguments to do some custom processing.

Please note that if your app is already opened and you launch a "action_app" intent, you need a bit of extra logic in your MainActivity to ensure that arguments are refreshed from the new Intent, something like this:

```java
  @Override
  protected void onNewIntent(Intent intent) {
      super.onNewIntent(intent);
      Bundle bundle = intent.getExtras();
      getIntent().putExtras(bundle);
  }
```