### PR TITLE
[video_player] Made the video_player clean up after itself on iOS.

### DIFF
--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.8
+
+* Added support for cleaning up the plugin if used for add-to-app.
+
 ## 0.10.7
 
 * `VideoPlayerController` support for reading closed caption files. 

--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.10.8
 
-* Added support for cleaning up the plugin if used for add-to-app.
+* Added support for cleaning up the plugin if used for add-to-app (Flutter
+  v1.15.3 is required for that feature).
 
 ## 0.10.7
 

--- a/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m
@@ -390,6 +390,9 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
   return nil;
 }
 
+/// This method allows you to dispose without touching the event channel.  This
+/// is useful for the case where the Engine is in the process of deconstruction
+/// so the channel is going to die or is already dead.
 - (void)disposeSansEventChannel {
   _disposed = true;
   [_displayLink invalidate];
@@ -422,7 +425,6 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 @property(readonly, weak, nonatomic) NSObject<FlutterBinaryMessenger>* messenger;
 @property(readonly, nonatomic) NSMutableDictionary* players;
 @property(readonly, weak, nonatomic) NSObject<FlutterPluginRegistrar>* registrar;
-
 @end
 
 @implementation FLTVideoPlayerPlugin

--- a/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m
@@ -6,6 +6,10 @@
 #import <AVFoundation/AVFoundation.h>
 #import <GLKit/GLKit.h>
 
+#if !__has_feature(objc_arc)
+#error Code Requires ARC.
+#endif
+
 int64_t FLTCMTimeToMillis(CMTime time) {
   if (time.timescale == 0) return 0;
   return time.value * 1000 / time.timescale;
@@ -13,7 +17,7 @@ int64_t FLTCMTimeToMillis(CMTime time) {
 
 @interface FLTFrameUpdater : NSObject
 @property(nonatomic) int64_t textureId;
-@property(nonatomic, readonly) NSObject<FlutterTextureRegistry>* registry;
+@property(nonatomic, weak, readonly) NSObject<FlutterTextureRegistry>* registry;
 - (void)onDisplayLink:(CADisplayLink*)link;
 @end
 
@@ -386,7 +390,7 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
   return nil;
 }
 
-- (void)dispose {
+- (void)disposeSansEventChannel {
   _disposed = true;
   [_displayLink invalidate];
   [[_player currentItem] removeObserver:self forKeyPath:@"status" context:statusContext];
@@ -404,16 +408,20 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
                                 context:playbackBufferFullContext];
   [_player replaceCurrentItemWithPlayerItem:nil];
   [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+- (void)dispose {
+  [self disposeSansEventChannel];
   [_eventChannel setStreamHandler:nil];
 }
 
 @end
 
 @interface FLTVideoPlayerPlugin ()
-@property(readonly, nonatomic) NSObject<FlutterTextureRegistry>* registry;
-@property(readonly, nonatomic) NSObject<FlutterBinaryMessenger>* messenger;
+@property(readonly, weak, nonatomic) NSObject<FlutterTextureRegistry>* registry;
+@property(readonly, weak, nonatomic) NSObject<FlutterBinaryMessenger>* messenger;
 @property(readonly, nonatomic) NSMutableDictionary* players;
-@property(readonly, nonatomic) NSObject<FlutterPluginRegistrar>* registrar;
+@property(readonly, weak, nonatomic) NSObject<FlutterPluginRegistrar>* registrar;
 
 @end
 
@@ -424,6 +432,7 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
                                   binaryMessenger:[registrar messenger]];
   FLTVideoPlayerPlugin* instance = [[FLTVideoPlayerPlugin alloc] initWithRegistrar:registrar];
   [registrar addMethodCallDelegate:instance channel:channel];
+  [registrar publish:instance];
 }
 
 - (instancetype)initWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
@@ -434,6 +443,14 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
   _registrar = registrar;
   _players = [NSMutableDictionary dictionaryWithCapacity:1];
   return self;
+}
+
+- (void)detachFromEngineForRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
+  for (NSNumber* textureId in _players.allKeys) {
+    FLTVideoPlayer* player = _players[textureId];
+    [player disposeSansEventChannel];
+  }
+  [_players removeAllObjects];
 }
 
 - (void)onPlayerSetup:(FLTVideoPlayer*)player
@@ -485,7 +502,6 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     } else {
       result(FlutterMethodNotImplemented);
     }
-
   } else {
     NSDictionary* argsMap = call.arguments;
     int64_t textureId = ((NSNumber*)argsMap[@"textureId"]).unsignedIntegerValue;

--- a/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m
@@ -423,8 +423,8 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 @interface FLTVideoPlayerPlugin ()
 @property(readonly, weak, nonatomic) NSObject<FlutterTextureRegistry>* registry;
 @property(readonly, weak, nonatomic) NSObject<FlutterBinaryMessenger>* messenger;
-@property(readonly, nonatomic) NSMutableDictionary* players;
-@property(readonly, weak, nonatomic) NSObject<FlutterPluginRegistrar>* registrar;
+@property(readonly, strong, nonatomic) NSMutableDictionary* players;
+@property(readonly, strong, nonatomic) NSObject<FlutterPluginRegistrar>* registrar;
 @end
 
 @implementation FLTVideoPlayerPlugin

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -1,7 +1,7 @@
 name: video_player
 description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android and iOS.
-version: 0.10.7
+version: 0.10.8
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player
 
 flutter:


### PR DESCRIPTION
## Description

For add-to-app users of video_player, the plugin doesn't clean up its resources, like it's display link which causes a crash.  This handles the event that we are detaching the plugin and cleans everything up as a result.

## Related Issues

https://github.com/flutter/flutter/issues/50761

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
