### PR TITLE
[e2e] Adding failure details for driver tests

### DIFF
--- a/packages/e2e/CHANGELOG.md
+++ b/packages/e2e/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.1
+## 0.4.0
 
 * **Breaking change** Driver request_data call's response has changed to
   encapsulate the failure details.

--- a/packages/e2e/CHANGELOG.md
+++ b/packages/e2e/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.1
+
+* **Breaking change** Driver request_data call's response has changed to
+  encapsulate the failure details.
+* Details for failure cases are added: failed method name, stack trace.
+
 ## 0.3.0+1
 
 * Replace deprecated `getFlutterEngine` call on Android.

--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -51,7 +51,7 @@ Future<void> main() async {
   final FlutterDriver driver = await FlutterDriver.connect();
   final String jsonResult =
       await driver.requestData(null, timeout: const Duration(minutes: 1));
-  common.Response response = common.Response.fromJson(jsonResult);
+  final common.Response response = common.Response.fromJson(jsonResult);
   await driver.close();
   exit(response.result == 'pass' ? 0 : 1);
 }
@@ -71,7 +71,7 @@ cd example
 flutter drive --driver=test_driver/<package_name>_test.dart test/<package_name>_e2e.dart
 ```
 
-You can run tests on web on release or profile mode.
+You can run tests on web in release or profile mode.
 
 First you need to make sure you have downloaded the driver for the browser.
 

--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -53,7 +53,7 @@ Future<void> main() async {
       await driver.requestData(null, timeout: const Duration(minutes: 1));
   final common.Response response = common.Response.fromJson(jsonResult);
   await driver.close();
-  exit(response.result == 'pass' ? 0 : 1);
+  exit(response.allTestsPassed ? 0 : 1);
 }
 ```
 

--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -43,18 +43,11 @@ Put the a file named `<package_name>_e2e_test.dart` in the app' `test_driver` di
 
 ```dart
 import 'dart:async';
-import 'dart:io';
-import 'package:e2e/common.dart' as common;
-import 'package:flutter_driver/flutter_driver.dart';
 
-Future<void> main() async {
-  final FlutterDriver driver = await FlutterDriver.connect();
-  final String jsonResult =
-      await driver.requestData(null, timeout: const Duration(minutes: 1));
-  final common.Response response = common.Response.fromJson(jsonResult);
-  await driver.close();
-  exit(response.allTestsPassed ? 0 : 1);
-}
+import 'package:e2e/e2e_driver.dart' as e2e;
+
+Future<void> main() async => e2e.main();
+
 ```
 
 To run a example app test with Flutter driver:

--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -44,14 +44,16 @@ Put the a file named `<package_name>_e2e_test.dart` in the app' `test_driver` di
 ```dart
 import 'dart:async';
 import 'dart:io';
+import 'package:e2e/common.dart' as common;
 import 'package:flutter_driver/flutter_driver.dart';
 
 Future<void> main() async {
   final FlutterDriver driver = await FlutterDriver.connect();
-  final String result =
+  final String jsonResult =
       await driver.requestData(null, timeout: const Duration(minutes: 1));
+  common.Response response = common.Response.fromJson(jsonResult);
   await driver.close();
-  exit(result == 'pass' ? 0 : 1);
+  exit(response.result == 'pass' ? 0 : 1);
 }
 ```
 
