### PR TITLE
Make FlutterRunner launch deterministic when running other tests.

### DIFF
--- a/packages/e2e/CHANGELOG.md
+++ b/packages/e2e/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 0.2.4+5
+## 0.3.0
 
 * Flake fix; more deterministic behavior for launching activity.
+* Renames `FlutterRunner` to `FlutterTestRunner` to avoid conflict with Fuchsia.
 
 ## 0.2.4+4
 

--- a/packages/e2e/CHANGELOG.md
+++ b/packages/e2e/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.4+5
+
+* Flake fix; more deterministic behavior for launching activity.
+
 ## 0.2.4+4
 
 * Fixed a hang that occurred on platforms that don't have a `MethodChannel` listener registered..

--- a/packages/e2e/CHANGELOG.md
+++ b/packages/e2e/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.3.0
 
-* Flake fix; more deterministic behavior for launching activity.
+* Updates documentation to instruct developers not to launch the activity since
+  we are doing it for them.
 * Renames `FlutterRunner` to `FlutterTestRunner` to avoid conflict with Fuchsia.
 
 ## 0.2.4+4

--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -93,10 +93,10 @@ import dev.flutter.plugins.e2e.FlutterRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class MainActivityTest {
   @Rule
-  public ActivityTestRule<MainActivity> rule = new ActivityTestRule<>(MainActivity.class);
+  public ActivityTestRule<MainActivity> rule = new ActivityTestRule<>(MainActivity.class, true, false);
 }
 ```
 

--- a/packages/e2e/android/src/main/java/dev/flutter/plugins/e2e/FlutterRunner.java
+++ b/packages/e2e/android/src/main/java/dev/flutter/plugins/e2e/FlutterRunner.java
@@ -33,8 +33,6 @@ public class FlutterTestRunner extends Runner {
         try {
           Object instance = testClass.newInstance();
           rule = (ActivityTestRule<Activity>) field.get(instance);
-          // Launching the activity here seems to keep us from being terminated early
-          rule.launchActivity(null);
         } catch (InstantiationException | IllegalAccessException e) {
           // This might occur if the developer did not make the rule public.
           // We could call field.setAccessible(true) but it seems better to throw.
@@ -55,7 +53,7 @@ public class FlutterTestRunner extends Runner {
       rule.launchActivity(null);
     } catch (RuntimeException e) {
       Log.v(TAG, e);
-      Log.v(TAG, "launchActivity failed, possibly because the activity was already running.")
+      Log.v(TAG, "launchActivity failed, possibly because the activity was already running.");
       Log.v(TAG, "Try disabling auto-launch of the activity, e.g. ActivityTestRule<>(MainActivity.class, true, false);");
     }
     Map<String, String> results = null;

--- a/packages/e2e/android/src/main/java/dev/flutter/plugins/e2e/FlutterRunner.java
+++ b/packages/e2e/android/src/main/java/dev/flutter/plugins/e2e/FlutterRunner.java
@@ -5,6 +5,7 @@
 package dev.flutter.plugins.e2e;
 
 import android.app.Activity;
+import android.util.Log;
 import androidx.test.rule.ActivityTestRule;
 import java.lang.reflect.Field;
 import java.util.Map;
@@ -16,8 +17,10 @@ import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunNotifier;
 
 public class FlutterRunner extends Runner {
+  private static final String TAG = "FlutterRunner";
 
   final Class testClass;
+  ActivityTestRule<Activity> rule;
 
   public FlutterRunner(Class<?> testClass) {
     super();
@@ -29,7 +32,8 @@ public class FlutterRunner extends Runner {
       if (field.isAnnotationPresent(Rule.class)) {
         try {
           Object instance = testClass.newInstance();
-          ActivityTestRule<Activity> rule = (ActivityTestRule<Activity>) field.get(instance);
+          rule = (ActivityTestRule<Activity>) field.get(instance);
+          // Launching the activity here seems to keep us from being terminated early
           rule.launchActivity(null);
         } catch (InstantiationException | IllegalAccessException e) {
           // This might occur if the developer did not make the rule public.
@@ -47,6 +51,13 @@ public class FlutterRunner extends Runner {
 
   @Override
   public void run(RunNotifier notifier) {
+    try {
+      rule.launchActivity(null);
+    } catch (RuntimeException e) {
+      Log.v(TAG, e);
+      Log.v(TAG, "launchActivity failed, possibly because the activity was already running.")
+      Log.v(TAG, "Try disabling auto-launch of the activity, e.g. ActivityTestRule<>(MainActivity.class, true, false);");
+    }
     Map<String, String> results = null;
     try {
       results = E2EPlugin.testResults.get();

--- a/packages/e2e/android/src/main/java/dev/flutter/plugins/e2e/FlutterRunner.java
+++ b/packages/e2e/android/src/main/java/dev/flutter/plugins/e2e/FlutterRunner.java
@@ -16,8 +16,8 @@ import org.junit.runner.Runner;
 import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunNotifier;
 
-public class FlutterRunner extends Runner {
-  private static final String TAG = "FlutterRunner";
+public class FlutterTestRunner extends Runner {
+  private static final String TAG = "FlutterTestRunner";
 
   final Class testClass;
   ActivityTestRule<Activity> rule;

--- a/packages/e2e/android/src/main/java/dev/flutter/plugins/e2e/FlutterTestRunner.java
+++ b/packages/e2e/android/src/main/java/dev/flutter/plugins/e2e/FlutterTestRunner.java
@@ -56,7 +56,9 @@ public class FlutterTestRunner extends Runner {
       rule.launchActivity(null);
     } catch (RuntimeException e) {
       Log.v(TAG, "launchActivity failed, possibly because the activity was already running. " + e);
-      Log.v(TAG, "Try disabling auto-launch of the activity, e.g. ActivityTestRule<>(MainActivity.class, true, false);");
+      Log.v(
+          TAG,
+          "Try disabling auto-launch of the activity, e.g. ActivityTestRule<>(MainActivity.class, true, false);");
     }
     Map<String, String> results = null;
     try {

--- a/packages/e2e/android/src/main/java/dev/flutter/plugins/e2e/FlutterTestRunner.java
+++ b/packages/e2e/android/src/main/java/dev/flutter/plugins/e2e/FlutterTestRunner.java
@@ -22,7 +22,7 @@ public class FlutterTestRunner extends Runner {
   final Class testClass;
   ActivityTestRule<Activity> rule;
 
-  public FlutterRunner(Class<?> testClass) {
+  public FlutterTestRunner(Class<?> testClass) {
     super();
     this.testClass = testClass;
 
@@ -52,8 +52,7 @@ public class FlutterTestRunner extends Runner {
     try {
       rule.launchActivity(null);
     } catch (RuntimeException e) {
-      Log.v(TAG, e);
-      Log.v(TAG, "launchActivity failed, possibly because the activity was already running.");
+      Log.v(TAG, "launchActivity failed, possibly because the activity was already running. " + e);
       Log.v(TAG, "Try disabling auto-launch of the activity, e.g. ActivityTestRule<>(MainActivity.class, true, false);");
     }
     Map<String, String> results = null;

--- a/packages/e2e/android/src/main/java/dev/flutter/plugins/e2e/FlutterTestRunner.java
+++ b/packages/e2e/android/src/main/java/dev/flutter/plugins/e2e/FlutterTestRunner.java
@@ -20,7 +20,7 @@ public class FlutterTestRunner extends Runner {
   private static final String TAG = "FlutterTestRunner";
 
   final Class testClass;
-  final ActivityTestRule<Activity> rule;
+  ActivityTestRule<Activity> rule = null;
 
   public FlutterTestRunner(Class<?> testClass) {
     super();
@@ -49,6 +49,9 @@ public class FlutterTestRunner extends Runner {
 
   @Override
   public void run(RunNotifier notifier) {
+    if (rule == null) {
+      throw new RuntimeException("Unable to run tests due to missing activity rule");
+    }
     try {
       rule.launchActivity(null);
     } catch (RuntimeException e) {

--- a/packages/e2e/android/src/main/java/dev/flutter/plugins/e2e/FlutterTestRunner.java
+++ b/packages/e2e/android/src/main/java/dev/flutter/plugins/e2e/FlutterTestRunner.java
@@ -20,7 +20,7 @@ public class FlutterTestRunner extends Runner {
   private static final String TAG = "FlutterTestRunner";
 
   final Class testClass;
-  ActivityTestRule<Activity> rule;
+  final ActivityTestRule<Activity> rule;
 
   public FlutterTestRunner(Class<?> testClass) {
     super();

--- a/packages/e2e/example/android/app/src/androidTest/java/com/example/e2e_example/EmbedderV1ActivityTest.java
+++ b/packages/e2e/example/android/app/src/androidTest/java/com/example/e2e_example/EmbedderV1ActivityTest.java
@@ -1,7 +1,7 @@
 package com.example.e2e_example;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 

--- a/packages/e2e/example/android/app/src/androidTest/java/com/example/e2e_example/EmbedderV1ActivityTest.java
+++ b/packages/e2e/example/android/app/src/androidTest/java/com/example/e2e_example/EmbedderV1ActivityTest.java
@@ -5,9 +5,9 @@ import dev.flutter.plugins.e2e.FlutterRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class EmbedderV1ActivityTest {
   @Rule
   public ActivityTestRule<EmbedderV1Activity> rule =
-      new ActivityTestRule<>(EmbedderV1Activity.class);
+      new ActivityTestRule<>(EmbedderV1Activity.class, true, false);
 }

--- a/packages/e2e/example/android/app/src/androidTest/java/com/example/e2e_example/MainActivityTest.java
+++ b/packages/e2e/example/android/app/src/androidTest/java/com/example/e2e_example/MainActivityTest.java
@@ -5,7 +5,7 @@ import dev.flutter.plugins.e2e.FlutterRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class MainActivityTest {
-  @Rule public ActivityTestRule<MainActivity> rule = new ActivityTestRule<>(MainActivity.class);
+  @Rule public ActivityTestRule<MainActivity> rule = new ActivityTestRule<>(MainActivity.class, true, false);
 }

--- a/packages/e2e/example/android/app/src/androidTest/java/com/example/e2e_example/MainActivityTest.java
+++ b/packages/e2e/example/android/app/src/androidTest/java/com/example/e2e_example/MainActivityTest.java
@@ -7,5 +7,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(FlutterTestRunner.class)
 public class MainActivityTest {
-  @Rule public ActivityTestRule<MainActivity> rule = new ActivityTestRule<>(MainActivity.class, true, false);
+  @Rule
+  public ActivityTestRule<MainActivity> rule =
+      new ActivityTestRule<>(MainActivity.class, true, false);
 }

--- a/packages/e2e/example/android/app/src/androidTest/java/com/example/e2e_example/MainActivityTest.java
+++ b/packages/e2e/example/android/app/src/androidTest/java/com/example/e2e_example/MainActivityTest.java
@@ -1,7 +1,7 @@
 package com.example.e2e_example;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 

--- a/packages/e2e/pubspec.yaml
+++ b/packages/e2e/pubspec.yaml
@@ -1,6 +1,6 @@
 name: e2e
 description: Runs tests that use the flutter_test API as integration tests.
-version: 0.2.4+5
+version: 0.3.0
 homepage: https://github.com/flutter/plugins/tree/master/packages/e2e
 
 environment:

--- a/packages/e2e/pubspec.yaml
+++ b/packages/e2e/pubspec.yaml
@@ -1,6 +1,6 @@
 name: e2e
 description: Runs tests that use the flutter_test API as integration tests.
-version: 0.2.4+4
+version: 0.2.4+5
 homepage: https://github.com/flutter/plugins/tree/master/packages/e2e
 
 environment:


### PR DESCRIPTION
Fixes a flake where `FlutterRunner` didn't always launch properly.

Instead we are opting out of the Android test rule's auto-launch and having the runner do it manually.

Also renamed `FlutterRunner` to `FlutterTestRunner` to avoid conflict with Fuchsia.