### PR TITLE
[url_launcher_macos] add a no-op android implementation

### DIFF
--- a/packages/url_launcher/url_launcher_macos/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_macos/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.0.1+1
+
+* Add an android/ folder with no-op implementation to workaround https://github.com/flutter/flutter/issues/46304
 # 0.0.1
 
-- Initial open-source release.
+* Initial open-source release.

--- a/packages/url_launcher/url_launcher_macos/android/.gitignore
+++ b/packages/url_launcher/url_launcher_macos/android/.gitignore
@@ -1,0 +1,8 @@
+*.iml
+.gradle
+/local.properties
+/.idea/workspace.xml
+/.idea/libraries
+.DS_Store
+/build
+/captures

--- a/packages/url_launcher/url_launcher_macos/android/build.gradle
+++ b/packages/url_launcher/url_launcher_macos/android/build.gradle
@@ -1,0 +1,34 @@
+group 'io.flutter.plugins.url_launcher_macos'
+version '1.0'
+
+buildscript {
+    repositories {
+        google()
+        jcenter()
+    }
+
+    dependencies {
+        classpath 'com.android.tools.build:gradle:3.5.0'
+    }
+}
+
+rootProject.allprojects {
+    repositories {
+        google()
+        jcenter()
+    }
+}
+
+apply plugin: 'com.android.library'
+
+android {
+    compileSdkVersion 28
+
+    defaultConfig {
+        minSdkVersion 16
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+    lintOptions {
+        disable 'InvalidPackage'
+    }
+}

--- a/packages/url_launcher/url_launcher_macos/android/gradle.properties
+++ b/packages/url_launcher/url_launcher_macos/android/gradle.properties
@@ -1,0 +1,4 @@
+org.gradle.jvmargs=-Xmx1536M
+android.enableR8=true
+android.useAndroidX=true
+android.enableJetifier=true

--- a/packages/url_launcher/url_launcher_macos/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/url_launcher/url_launcher_macos/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip

--- a/packages/url_launcher/url_launcher_macos/android/settings.gradle
+++ b/packages/url_launcher/url_launcher_macos/android/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'url_launcher_macos'

--- a/packages/url_launcher/url_launcher_macos/android/src/main/AndroidManifest.xml
+++ b/packages/url_launcher/url_launcher_macos/android/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="io.flutter.plugins.url_launcher_macos">
+</manifest>

--- a/packages/url_launcher/url_launcher_macos/android/src/main/java/io/flutter/plugins/url_launcher_macos/UrlLauncherMacosPlugin.java
+++ b/packages/url_launcher/url_launcher_macos/android/src/main/java/io/flutter/plugins/url_launcher_macos/UrlLauncherMacosPlugin.java
@@ -1,0 +1,15 @@
+package io.flutter.plugins.url_launcher_macos;
+
+import androidx.annotation.NonNull;
+import io.flutter.embedding.engine.plugins.FlutterPlugin;
+import io.flutter.plugin.common.PluginRegistry.Registrar;
+
+public class UrlLauncherMacosPlugin implements FlutterPlugin {
+  @Override
+  public void onAttachedToEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {}
+
+  public static void registerWith(Registrar registrar) {}
+
+  @Override
+  public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {}
+}

--- a/packages/url_launcher/url_launcher_macos/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_macos/pubspec.yaml
@@ -1,6 +1,6 @@
 name: url_launcher_macos
 description: macOS implementation of the url_launcher plugin.
-version: 0.0.1
+version: 0.0.1+1
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher_macos
 
 flutter:


### PR DESCRIPTION
Adding an `android/` folder as a temporary mitigation for:

https://github.com/flutter/flutter/issues/46304
https://github.com/flutter/flutter/issues/46790