### PR TITLE
[image_picker] fix getting wrong png data from photo library on iOS 13+

### DIFF
--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.3+5
+
+* iOS: Fixes an issue where picking PNG image from Gallery would be turned into JPEG on iOS 13.
+
 ## 0.6.3+4
 
 * Make the pedantic dev_dependency explicit.

--- a/packages/image_picker/ios/Classes/FLTImagePickerPlugin.m
+++ b/packages/image_picker/ios/Classes/FLTImagePickerPlugin.m
@@ -293,11 +293,11 @@ static const int SOURCE_GALLERY = 1;
       [self saveImageWithPickerInfo:info image:image imageQuality:imageQuality];
     } else {
       __weak typeof(self) weakSelf = self;
-      /// iOS 13.0+ has deprecated requestImageDataForAsset instance,
-      /// using requestImageDataAndOrientationForAsset instead.
+      // iOS 13.0+ has deprecated requestImageDataForAsset instance,
+      // using requestImageDataAndOrientationForAsset instead.
       if (@available(iOS 13.0, *)) {
-        /// The image data returned to resultHandler will become JPEG format, if the [options] is not provided
-        /// or [options.version] is not set as PHImageRequestOptionsVersionOriginal.
+        // The image data returned to resultHandler will become JPEG format, if the [options] is not provided
+        // or [options.version] is not set as PHImageRequestOptionsVersionOriginal.
         PHImageRequestOptions *options = [[PHImageRequestOptions alloc] init];
         options.version = PHImageRequestOptionsVersionOriginal;
         [[PHImageManager defaultManager]

--- a/packages/image_picker/ios/Classes/FLTImagePickerPlugin.m
+++ b/packages/image_picker/ios/Classes/FLTImagePickerPlugin.m
@@ -293,10 +293,11 @@ static const int SOURCE_GALLERY = 1;
       [self saveImageWithPickerInfo:info image:image imageQuality:imageQuality];
     } else {
       __weak typeof(self) weakSelf = self;
-      // iOS 13.0+ has deprecated requestImageDataForAsset instance, using requestImageDataAndOrientationForAsset instead.
+      /// iOS 13.0+ has deprecated requestImageDataForAsset instance,
+      /// using requestImageDataAndOrientationForAsset instead.
       if (@available(iOS 13.0, *)) {
-        // The image data returned to resultHandler will become JPEG format, if the PHImageRequestOptions.version
-        // is not set to PHImageRequestOptionsVersionOriginal while requesting.
+        /// The image data returned to resultHandler will become JPEG format, if the [options] is not provided
+        /// or [options.version] is not set as PHImageRequestOptionsVersionOriginal.
         PHImageRequestOptions *options = [[PHImageRequestOptions alloc] init];
         options.version = PHImageRequestOptionsVersionOriginal;
         [[PHImageManager defaultManager]

--- a/packages/image_picker/ios/Classes/FLTImagePickerPlugin.m
+++ b/packages/image_picker/ios/Classes/FLTImagePickerPlugin.m
@@ -293,18 +293,38 @@ static const int SOURCE_GALLERY = 1;
       [self saveImageWithPickerInfo:info image:image imageQuality:imageQuality];
     } else {
       __weak typeof(self) weakSelf = self;
-      [[PHImageManager defaultManager]
-          requestImageDataForAsset:originalAsset
-                           options:nil
-                     resultHandler:^(NSData *_Nullable imageData, NSString *_Nullable dataUTI,
-                                     UIImageOrientation orientation, NSDictionary *_Nullable info) {
-                       // maxWidth and maxHeight are used only for GIF images.
-                       [weakSelf saveImageWithOriginalImageData:imageData
-                                                          image:image
-                                                       maxWidth:maxWidth
-                                                      maxHeight:maxHeight
-                                                   imageQuality:imageQuality];
-                     }];
+      // iOS 13.0+ has deprecated requestImageDataForAsset instance, using requestImageDataAndOrientationForAsset instead.
+      if (@available(iOS 13.0, *)) {
+        // The image data returned to resultHandler will become JPEG format, if the PHImageRequestOptions.version
+        // is not set to PHImageRequestOptionsVersionOriginal while requesting.
+        PHImageRequestOptions *options = [[PHImageRequestOptions alloc] init];
+        options.version = PHImageRequestOptionsVersionOriginal;
+        [[PHImageManager defaultManager]
+            requestImageDataAndOrientationForAsset:originalAsset
+                                           options:options
+                                     resultHandler:^(NSData *_Nullable imageData, NSString *_Nullable dataUTI,
+                                                    CGImagePropertyOrientation orientation, NSDictionary *_Nullable info) {
+                          // maxWidth and maxHeight are used only for GIF images.
+                          [weakSelf saveImageWithOriginalImageData:imageData
+                                                             image:image
+                                                          maxWidth:maxWidth
+                                                         maxHeight:maxHeight
+                                                      imageQuality:imageQuality];
+                       }];
+      } else {
+        [[PHImageManager defaultManager]
+            requestImageDataForAsset:originalAsset
+                            options:nil
+                      resultHandler:^(NSData *_Nullable imageData, NSString *_Nullable dataUTI,
+                                      UIImageOrientation orientation, NSDictionary *_Nullable info) {
+                        // maxWidth and maxHeight are used only for GIF images.
+                        [weakSelf saveImageWithOriginalImageData:imageData
+                                                            image:image
+                                                        maxWidth:maxWidth
+                                                        maxHeight:maxHeight
+                                                    imageQuality:imageQuality];
+                      }];
+      }
     }
   }
   _arguments = nil;

--- a/packages/image_picker/ios/Classes/FLTImagePickerPlugin.m
+++ b/packages/image_picker/ios/Classes/FLTImagePickerPlugin.m
@@ -293,31 +293,36 @@ static const int SOURCE_GALLERY = 1;
       [self saveImageWithPickerInfo:info image:image imageQuality:imageQuality];
     } else {
       __weak typeof(self) weakSelf = self;
-      // According to Apple development documentation, requestImageDataForAsset is introduced in iOS 8
-      // and deprecated in iOS 13. Thus, we have to use requestImageDataAndOrientationForAsset on iOS 13.
+      // According to Apple development documentation, requestImageDataForAsset is introduced in iOS
+      // 8 and deprecated in iOS 13. Thus, we have to use requestImageDataAndOrientationForAsset on
+      // iOS 13.
       if (@available(iOS 13.0, *)) {
         // The image data returned to resultHandler will be turned into JPEG format,
-        // if the [options] is not provide or [options.version] is not PHImageRequestOptionsVersionOriginal.
+        // if the [options] is not provide or [options.version] is not
+        // PHImageRequestOptionsVersionOriginal.
         PHImageRequestOptions *options = [[PHImageRequestOptions alloc] init];
         options.version = PHImageRequestOptionsVersionOriginal;
         [[PHImageManager defaultManager]
             requestImageDataAndOrientationForAsset:originalAsset
                                            options:options
-                                     resultHandler:^(NSData *_Nullable imageData, NSString *_Nullable dataUTI,
-                                                     CGImagePropertyOrientation orientation, NSDictionary *_Nullable info) {
-                         // maxWidth and maxHeight are used only for GIF images.
-                         [weakSelf saveImageWithOriginalImageData:imageData
-                                                            image:image
-                                                         maxWidth:maxWidth
-                                                        maxHeight:maxHeight
-                                                     imageQuality:imageQuality];
-                       }];
+                                     resultHandler:^(NSData *_Nullable imageData,
+                                                     NSString *_Nullable dataUTI,
+                                                     CGImagePropertyOrientation orientation,
+                                                     NSDictionary *_Nullable info) {
+                                       // maxWidth and maxHeight are used only for GIF images.
+                                       [weakSelf saveImageWithOriginalImageData:imageData
+                                                                          image:image
+                                                                       maxWidth:maxWidth
+                                                                      maxHeight:maxHeight
+                                                                   imageQuality:imageQuality];
+                                     }];
       } else {
         [[PHImageManager defaultManager]
             requestImageDataForAsset:originalAsset
                              options:nil
                        resultHandler:^(NSData *_Nullable imageData, NSString *_Nullable dataUTI,
-                                       UIImageOrientation orientation, NSDictionary *_Nullable info) {
+                                       UIImageOrientation orientation,
+                                       NSDictionary *_Nullable info) {
                          // maxWidth and maxHeight are used only for GIF images.
                          [weakSelf saveImageWithOriginalImageData:imageData
                                                             image:image

--- a/packages/image_picker/ios/Classes/FLTImagePickerPlugin.m
+++ b/packages/image_picker/ios/Classes/FLTImagePickerPlugin.m
@@ -293,38 +293,38 @@ static const int SOURCE_GALLERY = 1;
       [self saveImageWithPickerInfo:info image:image imageQuality:imageQuality];
     } else {
       __weak typeof(self) weakSelf = self;
-      // iOS 13.0+ has deprecated requestImageDataForAsset instance,
-      // using requestImageDataAndOrientationForAsset instead.
+      // According to Apple development documentation, requestImageDataForAsset is introduced in iOS 8
+      // and deprecated in iOS 13. Thus, we have to use requestImageDataAndOrientationForAsset on iOS 13.
       if (@available(iOS 13.0, *)) {
-        // The image data returned to resultHandler will become JPEG format, if the [options] is not provided
-        // or [options.version] is not set as PHImageRequestOptionsVersionOriginal.
+        // The image data returned to resultHandler will be turned into JPEG format,
+        // if the [options] is not provide or [options.version] is not PHImageRequestOptionsVersionOriginal.
         PHImageRequestOptions *options = [[PHImageRequestOptions alloc] init];
         options.version = PHImageRequestOptionsVersionOriginal;
         [[PHImageManager defaultManager]
             requestImageDataAndOrientationForAsset:originalAsset
                                            options:options
                                      resultHandler:^(NSData *_Nullable imageData, NSString *_Nullable dataUTI,
-                                                    CGImagePropertyOrientation orientation, NSDictionary *_Nullable info) {
-                          // maxWidth and maxHeight are used only for GIF images.
-                          [weakSelf saveImageWithOriginalImageData:imageData
-                                                             image:image
-                                                          maxWidth:maxWidth
-                                                         maxHeight:maxHeight
-                                                      imageQuality:imageQuality];
+                                                     CGImagePropertyOrientation orientation, NSDictionary *_Nullable info) {
+                         // maxWidth and maxHeight are used only for GIF images.
+                         [weakSelf saveImageWithOriginalImageData:imageData
+                                                            image:image
+                                                         maxWidth:maxWidth
+                                                        maxHeight:maxHeight
+                                                     imageQuality:imageQuality];
                        }];
       } else {
         [[PHImageManager defaultManager]
             requestImageDataForAsset:originalAsset
-                            options:nil
-                      resultHandler:^(NSData *_Nullable imageData, NSString *_Nullable dataUTI,
-                                      UIImageOrientation orientation, NSDictionary *_Nullable info) {
-                        // maxWidth and maxHeight are used only for GIF images.
-                        [weakSelf saveImageWithOriginalImageData:imageData
+                             options:nil
+                       resultHandler:^(NSData *_Nullable imageData, NSString *_Nullable dataUTI,
+                                       UIImageOrientation orientation, NSDictionary *_Nullable info) {
+                         // maxWidth and maxHeight are used only for GIF images.
+                         [weakSelf saveImageWithOriginalImageData:imageData
                                                             image:image
-                                                        maxWidth:maxWidth
+                                                         maxWidth:maxWidth
                                                         maxHeight:maxHeight
-                                                    imageQuality:imageQuality];
-                      }];
+                                                     imageQuality:imageQuality];
+                       }];
       }
     }
   }

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker
 description: Flutter plugin for selecting images from the Android and iOS image
   library, and taking new pictures with the camera.
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.6.3+4
+version: 0.6.3+5
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

The image_picker plugin using method **requestImageDataForAsset** to read the data from photo library. But, the data of a png image that retrieved from album, will always starts with byte 0xFF, which is a JPEG format but not PNG, on iOS 13+. So, the original PNG file will be turned into a JPEG image, and all the transparent parts will be lost. 

After I do some tests on these code, I found that the image data will be turned into JPEG format if  `[options]` is null or `[options.version]` is **NOT** `PHImageRequestOptionsVersionOriginal`. Once I call  **requestImageDataForAsset** with `[options.version]` been set to `PHImageRequestOptionsVersionOriginal`, the image data starts with byte **0x89** as I expected. And, all the transparent parts are where it should be.

This happened on iOS 13+ device only, and will not affect iOS 12 and below. Also, the **requestImageDataForAsset** has been marked as duplicated on iOS 13+ document, should use **requestImageDataAndOrientationForAsset** instead.

## Related Issues

[\[image_picker\]Fixed losing transparency of PNGs #742]

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[\[image_picker\]Fixed losing transparency of PNGs #742]: https://github.com/flutter/plugins/pull/742

