### PR TITLE
[url_launcher] Alternative to `isMock`

### DIFF
--- a/packages/url_launcher/url_launcher/test/url_launcher_test.dart
+++ b/packages/url_launcher/url_launcher/test/url_launcher_test.dart
@@ -13,7 +13,6 @@ import 'package:flutter/services.dart' show PlatformException;
 
 void main() {
   final MockUrlLauncher mock = MockUrlLauncher();
-  when(mock.isMock).thenReturn(true);
   UrlLauncherPlatform.instance = mock;
 
   test('closeWebView default behavior', () async {
@@ -208,4 +207,4 @@ void main() {
   });
 }
 
-class MockUrlLauncher extends Mock implements UrlLauncherPlatform {}
+class MockUrlLauncher extends Mock with MockPlatformInterface implements UrlLauncherPlatform {}

--- a/packages/url_launcher/url_launcher_platform_interface/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_platform_interface/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 1.0.4
 
 * Use an assertion to ensure `isMock` is not used in release builds.
-* Prevent `noSuchMethod` from being used to bypass `isMock`.
+* Prevent `noSuchMethod` from being used to bypass checks that
+  `UrlLauncherPlatform` isn't implemented with `implements`.
 
 ## 1.0.3
 

--- a/packages/url_launcher/url_launcher_platform_interface/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_platform_interface/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.4
+
+* Use an assertion to ensure `isMock` is not used in release builds.
+* Prevent `noSuchMethod` from being used to bypass `isMock`.
+
 ## 1.0.3
 
 * Minor DartDoc changes and add a lint for missing DartDocs.

--- a/packages/url_launcher/url_launcher_platform_interface/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_platform_interface/CHANGELOG.md
@@ -1,8 +1,7 @@
 ## 1.0.4
 
-* Use an assertion to ensure `isMock` is not used in release builds.
-* Prevent `noSuchMethod` from being used to bypass checks that
-  `UrlLauncherPlatform` isn't implemented with `implements`.
+* Remove `@visibleForTesting` API `isMock`.
+* Introduces `MockPlatformInterface` and `PlatformInterface`.
 
 ## 1.0.3
 

--- a/packages/url_launcher/url_launcher_platform_interface/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_platform_interface/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.0.4
 
 * Remove `@visibleForTesting` API `isMock`.
-* Introduces `MockPlatformInterface` and `PlatformInterface`.
+* Introduces `MockPlatformInterface` and `PlatformInterface` classes.
 
 ## 1.0.3
 

--- a/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
@@ -42,7 +42,7 @@ abstract class UrlLauncherPlatform {
     assert(() {
       assertionsEnabled = true;
       return true;
-    });
+    }());
     if (!assertionsEnabled || !instance.isMock) {
       try {
         if (_verificationToken != instance._verifyProvidesDefaultImplementations()) {

--- a/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
@@ -92,7 +92,7 @@ abstract class UrlLauncherPlatform {
   // implemented with `implements`.
   Object _verifyProvidesDefaultImplementations() => _verificationToken;
 
-  // Private object used to determine if `_verifyProvidesDefaultImplementations`
-  // has been overridden with `noSuchMethod`.
+  // Private object used to ensure that `_verifyProvidesDefaultImplementations`
+  // cannot be implemented using `noSuchMethod`.
   static const Object _verificationToken = const Object();
 }

--- a/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
@@ -16,7 +16,7 @@ import 'method_channel_url_launcher.dart';
 // https://github.com/flutter/flutter/issues/43368
 abstract class PlatformInterface {
   /// Pass a class-specific `const Object()` as the `token`.
-  PlatformInterface({ @required Object token }) : _instanceToken = token;
+  PlatformInterface({@required Object token}) : _instanceToken = token;
 
   final Object _instanceToken;
 

--- a/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
@@ -45,7 +45,8 @@ abstract class UrlLauncherPlatform {
     }());
     if (!assertionsEnabled || !instance.isMock) {
       try {
-        if (_verificationToken != instance._verifyProvidesDefaultImplementations()) {
+        if (identical(_verificationToken,
+            instance._verifyProvidesDefaultImplementations())) {
           throw AssertionError(
               'Platform interfaces must not be implemented with `implements`');
         }

--- a/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
@@ -26,7 +26,8 @@ abstract class PlatformInterface {
   /// This is used to ensure that implementers are using `extends` rather than
   /// `implements`.
   ///
-  /// Subclasses of [MockPlatformInterface] are assumed to be valid.
+  /// Subclasses of [MockPlatformInterface] are assumed to be valid in debug
+  /// builds.
   ///
   /// This is implemented as a static method so that it cannot be overridden
   /// with `noSuchMethod`.
@@ -51,9 +52,10 @@ abstract class PlatformInterface {
 
 /// A [PlatformInterface] mixin that can be combined with mockito's `Mock`.
 ///
-/// It always returns `true` when passed to [PlatformInterface.isValid].
+/// It passes the [PlatformInterface.verifyToken] check even though it isn't
+/// using `extends`.
 ///
-/// For use in testing only. Throws `AssertionError` when used in release mode.
+/// This class is intended for use in tests only.
 @visibleForTesting
 abstract class MockPlatformInterface implements PlatformInterface {
   static const Object _token = const Object();

--- a/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
@@ -13,10 +13,10 @@ import 'method_channel_url_launcher.dart';
 /// Provides helper methods for ensuring that platform interfaces are
 /// implemented using `extends` instead of `implements`.
 class PlatformInterface {
-  PlatformInterface({ Object token }) : _token = token;
+  PlatformInterface({Object token}) : _instanceToken = token;
 
   // Pass a `const Object()` here to distinguish
-  final Object _token;
+  final Object _instanceToken;
 
   // Mock implementations can return true here using `noSuchMethod`.
   //
@@ -29,8 +29,10 @@ class PlatformInterface {
   /// Return true if the platform instance has a token that matches the
   /// provided token. This is used to ensure that implementers are using
   /// `extends` rather than `implements`.
+  ///
+  /// Subclasses of [MockPlatformInterface] are assumed to be valid.
   static bool isValid(PlatformInterface instance, Object token) {
-    return _isMock || identical(token, instance._token);
+    return instance._isMock || identical(token, instance._instanceToken);
   }
 }
 

--- a/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
@@ -13,8 +13,9 @@ import 'method_channel_url_launcher.dart';
 /// Provides helper methods for ensuring that platform interfaces are
 /// implemented using `extends` instead of `implements`.
 class PlatformInterface {
-  PlatformInterface({ Object token }) : _verificationToken = token;
+  PlatformInterface({ Object token }) : _token = token;
 
+  // Pass a `const Object()` here to distinguish
   final Object _token;
 
   // Mock implementations can return true here using `noSuchMethod`.
@@ -25,22 +26,12 @@ class PlatformInterface {
   // implemented with `implements`.
   bool get _isMock => false;
 
-  /// Returns the instance.
-  static void verifyToken<T>(Object token, PlatformInterface instance) {
-    assert(identical(token, instance._token));
+  /// Return true if the platform instance has a token that matches the
+  /// provided token. This is used to ensure that implementers are using
+  /// `extends` rather than `implements`.
+  static bool isValid(PlatformInterface instance, Object token) {
+    return _isMock || identical(token, instance._token);
   }
-
-  // This method makes sure that UrlLauncher isn't implemented with `implements`.
-  //
-  // See class doc for more details on why implementing this class is forbidden.
-  //
-  // This private method is called by the instance setter, which fails if the class is
-  // implemented with `implements`.
-  Object _verifyProvidesDefaultImplementations() => _verificationToken;
-
-  // Private object used to ensure that `_verifyProvidesDefaultImplementations`
-  // cannot be implemented using `noSuchMethod`.
-  static const Object _verificationToken = const Object();
 }
 
 /// A [PlatformInterface] that can be mocked with mockito.
@@ -87,7 +78,7 @@ abstract class UrlLauncherPlatform extends PlatformInterface {
   // TODO(amirh): Extract common platform interface logic.
   // https://github.com/flutter/flutter/issues/43368
   static set instance(UrlLauncherPlatform instance) {
-    PlatformInterface.verifyToken(_token, instance);
+    assert(PlatformInterface.isValid(instance, _token));
     _instance = instance;
   }
 

--- a/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
@@ -20,9 +20,11 @@ abstract class PlatformInterface {
 
   final Object _instanceToken;
 
-  /// Return true if the platform instance has a token that matches the
-  /// provided token. This is used to ensure that implementers are using
-  /// `extends` rather than `implements`.
+  /// Return `true `if the platform instance has a token that matches the
+  /// provided token.
+  /// 
+  /// This is used to ensure that implementers are using `extends` rather than
+  /// `implements`.
   ///
   /// Subclasses of [MockPlatformInterface] are assumed to be valid.
   static bool isValid(PlatformInterface instance, Object token) {
@@ -45,7 +47,7 @@ abstract class PlatformInterface {
 
 /// A [PlatformInterface] mixin that can be combined with mockito's `Mock`.
 ///
-/// It always returns true when passed to [PlatformInterface.isValid].
+/// It always returns `true` when passed to [PlatformInterface.isValid].
 ///
 /// For use in testing only. Throws `AssertionError` when used in release mode.
 @visibleForTesting

--- a/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
@@ -58,7 +58,7 @@ abstract class PlatformInterface {
 /// This class is intended for use in tests only.
 @visibleForTesting
 abstract class MockPlatformInterface implements PlatformInterface {
-  static const Object _token = const Object();
+  static const Object _token = Object();
 
   @override
   Object get _instanceToken => _token;
@@ -76,7 +76,7 @@ abstract class UrlLauncherPlatform extends PlatformInterface {
 
   static UrlLauncherPlatform _instance = MethodChannelUrlLauncher();
 
-  static const Object _token = const Object();
+  static const Object _token = Object();
 
   /// The default instance of [UrlLauncherPlatform] to use.
   ///

--- a/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
@@ -10,14 +10,14 @@ import 'method_channel_url_launcher.dart';
 
 /// Base class for platform interfaces.
 ///
-/// Provides helper methods for ensuring that platform interfaces are
+/// Provides a static helper method for ensuring that platform interfaces are
 /// implemented using `extends` instead of `implements`.
 // TODO(amirh): Extract common platform interface logic.
 // https://github.com/flutter/flutter/issues/43368
-class PlatformInterface {
+abstract class PlatformInterface {
+  /// Pass a class-specific `const Object()` as the `token`.
   PlatformInterface({Object token}) : _instanceToken = token;
 
-  // Pass a `const Object()` here to distinguish
   final Object _instanceToken;
 
   // Mock implementations can return true here using `noSuchMethod`.
@@ -38,11 +38,13 @@ class PlatformInterface {
   }
 }
 
-/// A [PlatformInterface] that can be mocked with mockito.
+/// A [PlatformInterface] mixin that can be combined with mockito's `Mock`.
+///
+/// It always returns true when passed to [PlatformInterface.isValid].
 ///
 /// Throws an `AssertionError` when used in release builds.
 @visibleForTesting
-class MockPlatformInterface extends PlatformInterface {
+abstract class MockPlatformInterface extends PlatformInterface {
   @override
   bool get _isMock {
     bool assertionsEnabled = false;

--- a/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
@@ -45,7 +45,7 @@ abstract class UrlLauncherPlatform {
     }());
     if (!assertionsEnabled || !instance.isMock) {
       try {
-        if (identical(_verificationToken,
+        if (!identical(_verificationToken,
             instance._verifyProvidesDefaultImplementations())) {
           throw AssertionError(
               'Platform interfaces must not be implemented with `implements`');
@@ -94,5 +94,5 @@ abstract class UrlLauncherPlatform {
 
   // Private object used to determine if `_verifyProvidesDefaultImplementations`
   // has been overridden with `noSuchMethod`.
-  static Object _verificationToken = Object();
+  static const Object _verificationToken = const Object();
 }

--- a/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
@@ -29,17 +29,7 @@ abstract class PlatformInterface {
   /// Subclasses of [MockPlatformInterface] are assumed to be valid.
   static bool isValid(PlatformInterface instance, Object token) {
     if (identical(instance._instanceToken, MockPlatformInterface._token)) {
-      bool assertionsEnabled = false;
-      assert(() {
-        assertionsEnabled = true;
-        return true;
-      }());
-      if (assertionsEnabled) {
-        return true;
-      } else {
-        throw AssertionError(
-            '`MockPlatformInterface` is not intended for use in release builds.');
-      }
+      return true;
     }
     return identical(token, instance._instanceToken);
   }
@@ -55,7 +45,19 @@ abstract class MockPlatformInterface implements PlatformInterface {
   static const Object _token = const Object();
 
   @override
-  final Object _instanceToken = _token;
+  Object get _instanceToken {
+    bool assertionsEnabled = false;
+    assert(() {
+      assertionsEnabled = true;
+      return true;
+    }());
+    if (assertionsEnabled) {
+      return _token;
+    } else {
+      throw AssertionError(
+          '`MockPlatformInterface` is not intended for use in release builds.');
+    }
+  }
 }
 
 /// The interface that implementations of url_launcher must implement.

--- a/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
@@ -32,11 +32,11 @@ abstract class PlatformInterface {
         assertionsEnabled = true;
         return true;
       }());
-      if (!assertionsEnabled) {
+      if (assertionsEnabled) {
+        return true;
+      } else {
         throw AssertionError(
             '`MockPlatformInterface` is not intended for use in release builds.');
-      } else {
-        return true;
       }
     }
     return identical(token, instance._instanceToken);

--- a/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
@@ -16,7 +16,7 @@ import 'method_channel_url_launcher.dart';
 // https://github.com/flutter/flutter/issues/43368
 abstract class PlatformInterface {
   /// Pass a class-specific `const Object()` as the `token`.
-  PlatformInterface({Object token}) : _instanceToken = token;
+  PlatformInterface({ @required Object token }) : _instanceToken = token;
 
   final Object _instanceToken;
 
@@ -42,9 +42,9 @@ abstract class PlatformInterface {
 ///
 /// It always returns true when passed to [PlatformInterface.isValid].
 ///
-/// Throws an `AssertionError` when used in release builds.
+/// For use in testing only. Throws `AssertionError` when used in release mode.
 @visibleForTesting
-abstract class MockPlatformInterface extends PlatformInterface {
+abstract class MockPlatformInterface implements PlatformInterface {
   @override
   bool get _isMock {
     bool assertionsEnabled = false;

--- a/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
@@ -91,7 +91,7 @@ abstract class UrlLauncherPlatform {
   // implemented with `implements`.
   Object _verifyProvidesDefaultImplementations() => _verificationToken;
 
-  // Private object used to determine whether  mocks from instances of  genuine  if _verifyProvidesDefaultImplementations
-  // has been overridden with noSuchMethod.
+  // Private object used to determine if `_verifyProvidesDefaultImplementations`
+  // has been overridden with `noSuchMethod`.
   static Object _verificationToken = Object();
 }

--- a/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
@@ -12,6 +12,8 @@ import 'method_channel_url_launcher.dart';
 ///
 /// Provides helper methods for ensuring that platform interfaces are
 /// implemented using `extends` instead of `implements`.
+// TODO(amirh): Extract common platform interface logic.
+// https://github.com/flutter/flutter/issues/43368
 class PlatformInterface {
   PlatformInterface({Object token}) : _instanceToken = token;
 
@@ -77,8 +79,6 @@ abstract class UrlLauncherPlatform extends PlatformInterface {
 
   /// Platform-specific plugins should set this with their own platform-specific
   /// class that extends [UrlLauncherPlatform] when they register themselves.
-  // TODO(amirh): Extract common platform interface logic.
-  // https://github.com/flutter/flutter/issues/43368
   static set instance(UrlLauncherPlatform instance) {
     assert(PlatformInterface.isValid(instance, _token));
     _instance = instance;

--- a/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
@@ -22,7 +22,7 @@ abstract class PlatformInterface {
 
   /// Ensures that the platform instance has a token that matches the
   /// provided token and throws [AssertionError] if not.
-  /// 
+  ///
   /// This is used to ensure that implementers are using `extends` rather than
   /// `implements`.
   ///

--- a/packages/url_launcher/url_launcher_platform_interface/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.0.3
+version: 1.0.4
 
 dependencies:
   flutter:

--- a/packages/url_launcher/url_launcher_platform_interface/test/method_channel_url_launcher_test.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/test/method_channel_url_launcher_test.dart
@@ -27,7 +27,6 @@ void main() {
     test('Can be mocked with `implements`', () {
       final ImplementsUrlLauncherPlatform mock =
           ImplementsUrlLauncherPlatform();
-      when(mock.isMock).thenReturn(true);
       UrlLauncherPlatform.instance = mock;
     });
 
@@ -280,7 +279,8 @@ void main() {
   });
 }
 
-class ImplementsUrlLauncherPlatform extends Mock
-    implements UrlLauncherPlatform {}
+class ImplementsUrlLauncherPlatform extends Mock with MockPlatformInterface
+    implements UrlLauncherPlatform {
+}
 
 class ExtendsUrlLauncherPlatform extends UrlLauncherPlatform {}

--- a/packages/url_launcher/url_launcher_platform_interface/test/method_channel_url_launcher_test.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/test/method_channel_url_launcher_test.dart
@@ -25,8 +25,8 @@ void main() {
     });
 
     test('Can be mocked with `implements`', () {
-      final ImplementsUrlLauncherPlatform mock =
-          ImplementsUrlLauncherPlatform();
+      final UrlLauncherPlatform mock =
+          ImplementsUrlLauncherPlatformUsingMockPlatformInterface();
       UrlLauncherPlatform.instance = mock;
     });
 
@@ -279,8 +279,11 @@ void main() {
   });
 }
 
-class ImplementsUrlLauncherPlatform extends Mock with MockPlatformInterface
-    implements UrlLauncherPlatform {
-}
+class ImplementsUrlLauncherPlatform extends Mock
+    implements UrlLauncherPlatform {}
+
+class ImplementsUrlLauncherPlatformUsingMockPlatformInterface extends Mock
+    with MockPlatformInterface
+    implements UrlLauncherPlatform {}
 
 class ExtendsUrlLauncherPlatform extends UrlLauncherPlatform {}


### PR DESCRIPTION
This is an attempt to address what I understand to be the underlying motivation of @Hixie's [comment](https://github.com/flutter/plugins/pull/2230#issuecomment-558856299) on #2230.

## Problem

The `isMock` API is currently in the public docs (despite being `@visibleForTesting`) and we're not thrilled about it.

The `@visibleForTesting` annotation on `isMock` results in a warning that can be easily ignored by the plugin consumer. This could create a maintenance burden if platform implementers create packages that use the `isMock` backdoor to implement rather than extend the platform interface.

Furthermore, it is currently possible to bypass `isMock` trivially with `noSuchMethod`.

## Solution

This PR proposes a base class `PlatformInterface` that plugins can extend. It provides a static validation method that is used to ensure that subclasses use `extends` rather than `implements`. The verification is performed using an `identical` comparison on a private `Object` token.

I believe that this approach makes it impossible to bypass the validation check using `noSuchMethod`.

The base classes should be extracted into a common package, see https://github.com/flutter/flutter/issues/43368

To avoid introducing new API surface area that we later have to remove we should probably move the `PlatformInterface` class into either the Flutter SDK or a package.

/cc @amirh @goderbauer 