### PR TITLE
[e2e] Updates to support simultaneous E2E and Espresso tests

### DIFF
--- a/packages/e2e/example/android/app/build.gradle
+++ b/packages/e2e/example/android/app/build.gradle
@@ -56,6 +56,8 @@ flutter {
 
 dependencies {
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    testImplementation "com.google.truth:truth:1.0"
+    androidTestImplementation 'androidx.test:runner:1.1.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
+    api 'androidx.test:core:1.2.0'
 }

--- a/packages/e2e/example/android/app/src/androidTest/java/com/example/e2e_example/MainActivityEspressoTest.java
+++ b/packages/e2e/example/android/app/src/androidTest/java/com/example/e2e_example/MainActivityEspressoTest.java
@@ -1,0 +1,36 @@
+package com.example.e2e_example;
+
+import static androidx.test.espresso.Espresso.pressBackUnconditionally;
+import static androidx.test.espresso.flutter.EspressoFlutter.onFlutterWidget;
+import static androidx.test.espresso.flutter.action.FlutterActions.click;
+import static androidx.test.espresso.flutter.assertion.FlutterAssertions.matches;
+import static androidx.test.espresso.flutter.matcher.FlutterMatchers.withText;
+import static androidx.test.espresso.flutter.matcher.FlutterMatchers.withTooltip;
+import static androidx.test.espresso.flutter.matcher.FlutterMatchers.withValueKey;
+
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.rule.ActivityTestRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public final class MainActivityEspressoTest {
+
+    @Rule
+    public ActivityTestRule<MainActivity> myActivityTestRule =
+            new ActivityTestRule<>(MainActivity.class, true, false);
+
+    @Before
+    public void setUp() {
+        ActivityScenario.launch(MainActivity.class);
+    }
+
+    @Test
+    public void checkText() throws Exception {
+        onFlutterWidget(withValueKey("ResultText"))
+                .check(matches(withText("Platform: android")));
+    }
+}

--- a/packages/e2e/example/android/app/src/debug/AndroidManifest.xml
+++ b/packages/e2e/example/android/app/src/debug/AndroidManifest.xml
@@ -4,4 +4,5 @@
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
+    <application android:usesCleartextTraffic="true"/>
 </manifest>

--- a/packages/e2e/example/pubspec.yaml
+++ b/packages/e2e/example/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-
+  espresso: ^0.0.1+3
   cupertino_icons: ^0.1.2
 
 dev_dependencies:


### PR DESCRIPTION
Right now we're using a mock implementation of the driver extension protocol. This change switches to using the real one for now. It allows EarlGrey and Espresso tests to talk to an app that is using `E2EWidgetsFlutterBinding`

Fixes https://github.com/flutter/flutter/issues/51781