### PR TITLE
WIP Reduce CI testing time, add caching

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 pub_cache:
   folder: $HOME/.pub-cache
   fingerprint_script: echo $OS; grep -r --include=pubspec.yaml 'PUBSPEC CHECKSUM' "$CIRRUS_WORKING_DIR"
-upgrade_script:
+setup_script:
   - date
   - git fetch origin master
   - date
@@ -13,8 +13,9 @@ activate_script:
 flutter_master_template: &FLUTTER_MASTER_TEMPLATE
   environment:
     CHANNEL: "master"
-  upgrade_script:
+  setup_script:
     - date
+    - which flutter
     - flutter channel $CHANNEL
     - flutter upgrade
     - date
@@ -22,13 +23,10 @@ flutter_master_template: &FLUTTER_MASTER_TEMPLATE
 flutter_stable_template: &FLUTTER_STABLE_TEMPLATE
   environment:
     CHANNEL: "stable"
-  flutter_artifacts_cache:
-    folder: $FLUTTER_HOME/bin/cache/artifacts
-    fingerprint_script: echo $OS; cat ${FLUTTER_HOME}/bin/internal/*.version
   flutter_pkg_cache:
     folder: $FLUTTER_HOME/bin/cache/pkg
     fingerprint_script: echo $OS; cat ${FLUTTER_HOME}/bin/internal/*.version
-  upgrade_script:
+  setup_script:
     - date
     - flutter channel $CHANNEL
     - flutter upgrade
@@ -36,7 +34,7 @@ flutter_stable_template: &FLUTTER_STABLE_TEMPLATE
 
 flutter_stable_skip_web_template: &FLUTTER_STABLE_SKIP_WEB_TEMPLATE
   << : *FLUTTER_STABLE_TEMPLATE
-  test_script:
+  setup_script:
     # TODO(jackson): Allow web plugins once supported on stable
     # https://github.com/flutter/flutter/issues/42864
     - find . | grep _web$ | xargs rm -rf; fi

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,6 +15,7 @@ task:
     CHANNEL: "master" # Default to flutter master, tests can override.
   channel_script:
     - flutter channel $CHANNEL
+    - if [[ -f "$FLUTTER_HOME" ]]; then rm -rf $FLUTTER_HOME/bin/cache/*; fi
   # flutter_pkg_cache:
   #   folder: $FLUTTER_HOME/bin/cache/pkg
   #   fingerprint_script: echo $OS; cat ${FLUTTER_HOME}/bin/internal/*.version
@@ -110,6 +111,7 @@ task:
     CHANNEL: "master" # Default to flutter master, tests can override.
   channel_script:
     - flutter channel $CHANNEL
+    - if [[ -f "$FLUTTER_HOME" ]]; then rm -rf $FLUTTER_HOME/bin/cache/*; fi
   # flutter_pkg_cache:
   #   folder: $FLUTTER_HOME/bin/cache/pkg
   #   fingerprint_script: echo $OS; cat ${FLUTTER_HOME}/bin/internal/*.version

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,7 +15,7 @@ task:
     CHANNEL: "master" # Default to flutter master, tests can override.
   channel_script:
     - flutter channel $CHANNEL
-    - if [[ -f "$FLUTTER_HOME" ]]; then rm -rf $FLUTTER_HOME/bin/cache/*; fi
+    - rm -rf $FLUTTER_HOME/bin/cache/*
   # flutter_pkg_cache:
   #   folder: $FLUTTER_HOME/bin/cache/pkg
   #   fingerprint_script: echo $OS; cat ${FLUTTER_HOME}/bin/internal/*.version
@@ -111,7 +111,7 @@ task:
     CHANNEL: "master" # Default to flutter master, tests can override.
   channel_script:
     - flutter channel $CHANNEL
-    - if [[ -f "$FLUTTER_HOME" ]]; then rm -rf $FLUTTER_HOME/bin/cache/*; fi
+    - rm -rf $FLUTTER_HOME/bin/cache/*
   # flutter_pkg_cache:
   #   folder: $FLUTTER_HOME/bin/cache/pkg
   #   fingerprint_script: echo $OS; cat ${FLUTTER_HOME}/bin/internal/*.version

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -22,10 +22,6 @@ cache_stable_macos_template: &CACHE_STABLE_MACOS_TEMPLATE
   flutter_artifacts_macos_cache:
     folder: $FLUTTER_HOME/bin/cache/artifacts
 
-pub_linux_cache:
-  folder: $HOME/.pub-cache
-  fingerprint_script: echo $CIRRUS_OS
-  only_if: $CHANNEL == "stable"
 
 flutter_pkg_linux_cache:
   folder: $FLUTTER_HOME/bin/cache/pkg
@@ -40,6 +36,10 @@ task:
   environment:
     PATH: $PATH:$HOME/.pub-cache/bin
     CHANNEL: "stable" # Default to flutter stable to leverage caching.
+  pub_cache:
+    folder: $HOME/.pub-cache
+    fingerprint_script: echo $CIRRUS_OS
+    only_if: $CHANNEL == "stable"
   upgrade_script:
     - which flutter
     - flutter channel $CHANNEL
@@ -130,6 +130,10 @@ task:
     COCOAPODS_DISABLE_STATS: true
     PATH: $PATH:/usr/local/bin:$HOME/.pub-cache/bin
     CHANNEL: "stable" # Default to flutter stable to leverage caching.
+  pub_cache:
+    folder: $HOME/.pub-cache
+    fingerprint_script: echo $CIRRUS_OS
+    only_if: $CHANNEL == "stable"
   upgrade_script:
     - which flutter
     - flutter channel $CHANNEL

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,31 +1,31 @@
-base_task_template: &BASE_TASK_TEMPLATE
+flutter_template: &FLUTTER_TEMPLATE
   upgrade_script:
     - date
+    - which flutter
+    - flutter channel $CHANNEL
+    - flutter upgrade
     - git fetch origin master
-    - date
     - pub global activate flutter_plugin_tools
     - date
 
 flutter_master_template: &FLUTTER_MASTER_TEMPLATE
   environment:
     CHANNEL: "master"
-  setup_script:
-    - date
-    - which flutter
-    - flutter channel $CHANNEL
-    - flutter upgrade
-    - date
+  << : *FLUTTER_TEMPLATE
 
 flutter_stable_template: &FLUTTER_STABLE_TEMPLATE
   environment:
     CHANNEL: "stable"
   pub_cache:
     folder: $HOME/.pub-cache
-  setup_script:
-    - date
-    - flutter channel $CHANNEL
-    - flutter upgrade
-    - date
+    fingerprint_script: echo $CIRRUS_OS
+  flutter_pkg_cache:
+    folder: $FLUTTER_HOME/bin/cache/pkg
+    fingerprint_script: echo $CIRRUS_OS
+  flutter_artifacts_cache:
+    folder: $FLUTTER_HOME/bin/cache/artifacts
+    fingerprint_script: echo $CIRRUS_OS
+  << : *FLUTTER_TEMPLATE
 
 flutter_stable_skip_web_template: &FLUTTER_STABLE_SKIP_WEB_TEMPLATE
   << : *FLUTTER_STABLE_TEMPLATE
@@ -40,7 +40,6 @@ task:
     dockerfile: .ci/Dockerfile
     cpu: 8
     memory: 16G
-  << : *BASE_TASK_TEMPLATE
   matrix:
     - name: publishable
       << : *FLUTTER_STABLE_TEMPLATE

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,9 +1,10 @@
 flutter_template: &FLUTTER_TEMPLATE
   upgrade_script:
-    - date
     - which flutter
     - flutter channel $CHANNEL
+    - date
     - flutter upgrade
+    - date
     - git fetch origin master
     - pub global activate flutter_plugin_tools
     - date
@@ -16,15 +17,6 @@ flutter_master_template: &FLUTTER_MASTER_TEMPLATE
 flutter_stable_template: &FLUTTER_STABLE_TEMPLATE
   environment:
     CHANNEL: "stable"
-  pub_cache:
-    folder: $HOME/.pub-cache
-    fingerprint_script: echo $CIRRUS_OS
-  flutter_pkg_cache:
-    folder: $FLUTTER_HOME/bin/cache/pkg
-    fingerprint_script: echo $CIRRUS_OS
-  flutter_artifacts_cache:
-    folder: $FLUTTER_HOME/bin/cache/artifacts
-    fingerprint_script: echo $CIRRUS_OS
   << : *FLUTTER_TEMPLATE
 
 flutter_stable_skip_web_template: &FLUTTER_STABLE_SKIP_WEB_TEMPLATE
@@ -48,6 +40,15 @@ task:
         - ./script/check_publish.sh
         - date
     - name: format
+      pub_cache:
+        folder: $HOME/.pub-cache
+        fingerprint_script: echo $CIRRUS_OS
+      flutter_pkg_cache:
+        folder: $FLUTTER_HOME/bin/cache/pkg
+        fingerprint_script: echo $CIRRUS_OS; cat $FLUTTER_HOME/bin/internal/*.version
+      flutter_artifacts_cache:
+        folder: $FLUTTER_HOME/bin/cache/artifacts
+        fingerprint_script: echo $CIRRUS_OS; cat $FLUTTER_HOME/bin/internal/*.version
       << : *FLUTTER_STABLE_TEMPLATE
       install_script:
         - date

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 pub_cache:
   folder: $HOME/.pub-cache
   fingerprint_script: echo $OS; grep -r --include=pubspec.yaml 'PUBSPEC CHECKSUM' "$CIRRUS_WORKING_DIR"
-setup_script:
+fetch_plugins_script:
   - date
   - git fetch origin master
   - date
@@ -31,7 +31,7 @@ flutter_stable_template: &FLUTTER_STABLE_TEMPLATE
 
 flutter_stable_skip_web_template: &FLUTTER_STABLE_SKIP_WEB_TEMPLATE
   << : *FLUTTER_STABLE_TEMPLATE
-  setup_script:
+  remove_web_plugins_script:
     # TODO(jackson): Allow web plugins once supported on stable
     # https://github.com/flutter/flutter/issues/42864
     - find . | grep _web$ | xargs rm -rf; fi

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,35 +1,4 @@
-flutter_master_template: &FLUTTER_MASTER_TEMPLATE
-  environment:
-    CHANNEL: "master"
-  upgrade_script:
-    - which flutter
-    - flutter channel $CHANNEL
-    - date
-    - flutter upgrade
-    - git fetch origin master
-    - date
-  activate_script:
-    - date
-    - pub global activate flutter_plugin_tools
-    - date
-
-flutter_stable_template: &FLUTTER_STABLE_TEMPLATE
-  environment:
-    CHANNEL: "stable"
-  upgrade_script:
-    - which flutter
-    - flutter channel $CHANNEL
-    - date
-    - flutter upgrade
-    - git fetch origin master
-    - date
-  activate_script:
-    - date
-    - pub global activate flutter_plugin_tools
-    - date
-
-flutter_stable_skip_web_template: &FLUTTER_STABLE_SKIP_WEB_TEMPLATE
-  << : *FLUTTER_STABLE_TEMPLATE
+flutter_skip_web_template: &FLUTTER_SKIP_WEB_TEMPLATE
   remove_web_plugins_script:
     # TODO(jackson): Allow web plugins once supported on stable
     # https://github.com/flutter/flutter/issues/42864
@@ -61,16 +30,23 @@ task:
     memory: 16G
   environment:
     PATH: $PATH:$HOME/.pub-cache/bin
+    CHANNEL: "stable" # Default to flutter stable to leverage caching.
+  upgrade_script:
+    - which flutter
+    - flutter channel $CHANNEL
+    - date
+    - flutter upgrade
+    - git fetch origin master
+    - date
+  activate_script: pub global activate flutter_plugin_tools
   matrix:
     - name: publishable
       << : *CACHE_STABLE_LINUX_TEMPLATE
-      << : *FLUTTER_STABLE_TEMPLATE
       script:
-        - date
         - ./script/check_publish.sh
-        - date
     - name: format
-      << : *FLUTTER_MASTER_TEMPLATE
+      environment:
+         CHANNEL: "master"
       install_script:
         - date
         - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
@@ -79,33 +55,29 @@ task:
         - sudo apt-get install -y --allow-unauthenticated clang-format-7
         - date
       format_script:
-        - date
         - ./script/incremental_build.sh format --travis --clang-format=clang-format-7
-        - date
     - name: test
-      matrix:
-        - << : *FLUTTER_MASTER_TEMPLATE
-        - << : *CACHE_STABLE_LINUX_TEMPLATE
-          << : *FLUTTER_STABLE_SKIP_WEB_TEMPLATE
+        matrix:
+          - environment:
+              CHANNEL: "master"
+          - environment:
+              CHANNEL: "stable"
+            << : *CACHE_STABLE_LINUX_TEMPLATE
+            << : *FLUTTER_SKIP_WEB_TEMPLATE
       test_script:
-        - date
         - ./script/incremental_build.sh test
-        - date
     - name: analyze
-      << : *FLUTTER_MASTER_TEMPLATE
+      environment:
+         CHANNEL: "master"
       script:
-        - date
         - ./script/incremental_build.sh analyze
-        - date        
     - name: build_all_plugins_apk
       << : *CACHE_STABLE_LINUX_TEMPLATE
-      << : *FLUTTER_STABLE_SKIP_WEB_TEMPLATE
+      << : *FLUTTER_SKIP_WEB_TEMPLATE
       script:
-        - date
         - ./script/build_all_plugins_app.sh apk
-        - date
       depends_on:
-        - analyze
+        - format
         - publishable
     - name: build-apks+java-test+firebase-test-lab
       environment:
@@ -113,9 +85,12 @@ task:
           PLUGIN_SHARDING: "--shardIndex 0 --shardCount 2"
           PLUGIN_SHARDING: "--shardIndex 1 --shardCount 2"
         matrix:
-          - << : *FLUTTER_MASTER_TEMPLATE
-          - << : *CACHE_STABLE_LINUX_TEMPLATE
-            << : *FLUTTER_STABLE_SKIP_WEB_TEMPLATE
+          - environment:
+              CHANNEL: "master"
+          - environment:
+              CHANNEL: "stable"
+            << : *CACHE_STABLE_LINUX_TEMPLATE
+            << : *FLUTTER_SKIP_WEB_TEMPLATE
         MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
         GCLOUD_FIREBASE_TESTLAB_KEY: ENCRYPTED[07586610af1fdfc894e5969f70ef2458341b9b7e9c3b7c4225a663b4a48732b7208a4d91c3b7d45305a6b55fa2a37fc4]
       script:
@@ -142,7 +117,7 @@ task:
         - export CIRRUS_COMMIT_MESSAGE=`cat /tmp/cirrus_commit_message.txt`
         - date
       depends_on:
-        - analyze
+        - format
         - publishable
 
 task:
@@ -152,26 +127,29 @@ task:
   environment:
     COCOAPODS_DISABLE_STATS: true
     PATH: $PATH:/usr/local/bin:$HOME/.pub-cache/bin
-  create_simulator_script:
+    CHANNEL: "stable" # Default to flutter stable to leverage caching.
+  upgrade_script:
+    - which flutter
+    - flutter channel $CHANNEL
     - date
+    - flutter upgrade
+    - git fetch origin master
+    - date
+  activate_script: pub global activate flutter_plugin_tools
+  create_simulator_script:
     - xcrun simctl list
     - xcrun simctl create Flutter-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-X com.apple.CoreSimulator.SimRuntime.iOS-13-2 | xargs xcrun simctl boot
-    - date
   matrix:
     - name: build_all_plugins_ipa
       << : *CACHE_STABLE_MACOS_TEMPLATE
-      << : *FLUTTER_STABLE_SKIP_WEB_TEMPLATE
+      << : *FLUTTER_SKIP_WEB_TEMPLATE
       script:
-        - date
         - ./script/build_all_plugins_app.sh ios --no-codesign
-        - date
     - name: lint_darwin_plugins
       << : *CACHE_STABLE_MACOS_TEMPLATE
-      << : *FLUTTER_STABLE_SKIP_WEB_TEMPLATE
+      << : *FLUTTER_SKIP_WEB_TEMPLATE
       script:
-        - date
         - ./script/lint_darwin_plugins.sh
-        - date
     - name: build-ipas+drive-examples
       environment:
         matrix:
@@ -180,15 +158,19 @@ task:
           PLUGIN_SHARDING: "--shardIndex 2 --shardCount 4"
           PLUGIN_SHARDING: "--shardIndex 3 --shardCount 4"
         matrix:
-          - << : *FLUTTER_MASTER_TEMPLATE
-          - << : *CACHE_STABLE_MACOS_TEMPLATE
-            << : *FLUTTER_STABLE_SKIP_WEB_TEMPLATE
+          - environment:
+              CHANNEL: "master"
+          - environment:
+              CHANNEL: "stable"
+            << : *CACHE_STABLE_MACOS_TEMPLATE
+            << : *FLUTTER_SKIP_WEB_TEMPLATE
         SIMCTL_CHILD_MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
       script:
         - date
         - ./script/incremental_build.sh build-examples --ipa
+        - date
         - ./script/incremental_build.sh drive-examples
         - date
   depends_on:
-    - analyze
+    - format
     - publishable

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 base_task_template: &BASE_TASK_TEMPLATE
   pub_cache:
     folder: $HOME/.pub-cache
-    fingerprint_script: echo $OS; grep -r --include=pubspec.yaml 'PUBSPEC CHECKSUM' "$CIRRUS_WORKING_DIR"
+    fingerprint_script: echo $OS; grep -r --include=pubspec.yaml 'PUBSPEC CHECKSUM' .
   upgrade_script:
     - date
     - git fetch origin master

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -23,10 +23,10 @@ flutter_stable_template: &FLUTTER_STABLE_TEMPLATE
   environment:
     CHANNEL: "stable"
   flutter_artifacts_cache:
-    folder: ${FLUTTER_HOME}/bin/cache/artifacts
+    folder: $FLUTTER_HOME/bin/cache/artifacts
     fingerprint_script: echo $OS; cat ${FLUTTER_HOME}/bin/internal/*.version
   flutter_pkg_cache:
-    folder: ${FLUTTER_HOME}/bin/cache/pkg
+    folder: $FLUTTER_HOME/bin/cache/pkg
     fingerprint_script: echo $OS; cat ${FLUTTER_HOME}/bin/internal/*.version
   upgrade_script:
     - date

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,4 +1,6 @@
-flutter_template: &FLUTTER_TEMPLATE
+flutter_master_template: &FLUTTER_MASTER_TEMPLATE
+  environment:
+    CHANNEL: "master"
   upgrade_script:
     - which flutter
     - flutter channel $CHANNEL
@@ -11,15 +13,20 @@ flutter_template: &FLUTTER_TEMPLATE
     - pub global activate flutter_plugin_tools
     - date
 
-flutter_master_template: &FLUTTER_MASTER_TEMPLATE
-  << : *FLUTTER_TEMPLATE
-  environment:
-    CHANNEL: "master"
-
 flutter_stable_template: &FLUTTER_STABLE_TEMPLATE
-  << : *FLUTTER_TEMPLATE
   environment:
     CHANNEL: "stable"
+  upgrade_script:
+    - which flutter
+    - flutter channel $CHANNEL
+    - date
+    - flutter upgrade
+    - git fetch origin master
+    - date
+  activate_script:
+    - date
+    - pub global activate flutter_plugin_tools
+    - date
 
 flutter_stable_skip_web_template: &FLUTTER_STABLE_SKIP_WEB_TEMPLATE
   << : *FLUTTER_STABLE_TEMPLATE
@@ -98,6 +105,7 @@ task:
         - ./script/build_all_plugins_app.sh apk
         - date
       depends_on:
+        - analyze
         - publishable
     - name: build-apks+java-test+firebase-test-lab
       environment:
@@ -134,6 +142,7 @@ task:
         - export CIRRUS_COMMIT_MESSAGE=`cat /tmp/cirrus_commit_message.txt`
         - date
       depends_on:
+        - analyze
         - publishable
 
 task:
@@ -181,4 +190,5 @@ task:
         - ./script/incremental_build.sh drive-examples
         - date
   depends_on:
+    - analyze
     - publishable

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -105,6 +105,8 @@ task:
     COCOAPODS_DISABLE_STATS: true
     PATH: $PATH:/usr/local/bin:$HOME/.pub-cache/bin
     CHANNEL: "master" # Default to flutter master, tests can override.
+  channel_script:
+    - flutter channel $CHANNEL
   flutter_pkg_cache:
     folder: $FLUTTER_HOME/bin/cache/pkg
     fingerprint_script: echo $OS; cat ${FLUTTER_HOME}/bin/internal/*.version
@@ -112,8 +114,6 @@ task:
     folder: $FLUTTER_HOME/bin/cache/artifacts
     fingerprint_script: echo $OS; cat ${FLUTTER_HOME}/bin/internal/*.version
   upgrade_script:
-    - which flutter
-    - flutter channel $CHANNEL
     - flutter upgrade
     - git fetch origin master
   activate_script: pub global activate flutter_plugin_tools

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -22,6 +22,15 @@ cache_stable_macos_template: &CACHE_STABLE_MACOS_TEMPLATE
   flutter_artifacts_macos_cache:
     folder: $FLUTTER_HOME/bin/cache/artifacts
 
+pub_linux_cache:
+  folder: $HOME/.pub-cache
+  fingerprint_script: echo $CIRRUS_OS
+  only_if: $CHANNEL == "stable"
+
+flutter_pkg_linux_cache:
+  folder: $FLUTTER_HOME/bin/cache/pkg
+flutter_artifacts_linux_cache:
+  folder: $FLUTTER_HOME/bin/cache/artifacts
 task:
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
   container:
@@ -59,11 +68,9 @@ task:
     - name: test
         matrix:
           - name: test-master 
-            << : *CACHE_STABLE_LINUX_TEMPLATE
             environment:
               CHANNEL: "master"
           - name: test-stable 
-            << : *FLUTTER_SKIP_WEB_TEMPLATE
             environment:
               CHANNEL: "stable"
             
@@ -89,11 +96,9 @@ task:
           PLUGIN_SHARDING: "--shardIndex 1 --shardCount 2"
         matrix:
           - name: test-master 
-            << : *CACHE_STABLE_LINUX_TEMPLATE
             environment:
               CHANNEL: "master"
           - name: test-stable 
-            << : *FLUTTER_SKIP_WEB_TEMPLATE
             environment:
               CHANNEL: "stable"
         MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
@@ -164,11 +169,9 @@ task:
           PLUGIN_SHARDING: "--shardIndex 3 --shardCount 4"
         matrix:
           - name: test-master 
-            << : *CACHE_STABLE_MACOS_TEMPLATE
             environment:
               CHANNEL: "master"
           - name: test-stable 
-            << : *FLUTTER_SKIP_WEB_TEMPLATE
             environment:
               CHANNEL: "stable"
         SIMCTL_CHILD_MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,4 @@
 base_task_template: &BASE_TASK_TEMPLATE
-  pub_cache:
-    folder: $HOME/.pub-cache
-    fingerprint_script: echo $OS; grep -r --include=pubspec.yaml 'PUBSPEC CHECKSUM' .
   upgrade_script:
     - date
     - git fetch origin master
@@ -22,6 +19,9 @@ flutter_master_template: &FLUTTER_MASTER_TEMPLATE
 flutter_stable_template: &FLUTTER_STABLE_TEMPLATE
   environment:
     CHANNEL: "stable"
+  pub_cache:
+    folder: $HOME/.pub-cache
+    fingerprint_script: echo $OS; grep -r --include=pubspec.yaml "\:.*[0-9]\+"\. . | grep -v version | grep -v flutter | xargs
   setup_script:
     - date
     - flutter channel $CHANNEL

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -70,9 +70,9 @@ task:
     - name: test
       matrix:
         - name: master
-        << : *FLUTTER_MASTER_TEMPLATE
+          << : *FLUTTER_MASTER_TEMPLATE
         - name: stable
-        << : *FLUTTER_STABLE_SKIP_WEB_TEMPLATE
+          << : *FLUTTER_STABLE_SKIP_WEB_TEMPLATE
       test_script:
         - date
         - ./script/incremental_build.sh test

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,14 +12,14 @@ flutter_template: &FLUTTER_TEMPLATE
     - date
 
 flutter_master_template: &FLUTTER_MASTER_TEMPLATE
+  << : *FLUTTER_TEMPLATE
   environment:
     CHANNEL: "master"
-  << : *FLUTTER_TEMPLATE
 
 flutter_stable_template: &FLUTTER_STABLE_TEMPLATE
+  << : *FLUTTER_TEMPLATE
   environment:
     CHANNEL: "stable"
-  << : *FLUTTER_TEMPLATE
 
 flutter_stable_skip_web_template: &FLUTTER_STABLE_SKIP_WEB_TEMPLATE
   << : *FLUTTER_STABLE_TEMPLATE
@@ -27,6 +27,24 @@ flutter_stable_skip_web_template: &FLUTTER_STABLE_SKIP_WEB_TEMPLATE
     # TODO(jackson): Allow web plugins once supported on stable
     # https://github.com/flutter/flutter/issues/42864
     - find . | grep _web$ | xargs rm -rf
+
+# fingerprint_script doesn't seem to work in templates.
+# To keep OS caches from colliding, split them into separate caches.
+cache_stable_linux_template: &CACHE_STABLE_LINUX_TEMPLATE
+  pub_linux_cache:
+    folder: $HOME/.pub-cache
+  flutter_pkg_linux_cache:
+    folder: $FLUTTER_HOME/bin/cache/pkg
+  flutter_artifacts_linux_cache:
+    folder: $FLUTTER_HOME/bin/cache/artifacts
+
+cache_stable_macos_template: &CACHE_STABLE_MACOS_TEMPLATE
+  pub_macos_cache:
+    folder: $HOME/.pub-cache
+  flutter_pkg_macos_cache:
+    folder: $FLUTTER_HOME/bin/cache/pkg
+  flutter_artifacts_macos_cache:
+    folder: $FLUTTER_HOME/bin/cache/artifacts
 
 task:
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
@@ -38,22 +56,14 @@ task:
     PATH: $PATH:$HOME/.pub-cache/bin
   matrix:
     - name: publishable
+      << : *CACHE_STABLE_LINUX_TEMPLATE
       << : *FLUTTER_STABLE_TEMPLATE
       script:
         - date
         - ./script/check_publish.sh
         - date
     - name: format
-      pub_cache:
-        folder: $HOME/.pub-cache
-        fingerprint_script: echo $CIRRUS_OS
-      flutter_pkg_cache:
-        folder: $FLUTTER_HOME/bin/cache/pkg
-        fingerprint_script: echo $CIRRUS_OS; cat $FLUTTER_HOME/bin/internal/*.version
-      flutter_artifacts_cache:
-        folder: $FLUTTER_HOME/bin/cache/artifacts
-        fingerprint_script: echo $CIRRUS_OS; cat $FLUTTER_HOME/bin/internal/*.version
-      << : *FLUTTER_STABLE_TEMPLATE
+      << : *FLUTTER_MASTER_TEMPLATE
       install_script:
         - date
         - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
@@ -68,18 +78,20 @@ task:
     - name: test
       matrix:
         - << : *FLUTTER_MASTER_TEMPLATE
-        - << : *FLUTTER_STABLE_SKIP_WEB_TEMPLATE
+        - << : *CACHE_STABLE_LINUX_TEMPLATE
+          << : *FLUTTER_STABLE_SKIP_WEB_TEMPLATE
       test_script:
         - date
         - ./script/incremental_build.sh test
         - date
     - name: analyze
-      << : *FLUTTER_STABLE_TEMPLATE
+      << : *FLUTTER_MASTER_TEMPLATE
       script:
         - date
         - ./script/incremental_build.sh analyze
         - date        
     - name: build_all_plugins_apk
+      << : *CACHE_STABLE_LINUX_TEMPLATE
       << : *FLUTTER_STABLE_SKIP_WEB_TEMPLATE
       script:
         - date
@@ -94,7 +106,8 @@ task:
           PLUGIN_SHARDING: "--shardIndex 1 --shardCount 2"
         matrix:
           - << : *FLUTTER_MASTER_TEMPLATE
-          - << : *FLUTTER_STABLE_SKIP_WEB_TEMPLATE
+          - << : *CACHE_STABLE_LINUX_TEMPLATE
+            << : *FLUTTER_STABLE_SKIP_WEB_TEMPLATE
         MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
         GCLOUD_FIREBASE_TESTLAB_KEY: ENCRYPTED[07586610af1fdfc894e5969f70ef2458341b9b7e9c3b7c4225a663b4a48732b7208a4d91c3b7d45305a6b55fa2a37fc4]
       script:
@@ -137,12 +150,14 @@ task:
     - date
   matrix:
     - name: build_all_plugins_ipa
+      << : *CACHE_STABLE_MACOS_TEMPLATE
       << : *FLUTTER_STABLE_SKIP_WEB_TEMPLATE
       script:
         - date
         - ./script/build_all_plugins_app.sh ios --no-codesign
         - date
     - name: lint_darwin_plugins
+      << : *CACHE_STABLE_MACOS_TEMPLATE
       << : *FLUTTER_STABLE_SKIP_WEB_TEMPLATE
       script:
         - date
@@ -157,7 +172,8 @@ task:
           PLUGIN_SHARDING: "--shardIndex 3 --shardCount 4"
         matrix:
           - << : *FLUTTER_MASTER_TEMPLATE
-          - << : *FLUTTER_STABLE_SKIP_WEB_TEMPLATE
+          - << : *CACHE_STABLE_MACOS_TEMPLATE
+            << : *FLUTTER_STABLE_SKIP_WEB_TEMPLATE
         SIMCTL_CHILD_MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
       script:
         - date

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,14 +1,13 @@
-pub_cache:
-  folder: $HOME/.pub-cache
-  fingerprint_script: echo $OS; grep -r --include=pubspec.yaml 'PUBSPEC CHECKSUM' "$CIRRUS_WORKING_DIR"
-fetch_plugins_script:
-  - date
-  - git fetch origin master
-  - date
-activate_script: 
-  - date
-  - pub global activate flutter_plugin_tools
-  - date
+base_task_template: &BASE_TASK_TEMPLATE
+  pub_cache:
+    folder: $HOME/.pub-cache
+    fingerprint_script: echo $OS; grep -r --include=pubspec.yaml 'PUBSPEC CHECKSUM' "$CIRRUS_WORKING_DIR"
+  upgrade_script:
+    - date
+    - git fetch origin master
+    - date
+    - pub global activate flutter_plugin_tools
+    - date
 
 flutter_master_template: &FLUTTER_MASTER_TEMPLATE
   environment:
@@ -42,6 +41,7 @@ task:
     dockerfile: .ci/Dockerfile
     cpu: 8
     memory: 16G
+  << : *BASE_TASK_TEMPLATE
   matrix:
     - name: publishable
       << : *FLUTTER_STABLE_TEMPLATE
@@ -130,6 +130,7 @@ task:
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   osx_instance:
     image: mojave-flutter
+  << : *BASE_TASK_TEMPLATE
   environment:
     COCOAPODS_DISABLE_STATS: true
     PATH: $PATH:/usr/local/bin

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,10 +12,9 @@ task:
     memory: 16G
   environment:
     PATH: $PATH:$HOME/.pub-cache/bin
-    CHANNEL: "stable" # Default to flutter stable, tests can override.
-  pub_cache:
-    folder: $HOME/.pub-cache
-    fingerprint_script: echo $OS; grep -r --include=pubspec.yaml '\:.*[0-9]\+\.' . | grep -v 'version\|flutter\|sdk'| xargs
+    CHANNEL: "master" # Default to flutter master, tests can override.
+  channel_script:
+    - flutter channel $CHANNEL
   flutter_pkg_cache:
     folder: $FLUTTER_HOME/bin/cache/pkg
     fingerprint_script: echo $OS; cat ${FLUTTER_HOME}/bin/internal/*.version
@@ -23,22 +22,22 @@ task:
     folder: $FLUTTER_HOME/bin/cache/artifacts
     fingerprint_script: echo $OS; cat ${FLUTTER_HOME}/bin/internal/*.version
   upgrade_script:
-    - flutter channel $CHANNEL
     - flutter upgrade
     - git fetch origin master
   activate_script: pub global activate flutter_plugin_tools
   matrix:
     - name: publishable
+      environment:
+         CHANNEL: "stable"
       script:
         - ./script/check_publish.sh
     - name: format
-      environment:
-         CHANNEL: "master"
       install_script:
         - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         - sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main"
         - sudo apt-get update
         - sudo apt-get install -y --allow-unauthenticated clang-format-7
+        - dpkg -L clang-format-7
       format_script: ./script/incremental_build.sh format --travis --clang-format=clang-format-7
     - name: test
       << : *FLUTTER_SKIP_WEB_TEMPLATE
@@ -48,18 +47,20 @@ task:
           CHANNEL: "stable"
       test_script:
         - ./script/incremental_build.sh test
+      depends_on:
+        - publishable # Upload the stable cache first.
+        - format # Upload the master cache first.
     - name: analyze
-      environment:
-         CHANNEL: "master"
       script:
         - ./script/incremental_build.sh analyze
+      depends_on:
+        - format # Upload the master cache first.
     - name: build_all_plugins_apk
       << : *FLUTTER_SKIP_WEB_TEMPLATE
       script:
         - ./script/build_all_plugins_app.sh apk
       depends_on:
-        - format
-        - publishable
+        - format # Upload the master cache first.
     - name: build-apks+java-test+firebase-test-lab
       << : *FLUTTER_SKIP_WEB_TEMPLATE
       environment:
@@ -93,8 +94,8 @@ task:
         - export CIRRUS_CHANGE_MESSAGE=`cat /tmp/cirrus_change_message.txt`
         - export CIRRUS_COMMIT_MESSAGE=`cat /tmp/cirrus_commit_message.txt`
       depends_on:
-        - format
         - publishable
+        - format
 
 task:
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
@@ -103,10 +104,7 @@ task:
   environment:
     COCOAPODS_DISABLE_STATS: true
     PATH: $PATH:/usr/local/bin:$HOME/.pub-cache/bin
-    CHANNEL: "stable" # Default to flutter stable, tests can override.
-  pub_cache:
-    folder: $HOME/.pub-cache
-    fingerprint_script: echo $OS; echo $CHANNEL; grep -r --include=pubspec.yaml '\:.*[0-9]\+\.' . | grep -v 'version\|flutter\|sdk'| xargs
+    CHANNEL: "master" # Default to flutter master, tests can override.
   flutter_pkg_cache:
     folder: $FLUTTER_HOME/bin/cache/pkg
     fingerprint_script: echo $OS; cat ${FLUTTER_HOME}/bin/internal/*.version
@@ -119,20 +117,20 @@ task:
     - flutter upgrade
     - git fetch origin master
   activate_script: pub global activate flutter_plugin_tools
+  << : *FLUTTER_SKIP_WEB_TEMPLATE
   create_simulator_script:
     - xcrun simctl list
     - xcrun simctl create Flutter-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-X com.apple.CoreSimulator.SimRuntime.iOS-13-2 | xargs xcrun simctl boot
   matrix:
     - name: build_all_plugins_ipa
-      << : *FLUTTER_SKIP_WEB_TEMPLATE
       script:
         - ./script/build_all_plugins_app.sh ios --no-codesign
     - name: lint_darwin_plugins
-      << : *FLUTTER_SKIP_WEB_TEMPLATE
+      environment:
+         CHANNEL: "stable"
       script:
         - ./script/lint_darwin_plugins.sh
     - name: build-ipas+drive-examples
-      << : *FLUTTER_SKIP_WEB_TEMPLATE
       environment:
         matrix:
           PLUGIN_SHARDING: "--shardIndex 0 --shardCount 4"
@@ -146,6 +144,6 @@ task:
       script:
         - ./script/incremental_build.sh build-examples --ipa
         - ./script/incremental_build.sh drive-examples
-  depends_on:
-    - format
-    - publishable
+      depends_on:
+        - build_all_plugins_ipa # Upload the master cache first.
+        - lint_darwin_plugins # Upload the stable cache first.

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,24 +4,6 @@ flutter_skip_web_template: &FLUTTER_SKIP_WEB_TEMPLATE
     # https://github.com/flutter/flutter/issues/42864
     - if [[ "$CHANNEL" -eq "stable" ]]; then find . | grep _web$ | xargs rm -rf; fi
 
-# fingerprint_script doesn't seem to work in templates.
-# To keep OS caches from colliding, split them into separate caches.
-cache_stable_linux_template: &CACHE_STABLE_LINUX_TEMPLATE
-  pub_linux_cache:
-    folder: $HOME/.pub-cache
-  flutter_pkg_linux_cache:
-    folder: $FLUTTER_HOME/bin/cache/pkg
-  flutter_artifacts_linux_cache:
-    folder: $FLUTTER_HOME/bin/cache/artifacts
-
-cache_stable_macos_template: &CACHE_STABLE_MACOS_TEMPLATE
-  pub_macos_cache:
-    folder: $HOME/.pub-cache
-  flutter_pkg_macos_cache:
-    folder: $FLUTTER_HOME/bin/cache/pkg
-  flutter_artifacts_macos_cache:
-    folder: $FLUTTER_HOME/bin/cache/artifacts
-
 task:
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
   container:
@@ -31,29 +13,32 @@ task:
   environment:
     PATH: $PATH:$HOME/.pub-cache/bin
     CHANNEL: "stable" # Default to flutter stable, tests can override.
+  pub_cache:
+    folder: $HOME/.pub-cache
+    fingerprint_script: echo $OS; grep -r --include=pubspec.yaml '\:.*[0-9]\+\.' . | grep -v 'version\|flutter\|sdk'| xargs
+  flutter_pkg_cache:
+    folder: $FLUTTER_HOME/bin/cache/pkg
+    fingerprint_script: echo $OS; cat ${FLUTTER_HOME}/bin/internal/*.version
+  flutter_artifacts_cache:
+    folder: $FLUTTER_HOME/bin/cache/artifacts
+    fingerprint_script: echo $OS; cat ${FLUTTER_HOME}/bin/internal/*.version
   upgrade_script:
-    - which flutter
     - flutter channel $CHANNEL
-    - date
     - flutter upgrade
     - git fetch origin master
-    - date
   activate_script: pub global activate flutter_plugin_tools
   matrix:
     - name: publishable
-      << : *CACHE_STABLE_LINUX_TEMPLATE
       script:
         - ./script/check_publish.sh
     - name: format
       environment:
          CHANNEL: "master"
       install_script:
-        - date
         - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         - sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main"
         - sudo apt-get update
         - sudo apt-get install -y --allow-unauthenticated clang-format-7
-        - date
       format_script: ./script/incremental_build.sh format --travis --clang-format=clang-format-7
     - name: test
       << : *FLUTTER_SKIP_WEB_TEMPLATE
@@ -69,7 +54,6 @@ task:
       script:
         - ./script/incremental_build.sh analyze
     - name: build_all_plugins_apk
-      << : *CACHE_STABLE_LINUX_TEMPLATE
       << : *FLUTTER_SKIP_WEB_TEMPLATE
       script:
         - ./script/build_all_plugins_app.sh apk
@@ -88,7 +72,6 @@ task:
         MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
         GCLOUD_FIREBASE_TESTLAB_KEY: ENCRYPTED[07586610af1fdfc894e5969f70ef2458341b9b7e9c3b7c4225a663b4a48732b7208a4d91c3b7d45305a6b55fa2a37fc4]
       script:
-        - date
         # Unsetting CIRRUS_CHANGE_MESSAGE and CIRRUS_COMMIT_MESSAGE as they
         # might include non-ASCII characters which makes Gradle crash.
         # See: https://github.com/flutter/flutter/issues/24935
@@ -109,7 +92,6 @@ task:
         - fi
         - export CIRRUS_CHANGE_MESSAGE=`cat /tmp/cirrus_change_message.txt`
         - export CIRRUS_COMMIT_MESSAGE=`cat /tmp/cirrus_commit_message.txt`
-        - date
       depends_on:
         - format
         - publishable
@@ -122,25 +104,30 @@ task:
     COCOAPODS_DISABLE_STATS: true
     PATH: $PATH:/usr/local/bin:$HOME/.pub-cache/bin
     CHANNEL: "stable" # Default to flutter stable, tests can override.
+  pub_cache:
+    folder: $HOME/.pub-cache
+    fingerprint_script: echo $OS; echo $CHANNEL; grep -r --include=pubspec.yaml '\:.*[0-9]\+\.' . | grep -v 'version\|flutter\|sdk'| xargs
+  flutter_pkg_cache:
+    folder: $FLUTTER_HOME/bin/cache/pkg
+    fingerprint_script: echo $OS; cat ${FLUTTER_HOME}/bin/internal/*.version
+  flutter_artifacts_cache:
+    folder: $FLUTTER_HOME/bin/cache/artifacts
+    fingerprint_script: echo $OS; cat ${FLUTTER_HOME}/bin/internal/*.version
   upgrade_script:
     - which flutter
     - flutter channel $CHANNEL
-    - date
     - flutter upgrade
     - git fetch origin master
-    - date
   activate_script: pub global activate flutter_plugin_tools
   create_simulator_script:
     - xcrun simctl list
     - xcrun simctl create Flutter-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-X com.apple.CoreSimulator.SimRuntime.iOS-13-2 | xargs xcrun simctl boot
   matrix:
     - name: build_all_plugins_ipa
-      << : *CACHE_STABLE_MACOS_TEMPLATE
       << : *FLUTTER_SKIP_WEB_TEMPLATE
       script:
         - ./script/build_all_plugins_app.sh ios --no-codesign
     - name: lint_darwin_plugins
-      << : *CACHE_STABLE_MACOS_TEMPLATE
       << : *FLUTTER_SKIP_WEB_TEMPLATE
       script:
         - ./script/lint_darwin_plugins.sh
@@ -157,11 +144,8 @@ task:
           CHANNEL: "stable"
         SIMCTL_CHILD_MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
       script:
-        - date
         - ./script/incremental_build.sh build-examples --ipa
-        - date
         - ./script/incremental_build.sh drive-examples
-        - date
   depends_on:
     - format
     - publishable

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -58,12 +58,15 @@ task:
         - ./script/incremental_build.sh format --travis --clang-format=clang-format-7
     - name: test
         matrix:
-          - environment:
-              CHANNEL: "master"
-          - environment:
-              CHANNEL: "stable"
+          - name: test-master 
             << : *CACHE_STABLE_LINUX_TEMPLATE
+            environment:
+              CHANNEL: "master"
+          - name: test-stable 
             << : *FLUTTER_SKIP_WEB_TEMPLATE
+            environment:
+              CHANNEL: "stable"
+            
       test_script:
         - ./script/incremental_build.sh test
     - name: analyze
@@ -85,12 +88,14 @@ task:
           PLUGIN_SHARDING: "--shardIndex 0 --shardCount 2"
           PLUGIN_SHARDING: "--shardIndex 1 --shardCount 2"
         matrix:
-          - environment:
-              CHANNEL: "master"
-          - environment:
-              CHANNEL: "stable"
+          - name: test-master 
             << : *CACHE_STABLE_LINUX_TEMPLATE
+            environment:
+              CHANNEL: "master"
+          - name: test-stable 
             << : *FLUTTER_SKIP_WEB_TEMPLATE
+            environment:
+              CHANNEL: "stable"
         MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
         GCLOUD_FIREBASE_TESTLAB_KEY: ENCRYPTED[07586610af1fdfc894e5969f70ef2458341b9b7e9c3b7c4225a663b4a48732b7208a4d91c3b7d45305a6b55fa2a37fc4]
       script:
@@ -158,12 +163,14 @@ task:
           PLUGIN_SHARDING: "--shardIndex 2 --shardCount 4"
           PLUGIN_SHARDING: "--shardIndex 3 --shardCount 4"
         matrix:
-          - environment:
-              CHANNEL: "master"
-          - environment:
-              CHANNEL: "stable"
+          - name: test-master 
             << : *CACHE_STABLE_MACOS_TEMPLATE
+            environment:
+              CHANNEL: "master"
+          - name: test-stable 
             << : *FLUTTER_SKIP_WEB_TEMPLATE
+            environment:
+              CHANNEL: "stable"
         SIMCTL_CHILD_MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
       script:
         - date

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -21,7 +21,7 @@ flutter_stable_template: &FLUTTER_STABLE_TEMPLATE
     CHANNEL: "stable"
   pub_cache:
     folder: $HOME/.pub-cache
-    fingerprint_script: echo $OS; grep -r --include=pubspec.yaml "\:.*[0-9]\+"\. . | grep -v version | grep -v flutter | xargs
+    fingerprint_script: echo $OS; grep -r --include=pubspec.yaml '\:.*[0-9]\+\.' . | grep -v 'version\|flutter\|sdk'| xargs
   setup_script:
     - date
     - flutter channel $CHANNEL

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -66,13 +66,10 @@ task:
       format_script:
         - ./script/incremental_build.sh format --travis --clang-format=clang-format-7
     - name: test
-        matrix:
-          - name: test-master 
-            environment:
-              CHANNEL: "master"
-          - name: test-stable 
-            environment:
-              CHANNEL: "stable"
+        environment:
+          matrix:
+            CHANNEL: "master"
+            CHANNEL: "stable"
             
       test_script:
         - ./script/incremental_build.sh test
@@ -94,13 +91,10 @@ task:
         matrix:
           PLUGIN_SHARDING: "--shardIndex 0 --shardCount 2"
           PLUGIN_SHARDING: "--shardIndex 1 --shardCount 2"
-        matrix:
-          - name: test-master 
-            environment:
-              CHANNEL: "master"
-          - name: test-stable 
-            environment:
-              CHANNEL: "stable"
+        environment:
+          matrix:
+            CHANNEL: "master"
+            CHANNEL: "stable"
         MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
         GCLOUD_FIREBASE_TESTLAB_KEY: ENCRYPTED[07586610af1fdfc894e5969f70ef2458341b9b7e9c3b7c4225a663b4a48732b7208a4d91c3b7d45305a6b55fa2a37fc4]
       script:
@@ -167,13 +161,10 @@ task:
           PLUGIN_SHARDING: "--shardIndex 1 --shardCount 4"
           PLUGIN_SHARDING: "--shardIndex 2 --shardCount 4"
           PLUGIN_SHARDING: "--shardIndex 3 --shardCount 4"
-        matrix:
-          - name: test-master 
-            environment:
-              CHANNEL: "master"
-          - name: test-stable 
-            environment:
-              CHANNEL: "stable"
+        environment:
+          matrix:
+            CHANNEL: "master"
+            CHANNEL: "stable"
         SIMCTL_CHILD_MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
       script:
         - date

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -23,9 +23,6 @@ flutter_master_template: &FLUTTER_MASTER_TEMPLATE
 flutter_stable_template: &FLUTTER_STABLE_TEMPLATE
   environment:
     CHANNEL: "stable"
-  flutter_pkg_cache:
-    folder: $FLUTTER_HOME/bin/cache/pkg
-    fingerprint_script: echo $OS; cat ${FLUTTER_HOME}/bin/internal/*.version
   setup_script:
     - date
     - flutter channel $CHANNEL

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,12 +15,15 @@ task:
     CHANNEL: "master" # Default to flutter master, tests can override.
   channel_script:
     - flutter channel $CHANNEL
-  flutter_pkg_cache:
-    folder: $FLUTTER_HOME/bin/cache/pkg
-    fingerprint_script: echo $OS; cat ${FLUTTER_HOME}/bin/internal/*.version
-  flutter_artifacts_cache:
-    folder: $FLUTTER_HOME/bin/cache/artifacts
-    fingerprint_script: echo $OS; cat ${FLUTTER_HOME}/bin/internal/*.version
+  # flutter_pkg_cache:
+  #   folder: $FLUTTER_HOME/bin/cache/pkg
+  #   fingerprint_script: echo $OS; cat ${FLUTTER_HOME}/bin/internal/*.version
+  # flutter_artifacts_cache:
+  #   folder: $FLUTTER_HOME/bin/cache/artifacts
+  #   fingerprint_script: echo $OS; cat ${FLUTTER_HOME}/bin/internal/*.version
+  # dart_cache:
+  #   folder: $FLUTTER_HOME/bin/cache/dart-sdk
+  #   fingerprint_script: echo $OS; cat ${FLUTTER_HOME}/bin/internal/*.version
   upgrade_script:
     - flutter upgrade
     - git fetch origin master
@@ -47,20 +50,20 @@ task:
           CHANNEL: "stable"
       test_script:
         - ./script/incremental_build.sh test
-      depends_on:
-        - publishable # Upload the stable cache first.
-        - format # Upload the master cache first.
+      # depends_on:
+      #   - publishable # Upload the stable cache first.
+      #   - format # Upload the master cache first.
     - name: analyze
       script:
         - ./script/incremental_build.sh analyze
-      depends_on:
-        - format # Upload the master cache first.
+      # depends_on:
+      #   - format # Upload the master cache first.
     - name: build_all_plugins_apk
       << : *FLUTTER_SKIP_WEB_TEMPLATE
       script:
         - ./script/build_all_plugins_app.sh apk
-      depends_on:
-        - format # Upload the master cache first.
+      # depends_on:
+      #   - format # Upload the master cache first.
     - name: build-apks+java-test+firebase-test-lab
       << : *FLUTTER_SKIP_WEB_TEMPLATE
       environment:
@@ -93,9 +96,9 @@ task:
         - fi
         - export CIRRUS_CHANGE_MESSAGE=`cat /tmp/cirrus_change_message.txt`
         - export CIRRUS_COMMIT_MESSAGE=`cat /tmp/cirrus_commit_message.txt`
-      depends_on:
-        - publishable
-        - format
+      # depends_on:
+      #   - publishable
+      #   - format
 
 task:
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
@@ -107,12 +110,15 @@ task:
     CHANNEL: "master" # Default to flutter master, tests can override.
   channel_script:
     - flutter channel $CHANNEL
-  flutter_pkg_cache:
-    folder: $FLUTTER_HOME/bin/cache/pkg
-    fingerprint_script: echo $OS; cat ${FLUTTER_HOME}/bin/internal/*.version
-  flutter_artifacts_cache:
-    folder: $FLUTTER_HOME/bin/cache/artifacts
-    fingerprint_script: echo $OS; cat ${FLUTTER_HOME}/bin/internal/*.version
+  # flutter_pkg_cache:
+  #   folder: $FLUTTER_HOME/bin/cache/pkg
+  #   fingerprint_script: echo $OS; cat ${FLUTTER_HOME}/bin/internal/*.version
+  # flutter_artifacts_cache:
+  #   folder: $FLUTTER_HOME/bin/cache/artifacts
+  #   fingerprint_script: echo $OS; cat ${FLUTTER_HOME}/bin/internal/*.version
+  # dart_cache:
+  #   folder: $FLUTTER_HOME/bin/cache/dart-sdk
+  #   fingerprint_script: echo $OS; cat ${FLUTTER_HOME}/bin/cache/dart-sdk/revision
   upgrade_script:
     - flutter upgrade
     - git fetch origin master
@@ -144,6 +150,6 @@ task:
       script:
         - ./script/incremental_build.sh build-examples --ipa
         - ./script/incremental_build.sh drive-examples
-      depends_on:
-        - build_all_plugins_ipa # Upload the master cache first.
-        - lint_darwin_plugins # Upload the stable cache first.
+      # depends_on:
+      #   - build_all_plugins_ipa # Upload the master cache first.
+      #   - lint_darwin_plugins # Upload the stable cache first.

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -86,7 +86,6 @@ task:
         - ./script/build_all_plugins_app.sh apk
         - date
       depends_on:
-        - format
         - publishable
     - name: build-apks+java-test+firebase-test-lab
       environment:
@@ -122,7 +121,6 @@ task:
         - export CIRRUS_COMMIT_MESSAGE=`cat /tmp/cirrus_commit_message.txt`
         - date
       depends_on:
-        - format
         - publishable
 
 task:
@@ -167,5 +165,4 @@ task:
         - ./script/incremental_build.sh drive-examples
         - date
   depends_on:
-    - format
     - publishable

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -66,11 +66,10 @@ task:
       format_script:
         - ./script/incremental_build.sh format --travis --clang-format=clang-format-7
     - name: test
-        environment:
-          matrix:
-            CHANNEL: "master"
-            CHANNEL: "stable"
-            
+      environment:
+        matrix:
+          CHANNEL: "master"
+          CHANNEL: "stable"
       test_script:
         - ./script/incremental_build.sh test
     - name: analyze
@@ -91,10 +90,9 @@ task:
         matrix:
           PLUGIN_SHARDING: "--shardIndex 0 --shardCount 2"
           PLUGIN_SHARDING: "--shardIndex 1 --shardCount 2"
-        environment:
-          matrix:
-            CHANNEL: "master"
-            CHANNEL: "stable"
+        matrix:
+          CHANNEL: "master"
+          CHANNEL: "stable"
         MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
         GCLOUD_FIREBASE_TESTLAB_KEY: ENCRYPTED[07586610af1fdfc894e5969f70ef2458341b9b7e9c3b7c4225a663b4a48732b7208a4d91c3b7d45305a6b55fa2a37fc4]
       script:
@@ -161,10 +159,9 @@ task:
           PLUGIN_SHARDING: "--shardIndex 1 --shardCount 4"
           PLUGIN_SHARDING: "--shardIndex 2 --shardCount 4"
           PLUGIN_SHARDING: "--shardIndex 3 --shardCount 4"
-        environment:
-          matrix:
-            CHANNEL: "master"
-            CHANNEL: "stable"
+        matrix:
+          CHANNEL: "master"
+          CHANNEL: "stable"
         SIMCTL_CHILD_MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
       script:
         - date

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -21,7 +21,6 @@ flutter_stable_template: &FLUTTER_STABLE_TEMPLATE
     CHANNEL: "stable"
   pub_cache:
     folder: $HOME/.pub-cache
-    fingerprint_script: echo $OS; grep -r --include=pubspec.yaml '\:.*[0-9]\+\.' . | grep -v 'version\|flutter\|sdk'| xargs
   setup_script:
     - date
     - flutter channel $CHANNEL

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,8 +4,10 @@ flutter_template: &FLUTTER_TEMPLATE
     - flutter channel $CHANNEL
     - date
     - flutter upgrade
-    - date
     - git fetch origin master
+    - date
+  activate_script:
+    - date
     - pub global activate flutter_plugin_tools
     - date
 
@@ -32,6 +34,8 @@ task:
     dockerfile: .ci/Dockerfile
     cpu: 8
     memory: 16G
+  environment:
+    PATH: $PATH:$HOME/.pub-cache/bin
   matrix:
     - name: publishable
       << : *FLUTTER_STABLE_TEMPLATE
@@ -63,10 +67,8 @@ task:
         - date
     - name: test
       matrix:
-        - name: master
-          << : *FLUTTER_MASTER_TEMPLATE
-        - name: stable
-          << : *FLUTTER_STABLE_SKIP_WEB_TEMPLATE
+        - << : *FLUTTER_MASTER_TEMPLATE
+        - << : *FLUTTER_STABLE_SKIP_WEB_TEMPLATE
       test_script:
         - date
         - ./script/incremental_build.sh test
@@ -92,10 +94,8 @@ task:
           PLUGIN_SHARDING: "--shardIndex 0 --shardCount 2"
           PLUGIN_SHARDING: "--shardIndex 1 --shardCount 2"
         matrix:
-          - name: master
-            << : *FLUTTER_MASTER_TEMPLATE
-          - name: stable
-            << : *FLUTTER_STABLE_SKIP_WEB_TEMPLATE
+          - << : *FLUTTER_MASTER_TEMPLATE
+          - << : *FLUTTER_STABLE_SKIP_WEB_TEMPLATE
         MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
         GCLOUD_FIREBASE_TESTLAB_KEY: ENCRYPTED[07586610af1fdfc894e5969f70ef2458341b9b7e9c3b7c4225a663b4a48732b7208a4d91c3b7d45305a6b55fa2a37fc4]
       script:
@@ -131,7 +131,7 @@ task:
     image: mojave-flutter
   environment:
     COCOAPODS_DISABLE_STATS: true
-    PATH: $PATH:/usr/local/bin
+    PATH: $PATH:/usr/local/bin:$HOME/.pub-cache/bin
   create_simulator_script:
     - date
     - xcrun simctl list
@@ -158,10 +158,8 @@ task:
           PLUGIN_SHARDING: "--shardIndex 2 --shardCount 4"
           PLUGIN_SHARDING: "--shardIndex 3 --shardCount 4"
         matrix:
-          - name: master
-            << : *FLUTTER_MASTER_TEMPLATE
-          - name: stable
-            << : *FLUTTER_STABLE_SKIP_WEB_TEMPLATE
+          - << : *FLUTTER_MASTER_TEMPLATE
+          - << : *FLUTTER_STABLE_SKIP_WEB_TEMPLATE
         SIMCTL_CHILD_MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
       script:
         - date

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -128,7 +128,6 @@ task:
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   osx_instance:
     image: mojave-flutter
-  << : *BASE_TASK_TEMPLATE
   environment:
     COCOAPODS_DISABLE_STATS: true
     PATH: $PATH:/usr/local/bin

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -89,7 +89,6 @@ task:
   setup_script:
     - pod --version
     - sudo gem list cocoapods
-    - pod repo remove master
   upgrade_script:
     - flutter channel stable
     - flutter upgrade

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -26,7 +26,7 @@ flutter_stable_skip_web_template: &FLUTTER_STABLE_SKIP_WEB_TEMPLATE
   remove_web_plugins_script:
     # TODO(jackson): Allow web plugins once supported on stable
     # https://github.com/flutter/flutter/issues/42864
-    - find . | grep _web$ | xargs rm -rf; fi
+    - find . | grep _web$ | xargs rm -rf
 
 task:
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,63 +1,111 @@
+pub_cache:
+  folder: $HOME/.pub-cache
+  fingerprint_script: echo $OS; grep -r --include=pubspec.yaml 'PUBSPEC CHECKSUM' "$CIRRUS_WORKING_DIR"
+upgrade_script:
+  - date
+  - git fetch origin master
+  - date
+activate_script: 
+  - date
+  - pub global activate flutter_plugin_tools
+  - date
+
+flutter_master_template: &FLUTTER_MASTER_TEMPLATE
+  environment:
+    CHANNEL: "master"
+  upgrade_script:
+    - date
+    - flutter channel $CHANNEL
+    - flutter upgrade
+    - date
+
+flutter_stable_template: &FLUTTER_STABLE_TEMPLATE
+  environment:
+    CHANNEL: "stable"
+  flutter_artifacts_cache:
+    folder: ${FLUTTER_HOME}/bin/cache/artifacts
+    fingerprint_script: echo $OS; cat ${FLUTTER_HOME}/bin/internal/*.version
+  flutter_pkg_cache:
+    folder: ${FLUTTER_HOME}/bin/cache/pkg
+    fingerprint_script: echo $OS; cat ${FLUTTER_HOME}/bin/internal/*.version
+  upgrade_script:
+    - date
+    - flutter channel $CHANNEL
+    - flutter upgrade
+    - date
+
+flutter_stable_skip_web_template: &FLUTTER_STABLE_SKIP_WEB_TEMPLATE
+  << : *FLUTTER_STABLE_TEMPLATE
+  test_script:
+    # TODO(jackson): Allow web plugins once supported on stable
+    # https://github.com/flutter/flutter/issues/42864
+    - find . | grep _web$ | xargs rm -rf; fi
+
 task:
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
   container:
     dockerfile: .ci/Dockerfile
     cpu: 8
     memory: 16G
-  upgrade_script:
-    - flutter channel stable
-    - flutter upgrade
-    - flutter channel master
-    - flutter upgrade
-    - git fetch origin master
-  activate_script: pub global activate flutter_plugin_tools
   matrix:
     - name: publishable
+      << : *FLUTTER_STABLE_TEMPLATE
       script:
-        - flutter channel stable
+        - date
         - ./script/check_publish.sh
+        - date
     - name: format
+      << : *FLUTTER_STABLE_TEMPLATE
       install_script:
+        - date
         - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         - sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main"
         - sudo apt-get update
         - sudo apt-get install -y --allow-unauthenticated clang-format-7
-      format_script: ./script/incremental_build.sh format --travis --clang-format=clang-format-7
+        - date
+      format_script:
+        - date
+        - ./script/incremental_build.sh format --travis --clang-format=clang-format-7
+        - date
     - name: test
-      env:
-        matrix:
-          CHANNEL: "master"
-          CHANNEL: "stable"
+      matrix:
+        - name: master
+        << : *FLUTTER_MASTER_TEMPLATE
+        - name: stable
+        << : *FLUTTER_STABLE_SKIP_WEB_TEMPLATE
       test_script:
-        # TODO(jackson): Allow web plugins once supported on stable
-        # https://github.com/flutter/flutter/issues/42864
-        - if [[ "$CHANNEL" -eq "stable" ]]; then find . | grep _web$ | xargs rm -rf; fi
-        - flutter channel $CHANNEL
+        - date
         - ./script/incremental_build.sh test
+        - date
     - name: analyze
-      script: ./script/incremental_build.sh analyze
-    - name: build_all_plugins_apk
+      << : *FLUTTER_STABLE_TEMPLATE
       script:
-        # TODO(jackson): Allow web plugins once supported on stable
-        # https://github.com/flutter/flutter/issues/42864
-        - if [[ "$CHANNEL" -eq "stable" ]]; then find . | grep _web$ | xargs rm -rf; fi
-        - flutter channel $CHANNEL
+        - date
+        - ./script/incremental_build.sh analyze
+        - date        
+    - name: build_all_plugins_apk
+      << : *FLUTTER_STABLE_SKIP_WEB_TEMPLATE
+      script:
+        - date
         - ./script/build_all_plugins_app.sh apk
+        - date
+      depends_on:
+        - format
+        - publishable
     - name: build-apks+java-test+firebase-test-lab
-      env:
+      environment:
         matrix:
           PLUGIN_SHARDING: "--shardIndex 0 --shardCount 2"
           PLUGIN_SHARDING: "--shardIndex 1 --shardCount 2"
         matrix:
-          CHANNEL: "master"
-          CHANNEL: "stable"
+          - name: master
+            << : *FLUTTER_MASTER_TEMPLATE
+          - name: stable
+            << : *FLUTTER_STABLE_SKIP_WEB_TEMPLATE
         MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
         GCLOUD_FIREBASE_TESTLAB_KEY: ENCRYPTED[07586610af1fdfc894e5969f70ef2458341b9b7e9c3b7c4225a663b4a48732b7208a4d91c3b7d45305a6b55fa2a37fc4]
       script:
-        # TODO(jackson): Allow web plugins once supported on stable
-        # https://github.com/flutter/flutter/issues/42864
-        - if [[ "$CHANNEL" -eq "stable" ]]; then find . | grep _web$ | xargs rm -rf; fi
-        - flutter channel $CHANNEL
+        - date
         # Unsetting CIRRUS_CHANGE_MESSAGE and CIRRUS_COMMIT_MESSAGE as they
         # might include non-ASCII characters which makes Gradle crash.
         # See: https://github.com/flutter/flutter/issues/24935
@@ -78,6 +126,10 @@ task:
         - fi
         - export CIRRUS_CHANGE_MESSAGE=`cat /tmp/cirrus_change_message.txt`
         - export CIRRUS_COMMIT_MESSAGE=`cat /tmp/cirrus_commit_message.txt`
+        - date
+      depends_on:
+        - format
+        - publishable
 
 task:
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
@@ -86,44 +138,42 @@ task:
   environment:
     COCOAPODS_DISABLE_STATS: true
     PATH: $PATH:/usr/local/bin
-  setup_script:
-    - pod --version
-    - sudo gem list cocoapods
-  upgrade_script:
-    - flutter channel stable
-    - flutter upgrade
-    - flutter channel master
-    - flutter upgrade
-    - git fetch origin master
-  activate_script: pub global activate flutter_plugin_tools
   create_simulator_script:
+    - date
     - xcrun simctl list
     - xcrun simctl create Flutter-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-X com.apple.CoreSimulator.SimRuntime.iOS-13-2 | xargs xcrun simctl boot
+    - date
   matrix:
     - name: build_all_plugins_ipa
+      << : *FLUTTER_STABLE_SKIP_WEB_TEMPLATE
       script:
-        # TODO(jackson): Allow web plugins once supported on stable
-        # https://github.com/flutter/flutter/issues/42864
-        - if [[ "$CHANNEL" -eq "stable" ]]; then find . | grep _web$ | xargs rm -rf; fi
-        - flutter channel $CHANNEL
+        - date
         - ./script/build_all_plugins_app.sh ios --no-codesign
+        - date
     - name: lint_darwin_plugins
-      script: ./script/lint_darwin_plugins.sh
+      << : *FLUTTER_STABLE_SKIP_WEB_TEMPLATE
+      script:
+        - date
+        - ./script/lint_darwin_plugins.sh
+        - date
     - name: build-ipas+drive-examples
-      env:
+      environment:
         matrix:
           PLUGIN_SHARDING: "--shardIndex 0 --shardCount 4"
           PLUGIN_SHARDING: "--shardIndex 1 --shardCount 4"
           PLUGIN_SHARDING: "--shardIndex 2 --shardCount 4"
           PLUGIN_SHARDING: "--shardIndex 3 --shardCount 4"
         matrix:
-          CHANNEL: "master"
-          CHANNEL: "stable"
+          - name: master
+            << : *FLUTTER_MASTER_TEMPLATE
+          - name: stable
+            << : *FLUTTER_STABLE_SKIP_WEB_TEMPLATE
         SIMCTL_CHILD_MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
-      build_script:
-        # TODO(jackson): Allow web plugins once supported on stable
-        # https://github.com/flutter/flutter/issues/42864
-        - if [[ "$CHANNEL" -eq "stable" ]]; then find . | grep _web$ | xargs rm -rf; fi
-        - flutter channel $CHANNEL
+      script:
+        - date
         - ./script/incremental_build.sh build-examples --ipa
         - ./script/incremental_build.sh drive-examples
+        - date
+  depends_on:
+    - format
+    - publishable

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -82,9 +82,14 @@ task:
 task:
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   osx_instance:
-    image: mojave-xcode-11.2.1-flutter
+    image: mojave-flutter
+  environment:
+    COCOAPODS_DISABLE_STATS: true
+    PATH: $PATH:/usr/local/bin
   setup_script:
-    - pod repo update
+    - pod --version
+    - sudo gem list cocoapods
+    - pod repo remove master
   upgrade_script:
     - flutter channel stable
     - flutter upgrade
@@ -107,7 +112,6 @@ task:
       script: ./script/lint_darwin_plugins.sh
     - name: build-ipas+drive-examples
       env:
-        PATH: $PATH:/usr/local/bin
         matrix:
           PLUGIN_SHARDING: "--shardIndex 0 --shardCount 4"
           PLUGIN_SHARDING: "--shardIndex 1 --shardCount 4"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,7 +2,7 @@ flutter_skip_web_template: &FLUTTER_SKIP_WEB_TEMPLATE
   remove_web_plugins_script:
     # TODO(jackson): Allow web plugins once supported on stable
     # https://github.com/flutter/flutter/issues/42864
-    - find . | grep _web$ | xargs rm -rf
+    - if [[ "$CHANNEL" -eq "stable" ]]; then find . | grep _web$ | xargs rm -rf; fi
 
 # fingerprint_script doesn't seem to work in templates.
 # To keep OS caches from colliding, split them into separate caches.
@@ -22,11 +22,6 @@ cache_stable_macos_template: &CACHE_STABLE_MACOS_TEMPLATE
   flutter_artifacts_macos_cache:
     folder: $FLUTTER_HOME/bin/cache/artifacts
 
-
-flutter_pkg_linux_cache:
-  folder: $FLUTTER_HOME/bin/cache/pkg
-flutter_artifacts_linux_cache:
-  folder: $FLUTTER_HOME/bin/cache/artifacts
 task:
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
   container:
@@ -35,11 +30,7 @@ task:
     memory: 16G
   environment:
     PATH: $PATH:$HOME/.pub-cache/bin
-    CHANNEL: "stable" # Default to flutter stable to leverage caching.
-  pub_cache:
-    folder: $HOME/.pub-cache
-    fingerprint_script: echo $CIRRUS_OS
-    only_if: $CHANNEL == "stable"
+    CHANNEL: "stable" # Default to flutter stable, tests can override.
   upgrade_script:
     - which flutter
     - flutter channel $CHANNEL
@@ -63,9 +54,9 @@ task:
         - sudo apt-get update
         - sudo apt-get install -y --allow-unauthenticated clang-format-7
         - date
-      format_script:
-        - ./script/incremental_build.sh format --travis --clang-format=clang-format-7
+      format_script: ./script/incremental_build.sh format --travis --clang-format=clang-format-7
     - name: test
+      << : *FLUTTER_SKIP_WEB_TEMPLATE
       environment:
         matrix:
           CHANNEL: "master"
@@ -86,6 +77,7 @@ task:
         - format
         - publishable
     - name: build-apks+java-test+firebase-test-lab
+      << : *FLUTTER_SKIP_WEB_TEMPLATE
       environment:
         matrix:
           PLUGIN_SHARDING: "--shardIndex 0 --shardCount 2"
@@ -129,11 +121,7 @@ task:
   environment:
     COCOAPODS_DISABLE_STATS: true
     PATH: $PATH:/usr/local/bin:$HOME/.pub-cache/bin
-    CHANNEL: "stable" # Default to flutter stable to leverage caching.
-  pub_cache:
-    folder: $HOME/.pub-cache
-    fingerprint_script: echo $CIRRUS_OS
-    only_if: $CHANNEL == "stable"
+    CHANNEL: "stable" # Default to flutter stable, tests can override.
   upgrade_script:
     - which flutter
     - flutter channel $CHANNEL
@@ -157,6 +145,7 @@ task:
       script:
         - ./script/lint_darwin_plugins.sh
     - name: build-ipas+drive-examples
+      << : *FLUTTER_SKIP_WEB_TEMPLATE
       environment:
         matrix:
           PLUGIN_SHARDING: "--shardIndex 0 --shardCount 4"

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -4,6 +4,8 @@ analyzer:
     # Ignore generated files
     - '**/*.g.dart'
     - 'lib/src/generated/*.dart'
+  enable-experiment:
+    - extension-methods
 linter:
   rules:
     - public_member_api_docs

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -4,8 +4,6 @@ analyzer:
     # Ignore generated files
     - '**/*.g.dart'
     - '**/lib/src/generated/*.dart'
-  enable-experiment:
-    - extension-methods
 linter:
   rules:
     - public_member_api_docs

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -3,7 +3,7 @@ analyzer:
   exclude:
     # Ignore generated files
     - '**/*.g.dart'
-    - 'lib/src/generated/*.dart'
+    - '**/lib/src/generated/*.dart'
   enable-experiment:
     - extension-methods
 linter:


### PR DESCRIPTION
## Description

- CocoaPods 1.8 uses a CDN instead of a local spec repository.  `pod repo update` is no longer necessary.  Remove.
- Add pub cache
- Add stable Flutter SDK cache