### PR TITLE
[webview_flutter] Add Android support for scaling a web page

### DIFF
--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -158,9 +158,6 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
       case "getTitle":
         getTitle(result);
         break;
-      case "setInitialScale":
-        setInitialScale(methodCall, result);
-        break;
       default:
         result.notImplemented();
     }
@@ -257,12 +254,6 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
     result.success(webView.getTitle());
   }
 
-  private void setInitialScale(MethodCall methodCall, Result result) {
-    final Integer scaleInPercent = (Integer) methodCall.arguments;
-    webView.setInitialScale(scaleInPercent);
-    result.success(null);
-  }
-
   private void applySettings(Map<String, Object> settings) {
     for (String key : settings.keySet()) {
       switch (key) {
@@ -286,6 +277,10 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
           break;
         case "userAgent":
           updateUserAgent((String) settings.get(key));
+          break;
+        case "initialScale":
+          final Double initialScale = (Double) settings.get(key);
+          webView.setInitialScale(initialScale.intValue());
           break;
         default:
           throw new IllegalArgumentException("Unknown WebView setting: " + key);

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -158,6 +158,9 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
       case "getTitle":
         getTitle(result);
         break;
+      case "setInitialScale":
+        setInitialScale(methodCall, result);
+        break;
       default:
         result.notImplemented();
     }
@@ -252,6 +255,12 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
 
   private void getTitle(Result result) {
     result.success(webView.getTitle());
+  }
+
+  private void setInitialScale(MethodCall methodCall, Result result) {
+    final Integer scaleInPercent = (Integer) methodCall.arguments;
+    webView.setInitialScale(scaleInPercent);
+    result.success(null);
   }
 
   private void applySettings(Map<String, Object> settings) {

--- a/packages/webview_flutter/example/test_driver/webview_flutter_e2e.dart
+++ b/packages/webview_flutter/example/test_driver/webview_flutter_e2e.dart
@@ -563,7 +563,7 @@ void main() {
       () => controller.setInitialScale(150),
       throwsA(isA<AssertionError>()),
     );
-  });
+  }, skip: defaultTargetPlatform != TargetPlatform.android);
 
   group('NavigationDelegate', () {
     final String blankPage = "<!DOCTYPE html><head></head><body></body></html>";

--- a/packages/webview_flutter/example/test_driver/webview_flutter_e2e.dart
+++ b/packages/webview_flutter/example/test_driver/webview_flutter_e2e.dart
@@ -536,6 +536,35 @@ void main() {
     expect(title, 'Some title');
   });
 
+  testWidgets('setInitialScale', (WidgetTester tester) async {
+    final Completer<WebViewController> controllerCompleter =
+        Completer<WebViewController>();
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: WebView(
+          key: GlobalKey(),
+          initialUrl: 'https://flutter.dev/',
+          onWebViewCreated: (WebViewController controller) {
+            controllerCompleter.complete(controller);
+          },
+        ),
+      ),
+    );
+
+    final WebViewController controller = await controllerCompleter.future;
+    expect(controller.setInitialScale(50), completes);
+    expect(
+      () => controller.setInitialScale(-1),
+      throwsA(isA<AssertionError>()),
+    );
+    expect(
+      () => controller.setInitialScale(150),
+      throwsA(isA<AssertionError>()),
+    );
+  });
+
   group('NavigationDelegate', () {
     final String blankPage = "<!DOCTYPE html><head></head><body></body></html>";
     final String blankPageEncoded = 'data:text/html;charset=utf-8;base64,' +

--- a/packages/webview_flutter/lib/platform_interface.dart
+++ b/packages/webview_flutter/lib/platform_interface.dart
@@ -168,6 +168,25 @@ abstract class WebViewPlatformController {
         "WebView getTitle is not implemented on the current platform");
   }
 
+  /// Sets the initial scale of page content.
+  ///
+  /// Only supported on Android.
+  ///
+  /// [scaleInPercent] must be between 0 and 100 inclusive.
+  ///
+  /// The behavior for the default initial scale depends on whether the WebView
+  /// supports the "viewport" HTML meta tag, whether the WebView is set to use a
+  /// wide viewport, and whether the WebView loads pages in overview mode, that
+  /// is, zooms out the content to fit on screen by width.
+  ///
+  /// If the content fits into the WebView control by width, then the zoom is
+  /// set to 100%. When loading wide content and the WebView is supporting wide
+  /// content, the content will be zoomed out to be fit by width into the
+  /// WebView control, otherwise not. If initial scale is greater than 0,
+  /// WebView starts with this value as initial scale.
+  ///
+  /// Please note that unlike the scale properties in the viewport meta tag,
+  /// this method doesn't take the screen density into account.
   Future<void> setInitialScale(int scaleInPercent) {
     throw UnimplementedError(
         "WebView setInitialScale is not implemented on the current platform");

--- a/packages/webview_flutter/lib/platform_interface.dart
+++ b/packages/webview_flutter/lib/platform_interface.dart
@@ -167,6 +167,11 @@ abstract class WebViewPlatformController {
     throw UnimplementedError(
         "WebView getTitle is not implemented on the current platform");
   }
+
+  Future<void> setInitialScale(int scaleInPercent) {
+    throw UnimplementedError(
+        "WebView setInitialScale is not implemented on the current platform");
+  }
 }
 
 /// A single setting for configuring a WebViewPlatform which may be absent.

--- a/packages/webview_flutter/lib/platform_interface.dart
+++ b/packages/webview_flutter/lib/platform_interface.dart
@@ -167,30 +167,6 @@ abstract class WebViewPlatformController {
     throw UnimplementedError(
         "WebView getTitle is not implemented on the current platform");
   }
-
-  /// Sets the initial scale of page content.
-  ///
-  /// Only supported on Android.
-  ///
-  /// [scaleInPercent] must be between 0 and 100 inclusive.
-  ///
-  /// The behavior for the default initial scale depends on whether the WebView
-  /// supports the "viewport" HTML meta tag, whether the WebView is set to use a
-  /// wide viewport, and whether the WebView loads pages in overview mode, that
-  /// is, zooms out the content to fit on screen by width.
-  ///
-  /// If the content fits into the WebView control by width, then the zoom is
-  /// set to 100%. When loading wide content and the WebView is supporting wide
-  /// content, the content will be zoomed out to be fit by width into the
-  /// WebView control, otherwise not. If initial scale is greater than 0,
-  /// WebView starts with this value as initial scale.
-  ///
-  /// Please note that unlike the scale properties in the viewport meta tag,
-  /// this method doesn't take the screen density into account.
-  Future<void> setInitialScale(int scaleInPercent) {
-    throw UnimplementedError(
-        "WebView setInitialScale is not implemented on the current platform");
-  }
 }
 
 /// A single setting for configuring a WebViewPlatform which may be absent.
