### PR TITLE
[webview_flutter] Implement onJSAlert, onJSConfirm, onJSPrompt interface

### DIFF
--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.19+6
+
+* Implement onJSAlert, onJSConfirm, onJSPrompt interface.
+
 ## 0.3.19+5
 
 * On iOS, always keep contentInsets of the WebView to be 0.

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebChromeClient.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebChromeClient.java
@@ -1,0 +1,123 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.plugins.webviewflutter;
+
+import android.webkit.JsPromptResult;
+import android.webkit.JsResult;
+import android.webkit.WebChromeClient;
+import android.webkit.WebView;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.flutter.plugin.common.MethodChannel;
+
+class FlutterWebChromeClient {
+  private static final String TAG = "FlutterWebViewClient";
+  private final MethodChannel methodChannel;
+
+  FlutterWebChromeClient(MethodChannel methodChannel) {
+    this.methodChannel = methodChannel;
+  }
+
+  WebChromeClient createWebChromeClient() {
+    return new WebChromeClient() {
+
+      @Override
+      public boolean onJsAlert(WebView view, String url, String message, final JsResult result) {
+        Map<String, Object> args = new HashMap<>();
+        args.put("url", url);
+        args.put("message", message);
+        methodChannel.invokeMethod("onJsAlert", args, new MethodChannel.Result() {
+          @Override
+          public void success(Object o) {
+            if (result != null) {
+              result.confirm();
+            }
+          }
+
+          @Override
+          public void error(String errorCode, String errorMessage, Object errorDetails) {
+            System.out.println("error");
+          }
+
+          @Override
+          public void notImplemented() {
+            System.out.println("notImplemented");
+          }
+        });
+        return true;
+      }
+
+      @Override
+      public boolean onJsConfirm(WebView view, String url, String message, final JsResult result) {
+        Map<String, Object> args = new HashMap<>();
+        args.put("url", url);
+        args.put("message", message);
+        methodChannel.invokeMethod("onJsConfirm", args, new MethodChannel.Result() {
+          @Override
+          public void success(Object o) {
+            if (o instanceof Boolean) {
+              boolean boolResult = (Boolean) o;
+              if (result != null) {
+                if (boolResult) {
+                  result.confirm();
+                } else {
+                  result.cancel();
+                }
+              }
+            }
+          }
+
+          @Override
+          public void error(String errorCode, String errorMessage, Object errorDetails) {
+            System.out.println("error");
+          }
+
+          @Override
+          public void notImplemented() {
+            System.out.println("notImplemented");
+          }
+        });
+        return true;
+      }
+
+      @Override
+      public boolean onJsPrompt(WebView view, String url, String message, String defaultValue, final JsPromptResult result) {
+        Map<String, Object> args = new HashMap<>();
+        args.put("url", url);
+        args.put("message", message);
+        args.put("defaultText", defaultValue);
+        methodChannel.invokeMethod("onJsPrompt", args, new MethodChannel.Result() {
+          @Override
+          public void success(Object o) {
+            if (o instanceof String) {
+              String str = (String) o;
+              if (result != null) {
+                if (!str.isEmpty()) {
+                  result.confirm(str);
+                } else {
+                  result.confirm("");
+                }
+              }
+            }
+          }
+
+          @Override
+          public void error(String errorCode, String errorMessage, Object errorDetails) {
+            System.out.println("error");
+          }
+
+          @Override
+          public void notImplemented() {
+            System.out.println("notImplemented");
+          }
+        });
+        return true;
+      }
+    };
+  }
+}
+

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -10,6 +10,7 @@ import android.hardware.display.DisplayManager;
 import android.os.Build;
 import android.os.Handler;
 import android.view.View;
+import android.webkit.WebChromeClient;
 import android.webkit.WebStorage;
 import android.webkit.WebViewClient;
 import io.flutter.plugin.common.BinaryMessenger;
@@ -27,6 +28,7 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
   private final InputAwareWebView webView;
   private final MethodChannel methodChannel;
   private final FlutterWebViewClient flutterWebViewClient;
+  private final FlutterWebChromeClient flutterWebChromeClient;
   private final Handler platformThreadHandler;
 
   @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
