### PR TITLE
Remove AndroidX references from no-op android implementations

### DIFF
--- a/packages/url_launcher/url_launcher_macos/android/build.gradle
+++ b/packages/url_launcher/url_launcher_macos/android/build.gradle
@@ -26,7 +26,6 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {
         disable 'InvalidPackage'

--- a/packages/url_launcher/url_launcher_macos/android/gradle.properties
+++ b/packages/url_launcher/url_launcher_macos/android/gradle.properties
@@ -1,4 +1,2 @@
 org.gradle.jvmargs=-Xmx1536M
 android.enableR8=true
-android.useAndroidX=true
-android.enableJetifier=true

--- a/packages/url_launcher/url_launcher_macos/android/src/main/java/io/flutter/plugins/url_launcher_macos/UrlLauncherMacosPlugin.java
+++ b/packages/url_launcher/url_launcher_macos/android/src/main/java/io/flutter/plugins/url_launcher_macos/UrlLauncherMacosPlugin.java
@@ -1,15 +1,14 @@
 package io.flutter.plugins.url_launcher_macos;
 
-import androidx.annotation.NonNull;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 public class UrlLauncherMacosPlugin implements FlutterPlugin {
   @Override
-  public void onAttachedToEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {}
+  public void onAttachedToEngine(FlutterPluginBinding flutterPluginBinding) {}
 
   public static void registerWith(Registrar registrar) {}
 
   @Override
-  public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {}
+  public void onDetachedFromEngine(FlutterPluginBinding binding) {}
 }

--- a/packages/url_launcher/url_launcher_web/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.0+2
+
+- Remove androidx references from the no-op android implemenation.
+
 # 0.1.0+1
 
 - Add an android/ folder with no-op implementation to workaround https://github.com/flutter/flutter/issues/46304.

--- a/packages/url_launcher/url_launcher_web/android/build.gradle
+++ b/packages/url_launcher/url_launcher_web/android/build.gradle
@@ -26,7 +26,6 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {
         disable 'InvalidPackage'

--- a/packages/url_launcher/url_launcher_web/android/gradle.properties
+++ b/packages/url_launcher/url_launcher_web/android/gradle.properties
@@ -1,4 +1,2 @@
 org.gradle.jvmargs=-Xmx1536M
 android.enableR8=true
-android.useAndroidX=true
-android.enableJetifier=true

--- a/packages/url_launcher/url_launcher_web/android/src/main/java/io/flutter/url_launcher_web/UrlLauncherWebPlugin.java
+++ b/packages/url_launcher/url_launcher_web/android/src/main/java/io/flutter/url_launcher_web/UrlLauncherWebPlugin.java
@@ -4,14 +4,13 @@
 
 package io.flutter.url_launcher_web;
 
-import androidx.annotation.NonNull;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 /** UrlLauncherWebPlugin */
 public class UrlLauncherWebPlugin implements FlutterPlugin {
   @Override
-  public void onAttachedToEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {}
+  public void onAttachedToEngine(FlutterPluginBinding flutterPluginBinding) {}
 
   // This static function is optional and equivalent to onAttachedToEngine. It supports the old
   // pre-Flutter-1.12 Android projects. You are encouraged to continue supporting
@@ -25,5 +24,5 @@ public class UrlLauncherWebPlugin implements FlutterPlugin {
   public static void registerWith(Registrar registrar) {}
 
   @Override
-  public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {}
+  public void onDetachedFromEngine(FlutterPluginBinding binding) {}
 }

--- a/packages/url_launcher/url_launcher_web/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: url_launcher_web
 description: Web platform implementation of url_launcher
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher_web
-version: 0.1.0+1
+version: 0.1.0+2
 
 flutter:
   plugin:

--- a/packages/video_player/video_player_web/android/build.gradle
+++ b/packages/video_player/video_player_web/android/build.gradle
@@ -26,7 +26,6 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {
         disable 'InvalidPackage'

--- a/packages/video_player/video_player_web/android/gradle.properties
+++ b/packages/video_player/video_player_web/android/gradle.properties
@@ -1,4 +1,2 @@
 org.gradle.jvmargs=-Xmx1536M
 android.enableR8=true
-android.useAndroidX=true
-android.enableJetifier=true

--- a/packages/video_player/video_player_web/android/src/main/java/io/flutter/plugins/video_player_web/VideoPlayerWebPlugin.java
+++ b/packages/video_player/video_player_web/android/src/main/java/io/flutter/plugins/video_player_web/VideoPlayerWebPlugin.java
@@ -1,6 +1,5 @@
 package io.flutter.plugins.video_player_web;
 
-import androidx.annotation.NonNull;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel.Result;
@@ -9,13 +8,10 @@ import io.flutter.plugin.common.PluginRegistry.Registrar;
 /** VideoPlayerWebPlugin */
 public class VideoPlayerWebPlugin implements FlutterPlugin {
   @Override
-  public void onAttachedToEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {}
+  public void onAttachedToEngine(FlutterPluginBinding flutterPluginBinding) {}
 
   public static void registerWith(Registrar registrar) {}
 
   @Override
-  public void onMethodCall(@NonNull MethodCall call, @NonNull Result result) {}
-
-  @Override
-  public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {}
+  public void onDetachedFromEngine(FlutterPluginBinding binding) {}
 }

--- a/packages/video_player/video_player_web/android/src/main/java/io/flutter/plugins/video_player_web/VideoPlayerWebPlugin.java
+++ b/packages/video_player/video_player_web/android/src/main/java/io/flutter/plugins/video_player_web/VideoPlayerWebPlugin.java
@@ -1,8 +1,6 @@
 package io.flutter.plugins.video_player_web;
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
-import io.flutter.plugin.common.MethodCall;
-import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 /** VideoPlayerWebPlugin */


### PR DESCRIPTION
## Description

Removes androidx references from no-op android implementations for: url_launcher_macos, url_launcher_web, and video_player web.

Only url_launcher_web gets a version bump as the others weren't published yet.

## Related Issues

https://github.com/flutter/flutter/issues/46898