### PR TITLE
[e2e] fix flutter driver code snippet in readme and improve formatting of code snippets

### DIFF
--- a/packages/e2e/CHANGELOG.md
+++ b/packages/e2e/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.4+3
+
+* Fixed code snippet in the readme under the "Using Flutter driver to run tests" section.
+
 ## 0.2.4+2
 
 * Make the pedantic dev_dependency explicit.

--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -41,12 +41,15 @@ Note that the tests don't use the `FlutterDriver` API, they use `testWidgets` in
 
 Put the a file named `<package_name>_e2e_test.dart` in the app' `test_driver` directory:
 
-```
+```dart
+import 'dart:async';
+import 'dart:io';
 import 'package:flutter_driver/flutter_driver.dart';
 
 Future<void> main() async {
   final FlutterDriver driver = await FlutterDriver.connect();
-  await driver.requestData(null, timeout: const Duration(minutes: 1));
+  final String result =
+      await driver.requestData(null, timeout: const Duration(minutes: 1));
   await driver.close();
   exit(result == 'pass' ? 0 : 1);
 }
@@ -73,7 +76,7 @@ Create an instrumentation test file in your application's
 com, example, and myapp with values from your app's package name). You can name
 this test file MainActivityTest.java or another name of your choice.
 
-```
+```java
 package com.example.myapp;
 
 import androidx.test.rule.ActivityTestRule;

--- a/packages/e2e/pubspec.yaml
+++ b/packages/e2e/pubspec.yaml
@@ -1,6 +1,6 @@
 name: e2e
 description: Runs tests that use the flutter_test API as integration tests.
-version: 0.2.4+2
+version: 0.2.4+3
 homepage: https://github.com/flutter/plugins/tree/master/packages/e2e
 
 environment:


### PR DESCRIPTION
## Description

The readme documentation has for the `e2e` package has a code snippet on how to create a test using Flutter driver. Copying the code snippet there doesn't work as it is incomplete due to missing imports and doesn't declare a variable that is referenced later on.

## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.