### PR TITLE
[shared_preferences] Fixes gradle version for shared preferences (macos, web) bug on android

### DIFF
--- a/packages/shared_preferences/shared_preferences_macos/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.2
+
+* Bump gradle version to avoid bugs with android projects
+
 ## 0.0.1+3
 
 * Update README.

--- a/packages/shared_preferences/shared_preferences_macos/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_macos/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.0.2
+## 0.0.1+4
 
 * Bump gradle version to avoid bugs with android projects
 

--- a/packages/shared_preferences/shared_preferences_macos/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/shared_preferences/shared_preferences_macos/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/packages/shared_preferences/shared_preferences_macos/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_macos/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shared_preferences_macos
 description: macOS implementation of the shared_preferences plugin.
-version: 0.0.1+3
+version: 0.0.2
 homepage: https://github.com/flutter/plugins/tree/master/packages/shared_preferences/shared_preferences_macos
 
 flutter:

--- a/packages/shared_preferences/shared_preferences_macos/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_macos/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shared_preferences_macos
 description: macOS implementation of the shared_preferences plugin.
-version: 0.0.2
+version: 0.0.1+4
 homepage: https://github.com/flutter/plugins/tree/master/packages/shared_preferences/shared_preferences_macos
 
 flutter:

--- a/packages/shared_preferences/shared_preferences_web/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_web/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.0.2
+## 0.1.2+3
 
 * Bump gradle version to avoid bugs with android projects
 

--- a/packages/shared_preferences/shared_preferences_web/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.2
+
+* Bump gradle version to avoid bugs with android projects
+
 # 0.1.2+2
 
 * Remove unused onMethodCall method.

--- a/packages/shared_preferences/shared_preferences_web/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/shared_preferences/shared_preferences_web/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/packages/shared_preferences/shared_preferences_web/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: shared_preferences_web
 description: Web platform implementation of shared_preferences
 homepage: https://github.com/flutter/plugins/tree/master/packages/shared_preferences/shared_preferences_web
-version: 0.1.2+2
+version: 0.1.3
 
 flutter:
   plugin:

--- a/packages/shared_preferences/shared_preferences_web/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: shared_preferences_web
 description: Web platform implementation of shared_preferences
 homepage: https://github.com/flutter/plugins/tree/master/packages/shared_preferences/shared_preferences_web
-version: 0.1.3
+version: 0.1.2+3
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Fixes gradle version for shared preferences (macos, web) bug on android

For some reason the version of gradle inside the android folders of the "sub packages" is different than the real one on the real `shared_preferences` plugin.

Even though my project only depends on the main package, I get an error when I try to run it:

```
FAILURE: Build failed with an exception.

* Where:
Build file '<...>/flutter/.pub-cache/hosted/pub.dartlang.org/shared_preferences_web-0.1.2+2/android/build.gradle' line: 22

* What went wrong:
A problem occurred evaluating root project 'shared_preferences_web'.
> Failed to apply plugin [id 'com.android.library']
   > Minimum supported Gradle version is 5.4.1. Current version is 4.10.2. If using the gradle wrapper, try editing the distributionUrl in <...>/flutter/.pub-cache/hosted/pub.dartlang.org/shared_preferences_web-0.1.2+2/android/gradle/wrapper/gradle-wrapper.properties to gradle-5.4.1-all.zip

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 0s

The plugin shared_preferences_web could not be built due to the issue above.
```

And the same for macos.

## Related Issues

See related issue on stackoverflow: https://stackoverflow.com/questions/59468295/failure-build-failed-with-an-exception-shared-preference-and-gradle-wrapper-pr

## Checklist

Most of the checklist does not apply because it's just a version bump (no need to write tests for that, for example).

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.