@@ -53,6 +55,10 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
     methodChannel.setMethodCallHandler(this);
 
     flutterWebViewClient = new FlutterWebViewClient(methodChannel);
+    flutterWebChromeClient = new FlutterWebChromeClient(methodChannel);
+    final WebChromeClient webChromeClient =
+            flutterWebChromeClient.createWebChromeClient();
+    webView.setWebChromeClient(webChromeClient);
     applySettings((Map<String, Object>) params.get("settings"));
 
     if (params.containsKey(JS_CHANNEL_NAMES_FIELD)) {

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -228,6 +228,10 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
         new android.webkit.ValueCallback<String>() {
           @Override
           public void onReceiveValue(String value) {
+            if (value.startsWith("\"") && value.endsWith("\"")) {
+              // Unwrap double quote (String type)
+              value = value.substring(1, value.length() - 1);
+            }
             result.success(value);
           }
         });

--- a/packages/webview_flutter/example/lib/cupertino_dialogs.dart
+++ b/packages/webview_flutter/example/lib/cupertino_dialogs.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/cupertino.dart';
+
+/// An example for cupertino style alert dialog.
+class MyCupertinoAlertDialog extends StatelessWidget {
+  /// Dialog message.
+  final String message;
+
+  /// Constructs an instance with a message.
+  MyCupertinoAlertDialog({this.message = ''});
+
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoAlertDialog(
+      content: Text(message),
+      actions: <Widget>[
+        CupertinoDialogAction(
+            child: const Text('OK'),
+            onPressed: () {
+              Navigator.of(context).pop();
+            }),
+      ],
+    );
+  }
+}
+
+/// An example for cupertino style confirm dialog.
+class CupertinoConfirmDialog extends StatelessWidget {
+  /// Dialog message.
+  final String message;
+
+  /// Constructs an instance with a message.
+  CupertinoConfirmDialog({this.message = ''});
+
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoAlertDialog(
+      content: Text(message),
+      actions: <Widget>[
+        CupertinoDialogAction(
+            child: const Text('Cancel'),
+            onPressed: () {
+              Navigator.of(context).pop(false);
+            }),
+        CupertinoDialogAction(
+            child: const Text('OK'),
+            onPressed: () {
+              Navigator.of(context).pop(true);
+            }),
+      ],
+    );
+  }
+}
+
+/// An example for cupertino style prompt dialog.
+class CupertinoPromptDialog extends StatefulWidget {
+  /// Dialog message.
+  final String message;
+  /// Dialog default text.
+  final String defaultText;
+
+  /// Constructs an instance with a message and default text.
+  CupertinoPromptDialog({Key key, this.message, this.defaultText}) : super(key: key);
+
+  @override
+  _PromptDialogState createState() => _PromptDialogState();
+}
+
+class _PromptDialogState extends State<CupertinoPromptDialog> {
+  TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController();
+    _controller.text = widget.defaultText;
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoAlertDialog(
+      content: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Text(widget.message),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(0, 16, 0, 0),
+              child: CupertinoTextField(
+                controller: _controller,
+                cursorColor: CupertinoColors.inactiveGray,
+                style: const TextStyle(
+                  fontSize: 16,
+                ),
+                maxLines: 1,
+                decoration: BoxDecoration(
+                  color: CupertinoColors.white,
+                  border: Border.all(
+                    width: 1.2,
+                    color: CupertinoColors.inactiveGray,
+                  ),
+                  borderRadius: BorderRadius.circular(8.0),
+                ),
+              ),
+            )
+          ]),
+      actions: <Widget>[
+        CupertinoDialogAction(
+            child: const Text('Cancel'),
+            onPressed: () {
+              Navigator.of(context).pop('');
+            }),
+        CupertinoDialogAction(
+            child: const Text('OK'),
+            onPressed: () {
+              Navigator.of(context).pop(_controller.text);
+            }),
+      ],
+    );
+  }
+}