@@ -69,7 +71,7 @@ cd example
 flutter drive --driver=test_driver/<package_name>_test.dart test/<package_name>_e2e.dart
 ```
 
-You can run tests on web on release mode.
+You can run tests on web on release or profile mode.
 
 First you need to make sure you have downloaded the driver for the browser.
 

--- a/packages/e2e/example/test_driver/example_e2e_test.dart
+++ b/packages/e2e/example/test_driver/example_e2e_test.dart
@@ -11,7 +11,7 @@ Future<void> main() async {
   common.Response response = common.Response.fromJson(jsonResult);
   await driver.close();
 
-  if(response.result == 'pass') {
+  if (response.result == 'pass') {
     exit(0);
   } else {
     print('Failure Details:\n${response.failureDetails}');

--- a/packages/e2e/example/test_driver/example_e2e_test.dart
+++ b/packages/e2e/example/test_driver/example_e2e_test.dart
@@ -8,7 +8,7 @@ Future<void> main() async {
   final FlutterDriver driver = await FlutterDriver.connect();
   final String jsonResult =
       await driver.requestData(null, timeout: const Duration(minutes: 1));
-  common.Response response = common.Response.fromJson(jsonResult);
+  final common.Response response = common.Response.fromJson(jsonResult);
   await driver.close();
 
   if (response.result == 'pass') {

--- a/packages/e2e/example/test_driver/example_e2e_test.dart
+++ b/packages/e2e/example/test_driver/example_e2e_test.dart
@@ -11,10 +11,12 @@ Future<void> main() async {
   final common.Response response = common.Response.fromJson(jsonResult);
   await driver.close();
 
-  if (response.result == 'pass') {
+  if (response.allTestsPassed) {
+    print('All tests passed.');
     exit(0);
   } else {
-    print('Failure Details:\n${response.failureDetails}');
+    response.formattedFailureDetails;
+    print('Failure Details:\n${response.formattedFailureDetails}');
     exit(1);
   }
 }

--- a/packages/e2e/example/test_driver/example_e2e_test.dart
+++ b/packages/e2e/example/test_driver/example_e2e_test.dart
@@ -1,22 +1,5 @@
 import 'dart:async';
-import 'dart:io';
 
-import 'package:e2e/common.dart' as common;
-import 'package:flutter_driver/flutter_driver.dart';
+import 'package:e2e/e2e_driver.dart' as e2e;
 
-Future<void> main() async {
-  final FlutterDriver driver = await FlutterDriver.connect();
-  final String jsonResult =
-      await driver.requestData(null, timeout: const Duration(minutes: 1));
-  final common.Response response = common.Response.fromJson(jsonResult);
-  await driver.close();
-
-  if (response.allTestsPassed) {
-    print('All tests passed.');
-    exit(0);
-  } else {
-    response.formattedFailureDetails;
-    print('Failure Details:\n${response.formattedFailureDetails}');
-    exit(1);
-  }
-}
+Future<void> main() async => e2e.main();

--- a/packages/e2e/example/test_driver/example_e2e_test.dart
+++ b/packages/e2e/example/test_driver/example_e2e_test.dart
@@ -1,12 +1,20 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:e2e/common.dart' as common;
 import 'package:flutter_driver/flutter_driver.dart';
 
 Future<void> main() async {
   final FlutterDriver driver = await FlutterDriver.connect();
-  final String result =
+  final String jsonResult =
       await driver.requestData(null, timeout: const Duration(minutes: 1));
+  common.Response response = common.Response.fromJson(jsonResult);
   await driver.close();
-  exit(result == 'pass' ? 0 : 1);
+
+  if(response.result == 'pass') {
+    exit(0);
+  } else {
+    print('Failure Details:\n${response.failureDetails}');
+    exit(1);
+  }
 }

--- a/packages/e2e/example/test_driver/failure_test.dart
+++ b/packages/e2e/example/test_driver/failure_test.dart
@@ -12,8 +12,8 @@ Future<void> main() async {
     common.Response response = common.Response.fromJson(jsonResult);
     await driver.close();
     expect(
-      response.result,
-      'fail',
+      response.allTestsPassed,
+      false,
     );
   });
 }

--- a/packages/e2e/example/test_driver/failure_test.dart
+++ b/packages/e2e/example/test_driver/failure_test.dart
@@ -1,16 +1,18 @@
 import 'dart:async';
 
+import 'package:e2e/common.dart' as common;
 import 'package:flutter_driver/flutter_driver.dart';
 import 'package:test/test.dart';
 
 Future<void> main() async {
   test('fails gracefully', () async {
     final FlutterDriver driver = await FlutterDriver.connect();
-    final String result =
+    final String jsonResult =
         await driver.requestData(null, timeout: const Duration(minutes: 1));
+    common.Response response = common.Response.fromJson(jsonResult);
     await driver.close();
     expect(
-      result,
+      response.result,
       'fail',
     );
   });

--- a/packages/e2e/lib/common.dart
+++ b/packages/e2e/lib/common.dart
@@ -42,7 +42,7 @@ class Response {
 
 /// Method for formating the test failures' details.
 String formatFailures(Map<String, String> failureDetails) {
-  if(failureDetails.isEmpty) {
+  if (failureDetails.isEmpty) {
     return '';
   }
   StringBuffer sb = StringBuffer();

--- a/packages/e2e/lib/common.dart
+++ b/packages/e2e/lib/common.dart
@@ -7,7 +7,7 @@ import 'dart:convert';
 /// An object sent from e2e back to the Flutter Driver in response to
 /// `request_data` command.
 class Response {
-  final Map<String, dynamic> _failureDetails;
+  final List<Failure> _failureDetails;
 
   final bool _allTestsPassed;
 
@@ -26,42 +26,88 @@ class Response {
   String get formattedFailureDetails =>
       _allTestsPassed ? '' : formatFailures(_failureDetails);
 
-  /// Failure details as a map.
-  Map<String, dynamic> get failureDetails => _failureDetails;
+  /// Failure details as a list.
+  List<Failure> get failureDetails => _failureDetails;
 
   /// Serializes this message to a JSON map.
-  String toJson() => json.encode(<String, String>{
+  String toJson() => json.encode(<String, dynamic>{
         'result': allTestsPassed.toString(),
-        'failureDetails': json.encode(_failureDetails),
+        'failureDetails': _failureDetailsAsString(),
       });
 
   /// Deserializes the result from JSON.
   static Response fromJson(String source) {
-    Map<String, dynamic> result = json.decode(source);
-    if (result['result'] == 'true') {
+    Map<String, dynamic> responseJson = json.decode(source);
+    if (responseJson['result'] == 'true') {
       return Response.allTestsPassed();
     } else {
-      final Map<String, dynamic> failureDetailsAsMap =
-          json.decode(result['failureDetails']);
-
-      return Response.someTestsFailed(failureDetailsAsMap);
+      return Response.someTestsFailed(
+          _failureDetailsFromJson(responseJson['failureDetails']));
     }
   }
 
   /// Method for formating the test failures' details.
-  String formatFailures(Map<String, dynamic> failureDetails) {
+  String formatFailures(List<Failure> failureDetails) {
     if (failureDetails.isEmpty) {
       return '';
     }
 
     StringBuffer sb = StringBuffer();
     int failureCount = 1;
-    failureDetails.forEach((methodName, details) {
-      sb.writeln('Failure in method: $methodName');
-      sb.writeln('$details');
+    failureDetails.forEach((Failure f) {
+      sb.writeln('Failure in method: ${f.methodName}');
+      sb.writeln('${f.details}');
       sb.writeln('end of failure ${failureCount.toString()}\n\n');
       failureCount++;
     });
     return sb.toString();
+  }
+
+  /// Create a list of Strings from [_failureDetails].
+  List<String> _failureDetailsAsString() {
+    final List<String> list = List<String>();
+    if(_failureDetails == null || _failureDetails.isEmpty) {
+      return list;
+    }
+
+    _failureDetails.forEach((Failure f) {
+      list.add(f.toString());
+    });
+
+    return list;
+  }
+
+  /// Creates a [Failure] list using a json response.
+  static List<Failure> _failureDetailsFromJson(List<dynamic> list) {
+    final List<Failure> failureList = List<Failure>();
+    list.forEach((s) {
+      final String failure = s as String;
+      failureList.add(Failure.fromJsonString(failure));
+    });
+    return failureList;
+  }
+}
+
+/// Representing a failure includes the method name and the failure details.
+class Failure {
+  final String methodName;
+  final String details;
+
+  /// Constructor requiring all fields during initialization.
+  Failure(this.methodName, this.details);
+
+  /// Serializes the object to JSON.
+  @override
+  String toString() {
+    return json.encode(<String, String>{
+      'methodName': methodName,
+      'details': details,
+    });
+  }
+
+  /// Decode a JSON string to create a Failure object.
+  static Failure fromJsonString(String jsonString) {
+    Map<String, dynamic> failure = json.decode(jsonString);
+    return Failure(failure['methodName'], failure['details']);
   }
 }

--- a/packages/e2e/lib/common.dart
+++ b/packages/e2e/lib/common.dart
@@ -1,0 +1,57 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+
+/// An object sent from e2e back to the Flutter Driver in response to
+/// `request_data` command.
+class Response {
+  String _failureDetails;
+
+  final bool _allTestsPassed;
+
+  /// Constructor which receives tests results' flag and failure details.
+  Response(this._allTestsPassed, String failureDetails) {
+    this._failureDetails = failureDetails;
+  }
+
+  /// Whether the test run successfully or not.
+  String get result => _allTestsPassed ? 'pass' : 'fail';
+
+  /// If the result are failures get the formatted details.
+  String get failureDetails => _allTestsPassed ? '' : _failureDetails;
+
+  /// Convert a string pass/fail result to a boolean.
+  static bool allTestsPassed(String result) => (result == 'pass')
+      ? true
+      : (result == 'fail') ? false : throw 'Invalid State for result.';
+
+  /// Serializes this message to a JSON map.
+  String toJson() => json.encode(<String, String>{
+        'result': result,
+        'failureDetails': _failureDetails,
+      });
+
+  /// Deserializes the result from JSON.
+  static Response fromJson(String source) {
+    Map<String, dynamic> result = json.decode(source);
+    return Response(allTestsPassed(result['result']), result['failureDetails']);
+  }
+}
+
+/// Method for formating the test failures' details.
+String formatFailures(Map<String, String> failureDetails) {
+  if(failureDetails.isEmpty) {
+    return '';
+  }
+  StringBuffer sb = StringBuffer();
+  int failureCount = 1;
+  failureDetails.forEach((methodName, details) {
+    sb.writeln('Failure in method: $methodName');
+    sb.writeln('$details');
+    sb.writeln('end of failure ${failureCount.toString()}\n\n');
+    failureCount++;
+  });
+  return sb.toString();
+}

--- a/packages/e2e/lib/common.dart
+++ b/packages/e2e/lib/common.dart
@@ -7,23 +7,26 @@ import 'dart:convert';
 /// An object sent from e2e back to the Flutter Driver in response to
 /// `request_data` command.
 class Response {
-  String _failureDetails;
+  final String _failureDetails;
 
   final bool _allTestsPassed;
 
-  /// Constructor which receives tests results' flag and failure details.
-  Response(this._allTestsPassed, String failureDetails) {
-    this._failureDetails = failureDetails;
-  }
+  /// Constructor to use for positive response.
+  Response.allTestsPassed()
+      : this._allTestsPassed = true,
+        this._failureDetails = '';
 
-  /// Whether the test run successfully or not.
+  /// Constructor for failure response.
+  Response.someTestsFailed(this._failureDetails) : this._allTestsPassed = false;
+
+  /// Whether the test ran successfully or not.
   String get result => _allTestsPassed ? 'pass' : 'fail';
 
   /// If the result are failures get the formatted details.
   String get failureDetails => _allTestsPassed ? '' : _failureDetails;
 
   /// Convert a string pass/fail result to a boolean.
-  static bool allTestsPassed(String result) => (result == 'pass')
+  static bool testsPassed(String result) => (result == 'pass')
       ? true
       : (result == 'fail') ? false : throw 'Invalid State for result.';
 
@@ -36,7 +39,11 @@ class Response {
   /// Deserializes the result from JSON.
   static Response fromJson(String source) {
     Map<String, dynamic> result = json.decode(source);
-    return Response(allTestsPassed(result['result']), result['failureDetails']);
+    if (testsPassed(result['result'])) {
+      return Response.allTestsPassed();
+    } else {
+      return Response.someTestsFailed(result['failureDetails']);
+    }
   }
 }
 

--- a/packages/e2e/lib/common.dart
+++ b/packages/e2e/lib/common.dart
@@ -66,7 +66,7 @@ class Response {
   /// Create a list of Strings from [_failureDetails].
   List<String> _failureDetailsAsString() {
     final List<String> list = List<String>();
-    if(_failureDetails == null || _failureDetails.isEmpty) {
+    if (_failureDetails == null || _failureDetails.isEmpty) {
       return list;
     }
 

--- a/packages/e2e/lib/common.dart
+++ b/packages/e2e/lib/common.dart
@@ -90,7 +90,9 @@ class Response {
 
 /// Representing a failure includes the method name and the failure details.
 class Failure {
+  /// The name of the test method which failed.
   final String methodName;
+  /// The details of the failure such as stack trace.
   final String details;
 
   /// Constructor requiring all fields during initialization.

--- a/packages/e2e/lib/common.dart
+++ b/packages/e2e/lib/common.dart
@@ -92,6 +92,7 @@ class Response {
 class Failure {
   /// The name of the test method which failed.
   final String methodName;
+
   /// The details of the failure such as stack trace.
   final String details;
 

--- a/packages/e2e/lib/e2e.dart
+++ b/packages/e2e/lib/e2e.dart
@@ -41,7 +41,7 @@ class E2EWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding {
   /// Stores failure details.
   ///
   /// Failed test method's names used as key.
-  final Map<String, String> _failureMethodsDetails = Map<String, String>();
+  final List<Failure> _failureMethodsDetails = List<Failure>();
 
   /// Similar to [WidgetsFlutterBinding.ensureInitialized].
   ///
@@ -103,7 +103,7 @@ class E2EWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding {
     reportTestException =
         (FlutterErrorDetails details, String testDescription) {
       _results[description] = 'failed';
-      _failureMethodsDetails[testDescription] = details.toString();
+      _failureMethodsDetails.add(Failure(testDescription,details.toString()));
       if (!_allTestsPassed.isCompleted) _allTestsPassed.complete(false);
       valueBeforeTest(details, testDescription);
     };

--- a/packages/e2e/lib/e2e.dart
+++ b/packages/e2e/lib/e2e.dart
@@ -72,8 +72,7 @@ class E2EWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding {
           response = <String, String>{
             'message': allTestsPassed
                 ? Response.allTestsPassed().toJson()
-                : Response.someTestsFailed(_failureMethodsDetails)
-                    .toJson(),
+                : Response.someTestsFailed(_failureMethodsDetails).toJson(),
           };
           break;
         case 'get_health':

--- a/packages/e2e/lib/e2e.dart
+++ b/packages/e2e/lib/e2e.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
@@ -71,8 +72,7 @@ class E2EWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding {
           response = <String, String>{
             'message': allTestsPassed
                 ? Response.allTestsPassed().toJson()
-                : Response.someTestsFailed(
-                        formatFailures(_failureMethodsDetails))
+                : Response.someTestsFailed(_failureMethodsDetails)
                     .toJson(),
           };
           break;

--- a/packages/e2e/lib/e2e.dart
+++ b/packages/e2e/lib/e2e.dart
@@ -70,7 +70,7 @@ class E2EWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding {
           final bool allTestsPassed = await _allTestsPassed.future;
           response = <String, String>{
             'message': allTestsPassed
-                ? Response.allTestsPassed()
+                ? Response.allTestsPassed().toJson()
                 : Response.someTestsFailed(
                         formatFailures(_failureMethodsDetails))
                     .toJson(),

--- a/packages/e2e/lib/e2e.dart
+++ b/packages/e2e/lib/e2e.dart
@@ -103,7 +103,7 @@ class E2EWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding {
     reportTestException =
         (FlutterErrorDetails details, String testDescription) {
       _results[description] = 'failed';
-      _failureMethodsDetails.add(Failure(testDescription,details.toString()));
+      _failureMethodsDetails.add(Failure(testDescription, details.toString()));
       if (!_allTestsPassed.isCompleted) _allTestsPassed.complete(false);
       valueBeforeTest(details, testDescription);
     };

--- a/packages/e2e/lib/e2e.dart
+++ b/packages/e2e/lib/e2e.dart
@@ -37,9 +37,9 @@ class E2EWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding {
 
   final Completer<bool> _allTestsPassed = Completer<bool>();
 
-  /// Map which stores failure details.
+  /// Stores failure details.
   ///
-  /// Method names are used as key.
+  /// Failed test method's names used as key.
   final Map<String, String> _failureMethodsDetails = Map<String, String>();
 
   /// Similar to [WidgetsFlutterBinding.ensureInitialized].
@@ -69,8 +69,10 @@ class E2EWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding {
         case 'request_data':
           final bool allTestsPassed = await _allTestsPassed.future;
           response = <String, String>{
-            'message':
-                Response(allTestsPassed, formatFailures(_failureMethodsDetails))
+            'message': allTestsPassed
+                ? Response.allTestsPassed()
+                : Response.someTestsFailed(
+                        formatFailures(_failureMethodsDetails))
                     .toJson(),
           };
           break;

--- a/packages/e2e/lib/e2e.dart
+++ b/packages/e2e/lib/e2e.dart
@@ -8,6 +8,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
+import 'common.dart';
 import '_extension_io.dart' if (dart.library.html) '_extension_web.dart';
 
 /// A subclass of [LiveTestWidgetsFlutterBinding] that reports tests results
@@ -36,6 +37,11 @@ class E2EWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding {
 
   final Completer<bool> _allTestsPassed = Completer<bool>();
 
+  /// Map which stores failure details.
+  ///
+  /// Method names are used as key.
+  final Map<String, String> _failureMethodsDetails = Map<String, String>();
+
   /// Similar to [WidgetsFlutterBinding.ensureInitialized].
   ///
   /// Returns an instance of the [E2EWidgetsFlutterBinding], creating and
@@ -63,7 +69,9 @@ class E2EWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding {
         case 'request_data':
           final bool allTestsPassed = await _allTestsPassed.future;
           response = <String, String>{
-            'message': allTestsPassed ? 'pass' : 'fail',
+            'message':
+                Response(allTestsPassed, formatFailures(_failureMethodsDetails))
+                    .toJson(),
           };
           break;
         case 'get_health':
@@ -94,6 +102,7 @@ class E2EWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding {
     reportTestException =
         (FlutterErrorDetails details, String testDescription) {
       _results[description] = 'failed';
+      _failureMethodsDetails[testDescription] = details.toString();
       if (!_allTestsPassed.isCompleted) _allTestsPassed.complete(false);
       valueBeforeTest(details, testDescription);
     };

--- a/packages/e2e/lib/e2e_driver.dart
+++ b/packages/e2e/lib/e2e_driver.dart
@@ -1,14 +1,14 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:e2e/common.dart' as e2ecommon;
+import 'package:e2e/common.dart' as e2e;
 import 'package:flutter_driver/flutter_driver.dart';
 
 Future<void> main() async {
   final FlutterDriver driver = await FlutterDriver.connect();
   final String jsonResult =
       await driver.requestData(null, timeout: const Duration(minutes: 1));
-  final e2ecommon.Response response = e2ecommon.Response.fromJson(jsonResult);
+  final e2e.Response response = e2e.Response.fromJson(jsonResult);
   await driver.close();
 
   if (response.allTestsPassed) {

--- a/packages/e2e/lib/e2e_driver.dart
+++ b/packages/e2e/lib/e2e_driver.dart
@@ -1,0 +1,21 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:e2e/common.dart' as e2ecommon;
+import 'package:flutter_driver/flutter_driver.dart';
+
+Future<void> main() async {
+  final FlutterDriver driver = await FlutterDriver.connect();
+  final String jsonResult =
+      await driver.requestData(null, timeout: const Duration(minutes: 1));
+  final e2ecommon.Response response = e2ecommon.Response.fromJson(jsonResult);
+  await driver.close();
+
+  if (response.allTestsPassed) {
+    print('All tests passed.');
+    exit(0);
+  } else {
+    print('Failure Details:\n${response.formattedFailureDetails}');
+    exit(1);
+  }
+}

--- a/packages/e2e/pubspec.yaml
+++ b/packages/e2e/pubspec.yaml
@@ -10,6 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_driver:
+    sdk: flutter
   flutter_test:
     sdk: flutter
 

--- a/packages/e2e/pubspec.yaml
+++ b/packages/e2e/pubspec.yaml
@@ -1,6 +1,6 @@
 name: e2e
 description: Runs tests that use the flutter_test API as integration tests.
-version: 0.3.0+1
+version: 0.3.1
 homepage: https://github.com/flutter/plugins/tree/master/packages/e2e
 
 environment:

--- a/packages/e2e/pubspec.yaml
+++ b/packages/e2e/pubspec.yaml
@@ -1,6 +1,6 @@
 name: e2e
 description: Runs tests that use the flutter_test API as integration tests.
-version: 0.3.1
+version: 0.4.0
 homepage: https://github.com/flutter/plugins/tree/master/packages/e2e
 
 environment:


### PR DESCRIPTION
## Description

Adding failure details for driver tests.

**Before the change the failure output was something like:**
```
[+2616 ms] result fail
[  +88 ms] Stopping application instance.
[        ] Stopping application.
[   +2 ms] "flutter drive" took 22,861ms.

