### PR TITLE
[e2e] Split native test cases aligning to the Dart test cases.

### DIFF
--- a/packages/e2e/ios/Classes/E2EIosTest.h
+++ b/packages/e2e/ios/Classes/E2EIosTest.h
@@ -9,31 +9,29 @@
 
 - (instancetype)init NS_UNAVAILABLE;
 
-- (instancetype)initWithTestCase:(NSString *)testCase
-                      withResult:(NSString *)result;
+- (instancetype)initWithTestCase:(NSString *)testCase withResult:(NSString *)result;
 
 @end
 
 NSArray<NSInvocation *> *E2EMakeTestInvocations(Class xcTestCase);
 
-#define E2E_IOS_RUNNER(__test_class)                                           \
-@interface __test_class : XCTestCase                                           \
-@end                                                                           \
-\
-@implementation __test_class                                                   \
-\
-+ (NSArray<NSInvocation *> *)testInvocations {                                 \
-  return E2EMakeTestInvocations([self class]);                                 \
-}                                                                              \
-\
-- (void)printTestResult {                                                      \
-  NSDictionary<NSString *, E2EIosTestResult *> *results =                      \
-      objc_getAssociatedObject([self class], @selector(printTestResult));      \
-  E2EIosTestResult *testResult = results[NSStringFromSelector(_cmd)];          \
-  if (![testResult.result isEqualToString:@"success"]) {                       \
-    XCTFail("'%@' failed with message: %@",                                    \
-            testResult.testCase, testResult.result);                           \
-  }                                                                            \
-}                                                                              \
-\
-@end
+#define E2E_IOS_RUNNER(__test_class)                                                   \
+  @interface __test_class : XCTestCase                                                 \
+  @end                                                                                 \
+                                                                                       \
+  @implementation __test_class                                                         \
+                                                                                       \
+  +(NSArray<NSInvocation *> *)testInvocations {                                        \
+    return E2EMakeTestInvocations([self class]);                                       \
+  }                                                                                    \
+                                                                                       \
+  -(void)printTestResult {                                                             \
+    NSDictionary<NSString *, E2EIosTestResult *> *results =                            \
+        objc_getAssociatedObject([self class], @selector(printTestResult));            \
+    E2EIosTestResult *testResult = results[NSStringFromSelector(_cmd)];                \
+    if (![testResult.result isEqualToString:@"success"]) {                             \
+      XCTFail("'%@' failed with message: %@", testResult.testCase, testResult.result); \
+    }                                                                                  \
+  }                                                                                    \
+                                                                                       \
+  @end

--- a/packages/e2e/ios/Classes/E2EIosTest.h
+++ b/packages/e2e/ios/Classes/E2EIosTest.h
@@ -1,22 +1,39 @@
 #import <Foundation/Foundation.h>
+#include <objc/runtime.h>
 
-@interface E2EIosTest : NSObject
+@interface E2EIosTestResult : NSObject
 
-- (BOOL)testE2E:(NSString **)testResult;
+@property(nonatomic, readonly) NSString *testCase;
+
+@property(nonatomic, readonly) NSString *result;
+
+- (instancetype)init NS_UNAVAILABLE;
+
+- (instancetype)initWithTestCase:(NSString *)testCase
+                      withResult:(NSString *)result;
 
 @end
 
-#define E2E_IOS_RUNNER(__test_class)                    \
-  @interface __test_class : XCTestCase                  \
-  @end                                                  \
-                                                        \
-  @implementation __test_class                          \
-                                                        \
-  -(void)testE2E {                                      \
-    NSString *testResult;                               \
-    E2EIosTest *e2eIosTest = [[E2EIosTest alloc] init]; \
-    BOOL testPass = [e2eIosTest testE2E:&testResult];   \
-    XCTAssertTrue(testPass, @"%@", testResult);         \
-  }                                                     \
-                                                        \
-  @end
+NSArray<NSInvocation *> *E2EMakeTestInvocations(Class xcTestCase);
+
+#define E2E_IOS_RUNNER(__test_class)                                           \
+@interface __test_class : XCTestCase                                           \
+@end                                                                           \
+\
+@implementation __test_class                                                   \
+\
++ (NSArray<NSInvocation *> *)testInvocations {                                 \
+  return E2EMakeTestInvocations([self class]);                                 \
+}                                                                              \
+\
+- (void)printTestResult {                                                      \
+  NSDictionary<NSString *, E2EIosTestResult *> *results =                      \
+      objc_getAssociatedObject([self class], @selector(printTestResult));      \
+  E2EIosTestResult *testResult = results[NSStringFromSelector(_cmd)];          \
+  if (![testResult.result isEqualToString:@"success"]) {                       \
+    XCTFail("'%@' failed with message: %@",                                    \
+            testResult.testCase, testResult.result);                           \
+  }                                                                            \
+}                                                                              \
+\
+@end

--- a/packages/e2e/ios/Classes/E2EIosTest.m
+++ b/packages/e2e/ios/Classes/E2EIosTest.m
@@ -3,8 +3,7 @@
 
 @implementation E2EIosTestResult
 