@@ -256,8 +232,11 @@ class WebSettings {
     this.hasNavigationDelegate,
     this.debuggingEnabled,
     this.gestureNavigationEnabled,
+    this.initialScale,
     @required this.userAgent,
-  }) : assert(userAgent != null);
+  })  : assert(initialScale == null || initialScale >= 0),
+        assert(initialScale == null || initialScale <= 100),
+        assert(userAgent != null);
 
   /// The JavaScript execution mode to be used by the webview.
   final JavascriptMode javascriptMode;
@@ -285,9 +264,30 @@ class WebSettings {
   /// See also: [WebView.gestureNavigationEnabled]
   final bool gestureNavigationEnabled;
 
+  /// Sets the initial scale of page content.
+  ///
+  /// Only supported on Android.
+  ///
+  /// Must be between 0 and 100 inclusive.
+  ///
+  /// The behavior for the default initial scale depends on whether the WebView
+  /// supports the "viewport" HTML meta tag, whether the WebView is set to use a
+  /// wide viewport, and whether the WebView loads pages in overview mode, that
+  /// is, zooms out the content to fit on screen by width.
+  ///
+  /// If the content fits into the WebView control by width, then the zoom is
+  /// set to 100%. When loading wide content and the WebView is supporting wide
+  /// content, the content will be zoomed out to be fit by width into the
+  /// WebView control, otherwise not. If initial scale is greater than 0,
+  /// WebView starts with this value as initial scale.
+  ///
+  /// Please note that unlike the scale properties in the viewport meta tag,
+  /// this method doesn't take the screen density into account.
+  final double initialScale;
+
   @override
   String toString() {
-    return 'WebSettings(javascriptMode: $javascriptMode, hasNavigationDelegate: $hasNavigationDelegate, debuggingEnabled: $debuggingEnabled, gestureNavigationEnabled: $gestureNavigationEnabled, userAgent: $userAgent)';
+    return 'WebSettings(javascriptMode: $javascriptMode, hasNavigationDelegate: $hasNavigationDelegate, debuggingEnabled: $debuggingEnabled, gestureNavigationEnabled: $gestureNavigationEnabled, userAgent: $userAgent, initialScale: $initialScale)';
   }
 }
 

