### PR TITLE
[video_player_platform_interface] Fix some pedantic lints

### DIFF
--- a/packages/video_player/video_player_platform_interface/CHANGELOG.md
+++ b/packages/video_player/video_player_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2
+
+* Fix unawaited futures in the tests.
+
 ## 1.0.1
 
 * Return correct platform event type when buffering

--- a/packages/video_player/video_player_platform_interface/analysis_options.yaml
+++ b/packages/video_player/video_player_platform_interface/analysis_options.yaml
@@ -8,4 +8,3 @@ include: ../../../analysis_options.yaml
 analyzer:
   errors:
     public_member_api_docs: ignore
-    unawaited_futures: ignore

--- a/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
+++ b/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
@@ -27,6 +27,8 @@ abstract class VideoPlayerPlatform {
   @visibleForTesting
   bool get isMock => false;
 
+  static VideoPlayerPlatform _instance = MethodChannelVideoPlayer();
+
   /// The default instance of [VideoPlayerPlatform] to use.
   ///
   /// Platform-specific plugins should override this with their own
@@ -34,8 +36,6 @@ abstract class VideoPlayerPlatform {
   /// register themselves.
   ///
   /// Defaults to [MethodChannelVideoPlayer].
-  static VideoPlayerPlatform _instance = MethodChannelVideoPlayer();
-
   static VideoPlayerPlatform get instance => _instance;
 
   // TODO(amirh): Extract common platform interface logic.

--- a/packages/video_player/video_player_platform_interface/pubspec.yaml
+++ b/packages/video_player/video_player_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.0.1
+version: 1.0.2
 
 dependencies:
   flutter:

--- a/packages/video_player/video_player_platform_interface/test/method_channel_video_player_test.dart
+++ b/packages/video_player/video_player_platform_interface/test/method_channel_video_player_test.dart
@@ -233,7 +233,7 @@ void main() {
             // with `ServicesBinding.instance.defaultBinaryMessenger` when it's
             // available on all the versions of Flutter that we test.
             // ignore: deprecated_member_use
-            defaultBinaryMessenger.handlePlatformMessage(
+            await defaultBinaryMessenger.handlePlatformMessage(
                 "flutter.io/videoPlayer/videoEvents123",
                 const StandardMethodCodec()
                     .encodeSuccessEnvelope(<String, dynamic>{
@@ -248,7 +248,7 @@ void main() {
             // with `ServicesBinding.instance.defaultBinaryMessenger` when it's
             // available on all the versions of Flutter that we test.
             // ignore: deprecated_member_use
-            defaultBinaryMessenger.handlePlatformMessage(
+            await defaultBinaryMessenger.handlePlatformMessage(
                 "flutter.io/videoPlayer/videoEvents123",
                 const StandardMethodCodec()
                     .encodeSuccessEnvelope(<String, dynamic>{
@@ -260,7 +260,7 @@ void main() {
             // with `ServicesBinding.instance.defaultBinaryMessenger` when it's
             // available on all the versions of Flutter that we test.
             // ignore: deprecated_member_use
-            defaultBinaryMessenger.handlePlatformMessage(
+            await defaultBinaryMessenger.handlePlatformMessage(
                 "flutter.io/videoPlayer/videoEvents123",
                 const StandardMethodCodec()
                     .encodeSuccessEnvelope(<String, dynamic>{
@@ -276,7 +276,7 @@ void main() {
             // with `ServicesBinding.instance.defaultBinaryMessenger` when it's
             // available on all the versions of Flutter that we test.
             // ignore: deprecated_member_use
-            defaultBinaryMessenger.handlePlatformMessage(
+            await defaultBinaryMessenger.handlePlatformMessage(
                 "flutter.io/videoPlayer/videoEvents123",
                 const StandardMethodCodec()
                     .encodeSuccessEnvelope(<String, dynamic>{
@@ -288,7 +288,7 @@ void main() {
             // with `ServicesBinding.instance.defaultBinaryMessenger` when it's
             // available on all the versions of Flutter that we test.
             // ignore: deprecated_member_use
-            defaultBinaryMessenger.handlePlatformMessage(
+            await defaultBinaryMessenger.handlePlatformMessage(
                 "flutter.io/videoPlayer/videoEvents123",
                 const StandardMethodCodec()
                     .encodeSuccessEnvelope(<String, dynamic>{


### PR DESCRIPTION
## Description

Fixes unawaited_futures. There are still some undocumented members here
that are unclear to me, so unfortunately the analysis_options.yaml is
still there.

## Related Issues

flutter/flutter#45440
flutter/flutter#46119

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