--- a/packages/webview_flutter/example/lib/material_dialogs.dart
+++ b/packages/webview_flutter/example/lib/material_dialogs.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+
+/// An example for material style alert dialog.
+class MyAlertDialog extends StatelessWidget {
+  /// dialog message
+  final String message;
+
+  /// Constructs an instance with a message.
+  MyAlertDialog({this.message = ''});
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      content: Text(message),
+      actions: <Widget>[
+        FlatButton(
+            child: const Text('OK'),
+            onPressed: () {
+              Navigator.of(context).pop();
+            }),
+      ],
+    );
+  }
+}
+
+/// An example for material style confirm dialog.
+class ConfirmDialog extends StatelessWidget {
+  /// dialog message
+  final String message;
+
+  /// Constructs an instance with a message.
+  ConfirmDialog({this.message = ''});
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      content: Text(message),
+      actions: <Widget>[
+        FlatButton(
+            child: const Text('Cancel'),
+            onPressed: () {
+              Navigator.of(context).pop(false);
+            }),
+        FlatButton(
+            child: const Text('OK'),
+            onPressed: () {
+              Navigator.of(context).pop(true);
+            }),
+      ],
+    );
+  }
+}
+
+/// An example for material style prompt dialog.
+class PromptDialog extends StatefulWidget {
+  /// dialog message
+  final String message;
+  /// dialog default text
+  final String defaultText;
+
+  /// Constructs an instance with a message and default text.
+  PromptDialog({Key key, this.message, this.defaultText = ''})
+      : super(key: key);
+
+  @override
+  _PromptDialogState createState() => _PromptDialogState();
+}
+
+class _PromptDialogState extends State<PromptDialog> {
+  TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController();
+    _controller.text = widget.defaultText;
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      content: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Text(widget.message),
+            TextField(controller: _controller),
+          ]),
+      actions: <Widget>[
+        FlatButton(
+            child: const Text('Cancel'),
+            onPressed: () {
+              Navigator.of(context).pop('');
+            }),
+        FlatButton(
+            child: const Text('OK'),
+            onPressed: () {
+              Navigator.of(context).pop(_controller.text);
+            }),
+      ],
+    );
+  }
+}

--- a/packages/webview_flutter/ios/Classes/FLTWKUIDelegate.h
+++ b/packages/webview_flutter/ios/Classes/FLTWKUIDelegate.h
@@ -1,0 +1,16 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <Flutter/Flutter.h>
+#import <WebKit/WebKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface FLTWKUIDelegate : NSObject <WKUIDelegate>
+
+- (instancetype)initWithChannel:(FlutterMethodChannel*)channel;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/webview_flutter/ios/Classes/FLTWKUIDelegate.m
+++ b/packages/webview_flutter/ios/Classes/FLTWKUIDelegate.m
@@ -18,27 +18,61 @@
 
 #pragma mark - WKUIDelegate conformance
 
-- (void)webView:(WKWebView *)webView runJavaScriptAlertPanelWithMessage:(NSString *)message initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(void))completionHandler
+- (void)webView:(WKWebView *)webView
+runJavaScriptAlertPanelWithMessage:(NSString *)message
+initiatedByFrame:(WKFrameInfo *)frame
+completionHandler:(void (^)(void))completionHandler
 {
-  [_methodChannel invokeMethod:@"onJsAlert" arguments:@{@"url": webView.URL.absoluteString, @"message": message} result:^(id  _Nullable result) {
-    completionHandler();
-  }];
+    [_methodChannel invokeMethod:@"onJsAlert"
+                       arguments:@{
+                           @"url": webView.URL.absoluteString,
+                           @"message": message
+                       }
+                          result:^(id  _Nullable result) {
+        completionHandler();
+    }];
 }
 
-- (void)webView:(WKWebView *)webView runJavaScriptConfirmPanelWithMessage:(NSString *)message initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(BOOL result))completionHandler
+- (void)webView:(WKWebView *)webView
+runJavaScriptConfirmPanelWithMessage:(NSString *)message
+initiatedByFrame:(WKFrameInfo *)frame
+completionHandler:(void (^)(BOOL result))completionHandler
 {
-  [_methodChannel invokeMethod:@"onJsConfirm" arguments:@{@"url": webView.URL.absoluteString, @"message": message} result:^(id  _Nullable result) {
-    NSNumber* b = result;
-    completionHandler([b boolValue]);
-  }];
+    [_methodChannel invokeMethod:@"onJsConfirm"
+                       arguments:@{
+                           @"url": webView.URL.absoluteString,
+                           @"message": message
+                       }
+                          result:^(id  _Nullable result) {
+        if ([result isKindOfClass:[NSNumber class]]) {
+            NSNumber* b = result;
+            completionHandler([b boolValue]);
+            return;
+        }
+        completionHandler(NO);
+    }];
 }
 