--- a/packages/webview_flutter/lib/src/webview_method_channel.dart
+++ b/packages/webview_flutter/lib/src/webview_method_channel.dart
@@ -157,4 +157,9 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
       'autoMediaPlaybackPolicy': creationParams.autoMediaPlaybackPolicy.index,
     };
   }
+
+  @override
+  Future<void> setInitialScale(int scaleInPercent) {
+    return _channel.invokeMethod<void>("setInitialScale", scaleInPercent);
+  }
 }

--- a/packages/webview_flutter/lib/src/webview_method_channel.dart
+++ b/packages/webview_flutter/lib/src/webview_method_channel.dart
@@ -138,7 +138,10 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
     _addIfNonNull('hasNavigationDelegate', settings.hasNavigationDelegate);
     _addIfNonNull('debuggingEnabled', settings.debuggingEnabled);
     _addIfNonNull(
-        'gestureNavigationEnabled', settings.gestureNavigationEnabled);
+      'gestureNavigationEnabled',
+      settings.gestureNavigationEnabled,
+    );
+    _addIfNonNull('initialScale', settings.initialScale);
     _addSettingIfPresent('userAgent', settings.userAgent);
     return map;
   }
@@ -148,7 +151,8 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
   /// This is used for the `creationParams` argument of the platform views created by
   /// [AndroidWebViewBuilder] and [CupertinoWebViewBuilder].
   static Map<String, dynamic> creationParamsToMap(
-      CreationParams creationParams) {
+    CreationParams creationParams,
+  ) {
     return <String, dynamic>{
       'initialUrl': creationParams.initialUrl,
       'settings': _webSettingsToMap(creationParams.webSettings),
@@ -156,10 +160,5 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
       'userAgent': creationParams.userAgent,
       'autoMediaPlaybackPolicy': creationParams.autoMediaPlaybackPolicy.index,
     };
-  }
-
-  @override
-  Future<void> setInitialScale(int scaleInPercent) {
-    return _channel.invokeMethod<void>("setInitialScale", scaleInPercent);
   }
 }

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -660,7 +660,28 @@ class WebViewController {
     return _webViewPlatformController.getTitle();
   }
 
