### PR TITLE
[webview_flutter] Remove the upper bound from the Flutter SDK constraint

### DIFF
--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.3.19+7
 
-* Remove the Flutter SDK contraint upper bound.
+* Remove the Flutter SDK constraint upper bound.
 
 ## 0.3.19+6
 

--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.19+7
+
+* Remove the Flutter SDK contraint upper bound.
+
 ## 0.3.19+6
 
 * Enable opening links that target the "_blank" window (links open in same window).

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -1,11 +1,11 @@
 name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
-version: 0.3.19+6
+version: 0.3.19+7
 homepage: https://github.com/flutter/plugins/tree/master/packages/webview_flutter
 
 environment:
   sdk: ">=2.0.0-dev.68.0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.5 <2.0.0"
+  flutter: ">=1.12.13+hotfix.5"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Description

As the Flutter SDK does not follow semver, an upper bound has no semantic meaning.

Using this plugin as a canary to check if anything breaks when we remove this bound.
