### PR TITLE
[google_sign_in_web] Add empty podspec to plugin.

### DIFF
--- a/packages/google_sign_in/google_sign_in_web/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.1
+
+* Add podspec to enable compilation on iOS.
+
 ## 0.8.0
 
 * Flutter for web initial release

--- a/packages/google_sign_in/google_sign_in_web/ios/google_sign_in_web.podspec
+++ b/packages/google_sign_in/google_sign_in_web/ios/google_sign_in_web.podspec
@@ -1,0 +1,21 @@
+#
+# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
+#
+Pod::Spec.new do |s|
+    s.name             = 'google_sign_in_web'
+    s.version          = '0.8.1'
+    s.summary          = 'No-op implementation of google_sign_in_web web plugin to avoid build issues on iOS'
+    s.description      = <<-DESC
+  temp fake google_sign_in_web plugin
+                         DESC
+    s.homepage         = 'https://github.com/flutter/plugins/tree/master/packages/google_sign_in/google_sign_in_web'
+    s.license          = { :file => '../LICENSE' }
+    s.author           = { 'Flutter Team' => 'flutter-dev@googlegroups.com' }
+    s.source           = { :path => '.' }
+    s.source_files = 'Classes/**/*'
+    s.public_header_files = 'Classes/**/*.h'
+    s.dependency 'Flutter'
+  
+    s.ios.deployment_target = '8.0'
+  end
+  

--- a/packages/google_sign_in/google_sign_in_web/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_web/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android, iOS and Web.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_sign_in/google_sign_in_web
-version: 0.8.0
+version: 0.8.1
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Add an empty podspec file, so this plugin doesn't break compilation on IOS.

Similar to [this](https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher_web/ios).

## Related Issues

* https://github.com/flutter/flutter/issues/45571

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
