### PR TITLE
[image_picker] update flutter_plugin_android_lifecycle version

### DIFF
--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.6.3+2
 
 * Bump RoboElectric dependency to 4.3.1 and update resource usage.
+* Android: Fix reflection crash: Update flutter_plugin_android_lifecycle dependency to 1.0.4 
 
 ## 0.6.3+1
 

--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,7 +1,10 @@
+## 0.6.3+3
+
+* Android: Fix reflection crash: Update flutter_plugin_android_lifecycle dependency to 1.0.4 
+
 ## 0.6.3+2
 
 * Bump RoboElectric dependency to 4.3.1 and update resource usage.
-* Android: Fix reflection crash: Update flutter_plugin_android_lifecycle dependency to 1.0.4 
 
 ## 0.6.3+1
 

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker
 description: Flutter plugin for selecting images from the Android and iOS image
   library, and taking new pictures with the camera.
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.6.3+2
+version: 0.6.3+3
 
 flutter:
   plugin:

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -16,7 +16,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_plugin_android_lifecycle: ^1.0.2
+  flutter_plugin_android_lifecycle: ^1.0.4
 
 dev_dependencies:
   video_player: ^0.10.3


### PR DESCRIPTION
## Description

`flutter_plugin_android_lifecycle: 1.0.3` was causing a crash in Android. It's fixed in `1.0.4`. But the crash is still reproduced if `version: "1.0.3"` is saved in pubspec.lock.

This PR updates the dependency to `^1.0.4`

## Related Issues

https://github.com/flutter/flutter/issues/48622 (original issue)
https://github.com/flutter/flutter/issues/48906 (more detailed reproduction steps)

## Breaking Change

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
