### PR TITLE
[in_app_purchase] Fix wrong _pendingCompletePurchase flag value

### DIFF
--- a/packages/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0+3
+
+* Fix pendingCompletePurchase flag status to allow to complete the pruchsase. 
+
 ## 0.3.0+2
 
 * Update te example app to avoid using deprecated api.

--- a/packages/in_app_purchase/lib/src/in_app_purchase/purchase_details.dart
+++ b/packages/in_app_purchase/lib/src/in_app_purchase/purchase_details.dart
@@ -193,9 +193,10 @@ class PurchaseDetails {
             : null,
         this.skPaymentTransaction = transaction,
         this.billingClientPurchase = null,
-        _status = SKTransactionStatusConverter()
-            .toPurchaseStatus(transaction.transactionState),
-        _platform = _kPlatformIOS;
+        _platform = _kPlatformIOS {
+    status = SKTransactionStatusConverter()
+        .toPurchaseStatus(transaction.transactionState);
+  }
 
   /// Generate a [PurchaseDetails] object based on an Android [Purchase] object.
   PurchaseDetails.fromPurchase(PurchaseWrapper purchase)
@@ -208,9 +209,9 @@ class PurchaseDetails {
         this.transactionDate = purchase.purchaseTime.toString(),
         this.skPaymentTransaction = null,
         this.billingClientPurchase = purchase,
-        _status =
-            PurchaseStateConverter().toPurchaseStatus(purchase.purchaseState),
-        _platform = _kPlatformAndroid;
+        _platform = _kPlatformAndroid {
+    status = PurchaseStateConverter().toPurchaseStatus(purchase.purchaseState);
+  }
 }
 
 /// The response object for fetching the past purchases.

--- a/packages/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/pubspec.yaml
@@ -1,7 +1,7 @@
 name: in_app_purchase
 description: A Flutter plugin for in-app purchases. Exposes APIs for making in-app purchases through the App Store and Google Play.
 homepage: https://github.com/flutter/plugins/tree/master/packages/in_app_purchase
-version: 0.3.0+2
+version: 0.3.0+3
 
 
 dependencies:

--- a/packages/in_app_purchase/test/billing_client_wrappers/purchase_wrapper_test.dart
+++ b/packages/in_app_purchase/test/billing_client_wrappers/purchase_wrapper_test.dart
@@ -69,6 +69,7 @@ void main() {
           dummyPurchase.purchaseToken);
       expect(details.skPaymentTransaction, null);
       expect(details.billingClientPurchase, dummyPurchase);
+      expect(details.pendingCompletePurchase, true);
     });
   });
 

--- a/packages/in_app_purchase/test/store_kit_wrappers/sk_product_test.dart
+++ b/packages/in_app_purchase/test/store_kit_wrappers/sk_product_test.dart
@@ -139,6 +139,7 @@ void main() {
       expect(details.verificationData.source, IAPSource.AppStore);
       expect(details.skPaymentTransaction, dummyTransaction);
       expect(details.billingClientPurchase, null);
+      expect(details.pendingCompletePurchase, true);
     });
     test('Should generate correct map of the payment object', () {
       Map map = dummyPayment.toMap();


### PR DESCRIPTION
## Description

When purchasing the _pendingCompletePurchase flag is always set to false as we were not using the setter that was setting _pendingCompletePurchase to true when purchasing status was true.

## Related Issues

flutter/flutter#49083

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
