### PR TITLE
Migrate away from deprecated `BinaryMessages`

### DIFF
--- a/packages/connectivity/CHANGELOG.md
+++ b/packages/connectivity/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.4.7
+## 0.4.6+2
 
 * Migrate deprecated BinaryMessages to ServicesBinding.instance.defaultBinaryMessenger.
 * Bump Flutter SDK to 1.12.13+hotfix.5 or greater (current stable).

--- a/packages/connectivity/CHANGELOG.md
+++ b/packages/connectivity/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.7
+
+* Migrate deprecated BinaryMessages to ServicesBinding.instance.defaultBinaryMessenger.
+* Bump Flutter SDK to 1.12.13+hotfix.5 or greater (current stable).
+
 ## 0.4.6+1
 
 * Remove the deprecated `author:` field from pubspec.yaml

--- a/packages/connectivity/pubspec.yaml
+++ b/packages/connectivity/pubspec.yaml
@@ -2,7 +2,7 @@ name: connectivity
 description: Flutter plugin for discovering the state of the network (WiFi &
   mobile/cellular) connectivity on Android and iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/connectivity
-version: 0.4.6+1
+version: 0.4.7
 
 flutter:
   plugin:
@@ -28,4 +28,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=1.10.0 <2.0.0"
+  flutter: ">=1.12.13+hotfix.5 <2.0.0"

--- a/packages/connectivity/pubspec.yaml
+++ b/packages/connectivity/pubspec.yaml
@@ -2,7 +2,7 @@ name: connectivity
 description: Flutter plugin for discovering the state of the network (WiFi &
   mobile/cellular) connectivity on Android and iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/connectivity
-version: 0.4.7
+version: 0.4.6+2
 
 flutter:
   plugin:

