### PR TITLE
Exclude path_provider packages

### DIFF
--- a/script/build_all_plugins_app.sh
+++ b/script/build_all_plugins_app.sh
@@ -18,6 +18,8 @@ readonly EXCLUDED_PLUGINS_LIST=(
   "google_sign_in_platform_interface"
   "google_sign_in_web"
   "instrumentation_adapter"
+  "path_provider_macos"
+  "path_provider_platform_interface"
   "plugin_platform_interface"
   "shared_preferences_macos"
   "shared_preferences_platform_interface"

--- a/script/build_all_plugins_app.sh
+++ b/script/build_all_plugins_app.sh
@@ -20,6 +20,7 @@ readonly EXCLUDED_PLUGINS_LIST=(
   "instrumentation_adapter"
   "path_provider_macos"
   "path_provider_platform_interface"
+  "path_provider_web"
   "plugin_platform_interface"
   "shared_preferences_macos"
   "shared_preferences_platform_interface"


### PR DESCRIPTION
Includes `path_provider_platform_interface` `path_provider_macos` `path_provider_web` to avoid build failures caused by path dependencies.

## Related Issues

https://github.com/flutter/flutter/issues/46307

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
