### PR TITLE
[connectivity] remove ios workspace setting for example app.

### DIFF
--- a/packages/connectivity/connectivity/CHANGELOG.md
+++ b/packages/connectivity/connectivity/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.8+2
+
+* Remove hard coded ios workspace setting of the example app.
+
 ## 0.4.8+1
 
 * Make the pedantic dev_dependency explicit.

--- a/packages/connectivity/connectivity/example/ios/Runner.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/packages/connectivity/connectivity/example/ios/Runner.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>BuildSystemType</key>
-	<string>Original</string>
-</dict>
-</plist>

--- a/packages/connectivity/connectivity/pubspec.yaml
+++ b/packages/connectivity/connectivity/pubspec.yaml
@@ -2,7 +2,7 @@ name: connectivity
 description: Flutter plugin for discovering the state of the network (WiFi &
   mobile/cellular) connectivity on Android and iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/connectivity/connectivity
-version: 0.4.8+1
+version: 0.4.8+2
 
 flutter:
   plugin:

--- a/packages/connectivity/connectivity_macos/CHANGELOG.md
+++ b/packages/connectivity/connectivity_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0+2
+
+* Remove hard coded ios workspace setting of the example app.
+
 ## 0.1.0+1
 
 * Make the pedantic dev_dependency explicit.

--- a/packages/connectivity/connectivity_macos/example/ios/Runner.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/packages/connectivity/connectivity_macos/example/ios/Runner.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>BuildSystemType</key>
-	<string>Original</string>
-</dict>
-</plist>

--- a/packages/connectivity/connectivity_macos/pubspec.yaml
+++ b/packages/connectivity/connectivity_macos/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_macos
 description: macOS implementation of the connectivity plugin.
-version: 0.1.0+1
+version: 0.1.0+2
 homepage: https://github.com/flutter/plugins/tree/master/packages/connectivity/connectivity_macos
 
 flutter:


### PR DESCRIPTION
## Description

The workspace setting sets the ios example app to use the legacy build system, which is incompatible with cirrus. This patch fixes that.