```
**The updated output:**
```
[+2782 ms] Failure Details:
[        ] Failure in method: verify text
[        ] ══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞═════════════════
[   +1 ms] The following TestFailure object was thrown running a test:
[        ]   Expected: <3>
[        ]   Actual: <2>
[        ] When the exception was thrown, this was the stack:
[        ]     at Object.wrapException (http://localhost:36633/main.dart.js:3646:17)
[        ]     at Object.throwExpression (http://localhost:36633/main.dart.js:3659:15)
[        ]     at Object.fail (http://localhost:36633/main.dart.js:16457:16)
[        ]     at Object._expect (http://localhost:36633/main.dart.js:16454:9)
[        ]     at Object.expect0 (http://localhost:36633/main.dart.js:16430:9)
[        ]     at Object.expect (http://localhost:36633/main.dart.js:19782:9)
[        ]     at http://localhost:36633/main.dart.js:82397:17
[        ]     at _wrapJsFunctionForAsync_closure.$protected (http://localhost:36633/main.dart.js:6615:15)
[        ]     at _wrapJsFunctionForAsync_closure.call$2 (http://localhost:36633/main.dart.js:37105:12)
[        ]     at StackZoneSpecification__registerBinaryCallback__closure.call$0 (http://localhost:36633/main.dart.js:80439:21)
[        ] The test description was:
[        ]   verify text
[        ] ═════════════════════════════════════════════════════════════════
[        ] end of failure 1
[        ] Failure in method: another failure
[        ] ══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞═════════════════
[        ] The following TestFailure object was thrown running a test:
[        ]   Expected: <3>
[        ]   Actual: <2>
[        ] When the exception was thrown, this was the stack:
[        ]     at Object.wrapException (http://localhost:36633/main.dart.js:3646:17)
[        ]     at Object.throwExpression (http://localhost:36633/main.dart.js:3659:15)
[        ]     at Object.fail (http://localhost:36633/main.dart.js:16457:16)
[        ]     at Object._expect (http://localhost:36633/main.dart.js:16454:9)
[        ]     at Object.expect0 (http://localhost:36633/main.dart.js:16430:9)
[        ]     at Object.expect (http://localhost:36633/main.dart.js:19782:9)
[        ]     at http://localhost:36633/main.dart.js:82426:17
[        ]     at _wrapJsFunctionForAsync_closure.$protected (http://localhost:36633/main.dart.js:6615:15)
[        ]     at _wrapJsFunctionForAsync_closure.call$2 (http://localhost:36633/main.dart.js:37105:12)
[        ]     at StackZoneSpecification__registerBinaryCallback__closure.call$0 (http://localhost:36633/main.dart.js:80439:21)
[        ] The test description was:
[        ]   another failure
[        ] ═════════════════════════════════════════════════════════════════
[        ] end of failure 2
[  +71 ms] Stopping application instance.
[        ] Stopping application.
[   +2 ms] "flutter drive" took 23,618ms.

```

## Related Issues

Fixes: https://github.com/flutter/flutter/issues/51940

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
