### PR TITLE
[in_app_purchases] Android: make sure properly disconnect the billing client object.

### DIFF
--- a/packages/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/CHANGELOG.md
@@ -1,6 +1,13 @@
+## 0.3.1
+
+* Android: Fix a bug where the `BillingClient` is disconnected when app goes to the background.
+* Android: Make sure the `BillingClient` object is disconnected before the activity is destroyed.
+* Android: Fix minor compiler warning.
+* Fix typo in CHANGELOG.
+
 ## 0.3.0+3
 
-* Fix pendingCompletePurchase flag status to allow to complete the pruchsase. 
+* Fix pendingCompletePurchase flag status to allow to complete purchases.
 
 ## 0.3.0+2
 

--- a/packages/in_app_purchase/android/src/main/java/io/flutter/plugins/inapppurchase/InAppPurchasePlugin.java
+++ b/packages/in_app_purchase/android/src/main/java/io/flutter/plugins/inapppurchase/InAppPurchasePlugin.java
@@ -98,4 +98,9 @@ public class InAppPurchasePlugin implements FlutterPlugin, ActivityAware {
     methodChannel = null;
     methodCallHandler = null;
   }
+
+  @VisibleForTesting
+  void setMethodCallHandler(MethodCallHandlerImpl methodCallHandler) {
+    this.methodCallHandler = methodCallHandler;
+  }
 }

--- a/packages/in_app_purchase/android/src/main/java/io/flutter/plugins/inapppurchase/InAppPurchasePlugin.java
+++ b/packages/in_app_purchase/android/src/main/java/io/flutter/plugins/inapppurchase/InAppPurchasePlugin.java
@@ -8,7 +8,6 @@ import android.app.Activity;
 import android.app.Application;
 import android.content.Context;
 import androidx.annotation.VisibleForTesting;
-import androidx.lifecycle.Lifecycle;
 import com.android.billingclient.api.BillingClient;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.embedding.engine.plugins.activity.ActivityAware;
