### PR TITLE
[android_alarm_manager] Fixed issue where callback lookup was failing in the background

### DIFF
--- a/packages/android_alarm_manager/CHANGELOG.md
+++ b/packages/android_alarm_manager/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.5+3
+
+* Fixed issue where callback lookup would fail while running in the background.
+
 ## 0.4.5+2
 
 * Remove the deprecated `author:` field from pubspec.yaml

--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/FlutterBackgroundExecutor.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/FlutterBackgroundExecutor.java
@@ -151,17 +151,22 @@ public class FlutterBackgroundExecutor implements MethodCallHandler {
       return;
     }
 
-    FlutterCallbackInformation flutterCallback =
-        FlutterCallbackInformation.lookupCallbackInformation(callbackHandle);
-    if (flutterCallback == null) {
-      Log.e(TAG, "Fatal: failed to find callback");
-      return;
-    }
     Log.i(TAG, "Starting AlarmService...");
     String appBundlePath = FlutterMain.findAppBundlePath(context);
     AssetManager assets = context.getAssets();
     if (appBundlePath != null && !isRunning()) {
       backgroundFlutterEngine = new FlutterEngine(context);
+
+      // We need to create an instance of `FlutterEngine` before looking up the
+      // callback. If we don't, the callback cache won't be initialized and the
+      // lookup will fail.
+      FlutterCallbackInformation flutterCallback =
+          FlutterCallbackInformation.lookupCallbackInformation(callbackHandle);
+      if (flutterCallback == null) {
+        Log.e(TAG, "Fatal: failed to find callback");
+        return;
+      }
+
       DartExecutor executor = backgroundFlutterEngine.getDartExecutor();
       initializeMethodChannel(executor);
       DartCallback dartCallback = new DartCallback(assets, appBundlePath, flutterCallback);

--- a/packages/android_alarm_manager/pubspec.yaml
+++ b/packages/android_alarm_manager/pubspec.yaml
@@ -1,7 +1,7 @@
 name: android_alarm_manager
 description: Flutter plugin for accessing the Android AlarmManager service, and
   running Dart code in the background when alarms fire.
-version: 0.4.5+2
+version: 0.4.5+3
 homepage: https://github.com/flutter/plugins/tree/master/packages/android_alarm_manager
 
 dependencies:


### PR DESCRIPTION
If callback lookup was attempted before Flutter was initialized, the callback cache would not yet be populated resulting in a failed callback lookup.

Fixes https://github.com/flutter/flutter/issues/47406