### PR TITLE
[google_maps_flutter] fix swift example in readme

### DIFF
--- a/packages/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/CHANGELOG.md
@@ -1,7 +1,10 @@
+## 0.5.21+17
+
+* Fix Swift example in README.md.
+
 ## 0.5.21+16
 
 * Fixed typo in LatLng's documentation.
-* Fix Swift example in README.md.
 
 ## 0.5.21+15
 

--- a/packages/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.5.21+16
 
 * Fixed typo in LatLng's documentation.
+* Fix Swift example in README.md.
 
 ## 0.5.21+15
 

--- a/packages/google_maps_flutter/README.md
+++ b/packages/google_maps_flutter/README.md
@@ -68,7 +68,7 @@ import GoogleMaps
 @objc class AppDelegate: FlutterAppDelegate {
   override func application(
     _ application: UIApplication,
-    didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
     GMSServices.provideAPIKey("YOUR KEY HERE")
     GeneratedPluginRegistrant.register(with: self)

--- a/packages/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter
-version: 0.5.21+16
+version: 0.5.21+17
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Description

This PR replaces `UIApplicationLaunchOptionsKey` with `UIApplication.LaunchOptionsKey` in example for swift because first one doesn't longer work due to https://github.com/flutter/flutter/pull/35763

## Related Issues

Here is a description of compile error which occurs when using `UIApplicationLaunchOptionsKey`:
https://stackoverflow.com/questions/59365426/flutter-google-maps-ios-build-fail