+  /// Sets the initial scale of page content.
+  ///
+  /// Only supported on Android.
+  ///
+  /// [scaleInPercent] must be between 0 and 100 inclusive.
+  ///
+  /// The behavior for the default initial scale depends on whether the WebView
+  /// supports the "viewport" HTML meta tag, whether the WebView is set to use a
+  /// wide viewport, and whether the WebView loads pages in overview mode, that
+  /// is, zooms out the content to fit on screen by width.
+  ///
+  /// If the content fits into the WebView control by width, then the zoom is
+  /// set to 100%. When loading wide content and the WebView is supporting wide
+  /// content, the content will be zoomed out to be fit by width into the
+  /// WebView control, otherwise not. If initial scale is greater than 0,
+  /// WebView starts with this value as initial scale.
+  ///
+  /// Please note that unlike the scale properties in the viewport meta tag,
+  /// this method doesn't take the screen density into account.
   Future<void> setInitialScale(int scaleInPercent) {
+    assert(scaleInPercent >= 0);
+    assert(scaleInPercent <= 100);
     return _webViewPlatformController.setInitialScale(scaleInPercent);
   }
 }

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -659,6 +659,10 @@ class WebViewController {
   Future<String> getTitle() {
     return _webViewPlatformController.getTitle();
   }
+
+  Future<void> setInitialScale(int scaleInPercent) {
+    return _webViewPlatformController.setInitialScale(scaleInPercent);
+  }
 }
 
 /// Manages cookies pertaining to all [WebView]s.

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -152,6 +152,7 @@ class WebView extends StatefulWidget {
     this.userAgent,
     this.initialMediaPlaybackPolicy =
         AutoMediaPlaybackPolicy.require_user_action_for_all_media_types,
+    this.initialScale,
   })  : assert(javascriptMode != null),
         assert(initialMediaPlaybackPolicy != null),
         super(key: key);
@@ -319,6 +320,27 @@ class WebView extends StatefulWidget {
   /// The default policy is [AutoMediaPlaybackPolicy.require_user_action_for_all_media_types].
   final AutoMediaPlaybackPolicy initialMediaPlaybackPolicy;
 
+  /// Sets the initial scale of page content.
+  ///
+  /// Only supported on Android.
+  ///
+  /// Must be between 0 and 100 inclusive.
+  ///
+  /// The behavior for the default initial scale depends on whether the WebView
+  /// supports the "viewport" HTML meta tag, whether the WebView is set to use a
+  /// wide viewport, and whether the WebView loads pages in overview mode, that
+  /// is, zooms out the content to fit on screen by width.
+  ///
+  /// If the content fits into the WebView control by width, then the zoom is
+  /// set to 100%. When loading wide content and the WebView is supporting wide
+  /// content, the content will be zoomed out to be fit by width into the
+  /// WebView control, otherwise not. If initial scale is greater than 0,
+  /// WebView starts with this value as initial scale.
+  ///
+  /// Please note that unlike the scale properties in the viewport meta tag,
+  /// this method doesn't take the screen density into account.
+  final double initialScale;
+
   @override
   State<StatefulWidget> createState() => _WebViewState();
 }
