### PR TITLE
Fix Get Available Biometrics Android

### DIFF
--- a/packages/local_auth/android/src/main/java/io/flutter/plugins/localauth/LocalAuthPlugin.java
+++ b/packages/local_auth/android/src/main/java/io/flutter/plugins/localauth/LocalAuthPlugin.java
@@ -21,6 +21,7 @@ import io.flutter.plugin.common.PluginRegistry.Registrar;
 import io.flutter.plugins.localauth.AuthenticationHelper.AuthCompletionHandler;
 import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
+import androidx.core.hardware.fingerprint.FingerprintManagerCompat;
 
 /**
  * Flutter plugin providing access to local authentication.
@@ -126,9 +127,12 @@ public class LocalAuthPlugin implements MethodCallHandler, FlutterPlugin, Activi
         }
         ArrayList<String> biometrics = new ArrayList<String>();
         PackageManager packageManager = activity.getPackageManager();
-        if (Build.VERSION.SDK_INT >= 23) {
-          if (packageManager.hasSystemFeature(PackageManager.FEATURE_FINGERPRINT)) {
+        FingerprintManagerCompat fingerprintMgr = FingerprintManagerCompat.from(activity);
+        if (fingerprintMgr.isHardwareDetected()) {
+          if (fingerprintMgr.hasEnrolledFingerprints()) {
             biometrics.add("fingerprint");
+          } else {
+            biometrics.add("undefined");
           }
         }
         if (Build.VERSION.SDK_INT >= 29) {


### PR DESCRIPTION
Issue get available biometrics function:
- From iOS: Biometrics type return from enroll of device.
- From Android: Biometrics type return from system of device.

Solved: change get available biometrics type of Android from system to enroll. It's same with iOS and working ok.