### PR TITLE
[ImagePicker] Captured Video quality and duration support

### DIFF
--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.3
+
+* Video Capture from Camera is supporting Duration and Quality parameters.
+
 ## 0.6.2+1
 
 * Android: Fix a crash when a non-image file is picked.

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
@@ -79,7 +79,10 @@ public class ImagePickerDelegate
   @VisibleForTesting static final int VIDEO_QUALITY_LOW = 0;
 
   @VisibleForTesting static final int FLUTTER_VIDEO_QUALITY_HIGH = 0;
-  @VisibleForTesting static final int FLUTTER_VIDEO_QUALITY_MEDIUM = 1; // Mapped to Low Quality Video Recording
+
+  @VisibleForTesting
+  static final int FLUTTER_VIDEO_QUALITY_MEDIUM = 1; // Mapped to Low Quality Video Recording
+
   @VisibleForTesting static final int FLUTTER_VIDEO_QUALITY_LOW = 2;
 
   @VisibleForTesting final String fileProviderName;
@@ -289,19 +292,21 @@ public class ImagePickerDelegate
 
     if (methodCall != null) {
       int quality =
-              methodCall.argument("quality") == null
-                      ? FLUTTER_VIDEO_QUALITY_HIGH
-                      : (int) methodCall.argument("quality");
-      int videoQuality = (quality == FLUTTER_VIDEO_QUALITY_HIGH) ? VIDEO_QUALITY_HIGH : VIDEO_QUALITY_LOW;
+          methodCall.argument("quality") == null
+              ? FLUTTER_VIDEO_QUALITY_HIGH
+              : (int) methodCall.argument("quality");
+      int videoQuality =
+          (quality == FLUTTER_VIDEO_QUALITY_HIGH) ? VIDEO_QUALITY_HIGH : VIDEO_QUALITY_LOW;
       intent.putExtra(MediaStore.EXTRA_VIDEO_QUALITY, videoQuality);
 
 
       int durationInSeconds =
-              methodCall.argument("duration") == null
-                      ? 0 // Zero means a limitless video recording session
-                      : (int) methodCall.argument("duration");
+          methodCall.argument("duration") == null
+              ? 0 // Zero means a limitless video recording session
+              : (int) methodCall.argument("duration");
       if (durationInSeconds < 0) {
-        finishWithError("not_valid_duration_input", "Duration in seconds can not be a negative number");
+        finishWithError(
+            "not_valid_duration_input", "Duration in seconds can not be a negative number");
         return;
       }
       intent.putExtra(MediaStore.EXTRA_DURATION_LIMIT, durationInSeconds);

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
@@ -75,6 +75,13 @@ public class ImagePickerDelegate
   @VisibleForTesting static final int REQUEST_EXTERNAL_VIDEO_STORAGE_PERMISSION = 2354;
   @VisibleForTesting static final int REQUEST_CAMERA_VIDEO_PERMISSION = 2355;
 
+  @VisibleForTesting static final int VIDEO_QUALITY_HIGH = 1;
+  @VisibleForTesting static final int VIDEO_QUALITY_LOW = 0;
+
+  @VisibleForTesting static final int FLUTTER_VIDEO_QUALITY_HIGH = 0;
+  @VisibleForTesting static final int FLUTTER_VIDEO_QUALITY_MEDIUM = 1; // Mapped to Low Quality Video Recording
+  @VisibleForTesting static final int FLUTTER_VIDEO_QUALITY_LOW = 2;
+
   @VisibleForTesting final String fileProviderName;
 
   private final Activity activity;
@@ -278,6 +285,26 @@ public class ImagePickerDelegate
     if (!canTakePhotos) {
       finishWithError("no_available_camera", "No cameras available for taking pictures.");
       return;
+    }
+
+    if (methodCall != null) {
+      int quality =
+              methodCall.argument("quality") == null
+                      ? FLUTTER_VIDEO_QUALITY_HIGH
+                      : (int) methodCall.argument("quality");
+      int videoQuality = (quality == FLUTTER_VIDEO_QUALITY_HIGH) ? VIDEO_QUALITY_HIGH : VIDEO_QUALITY_LOW;
+      intent.putExtra(MediaStore.EXTRA_VIDEO_QUALITY, videoQuality);
+
+
+      int durationInSeconds =
+              methodCall.argument("duration") == null
+                      ? 0 // Zero means a limitless video recording session
+                      : (int) methodCall.argument("duration");
+      if (durationInSeconds < 0) {
+        finishWithError("not_valid_duration_input", "Duration in seconds can not be a negative number");
+        return;
+      }
+      intent.putExtra(MediaStore.EXTRA_DURATION_LIMIT, durationInSeconds);
     }
 
     File videoFile = createTemporaryWritableVideoFile();

--- a/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
+++ b/packages/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
@@ -299,7 +299,6 @@ public class ImagePickerDelegate
           (quality == FLUTTER_VIDEO_QUALITY_HIGH) ? VIDEO_QUALITY_HIGH : VIDEO_QUALITY_LOW;
       intent.putExtra(MediaStore.EXTRA_VIDEO_QUALITY, videoQuality);
 
-
       int durationInSeconds =
           methodCall.argument("duration") == null
               ? 0 // Zero means a limitless video recording session

--- a/packages/image_picker/ios/Classes/ImagePickerPlugin.m
+++ b/packages/image_picker/ios/Classes/ImagePickerPlugin.m
@@ -22,6 +22,10 @@
 static const int SOURCE_CAMERA = 0;
 static const int SOURCE_GALLERY = 1;
 
+static const int QUALITY_HIGH = 0;
+static const int QUALITY_MEDIUM = 1;
+static const int QUALITY_LOW = 2;
+
 @implementation FLTImagePickerPlugin {
   NSDictionary *_arguments;
   UIImagePickerController *_imagePickerController;
@@ -87,10 +91,36 @@ static const int SOURCE_GALLERY = 1;
       (NSString *)kUTTypeMovie, (NSString *)kUTTypeAVIMovie, (NSString *)kUTTypeVideo,
       (NSString *)kUTTypeMPEG4
     ];
-    _imagePickerController.videoQuality = UIImagePickerControllerQualityTypeHigh;
-
+      
     self.result = result;
     _arguments = call.arguments;
+      
+    NSNumber* quality = [_arguments objectForKey:@"quality"];
+    int videoQuality = ([quality respondsToSelector:@selector(intValue)]) ? [quality intValue] : QUALITY_HIGH;
+    switch (videoQuality) {
+      case QUALITY_HIGH:
+        _imagePickerController.videoQuality = UIImagePickerControllerQualityTypeHigh;
+        break;
+      case QUALITY_MEDIUM:
+        _imagePickerController.videoQuality = UIImagePickerControllerQualityTypeMedium;
+        break;
+      case QUALITY_LOW:
+        _imagePickerController.videoQuality = UIImagePickerControllerQualityTypeLow;
+        break;
+      default:
+        _imagePickerController.videoQuality = UIImagePickerControllerQualityTypeHigh;
+        break;
+    }
+    
+    NSNumber* duration = [_arguments objectForKey:@"duration"];
+    int videoDuration = ([duration respondsToSelector:@selector(intValue)]) ? [duration intValue] : 0;
+      if(videoDuration < 0){
+          result([FlutterError errorWithCode:@"not_valid_duration_input"
+          message:@"Duration in seconds can not be a negative number"
+          details:nil]);
+          return;
+      }
+    _imagePickerController.videoMaximumDuration = videoDuration;
 
     int imageSource = [[_arguments objectForKey:@"source"] intValue];
 

--- a/packages/image_picker/ios/Classes/ImagePickerPlugin.m
+++ b/packages/image_picker/ios/Classes/ImagePickerPlugin.m
@@ -91,13 +91,13 @@ static const int QUALITY_LOW = 2;
       (NSString *)kUTTypeMovie, (NSString *)kUTTypeAVIMovie, (NSString *)kUTTypeVideo,
       (NSString *)kUTTypeMPEG4
     ];
