### PR TITLE
Disable stable for check publish

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,6 +14,9 @@ task:
   matrix:
     - name: publishable
       script:
+        # Temporarily disabling CI on stable to allow using new Flutter features closely
+        # before a new release.
+        # TODO(amirh): re-enable this
         - flutter channel master
         - ./script/check_publish.sh
     - name: format

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,7 +14,7 @@ task:
   matrix:
     - name: publishable
       script:
-        - flutter channel stable
+        - flutter channel master
         - ./script/check_publish.sh
     - name: format
       install_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,7 +16,7 @@ task:
       script:
         # Temporarily disabling CI on stable to allow using new Flutter features closely
         # before a new release.
-        # TODO(amirh): re-enable this
+        # TODO(franciscojma): re-enable this
         - flutter channel master
         - ./script/check_publish.sh
     - name: format


### PR DESCRIPTION
Continuation of https://github.com/flutter/plugins/pull/2367 to enable publishing macos plugins with the new pubspec formats.