### PR TITLE
[many] Replace deprecated getFlutterEngine calls on Android

### DIFF
--- a/packages/android_alarm_manager/CHANGELOG.md
+++ b/packages/android_alarm_manager/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.5+6
+
+* Replace deprecated `getFlutterEngine` call on Android.
+
 ## 0.4.5+5
 
 * Added an Espresso test.

--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AndroidAlarmManagerPlugin.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AndroidAlarmManagerPlugin.java
@@ -63,8 +63,7 @@ public class AndroidAlarmManagerPlugin implements FlutterPlugin, MethodCallHandl
 
   @Override
   public void onAttachedToEngine(FlutterPluginBinding binding) {
-    onAttachedToEngine(
-        binding.getApplicationContext(), binding.getBinaryMessenger());
+    onAttachedToEngine(binding.getApplicationContext(), binding.getBinaryMessenger());
   }
 
   public void onAttachedToEngine(Context applicationContext, BinaryMessenger messenger) {

--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AndroidAlarmManagerPlugin.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AndroidAlarmManagerPlugin.java
@@ -64,7 +64,7 @@ public class AndroidAlarmManagerPlugin implements FlutterPlugin, MethodCallHandl
   @Override
   public void onAttachedToEngine(FlutterPluginBinding binding) {
     onAttachedToEngine(
-        binding.getApplicationContext(), binding.getFlutterEngine().getDartExecutor());
+        binding.getApplicationContext(), binding.getBinaryMessenger());
   }
 
   public void onAttachedToEngine(Context applicationContext, BinaryMessenger messenger) {

--- a/packages/android_alarm_manager/pubspec.yaml
+++ b/packages/android_alarm_manager/pubspec.yaml
@@ -1,7 +1,7 @@
 name: android_alarm_manager
 description: Flutter plugin for accessing the Android AlarmManager service, and
   running Dart code in the background when alarms fire.
-version: 0.4.5+5
+version: 0.4.5+6
 homepage: https://github.com/flutter/plugins/tree/master/packages/android_alarm_manager
 
 dependencies:

--- a/packages/camera/CHANGELOG.md
+++ b/packages/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.7+5
+
+* Replace deprecated `getFlutterEngine` call on Android.
+
 ## 0.5.7+4
 
 * Add `pedantic` to dev_dependency.

--- a/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
+++ b/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
@@ -68,7 +68,7 @@ public final class CameraPlugin implements FlutterPlugin, ActivityAware {
   public void onAttachedToActivity(@NonNull ActivityPluginBinding binding) {
     maybeStartListening(
         binding.getActivity(),
-        flutterPluginBinding.getFlutterEngine().getDartExecutor(),
+        flutterPluginBinding.getBinaryMessenger(),
         binding::addRequestPermissionsResultListener,
         flutterPluginBinding.getFlutterEngine().getRenderer());
   }

--- a/packages/camera/pubspec.yaml
+++ b/packages/camera/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera
 description: A Flutter plugin for getting information about and controlling the
   camera on Android and iOS. Supports previewing the camera feed, capturing images, capturing video,
   and streaming image buffers to dart.
-version: 0.5.7+4
+version: 0.5.7+5
 
 homepage: https://github.com/flutter/plugins/tree/master/packages/camera
 

--- a/packages/connectivity/connectivity/CHANGELOG.md
+++ b/packages/connectivity/connectivity/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.8+3
+
+* Replace deprecated `getFlutterEngine` call on Android.
+
 ## 0.4.8+2
 
 * Remove hard coded ios workspace setting of the example app.

--- a/packages/connectivity/connectivity/android/src/main/java/io/flutter/plugins/connectivity/ConnectivityPlugin.java
+++ b/packages/connectivity/connectivity/android/src/main/java/io/flutter/plugins/connectivity/ConnectivityPlugin.java
@@ -28,7 +28,7 @@ public class ConnectivityPlugin implements FlutterPlugin {
 
   @Override
   public void onAttachedToEngine(FlutterPluginBinding binding) {
-    setupChannels(binding.getFlutterEngine().getDartExecutor(), binding.getApplicationContext());
+    setupChannels(binding.getBinaryMessenger(), binding.getApplicationContext());
   }
 
   @Override

--- a/packages/connectivity/connectivity/pubspec.yaml
+++ b/packages/connectivity/connectivity/pubspec.yaml
@@ -2,7 +2,7 @@ name: connectivity
 description: Flutter plugin for discovering the state of the network (WiFi &
   mobile/cellular) connectivity on Android and iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/connectivity/connectivity
-version: 0.4.8+2
+version: 0.4.8+3
 
 flutter:
   plugin:

--- a/packages/e2e/CHANGELOG.md
+++ b/packages/e2e/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0+1
+
+* Replace deprecated `getFlutterEngine` call on Android.
+
 ## 0.3.0
 
 * Updates documentation to instruct developers not to launch the activity since

--- a/packages/e2e/android/src/main/java/dev/flutter/plugins/e2e/E2EPlugin.java
+++ b/packages/e2e/android/src/main/java/dev/flutter/plugins/e2e/E2EPlugin.java
@@ -31,8 +31,7 @@ public class E2EPlugin implements MethodCallHandler, FlutterPlugin {
 
   @Override
   public void onAttachedToEngine(FlutterPluginBinding binding) {
-    onAttachedToEngine(
-        binding.getApplicationContext(), binding.getBinaryMessenger());
+    onAttachedToEngine(binding.getApplicationContext(), binding.getBinaryMessenger());
   }
 
   private void onAttachedToEngine(Context applicationContext, BinaryMessenger messenger) {

--- a/packages/e2e/android/src/main/java/dev/flutter/plugins/e2e/E2EPlugin.java
+++ b/packages/e2e/android/src/main/java/dev/flutter/plugins/e2e/E2EPlugin.java
@@ -32,7 +32,7 @@ public class E2EPlugin implements MethodCallHandler, FlutterPlugin {
   @Override
   public void onAttachedToEngine(FlutterPluginBinding binding) {
     onAttachedToEngine(
-        binding.getApplicationContext(), binding.getFlutterEngine().getDartExecutor());
+        binding.getApplicationContext(), binding.getBinaryMessenger());
   }
 
   private void onAttachedToEngine(Context applicationContext, BinaryMessenger messenger) {

--- a/packages/e2e/pubspec.yaml
+++ b/packages/e2e/pubspec.yaml
@@ -1,6 +1,6 @@
 name: e2e
 description: Runs tests that use the flutter_test API as integration tests.
-version: 0.3.0
+version: 0.3.0+1
 homepage: https://github.com/flutter/plugins/tree/master/packages/e2e
 
 environment:

--- a/packages/espresso/CHANGELOG.md
+++ b/packages/espresso/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.1+5
+
+* Replace deprecated `getFlutterEngine` call on Android.
+
 ## 0.0.1+4
 
 * Remove Swift dependency.

--- a/packages/espresso/android/src/main/java/com/example/espresso/EspressoPlugin.java
+++ b/packages/espresso/android/src/main/java/com/example/espresso/EspressoPlugin.java
@@ -13,7 +13,7 @@ public class EspressoPlugin implements FlutterPlugin, MethodCallHandler {
   @Override
   public void onAttachedToEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {
     final MethodChannel channel =
-        new MethodChannel(flutterPluginBinding.getFlutterEngine().getDartExecutor(), "espresso");
+        new MethodChannel(flutterPluginBinding.getBinaryMessenger(), "espresso");
     channel.setMethodCallHandler(new EspressoPlugin());
   }
 

--- a/packages/espresso/pubspec.yaml
+++ b/packages/espresso/pubspec.yaml
@@ -1,6 +1,6 @@
 name: espresso
 description: Java classes for testing Flutter apps using Espresso.
-version: 0.0.1+4
+version: 0.0.1+5
 homepage: https://github.com/flutter/plugins/espresso
 
 environment:

--- a/packages/local_auth/CHANGELOG.md
+++ b/packages/local_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.1+4
+
+* Replace deprecated `getFlutterEngine` call on Android.
+
 ## 0.6.1+3
 
 * Make the pedantic dev_dependency explicit.

--- a/packages/local_auth/android/src/main/java/io/flutter/plugins/localauth/LocalAuthPlugin.java
+++ b/packages/local_auth/android/src/main/java/io/flutter/plugins/localauth/LocalAuthPlugin.java
@@ -169,7 +169,7 @@ public class LocalAuthPlugin implements MethodCallHandler, FlutterPlugin, Activi
 
   @Override
   public void onAttachedToEngine(FlutterPluginBinding binding) {
-    channel = new MethodChannel(binding.getFlutterEngine().getDartExecutor(), CHANNEL_NAME);
+    channel = new MethodChannel(binding.getBinaryMessenger(), CHANNEL_NAME);
   }
 
   @Override

--- a/packages/local_auth/pubspec.yaml
+++ b/packages/local_auth/pubspec.yaml
@@ -2,7 +2,7 @@ name: local_auth
 description: Flutter plugin for Android and iOS device authentication sensors
   such as Fingerprint Reader and Touch ID.
 homepage: https://github.com/flutter/plugins/tree/master/packages/local_auth
-version: 0.6.1+3
+version: 0.6.1+4
 
 flutter:
   plugin:

--- a/packages/package_info/CHANGELOG.md
+++ b/packages/package_info/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0+15
+
+* Replace deprecated `getFlutterEngine` call on Android.
+
 ## 0.4.0+14
 
 * Make the pedantic dev_dependency explicit.

--- a/packages/package_info/android/src/main/java/io/flutter/plugins/packageinfo/PackageInfoPlugin.java
+++ b/packages/package_info/android/src/main/java/io/flutter/plugins/packageinfo/PackageInfoPlugin.java
@@ -31,8 +31,7 @@ public class PackageInfoPlugin implements MethodCallHandler, FlutterPlugin {
 
   @Override
   public void onAttachedToEngine(FlutterPluginBinding binding) {
-    onAttachedToEngine(
-        binding.getApplicationContext(), binding.getBinaryMessenger());
+    onAttachedToEngine(binding.getApplicationContext(), binding.getBinaryMessenger());
   }
 
   private void onAttachedToEngine(Context applicationContext, BinaryMessenger messenger) {

--- a/packages/package_info/android/src/main/java/io/flutter/plugins/packageinfo/PackageInfoPlugin.java
+++ b/packages/package_info/android/src/main/java/io/flutter/plugins/packageinfo/PackageInfoPlugin.java
@@ -32,7 +32,7 @@ public class PackageInfoPlugin implements MethodCallHandler, FlutterPlugin {
   @Override
   public void onAttachedToEngine(FlutterPluginBinding binding) {
     onAttachedToEngine(
-        binding.getApplicationContext(), binding.getFlutterEngine().getDartExecutor());
+        binding.getApplicationContext(), binding.getBinaryMessenger());
   }
 
   private void onAttachedToEngine(Context applicationContext, BinaryMessenger messenger) {

--- a/packages/package_info/pubspec.yaml
+++ b/packages/package_info/pubspec.yaml
@@ -2,7 +2,7 @@ name: package_info
 description: Flutter plugin for querying information about the application
   package, such as CFBundleVersion on iOS or versionCode on Android.
 homepage: https://github.com/flutter/plugins/tree/master/packages/package_info
-version: 0.4.0+14
+version: 0.4.0+15
 
 flutter:
   plugin:

--- a/packages/path_provider/path_provider/CHANGELOG.md
+++ b/packages/path_provider/path_provider/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.6.6
+
+* Replace deprecated `getFlutterEngine` call on Android.
+
 ## 1.6.5
 
 * Remove unused class name in pubspec.

--- a/packages/path_provider/path_provider/android/src/main/java/io/flutter/plugins/pathprovider/PathProviderPlugin.java
+++ b/packages/path_provider/path_provider/android/src/main/java/io/flutter/plugins/pathprovider/PathProviderPlugin.java
@@ -35,9 +35,7 @@ public class PathProviderPlugin implements FlutterPlugin, MethodCallHandler {
 
   @Override
   public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
-    channel =
-        new MethodChannel(
-            binding.getBinaryMessenger(), "plugins.flutter.io/path_provider");
+    channel = new MethodChannel(binding.getBinaryMessenger(), "plugins.flutter.io/path_provider");
     context = binding.getApplicationContext();
     channel.setMethodCallHandler(this);
   }

--- a/packages/path_provider/path_provider/android/src/main/java/io/flutter/plugins/pathprovider/PathProviderPlugin.java
+++ b/packages/path_provider/path_provider/android/src/main/java/io/flutter/plugins/pathprovider/PathProviderPlugin.java
@@ -37,7 +37,7 @@ public class PathProviderPlugin implements FlutterPlugin, MethodCallHandler {
   public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
     channel =
         new MethodChannel(
-            binding.getFlutterEngine().getDartExecutor(), "plugins.flutter.io/path_provider");
+            binding.getBinaryMessenger(), "plugins.flutter.io/path_provider");
     context = binding.getApplicationContext();
     channel.setMethodCallHandler(this);
   }

--- a/packages/path_provider/path_provider/pubspec.yaml
+++ b/packages/path_provider/path_provider/pubspec.yaml
@@ -2,7 +2,7 @@ name: path_provider
 description: Flutter plugin for getting commonly used locations on the Android &
   iOS file systems, such as the temp and app data directories.
 homepage: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider
-version: 1.6.5
+version: 1.6.6
 
 flutter:
   plugin:

--- a/packages/quick_actions/CHANGELOG.md
+++ b/packages/quick_actions/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0+3
+
+* Replace deprecated `getFlutterEngine` call on Android.
+
 ## 0.4.0+2
 
 * Make the pedantic dev_dependency explicit.

--- a/packages/quick_actions/android/src/main/java/io/flutter/plugins/quickactions/QuickActionsPlugin.java
+++ b/packages/quick_actions/android/src/main/java/io/flutter/plugins/quickactions/QuickActionsPlugin.java
@@ -32,8 +32,7 @@ public class QuickActionsPlugin implements FlutterPlugin, ActivityAware {
 
   @Override
   public void onAttachedToEngine(FlutterPluginBinding binding) {
-    setupChannel(
-        binding.getBinaryMessenger(), binding.getApplicationContext(), null);
+    setupChannel(binding.getBinaryMessenger(), binding.getApplicationContext(), null);
   }
 
   @Override

--- a/packages/quick_actions/android/src/main/java/io/flutter/plugins/quickactions/QuickActionsPlugin.java
+++ b/packages/quick_actions/android/src/main/java/io/flutter/plugins/quickactions/QuickActionsPlugin.java
@@ -33,7 +33,7 @@ public class QuickActionsPlugin implements FlutterPlugin, ActivityAware {
   @Override
   public void onAttachedToEngine(FlutterPluginBinding binding) {
     setupChannel(
-        binding.getFlutterEngine().getDartExecutor(), binding.getApplicationContext(), null);
+        binding.getBinaryMessenger(), binding.getApplicationContext(), null);
   }
 
   @Override

--- a/packages/quick_actions/pubspec.yaml
+++ b/packages/quick_actions/pubspec.yaml
@@ -2,7 +2,7 @@ name: quick_actions
 description: Flutter plugin for creating shortcuts on home screen, also known as
   Quick Actions on iOS and App Shortcuts on Android.
 homepage: https://github.com/flutter/plugins/tree/master/packages/quick_actions
-version: 0.4.0+2
+version: 0.4.0+3
 
 flutter:
   plugin:

--- a/packages/sensors/CHANGELOG.md
+++ b/packages/sensors/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1+9
+
+* Replace deprecated `getFlutterEngine` call on Android.
+
 ## 0.4.1+8
 
 * Make the pedantic dev_dependency explicit.

--- a/packages/sensors/android/src/main/java/io/flutter/plugins/sensors/SensorsPlugin.java
+++ b/packages/sensors/android/src/main/java/io/flutter/plugins/sensors/SensorsPlugin.java
@@ -33,7 +33,7 @@ public class SensorsPlugin implements FlutterPlugin {
   @Override
   public void onAttachedToEngine(FlutterPluginBinding binding) {
     final Context context = binding.getApplicationContext();
-    setupEventChannels(context, binding.getFlutterEngine().getDartExecutor());
+    setupEventChannels(context, binding.getBinaryMessenger());
   }
 
   @Override

--- a/packages/sensors/pubspec.yaml
+++ b/packages/sensors/pubspec.yaml
@@ -2,7 +2,7 @@ name: sensors
 description: Flutter plugin for accessing the Android and iOS accelerometer and
   gyroscope sensors.
 homepage: https://github.com/flutter/plugins/tree/master/packages/sensors
-version: 0.4.1+8
+version: 0.4.1+9
 
 flutter:
   plugin:

--- a/packages/share/CHANGELOG.md
+++ b/packages/share/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.3+8
+
+* Replace deprecated `getFlutterEngine` call on Android.
+
 ## 0.6.3+7
 
 * Updated gradle version of example.

--- a/packages/share/android/src/main/java/io/flutter/plugins/share/SharePlugin.java
+++ b/packages/share/android/src/main/java/io/flutter/plugins/share/SharePlugin.java
@@ -27,7 +27,7 @@ public class SharePlugin implements FlutterPlugin, ActivityAware {
 
   @Override
   public void onAttachedToEngine(FlutterPluginBinding binding) {
-    setUpChannel(null, binding.getFlutterEngine().getDartExecutor());
+    setUpChannel(null, binding.getBinaryMessenger());
   }
 
   @Override

--- a/packages/share/pubspec.yaml
+++ b/packages/share/pubspec.yaml
@@ -2,7 +2,7 @@ name: share
 description: Flutter plugin for sharing content via the platform share UI, using
   the ACTION_SEND intent on Android and UIActivityViewController on iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/share
-version: 0.6.3+7
+version: 0.6.3+8
 
 flutter:
   plugin:

--- a/packages/url_launcher/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.4.4
+
+* Replace deprecated `getFlutterEngine` call on Android.
+
 ## 5.4.3
 
 * Fixed the launchUniversalLinkIos method.

--- a/packages/url_launcher/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/UrlLauncherPlugin.java
+++ b/packages/url_launcher/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/UrlLauncherPlugin.java
@@ -35,7 +35,7 @@ public final class UrlLauncherPlugin implements FlutterPlugin, ActivityAware {
   public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
     urlLauncher = new UrlLauncher(binding.getApplicationContext(), /*activity=*/ null);
     methodCallHandler = new MethodCallHandlerImpl(urlLauncher);
-    methodCallHandler.startListening(binding.getFlutterEngine().getDartExecutor());
+    methodCallHandler.startListening(binding.getBinaryMessenger());
   }
 
   @Override

--- a/packages/url_launcher/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher
 description: Flutter plugin for launching a URL on Android and iOS. Supports
   web, phone, SMS, and email schemes.
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher
-version: 5.4.3
+version: 5.4.4
 
 flutter:
   plugin:

--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.8+2
+
+* Replace deprecated `getFlutterEngine` call on Android.
+
 ## 0.10.8+1
 
 * Make the pedantic dev_dependency explicit.

--- a/packages/video_player/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -53,7 +53,7 @@ public class VideoPlayerPlugin implements MethodCallHandler, FlutterPlugin {
     this.flutterState =
         new FlutterState(
             binding.getApplicationContext(),
-            binding.getFlutterEngine().getDartExecutor(),
+            binding.getBinaryMessenger(),
             FlutterMain::getLookupKeyForAsset,
             FlutterMain::getLookupKeyForAsset,
             binding.getFlutterEngine().getRenderer());

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -1,7 +1,7 @@
 name: video_player
 description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android and iOS.
-version: 0.10.8+1
+version: 0.10.8+2
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player
 
 flutter:

--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.19+10
+
+* Replace deprecated `getFlutterEngine` call on Android.
+
 ## 0.3.19+9
 
 * Remove example app's iOS workspace settings.

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/WebViewFlutterPlugin.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/WebViewFlutterPlugin.java
@@ -52,7 +52,7 @@ public class WebViewFlutterPlugin implements FlutterPlugin {
 
   @Override
   public void onAttachedToEngine(FlutterPluginBinding binding) {
-    BinaryMessenger messenger = binding.getFlutterEngine().getDartExecutor();
+    BinaryMessenger messenger = binding.getBinaryMessenger();
     binding
         .getFlutterEngine()
         .getPlatformViewsController()


### PR DESCRIPTION
## Description

Fixes deprecation of the `getFlutterEngine` calls on Android by replacing them with `getBinaryMessenger`.

If you are unsure about this, see the same change for the `flutterfire` plugins: https://github.com/FirebaseExtended/flutterfire/pull/2050

## Related Issues

* Fixes https://github.com/flutter/flutter/issues/30377.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, this is *not* a breaking change.