### PR TITLE
[android_intent] Make action optional, as Intents can also resolve with just the component name

### DIFF
--- a/packages/android_intent/CHANGELOG.md
+++ b/packages/android_intent/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.6
+
+* Marks the `action` parameter as optional
+* Adds an assertion to ensure the intent receives an action, component or both.
+
 ## 0.3.5+1
 
 * Make the pedantic dev_dependency explicit.

--- a/packages/android_intent/android/src/main/java/io/flutter/plugins/androidintent/IntentSender.java
+++ b/packages/android_intent/android/src/main/java/io/flutter/plugins/androidintent/IntentSender.java
@@ -42,7 +42,7 @@ public final class IntentSender {
    * back to {@code applicationContext} and adds {@link Intent#FLAG_ACTIVITY_NEW_TASK} to the intent
    * before launching it.
    *
-   * @param action the Intent action, such as {@code ACTION_VIEW}.
+   * @param action the Intent action, such as {@code ACTION_VIEW} if non-null.
    * @param flags forwarded to {@link Intent#addFlags(int)} if non-null.
    * @param category forwarded to {@link Intent#addCategory(String)} if non-null.
    * @param data forwarded to {@link Intent#setData(Uri)} if non-null and 'type' parameter is null.
@@ -57,7 +57,7 @@ public final class IntentSender {
    *     Intent#setDataAndType(Uri, String)}
    */
   void send(
-      String action,
+      @Nullable String action,
       @Nullable Integer flags,
       @Nullable String category,
       @Nullable Uri data,
@@ -70,8 +70,11 @@ public final class IntentSender {
       return;
     }
 
-    Intent intent = new Intent(action);
+    Intent intent = new Intent();
 
+    if (action != null) {
+      intent.setAction(action);
+    }
     if (flags != null) {
       intent.addFlags(flags);
     }

--- a/packages/android_intent/android/src/main/java/io/flutter/plugins/androidintent/MethodCallHandlerImpl.java
+++ b/packages/android_intent/android/src/main/java/io/flutter/plugins/androidintent/MethodCallHandlerImpl.java
@@ -91,6 +91,10 @@ public final class MethodCallHandlerImpl implements MethodCallHandler {
   }
 
   private static String convertAction(String action) {
+    if (action == null) {
+      return null;
+    }
+
     switch (action) {
       case "action_view":
         return Intent.ACTION_VIEW;

--- a/packages/android_intent/android/src/test/java/io/flutter/plugins/androidintent/MethodCallHandlerImplTest.java
+++ b/packages/android_intent/android/src/test/java/io/flutter/plugins/androidintent/MethodCallHandlerImplTest.java
@@ -217,6 +217,30 @@ public class MethodCallHandlerImplTest {
     Intent intent = shadowOf((Application) context).getNextStartedActivity();
     assertNotNull(intent);
     assertNotNull(intent.getComponent());
+    assertEquals("foo", intent.getAction());
+    assertEquals(expectedComponent.getPackageName(), intent.getPackage());
+    assertEquals(expectedComponent.flattenToString(), intent.getComponent().flattenToString());
+  }
+
+  @Test
+  public void onMethodCall_setsOnlyComponentName() {
+    sender.setApplicationContext(context);
+    Map<String, Object> args = new HashMap<>();
+    ComponentName expectedComponent =
+        new ComponentName("io.flutter.plugins.androidintent", "MainActivity");
+    args.put("package", expectedComponent.getPackageName());
+    args.put("componentName", expectedComponent.getClassName());
+    Result result = mock(Result.class);
+    ShadowPackageManager shadowPm =
+        shadowOf(ApplicationProvider.getApplicationContext().getPackageManager());
+    shadowPm.addActivityIfNotPresent(expectedComponent);
+
+    methodCallHandler.onMethodCall(new MethodCall("launch", args), result);
+
+    verify(result, times(1)).success(null);
+    Intent intent = shadowOf((Application) context).getNextStartedActivity();
+    assertNotNull(intent);
+    assertNotNull(intent.getComponent());
     assertEquals(expectedComponent.getPackageName(), intent.getPackage());
     assertEquals(expectedComponent.flattenToString(), intent.getComponent().flattenToString());
   }

--- a/packages/android_intent/android/src/test/java/io/flutter/plugins/androidintent/MethodCallHandlerImplTest.java
+++ b/packages/android_intent/android/src/test/java/io/flutter/plugins/androidintent/MethodCallHandlerImplTest.java
@@ -218,8 +218,9 @@ public class MethodCallHandlerImplTest {
     assertNotNull(intent);
     assertNotNull(intent.getComponent());
     assertEquals("foo", intent.getAction());
-    assertEquals(expectedComponent.getPackageName(), intent.getPackage());
-    assertEquals(expectedComponent.flattenToString(), intent.getComponent().flattenToString());
+    assertEquals("io.flutter.plugins.androidintent", intent.getPackage());
+    assertEquals(
+        "io.flutter.plugins.androidintent/MainActivity", intent.getComponent().flattenToString());
   }
 
   @Test
@@ -241,8 +242,9 @@ public class MethodCallHandlerImplTest {
     Intent intent = shadowOf((Application) context).getNextStartedActivity();
     assertNotNull(intent);
     assertNotNull(intent.getComponent());
-    assertEquals(expectedComponent.getPackageName(), intent.getPackage());
-    assertEquals(expectedComponent.flattenToString(), intent.getComponent().flattenToString());
+    assertEquals("io.flutter.plugins.androidintent", intent.getPackage());
+    assertEquals(
+        "io.flutter.plugins.androidintent/MainActivity", intent.getComponent().flattenToString());
   }
 
   @Test

--- a/packages/android_intent/lib/android_intent.dart
+++ b/packages/android_intent/lib/android_intent.dart
@@ -29,7 +29,7 @@ class AndroidIntent {
   /// If not null, then [package] but also be provided.
   /// [type] refers to the type of the intent, can be null.
   const AndroidIntent({
-    @required this.action,
+    this.action,
     this.flags,
     this.category,
     this.data,
@@ -38,7 +38,8 @@ class AndroidIntent {
     this.componentName,
     Platform platform,
     this.type,
-  })  : assert(action != null),
+  })  : assert(action != null || componentName != null,
+            'action or component (or both) must be specified'),
         _channel = const MethodChannel(_kChannelName),
         _platform = platform ?? const LocalPlatform();
 

--- a/packages/android_intent/lib/android_intent.dart
+++ b/packages/android_intent/lib/android_intent.dart
@@ -47,9 +47,9 @@ class AndroidIntent {
   /// app code, it may break without warning.
   @visibleForTesting
   AndroidIntent.private({
-    @required this.action,
     @required Platform platform,
     @required MethodChannel channel,
+    this.action,
     this.flags,
     this.category,
     this.data,
@@ -57,7 +57,9 @@ class AndroidIntent {
     this.package,
     this.componentName,
     this.type,
-  })  : _channel = channel,
+  })  : assert(action != null || componentName != null,
+            'action or component (or both) must be specified'),
+        _channel = channel,
         _platform = platform;
 
   /// This is the general verb that the intent should attempt to do. This
@@ -132,7 +134,10 @@ class AndroidIntent {
     if (!_platform.isAndroid) {
       return;
     }
-    final Map<String, dynamic> args = <String, dynamic>{'action': action};
+    final Map<String, dynamic> args = <String, dynamic>{};
+    if (action != null) {
+      args['action'] = action;
+    }
     if (flags != null) {
       args['flags'] = convertFlags(flags);
     }

--- a/packages/android_intent/pubspec.yaml
+++ b/packages/android_intent/pubspec.yaml
@@ -1,7 +1,7 @@
 name: android_intent
 description: Flutter plugin for launching Android Intents. Not supported on iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/android_intent
-version: 0.3.5+1
+version: 0.3.6
 
 flutter:
   plugin:

--- a/packages/android_intent/test/android_intent_test.dart
+++ b/packages/android_intent/test/android_intent_test.dart
@@ -15,6 +15,7 @@ void main() {
   setUp(() {
     mockChannel = MockMethodChannel();
   });
+
   group('AndroidIntent', () {
     test('pass right params', () async {
       androidIntent = AndroidIntent.private(
@@ -32,34 +33,53 @@ void main() {
         'type': 'video/*',
       }));
     });
-    test('pass null value to action param', () async {
+
+    test('raises error if neither an action nor a component is provided', () {
+      try {
+        androidIntent = AndroidIntent(data: 'https://flutter.io');
+        fail('should raise an AssertionError');
+      } on AssertionError catch (e) {
+        expect(e.message, 'action or component (or both) must be specified');
+      } catch (e) {
+        fail('should raise an AssertionError');
+      }
+    });
+    test('can send Intent with an action and no component', () async {
       androidIntent = AndroidIntent.private(
-          action: null,
-          channel: mockChannel,
-          platform: FakePlatform(operatingSystem: 'android'));
+        action: 'action_view',
+        channel: mockChannel,
+        platform: FakePlatform(operatingSystem: 'android'),
+      );
       await androidIntent.launch();
       verify(mockChannel.invokeMethod<void>('launch', <String, Object>{
-        'action': null,
+        'action': 'action_view',
       }));
     });
 
-    test('asserts on missing action & component', () {
-      try {
-        AndroidIntent(data: 'https://flutter.io');
-      } on AssertionError catch (e) {
-        expect(e.message, 'action or component (or both) must be specified');
-      }
+    test('can send Intent with a component and no action', () async {
+      androidIntent = AndroidIntent.private(
+        package: 'packageName',
+        componentName: 'componentName',
+        channel: mockChannel,
+        platform: FakePlatform(operatingSystem: 'android'),
+      );
+      await androidIntent.launch();
+      verify(mockChannel.invokeMethod<void>('launch', <String, Object>{
+        'package': 'packageName',
+        'componentName': 'componentName',
+      }));
     });
 
     test('call in ios platform', () async {
       androidIntent = AndroidIntent.private(
-          action: null,
+          action: 'action_view',
           channel: mockChannel,
           platform: FakePlatform(operatingSystem: 'ios'));
       await androidIntent.launch();
       verifyZeroInteractions(mockChannel);
     });
   });
+
   group('convertFlags ', () {
     androidIntent = const AndroidIntent(
       action: 'action_view',

--- a/packages/android_intent/test/android_intent_test.dart
+++ b/packages/android_intent/test/android_intent_test.dart
@@ -43,6 +43,14 @@ void main() {
       }));
     });
 
+    test('asserts on missing action & component', () {
+      try {
+        AndroidIntent(data: 'https://flutter.io');
+      } on AssertionError catch (e) {
+        expect(e.message, 'action or component (or both) must be specified');
+      }
+    });
+
     test('call in ios platform', () async {
       androidIntent = AndroidIntent.private(
           action: null,


### PR DESCRIPTION
## Description

Android Intents can also be constructed with just the component name like so:
```
final Intent intent = new Intent();
intent.setComponent(componentName);
context.startActivity(intent);
```

Effectively, if the developer knows the target component, it can be called directly.

## Related Issues

Preparation work for https://github.com/flutter/flutter/issues/51942, which adds a "canResolve" method.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
