### PR TITLE
[none] Pass --custom-analysis flag through CI

### DIFF
--- a/script/incremental_build.sh
+++ b/script/incremental_build.sh
@@ -17,9 +17,8 @@ CUSTOM_ANALYSIS_PLUGINS=(
   "in_app_purchase"
   "camera"
   "google_sign_in/google_sign_in"
-  "google_sign_in/google_sign_in_web"
   "google_sign_in/google_sign_in_platform_interface"
-  "video_player/video_player_platform_interface"
+  "google_sign_in/google_sign_in_web"
 )
 # Comma-separated string of the list above
 readonly CUSTOM_FLAG=$(IFS=, ; echo "${CUSTOM_ANALYSIS_PLUGINS[*]}")

--- a/script/incremental_build.sh
+++ b/script/incremental_build.sh
@@ -6,10 +6,29 @@ readonly REPO_DIR="$(dirname "$SCRIPT_DIR")"
 
 source "$SCRIPT_DIR/common.sh"
 
+# Plugins that deliberately use their own analysis_options.yaml.
+#
+# This list should only be deleted from, never added to. This only exists
+# because we adopted stricter analysis rules recently and needed to exclude
+# already failing packages to start linting the repo as a whole.
+#
+# TODO(mklim): Remove everything from this list. https://github.com/flutter/flutter/issues/45440
+CUSTOM_ANALYSIS_PLUGINS=(
+  "in_app_purchase"
+  "camera"
+  "google_sign_in/google_sign_in"
+  "google_sign_in/google_sign_in_web"
+  "google_sign_in/google_sign_in_platform_interface"
+  "video_player/video_player_platform_interface"
+)
+# Comma-separated string of the list above
+readonly CUSTOM_FLAG=$(IFS=, ; echo "${CUSTOM_ANALYSIS_PLUGINS[*]}")
 # Set some default actions if run without arguments.
 ACTIONS=("$@")
 if [[ "${#ACTIONS[@]}" == 0 ]]; then
-  ACTIONS=("test" "analyze" "java-test")
+  ACTIONS=("analyze" "--custom-analysis" "$CUSTOM_FLAG" "test" "java-test")
+elif [ "${ACTIONS[@]}" == "analyze" ]; then
+  ACTIONS=("analyze" "--custom-analysis" "$CUSTOM_FLAG")
 fi
 
 BRANCH_NAME="${BRANCH_NAME:-"$(git rev-parse --abbrev-ref HEAD)"}"


### PR DESCRIPTION
## Description

This passes our currently failing plugins through to
flutter_plugin_tools to adjust to flutter/plugin_tools#75.

DO NOT MERGE until flutter/plugin_tools#75 has been merged and
published.

## Related Issues

flutter/flutter#45440

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