-- (instancetype)initWithTestCase:(NSString *)testCase
-                      withResult:(NSString *)result {
+- (instancetype)initWithTestCase:(NSString *)testCase withResult:(NSString *)result {
   self = [super init];
   if (self) {
     _testCase = testCase;
@@ -41,9 +40,9 @@ NSArray<NSInvocation *> *E2EMakeTestInvocations(Class xcTestCase) {
   NSCharacterSet *whiteSpaceSet = [NSCharacterSet whitespaceAndNewlineCharacterSet];
   NSMutableArray<NSInvocation *> *invocations = [@[] mutableCopy];
   for (NSString *testCase in e2ePlugin.testResults.allKeys) {
-    NSString *formattedTestCase =
-        [[testCase stringByTrimmingCharactersInSet:whiteSpaceSet]
-            stringByReplacingOccurrencesOfString:@" " withString:@"_"];
+    NSString *formattedTestCase = [[testCase stringByTrimmingCharactersInSet:whiteSpaceSet]
+        stringByReplacingOccurrencesOfString:@" "
+                                  withString:@"_"];
     results[formattedTestCase] =
         [[E2EIosTestResult alloc] initWithTestCase:testCase
                                         withResult:e2ePlugin.testResults[testCase]];
@@ -53,7 +52,7 @@ NSArray<NSInvocation *> *E2EMakeTestInvocations(Class xcTestCase) {
     invocation.selector = testSelector;
     [invocations addObject:invocation];
   }
-  objc_setAssociatedObject(xcTestCase, @selector(printTestResult),
-                           results, OBJC_ASSOCIATION_RETAIN);
+  objc_setAssociatedObject(xcTestCase, @selector(printTestResult), results,
+                           OBJC_ASSOCIATION_RETAIN);
   return invocations;
 }

--- a/packages/e2e/ios/Classes/E2EIosTest.m
+++ b/packages/e2e/ios/Classes/E2EIosTest.m
@@ -1,43 +1,59 @@
 #import "E2EIosTest.h"
 #import "E2EPlugin.h"
 
-@implementation E2EIosTest
+@implementation E2EIosTestResult
 
-- (BOOL)testE2E:(NSString **)testResult {
+- (instancetype)initWithTestCase:(NSString *)testCase
+                      withResult:(NSString *)result {
+  self = [super init];
+  if (self) {
+    _testCase = testCase;
+    _result = result;
+  }
+  return self;
+}
+
+@end
+
+static SEL AddTestCase(Class xcTestCase, NSString *name) {
+  SEL methodSelector = NSSelectorFromString(name);
+  Method realMethod = class_getInstanceMethod(xcTestCase, @selector(printTestResult));
+  IMP realImp = method_getImplementation(realMethod);
+  struct objc_method_description *desc = method_getDescription(realMethod);
+  class_addMethod(xcTestCase, methodSelector, realImp, desc->types);
+  return methodSelector;
+}
+
+NSArray<NSInvocation *> *E2EMakeTestInvocations(Class xcTestCase) {
+  NSMutableDictionary<NSString *, E2EIosTestResult *> *results = [@{} mutableCopy];
   E2EPlugin *e2ePlugin = [E2EPlugin instance];
   UIViewController *rootViewController =
       [[[[UIApplication sharedApplication] delegate] window] rootViewController];
   if (![rootViewController isKindOfClass:[FlutterViewController class]]) {
     NSLog(@"expected FlutterViewController as rootViewController.");
-    return NO;
+    return @[];
   }
   FlutterViewController *flutterViewController = (FlutterViewController *)rootViewController;
   [e2ePlugin setupChannels:flutterViewController.engine.binaryMessenger];
   while (!e2ePlugin.testResults) {
     CFRunLoopRunInMode(kCFRunLoopDefaultMode, 1.f, NO);
   }
-  NSDictionary<NSString *, NSString *> *testResults = e2ePlugin.testResults;
-  NSMutableArray<NSString *> *passedTests = [NSMutableArray array];
-  NSMutableArray<NSString *> *failedTests = [NSMutableArray array];
-  NSLog(@"==================== Test Results =====================");
-  for (NSString *test in testResults.allKeys) {
-    NSString *result = testResults[test];
-    if ([result isEqualToString:@"success"]) {
-      NSLog(@"%@ passed.", test);
-      [passedTests addObject:test];
-    } else {
-      NSLog(@"%@ failed.", test);
-      [failedTests addObject:test];
-    }
+  NSCharacterSet *whiteSpaceSet = [NSCharacterSet whitespaceAndNewlineCharacterSet];
+  NSMutableArray<NSInvocation *> *invocations = [@[] mutableCopy];
+  for (NSString *testCase in e2ePlugin.testResults.allKeys) {
+    NSString *formattedTestCase =
+        [[testCase stringByTrimmingCharactersInSet:whiteSpaceSet]
+            stringByReplacingOccurrencesOfString:@" " withString:@"_"];
+    results[formattedTestCase] =
+        [[E2EIosTestResult alloc] initWithTestCase:testCase
+                                        withResult:e2ePlugin.testResults[testCase]];
+    SEL testSelector = AddTestCase(xcTestCase, formattedTestCase);
+    NSMethodSignature *signature = [xcTestCase instanceMethodSignatureForSelector:testSelector];
+    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+    invocation.selector = testSelector;
+    [invocations addObject:invocation];
   }
-  NSLog(@"================== Test Results End ====================");
-  BOOL testPass = failedTests.count == 0;
-  if (!testPass && testResult) {
-    *testResult =
-        [NSString stringWithFormat:@"Detected failed E2E test(s) %@ among %@",
-                                   failedTests.description, testResults.allKeys.description];
-  }
-  return testPass;
+  objc_setAssociatedObject(xcTestCase, @selector(printTestResult),
+                           results, OBJC_ASSOCIATION_RETAIN);
+  return invocations;
 }
-
-@end


### PR DESCRIPTION
## Description

Now package:e2e test on iOS only has one test case called `testE2E`. This change will replace it with test cases that appear in the Dart source, by injecting methods during runtime.

## Related Issues

N/A

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
