### PR TITLE
[camera][in_app_purchase] Fix pedantic dependency. Remove `pubspec.yaml` in root folder.

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:pedantic/analysis_options.1.8.0.yaml
+include: package:pedantic/analysis_options.1.9.0.yaml
 analyzer:
   exclude:
     # Ignore generated files

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:pedantic/analysis_options.1.9.0.yaml
+include: package:pedantic/analysis_options.1.8.0.yaml
 analyzer:
   exclude:
     # Ignore generated files

--- a/packages/camera/CHANGELOG.md
+++ b/packages/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.7+4
+
+* Add `pedantic` to dev_dependency.
+
 ## 0.5.7+3
 
 * Fix an Android crash when permissions are requested multiple times.

--- a/packages/camera/example/pubspec.yaml
+++ b/packages/camera/example/pubspec.yaml
@@ -15,7 +15,7 @@ dev_dependencies:
     sdk: flutter
   flutter_driver:
     sdk: flutter
-  pedantic: ^1.9.0
+  pedantic: ^1.8.0
 
 flutter:
   uses-material-design: true

--- a/packages/camera/example/pubspec.yaml
+++ b/packages/camera/example/pubspec.yaml
@@ -15,6 +15,7 @@ dev_dependencies:
     sdk: flutter
   flutter_driver:
     sdk: flutter
+  pedantic: ^1.9.0
 
 flutter:
   uses-material-design: true

--- a/packages/camera/pubspec.yaml
+++ b/packages/camera/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera
 description: A Flutter plugin for getting information about and controlling the
   camera on Android and iOS. Supports previewing the camera feed, capturing images, capturing video,
   and streaming image buffers to dart.
-version: 0.5.7+3
+version: 0.5.7+4
 
 homepage: https://github.com/flutter/plugins/tree/master/packages/camera
 
@@ -17,6 +17,7 @@ dev_dependencies:
     sdk: flutter
   flutter_driver:
     sdk: flutter
+  pedantic: ^1.9.0
 
 flutter:
   plugin:

--- a/packages/camera/pubspec.yaml
+++ b/packages/camera/pubspec.yaml
@@ -17,7 +17,7 @@ dev_dependencies:
     sdk: flutter
   flutter_driver:
     sdk: flutter
-  pedantic: ^1.9.0
+  pedantic: ^1.8.0
 
 flutter:
   plugin:

--- a/packages/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1+1
+
+* Add `pedantic` to dev_dependency.
+
 ## 0.3.1
 
 * Android: Fix a bug where the `BillingClient` is disconnected when app goes to the background.

--- a/packages/in_app_purchase/example/pubspec.yaml
+++ b/packages/in_app_purchase/example/pubspec.yaml
@@ -15,6 +15,7 @@ dev_dependencies:
   in_app_purchase:
     path: ../
   e2e: ^0.2.0
+  pedantic: ^1.9.0
 
 flutter:
   uses-material-design: true

--- a/packages/in_app_purchase/example/pubspec.yaml
+++ b/packages/in_app_purchase/example/pubspec.yaml
@@ -15,7 +15,7 @@ dev_dependencies:
   in_app_purchase:
     path: ../
   e2e: ^0.2.0
-  pedantic: ^1.9.0
+  pedantic: ^1.8.0
 
 flutter:
   uses-material-design: true

--- a/packages/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/pubspec.yaml
@@ -1,7 +1,7 @@
 name: in_app_purchase
 description: A Flutter plugin for in-app purchases. Exposes APIs for making in-app purchases through the App Store and Google Play.
 homepage: https://github.com/flutter/plugins/tree/master/packages/in_app_purchase
-version: 0.3.1
+version: 0.3.1+1
 
 
 dependencies:
@@ -24,6 +24,7 @@ dev_dependencies:
   test: ^1.5.2
   shared_preferences: ^0.5.2
   e2e: ^0.2.0
+  pedantic: ^1.9.0
 
 flutter:
   plugin:

--- a/packages/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/pubspec.yaml
@@ -24,7 +24,7 @@ dev_dependencies:
   test: ^1.5.2
   shared_preferences: ^0.5.2
   e2e: ^0.2.0
-  pedantic: ^1.9.0
+  pedantic: ^1.8.0
 
 flutter:
   plugin:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,0 @@
-# This only exists so that we can include pedantic in the top level
-# analysis_options.yaml. Each plugin should be published from its own
-# subdirectory underneath packages/.
-name: flutter_plugins
-dev_dependencies:
-  pedantic: 1.8.0
-publish_to: none


### PR DESCRIPTION
## Description

The `./pubspec.yaml` doesn't ensure dependency for individual plugins. The `./pubspec.yaml` is not used anywhere, this PR remove the file.

`camera` and `in_app_purchase` needs to depend on `pedantic` because they implement custom rules which overrides the `./analysis_options.yaml`.

## Related Issues

https://github.com/flutter/flutter/issues/45440

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
