### PR TITLE
[camera] Resolve example null exception

### DIFF
--- a/packages/camera/CHANGELOG.md
+++ b/packages/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.7+1
+
+* Fix example null exception.
+
 ## 0.5.7
 
 * Fix unawaited futures.

--- a/packages/camera/example/lib/main.dart
+++ b/packages/camera/example/lib/main.dart
@@ -474,7 +474,7 @@ class CameraApp extends StatelessWidget {
   }
 }
 
-List<CameraDescription> cameras;
+List<CameraDescription> cameras = [];
 
 Future<void> main() async {
   // Fetch the available cameras before initializing the app.

--- a/packages/camera/pubspec.yaml
+++ b/packages/camera/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera
 description: A Flutter plugin for getting information about and controlling the
   camera on Android and iOS. Supports previewing the camera feed, capturing images, capturing video,
   and streaming image buffers to dart.
-version: 0.5.7
+version: 0.5.7+1
 
 authors:
   - Flutter Team <flutter-dev@googlegroups.com>


### PR DESCRIPTION
## Description

I did some automation tools, and find camera example may have null exception.

## Related Issues

```
════════ Exception caught by widgets library ═══════════════════════════════════════════════════════
The following NoSuchMethodError was thrown building CameraExampleHome(dirty, state: _CameraExampleHomeState#5438f):
The getter 'isEmpty' was called on null.
Receiver: null
Tried calling: isEmpty

The relevant error-causing widget was: 
  CameraExampleHome
When the exception was thrown, this was the stack: 
#0      Object.noSuchMethod (dart:core-patch/object_patch.dart:53:5)
#1      _CameraExampleHomeState._cameraTogglesRowWidget (package:camera_example/main.dart:249:17)
#2      _CameraExampleHomeState.build (package:camera_example/main.dart:111:17)
#3      StatefulElement.build (package:flutter/src/widgets/framework.dart:4334:27)
#4      ComponentElement.performRebuild (package:flutter/src/widgets/framework.dart:4223:15)
...
════════════════════════════════════════════════════════════════════════════════════════════════════
```
![Simulator Screen Shot - iPhone 11 Pro Max](https://user-images.githubusercontent.com/17288716/70147479-420eb680-16df-11ea-9bda-633f98245e06.png)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
