### PR TITLE
[e2e] Replaces the check for ActivityTestRule

### DIFF
--- a/packages/e2e/CHANGELOG.md
+++ b/packages/e2e/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1
+
+* Adds support for Android E2E tests that utilize other @Rule's, like GrantPermissionTest.
+
 ## 0.4.0
 
 * **Breaking change** Driver request_data call's response has changed to

--- a/packages/e2e/android/src/main/java/dev/flutter/plugins/e2e/FlutterTestRunner.java
+++ b/packages/e2e/android/src/main/java/dev/flutter/plugins/e2e/FlutterTestRunner.java
@@ -4,23 +4,24 @@
 
 package dev.flutter.plugins.e2e;
 
-import android.app.Activity;
 import android.util.Log;
 import androidx.test.rule.ActivityTestRule;
 import java.lang.reflect.Field;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import org.junit.Rule;
+import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runner.Runner;
 import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunNotifier;
 
 public class FlutterTestRunner extends Runner {
+
   private static final String TAG = "FlutterTestRunner";
 
   final Class testClass;
-  ActivityTestRule<Activity> rule = null;
+  TestRule rule = null;
 
   public FlutterTestRunner(Class<?> testClass) {
     super();
@@ -32,7 +33,10 @@ public class FlutterTestRunner extends Runner {
       if (field.isAnnotationPresent(Rule.class)) {
         try {
           Object instance = testClass.newInstance();
-          rule = (ActivityTestRule<Activity>) field.get(instance);
+          if (instance instanceof ActivityTestRule) {
+            rule = (TestRule) field.get(instance);
+            break;
+          }
         } catch (InstantiationException | IllegalAccessException e) {
           // This might occur if the developer did not make the rule public.
           // We could call field.setAccessible(true) but it seems better to throw.
@@ -53,7 +57,9 @@ public class FlutterTestRunner extends Runner {
       throw new RuntimeException("Unable to run tests due to missing activity rule");
     }
     try {
-      rule.launchActivity(null);
+      if (rule instanceof ActivityTestRule) {
+        ((ActivityTestRule) rule).launchActivity(null);
+      }
     } catch (RuntimeException e) {
       Log.v(TAG, "launchActivity failed, possibly because the activity was already running. " + e);
       Log.v(

--- a/packages/e2e/android/src/main/java/dev/flutter/plugins/e2e/FlutterTestRunner.java
+++ b/packages/e2e/android/src/main/java/dev/flutter/plugins/e2e/FlutterTestRunner.java
@@ -33,7 +33,7 @@ public class FlutterTestRunner extends Runner {
       if (field.isAnnotationPresent(Rule.class)) {
         try {
           Object instance = testClass.newInstance();
-          if (instance instanceof ActivityTestRule) {
+          if (field.get(instance) instanceof ActivityTestRule) {
             rule = (TestRule) field.get(instance);
             break;
           }

--- a/packages/e2e/example/android/app/src/androidTest/java/com/example/e2e_example/MainActivityWithPermissionTest.java
+++ b/packages/e2e/example/android/app/src/androidTest/java/com/example/e2e_example/MainActivityWithPermissionTest.java
@@ -8,9 +8,9 @@ import org.junit.Rule;
 import org.junit.runner.RunWith;
 
 /**
- * Demonstrates how a E2E test on Android can be run with permissions already
- * granted. This is helpful if developers want to test native App behavior that
- * depends on certain system service results which are guarded with permissions.
+ * Demonstrates how a E2E test on Android can be run with permissions already granted. This is
+ * helpful if developers want to test native App behavior that depends on certain system service
+ * results which are guarded with permissions.
  */
 @RunWith(FlutterTestRunner.class)
 public class MainActivityWithPermissionTest {

--- a/packages/e2e/example/android/app/src/androidTest/java/com/example/e2e_example/MainActivityWithPermissionTest.java
+++ b/packages/e2e/example/android/app/src/androidTest/java/com/example/e2e_example/MainActivityWithPermissionTest.java
@@ -1,0 +1,20 @@
+package com.example.e2e_example;
+
+import android.Manifest.permission;
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.rule.GrantPermissionRule;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+
+@RunWith(FlutterTestRunner.class)
+public class MainActivityWithPermissionTest {
+
+  @Rule
+  public GrantPermissionRule permissionRule =
+      GrantPermissionRule.grant(permission.ACCESS_COARSE_LOCATION);
+
+  @Rule
+  public ActivityTestRule<MainActivity> rule =
+      new ActivityTestRule<>(MainActivity.class, true, false);
+}

--- a/packages/e2e/example/android/app/src/androidTest/java/com/example/e2e_example/MainActivityWithPermissionTest.java
+++ b/packages/e2e/example/android/app/src/androidTest/java/com/example/e2e_example/MainActivityWithPermissionTest.java
@@ -7,6 +7,11 @@ import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
+/**
+ * Demonstrates how a E2E test on Android can be run with permissions already
+ * granted. This is helpful if developers want to test native App behavior that
+ * depends on certain system service results which are guarded with permissions.
+ */
 @RunWith(FlutterTestRunner.class)
 public class MainActivityWithPermissionTest {
 

--- a/packages/e2e/pubspec.yaml
+++ b/packages/e2e/pubspec.yaml
@@ -1,6 +1,6 @@
 name: e2e
 description: Runs tests that use the flutter_test API as integration tests.
-version: 0.4.0
+version: 0.4.1
 homepage: https://github.com/flutter/plugins/tree/master/packages/e2e
 
 environment:


### PR DESCRIPTION
## Description

Fixes the issue outlined in flutter/flutter#53660.

## Related issues

Fixes flutter/flutter#53660.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
