### PR TITLE
[android_alarm_manager] remove MainActivity references 

### DIFF
--- a/packages/android_alarm_manager/CHANGELOG.md
+++ b/packages/android_alarm_manager/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.5+8
+
+* Remove `MainActivity` references in android example app and tests.
+
 ## 0.4.5+7
 
 * Update minimum Flutter version to 1.12.13+hotfix.5

--- a/packages/android_alarm_manager/example/android/app/src/androidTest/java/io/plugins/androidalarmmanager/DriverExtensionActivity.java
+++ b/packages/android_alarm_manager/example/android/app/src/androidTest/java/io/plugins/androidalarmmanager/DriverExtensionActivity.java
@@ -3,8 +3,8 @@
 // found in the LICENSE file.
 
 package io.flutter.plugins.androidalarmmanagerexample;
-
 import androidx.annotation.NonNull;
+import io.flutter.embedding.android.FlutterActivity;
 
 public class DriverExtensionActivity extends FlutterActivity {
   @Override

--- a/packages/android_alarm_manager/example/android/app/src/androidTest/java/io/plugins/androidalarmmanager/DriverExtensionActivity.java
+++ b/packages/android_alarm_manager/example/android/app/src/androidTest/java/io/plugins/androidalarmmanager/DriverExtensionActivity.java
@@ -6,7 +6,7 @@ package io.flutter.plugins.androidalarmmanagerexample;
 
 import androidx.annotation.NonNull;
 
-public class DriverExtensionActivity extends MainActivity {
+public class DriverExtensionActivity extends FlutterActivity {
   @Override
   @NonNull
   public String getDartEntrypointFunctionName() {

--- a/packages/android_alarm_manager/example/android/app/src/androidTest/java/io/plugins/androidalarmmanager/DriverExtensionActivity.java
+++ b/packages/android_alarm_manager/example/android/app/src/androidTest/java/io/plugins/androidalarmmanager/DriverExtensionActivity.java
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 package io.flutter.plugins.androidalarmmanagerexample;
+
 import androidx.annotation.NonNull;
 import io.flutter.embedding.android.FlutterActivity;
 

--- a/packages/android_alarm_manager/example/android/app/src/androidTest/java/io/plugins/androidalarmmanager/MainActivityTest.java
+++ b/packages/android_alarm_manager/example/android/app/src/androidTest/java/io/plugins/androidalarmmanager/MainActivityTest.java
@@ -12,6 +12,6 @@ import org.junit.runner.RunWith;
 @RunWith(FlutterTestRunner.class)
 public class MainActivityTest {
   @Rule
-  public ActivityTestRule<MainActivity> rule =
-      new ActivityTestRule<>(MainActivity.class, true, false);
+  public ActivityTestRule<FlutterActivity> rule =
+      new ActivityTestRule<>(FlutterActivity.class, true, false);
 }

--- a/packages/android_alarm_manager/example/android/app/src/androidTest/java/io/plugins/androidalarmmanager/MainActivityTest.java
+++ b/packages/android_alarm_manager/example/android/app/src/androidTest/java/io/plugins/androidalarmmanager/MainActivityTest.java
@@ -6,6 +6,7 @@ package io.flutter.plugins.androidalarmmanagerexample;
 
 import androidx.test.rule.ActivityTestRule;
 import dev.flutter.plugins.e2e.FlutterTestRunner;
+import io.flutter.embedding.android.FlutterActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 

--- a/packages/android_alarm_manager/pubspec.yaml
+++ b/packages/android_alarm_manager/pubspec.yaml
@@ -1,7 +1,7 @@
 name: android_alarm_manager
 description: Flutter plugin for accessing the Android AlarmManager service, and
   running Dart code in the background when alarms fire.
-version: 0.4.5+7
+version: 0.4.5+8
 homepage: https://github.com/flutter/plugins/tree/master/packages/android_alarm_manager
 
 dependencies:


### PR DESCRIPTION
## Description

Following up https://github.com/flutter/plugins/commit/899744f38216ad4f8fed1bbd8126139d7d054c4c
The `MainActivity` was removed but there were still references left. 

## Related Issues

fix ci.

