### PR TITLE
[connectivity_platform_interface] Add `ConnectivityResult.unknown`.

### DIFF
--- a/packages/connectivity/connectivity_platform_interface/CHANGELOG.md
+++ b/packages/connectivity/connectivity_platform_interface/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.0
+
+* Added `ConnectivityResult.unknown`, for the cases where the plugin is unable to determine the
+connectivity status of the device. _(This happens mostly in the `web` platform.)_
+
 ## 1.0.3
 
 * Make the pedantic dev_dependency explicit.

--- a/packages/connectivity/connectivity_platform_interface/lib/src/enums.dart
+++ b/packages/connectivity/connectivity_platform_interface/lib/src/enums.dart
@@ -7,7 +7,10 @@ enum ConnectivityResult {
   mobile,
 
   /// None: Device not connected to any network
-  none
+  none,
+
+  /// Unknown: The plugin wasn't able to determine the connectivity status of the device
+  unknown,
 }
 
 /// The status of the location service authorization.

--- a/packages/connectivity/connectivity_platform_interface/lib/src/utils.dart
+++ b/packages/connectivity/connectivity_platform_interface/lib/src/utils.dart
@@ -8,8 +8,9 @@ ConnectivityResult parseConnectivityResult(String state) {
     case 'mobile':
       return ConnectivityResult.mobile;
     case 'none':
-    default:
       return ConnectivityResult.none;
+    default:
+      return ConnectivityResult.unknown;
   }
 }
 

--- a/packages/connectivity/connectivity_platform_interface/pubspec.yaml
+++ b/packages/connectivity/connectivity_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the connectivity plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/connectivity/connectivity_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.0.3
+version: 2.0.0
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Description

Some platforms might not be able to determine the connectivity status of
the device on which the app is running (like some desktop Web browsers).

This allows users of the `connectivity` plugin to distinguish between
"no connectivity" and "connectivity couldn't be determined".

This requires a Major Version bump for users of the plugin who may be
switch/case on ConnectivityResult values, since Dart forces users to be
exhaustive in those cases (if they don't have a "default" entry, this
new value becomes a compilation error in their code).

This will also cause a Major Version bump in the core `connectivity`
plugin itself. This change will happen in a separate PR.


## Related Issues

Needed for: https://github.com/flutter/plugins/pull/2545

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
