### PR TITLE
[url_launcher_web] Add a no-op android/ folder

### DIFF
--- a/packages/url_launcher/url_launcher_web/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.0+1
+
+- Add an android/ folder with no-op implementation to workaround https://github.com/flutter/flutter/issues/46304.
+
 # 0.1.0
 
 - Update docs and pubspec.

--- a/packages/url_launcher/url_launcher_web/android/.gitignore
+++ b/packages/url_launcher/url_launcher_web/android/.gitignore
@@ -1,0 +1,8 @@
+*.iml
+.gradle
+/local.properties
+/.idea/workspace.xml
+/.idea/libraries
+.DS_Store
+/build
+/captures

--- a/packages/url_launcher/url_launcher_web/android/build.gradle
+++ b/packages/url_launcher/url_launcher_web/android/build.gradle
@@ -1,0 +1,34 @@
+group 'io.flutter.url_launcher_web'
+version '1.0'
+
+buildscript {
+    repositories {
+        google()
+        jcenter()
+    }
+
+    dependencies {
+        classpath 'com.android.tools.build:gradle:3.5.0'
+    }
+}
+
+rootProject.allprojects {
+    repositories {
+        google()
+        jcenter()
+    }
+}
+
+apply plugin: 'com.android.library'
+
+android {
+    compileSdkVersion 28
+
+    defaultConfig {
+        minSdkVersion 16
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+    lintOptions {
+        disable 'InvalidPackage'
+    }
+}

--- a/packages/url_launcher/url_launcher_web/android/gradle.properties
+++ b/packages/url_launcher/url_launcher_web/android/gradle.properties
@@ -1,0 +1,4 @@
+org.gradle.jvmargs=-Xmx1536M
+android.enableR8=true
+android.useAndroidX=true
+android.enableJetifier=true

--- a/packages/url_launcher/url_launcher_web/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/url_launcher/url_launcher_web/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip

--- a/packages/url_launcher/url_launcher_web/android/settings.gradle
+++ b/packages/url_launcher/url_launcher_web/android/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'url_launcher_web'

--- a/packages/url_launcher/url_launcher_web/android/src/main/AndroidManifest.xml
+++ b/packages/url_launcher/url_launcher_web/android/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="io.flutter.url_launcher_web">
+</manifest>

--- a/packages/url_launcher/url_launcher_web/android/src/main/java/io/flutter/url_launcher_web/UrlLauncherWebPlugin.java
+++ b/packages/url_launcher/url_launcher_web/android/src/main/java/io/flutter/url_launcher_web/UrlLauncherWebPlugin.java
@@ -6,17 +6,12 @@ package io.flutter.url_launcher_web;
 
 import androidx.annotation.NonNull;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
-import io.flutter.plugin.common.MethodCall;
-import io.flutter.plugin.common.MethodChannel;
-import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
-import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 /** UrlLauncherWebPlugin */
 public class UrlLauncherWebPlugin implements FlutterPlugin {
   @Override
-  public void onAttachedToEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {
-  }
+  public void onAttachedToEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {}
 
   // This static function is optional and equivalent to onAttachedToEngine. It supports the old
   // pre-Flutter-1.12 Android projects. You are encouraged to continue supporting
@@ -27,10 +22,8 @@ public class UrlLauncherWebPlugin implements FlutterPlugin {
   // them functionally equivalent. Only one of onAttachedToEngine or registerWith will be called
   // depending on the user's project. onAttachedToEngine or registerWith must both be defined
   // in the same class.
-  public static void registerWith(Registrar registrar) {
-  }
+  public static void registerWith(Registrar registrar) {}
 
   @Override
-  public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
-  }
+  public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {}
 }

--- a/packages/url_launcher/url_launcher_web/android/src/main/java/io/flutter/url_launcher_web/UrlLauncherWebPlugin.java
+++ b/packages/url_launcher/url_launcher_web/android/src/main/java/io/flutter/url_launcher_web/UrlLauncherWebPlugin.java
@@ -1,0 +1,36 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.url_launcher_web;
+
+import androidx.annotation.NonNull;
+import io.flutter.embedding.engine.plugins.FlutterPlugin;
+import io.flutter.plugin.common.MethodCall;
+import io.flutter.plugin.common.MethodChannel;
+import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
+import io.flutter.plugin.common.MethodChannel.Result;
+import io.flutter.plugin.common.PluginRegistry.Registrar;
+
+/** UrlLauncherWebPlugin */
+public class UrlLauncherWebPlugin implements FlutterPlugin {
+  @Override
+  public void onAttachedToEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {
+  }
+
+  // This static function is optional and equivalent to onAttachedToEngine. It supports the old
+  // pre-Flutter-1.12 Android projects. You are encouraged to continue supporting
+  // plugin registration via this function while apps migrate to use the new Android APIs
+  // post-flutter-1.12 via https://flutter.dev/go/android-project-migration.
+  //
+  // It is encouraged to share logic between onAttachedToEngine and registerWith to keep
+  // them functionally equivalent. Only one of onAttachedToEngine or registerWith will be called
+  // depending on the user's project. onAttachedToEngine or registerWith must both be defined
+  // in the same class.
+  public static void registerWith(Registrar registrar) {
+  }
+
+  @Override
+  public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
+  }
+}

--- a/packages/url_launcher/url_launcher_web/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher_web
 description: Web platform implementation of url_launcher
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher_web
-version: 0.1.0
+version: 0.1.0+1
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

A bug is preventing applications that use federated web plugins to build for Android.
This is working around that bug by adding an android/ folder with a no-op implementation.

## Related Issues

https://github.com/flutter/flutter/issues/46304

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
