### PR TITLE
[url_launcher] Use the common PlatformInterface functionality

### DIFF
--- a/packages/url_launcher/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.4.1
+
+* Update unit tests to work with the PlatformInterface from package `plugin_platform_interface`.
+
 ## 5.4.0
 
 * Support macos by default.

--- a/packages/url_launcher/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/pubspec.yaml
@@ -28,6 +28,10 @@ dependencies:
   # https://github.com/flutter/flutter/issues/46264
   url_launcher_web: ^0.1.0+1
   url_launcher_macos: ^0.0.1
+
+# Temporarily overriding the dependency to keep CI green.
+# WILL REMOVE THIS PRIOR TO PUBLISHING THIS PACKAGE.
+# TODO(amirh): remove after publishing the platform interface
 dependency_overrides:
   url_launcher_platform_interface:
     path: ../url_launcher_platform_interface

--- a/packages/url_launcher/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher
 description: Flutter plugin for launching a URL on Android and iOS. Supports
   web, phone, SMS, and email schemes.
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher
-version: 5.4.0
+version: 5.4.1
 
 flutter:
   plugin:
@@ -28,12 +28,16 @@ dependencies:
   # https://github.com/flutter/flutter/issues/46264
   url_launcher_web: ^0.1.0+1
   url_launcher_macos: ^0.0.1
+dependency_overrides:
+  url_launcher_platform_interface:
+    path: ../url_launcher_platform_interface
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   test: ^1.3.0
   mockito: ^4.1.1
+  plugin_platform_interface: ^1.0.0
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"

--- a/packages/url_launcher/url_launcher/test/url_launcher_test.dart
+++ b/packages/url_launcher/url_launcher/test/url_launcher_test.dart
@@ -7,13 +7,13 @@ import 'dart:ui';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:flutter/foundation.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 import 'package:flutter/services.dart' show PlatformException;
 
 void main() {
   final MockUrlLauncher mock = MockUrlLauncher();
-  when(mock.isMock).thenReturn(true);
   UrlLauncherPlatform.instance = mock;
 
   test('closeWebView default behavior', () async {
@@ -208,4 +208,6 @@ void main() {
   });
 }
 
-class MockUrlLauncher extends Mock implements UrlLauncherPlatform {}
+class MockUrlLauncher extends Mock
+    with MockPlatformInterfaceMixin
+    implements UrlLauncherPlatform {}

--- a/packages/url_launcher/url_launcher_platform_interface/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_platform_interface/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.0.4
+
+* Use the common PlatformInterface code from plugin_platform_interface.
+* [TEST ONLY BREAKING CHANGE] remove UrlLauncherPlatform.isMock, we're not increasing the major version
+  as doing so for platform interfaces has bad implications, given that this is only going to break
+  test code, and that the plugin is young and shouldn't have third-party users we've decided to land
+  this as a patch bump.
+
 ## 1.0.3
 
 * Minor DartDoc changes and add a lint for missing DartDocs.

--- a/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
@@ -4,7 +4,8 @@
 
 import 'dart:async';
 
-import 'package:meta/meta.dart' show required, visibleForTesting;
+import 'package:meta/meta.dart' show required;
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 import 'method_channel_url_launcher.dart';
 
@@ -15,14 +16,11 @@ import 'method_channel_url_launcher.dart';
 /// (using `extends`) ensures that the subclass will get the default implementation, while
 /// platform implementations that `implements` this interface will be broken by newly added
 /// [UrlLauncherPlatform] methods.
-abstract class UrlLauncherPlatform {
-  /// Only mock implementations should set this to true.
-  ///
-  /// Mockito mocks are implementing this class with `implements` which is forbidden for anything
-  /// other than mocks (see class docs). This property provides a backdoor for mockito mocks to
-  /// skip the verification that the class isn't implemented with `implements`.
-  @visibleForTesting
-  bool get isMock => false;
+abstract class UrlLauncherPlatform extends PlatformInterface {
+  /// Constructs a UrlLauncherPlatform.
+  UrlLauncherPlatform() : super(token: _token);
+
+  static const Object _token = Object();
 
   static UrlLauncherPlatform _instance = MethodChannelUrlLauncher();
 
@@ -36,14 +34,7 @@ abstract class UrlLauncherPlatform {
   // TODO(amirh): Extract common platform interface logic.
   // https://github.com/flutter/flutter/issues/43368
   static set instance(UrlLauncherPlatform instance) {
-    if (!instance.isMock) {
-      try {
-        instance._verifyProvidesDefaultImplementations();
-      } on NoSuchMethodError catch (_) {
-        throw AssertionError(
-            'Platform interfaces must not be implemented with `implements`');
-      }
-    }
+    PlatformInterface.verifyToken(instance, _token);
     _instance = instance;
   }
 
@@ -72,12 +63,4 @@ abstract class UrlLauncherPlatform {
   Future<void> closeWebView() {
     throw UnimplementedError('closeWebView() has not been implemented.');
   }
-
-  // This method makes sure that UrlLauncher isn't implemented with `implements`.
-  //
-  // See class doc for more details on why implementing this class is forbidden.
-  //
-  // This private method is called by the instance setter, which fails if the class is
-  // implemented with `implements`.
-  void _verifyProvidesDefaultImplementations() {}
 }

--- a/packages/url_launcher/url_launcher_platform_interface/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_platform_interface/pubspec.yaml
@@ -9,6 +9,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.0.5
+  plugin_platform_interface: ^1.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/url_launcher/url_launcher_platform_interface/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the url_launcher plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.0.3
+version: 1.0.4
 
 dependencies:
   flutter:

--- a/packages/url_launcher/url_launcher_platform_interface/test/method_channel_url_launcher_test.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/test/method_channel_url_launcher_test.dart
@@ -5,6 +5,7 @@
 import 'package:mockito/mockito.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 import 'package:url_launcher_platform_interface/method_channel_url_launcher.dart';
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
@@ -25,9 +26,7 @@ void main() {
     });
 
     test('Can be mocked with `implements`', () {
-      final ImplementsUrlLauncherPlatform mock =
-          ImplementsUrlLauncherPlatform();
-      when(mock.isMock).thenReturn(true);
+      final UrlLauncherPlatformMock mock = UrlLauncherPlatformMock();
       UrlLauncherPlatform.instance = mock;
     });
 
@@ -279,6 +278,10 @@ void main() {
     });
   });
 }
