### PR TITLE
[battery] Announce API stability and compatibility with 1.0.0

### DIFF
--- a/packages/battery/CHANGELOG.md
+++ b/packages/battery/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1+9
+
+* Declare API stability and compatibility with `1.0.0` (more details at: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0).
+
 ## 0.3.1+8
 
 * Make the pedantic dev_dependency explicit.

--- a/packages/battery/README.md
+++ b/packages/battery/README.md
@@ -1,5 +1,12 @@
 # Battery
 
+**Please set your constraint to `battery: '>=0.3.y+x <2.0.0'`**
+
+## Backward compatible 1.0.0 version is coming
+The battery plugin has reached a stable API, we guarantee that version `1.0.0` will be backward compatible with `0.3.y+z`.
+Please use `battery: '>=0.3.y+x <2.0.0'` as your dependency constraint to allow a smoother ecosystem migration.
+For more details see: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
+
 [![pub package](https://img.shields.io/pub/v/battery.svg)](https://pub.dartlang.org/packages/battery)
 
 A Flutter plugin to access various information about the battery of the device the app is running on.

--- a/packages/battery/pubspec.yaml
+++ b/packages/battery/pubspec.yaml
@@ -2,7 +2,10 @@ name: battery
 description: Flutter plugin for accessing information about the battery state
   (full, charging, discharging) on Android and iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/battery
-version: 0.3.1+8
+# 0.3.y+z is compatible with 1.0.0, if you land a breaking change bump
+# the version to 2.0.0.
+# See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
+version: 0.3.1+9
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Announce that the package is going to be compatible with 1.0.0 and encourage users to set their constraints accordingly.


@collinjackson @csells after we're happy with the wording here I'll apply it to more plugins we want to upgrade to 1.0.0