@@ -393,12 +415,15 @@ WebSettings _webSettingsFromWidget(WebView widget) {
     debuggingEnabled: widget.debuggingEnabled,
     gestureNavigationEnabled: widget.gestureNavigationEnabled,
     userAgent: WebSetting<String>.of(widget.userAgent),
+    initialScale: widget.initialScale,
   );
 }
 
 // This method assumes that no fields in `currentValue` are null.
 WebSettings _clearUnchangedWebSettings(
-    WebSettings currentValue, WebSettings newValue) {
+  WebSettings currentValue,
+  WebSettings newValue,
+) {
   assert(currentValue.javascriptMode != null);
   assert(currentValue.hasNavigationDelegate != null);
   assert(currentValue.debuggingEnabled != null);
@@ -406,11 +431,13 @@ WebSettings _clearUnchangedWebSettings(
   assert(newValue.javascriptMode != null);
   assert(newValue.hasNavigationDelegate != null);
   assert(newValue.debuggingEnabled != null);
+  assert(newValue.initialScale != null);
   assert(newValue.userAgent.isPresent);
 
   JavascriptMode javascriptMode;
   bool hasNavigationDelegate;
   bool debuggingEnabled;
+  double initialScale;
   WebSetting<String> userAgent = WebSetting<String>.absent();
   if (currentValue.javascriptMode != newValue.javascriptMode) {
     javascriptMode = newValue.javascriptMode;
@@ -421,6 +448,9 @@ WebSettings _clearUnchangedWebSettings(
   if (currentValue.debuggingEnabled != newValue.debuggingEnabled) {
     debuggingEnabled = newValue.debuggingEnabled;
   }
+  if (currentValue.initialScale != newValue.initialScale) {
+    initialScale = newValue.initialScale;
+  }
   if (currentValue.userAgent != newValue.userAgent) {
     userAgent = newValue.userAgent;
   }
@@ -430,6 +460,7 @@ WebSettings _clearUnchangedWebSettings(
     hasNavigationDelegate: hasNavigationDelegate,
     debuggingEnabled: debuggingEnabled,
     userAgent: userAgent,
+    initialScale: initialScale,
   );
 }
 
@@ -658,32 +689,6 @@ class WebViewController {
   /// Returns the title of the currently loaded page.
   Future<String> getTitle() {
     return _webViewPlatformController.getTitle();
-  }
-
-  /// Sets the initial scale of page content.
-  ///
-  /// Only supported on Android.
-  ///
-  /// [scaleInPercent] must be between 0 and 100 inclusive.
-  ///
-  /// The behavior for the default initial scale depends on whether the WebView
-  /// supports the "viewport" HTML meta tag, whether the WebView is set to use a
-  /// wide viewport, and whether the WebView loads pages in overview mode, that
-  /// is, zooms out the content to fit on screen by width.
-  ///
-  /// If the content fits into the WebView control by width, then the zoom is
-  /// set to 100%. When loading wide content and the WebView is supporting wide
-  /// content, the content will be zoomed out to be fit by width into the
-  /// WebView control, otherwise not. If initial scale is greater than 0,
-  /// WebView starts with this value as initial scale.
-  ///
-  /// Please note that unlike the scale properties in the viewport meta tag,
-  /// this method doesn't take the screen density into account.
-  Future<void> setInitialScale(int scaleInPercent) {
-    assert(scaleInPercent >= 0);
-    assert(scaleInPercent <= 100);
-    assert(defaultTargetPlatform == TargetPlatform.android);
-    return _webViewPlatformController.setInitialScale(scaleInPercent);
   }
 }
 

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -682,6 +682,7 @@ class WebViewController {
   Future<void> setInitialScale(int scaleInPercent) {
     assert(scaleInPercent >= 0);
     assert(scaleInPercent <= 100);
+    assert(defaultTargetPlatform == TargetPlatform.android);
     return _webViewPlatformController.setInitialScale(scaleInPercent);
   }
 }


### PR DESCRIPTION
## Description

Adds Android support for scaling a web page. 

I have not been able to find a simple equivalent method for [WKWebview](https://developer.apple.com/documentation/webkit/wkwebview?language=objc) on iOS.

Some explored options:
* [setMagnification:centeredAtPoint:](https://developer.apple.com/documentation/webkit/wkwebview/1414996-setmagnification?language=objc) is only supported on Mac 10+.
* [UIScrollView.zoomScale](https://developer.apple.com/documentation/uikit/uiscrollview/1619419-zoomscale?language=objc). This only sets the zoom of the Webview.
* [scalePageToFit](https://developer.apple.com/documentation/uikit/uiwebview/1617950-scalespagetofit?language=objc) in conjunction with zoom. Only supported for [UIWebView](https://developer.apple.com/documentation/uikit/uiwebview?language=objc), while we use `WKWebView`. `UIWebView` is now deprecated.
* Adding width `viewport` meta tag: https://stackoverflow.com/a/26583062/9711864. I believe this could work, but I haven't tested it.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/50837

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