+
+class UrlLauncherPlatformMock extends Mock
+    with MockPlatformInterfaceMixin
+    implements UrlLauncherPlatform {}
 
 class ImplementsUrlLauncherPlatform extends Mock
     implements UrlLauncherPlatform {}

--- a/script/check_publish.sh
+++ b/script/check_publish.sh
@@ -14,6 +14,14 @@ function check_publish() {
   local failures=()
   for dir in $(pub global run flutter_plugin_tools list --plugins="$1"); do
     local package_name=$(basename "$dir")
+
+    # Temporarily skipping publish check for url_launcher while it has a
+    # dependency override.
+    # TODO(amirh): remove this after publishing url_launcher_platform_interface
+    if [[ $package_name == "url_launcher" ]]; then
+      echo "Skipping publish check for $package_name"
+      continue
+    fi
     echo "Checking that $package_name can be published."
     if [[ $(cd "$dir" && cat pubspec.yaml | grep -E "^publish_to: none") ]]; then
       echo "Package $package_name is marked as unpublishable. Skipping."


### PR DESCRIPTION
## Description

### url_launcher_platform_interface
Replace the current mechanism for protecting against implements with the common PlatformInterface class from the plugin_platform_interface package.

### url_launcher

Update the unit test to work with the newly used PlatformInterface.
To keep CI green this includes a path dependency override.

This change is going to land and publish with the following sequence:

1. land this PR
2. publish url_launcher_platform_interface
3. land a PR to remove the dependency override from url_launcher, bump it's dependency on url_launcher_platform_interface, and re-enable the publish check for url_launcher
4. publish url_launcher

## Related Issues

https://github.com/flutter/flutter/issues/43368

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

^ see changelog
