### PR TITLE
[webview_flutter] Expose loadData function for webviews

### DIFF
--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -174,6 +174,9 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
       case "loadUrl":
         loadUrl(methodCall, result);
         break;
+      case "loadData":
+        loadData(methodCall, result);
+        break;
       case "updateSettings":
         updateSettings(methodCall, result);
         break;
@@ -238,6 +241,18 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
     webView.loadUrl(url, headers);
     result.success(null);
   }
+
+  @SuppressWarnings("unchecked")
+  private void loadData(MethodCall methodCall, Result result) {
+    Map<String, Object> request = (Map<String, Object>) methodCall.arguments;
+    String baseUrl = (String) request.get("baseUrl");
+    String data = (String) request.get("data");
+    String mimeType = (String) request.get("mimeType");
+    String encoding = (String) request.get("encoding");
+    webView.loadDataWithBaseURL(baseUrl, data, mimeType, encoding, "");
+    result.success(null);
+  }
+
 
   private void canGoBack(Result result) {
     result.success(webView.canGoBack());

--- a/packages/webview_flutter/ios/Classes/FlutterWebView.m
+++ b/packages/webview_flutter/ios/Classes/FlutterWebView.m
@@ -128,6 +128,8 @@
     [self onUpdateSettings:call result:result];
   } else if ([[call method] isEqualToString:@"loadUrl"]) {
     [self onLoadUrl:call result:result];
+  } else if ([[call method] isEqualToString:@"loadData"]) {
+    [self onLoadData:call result:result];
   } else if ([[call method] isEqualToString:@"canGoBack"]) {
     [self onCanGoBack:call result:result];
   } else if ([[call method] isEqualToString:@"canGoForward"]) {
@@ -177,6 +179,17 @@
     result([FlutterError
         errorWithCode:@"loadUrl_failed"
               message:@"Failed parsing the URL"
+              details:[NSString stringWithFormat:@"Request was: '%@'", [call arguments]]]);
+  } else {
+    result(nil);
+  }
+}
+
+- (void)onLoadData:(FlutterMethodCall*)call result:(FlutterResult)result {
+  if (![self loadData:[call arguments]]) {
+    result([FlutterError
+        errorWithCode:@"loadData_failed"
+              message:@"Failed parsing the data"
               details:[NSString stringWithFormat:@"Request was: '%@'", [call arguments]]]);
   } else {
     result(nil);
@@ -410,6 +423,20 @@
   [request setAllHTTPHeaderFields:headers];
   [_webView loadRequest:request];
   return true;
+}
+
+- (bool)loadData:(NSDictionary<NSString*, id>*)request {
+  if (!request) {
+    return false;
+  }
+
+  NSString* data = request[@"data"];
+  NSString* baseUrl = request[@"baseUrl"];
+  NSString* mimeType = request[@"mimeType"];
+  NSString* encoding = request[@"encoding"];
+  NSData* nsData = [data dataUsingEncoding:NSUTF8StringEncoding];
+  NSURL* nsUrl = [NSURL URLWithString:baseUrl];
+  return [_webView loadData:nsData MIMEType:mimeType characterEncodingName:encoding baseURL:nsUrl];
 }
 
 - (void)registerJavaScriptChannels:(NSSet*)channelNames

--- a/packages/webview_flutter/lib/platform_interface.dart
+++ b/packages/webview_flutter/lib/platform_interface.dart
@@ -182,6 +182,12 @@ abstract class WebViewPlatformController {
         "WebView loadUrl is not implemented on the current platform");
   }
 
+  Future<void> loadData(
+      String baseUrl, String data, String mimeType, String encoding) {
+    throw UnimplementedError(
+        "WebView loadData is not implemented on the current platform");
+  }
+
   /// Updates the webview settings.
   ///
   /// Any non null field in `settings` will be set as the new setting value.

--- a/packages/webview_flutter/lib/src/webview_method_channel.dart
+++ b/packages/webview_flutter/lib/src/webview_method_channel.dart
@@ -80,6 +80,22 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
     });
   }
 
+      @override
+  Future<void> loadData(
+    String baseUrl,
+    String data,
+    String mimeType,
+    String encoding
+  ) async {
+    print("loadData call");
+    return _channel.invokeMethod<void>('loadData', <String, dynamic>{
+      'baseUrl': baseUrl,
+      'data': data,
+      'mimeType': mimeType,
+      'encoding': encoding,
+    });
+  }
+
   @override
   Future<String> currentUrl() => _channel.invokeMethod<String>('currentUrl');
 

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -613,6 +613,14 @@ class WebViewController {
     return _webViewPlatformController.loadUrl(url, headers);
   }
 
+  Future<void> loadData(
+    String baseUrl, 
+    String data,
+    String mimeType,
+    String encoding) async {
+    return _webViewPlatformController.loadData(baseUrl, data, mimeType, encoding);
+  }
+
   /// Accessor to the current URL that the WebView is displaying.
   ///
   /// If [WebView.initialUrl] was never specified, returns `null`.


### PR DESCRIPTION
## Description

Expose `loadData` on the webview controller. This allows developers to load html directly into the webview.

This is a draft PR. I'm using this change in a product, but it is not ready to be merged into flutter/plugins yet. For example: e2e tests for this feature are still missing.

I wanted to open this PR anyway to get early feedback. I have seen @amirh reply to earlier PR's regarding this feature. I hope you can give some feedback on this approach?

For example; should we make loadUrl and loadData throw an exception when the other one was used before? We can keep that knowledge on the dart side and just throw a dart exception, or should it be tried and possibly return an error depending on the platform implementation handles it?

## Related Issues

This fixes flutter/flutter#32827

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