-      
+
     self.result = result;
     _arguments = call.arguments;
-      
+
     NSNumber *quality = [_arguments objectForKey:@"quality"];
     int videoQuality =
-      ([quality respondsToSelector:@selector(intValue)]) ? [quality intValue] : QUALITY_HIGH;
+        ([quality respondsToSelector:@selector(intValue)]) ? [quality intValue] : QUALITY_HIGH;
     switch (videoQuality) {
       case QUALITY_HIGH:
         _imagePickerController.videoQuality = UIImagePickerControllerQualityTypeHigh;
@@ -112,10 +112,10 @@ static const int QUALITY_LOW = 2;
         _imagePickerController.videoQuality = UIImagePickerControllerQualityTypeHigh;
         break;
     }
-    
+
     NSNumber *duration = [_arguments objectForKey:@"duration"];
     int videoDuration =
-      ([duration respondsToSelector:@selector(intValue)]) ? [duration intValue] : 0;
+        ([duration respondsToSelector:@selector(intValue)]) ? [duration intValue] : 0;
     if (videoDuration < 0) {
       result([FlutterError errorWithCode:@"not_valid_duration_input"
                                  message:@"Duration in seconds can not be a negative number"

--- a/packages/image_picker/ios/Classes/ImagePickerPlugin.m
+++ b/packages/image_picker/ios/Classes/ImagePickerPlugin.m
@@ -95,8 +95,9 @@ static const int QUALITY_LOW = 2;
     self.result = result;
     _arguments = call.arguments;
       
-    NSNumber* quality = [_arguments objectForKey:@"quality"];
-    int videoQuality = ([quality respondsToSelector:@selector(intValue)]) ? [quality intValue] : QUALITY_HIGH;
+    NSNumber *quality = [_arguments objectForKey:@"quality"];
+    int videoQuality =
+      ([quality respondsToSelector:@selector(intValue)]) ? [quality intValue] : QUALITY_HIGH;
     switch (videoQuality) {
       case QUALITY_HIGH:
         _imagePickerController.videoQuality = UIImagePickerControllerQualityTypeHigh;
@@ -112,14 +113,15 @@ static const int QUALITY_LOW = 2;
         break;
     }
     
-    NSNumber* duration = [_arguments objectForKey:@"duration"];
-    int videoDuration = ([duration respondsToSelector:@selector(intValue)]) ? [duration intValue] : 0;
-      if(videoDuration < 0){
-          result([FlutterError errorWithCode:@"not_valid_duration_input"
-          message:@"Duration in seconds can not be a negative number"
-          details:nil]);
-          return;
-      }
+    NSNumber *duration = [_arguments objectForKey:@"duration"];
+    int videoDuration =
+      ([duration respondsToSelector:@selector(intValue)]) ? [duration intValue] : 0;
+    if (videoDuration < 0) {
+      result([FlutterError errorWithCode:@"not_valid_duration_input"
+                                 message:@"Duration in seconds can not be a negative number"
+                                 details:nil]);
+      return;
+    }
     _imagePickerController.videoMaximumDuration = videoDuration;
 
     int imageSource = [[_arguments objectForKey:@"source"] intValue];

--- a/packages/image_picker/lib/image_picker.dart
+++ b/packages/image_picker/lib/image_picker.dart
@@ -23,6 +23,18 @@ enum ImageSource {
   gallery,
 }
 
+/// Specifies the video quality to be picked from Camera.
+enum VideoQuality {
+  /// High Qulaity Video with Maximum size.
+  High,
+
+  /// Medium Qulaity Video.
+  Medium,
+
+  /// Low Qulaity Video.
+  Low,
+}
+
 /// Provides an easy way to pick an image/video from the image library,
 /// or to take a picture/video with the camera.
 class ImagePicker {
@@ -79,16 +91,25 @@ class ImagePicker {
   /// The [source] argument controls where the video comes from. This can
   /// be either [ImageSource.camera] or [ImageSource.gallery].
   ///
+  /// The [quality] optional argument controls the video quality and its size on correspondence. This can
+  /// be either [VideoQuality.High] (default), [VideoQuality.Medium](supported in iOS only) or [VideoQuality.Low].
+  ///
+  /// The [durationInSeconds] optional argument controls the video length in seconds. The default value is Zero - which means a limitless video length.
+  ///
   /// In Android, the MainActivity can be destroyed for various fo reasons. If that happens, the result will be lost
   /// in this call. You can then call [retrieveLostData] when your app relaunches to retrieve the lost data.
   static Future<File> pickVideo({
     @required ImageSource source,
+    VideoQuality quality = VideoQuality.High,
+    int durationInSeconds = 0, // Zero Means limitless video duration
   }) async {
     assert(source != null);
     final String path = await _channel.invokeMethod<String>(
       'pickVideo',
       <String, dynamic>{
         'source': source.index,
+        'quality' : quality.index,
+        'duration' : durationInSeconds,
       },
     );
     return path == null ? null : File(path);

--- a/packages/image_picker/lib/image_picker.dart
+++ b/packages/image_picker/lib/image_picker.dart
@@ -25,13 +25,13 @@ enum ImageSource {
 
 /// Specifies the video quality to be picked from Camera.
 enum VideoQuality {
-  /// High Qulaity Video with Maximum size.
+  /// High Quality Video with Maximum size.
   High,
 
-  /// Medium Qulaity Video.
+  /// Medium Quality Video.
   Medium,
 
-  /// Low Qulaity Video.
+  /// Low Quality Video.
   Low,
 }
 
@@ -94,7 +94,8 @@ class ImagePicker {
   /// The [quality] optional argument controls the video quality and its size on correspondence. This can
   /// be either [VideoQuality.High] (default), [VideoQuality.Medium](supported in iOS only) or [VideoQuality.Low].
   ///
-  /// The [durationInSeconds] optional argument controls the video length in seconds. The default value is Zero - which means a limitless video length.
+  /// The [durationInSeconds] optional argument controls the video length in seconds.
+  /// The default value is Zero - which means a limitless video length.
   ///
   /// In Android, the MainActivity can be destroyed for various fo reasons. If that happens, the result will be lost
   /// in this call. You can then call [retrieveLostData] when your app relaunches to retrieve the lost data.

--- a/packages/image_picker/lib/image_picker.dart
+++ b/packages/image_picker/lib/image_picker.dart
@@ -104,6 +104,11 @@ class ImagePicker {
     int durationInSeconds = 0, // Zero Means limitless video duration
   }) async {
     assert(source != null);
+
+    if (durationInSeconds != null && durationInSeconds < 0) {
+      throw ArgumentError.value(durationInSeconds, 'DurationInSeconds can not be a negative number');
+    }
+
     final String path = await _channel.invokeMethod<String>(
       'pickVideo',
       <String, dynamic>{

--- a/packages/image_picker/lib/image_picker.dart
+++ b/packages/image_picker/lib/image_picker.dart
@@ -106,15 +106,16 @@ class ImagePicker {
     assert(source != null);
 
     if (durationInSeconds != null && durationInSeconds < 0) {
-      throw ArgumentError.value(durationInSeconds, 'DurationInSeconds can not be a negative number');
+      throw ArgumentError.value(
+          durationInSeconds, 'DurationInSeconds can not be a negative number');
     }
 
     final String path = await _channel.invokeMethod<String>(
       'pickVideo',
       <String, dynamic>{
         'source': source.index,
-        'quality' : quality.index,
-        'duration' : durationInSeconds,
+        'quality': quality.index,
+        'duration': durationInSeconds,
       },
     );
     return path == null ? null : File(path);

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -5,7 +5,7 @@ authors:
   - Flutter Team <flutter-dev@googlegroups.com>
   - Rhodes Davis Jr. <rody.davis.jr@gmail.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.6.2+1
+version: 0.6.3
 
 flutter:
   plugin:

--- a/packages/image_picker/test/image_picker_test.dart
+++ b/packages/image_picker/test/image_picker_test.dart
@@ -147,10 +147,23 @@ void main() {
       test('passes the image source argument correctly', () async {
         await ImagePicker.pickVideo(source: ImageSource.camera);
         await ImagePicker.pickVideo(source: ImageSource.gallery);
-        await ImagePicker.pickVideo(source: ImageSource.camera, quality: VideoQuality.Medium, );
-        await ImagePicker.pickVideo(source: ImageSource.camera, quality: VideoQuality.Low);
-        await ImagePicker.pickVideo(source: ImageSource.camera, quality: VideoQuality.Low, durationInSeconds: 15);
-        await ImagePicker.pickVideo(source: ImageSource.camera, durationInSeconds: 15);
+        await ImagePicker.pickVideo(
+          source: ImageSource.camera,
+          quality: VideoQuality.Medium,
+        );
+        await ImagePicker.pickVideo(
+          source: ImageSource.camera,
+          quality: VideoQuality.Low,
+        );
+        await ImagePicker.pickVideo(
+          source: ImageSource.camera,
+          quality: VideoQuality.Low,
+          durationInSeconds: 15,
+        );
+        await ImagePicker.pickVideo(
+          source: ImageSource.camera,
+          durationInSeconds: 15,
+        );
 
         expect(
           log,
@@ -191,15 +204,21 @@ void main() {
 
       test('does not accept a negative durationInSeconds argument', () {
         expect(
-          ImagePicker.pickVideo(source: ImageSource.camera, durationInSeconds: -10),
+          ImagePicker.pickVideo(
+            source: ImageSource.camera,
+            durationInSeconds: -10,
+          ),
           throwsArgumentError,
         );
 
         expect(
-          ImagePicker.pickVideo(source: ImageSource.camera, quality: VideoQuality.Low, durationInSeconds: -10),
+          ImagePicker.pickVideo(
+            source: ImageSource.camera,
+            quality: VideoQuality.Low,
+            durationInSeconds: -10,
+          ),
           throwsArgumentError,
         );
-
       });
 
       test('handles a null image path response gracefully', () async {

--- a/packages/image_picker/test/image_picker_test.dart
+++ b/packages/image_picker/test/image_picker_test.dart
@@ -147,18 +147,59 @@ void main() {
       test('passes the image source argument correctly', () async {
         await ImagePicker.pickVideo(source: ImageSource.camera);
         await ImagePicker.pickVideo(source: ImageSource.gallery);
+        await ImagePicker.pickVideo(source: ImageSource.camera, quality: VideoQuality.Medium, );
+        await ImagePicker.pickVideo(source: ImageSource.camera, quality: VideoQuality.Low);
+        await ImagePicker.pickVideo(source: ImageSource.camera, quality: VideoQuality.Low, durationInSeconds: 15);
+        await ImagePicker.pickVideo(source: ImageSource.camera, durationInSeconds: 15);
 
         expect(
           log,
           <Matcher>[
             isMethodCall('pickVideo', arguments: <String, dynamic>{
               'source': 0,
+              'quality': 0,
+              'duration': 0
             }),
             isMethodCall('pickVideo', arguments: <String, dynamic>{
               'source': 1,
+              'quality': 0,
+              'duration': 0
+            }),
+            isMethodCall('pickVideo', arguments: <String, dynamic>{
+              'source': 0,
+              'quality': 1,
+              'duration': 0
+            }),
+            isMethodCall('pickVideo', arguments: <String, dynamic>{
+              'source': 0,
+              'quality': 2,
+              'duration': 0
+            }),
+            isMethodCall('pickVideo', arguments: <String, dynamic>{
+              'source': 0,
+              'quality': 2,
+              'duration': 15
+            }),
+            isMethodCall('pickVideo', arguments: <String, dynamic>{
+              'source': 0,
+              'quality': 0,
+              'duration': 15
             }),
           ],
         );
+      });
+
+      test('does not accept a negative durationInSeconds argument', () {
+        expect(
+          ImagePicker.pickVideo(source: ImageSource.camera, durationInSeconds: -10),
+          throwsArgumentError,
+        );
+
+        expect(
+          ImagePicker.pickVideo(source: ImageSource.camera, quality: VideoQuality.Low, durationInSeconds: -10),
+          throwsArgumentError,
+        );
+
       });
 
       test('handles a null image path response gracefully', () async {


### PR DESCRIPTION
## Description

*Starting using the Plugin, I found that there are no extra parameters could be passed to the pickVideo function. This behavior limits the usage of the library especially having no record duration could lead to a huge file size that is very hard to upload to a server.

In this PR, I have implemented optional two parameters for pickVideo function (quality, durationInSeconds) which were covered in the three levels (Dart, iOS Objective-C, and Android Java Library) that controlled the outcome video recorded from the device Camera

The changes are on iOS (ImagePickerPlugin.m), Android(ImagePickerDelegate.java), Dart (image_picker.dart),(test/image_picker_test.dart).

Being implemented as optional parameters, it will not break any previous code implementations and supports the default behavior as currently implemented if the parameters are not passed. (High-Quality video, No duration record duration).
*

## Related Issues

*[flutter/flutter#40035](https://github.com/flutter/flutter/issues/40035)*

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/