### PR TITLE
Bump roboelectric version

### DIFF
--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.3+2
+
+* Bump RoboElectric dependency to 4.3.1 and update resource usage.
+
 ## 0.6.3+1
 
 * Fix an issue that the example app won't launch the image picker after Android V2 embedding migration.

--- a/packages/image_picker/example/android/app/build.gradle
+++ b/packages/image_picker/example/android/app/build.gradle
@@ -26,6 +26,7 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     compileSdkVersion 28
+    testOptions.unitTests.includeAndroidResources = true
 
     lintOptions {
         disable 'InvalidPackage'

--- a/packages/image_picker/example/android/app/build.gradle
+++ b/packages/image_picker/example/android/app/build.gradle
@@ -62,5 +62,5 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:2.17.0'
     androidTestImplementation 'androidx.test:runner:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
-    testImplementation "org.robolectric:robolectric:3.3.2"
+    testImplementation "org.robolectric:robolectric:4.3.1"
 }

--- a/packages/image_picker/example/android/gradle.properties
+++ b/packages/image_picker/example/android/gradle.properties
@@ -2,3 +2,4 @@ org.gradle.jvmargs=-Xmx1536M
 android.enableR8=true
 android.useAndroidX=true
 android.enableJetifier=true
+android.enableUnitTestBinaryResources=true

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker
 description: Flutter plugin for selecting images from the Android and iOS image
   library, and taking new pictures with the camera.
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.6.3+1
+version: 0.6.3+2
 
 flutter:
   plugin:


### PR DESCRIPTION
Fixes CI

Fixes https://github.com/flutter/flutter/issues/48943

Maven has changed their access policies as of today: https://support.sonatype.com/hc/en-us/articles/360041287334

The old version of roboelectric is refering to http resources in its POM.  This one is good.

@amirh