### PR TITLE
[google_maps_flutter] Rename 'Page' in the example app to avoid type conflict with the Flutter Framework.

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.25+3
+
+* Rename 'Page' in the example app to avoid type conflict with the Flutter Framework.
+
 ## 0.5.25+2
 
 * Avoid unnecessary map elements updates by ignoring not platform related attributes (eg. onTap)

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/animate_camera.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/animate_camera.dart
@@ -9,7 +9,7 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 
 import 'page.dart';
 
-class AnimateCameraPage extends Page {
+class AnimateCameraPage extends GoogleMapExampleAppPage {
   AnimateCameraPage()
       : super(const Icon(Icons.map), 'Camera control, animated');
 

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/main.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/main.dart
@@ -20,7 +20,7 @@ import 'place_polyline.dart';
 import 'scrolling_map.dart';
 import 'snapshot.dart';
 
-final List<Page> _allPages = <Page>[
+final List<GoogleMapExampleAppPage> _allPages = <GoogleMapExampleAppPage>[
   MapUiPage(),
   MapCoordinatesPage(),
   MapClickPage(),
@@ -37,7 +37,7 @@ final List<Page> _allPages = <Page>[
 ];
 
 class MapsDemo extends StatelessWidget {
-  void _pushPage(BuildContext context, Page page) {
+  void _pushPage(BuildContext context, GoogleMapExampleAppPage page) {
     Navigator.of(context).push(MaterialPageRoute<void>(
         builder: (_) => Scaffold(
               appBar: AppBar(title: Text(page.title)),

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/map_click.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/map_click.dart
@@ -12,7 +12,7 @@ import 'page.dart';
 const CameraPosition _kInitialPosition =
     CameraPosition(target: LatLng(-33.852, 151.211), zoom: 11.0);
 
-class MapClickPage extends Page {
+class MapClickPage extends GoogleMapExampleAppPage {
   MapClickPage() : super(const Icon(Icons.mouse), 'Map click');
 
   @override

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/map_coordinates.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/map_coordinates.dart
@@ -12,7 +12,7 @@ import 'page.dart';
 const CameraPosition _kInitialPosition =
     CameraPosition(target: LatLng(-33.852, 151.211), zoom: 11.0);
 
-class MapCoordinatesPage extends Page {
+class MapCoordinatesPage extends GoogleMapExampleAppPage {
   MapCoordinatesPage() : super(const Icon(Icons.map), 'Map coordinates');
 
   @override

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/map_ui.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/map_ui.dart
@@ -15,7 +15,7 @@ final LatLngBounds sydneyBounds = LatLngBounds(
   northeast: const LatLng(-33.571835, 151.325952),
 );
 
-class MapUiPage extends Page {
+class MapUiPage extends GoogleMapExampleAppPage {
   MapUiPage() : super(const Icon(Icons.map), 'User interface');
 
   @override

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/marker_icons.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/marker_icons.dart
@@ -10,7 +10,7 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 
 import 'page.dart';
 
-class MarkerIconsPage extends Page {
+class MarkerIconsPage extends GoogleMapExampleAppPage {
   MarkerIconsPage() : super(const Icon(Icons.image), 'Marker icons');
 
   @override

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/move_camera.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/move_camera.dart
@@ -9,7 +9,7 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 
 import 'page.dart';
 
-class MoveCameraPage extends Page {
+class MoveCameraPage extends GoogleMapExampleAppPage {
   MoveCameraPage() : super(const Icon(Icons.map), 'Camera control');
 
   @override

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/padding.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/padding.dart
@@ -8,7 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'page.dart';
 
-class PaddingPage extends Page {
+class PaddingPage extends GoogleMapExampleAppPage {
   PaddingPage() : super(const Icon(Icons.map), 'Add padding to the map');
 
   @override

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/page.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/page.dart
@@ -6,8 +6,8 @@
 
 import 'package:flutter/material.dart';
 
-abstract class Page extends StatelessWidget {
-  const Page(this.leading, this.title);
+abstract class GoogleMapExampleAppPage extends StatelessWidget {
+  const GoogleMapExampleAppPage(this.leading, this.title);
 
   final Widget leading;
   final String title;

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/place_circle.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/place_circle.dart
@@ -9,7 +9,7 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 
 import 'page.dart';
 
-class PlaceCirclePage extends Page {
+class PlaceCirclePage extends GoogleMapExampleAppPage {
   PlaceCirclePage() : super(const Icon(Icons.linear_scale), 'Place circle');
 
   @override

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/place_marker.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/place_marker.dart
@@ -13,7 +13,7 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 
 import 'page.dart';
 
-class PlaceMarkerPage extends Page {
+class PlaceMarkerPage extends GoogleMapExampleAppPage {
   PlaceMarkerPage() : super(const Icon(Icons.place), 'Place marker');
 
   @override

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/place_polygon.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/place_polygon.dart
@@ -9,7 +9,7 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 
 import 'page.dart';
 
-class PlacePolygonPage extends Page {
+class PlacePolygonPage extends GoogleMapExampleAppPage {
   PlacePolygonPage() : super(const Icon(Icons.linear_scale), 'Place polygon');
 
   @override

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/place_polyline.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/place_polyline.dart
@@ -11,7 +11,7 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 
 import 'page.dart';
 
-class PlacePolylinePage extends Page {
+class PlacePolylinePage extends GoogleMapExampleAppPage {
   PlacePolylinePage() : super(const Icon(Icons.linear_scale), 'Place polyline');
 
   @override

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/scrolling_map.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/scrolling_map.dart
@@ -12,7 +12,7 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 
 import 'page.dart';
 
-class ScrollingMapPage extends Page {
+class ScrollingMapPage extends GoogleMapExampleAppPage {
   ScrollingMapPage() : super(const Icon(Icons.map), 'Scrolling map');
 
   @override

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/snapshot.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/snapshot.dart
@@ -14,7 +14,7 @@ import 'page.dart';
 const CameraPosition _kInitialPosition =
     CameraPosition(target: LatLng(-33.852, 151.211), zoom: 11.0);
 
-class SnapshotPage extends Page {
+class SnapshotPage extends GoogleMapExampleAppPage {
   SnapshotPage()
       : super(const Icon(Icons.camera_alt), 'Take a snapshot of the map');
 

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter/google_maps_flutter
-version: 0.5.25+2
+version: 0.5.25+3
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Description

https://github.com/flutter/flutter/commit/a206bf7e2f3d64fb4453d87bad80f8e7acddcf0a introduced a `Page` API in the framework and it has conflicts with the example app of the plugin.

