### PR TITLE
Configure Cirrus Branch Guard

### DIFF
--- a/.github/workflows/branch-guard.yml
+++ b/.github/workflows/branch-guard.yml
@@ -1,0 +1,17 @@
+on:
+  pull_request: # to update newly open PRs or when a PR is synced
+  check_suite: # to update all PRs upon a Check Suite completion
+    type: ['completed']
+  
+name: Branch Guard
+jobs:
+  branch-guard:
+    name: Branch Guard
+    if: github.event.check_suite.head_branch == 'master' || github.event.pull_request.base.ref == 'master'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: cirrus-actions/branch-guard@v1.2
+      with:
+        appsToCheck: Cirrus CI # or any other App name (can be a comma separated list of names)
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

This should add a presubmit that's block PR from landing while the tree is red.

## Related Issues

https://github.com/flutter/flutter/issues/28921
