### PR TITLE
[webview_flutter]  Fix the issue that webview cannot load assets html and local html

### DIFF
--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -122,6 +122,12 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
       case "loadUrl":
         loadUrl(methodCall, result);
         break;
+      case "loadAssetHtmlFile":
+        loadAssetHtmlFile(methodCall, result);
+        break;
+      case "loadLocalHtmlFile":
+        loadLocalHtmlFile(methodCall, result);
+        break;
       case "updateSettings":
         updateSettings(methodCall, result);
         break;
@@ -172,6 +178,18 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
       headers = Collections.emptyMap();
     }
     webView.loadUrl(url, headers);
+    result.success(null);
+  }
+
+  private void loadAssetHtmlFile(MethodCall methodCall, Result result) {
+    String url = (String) methodCall.arguments;
+    webView.loadUrl("file:///android_asset/flutter_assets/" + url);
+    result.success(null);
+  }
+
+  private void loadLocalHtmlFile(MethodCall methodCall, Result result) {
+    String url = (String) methodCall.arguments;
+    webView.loadUrl("file:///" + url);
     result.success(null);
   }
 

--- a/packages/webview_flutter/ios/Classes/FLTWebViewFlutterPlugin.m
+++ b/packages/webview_flutter/ios/Classes/FLTWebViewFlutterPlugin.m
@@ -10,7 +10,7 @@
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
   FLTWebViewFactory* webviewFactory =
-      [[FLTWebViewFactory alloc] initWithMessenger:registrar.messenger];
+      [[FLTWebViewFactory alloc] initWithRegistrar:registrar];
   [registrar registerViewFactory:webviewFactory withId:@"plugins.flutter.io/webview"];
   [FLTCookieManager registerWithRegistrar:registrar];
 }

--- a/packages/webview_flutter/ios/Classes/FLTWebViewFlutterPlugin.m
+++ b/packages/webview_flutter/ios/Classes/FLTWebViewFlutterPlugin.m
@@ -9,8 +9,7 @@
 @implementation FLTWebViewFlutterPlugin
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
-  FLTWebViewFactory* webviewFactory =
-      [[FLTWebViewFactory alloc] initWithRegistrar:registrar];
+  FLTWebViewFactory* webviewFactory = [[FLTWebViewFactory alloc] initWithRegistrar:registrar];
   [registrar registerViewFactory:webviewFactory withId:@"plugins.flutter.io/webview"];
   [FLTCookieManager registerWithRegistrar:registrar];
 }

--- a/packages/webview_flutter/ios/Classes/FlutterWebView.h
+++ b/packages/webview_flutter/ios/Classes/FlutterWebView.h
@@ -12,13 +12,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithFrame:(CGRect)frame
                viewIdentifier:(int64_t)viewId
                     arguments:(id _Nullable)args
-              binaryMessenger:(NSObject<FlutterBinaryMessenger>*)messenger;
+              registrar:(NSObject<FlutterPluginRegistrar>*)registrar;
 
 - (UIView*)view;
 @end
 
 @interface FLTWebViewFactory : NSObject <FlutterPlatformViewFactory>