--- a/packages/connectivity/test/connectivity_test.dart
+++ b/packages/connectivity/test/connectivity_test.dart
@@ -38,10 +38,8 @@ void main() {
           .setMockMethodCallHandler((MethodCall methodCall) async {
         switch (methodCall.method) {
           case 'listen':
-            // TODO(hterkelsen): Remove this when defaultBinaryMessages is in stable.
-            // https://github.com/flutter/flutter/issues/33446
-            // ignore: deprecated_member_use
-            await BinaryMessages.handlePlatformMessage(
+            await ServicesBinding.instance.defaultBinaryMessenger
+                .handlePlatformMessage(
               Connectivity.eventChannel.name,
               Connectivity.eventChannel.codec.encodeSuccessEnvelope('wifi'),
               (_) {},

--- a/packages/sensors/CHANGELOG.md
+++ b/packages/sensors/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.2
+
+* Migrate from deprecated BinaryMessages to ServicesBinding.instance.defaultBinaryMessenger.
+* Require Flutter SDK 1.12.13+hotfix.5 or greater (current stable).
+
 ## 0.4.1+5
 
 * Fix example `setState()` called after `dispose()` by canceling the timer.

--- a/packages/sensors/CHANGELOG.md
+++ b/packages/sensors/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.4.2
+## 0.4.1+6
 
 * Migrate from deprecated BinaryMessages to ServicesBinding.instance.defaultBinaryMessenger.
 * Require Flutter SDK 1.12.13+hotfix.5 or greater (current stable).

--- a/packages/sensors/pubspec.yaml
+++ b/packages/sensors/pubspec.yaml
@@ -2,7 +2,7 @@ name: sensors
 description: Flutter plugin for accessing the Android and iOS accelerometer and
   gyroscope sensors.
 homepage: https://github.com/flutter/plugins/tree/master/packages/sensors
-version: 0.4.2
+version: 0.4.1+6
 
 flutter:
   plugin:

--- a/packages/sensors/pubspec.yaml
+++ b/packages/sensors/pubspec.yaml
@@ -2,7 +2,7 @@ name: sensors
 description: Flutter plugin for accessing the Android and iOS accelerometer and
   gyroscope sensors.
 homepage: https://github.com/flutter/plugins/tree/master/packages/sensors
-version: 0.4.1+5
+version: 0.4.2
 
 flutter:
   plugin:
@@ -26,4 +26,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=1.10.0 <2.0.0"
+  flutter: ">=1.12.13+hotfix.5 <2.0.0"

--- a/packages/sensors/test/sensors_test.dart
+++ b/packages/sensors/test/sensors_test.dart
@@ -53,20 +53,15 @@ void _initializeFakeSensorChannel(String channelName, List<double> sensorData) {
   const StandardMethodCodec standardMethod = StandardMethodCodec();
 
   void _emitEvent(ByteData event) {
-    // TODO(hterkelsen): Remove this when defaultBinaryMessages is in stable.
-    // https://github.com/flutter/flutter/issues/33446
-    // ignore: deprecated_member_use
-    BinaryMessages.handlePlatformMessage(
+    ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
       channelName,
       event,
       (ByteData reply) {},
     );
   }
 
-  // TODO(hterkelsen): Remove this when defaultBinaryMessages is in stable.
-  // https://github.com/flutter/flutter/issues/33446
-  // ignore: deprecated_member_use
-  BinaryMessages.setMockMessageHandler(channelName, (ByteData message) async {
+  ServicesBinding.instance.defaultBinaryMessenger
+      .setMockMessageHandler(channelName, (ByteData message) async {
     final MethodCall methodCall = standardMethod.decodeMethodCall(message);
     if (methodCall.method == 'listen') {
       _emitEvent(standardMethod.encodeSuccessEnvelope(sensorData));

--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.20
+## 0.3.19+2
 
 * Migrate from deprecated BinaryMessages to ServicesBinding.instance.defaultBinaryMessenger.
 

--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.20
+
+* Migrate from deprecated BinaryMessages to ServicesBinding.instance.defaultBinaryMessenger.
+
 ## 0.3.19+1
 
 * Raise min Flutter SDK requirement to the latest stable. v2 embedding apps no

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
-version: 0.3.20
+version: 0.3.19+2
 homepage: https://github.com/flutter/plugins/tree/master/packages/webview_flutter
 
 environment:

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
-version: 0.3.19+1
+version: 0.3.20
 homepage: https://github.com/flutter/plugins/tree/master/packages/webview_flutter
 
 environment:

--- a/packages/webview_flutter/test/webview_flutter_test.dart
+++ b/packages/webview_flutter/test/webview_flutter_test.dart
@@ -994,11 +994,8 @@ class FakePlatformWebView {
     };
     final ByteData data = codec
         .encodeMethodCall(MethodCall('javascriptChannelMessage', arguments));
-    // TODO(hterkelsen): Remove this when defaultBinaryMessages is in stable.
-    // https://github.com/flutter/flutter/issues/33446
-    // ignore: deprecated_member_use
-    BinaryMessages.handlePlatformMessage(
-        channel.name, data, (ByteData data) {});
+    ServicesBinding.instance.defaultBinaryMessenger
+        .handlePlatformMessage(channel.name, data, (ByteData data) {});
   }
 
   // Fakes a main frame navigation that was initiated by the webview, e.g when
@@ -1016,10 +1013,8 @@ class FakePlatformWebView {
     };
     final ByteData data =
         codec.encodeMethodCall(MethodCall('navigationRequest', arguments));
-    // TODO(hterkelsen): Remove this when defaultBinaryMessages is in stable.
-    // https://github.com/flutter/flutter/issues/33446
-    // ignore: deprecated_member_use
-    BinaryMessages.handlePlatformMessage(channel.name, data, (ByteData data) {
+    ServicesBinding.instance.defaultBinaryMessenger
+        .handlePlatformMessage(channel.name, data, (ByteData data) {
       final bool allow = codec.decodeEnvelope(data);
       if (allow) {
         _loadUrl(url);
@@ -1035,10 +1030,7 @@ class FakePlatformWebView {
       <dynamic, dynamic>{'url': currentUrl},
     ));
 
-    // TODO(hterkelsen): Remove this when defaultBinaryMessages is in stable.
-    // https://github.com/flutter/flutter/issues/33446
-    // ignore: deprecated_member_use
-    BinaryMessages.handlePlatformMessage(
+    ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
       channel.name,
       data,
       (ByteData data) {},
@@ -1053,10 +1045,7 @@ class FakePlatformWebView {
       <dynamic, dynamic>{'url': currentUrl},
     ));
 
-    // TODO(hterkelsen): Remove this when defaultBinaryMessages is in stable.
-    // https://github.com/flutter/flutter/issues/33446
-    // ignore: deprecated_member_use
-    BinaryMessages.handlePlatformMessage(
+    ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
       channel.name,
       data,
       (ByteData data) {},


### PR DESCRIPTION
## Description

Migrate away from the deprecated `BinaryMessages` to its supported replacement, `ServicesBinding.instance.defaultBinaryMessenger`.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/33446

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
