### PR TITLE
[image_picker] fix bug, sometimes double click cancel button will crash

### DIFF
--- a/packages/image_picker/image_picker/CHANGELOG.md
+++ b/packages/image_picker/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.6+4
+
+* Fix bug, sometimes double click cancel button will crash.
+
 ## 0.6.6+3
 
 * Update README

--- a/packages/image_picker/image_picker/ios/Classes/FLTImagePickerPlugin.m
+++ b/packages/image_picker/image_picker/ios/Classes/FLTImagePickerPlugin.m
@@ -326,8 +326,10 @@ static const int SOURCE_GALLERY = 1;
 
 - (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker {
   [_imagePickerController dismissViewControllerAnimated:YES completion:nil];
+  if (!self.result) {
+    return;
+  }
   self.result(nil);
-
   self.result = nil;
   _arguments = nil;
 }

--- a/packages/image_picker/image_picker/ios/Tests/ImagePickerPluginTests.m
+++ b/packages/image_picker/image_picker/ios/Tests/ImagePickerPluginTests.m
@@ -10,6 +10,7 @@
 @interface FLTImagePickerPlugin (Test)
 @property(copy, nonatomic) FlutterResult result;
 - (void)handleSavedPath:(NSString *)path;
+- (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker;
 @end
 
 @interface ImagePickerPluginTests : XCTestCase
@@ -64,6 +65,25 @@
                     }];
   XCTAssertEqual([plugin getImagePickerController].cameraDevice,
                  UIImagePickerControllerCameraDeviceRear);
+}
+
+- (void)testPluginPickImageDeviceCancelClickMultipleTimes {
+  if ([UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera]) {
+    return;
+  }
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewController:[UIViewController new]];
+  FlutterMethodCall *call =
+      [FlutterMethodCall methodCallWithMethodName:@"pickImage"
+                                        arguments:@{@"source" : @(0), @"cameraDevice" : @(1)}];
+  [plugin handleMethodCall:call
+                    result:^(id _Nullable r){
+                    }];
+  plugin.result = ^(id result) {
+
+  };
+  [plugin imagePickerControllerDidCancel:[plugin getImagePickerController]];
+  [plugin imagePickerControllerDidCancel:[plugin getImagePickerController]];
 }
 
 - (void)testPluginPickVideoDeviceFront {

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker
 description: Flutter plugin for selecting images from the Android and iOS image
   library, and taking new pictures with the camera.
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker/image_picker
-version: 0.6.6+3
+version: 0.6.6+4
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Sometimes double click cancel button will crash.

## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
