### PR TITLE
Temporarily disable CI on stable Flutter

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -27,7 +27,11 @@ task:
       env:
         matrix:
           CHANNEL: "master"
-          CHANNEL: "stable"
+          # Temporarily disabling CI on stable to allow using new Flutter features closely
+          # before a new release.
+          # TODO(amirh): re-enable this
+          # https://github.com/flutter/flutter/issues/46258
+          # CHANNEL: "stable"
       test_script:
         # TODO(jackson): Allow web plugins once supported on stable
         # https://github.com/flutter/flutter/issues/42864
@@ -50,7 +54,11 @@ task:
           PLUGIN_SHARDING: "--shardIndex 1 --shardCount 2"
         matrix:
           CHANNEL: "master"
-          CHANNEL: "stable"
+          # Temporarily disabling CI on stable to allow using new Flutter features closely
+          # before a new release.
+          # TODO(amirh): re-enable this
+          # https://github.com/flutter/flutter/issues/46258
+          # CHANNEL: "stable"
         MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
         GCLOUD_FIREBASE_TESTLAB_KEY: ENCRYPTED[07586610af1fdfc894e5969f70ef2458341b9b7e9c3b7c4225a663b4a48732b7208a4d91c3b7d45305a6b55fa2a37fc4]
       script:
@@ -115,7 +123,11 @@ task:
           PLUGIN_SHARDING: "--shardIndex 3 --shardCount 4"
         matrix:
           CHANNEL: "master"
-          CHANNEL: "stable"
+          # Temporarily disabling CI on stable to allow using new Flutter features closely
+          # before a new release.
+          # TODO(amirh): re-enable this
+          # https://github.com/flutter/flutter/issues/46258
+          # CHANNEL: "stable"
         SIMCTL_CHILD_MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
       build_script:
         # TODO(jackson): Allow web plugins once supported on stable


### PR DESCRIPTION
To enable using new Flutter features closely before a new release we're temporarily disabling CI on stable.

https://github.com/flutter/flutter/issues/46258 for re-enabling.

cc @jmagman this conflicts with https://github.com/flutter/plugins/pull/2357, we need to disable stable ASAP to unblock endorsing web plugins,  not sure how close is the other PR to landing I'm ok with waiting for the other PR first (or @jmagman if you can land i#2357 with stable disabled already 😄 ).

cc @collinjackson 