### PR TITLE
Updates CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,16 +9,14 @@ packages/android_intent/* @mklim
 packages/battery/* @amirh
 packages/camera/* @bparrishMines @mklim
 packages/connectivity/* @cyanglaz
+packages/e2e/* @collinjackson @digiter
+packages/espresso/* @collinjackson @adazh
 packages/google_maps_flutter/* @cyanglaz
 packages/google_sign_in/* @cyanglaz @mehmetf
 packages/image_picker/* @cyanglaz
 packages/in_app_purchase/* @mklim @cyanglaz
 packages/ios_platform_images/* @gaaclarke
-packages/instrumentation_adapter/* @collinjackson @digiter
 packages/package_info/* @cyanglaz
-packages/path_provider/* @collinjackson
-packages/quick_actions/* @collinjackson
-packages/shared_preferences/* @collinjackson
 packages/url_launcher/* @mklim
 packages/video_player/* @iskakaushik @cyanglaz
 packages/webview_flutter/* @amirh


### PR DESCRIPTION
Removes @collinjackson from path_provider, quick_actions, shared_preferences since I'm not currently focusing on these.

Adds @collinjackson and @adazh to new package espresso.

Renames instrumentation_adapter to e2e.