### PR TITLE
 [url_launcher] Fixed when there are line break (CRLF,LF) in the urlString

### DIFF
--- a/packages/url_launcher/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/url_launcher/lib/url_launcher.dart
@@ -84,7 +84,7 @@ Future<bool> launch(
         : SystemUiOverlayStyle.light);
   }
   final bool result = await UrlLauncherPlatform.instance.launch(
-    urlString,
+    url.toString(),
     useSafariVC: forceSafariVC ?? isWebURL,
     useWebView: forceWebView ?? false,
     enableJavaScript: enableJavaScript ?? false,
@@ -105,7 +105,7 @@ Future<bool> canLaunch(String urlString) async {
   if (urlString == null) {
     return false;
   }
-  return await UrlLauncherPlatform.instance.canLaunch(urlString);
+  return await UrlLauncherPlatform.instance.canLaunch(urlString.trimLeft());
 }
 
 /// Closes the current WebView, if one was previously opened via a call to [launch].


### PR DESCRIPTION
## Description

If the URL contains a line break (LF, CRLF), the iOS app will fail with canLaunch.
And if there is a line break, there is not working.

## Related Issues

- No issues

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
