### PR TITLE
[url_launcher] fix: url_launcher - updated _launchUniversalLinkIos and Added Tests

### DIFF
--- a/packages/url_launcher/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.4.3
+
+* Fixed the launchUniversalLinkIos method.
+
 ## 5.4.2
 
 * Make the pedantic dev_dependency explicit.

--- a/packages/url_launcher/url_launcher/example/lib/main.dart
+++ b/packages/url_launcher/url_launcher/example/lib/main.dart
@@ -91,15 +91,15 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 
   Future<void> _launchUniversalLinkIos(String url) async {
-    if (await canLaunch('https://youtube.com')) {
+    if (await canLaunch(url)) {
       final bool nativeAppLaunchSucceeded = await launch(
-        'https://youtube.com',
+        url,
         forceSafariVC: false,
         universalLinksOnly: true,
       );
       if (!nativeAppLaunchSucceeded) {
         await launch(
-          'https://youtube.com',
+          url,
           forceSafariVC: true,
         );
       }

--- a/packages/url_launcher/url_launcher/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/example/pubspec.yaml
@@ -12,6 +12,8 @@ dev_dependencies:
   flutter_driver:
     sdk: flutter
   pedantic: ^1.8.0
+  mockito: ^4.1.1
+  plugin_platform_interface: ^1.0.0
 
 flutter:
   uses-material-design: true

--- a/packages/url_launcher/url_launcher/example/test/url_launcher_example_test.dart
+++ b/packages/url_launcher/url_launcher/example/test/url_launcher_example_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+import 'package:mockito/mockito.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
+import 'package:url_launcher_example/main.dart';
+
+void main() {
+  final MockUrlLauncher mock = MockUrlLauncher();
+  UrlLauncherPlatform.instance = mock;
+
+  testWidgets('Can open URLs', (WidgetTester tester) async {
+    await tester.pumpWidget(MyApp());
+    const String defaultUrl = 'https://www.cylog.org/headers/';
+    when(mock.canLaunch(defaultUrl)).thenAnswer((_) => Future.value(true));
+    const Map<String, String> defaultHeaders = {'my_header_key': 'my_header_value'};
+    verifyNever(mock.launch(defaultUrl,
+        useSafariVC: false,
+        useWebView: false,
+        enableDomStorage: false,
+        enableJavaScript: false,
+        universalLinksOnly: false,
+        headers: defaultHeaders));
+
+    Finder browserlaunchBtn = find.widgetWithText(RaisedButton, 'Launch in browser');
+    expect(browserlaunchBtn, findsOneWidget);
+    await tester.tap(browserlaunchBtn);
+
+    verify(mock.launch(defaultUrl,
+            useSafariVC: false,
+            useWebView: false,
+            enableDomStorage: false,
+            enableJavaScript: false,
+            universalLinksOnly: false,
+            headers: defaultHeaders))
+        .called(1);
+  });
+}
+
+class MockUrlLauncher extends Mock with MockPlatformInterfaceMixin implements UrlLauncherPlatform {}

--- a/packages/url_launcher/url_launcher/example/test/url_launcher_example_test.dart
+++ b/packages/url_launcher/url_launcher/example/test/url_launcher_example_test.dart
@@ -13,7 +13,9 @@ void main() {
     await tester.pumpWidget(MyApp());
     const String defaultUrl = 'https://www.cylog.org/headers/';
     when(mock.canLaunch(defaultUrl)).thenAnswer((_) => Future.value(true));
-    const Map<String, String> defaultHeaders = {'my_header_key': 'my_header_value'};
+    const Map<String, String> defaultHeaders = {
++      'my_header_key': 'my_header_value'
++    };
     verifyNever(mock.launch(defaultUrl,
         useSafariVC: false,
         useWebView: false,
@@ -22,7 +24,8 @@ void main() {
         universalLinksOnly: false,
         headers: defaultHeaders));
 
-    Finder browserlaunchBtn = find.widgetWithText(RaisedButton, 'Launch in browser');
++    Finder browserlaunchBtn =
++        find.widgetWithText(RaisedButton, 'Launch in browser');
     expect(browserlaunchBtn, findsOneWidget);
     await tester.tap(browserlaunchBtn);
 
@@ -37,4 +40,6 @@ void main() {
   });
 }
 
-class MockUrlLauncher extends Mock with MockPlatformInterfaceMixin implements UrlLauncherPlatform {}
++class MockUrlLauncher extends Mock
++    with MockPlatformInterfaceMixin
++    implements UrlLauncherPlatform {}

--- a/packages/url_launcher/url_launcher/example/test/url_launcher_example_test.dart
+++ b/packages/url_launcher/url_launcher/example/test/url_launcher_example_test.dart
@@ -14,8 +14,8 @@ void main() {
     const String defaultUrl = 'https://www.cylog.org/headers/';
     when(mock.canLaunch(defaultUrl)).thenAnswer((_) => Future.value(true));
     const Map<String, String> defaultHeaders = {
-+      'my_header_key': 'my_header_value'
-+    };
+      'my_header_key': 'my_header_value'
+    };
     verifyNever(mock.launch(defaultUrl,
         useSafariVC: false,
         useWebView: false,
@@ -24,8 +24,8 @@ void main() {
         universalLinksOnly: false,
         headers: defaultHeaders));
 
-+    Finder browserlaunchBtn =
-+        find.widgetWithText(RaisedButton, 'Launch in browser');
+    Finder browserlaunchBtn =
+        find.widgetWithText(RaisedButton, 'Launch in browser');
     expect(browserlaunchBtn, findsOneWidget);
     await tester.tap(browserlaunchBtn);
 
@@ -40,6 +40,6 @@ void main() {
   });
 }
 
-+class MockUrlLauncher extends Mock
-+    with MockPlatformInterfaceMixin
-+    implements UrlLauncherPlatform {}
+class MockUrlLauncher extends Mock
+    with MockPlatformInterfaceMixin
+    implements UrlLauncherPlatform {}

--- a/packages/url_launcher/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher
 description: Flutter plugin for launching a URL on Android and iOS. Supports
   web, phone, SMS, and email schemes.
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher
-version: 5.4.2
+version: 5.4.3
 
 flutter:
   plugin:

--- a/packages/url_launcher/url_launcher_macos/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.0.1+5
+
+* Fixed the launchUniversalLinkIos method.
+
 # 0.0.1+4
 
 * Make the pedantic dev_dependency explicit.

--- a/packages/url_launcher/url_launcher_macos/example/lib/main.dart
+++ b/packages/url_launcher/url_launcher_macos/example/lib/main.dart
@@ -90,15 +90,15 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 
   Future<void> _launchUniversalLinkIos(String url) async {
-    if (await canLaunch('https://youtube.com')) {
+    if (await canLaunch(url)) {
       final bool nativeAppLaunchSucceeded = await launch(
-        'https://youtube.com',
+        url,
         forceSafariVC: false,
         universalLinksOnly: true,
       );
       if (!nativeAppLaunchSucceeded) {
         await launch(
-          'https://youtube.com',
+          url,
           forceSafariVC: true,
         );
       }

--- a/packages/url_launcher/url_launcher_macos/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_macos/pubspec.yaml
@@ -1,6 +1,6 @@
 name: url_launcher_macos
 description: macOS implementation of the url_launcher plugin.
-version: 0.0.1+4
+version: 0.0.1+5
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher_macos
 
 flutter:


### PR DESCRIPTION


## Description

updated _launchUniversalLinkIos  to launch the url passed. It could also be done that we remove the url argument passed and open the hardcoded url. Either of the case needs to be done.
## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
