### PR TITLE
[package_info, sensors] Announce API stability and compatibility with 1.0.0

### DIFF
--- a/packages/package_info/CHANGELOG.md
+++ b/packages/package_info/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0+16
+
+* Declare API stability and compatibility with `1.0.0` (more details at: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0).
+
 ## 0.4.0+15
 
 * Replace deprecated `getFlutterEngine` call on Android.

--- a/packages/package_info/README.md
+++ b/packages/package_info/README.md
@@ -3,6 +3,13 @@
 This Flutter plugin provides an API for querying information about an
 application package.
 
+**Please set your constraint to `package_info: '>=0.4.y+x <2.0.0'`**
+
+## Backward compatible 1.0.0 version is coming
+The package_info plugin has reached a stable API, we guarantee that version `1.0.0` will be backward compatible with `0.4.y+z`.
+Please use `package_info: '>=0.4.y+x <2.0.0'` as your dependency constraint to allow a smoother ecosystem migration.
+For more details see: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
+
 # Usage
 
 You can use the PackageInfo to query information about the

--- a/packages/package_info/pubspec.yaml
+++ b/packages/package_info/pubspec.yaml
@@ -2,7 +2,10 @@ name: package_info
 description: Flutter plugin for querying information about the application
   package, such as CFBundleVersion on iOS or versionCode on Android.
 homepage: https://github.com/flutter/plugins/tree/master/packages/package_info
-version: 0.4.0+15
+# 0.4.y+z is compatible with 1.0.0, if you land a breaking change bump
+# the version to 2.0.0.
+# See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
+version: 0.4.0+16
 
 flutter:
   plugin:

--- a/packages/sensors/CHANGELOG.md
+++ b/packages/sensors/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1+10
+
+* Declare API stability and compatibility with `1.0.0` (more details at: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0).
+
 ## 0.4.1+9
 
 * Replace deprecated `getFlutterEngine` call on Android.

--- a/packages/sensors/README.md
+++ b/packages/sensors/README.md
@@ -1,5 +1,12 @@
 # sensors
 
+**Please set your constraint to `sensors: '>=0.4.y+x <2.0.0'`**
+
+## Backward compatible 1.0.0 version is coming
+The sensors plugin has reached a stable API, we guarantee that version `1.0.0` will be backward compatible with `0.4.y+z`.
+Please use `sensors: '>=0.4.y+x <2.0.0'` as your dependency constraint to allow a smoother ecosystem migration.
+For more details see: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
+
 A Flutter plugin to access the accelerometer and gyroscope sensors.
 
 

--- a/packages/sensors/pubspec.yaml
+++ b/packages/sensors/pubspec.yaml
@@ -2,7 +2,10 @@ name: sensors
 description: Flutter plugin for accessing the Android and iOS accelerometer and
   gyroscope sensors.
 homepage: https://github.com/flutter/plugins/tree/master/packages/sensors
-version: 0.4.1+9
+# 0.4.y+z is compatible with 1.0.0, if you land a breaking change bump
+# the version to 2.0.0.
+# See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
+version: 0.4.1+10
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description
Announce that the package is going to be compatible with 1.0.0 and encourage users to set their constraints accordingly.

This is similar to https://github.com/flutter/plugins/pull/2597