### PR TITLE
[scripts] Exclude shared_preferences_windows package

### DIFF
--- a/script/build_all_plugins_app.sh
+++ b/script/build_all_plugins_app.sh
@@ -25,6 +25,7 @@ readonly EXCLUDED_PLUGINS_LIST=(
   "shared_preferences_macos"
   "shared_preferences_platform_interface"
   "shared_preferences_web"
+  "shared_preferences_windows"
   "url_launcher_macos"
   "url_launcher_platform_interface"
   "url_launcher_web"


### PR DESCRIPTION
## Description

Includes `shared_preferences_windows` in the  to avoid build failures caused by path dependencies.

## Related Issues

https://github.com/flutter/flutter/issues/44918

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