-- (instancetype)initWithMessenger:(NSObject<FlutterBinaryMessenger>*)messenger;
+- (instancetype)initWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar;
 @end
 
 /**

--- a/packages/webview_flutter/ios/Classes/FlutterWebView.h
+++ b/packages/webview_flutter/ios/Classes/FlutterWebView.h
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithFrame:(CGRect)frame
                viewIdentifier:(int64_t)viewId
                     arguments:(id _Nullable)args
-              registrar:(NSObject<FlutterPluginRegistrar>*)registrar;
+                    registrar:(NSObject<FlutterPluginRegistrar>*)registrar;
 
 - (UIView*)view;
 @end

--- a/packages/webview_flutter/ios/Classes/FlutterWebView.m
+++ b/packages/webview_flutter/ios/Classes/FlutterWebView.m
@@ -11,7 +11,7 @@
   NSObject<FlutterPluginRegistrar>* _registrar;
 }
 
-- (instancetype)initWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
+- (instancetype)initWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
   self = [super init];
   if (self) {
     _registrar = registrar;

--- a/packages/webview_flutter/ios/Classes/FlutterWebView.m
+++ b/packages/webview_flutter/ios/Classes/FlutterWebView.m
@@ -72,7 +72,7 @@
 - (instancetype)initWithFrame:(CGRect)frame
                viewIdentifier:(int64_t)viewId
                     arguments:(id _Nullable)args
-                    registrar:(nonnull NSObject<FlutterPluginRegistrar> *)registrar {
+                    registrar:(nonnull NSObject<FlutterPluginRegistrar>*)registrar {
   if (self = [super init]) {
     _viewId = viewId;
     _registrar = registrar;

--- a/packages/webview_flutter/ios/Classes/FlutterWebView.m
+++ b/packages/webview_flutter/ios/Classes/FlutterWebView.m
@@ -11,7 +11,7 @@
   NSObject<FlutterPluginRegistrar>* _registrar;
 }
 
-- (instancetype)initWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
+- (instancetype)initWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
   self = [super init];
   if (self) {
     _registrar = registrar;
@@ -30,7 +30,7 @@
   FLTWebViewController* webviewController = [[FLTWebViewController alloc] initWithFrame:frame
                                                                          viewIdentifier:viewId
                                                                               arguments:args
-                                                                        registrar:_registrar];
+                                                                              registrar:_registrar];
   return webviewController;
 }
 
@@ -72,12 +72,13 @@
 - (instancetype)initWithFrame:(CGRect)frame
                viewIdentifier:(int64_t)viewId
                     arguments:(id _Nullable)args
-              registrar:(nonnull NSObject<FlutterPluginRegistrar> *)registrar {
+                    registrar:(nonnull NSObject<FlutterPluginRegistrar> *)registrar {
   if (self = [super init]) {
     _viewId = viewId;
     _registrar = registrar;
     NSString* channelName = [NSString stringWithFormat:@"plugins.flutter.io/webview_%lld", viewId];
-    _channel = [FlutterMethodChannel methodChannelWithName:channelName binaryMessenger:_registrar.messenger];
+    _channel = [FlutterMethodChannel methodChannelWithName:channelName
+                                           binaryMessenger:_registrar.messenger];
     _javaScriptChannelNames = [[NSMutableSet alloc] init];
 
     WKUserContentController* userContentController = [[WKUserContentController alloc] init];
@@ -133,7 +134,7 @@
     [self onLoadUrl:call result:result];
   } else if ([[call method] isEqualToString:@"loadAssetHtmlFile"]) {
     [self onLoadAssetHtmlFile:call result:result];
-  }  else if ([[call method] isEqualToString:@"loadLocalHtmlFile"]) {
+  } else if ([[call method] isEqualToString:@"loadLocalHtmlFile"]) {
     [self onLoadLocalHtmlFile:call result:result];
   } else if ([[call method] isEqualToString:@"canGoBack"]) {
     [self onCanGoBack:call result:result];
@@ -410,8 +411,8 @@
   NSString* key = [_registrar lookupKeyForAsset:pathString];
   NSURL* baseURL = [[NSBundle mainBundle] URLForResource:key withExtension:nil];
   if (!baseURL) {
-      return false;
-   }
+    return false;
+  }
   NSURL* newUrl = baseURL;
   if ([array count] > 1) {
     NSString* queryString = [array objectAtIndex:1];
@@ -435,10 +436,10 @@
   NSString* key = [_registrar lookupKeyForAsset:pathString];
   NSURL* baseURL = [[NSBundle mainBundle] URLForResource:key withExtension:nil];
   if (!baseURL) {
-      [_webView loadFileURL:[NSURL fileURLWithPath:pathString] allowingReadAccessToURL:[NSURL fileURLWithPath:pathString]];
-      return true;
-
-   }
+    [_webView loadFileURL:[NSURL fileURLWithPath:pathString]
+        allowingReadAccessToURL:[NSURL fileURLWithPath:pathString]];
+    return true;
+  }
   NSURL* newUrl = baseURL;
   if ([array count] > 1) {
     NSString* queryString = [array objectAtIndex:1];

--- a/packages/webview_flutter/ios/Classes/FlutterWebView.m
+++ b/packages/webview_flutter/ios/Classes/FlutterWebView.m
@@ -8,12 +8,14 @@
 
 @implementation FLTWebViewFactory {
   NSObject<FlutterBinaryMessenger>* _messenger;
+  NSObject<FlutterPluginRegistrar>* _registrar;
 }
 
-- (instancetype)initWithMessenger:(NSObject<FlutterBinaryMessenger>*)messenger {
+- (instancetype)initWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
   self = [super init];
   if (self) {
-    _messenger = messenger;
+    _registrar = registrar;
+    _messenger = registrar.messenger;
   }
   return self;
 }
@@ -28,7 +30,7 @@
   FLTWebViewController* webviewController = [[FLTWebViewController alloc] initWithFrame:frame
                                                                          viewIdentifier:viewId
                                                                               arguments:args
-                                                                        binaryMessenger:_messenger];
+                                                                        registrar:_registrar];
   return webviewController;
 }
 
@@ -64,17 +66,18 @@
   // The set of registered JavaScript channel names.
   NSMutableSet* _javaScriptChannelNames;
   FLTWKNavigationDelegate* _navigationDelegate;
+  NSObject<FlutterPluginRegistrar>* _registrar;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
                viewIdentifier:(int64_t)viewId
                     arguments:(id _Nullable)args
-              binaryMessenger:(NSObject<FlutterBinaryMessenger>*)messenger {
+              registrar:(nonnull NSObject<FlutterPluginRegistrar> *)registrar {
   if (self = [super init]) {
     _viewId = viewId;
-
+    _registrar = registrar;
     NSString* channelName = [NSString stringWithFormat:@"plugins.flutter.io/webview_%lld", viewId];
-    _channel = [FlutterMethodChannel methodChannelWithName:channelName binaryMessenger:messenger];
+    _channel = [FlutterMethodChannel methodChannelWithName:channelName binaryMessenger:_registrar.messenger];
     _javaScriptChannelNames = [[NSMutableSet alloc] init];
 
     WKUserContentController* userContentController = [[WKUserContentController alloc] init];
@@ -182,6 +185,17 @@
 - (void)onLoadAssetHtmlFile:(FlutterMethodCall*)call result:(FlutterResult)result {
   NSString* url = [call arguments];
   if (![self loadAssetHtmlFile:url]) {
+    result([FlutterError errorWithCode:@"loadAssetHtmlFile_failed"
+                               message:@"Failed parsing the URL"
+                               details:[NSString stringWithFormat:@"URL was: '%@'", url]]);
+  } else {
+    result(nil);
+  }
+}
+
+- (void)onLoadLocalHtmlFile:(FlutterMethodCall*)call result:(FlutterResult)result {
+  NSString* url = [call arguments];
+  if (![self loadLocalHtmlFile:url]) {
     result([FlutterError errorWithCode:@"loadAssetHtmlFile_failed"
                                message:@"Failed parsing the URL"
                                details:[NSString stringWithFormat:@"URL was: '%@'", url]]);
@@ -397,6 +411,33 @@
   NSURL* baseURL = [[NSBundle mainBundle] URLForResource:key withExtension:nil];
   if (!baseURL) {
       return false;
+   }
+  NSURL* newUrl = baseURL;
+  if ([array count] > 1) {
+    NSString* queryString = [array objectAtIndex:1];
+    NSLog(@"%@%@", @"queryString: ", queryString);
+    NSString* queryPart = [NSString stringWithFormat:@"%@%@", @"?", queryString];
+    NSLog(@"%@%@", @"queryPart: ", queryPart);
+    newUrl = [NSURL URLWithString:queryPart relativeToURL:baseURL];
+  }
+  if (@available(iOS 9.0, *)) {
+    [_webView loadFileURL:newUrl allowingReadAccessToURL:[NSURL URLWithString:@"file:///"]];
+  } else {
+    return false;
+  }
+  return true;
+}
+
+- (bool)loadLocalHtmlFile:(NSString*)url {
+  NSArray* array = [url componentsSeparatedByString:@"?"];
+  NSString* pathString = [array objectAtIndex:0];
+  NSLog(@"%@%@", @"pathString: ", pathString);
+  NSString* key = [_registrar lookupKeyForAsset:pathString];
+  NSURL* baseURL = [[NSBundle mainBundle] URLForResource:key withExtension:nil];
+  if (!baseURL) {
+      [_webView loadFileURL:[NSURL fileURLWithPath:pathString] allowingReadAccessToURL:[NSURL fileURLWithPath:pathString]];
+      return true;
+
    }
   NSURL* newUrl = baseURL;
   if ([array count] > 1) {

--- a/packages/webview_flutter/lib/platform_interface.dart
+++ b/packages/webview_flutter/lib/platform_interface.dart
@@ -64,6 +64,26 @@ abstract class WebViewPlatformController {
         "WebView loadUrl is not implemented on the current platform");
   }
 
+  /// Load html file from local path
+  ///
+  /// `url` must not be null.
+  ///
+  /// Throws an ArgumentError if `url` is not a valid URL string.
+  Future<void> loadAssetHtmlFile(String url) {
+    throw UnimplementedError(
+        "WebView loadAssetHtmlFile is not implemented on the current platform");
+  }
+
+  /// Load html file from local path
+  ///
+  /// `url` must not be null.
+  ///
+  /// Throws an ArgumentError if `url` is not a valid URL string.
+  Future<void> loadLocalHtmlFile(String url) {
+    throw UnimplementedError(
+        "WebView loadLocalHtmlFile is not implemented on the current platform");
+  }
+
   /// Updates the webview settings.
   ///
   /// Any non null field in `settings` will be set as the new setting value.

--- a/packages/webview_flutter/lib/src/webview_method_channel.dart
+++ b/packages/webview_flutter/lib/src/webview_method_channel.dart
@@ -61,12 +61,12 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
   }
 
   @override
-    Future<void> loadAssetHtmlFile(String url) =>
-            _channel.invokeMethod<String>('loadAssetHtmlFile', url);
+  Future<void> loadAssetHtmlFile(String url) =>
+      _channel.invokeMethod<String>('loadAssetHtmlFile', url);
 
   @override
-    Future<void> loadLocalHtmlFile(String url) =>
-            _channel.invokeMethod<String>('loadLocalHtmlFile', url);
+  Future<void> loadLocalHtmlFile(String url) =>
+      _channel.invokeMethod<String>('loadLocalHtmlFile', url);
 
   @override
   Future<String> currentUrl() => _channel.invokeMethod<String>('currentUrl');

--- a/packages/webview_flutter/lib/src/webview_method_channel.dart
+++ b/packages/webview_flutter/lib/src/webview_method_channel.dart
@@ -61,10 +61,12 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
   }
 
   @override
-  Future<void> loadAssetHtmlFile(String url) => _channel.invokeMethod<String>('loadAssetHtmlFile', url);
+    Future<void> loadAssetHtmlFile(String url) =>
+            _channel.invokeMethod<String>('loadAssetHtmlFile', url);
 
   @override
-  Future<void> loadLocalHtmlFile(String url) => _channel.invokeMethod<String>('loadLocalHtmlFile', url);
+    Future<void> loadLocalHtmlFile(String url) =>
+            _channel.invokeMethod<String>('loadLocalHtmlFile', url);
 
   @override
   Future<String> currentUrl() => _channel.invokeMethod<String>('currentUrl');

--- a/packages/webview_flutter/lib/src/webview_method_channel.dart
+++ b/packages/webview_flutter/lib/src/webview_method_channel.dart
@@ -61,6 +61,12 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
   }
 
   @override
+  Future<void> loadAssetHtmlFile(String url) => _channel.invokeMethod<String>('loadAssetHtmlFile', url);
+
+  @override
+  Future<void> loadLocalHtmlFile(String url) => _channel.invokeMethod<String>('loadLocalHtmlFile', url);
+
+  @override
   Future<String> currentUrl() => _channel.invokeMethod<String>('currentUrl');
 
   @override

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -531,6 +531,24 @@ class WebViewController {
     return _webViewPlatformController.loadUrl(url, headers);
   }
 
+  /// Load html file from assets
+  ///
+  /// `url` must not be null.
+  Future<void> loadAssetHtmlFile(String url) async {
+    assert(url != null);
+    _validateUrlString(url);
+    return _webViewPlatformController.loadAssetHtmlFile(url);
+  }
+
+  /// Load html file from local path
+  ///
+  /// `url` must not be null.
+  Future<void> loadLocalHtmlFile(String url) async {
+    assert(url != null);
+    _validateUrlString(url);
+    return _webViewPlatformController.loadLocalHtmlFile(url);
+  }
+
   /// Accessor to the current URL that the WebView is displaying.
   ///
   /// If [WebView.initialUrl] was never specified, returns `null`.

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -545,7 +545,6 @@ class WebViewController {
   /// `url` must not be null.
   Future<void> loadLocalHtmlFile(String url) async {
     assert(url != null);
-    _validateUrlString(url);
     return _webViewPlatformController.loadLocalHtmlFile(url);
   }
 

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -536,7 +536,6 @@ class WebViewController {
   /// `url` must not be null.
   Future<void> loadAssetHtmlFile(String url) async {
     assert(url != null);
-    _validateUrlString(url);
     return _webViewPlatformController.loadAssetHtmlFile(url);
   }
 


### PR DESCRIPTION
Fix flutter/flutter#27086 

Now, flutter webview can load html file in two ways:

#### Assetfiles
```
    WebView(
      onWebViewCreated: (WebViewController controller) {
        final url = 'assets/index.html';
        controller.loadAssetHtmlFile(url);
      },
      javascriptMode: JavascriptMode.unrestricted,
    );
```
#### Localfiles
```
    WebView(
      onWebViewCreated: (WebViewController controller) {
        controller.loadLocalHtmlFile(filePath)
      },
      javascriptMode: JavascriptMode.unrestricted,
    );

  Future<void> downloadFile(String url) async {
    Dio dio = Dio();
    String path = (await getApplicationDocumentsDirectory()).path;
    String fileName=url.substring(url.lastIndexOf("/")+1);
    await Dio().download(url, '$path/$fileName',onReceiveProgress: (rec,total){
      progress = ((rec/total) * 100).floor();
      if(progress >= 100){
        filePath= '$path/$fileName';
      }
      setState(() {});
    });
  }
```
