### PR TITLE
[local_auth] Fix adding fingerprint to the methods when device's config file is out

### DIFF
--- a/packages/local_auth/android/src/main/java/io/flutter/plugins/localauth/LocalAuthPlugin.java
+++ b/packages/local_auth/android/src/main/java/io/flutter/plugins/localauth/LocalAuthPlugin.java
@@ -7,6 +7,7 @@ package io.flutter.plugins.localauth;
 import android.app.Activity;
 import android.content.pm.PackageManager;
 import android.os.Build;
+import androidx.core.hardware.fingerprint.FingerprintManagerCompat;
 import androidx.fragment.app.FragmentActivity;
 import androidx.lifecycle.Lifecycle;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
@@ -129,6 +130,12 @@ public class LocalAuthPlugin implements MethodCallHandler, FlutterPlugin, Activi
         if (Build.VERSION.SDK_INT >= 23) {
           if (packageManager.hasSystemFeature(PackageManager.FEATURE_FINGERPRINT)) {
             biometrics.add("fingerprint");
+          } else {
+            FingerprintManagerCompat fingerprintManager =
+                FingerprintManagerCompat.from(activity.getApplicationContext());
+            if (fingerprintManager.isHardwareDetected()) {
+              biometrics.add("fingerprint");
+            }
           }
         }
         if (Build.VERSION.SDK_INT >= 29) {


### PR DESCRIPTION
Fix adding fingerprint to the methods when device's config file is out.
For issue: https://github.com/flutter/flutter/issues/46227#issuecomment-562622519