### PR TITLE
[google_maps_flutter] Add steps to set up google map sdk on each platform in readme.

### DIFF
--- a/packages/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.22+2
+
+* Update README: Add steps to enable Google Map SDK in the Google Developer Console.
+
 ## 0.5.22+1
 
 * Fix for toggling traffic layer on Android not working

--- a/packages/google_maps_flutter/README.md
+++ b/packages/google_maps_flutter/README.md
@@ -24,7 +24,18 @@ To use this plugin, add `google_maps_flutter` as a [dependency in your pubspec.y
 
 ## Getting Started
 
-Get an API key at <https://cloud.google.com/maps-platform/>.
+* Get an API key at <https://cloud.google.com/maps-platform/>.
+
+* Enable Google Map SDK for each platform.
+  * Go to [Google Developers Console](https://console.cloud.google.com/).
+  * Choose the project that you want to enable Google Maps on.
+  * Select the navigation menu and then select "Google Maps".
+  * Select "APIs" under the Google Maps menu.
+  * To enable Google Map for Android, select "Maps SDK for Android" in the "Additional APIs" section, then select "ENABLE".
+  * To enable Google Map for iOS, select "Maps SDK for iOS" in the "Additional APIs" section, then select "ENABLE".
+  * Make sure the APIs you enabled are under the "Enabled APIs" section.
+
+* You can also find a detailed steps to get start with Google Maps Platform [here](https://developers.google.com/maps/gmp-get-started).
 
 ### Android
 

--- a/packages/google_maps_flutter/README.md
+++ b/packages/google_maps_flutter/README.md
@@ -31,11 +31,11 @@ To use this plugin, add `google_maps_flutter` as a [dependency in your pubspec.y
   * Choose the project that you want to enable Google Maps on.
   * Select the navigation menu and then select "Google Maps".
   * Select "APIs" under the Google Maps menu.
-  * To enable Google Map for Android, select "Maps SDK for Android" in the "Additional APIs" section, then select "ENABLE".
-  * To enable Google Map for iOS, select "Maps SDK for iOS" in the "Additional APIs" section, then select "ENABLE".
+  * To enable Google Maps for Android, select "Maps SDK for Android" in the "Additional APIs" section, then select "ENABLE".
+  * To enable Google Maps for iOS, select "Maps SDK for iOS" in the "Additional APIs" section, then select "ENABLE".
   * Make sure the APIs you enabled are under the "Enabled APIs" section.
 
-* You can also find a detailed steps to get start with Google Maps Platform [here](https://developers.google.com/maps/gmp-get-started).
+* You can also find detailed steps to get start with Google Maps Platform [here](https://developers.google.com/maps/gmp-get-started).
 
 ### Android
 

--- a/packages/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter
-version: 0.5.22+1
+version: 0.5.22+2
 
 dependencies:
   flutter:


### PR DESCRIPTION
People seem to have trouble stepping up Google Map SDKs(issue here: https://github.com/flutter/flutter/issues/30649). We should make our set up guide clearer.