-- (void)webView:(WKWebView *)webView runJavaScriptTextInputPanelWithPrompt:(NSString *)prompt defaultText:(NSString *)defaultText initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(NSString *result))completionHandler
+- (void)webView:(WKWebView *)webView
+runJavaScriptTextInputPanelWithPrompt:(NSString *)prompt
+    defaultText:(NSString *)defaultText
+initiatedByFrame:(WKFrameInfo *)frame
+completionHandler:(void (^)(NSString *result))completionHandler
 {
-  [_methodChannel invokeMethod:@"onJsPrompt" arguments:@{@"url": webView.URL.absoluteString, @"message": prompt, @"defaultText": defaultText} result:^(id  _Nullable result) {
-    NSString *str = result;
-    completionHandler(str);
-  }];
+    [_methodChannel invokeMethod:@"onJsPrompt"
+                       arguments:@{
+                           @"url": webView.URL.absoluteString,
+                           @"message": prompt,
+                           @"defaultText": defaultText
+                       }
+                          result:^(id  _Nullable result) {
+        if ([result isKindOfClass: [NSString class]]) {
+            NSString *str = result;
+            completionHandler(str);
+            return;
+        }
+        completionHandler(@"");
+    }];
 }
 
 @end

--- a/packages/webview_flutter/ios/Classes/FLTWKUIDelegate.m
+++ b/packages/webview_flutter/ios/Classes/FLTWKUIDelegate.m
@@ -1,0 +1,44 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "FLTWKUIDelegate.h"
+
+@implementation FLTWKUIDelegate {
+  FlutterMethodChannel* _methodChannel;
+}
+
+- (instancetype)initWithChannel:(FlutterMethodChannel*)channel {
+  self = [super init];
+  if (self) {
+    _methodChannel = channel;
+  }
+  return self;
+}
+
+#pragma mark - WKUIDelegate conformance
+
+- (void)webView:(WKWebView *)webView runJavaScriptAlertPanelWithMessage:(NSString *)message initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(void))completionHandler
+{
+  [_methodChannel invokeMethod:@"onJsAlert" arguments:@{@"url": webView.URL.absoluteString, @"message": message} result:^(id  _Nullable result) {
+    completionHandler();
+  }];
+}
+
+- (void)webView:(WKWebView *)webView runJavaScriptConfirmPanelWithMessage:(NSString *)message initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(BOOL result))completionHandler
+{
+  [_methodChannel invokeMethod:@"onJsConfirm" arguments:@{@"url": webView.URL.absoluteString, @"message": message} result:^(id  _Nullable result) {
+    NSNumber* b = result;
+    completionHandler([b boolValue]);
+  }];
+}
+
+- (void)webView:(WKWebView *)webView runJavaScriptTextInputPanelWithPrompt:(NSString *)prompt defaultText:(NSString *)defaultText initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(NSString *result))completionHandler
+{
+  [_methodChannel invokeMethod:@"onJsPrompt" arguments:@{@"url": webView.URL.absoluteString, @"message": prompt, @"defaultText": defaultText} result:^(id  _Nullable result) {
+    NSString *str = result;
+    completionHandler(str);
+  }];
+}
+
+@end

--- a/packages/webview_flutter/ios/Classes/FlutterWebView.m
+++ b/packages/webview_flutter/ios/Classes/FlutterWebView.m
@@ -4,6 +4,7 @@
 
 #import "FlutterWebView.h"
 #import "FLTWKNavigationDelegate.h"
