### PR TITLE
[plugin_platform_interface] Don't use const Object as a token

### DIFF
--- a/packages/plugin_platform_interface/CHANGELOG.md
+++ b/packages/plugin_platform_interface/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.0.1
 
-* Fixed a bug that made all platform interface apeear as mock on release builds (https://github.com/flutter/flutter/issues/46941).
+* Fixed a bug that made all platform interfaces appear as mocks in release builds (https://github.com/flutter/flutter/issues/46941).
 
 ## 1.0.0 - Initial release.
 

--- a/packages/plugin_platform_interface/CHANGELOG.md
+++ b/packages/plugin_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+* Fixed a bug that made all platform interface apeear as mock on release builds (https://github.com/flutter/flutter/issues/46941).
+
 ## 1.0.0 - Initial release.
 
 * Provides `PlatformInterface` with common mechanism for enforcing that a platform interface

--- a/packages/plugin_platform_interface/README.md
+++ b/packages/plugin_platform_interface/README.md
@@ -18,7 +18,7 @@ abstract class UrlLauncherPlatform extends PlatformInterface {
 
   static UrlLauncherPlatform _instance = MethodChannelUrlLauncher();
 
-  static const Object _token = Object();
+  static final Object _token = Object();
 
   static UrlLauncherPlatform get instance => _instance;
 

--- a/packages/plugin_platform_interface/lib/plugin_platform_interface.dart
+++ b/packages/plugin_platform_interface/lib/plugin_platform_interface.dart
@@ -91,7 +91,7 @@ abstract class PlatformInterface {
 /// ```
 @visibleForTesting
 abstract class MockPlatformInterfaceMixin implements PlatformInterface {
-  static const Object _token = Object();
+  static final Object _token = Object();
 
   @override
   Object get _instanceToken => _token;

--- a/packages/plugin_platform_interface/lib/plugin_platform_interface.dart
+++ b/packages/plugin_platform_interface/lib/plugin_platform_interface.dart
@@ -70,7 +70,8 @@ abstract class PlatformInterface {
       return;
     }
     if (!identical(token, instance._instanceToken)) {
-      throw AssertionError('Platform interfaces must not be implemented with `implements`');
+      throw AssertionError(
+          'Platform interfaces must not be implemented with `implements`');
     }
   }
 }

--- a/packages/plugin_platform_interface/lib/plugin_platform_interface.dart
+++ b/packages/plugin_platform_interface/lib/plugin_platform_interface.dart
@@ -90,7 +90,4 @@ abstract class PlatformInterface {
 ///    implements UrlLauncherPlatform {}
 /// ```
 @visibleForTesting
-abstract class MockPlatformInterfaceMixin implements PlatformInterface {
-  @override
-  Object get _instanceToken => null;
-}
+abstract class MockPlatformInterfaceMixin implements PlatformInterface {}

--- a/packages/plugin_platform_interface/lib/plugin_platform_interface.dart
+++ b/packages/plugin_platform_interface/lib/plugin_platform_interface.dart
@@ -57,7 +57,7 @@ abstract class PlatformInterface {
   /// This is implemented as a static method so that it cannot be overridden
   /// with `noSuchMethod`.
   static void verifyToken(PlatformInterface instance, Object token) {
-    if (identical(instance._instanceToken, MockPlatformInterfaceMixin._token)) {
+    if (instance is MockPlatformInterfaceMixin) {
       bool assertionsEnabled = false;
       assert(() {
         assertionsEnabled = true;
@@ -67,10 +67,10 @@ abstract class PlatformInterface {
         throw AssertionError(
             '`MockPlatformInterfaceMixin` is not intended for use in release builds.');
       }
+      return;
     }
     if (!identical(token, instance._instanceToken)) {
-      throw AssertionError(
-          'Platform interfaces must not be implemented with `implements`');
+      throw AssertionError('Platform interfaces must not be implemented with `implements`');
     }
   }
 }
@@ -91,8 +91,6 @@ abstract class PlatformInterface {
 /// ```
 @visibleForTesting
 abstract class MockPlatformInterfaceMixin implements PlatformInterface {
-  static final Object _token = Object();
-
   @override
-  Object get _instanceToken => _token;
+  Object get _instanceToken => null;
 }

--- a/packages/plugin_platform_interface/pubspec.yaml
+++ b/packages/plugin_platform_interface/pubspec.yaml
@@ -12,7 +12,7 @@ description: Reusable base class for Flutter plugin platform interfaces.
 # be done when absolutely necessary and after the ecosystem has already migrated to 1.X.Y version
 # that is forward compatible with 2.0.0 (ideally the ecosystem have migrated to depend on:
 # `plugin_platform_interface: >=1.X.Y <3.0.0`).
-version: 1.0.0
+version: 1.0.1
 
 homepage: https://github.com/flutter/plugins/plugin_platform_interface
 

--- a/packages/plugin_platform_interface/test/plugin_platform_interface_test.dart
+++ b/packages/plugin_platform_interface/test/plugin_platform_interface_test.dart
@@ -10,7 +10,7 @@ import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 class SamplePluginPlatform extends PlatformInterface {
   SamplePluginPlatform() : super(token: _token);
 
-  static const Object _token = Object();
+  static final Object _token = Object();
 
   static set instance(SamplePluginPlatform instance) {
     PlatformInterface.verifyToken(instance, _token);


### PR DESCRIPTION
## Description

Platform interface tokens must be unique, we've mistakenly used const Objects as a token (and all const Objects are identical).

Thanks @buntagonalprism for noticing and investigating!

We should probably follow-up with the PlatformInterface forcing tokens that are not const Objects (though this will be a breaking change).

I'm not sure whether we can test the failing scenario as it will require running tests in release mode.

## Related Issues

https://github.com/flutter/flutter/issues/46941

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.