### PR TITLE
re-enable stable CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,10 +16,7 @@ task:
   matrix:
     - name: publishable
       script:
-        # Temporarily disabling CI on stable to allow using new Flutter features closely
-        # before a new release.
-        # TODO(franciscojma): re-enable this
-        - flutter channel master
+        - flutter channel stable
         - ./script/check_publish.sh
     - name: format
       install_script:
@@ -32,11 +29,7 @@ task:
       env:
         matrix:
           CHANNEL: "master"
-          # Temporarily disabling CI on stable to allow using new Flutter features closely
-          # before a new release.
-          # TODO(amirh): re-enable this
-          # https://github.com/flutter/flutter/issues/46258
-          # CHANNEL: "stable"
+          CHANNEL: "stable"
       test_script:
         # TODO(jackson): Allow web plugins once supported on stable
         # https://github.com/flutter/flutter/issues/42864
@@ -59,11 +52,7 @@ task:
           PLUGIN_SHARDING: "--shardIndex 1 --shardCount 2"
         matrix:
           CHANNEL: "master"
-          # Temporarily disabling CI on stable to allow using new Flutter features closely
-          # before a new release.
-          # TODO(amirh): re-enable this
-          # https://github.com/flutter/flutter/issues/46258
-          # CHANNEL: "stable"
+          CHANNEL: "stable"
         MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
         GCLOUD_FIREBASE_TESTLAB_KEY: ENCRYPTED[07586610af1fdfc894e5969f70ef2458341b9b7e9c3b7c4225a663b4a48732b7208a4d91c3b7d45305a6b55fa2a37fc4]
       script:
@@ -132,9 +121,7 @@ task:
           CHANNEL: "master"
           # Temporarily disabling CI on stable to allow using new Flutter features closely
           # before a new release.
-          # TODO(amirh): re-enable this
-          # https://github.com/flutter/flutter/issues/46258
-          # CHANNEL: "stable"
+          CHANNEL: "stable"
         SIMCTL_CHILD_MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
       build_script:
         # TODO(jackson): Allow web plugins once supported on stable

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -119,8 +119,6 @@ task:
           PLUGIN_SHARDING: "--shardIndex 3 --shardCount 4"
         matrix:
           CHANNEL: "master"
-          # Temporarily disabling CI on stable to allow using new Flutter features closely
-          # before a new release.
           CHANNEL: "stable"
         SIMCTL_CHILD_MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
       build_script:


### PR DESCRIPTION
Stable CI was temporarily disabled waiting for the next stable release, now that it's out re-enabling.

https://github.com/flutter/flutter/issues/46258