+#import "FLTWKUIDelegate.h"
 #import "JavaScriptChannelHandler.h"
 
 @implementation FLTWebViewFactory {
@@ -64,6 +65,7 @@
   // The set of registered JavaScript channel names.
   NSMutableSet* _javaScriptChannelNames;
   FLTWKNavigationDelegate* _navigationDelegate;
+  FLTWKUIDelegate* _uiDelegate;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -94,6 +96,8 @@
     _webView = [[FLTWKWebView alloc] initWithFrame:frame configuration:configuration];
     _navigationDelegate = [[FLTWKNavigationDelegate alloc] initWithChannel:_channel];
     _webView.navigationDelegate = _navigationDelegate;
+    _uiDelegate = [[FLTWKUIDelegate alloc] initWithChannel:_channel];
+    _webView.UIDelegate = _uiDelegate;
     __weak __typeof__(self) weakSelf = self;
     [_channel setMethodCallHandler:^(FlutterMethodCall* call, FlutterResult result) {
       [weakSelf onMethodCall:call result:result];

--- a/packages/webview_flutter/lib/platform_interface.dart
+++ b/packages/webview_flutter/lib/platform_interface.dart
@@ -28,6 +28,29 @@ abstract class WebViewPlatformCallbacksHandler {
 
   /// Invoked by [WebViewPlatformController] when a page has finished loading.
   void onPageFinished(String url);
+
+  /// Invoked by [WebViewPlatformController] when page fire an Alert dialog from JavaScript.
+  ///
+  /// Return a future.
+  /// Fulfill the returned future when dialog closed.
+  Future<Null> onJSAlert(String url, String message) async {}
+
+  /// Invoked by [WebViewPlatformController] when page fire an Confirm dialog from JavaScript.
+  ///
+  /// Return a future for dialog respond.
+  /// Fulfill true if user click 'OK' button, false if user click 'Cancel' button.
+  Future<bool> onJSConfirm(String url, String message) async {
+    return false;
+  }
+
+  /// Invoked by [WebViewPlatformController] when page fire an Prompt dialog from JavaScript.
+  ///
+  /// Return a future for user input input text.
+  /// Returns an empty strings when dialog cancelled.
+  Future<String> onJSPrompt(
+      String url, String message, String defaultText) async {
+    return '';
+  }
 }
 
 /// Interface for talking to the webview's platform implementation.

--- a/packages/webview_flutter/lib/src/webview_method_channel.dart
+++ b/packages/webview_flutter/lib/src/webview_method_channel.dart
@@ -25,7 +25,7 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
   static const MethodChannel _cookieManagerChannel =
       MethodChannel('plugins.flutter.io/cookie_manager');
 
-  Future<bool> _onMethodCall(MethodCall call) async {
+  Future<dynamic> _onMethodCall(MethodCall call) async {
     switch (call.method) {
       case 'javascriptChannelMessage':
         final String channel = call.arguments['channel'];
@@ -43,6 +43,28 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
       case 'onPageStarted':
         _platformCallbacksHandler.onPageStarted(call.arguments['url']);
         return null;
+      case 'onJsAlert':
+        if (_platformCallbacksHandler.onJSAlert != null) {
+          await _platformCallbacksHandler.onJSAlert(
+              call.arguments['url'], call.arguments['message']);
+        }
+        return null;
+      case 'onJsConfirm':
+        if (_platformCallbacksHandler.onJSConfirm != null) {
+          final result = await _platformCallbacksHandler.onJSConfirm(
+              call.arguments['url'], call.arguments['message']);
+          return result;
+        }
+        return false;
+      case 'onJsPrompt':
+        if (_platformCallbacksHandler.onJSPrompt != null) {
+          final result = await _platformCallbacksHandler.onJSPrompt(
+              call.arguments['url'],
+              call.arguments['message'],
+              call.arguments['defaultText']);
+          return result;
+        }
+        return '';
     }
     throw MissingPluginException(
         '${call.method} was invoked but has no handler');

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -79,6 +79,16 @@ typedef void PageStartedCallback(String url);
 /// Signature for when a [WebView] has finished loading a page.
 typedef void PageFinishedCallback(String url);
 
+/// Signature for when a page fire an Alert dialog by JavaScript.
+typedef Future<Null> JSAlertCallback(String url, String message);
+
+/// Signature for when a page fire an Confirm dialog by JavaScript.
+typedef Future<bool> JSConfirmCallback(String url, String message);
+
+/// Signature for when a page fire an Prompt dialog by JavaScript.
+typedef Future<String> JSPromptCallback(
+    String url, String message, String defaultText);
+
 /// Specifies possible restrictions on automatic media playback.
 ///
 /// This is typically used in [WebView.initialMediaPlaybackPolicy].
@@ -147,6 +157,9 @@ class WebView extends StatefulWidget {
     this.gestureRecognizers,
     this.onPageStarted,
     this.onPageFinished,
+    this.onJSAlert,
+    this.onJSConfirm,
+    this.onJSPrompt,
     this.debuggingEnabled = false,
     this.gestureNavigationEnabled = false,
     this.userAgent,
@@ -276,6 +289,24 @@ class WebView extends StatefulWidget {
   /// directly in the HTML has been loaded and code injected with
   /// [WebViewController.evaluateJavascript] can assume this.
   final PageFinishedCallback onPageFinished;
+
+  /// Invoked when a page fire an Alert dialog by JavaScript.
+  ///
+  /// You have to implement your Alert dialog on your own way.
+  /// Default value will consumed dialog callback.
+  final JSAlertCallback onJSAlert;
+
+  /// Invoked when a page fire an Confirm dialog by JavaScript.
+  ///
+  /// You have to implement your Confirm dialog on your own way.
+  /// Default value will consumed dialog callback.
+  final JSConfirmCallback onJSConfirm;
+
+  /// Invoked when a page fire an Prompt dialog by JavaScript.
+  ///
+  /// You have to implement your Prompt dialog on your own way.
+  /// Default value will consumed dialog callback.
+  final JSPromptCallback onJSPrompt;
 
   /// Controls whether WebView debugging is enabled.
   ///
@@ -480,6 +511,30 @@ class _PlatformCallbacksHandler implements WebViewPlatformCallbacksHandler {
     if (_widget.onPageFinished != null) {
       _widget.onPageFinished(url);
     }
+  }
+
+  @override
+  Future<Null> onJSAlert(String url, String message) async {
+    if (_widget.onJSAlert != null) {
+      await _widget.onJSAlert(url, message);
+    }
+  }
+
+  @override
+  Future<bool> onJSConfirm(String url, String message) async {
+    if (_widget.onJSConfirm != null) {
+      return await _widget.onJSConfirm(url, message);
+    }
+    return false;
+  }
+
+  @override
+  Future<String> onJSPrompt(
+      String url, String message, String defaultText) async {
+    if (_widget.onJSPrompt != null) {
+      return await _widget.onJSPrompt(url, message, defaultText);
+    }
+    return '';
   }
 
   void _updateJavascriptChannelsFromSet(Set<JavascriptChannel> channels) {

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
-version: 0.3.19+5
+version: 0.3.19+6
 homepage: https://github.com/flutter/plugins/tree/master/packages/webview_flutter
 
 environment:


### PR DESCRIPTION
## Description

Enhance pull request of #2012 .

Implement onJSAlert, onJSConfirm, onJSPrompt interface.

Instead of implement native code, I advocate it handling that Flutter side.
Let developer implement their own alert dialogs at Flutter.
I extract both iOS and Android native callback into three functions.

**Native callback**

|         | Android                                                                                                               | iOS                                                                                              
|---------|-----------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|
| Alert   | public boolean onJsAlert(WebView view, String url, String message, final JsResult result)                             | webView(_:runJavaScriptAlertPanelWithMessage:initiatedByFrame:completionHandler:)                |
| Confirm | public boolean onJsConfirm(WebView view, String url, String message, final JsResult result)                           | webView(_:runJavaScriptConfirmPanelWithMessage:initiatedByFrame:completionHandler:)              | 
| Prompt  | public boolean onJsPrompt(WebView view, String url, String message, String defaultValue, final JsPromptResult result) | webView(_:runJavaScriptTextInputPanelWithPrompt:defaultText:initiatedByFrame:completionHandler:) |

**Flutter callback**

|         | Flutter                                                 |
|---------|---------------------------------------------------------|
| Alert   | JSAlertCallback onJSAlert;     |
| Confirm | JSConfirmCallback onJSConfirm; |
| Prompt  | JSPromptCallback onJSPrompt;   |

Also, add working examples.

## Related Issues

- Issue flutter/flutter#34853
- Issue flutter/flutter#30358
- Pull request #2012 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