@@ -46,7 +45,6 @@ public class InAppPurchasePlugin implements FlutterPlugin, ActivityAware {
 
   private MethodChannel methodChannel;
   private MethodCallHandlerImpl methodCallHandler;
-  private Lifecycle lifecycle;
 
   /** Plugin registration. */
   public static void registerWith(Registrar registrar) {

--- a/packages/in_app_purchase/android/src/main/java/io/flutter/plugins/inapppurchase/MethodCallHandlerImpl.java
+++ b/packages/in_app_purchase/android/src/main/java/io/flutter/plugins/inapppurchase/MethodCallHandlerImpl.java
@@ -69,7 +69,6 @@ class MethodCallHandlerImpl
     this.activity = activity;
   }
 
-  // Activity Life Cycle callbacks
   @Override
   public void onActivityCreated(Activity activity, Bundle savedInstanceState) {}
 

--- a/packages/in_app_purchase/android/src/main/java/io/flutter/plugins/inapppurchase/MethodCallHandlerImpl.java
+++ b/packages/in_app_purchase/android/src/main/java/io/flutter/plugins/inapppurchase/MethodCallHandlerImpl.java
@@ -9,7 +9,9 @@ import static io.flutter.plugins.inapppurchase.Translator.fromPurchasesResult;
 import static io.flutter.plugins.inapppurchase.Translator.fromSkuDetailsList;
 
 import android.app.Activity;
+import android.app.Application;
 import android.content.Context;
+import android.os.Bundle;
 import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -33,7 +35,8 @@ import java.util.List;
 import java.util.Map;
 
 /** Handles method channel for the plugin. */
-class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
+class MethodCallHandlerImpl
+    implements MethodChannel.MethodCallHandler, Application.ActivityLifecycleCallbacks {
 
   private static final String TAG = "InAppPurchasePlugin";
 
@@ -64,6 +67,39 @@ class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
    */
   void setActivity(@Nullable Activity activity) {
     this.activity = activity;
+  }
+
+  // Activity Life Cycle callbacks
+  @Override
+  public void onActivityCreated(Activity activity, Bundle savedInstanceState) {}
+
+  @Override
+  public void onActivityStarted(Activity activity) {}
+
+  @Override
+  public void onActivityResumed(Activity activity) {}
+
+  @Override
+  public void onActivityPaused(Activity activity) {}
+
+  @Override
+  public void onActivitySaveInstanceState(Activity activity, Bundle outState) {}
+
+  @Override
+  public void onActivityDestroyed(Activity activity) {
+    if (this.activity == activity) {
+      if (this.applicationContext != null) {
+        ((Application) this.applicationContext).unregisterActivityLifecycleCallbacks(this);
+      }
+      endBillingClientConnection();
+    }
+  }
+
+  @Override
+  public void onActivityStopped(Activity activity) {}
+
+  void onDetachedFromActivity() {
+    endBillingClientConnection();
   }
 
   @Override
@@ -113,11 +149,15 @@ class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
   }
 
   private void endConnection(final MethodChannel.Result result) {
+    endBillingClientConnection();
+    result.success(null);
+  }
+
+  private void endBillingClientConnection() {
     if (billingClient != null) {
       billingClient.endConnection();
       billingClient = null;
     }
-    result.success(null);
   }
 
   private void isReady(MethodChannel.Result result) {

--- a/packages/in_app_purchase/android/src/main/java/io/flutter/plugins/inapppurchase/MethodCallHandlerImpl.java
+++ b/packages/in_app_purchase/android/src/main/java/io/flutter/plugins/inapppurchase/MethodCallHandlerImpl.java
@@ -87,10 +87,8 @@ class MethodCallHandlerImpl
 
   @Override
   public void onActivityDestroyed(Activity activity) {
-    if (this.activity == activity) {
-      if (this.applicationContext != null) {
-        ((Application) this.applicationContext).unregisterActivityLifecycleCallbacks(this);
-      }
+    if (this.activity == activity && this.applicationContext != null) {
+      ((Application) this.applicationContext).unregisterActivityLifecycleCallbacks(this);
       endBillingClientConnection();
     }
   }

--- a/packages/in_app_purchase/example/android/app/src/test/java/io/flutter/plugins/inapppurchase/MethodCallHandlerTest.java
+++ b/packages/in_app_purchase/example/android/app/src/test/java/io/flutter/plugins/inapppurchase/MethodCallHandlerTest.java
@@ -52,6 +52,7 @@ import com.android.billingclient.api.PurchaseHistoryResponseListener;
 import com.android.billingclient.api.SkuDetails;
 import com.android.billingclient.api.SkuDetailsParams;
 import com.android.billingclient.api.SkuDetailsResponseListener;
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.Result;
@@ -73,6 +74,7 @@ public class MethodCallHandlerTest {
   @Spy Result result;
   @Mock Activity activity;
   @Mock Context context;
+  @Mock ActivityPluginBinding mockActivityPluginBinding;
 
   @Before
   public void setUp() {
@@ -82,6 +84,7 @@ public class MethodCallHandlerTest {
             @NonNull MethodChannel channel,
             boolean enablePendingPurchases) -> mockBillingClient;
     methodChannelHandler = new MethodCallHandlerImpl(activity, context, mockMethodChannel, factory);
+    when(mockActivityPluginBinding.getActivity()).thenReturn(activity);
   }
 
   @Test
@@ -549,6 +552,15 @@ public class MethodCallHandlerTest {
     // Verify we pass the response code to result
     verify(result, never()).error(any(), any(), any());
     verify(result, times(1)).success(fromBillingResult(billingResult));
+  }
+
+  @Test
+  public void endConnection_if_activity_dettached() {
+    InAppPurchasePlugin plugin = new InAppPurchasePlugin();
+    plugin.setMethodCallHandler(methodChannelHandler);
+    mockStartConnection();
+    plugin.onDetachedFromActivity();
+    verify(mockBillingClient).endConnection();
   }
 
   private ArgumentCaptor<BillingClientStateListener> mockStartConnection() {

--- a/packages/in_app_purchase/example/lib/main.dart
+++ b/packages/in_app_purchase/example/lib/main.dart
@@ -110,6 +110,7 @@ class _MyAppState extends State<MyApp> {
     final List<PurchaseDetails> verifiedPurchases = [];
     for (PurchaseDetails purchase in purchaseResponse.pastPurchases) {
       if (await _verifyPurchase(purchase)) {
+        await _connection.consumePurchase(purchase);
         verifiedPurchases.add(purchase);
       }
     }

--- a/packages/in_app_purchase/example/lib/main.dart
+++ b/packages/in_app_purchase/example/lib/main.dart
@@ -110,7 +110,6 @@ class _MyAppState extends State<MyApp> {
     final List<PurchaseDetails> verifiedPurchases = [];
     for (PurchaseDetails purchase in purchaseResponse.pastPurchases) {
       if (await _verifyPurchase(purchase)) {
-        await _connection.consumePurchase(purchase);
         verifiedPurchases.add(purchase);
       }
     }

--- a/packages/in_app_purchase/lib/src/in_app_purchase/google_play_connection.dart
+++ b/packages/in_app_purchase/lib/src/in_app_purchase/google_play_connection.dart
@@ -176,8 +176,6 @@ class GooglePlayConnection
   Future<void> _connect() =>
       billingClient.startConnection(onBillingServiceDisconnected: () {});
 
-  Future<void> _disconnect() => billingClient.endConnection();
-
   /// Query the product detail list.
   ///
   /// This method only returns [ProductDetailsResponse].

--- a/packages/in_app_purchase/lib/src/in_app_purchase/google_play_connection.dart
+++ b/packages/in_app_purchase/lib/src/in_app_purchase/google_play_connection.dart
@@ -174,9 +174,7 @@ class GooglePlayConnection
   }
 
   Future<void> _connect() =>
-      billingClient.startConnection(onBillingServiceDisconnected: () {
-        print('billing service disconnectd');
-      });
+      billingClient.startConnection(onBillingServiceDisconnected: () {});
 
   Future<void> _disconnect() => billingClient.endConnection();
 

--- a/packages/in_app_purchase/lib/src/in_app_purchase/google_play_connection.dart
+++ b/packages/in_app_purchase/lib/src/in_app_purchase/google_play_connection.dart
@@ -161,19 +161,6 @@ class GooglePlayConnection
         'The method <refreshPurchaseVerificationData> only works on iOS.');
   }
 
-  @override
-  void didChangeAppLifecycleState(AppLifecycleState state) {
-    switch (state) {
-      case AppLifecycleState.paused:
-        _disconnect();
-        break;
-      case AppLifecycleState.resumed:
-        _readyFuture = _connect();
-        break;
-      default:
-    }
-  }
-
   @visibleForTesting
   static void reset() => _instance = null;
 
@@ -187,7 +174,9 @@ class GooglePlayConnection
   }
 
   Future<void> _connect() =>
-      billingClient.startConnection(onBillingServiceDisconnected: () {});
+      billingClient.startConnection(onBillingServiceDisconnected: () {
+        print('billing service disconnectd');
+      });
 
   Future<void> _disconnect() => billingClient.endConnection();
 

--- a/packages/in_app_purchase/test/in_app_purchase_connection/google_play_connection_test.dart
+++ b/packages/in_app_purchase/test/in_app_purchase_connection/google_play_connection_test.dart
@@ -56,18 +56,6 @@ void main() {
     test('connects on initialization', () {
       expect(stubPlatform.countPreviousCalls(startConnectionCall), equals(1));
     });
-
-    test('disconnects on app pause', () {
-      expect(stubPlatform.countPreviousCalls(endConnectionCall), equals(0));
-      connection.didChangeAppLifecycleState(AppLifecycleState.paused);
-      expect(stubPlatform.countPreviousCalls(endConnectionCall), equals(1));
-    });
-
-    test('reconnects on app resume', () {
-      expect(stubPlatform.countPreviousCalls(startConnectionCall), equals(1));
-      connection.didChangeAppLifecycleState(AppLifecycleState.resumed);
-      expect(stubPlatform.countPreviousCalls(startConnectionCall), equals(2));
-    });
   });
 
   group('isAvailable', () {


### PR DESCRIPTION
## Description

Fixes a bug that the plugin disconnect the billing client at an inappropriate place. Also fixed some minor compiling warnings.

## Related Issues

https://github.com/flutter/flutter/issues/33210

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
