### PR TITLE
[Google Map] Correctly check map configurations on Widget update

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,4 @@
-# Below is a list of people and organizations that have contributed
+﻿# Below is a list of people and organizations that have contributed
 # to the Flutter project. Names should be added to the list like so:
 #
 #   Name/Organization <email address>
@@ -49,3 +49,4 @@ Luigi Agosti <luigi@tengio.com>
 Quentin Le Guennec <quentin@tengio.com>
 Koushik Ravikumar <koushik@tengio.com>
 Nissim Dsilva <nissim@tengio.com>
+Klaus Jokinen <klasudeveloper@gmail.com>

--- a/packages/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.21+16
+
+* Fix Widget from updating configurations when there is nothing to update.
+
 ## 0.5.21+15
 
 * Remove the deprecated `author:` field from pubspec.yaml

--- a/packages/google_maps_flutter/lib/src/google_map.dart
+++ b/packages/google_maps_flutter/lib/src/google_map.dart
@@ -253,7 +253,6 @@ class _GoogleMapState extends State<GoogleMap> {
 
   @override
   void didUpdateWidget(GoogleMap oldWidget) {
-    print('LOCAL');
     super.didUpdateWidget(oldWidget);
     _updateOptions();
     _updateMarkers();

--- a/packages/google_maps_flutter/lib/src/google_map.dart
+++ b/packages/google_maps_flutter/lib/src/google_map.dart
@@ -253,6 +253,7 @@ class _GoogleMapState extends State<GoogleMap> {
 
   @override
   void didUpdateWidget(GoogleMap oldWidget) {
+    print('LOCAL');
     super.didUpdateWidget(oldWidget);
     _updateOptions();
     _updateMarkers();
@@ -265,6 +266,7 @@ class _GoogleMapState extends State<GoogleMap> {
     final _GoogleMapOptions newOptions = _GoogleMapOptions.fromWidget(widget);
     final Map<String, dynamic> updates =
         _googleMapOptions.updatesMap(newOptions);
+
     if (updates.isEmpty) {
       return;
     }
@@ -275,6 +277,14 @@ class _GoogleMapState extends State<GoogleMap> {
   }
 
   void _updateMarkers() async {
+    final _markerUpdates =
+        _MarkerUpdates.from(_markers.values.toSet(), widget.markers);
+
+    if (_markerUpdates.markerIdsToRemove.isEmpty &&
+        _markerUpdates.markersToAdd.isEmpty &&
+        _markerUpdates.markersToChange.isEmpty) {
+      return;
+    }
     final GoogleMapController controller = await _controller.future;
     // ignore: unawaited_futures
     controller._updateMarkers(
@@ -283,6 +293,14 @@ class _GoogleMapState extends State<GoogleMap> {
   }
 
   void _updatePolygons() async {
+    final _polygonUpdates =
+        _PolygonUpdates.from(_polygons.values.toSet(), widget.polygons);
+
+    if (_polygonUpdates.polygonIdsToRemove.isEmpty &&
+        _polygonUpdates.polygonsToAdd.isEmpty &&
+        _polygonUpdates.polygonsToChange.isEmpty) {
+      return;
+    }
     final GoogleMapController controller = await _controller.future;
     // ignore: unawaited_futures
     controller._updatePolygons(
@@ -291,6 +309,14 @@ class _GoogleMapState extends State<GoogleMap> {
   }
 
   void _updatePolylines() async {
+    final _polylineUpdates =
+        _PolylineUpdates.from(_polylines.values.toSet(), widget.polylines);
+
+    if (_polylineUpdates.polylineIdsToRemove.isEmpty &&
+        _polylineUpdates.polylinesToAdd.isEmpty &&
+        _polylineUpdates.polylinesToChange.isEmpty) {
+      return;
+    }
     final GoogleMapController controller = await _controller.future;
     // ignore: unawaited_futures
     controller._updatePolylines(
@@ -299,6 +325,14 @@ class _GoogleMapState extends State<GoogleMap> {
   }
 
   void _updateCircles() async {
+    final _circleUpdates =
+        _CircleUpdates.from(_circles.values.toSet(), widget.circles);
+
+    if (_circleUpdates.circleIdsToRemove.isEmpty &&
+        _circleUpdates.circlesToAdd.isEmpty &&
+        _circleUpdates.circlesToChange.isEmpty) {
+      return;
+    }
     final GoogleMapController controller = await _controller.future;
     // ignore: unawaited_futures
     controller._updateCircles(
@@ -312,7 +346,9 @@ class _GoogleMapState extends State<GoogleMap> {
       widget.initialCameraPosition,
       this,
     );
+
     _controller.complete(controller);
+
     if (widget.onMapCreated != null) {
       widget.onMapCreated(controller);
     }
@@ -491,7 +527,11 @@ class _GoogleMapOptions {
     final Map<String, dynamic> prevOptionsMap = toMap();
 
     return newOptions.toMap()
-      ..removeWhere(
-          (String key, dynamic value) => prevOptionsMap[key] == value);
+      ..removeWhere((String key, dynamic value) {
+        if (value is List) {
+          return listEquals(prevOptionsMap[key], value);
+        }
+        return prevOptionsMap[key] == value;
+      });
   }
 }

--- a/packages/google_maps_flutter/lib/src/google_map.dart
+++ b/packages/google_maps_flutter/lib/src/google_map.dart
@@ -286,8 +286,7 @@ class _GoogleMapState extends State<GoogleMap> {
     }
     final GoogleMapController controller = await _controller.future;
     // ignore: unawaited_futures
-    controller._updateMarkers(
-        _MarkerUpdates.from(_markers.values.toSet(), widget.markers));
+    controller._updateMarkers(_markerUpdates);
     _markers = _keyByMarkerId(widget.markers);
   }
 
@@ -302,8 +301,7 @@ class _GoogleMapState extends State<GoogleMap> {
     }
     final GoogleMapController controller = await _controller.future;
     // ignore: unawaited_futures
-    controller._updatePolygons(
-        _PolygonUpdates.from(_polygons.values.toSet(), widget.polygons));
+    controller._updatePolygons(_polygonUpdates);
     _polygons = _keyByPolygonId(widget.polygons);
   }
 
@@ -318,8 +316,7 @@ class _GoogleMapState extends State<GoogleMap> {
     }
     final GoogleMapController controller = await _controller.future;
     // ignore: unawaited_futures
-    controller._updatePolylines(
-        _PolylineUpdates.from(_polylines.values.toSet(), widget.polylines));
+    controller._updatePolylines(_polylineUpdates);
     _polylines = _keyByPolylineId(widget.polylines);
   }
 
@@ -334,8 +331,7 @@ class _GoogleMapState extends State<GoogleMap> {
     }
     final GoogleMapController controller = await _controller.future;
     // ignore: unawaited_futures
-    controller._updateCircles(
-        _CircleUpdates.from(_circles.values.toSet(), widget.circles));
+    controller._updateCircles(_circleUpdates);
     _circles = _keyByCircleId(widget.circles);
   }
 


### PR DESCRIPTION
## Description

*Correctly check map configurations on Widget update*
 *  _updateOptions();
 *  _updateMarkers();
 *  _updatePolygons();
 *  _updatePolylines();
 *  _updateCircles();

Current implementation didn't check for changes*  in the above configurations causing an error when sending incorrect values to methodChannel.

* `_updateMapOptions `didn't check for List equality on `updatesMap `method when doing a distinct check.

## Related Issues

*flutter/flutter#47619.*

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [X] No, this is *not* a breaking change.
