### PR TITLE
[local_auth]Fix app crash when biometrics lockout on ios 13

### DIFF
--- a/packages/local_auth/ios/Classes/FLTLocalAuthPlugin.m
+++ b/packages/local_auth/ios/Classes/FLTLocalAuthPlugin.m
@@ -108,9 +108,6 @@
                             case LAErrorTouchIDNotAvailable:
                             case LAErrorTouchIDNotEnrolled:
                             case LAErrorTouchIDLockout:
-                              [self handleErrors:error
-                                   flutterArguments:arguments
-                                  withFlutterResult:result];
                               return;
                             case LAErrorSystemCancel:
                               if ([arguments[@"stickyAuth"] boolValue]) {


### PR DESCRIPTION
Fix app crash when biometrics lockout on ios 13