### PR TITLE
Revert "[android_alarm_manager] Update minimum Flutter version to 1.12.0"

### DIFF
--- a/packages/android_alarm_manager/pubspec.yaml
+++ b/packages/android_alarm_manager/pubspec.yaml
@@ -22,4 +22,5 @@ flutter:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=1.12.0 <2.0.0"
+  # TODO(bkonyi): set minimum Flutter version to next stable release
+  flutter: ">=1.2.0 <2.0.0"


### PR DESCRIPTION
Reverts flutter/plugins#2327

Reverting to unblock CI.

@bkonyi not sure if you have a plan for a fix or whether you want to re-publish the reverted plugin, please follow-up.