### PR TITLE
[video_player] avoid screen dim when video playing

### DIFF
--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.10.10
+
+* Avoid screen dim when video playing.\
+  NOTE: Android need add permision:
+  > `<uses-permission android:name="android.permission.WAKE_LOCK"/>`
+
 ## 0.10.9+1
 
 * Readme updated to include web support and details on how to use for web
@@ -20,7 +26,6 @@
 
 * Added support for cleaning up the plugin if used for add-to-app (Flutter
   v1.15.3 is required for that feature).
-
 
 ## 0.10.7
 

--- a/packages/video_player/video_player/example/pubspec.yaml
+++ b/packages/video_player/video_player/example/pubspec.yaml
@@ -1,6 +1,5 @@
 name: video_player_example
 description: Demonstrates how to use the video_player plugin.
-version: 1.0.0+1
 
 dependencies:
   flutter:

--- a/packages/video_player/video_player/example/pubspec.yaml
+++ b/packages/video_player/video_player/example/pubspec.yaml
@@ -1,5 +1,6 @@
 name: video_player_example
 description: Demonstrates how to use the video_player plugin.
+version: 1.0.0+1
 
 dependencies:
   flutter:

--- a/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m
@@ -295,8 +295,10 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
   }
   if (_isPlaying) {
     [_player play];
+    [[UIApplication sharedApplication] setIdleTimerDisabled:YES];
   } else {
     [_player pause];
+    [[UIApplication sharedApplication] setIdleTimerDisabled:NO];
   }
   _displayLink.paused = !_isPlaying;
 }

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -1,7 +1,7 @@
 name: video_player
 description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android and iOS.
-version: 0.10.9+1
+version: 0.10.10
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player
 
 flutter:


### PR DESCRIPTION
## Description

Solve [52711](https://github.com/flutter/flutter/issues/52711).
To avoid video screen dim when playing video, and reset when video paused.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
