### PR TITLE
[google_sign_in] Pass the client id to the platform interface.

### DIFF
--- a/packages/google_sign_in/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.1
+
+* Support passing `clientId` to the web plugin programmatically.
+
 ## 4.1.0
 
 * Support web by default.

--- a/packages/google_sign_in/google_sign_in/lib/google_sign_in.dart
+++ b/packages/google_sign_in/google_sign_in/lib/google_sign_in.dart
@@ -165,6 +165,7 @@ class GoogleSignIn {
     this.signInOption = SignInOption.standard,
     this.scopes = const <String>[],
     this.hostedDomain,
+    this.clientId,
   });
 
   /// Factory for creating default sign in user experience.
@@ -207,6 +208,9 @@ class GoogleSignIn {
   /// Domain to restrict sign-in to.
   final String hostedDomain;
 
+  /// Client ID being used to connect to google sign-in. Only supported on web.
+  final String clientId;
+
   StreamController<GoogleSignInAccount> _currentUserController =
       StreamController<GoogleSignInAccount>.broadcast();
 
@@ -240,6 +244,7 @@ class GoogleSignIn {
       signInOption: signInOption,
       scopes: scopes,
       hostedDomain: hostedDomain,
+      clientId: clientId,
     )..catchError((dynamic _) {
         // Invalidate initialization if it errors out.
         _initialization = null;

--- a/packages/google_sign_in/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_sign_in
 description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android and iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_sign_in/google_sign_in
-version: 4.1.0
+version: 4.1.1
 
 flutter:
   plugin:


### PR DESCRIPTION
The param exists in the platform interface but there was no way to pass anything to clientId through the external interface.