### PR TITLE
[camera] Fix crash from changing permissions

### DIFF
--- a/packages/camera/CHANGELOG.md
+++ b/packages/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.7+3
+
+* Fix an Android crash when permissions are requested multiple times.
+
 ## 0.5.7+2
 
 * Remove the deprecated `author:` field from pubspec.yaml

--- a/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPermissions.java
+++ b/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPermissions.java
@@ -4,6 +4,7 @@ import android.Manifest;
 import android.Manifest.permission;
 import android.app.Activity;
 import android.content.pm.PackageManager;
+import androidx.annotation.VisibleForTesting;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import io.flutter.plugin.common.PluginRegistry;
@@ -59,29 +60,38 @@ final class CameraPermissions {
         == PackageManager.PERMISSION_GRANTED;
   }
 
-  private static class CameraRequestPermissionsListener
+  @VisibleForTesting
+  static final class CameraRequestPermissionsListener
       implements PluginRegistry.RequestPermissionsResultListener {
+
+    // There's no way to unregister permission listeners in the v1 embedding, so we'll be called
+    // duplicate times in cases where the user denies and then grants a permission. Keep track of if
+    // we've responded before and bail out of handling the callback manually if this is a repeat
+    // call.
+    boolean alreadyCalled = false;
 
     final ResultCallback callback;
 
-    private CameraRequestPermissionsListener(ResultCallback callback) {
+    @VisibleForTesting
+    CameraRequestPermissionsListener(ResultCallback callback) {
       this.callback = callback;
     }
 
     @Override
     public boolean onRequestPermissionsResult(int id, String[] permissions, int[] grantResults) {
-      if (id == CAMERA_REQUEST_ID) {
-        if (grantResults[0] != PackageManager.PERMISSION_GRANTED) {
-          callback.onResult("cameraPermission", "MediaRecorderCamera permission not granted");
-        } else if (grantResults.length > 1
-            && grantResults[1] != PackageManager.PERMISSION_GRANTED) {
-          callback.onResult("cameraPermission", "MediaRecorderAudio permission not granted");
-        } else {
-          callback.onResult(null, null);
-        }
-        return true;
+      if (alreadyCalled || id != CAMERA_REQUEST_ID) {
+        return false;
       }
-      return false;
+
+      alreadyCalled = true;
+      if (grantResults[0] != PackageManager.PERMISSION_GRANTED) {
+        callback.onResult("cameraPermission", "MediaRecorderCamera permission not granted");
+      } else if (grantResults.length > 1 && grantResults[1] != PackageManager.PERMISSION_GRANTED) {
+        callback.onResult("cameraPermission", "MediaRecorderAudio permission not granted");
+      } else {
+        callback.onResult(null, null);
+      }
+      return true;
     }
   }
 }

--- a/packages/camera/android/src/test/java/io/flutter/plugins/camera/CameraPermissionsTest.java
+++ b/packages/camera/android/src/test/java/io/flutter/plugins/camera/CameraPermissionsTest.java
@@ -1,0 +1,23 @@
+package io.flutter.plugins.camera;
+
+import static junit.framework.TestCase.assertEquals;
+
+import android.content.pm.PackageManager;
+import io.flutter.plugins.camera.CameraPermissions.CameraRequestPermissionsListener;
+import org.junit.Test;
+
+public class CameraPermissionsTest {
+  @Test
+  public void listener_respondsOnce() {
+    final int[] calledCounter = {0};
+    CameraRequestPermissionsListener permissionsListener =
+        new CameraRequestPermissionsListener((String code, String desc) -> calledCounter[0]++);
+
+    permissionsListener.onRequestPermissionsResult(
+        9796, null, new int[] {PackageManager.PERMISSION_DENIED});
+    permissionsListener.onRequestPermissionsResult(
+        9796, null, new int[] {PackageManager.PERMISSION_GRANTED});
+
+    assertEquals(1, calledCounter[0]);
+  }
+}

--- a/packages/camera/pubspec.yaml
+++ b/packages/camera/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera
 description: A Flutter plugin for getting information about and controlling the
   camera on Android and iOS. Supports previewing the camera feed, capturing images, capturing video,
   and streaming image buffers to dart.
-version: 0.5.7+2
+version: 0.5.7+3
 
 homepage: https://github.com/flutter/plugins/tree/master/packages/camera
 


### PR DESCRIPTION
## Description

Our listeners are called for every single permissions change, not just
the first one. This resulted in multiple replies being sent to Dart and
fatal crashes. Change to instead manually keep track of responses and
only respond to the first call.

## Related Issues

Fixes flutter/flutter#26228

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
