### PR TITLE
[google_maps_flutter] Fixes toggling traffic layer not working on Android

### DIFF
--- a/packages/connectivity/ios/Classes/FLTConnectivityPlugin.m
+++ b/packages/connectivity/ios/Classes/FLTConnectivityPlugin.m
@@ -156,7 +156,9 @@
     case kCLAuthorizationStatusAuthorizedWhenInUse: {
       return @"authorizedWhenInUse";
     }
-    default: { return @"unknown"; }
+    default: {
+      return @"unknown";
+    }
   }
 }
 

--- a/packages/connectivity/ios/Classes/FLTConnectivityPlugin.m
+++ b/packages/connectivity/ios/Classes/FLTConnectivityPlugin.m
@@ -156,9 +156,7 @@
     case kCLAuthorizationStatusAuthorizedWhenInUse: {
       return @"authorizedWhenInUse";
     }
-    default: {
-      return @"unknown";
-    }
+    default: { return @"unknown"; }
   }
 }
 

--- a/packages/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.22+1
+
+* Fix for toggling traffic layer on Android not working
+
 ## 0.5.22
 
 * Support Android v2 embedding.

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
@@ -830,6 +830,9 @@ final class GoogleMapController
 
   public void setTrafficEnabled(boolean trafficEnabled) {
     this.trafficEnabled = trafficEnabled;
+    if (googleMap != null) {
+      googleMap.setTrafficEnabled(trafficEnabled);
+    }
   }
 
   public void setBuildingsEnabled(boolean buildingsEnabled) {

--- a/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
+++ b/packages/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
@@ -830,9 +830,10 @@ final class GoogleMapController
 
   public void setTrafficEnabled(boolean trafficEnabled) {
     this.trafficEnabled = trafficEnabled;
-    if (googleMap != null) {
-      googleMap.setTrafficEnabled(trafficEnabled);
+    if (googleMap == null) {
+      return;
     }
+    googleMap.setTrafficEnabled(trafficEnabled);
   }
 
   public void setBuildingsEnabled(boolean buildingsEnabled) {

--- a/packages/google_maps_flutter/example/lib/map_ui.dart
+++ b/packages/google_maps_flutter/example/lib/map_ui.dart
@@ -53,6 +53,7 @@ class MapUiBodyState extends State<MapUiBody> {
   bool _zoomGesturesEnabled = true;
   bool _indoorViewEnabled = true;
   bool _myLocationEnabled = true;
+  bool _myTrafficEnabled = false;
   bool _myLocationButtonEnabled = true;
   GoogleMapController _controller;
   bool _nightMode = false;
@@ -191,8 +192,7 @@ class MapUiBodyState extends State<MapUiBody> {
 
   Widget _myLocationToggler() {
     return FlatButton(
-      child: Text(
-          '${_myLocationButtonEnabled ? 'disable' : 'enable'} my location button'),
+      child: Text('${_myLocationEnabled ? 'disable' : 'enable'} my location'),
       onPressed: () {
         setState(() {
           _myLocationEnabled = !_myLocationEnabled;
@@ -208,6 +208,17 @@ class MapUiBodyState extends State<MapUiBody> {
       onPressed: () {
         setState(() {
           _myLocationButtonEnabled = !_myLocationButtonEnabled;
+        });
+      },
+    );
+  }
+
+  Widget _myTrafficToggler() {
+    return FlatButton(
+      child: Text('${_myTrafficEnabled ? 'disable' : 'enable'} my traffic'),
+      onPressed: () {
+        setState(() {
+          _myTrafficEnabled = !_myTrafficEnabled;
         });
       },
     );
@@ -260,6 +271,7 @@ class MapUiBodyState extends State<MapUiBody> {
       indoorViewEnabled: _indoorViewEnabled,
       myLocationEnabled: _myLocationEnabled,
       myLocationButtonEnabled: _myLocationButtonEnabled,
+      trafficEnabled: _myTrafficEnabled,
       onCameraMove: _updateCameraPosition,
     );
 
@@ -300,6 +312,7 @@ class MapUiBodyState extends State<MapUiBody> {
               _indoorViewToggler(),
               _myLocationToggler(),
               _myLocationButtonToggler(),
+              _myTrafficToggler(),
               _nightModeToggler(),
             ],
           ),

--- a/packages/google_maps_flutter/example/lib/map_ui.dart
+++ b/packages/google_maps_flutter/example/lib/map_ui.dart
@@ -192,7 +192,8 @@ class MapUiBodyState extends State<MapUiBody> {
 
   Widget _myLocationToggler() {
     return FlatButton(
-      child: Text('${_myLocationEnabled ? 'disable' : 'enable'} my location'),
+      child: Text(
+          '${_myLocationButtonEnabled ? 'disable' : 'enable'} my location button'),
       onPressed: () {
         setState(() {
           _myLocationEnabled = !_myLocationEnabled;

--- a/packages/google_maps_flutter/example/test_driver/google_maps_e2e.dart
+++ b/packages/google_maps_flutter/example/test_driver/google_maps_e2e.dart
@@ -434,8 +434,23 @@ void main() {
     ));
 
     final GoogleMapInspector inspector = await inspectorCompleter.future;
-    final bool isTrafficEnabled = await inspector.isTrafficEnabled();
+    bool isTrafficEnabled = await inspector.isTrafficEnabled();
     expect(isTrafficEnabled, true);
+
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: GoogleMap(
+        key: key,
+        initialCameraPosition: _kInitialCameraPosition,
+        trafficEnabled: false,
+        onMapCreated: (GoogleMapController controller) {
+          fail("OnMapCreated should get called only once.");
+        },
+      ),
+    ));
+
+    isTrafficEnabled = await inspector.isTrafficEnabled();
+    expect(isTrafficEnabled, false);
   });
 
   testWidgets('testBuildings', (WidgetTester tester) async {

--- a/packages/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter
-version: 0.5.22
+version: 0.5.22+1
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Description

Toggling the traffic layer for a google map on Android wouldn't update the map. The map now get's updated.

## Related Issues

flutter/flutter#47895
flutter/flutter#43740
flutter/flutter#42346


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
