### PR TITLE
[google_sign_in_web] Fix race condition on init.

### DIFF
--- a/packages/google_sign_in/google_sign_in_web/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_web/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Fix initialization error that causes https://github.com/flutter/flutter/issues/48527
 * Throw a PlatformException when there's an initialization problem (like wrong server-side config).
+* Throw a StateError when checking .initialized before calling .init()
+* Update setup instructions in the README.
 
 ## 0.8.2+1
 

--- a/packages/google_sign_in/google_sign_in_web/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_web/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.8.3
+
+* Fix initialization error that causes https://github.com/flutter/flutter/issues/48527
+* Throw a PlatformException when there's an initialization problem (like wrong server-side config).
+
 ## 0.8.2+1
 
 * Add a non-op Android implementation to avoid a flaky Gradle issue.

--- a/packages/google_sign_in/google_sign_in_web/README.md
+++ b/packages/google_sign_in/google_sign_in_web/README.md
@@ -5,18 +5,16 @@ The web implementation of [google_sign_in](https://pub.dev/google_sign_in/google
 ## Usage
 
 ### Import the package
-To use this plugin, follow the [plugin installation instructions](https://pub.dartlang.org/packages/google_sign_in#pub-pkg-tab-installing).
 
-Remember that for web plugins you need to depend both on the "native" version that provides the Dart interface that you'll use in your app), and the "web" version, that provides the implementation of the plugin for the web platform.
+This package is the endorsed implementation of `google_sign_in` for the web platform since version `4.1.0`, so it gets automatically added to your dependencies by depending on `google_sign_in: ^4.1.0`.
 
-This is what the above means to your `pubspec.yaml`:
+No modifications to your pubspec.yaml should be required in a recent enough version of Flutter (`>=1.12.13+hotfix.4`):
 
-```
+```yaml
 ...
 dependencies:
   ...
-  google_sign_in: ^4.0.14
-  google_sign_in_web: ^0.8.0
+  google_sign_in: ^4.1.0
   ...
 ...
 ```
@@ -28,8 +26,8 @@ First, go through the instructions [here](https://developers.google.com/identity
 On your `web/index.html` file, add the following `meta` tag, somewhere in the
 `head` of the document:
 
-```
-  <meta name="google-signin-client_id" content="YOUR_GOOGLE_SIGN_IN_OAUTH_CLIENT_ID.apps.googleusercontent.com">
+```html
+<meta name="google-signin-client_id" content="YOUR_GOOGLE_SIGN_IN_OAUTH_CLIENT_ID.apps.googleusercontent.com">
 ```
 
 Read the rest of the instructions if you need to add extra APIs (like Google People API).
@@ -74,7 +72,21 @@ Find the example wiring in the [Google sign-in example application](https://gith
 
 See the [google_sign_in.dart](https://github.com/flutter/plugins/blob/master/packages/google_sign_in/google_sign_in/lib/google_sign_in.dart) for more API details.
 
+## Contributions and Testing
+
+Tests are a crucial to contributions to this package. All new contributions should be reasonably tested.
+
+In order to run tests in this package, do:
+
+```
+flutter test --platform chrome -j1
+```
+
+Contributions to this package are welcome. Read the [Contributing to Flutter Plugins](https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md) guide to get started.
+
 ## Issues and feedback
 
 Please file [issues](https://github.com/flutter/flutter/issues/new)
-to send feedback or report a bug. Thank you!
+to send feedback or report a bug.
+
+**Thank you!**

--- a/packages/google_sign_in/google_sign_in_web/lib/google_sign_in_web.dart
+++ b/packages/google_sign_in/google_sign_in_web/lib/google_sign_in_web.dart
@@ -107,11 +107,11 @@ class GoogleSignInPlugin extends GoogleSignInPlatform {
       isAuthInitialized.complete();
     }), allowInterop((dynamic reason) {
       // onError
-      throw (PlatformException(
+      throw PlatformException(
         code: 'google_sign_in',
         message: reason.error,
         details: reason.details,
-      ));
+      );
     }));
 
     return null;

--- a/packages/google_sign_in/google_sign_in_web/lib/google_sign_in_web.dart
+++ b/packages/google_sign_in/google_sign_in_web/lib/google_sign_in_web.dart
@@ -38,7 +38,7 @@ class GoogleSignInPlugin extends GoogleSignInPlatform {
   }
 
   Future<void> _isGapiInitialized;
-  Future<void> _isAuthInitialized;
+  Future<void> _isAuthInitialized = Completer<void>().future;
 
   /// This is only exposed for testing. It shouldn't be accessed by users of the
   /// plugin as it could break at any point.

--- a/packages/google_sign_in/google_sign_in_web/lib/google_sign_in_web.dart
+++ b/packages/google_sign_in/google_sign_in_web/lib/google_sign_in_web.dart
@@ -5,14 +5,13 @@
 import 'dart:async';
 import 'dart:html' as html;
 
+import 'package:flutter/services.dart';
 import 'package:google_sign_in_platform_interface/google_sign_in_platform_interface.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:js/js.dart';
 import 'package:meta/meta.dart';
 
 import 'src/generated/gapiauth2.dart' as auth2;
-// TODO: Remove once this lands https://github.com/dart-lang/language/issues/671
-import 'src/generated/gapiauth2.dart' show GoogleAuthExtensions;
 import 'src/load_gapi.dart' as gapi;
 import 'src/utils.dart' show gapiUserToPluginUserData;
 
@@ -39,14 +38,15 @@ class GoogleSignInPlugin extends GoogleSignInPlatform {
   }
 
   Future<void> _isGapiInitialized;
+  Future<void> _isAuthInitialized;
 
   /// This is only exposed for testing. It shouldn't be accessed by users of the
   /// plugin as it could break at any point.
   @visibleForTesting
-  Future<void> get initialized => _isGapiInitialized;
+  Future<void> get initialized =>
+      Future.wait([_isGapiInitialized, _isAuthInitialized]);
 
   String _autoDetectedClientId;
-  FutureOr<auth2.GoogleUser> _lastSeenUser;
 
   /// Factory method that initializes the plugin with [GoogleSignInPlatform].
   static void registerWith(Registrar registrar) {
@@ -72,7 +72,7 @@ class GoogleSignInPlugin extends GoogleSignInPlatform {
         'Check https://developers.google.com/identity/protocols/googlescopes '
         'for a list of valid OAuth 2.0 scopes.');
 
-    await initialized;
+    await _isGapiInitialized;
 
     final auth2.GoogleAuth auth = auth2.init(auth2.ClientConfig(
       hosted_domain: hostedDomain,
@@ -81,19 +81,25 @@ class GoogleSignInPlugin extends GoogleSignInPlatform {
       client_id: appClientId,
     ));
 
-    // Subscribe to changes in the auth instance returned by init,
-    // and cache the _lastSeenUser as we get notified of new values.
-    final Completer<auth2.GoogleUser> initUserCompleter =
-        Completer<auth2.GoogleUser>();
+    Completer<void> isAuthInitialized = Completer<void>();
+    _isAuthInitialized = isAuthInitialized.future;
 
-    auth.currentUser.listen(allowInterop((auth2.GoogleUser nextUser) {
-      if (!initUserCompleter.isCompleted) {
-        initUserCompleter.complete(nextUser);
-      } else {
-        _lastSeenUser = nextUser;
-      }
+    auth.then(allowInterop((auth2.GoogleAuth initializedAuth) {
+      // onSuccess
+
+      // TODO: https://github.com/flutter/flutter/issues/48528
+      // This plugin doesn't notify the app of external changes to the
+      // state of the authentication, i.e: if you logout elsewhere...
+
+      isAuthInitialized.complete();
+    }), allowInterop((dynamic reason) {
+      // onError
+      throw (PlatformException(
+        code: 'google_sign_in',
+        message: reason.error,
+        details: reason.details,
+      ));
     }));
-    _lastSeenUser = initUserCompleter.future;
 
     return null;
   }
@@ -102,7 +108,8 @@ class GoogleSignInPlugin extends GoogleSignInPlatform {
   Future<GoogleSignInUserData> signInSilently() async {
     await initialized;
 
-    return gapiUserToPluginUserData(await _lastSeenUser);
+    return gapiUserToPluginUserData(
+        await auth2.getAuthInstance().currentUser.get());
   }
 
   @override
@@ -154,7 +161,6 @@ class GoogleSignInPlugin extends GoogleSignInPlatform {
   Future<void> clearAuthCache({String token}) async {
     await initialized;
 
-    _lastSeenUser = null;
     return auth2.getAuthInstance().disconnect();
   }
 }

--- a/packages/google_sign_in/google_sign_in_web/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_sign_in_web
 description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android, iOS and Web.
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_sign_in/google_sign_in_web
-version: 0.8.2+1
+version: 0.8.3
 
 flutter:
   plugin:

--- a/packages/google_sign_in/google_sign_in_web/test/auth2_test.dart
+++ b/packages/google_sign_in/google_sign_in_web/test/auth2_test.dart
@@ -27,9 +27,8 @@ void main() {
 
   GoogleSignInPlugin plugin;
 
-  setUp(() async {
+  setUp(() {
     plugin = GoogleSignInPlugin();
-    await plugin.initialized;
   });
 
   test('Init requires clientId', () async {
@@ -47,12 +46,13 @@ void main() {
   });
 
   group('Successful .init, then', () {
-    setUp(() {
-      plugin.init(
+    setUp(() async {
+      await plugin.init(
         hostedDomain: 'foo',
         scopes: <String>['some', 'scope'],
         clientId: '1234',
       );
+      await plugin.initialized;
     });
 
     test('signInSilently', () async {

--- a/packages/google_sign_in/google_sign_in_web/test/gapi_load_test.dart
+++ b/packages/google_sign_in/google_sign_in_web/test/gapi_load_test.dart
@@ -15,7 +15,8 @@ import 'utils.dart';
 void main() {
   gapiUrl = toBase64Url(gapi_mocks.auth2InitSuccess(GoogleSignInUserData()));
 
-  test('Plugin is initialized after GAPI fully loads and init is called', () async {
+  test('Plugin is initialized after GAPI fully loads and init is called',
+      () async {
     expect(
       html.querySelector('script[src^="data:"]'),
       isNull,

--- a/packages/google_sign_in/google_sign_in_web/test/gapi_load_test.dart
+++ b/packages/google_sign_in/google_sign_in_web/test/gapi_load_test.dart
@@ -28,11 +28,11 @@ void main() {
       isNotNull,
       reason: 'Mock script should be injected',
     );
-    expect(
-      plugin.initialized,
-      doesNotComplete,
-      reason: 'The plugin should only complete the future after calling .init',
-    );
+    expect(() {
+      plugin.initialized;
+    }, throwsStateError,
+        reason:
+            'The plugin should throw if checking for `initialized` before calling .init');
     await plugin.init(hostedDomain: '', clientId: '');
     await plugin.initialized;
     expect(

--- a/packages/google_sign_in/google_sign_in_web/test/gapi_load_test.dart
+++ b/packages/google_sign_in/google_sign_in_web/test/gapi_load_test.dart
@@ -7,14 +7,15 @@
 import 'dart:html' as html;
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:google_sign_in_platform_interface/google_sign_in_platform_interface.dart';
 import 'package:google_sign_in_web/google_sign_in_web.dart';
 import 'gapi_mocks/gapi_mocks.dart' as gapi_mocks;
 import 'utils.dart';
 
 void main() {
-  gapiUrl = toBase64Url(gapi_mocks.gapiInitSuccess());
+  gapiUrl = toBase64Url(gapi_mocks.auth2InitSuccess(GoogleSignInUserData()));
 
-  test('Plugin is initialized after GAPI fully loads', () async {
+  test('Plugin is initialized after GAPI fully loads and init is called', () async {
     expect(
       html.querySelector('script[src^="data:"]'),
       isNull,
@@ -26,6 +27,12 @@ void main() {
       isNotNull,
       reason: 'Mock script should be injected',
     );
+    expect(
+      plugin.initialized,
+      doesNotComplete,
+      reason: 'The plugin should only complete the future after calling .init',
+    );
+    await plugin.init(hostedDomain: '', clientId: '');
     await plugin.initialized;
     expect(
       plugin.initialized,

--- a/packages/google_sign_in/google_sign_in_web/test/gapi_mocks/gapi_mocks.dart
+++ b/packages/google_sign_in/google_sign_in_web/test/gapi_mocks/gapi_mocks.dart
@@ -10,5 +10,4 @@ import 'src/gapi.dart';
 import 'src/google_user.dart';
 import 'src/test_iife.dart';
 
-part 'src/gapi_load.dart';
 part 'src/auth2_init.dart';

--- a/packages/google_sign_in/google_sign_in_web/test/gapi_mocks/src/auth2_init.dart
+++ b/packages/google_sign_in/google_sign_in_web/test/gapi_mocks/src/auth2_init.dart
@@ -13,6 +13,11 @@ var mockUser = ${googleUser(userData)};
 function GapiAuth2() {}
 GapiAuth2.prototype.init = function (initOptions) {
   return {
+    then: (onSuccess, onError) => {
+      window.setTimeout(() => {
+        onSuccess(window.gapi.auth2);
+      }, 30);
+    },
     currentUser: {
       listen: (cb) => {
         window.setTimeout(() => {

--- a/packages/google_sign_in/google_sign_in_web/test/gapi_mocks/src/gapi_load.dart
+++ b/packages/google_sign_in/google_sign_in_web/test/gapi_mocks/src/gapi_load.dart
@@ -1,8 +1,0 @@
-// Copyright 2019 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
-part of gapi_mocks;
-
-// JS mock of a raw GAPI object.
-String gapiInitSuccess() => testIife(gapi());


### PR DESCRIPTION
## Description

The Auth object that `.init()` returns may not be fully ready by the time we start calling methods on it; however it has a `.then()` method that gets called when it is *really* ready to go.

* Add a completer to signal when Auth2 is ready.
* Move auth2-dependent init to the `then` method.
  * onSuccess, complete the auth2 ready future.
  * onError, throw a PlatformException. This is normally triggered when the domain:port of the web app hasn't been whitelisted on the google sign in console, and things like that. Useful for debugging.

## Related Issues

* https://github.com/flutter/flutter/issues/48527
* https://github.com/flutter/flutter/issues/47832

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
