### PR TITLE
shared_preferences: throw AssertionError on non-mock implementations

### DIFF
--- a/packages/shared_preferences/shared_preferences_platform_interface/lib/shared_preferences_platform_interface.dart
+++ b/packages/shared_preferences/shared_preferences_platform_interface/lib/shared_preferences_platform_interface.dart
@@ -24,10 +24,15 @@ abstract class SharedPreferencesStorePlatform {
   /// Platform-specific plugins should set this with their own platform-specific
   /// class that extends [SharedPreferencesStorePlatform] when they register themselves.
   static set instance(SharedPreferencesStorePlatform value) {
-    try {
-      instance._verifyProvidesDefaultImplementations();
-      _instance = value;
-    } on NoSuchMethodError catch (_) {}
+    if (!value.isMock) {
+      try {
+        value._verifyProvidesDefaultImplementations();
+      } on NoSuchMethodError catch (_) {
+        throw AssertionError(
+            'Platform interfaces must not be implemented with `implements`');
+      }
+    }
+    _instance = value;
   }
 
   static SharedPreferencesStorePlatform _instance =

--- a/packages/shared_preferences/shared_preferences_platform_interface/test/shared_preferences_platform_interface_test.dart
+++ b/packages/shared_preferences/shared_preferences_platform_interface/test/shared_preferences_platform_interface_test.dart
@@ -1,0 +1,48 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group(SharedPreferencesStorePlatform, () {
+    test('disallows implementing interface', () {
+      expect(
+        () {
+          SharedPreferencesStorePlatform.instance = IllegalImplementation();
+        },
+        throwsAssertionError,
+      );
+    });
+  });
+}
+
+class IllegalImplementation implements SharedPreferencesStorePlatform {
+  // Intentionally declare self as not a mock to trigger the
+  // compliance check.
+  @override
+  bool get isMock => false;
+
+  @override
+  Future<bool> clear() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Map<String, Object>> getAll() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<bool> remove(String key) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<bool> setValue(String valueType, String key, Object value) {
+    throw UnimplementedError();
+  }
+}


### PR DESCRIPTION
## Description

Throw AssertionError on non-mock implementations in shared_preferences.
