### PR TITLE
[e2e] Test multiple failure behavior

### DIFF
--- a/packages/e2e/CHANGELOG.md
+++ b/packages/e2e/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.3+1
+
+* Added a driver test for failure behavior.
+
 ## 0.2.3
 
 * Updates `E2EPlugin` and add skeleton iOS test case `E2EIosTest`.

--- a/packages/e2e/example/pubspec.yaml
+++ b/packages/e2e/example/pubspec.yaml
@@ -22,6 +22,7 @@ dev_dependencies:
     path: ../
   e2e_macos:
     path: ../e2e_macos
+  test: any
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/packages/e2e/example/test_driver/failure_e2e.dart
+++ b/packages/e2e/example/test_driver/failure_e2e.dart
@@ -1,0 +1,41 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io' show Platform;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:e2e/e2e.dart';
+
+import 'package:e2e_example/main.dart';
+
+// Tests the failure behavior of the E2EWidgetsFlutterBinding
+//
+// This test fails intentionally! It should be run using a test runner that
+// expects failure.
+void main() {
+  E2EWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('success', (WidgetTester tester) async {
+    expect(1+1, 2); // This should pass
+  });
+
+  testWidgets('failure 1', (WidgetTester tester) async {
+    // Build our app and trigger a frame.
+    await tester.pumpWidget(MyApp());
+
+    // Verify that platform version is retrieved.
+    expect(
+      find.byWidgetPredicate(
+            (Widget widget) =>
+        widget is Text &&
+            widget.data.startsWith('This should fail'),
+      ),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('failure 2', (WidgetTester tester) async {
+    expect(1+1, 3); // This should fail
+  });
+}

--- a/packages/e2e/example/test_driver/failure_e2e.dart
+++ b/packages/e2e/example/test_driver/failure_e2e.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io' show Platform;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:e2e/e2e.dart';
@@ -17,7 +16,7 @@ void main() {
   E2EWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets('success', (WidgetTester tester) async {
-    expect(1+1, 2); // This should pass
+    expect(1 + 1, 2); // This should pass
   });
 
   testWidgets('failure 1', (WidgetTester tester) async {
@@ -27,15 +26,14 @@ void main() {
     // Verify that platform version is retrieved.
     expect(
       find.byWidgetPredicate(
-            (Widget widget) =>
-        widget is Text &&
-            widget.data.startsWith('This should fail'),
+        (Widget widget) =>
+            widget is Text && widget.data.startsWith('This should fail'),
       ),
       findsOneWidget,
     );
   });
 
   testWidgets('failure 2', (WidgetTester tester) async {
-    expect(1+1, 3); // This should fail
+    expect(1 + 1, 3); // This should fail
   });
 }

--- a/packages/e2e/example/test_driver/failure_e2e_test.dart
+++ b/packages/e2e/example/test_driver/failure_e2e_test.dart
@@ -1,0 +1,19 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_driver/flutter_driver.dart';
+import 'package:test/test.dart';
+
+Future<void> main() async {
+  test('fails gracefully', () async {
+    final FlutterDriver driver = await FlutterDriver.connect();
+    final String result =
+        await driver.requestData(null, timeout: const Duration(minutes: 1));
+    await driver.close();
+    expect(
+      result,
+      'failure',
+      skip: true, // https://github.com/flutter/flutter/issues/48601
+    );
+  });
+}

--- a/packages/e2e/example/test_driver/failure_e2e_test.dart
+++ b/packages/e2e/example/test_driver/failure_e2e_test.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter_driver/flutter_driver.dart';
 import 'package:test/test.dart';

--- a/packages/e2e/pubspec.yaml
+++ b/packages/e2e/pubspec.yaml
@@ -1,6 +1,6 @@
 name: e2e
 description: Runs tests that use the flutter_test API as integration tests.
-version: 0.2.3
+version: 0.2.3+1
 homepage: https://github.com/flutter/plugins/tree/master/packages/e2e
 
 environment:


### PR DESCRIPTION
## Description

Adds a skipped integration test for flutter/flutter#48601.

Will be fixed by https://github.com/flutter/plugins/pull/2465

Note: Right now the plugins CI only runs e2e driver tests on iOS. However, this should be sufficient to exercise the fix for flutter/flutter#48601.

## Related Issues

https://github.com/flutter/flutter/issues/48601
