### PR TITLE
[webview_flutter] Add onReceivedError callback 

### DIFF
--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.20
+
+* Added support for receiving web resource loading errors. See `Webview.onWebResourceError`.
+
 ## 0.3.19+10
 
 * Replace deprecated `getFlutterEngine` call on Android.

--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.3.20
 
-* Added support for receiving web resource loading errors. See `Webview.onWebResourceError`.
+* Added support for receiving web resource loading errors. See `WebView.onWebResourceError`.
 
 ## 0.3.19+10
 

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewClient.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewClient.java
@@ -175,14 +175,18 @@ class FlutterWebViewClient {
         FlutterWebViewClient.this.onPageFinished(view, url);
       }
 
-      // We don't need to support the deprecated version since this WebViewClient is only used on
-      // API versions >= N. See `FlutterWebViewClient.createWebViewClient`.
       @TargetApi(Build.VERSION_CODES.M)
       @Override
       public void onReceivedError(
           WebView view, WebResourceRequest request, WebResourceError error) {
         FlutterWebViewClient.this.onReceivedError(
             error.getErrorCode(), error.getDescription().toString());
+      }
+
+      @Override
+      public void onReceivedError(
+          WebView view, int errorCode, String description, String failingUrl) {
+        FlutterWebViewClient.this.onReceivedError(errorCode, description);
       }
 
       @Override

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewClient.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewClient.java
@@ -123,9 +123,9 @@ class FlutterWebViewClient {
     methodChannel.invokeMethod("onPageFinished", args);
   }
 
-  private void onReceivedError(final String errorCode, final String description) {
+  private void onReceivedError(final int errorCode, final String description) {
     final Map<String, Object> args = new HashMap<>();
-    args.put("errorCode", errorCode);
+    args.put("errorCode", FlutterWebViewClient.errorCodeToString(errorCode));
     args.put("description", description);
     methodChannel.invokeMethod("onReceivedError", args);
   }
@@ -179,8 +179,7 @@ class FlutterWebViewClient {
       @TargetApi(Build.VERSION_CODES.M)
       @Override
       public void onReceivedError(WebView view, WebResourceRequest request, WebResourceError error) {
-        final String errorCode = FlutterWebViewClient.errorCodeToString(error.getErrorCode());
-        FlutterWebViewClient.this.onReceivedError(errorCode, error.getDescription().toString());
+        FlutterWebViewClient.this.onReceivedError(error.getErrorCode(), error.getDescription().toString());
       }
 
       @Override
@@ -219,14 +218,12 @@ class FlutterWebViewClient {
       @SuppressLint("RequiresFeature")
       @Override
       public void onReceivedError(WebView view, WebResourceRequest request, WebResourceErrorCompat error) {
-        final String errorCode = FlutterWebViewClient.errorCodeToString(error.getErrorCode());
-        FlutterWebViewClient.this.onReceivedError(errorCode, error.getDescription().toString());
+        FlutterWebViewClient.this.onReceivedError(error.getErrorCode(), error.getDescription().toString());
       }
 
       @Override
       public void onReceivedError(WebView view, int errorCode, String description, String failingUrl) {
-        final String errorCodeString = FlutterWebViewClient.errorCodeToString(errorCode);
-        FlutterWebViewClient.this.onReceivedError(errorCodeString, description);
+        FlutterWebViewClient.this.onReceivedError(errorCode, description);
       }
 
       @Override

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewClient.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewClient.java
@@ -37,37 +37,37 @@ class FlutterWebViewClient {
   private static String errorCodeToString(int errorCode) {
     switch (errorCode) {
       case WebViewClient.ERROR_AUTHENTICATION:
-        return "AUTHENTICATION";
+        return "authentication";
       case WebViewClient.ERROR_BAD_URL:
-        return "BAD_URL";
+        return "badUrl";
       case WebViewClient.ERROR_CONNECT:
-        return "CONNECT";
+        return "connect";
       case WebViewClient.ERROR_FAILED_SSL_HANDSHAKE:
-        return "FAILED_SSL_HANDSHAKE";
+        return "failedSslHandshake";
       case WebViewClient.ERROR_FILE:
-        return "FILE";
+        return "file";
       case WebViewClient.ERROR_FILE_NOT_FOUND:
-        return "FILE_NOT_FOUND";
+        return "fileNotFound";
       case WebViewClient.ERROR_HOST_LOOKUP:
-        return "HOST_LOOKUP";
+        return "hostLookup";
       case WebViewClient.ERROR_IO:
-        return "IO";
+        return "io";
       case WebViewClient.ERROR_PROXY_AUTHENTICATION:
-        return "PROXY_AUTHENTICATION";
+        return "proxyAuthentication";
       case WebViewClient.ERROR_REDIRECT_LOOP:
-        return "REDIRECT_LOOP";
+        return "redirectLoop";
       case WebViewClient.ERROR_TIMEOUT:
-        return "TIMEOUT";
+        return "timeout";
       case WebViewClient.ERROR_TOO_MANY_REQUESTS:
-        return "TOO_MANY_REQUESTS";
+        return "tooManyRequests";
       case WebViewClient.ERROR_UNKNOWN:
-        return "UNKNOWN";
+        return "unknown";
       case WebViewClient.ERROR_UNSAFE_RESOURCE:
-        return "UNSAFE_RESOURCE";
+        return "unsafeResource";
       case WebViewClient.ERROR_UNSUPPORTED_AUTH_SCHEME:
-        return "UNSUPPORTED_AUTH_SCHEME";
+        return "unsupportedAuthScheme";
       case WebViewClient.ERROR_UNSUPPORTED_SCHEME:
-        return "UNSUPPORTED_SCHEME";
+        return "unsupportedScheme";
     }
 
     final String message =
@@ -126,8 +126,9 @@ class FlutterWebViewClient {
 
   private void onReceivedError(final int errorCode, final String description) {
     final Map<String, Object> args = new HashMap<>();
-    args.put("errorCode", FlutterWebViewClient.errorCodeToString(errorCode));
+    args.put("errorCode", errorCode);
     args.put("description", description);
+    args.put("errorType", FlutterWebViewClient.errorCodeToString(errorCode));
     methodChannel.invokeMethod("onReceivedError", args);
   }
 

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewClient.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewClient.java
@@ -124,12 +124,12 @@ class FlutterWebViewClient {
     methodChannel.invokeMethod("onPageFinished", args);
   }
 
-  private void onReceivedError(final int errorCode, final String description) {
+  private void onWebResourceError(final int errorCode, final String description) {
     final Map<String, Object> args = new HashMap<>();
     args.put("errorCode", errorCode);
     args.put("description", description);
     args.put("errorType", FlutterWebViewClient.errorCodeToString(errorCode));
-    methodChannel.invokeMethod("onReceivedError", args);
+    methodChannel.invokeMethod("onWebResourceError", args);
   }
 
   private void notifyOnNavigationRequest(
@@ -180,14 +180,14 @@ class FlutterWebViewClient {
       @Override
       public void onReceivedError(
           WebView view, WebResourceRequest request, WebResourceError error) {
-        FlutterWebViewClient.this.onReceivedError(
+        FlutterWebViewClient.this.onWebResourceError(
             error.getErrorCode(), error.getDescription().toString());
       }
 
       @Override
       public void onReceivedError(
           WebView view, int errorCode, String description, String failingUrl) {
-        FlutterWebViewClient.this.onReceivedError(errorCode, description);
+        FlutterWebViewClient.this.onWebResourceError(errorCode, description);
       }
 
       @Override
@@ -227,14 +227,14 @@ class FlutterWebViewClient {
       @Override
       public void onReceivedError(
           WebView view, WebResourceRequest request, WebResourceErrorCompat error) {
-        FlutterWebViewClient.this.onReceivedError(
+        FlutterWebViewClient.this.onWebResourceError(
             error.getErrorCode(), error.getDescription().toString());
       }
 
       @Override
       public void onReceivedError(
           WebView view, int errorCode, String description, String failingUrl) {
-        FlutterWebViewClient.this.onReceivedError(errorCode, description);
+        FlutterWebViewClient.this.onWebResourceError(errorCode, description);
       }
 
       @Override

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewClient.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewClient.java
@@ -14,11 +14,11 @@ import android.webkit.WebResourceError;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
-import androidx.annotation.NonNull;
 import androidx.webkit.WebResourceErrorCompat;
 import androidx.webkit.WebViewClientCompat;
 import io.flutter.plugin.common.MethodChannel;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 // We need to use WebViewClientCompat to get
@@ -70,7 +70,8 @@ class FlutterWebViewClient {
         return "UNSUPPORTED_SCHEME";
     }
 
-    throw new IllegalArgumentException("" + errorCode);
+    final String message = String.format(Locale.getDefault(), "Could not find a string for errorCode: %d", errorCode);
+    throw new IllegalArgumentException(message);
   }
 
   @TargetApi(Build.VERSION_CODES.LOLLIPOP)
@@ -174,11 +175,12 @@ class FlutterWebViewClient {
       }
 
       // We don't need to support the deprecated version since this WebViewClient is only used on
-      // API versions >= N.
+      // API versions >= N. See `FlutterWebViewClient.createWebViewClient`.
       @TargetApi(Build.VERSION_CODES.M)
       @Override
       public void onReceivedError(WebView view, WebResourceRequest request, WebResourceError error) {
-        FlutterWebViewClient.this.onReceivedError(FlutterWebViewClient.errorCodeToString(error.getErrorCode()), error.getDescription().toString());
+        final String errorCode = FlutterWebViewClient.errorCodeToString(error.getErrorCode());
+        FlutterWebViewClient.this.onReceivedError(errorCode, error.getDescription().toString());
       }
 
       @Override
@@ -212,18 +214,19 @@ class FlutterWebViewClient {
         FlutterWebViewClient.this.onPageFinished(view, url);
       }
 
-      // We can suppress this lint since this method is only called when the
-      // WebViewFeature.RECEIVE_WEB_RESOURCE_ERROR feature is enabled. We call the deprecated method
-      // when a device doesn't support this.
+      // This method is only called when the WebViewFeature.RECEIVE_WEB_RESOURCE_ERROR feature is
+      // enabled. The deprecated method is called when a device doesn't support this.
       @SuppressLint("RequiresFeature")
       @Override
-      public void onReceivedError(@NonNull WebView view, @NonNull WebResourceRequest request, @NonNull WebResourceErrorCompat error) {
-        FlutterWebViewClient.this.onReceivedError(FlutterWebViewClient.errorCodeToString(error.getErrorCode()), error.getDescription().toString());
+      public void onReceivedError(WebView view, WebResourceRequest request, WebResourceErrorCompat error) {
+        final String errorCode = FlutterWebViewClient.errorCodeToString(error.getErrorCode());
+        FlutterWebViewClient.this.onReceivedError(errorCode, error.getDescription().toString());
       }
 
       @Override
       public void onReceivedError(WebView view, int errorCode, String description, String failingUrl) {
-        FlutterWebViewClient.this.onReceivedError(FlutterWebViewClient.errorCodeToString(errorCode), description);
+        final String errorCodeString = FlutterWebViewClient.errorCodeToString(errorCode);
+        FlutterWebViewClient.this.onReceivedError(errorCodeString, description);
       }
 
       @Override

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewClient.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewClient.java
@@ -35,7 +35,7 @@ class FlutterWebViewClient {
   }
 
   private static String errorCodeToString(int errorCode) {
-    switch(errorCode) {
+    switch (errorCode) {
       case WebViewClient.ERROR_AUTHENTICATION:
         return "AUTHENTICATION";
       case WebViewClient.ERROR_BAD_URL:
@@ -70,7 +70,8 @@ class FlutterWebViewClient {
         return "UNSUPPORTED_SCHEME";
     }
 
-    final String message = String.format(Locale.getDefault(), "Could not find a string for errorCode: %d", errorCode);
+    final String message =
+        String.format(Locale.getDefault(), "Could not find a string for errorCode: %d", errorCode);
     throw new IllegalArgumentException(message);
   }
 
@@ -178,8 +179,10 @@ class FlutterWebViewClient {
       // API versions >= N. See `FlutterWebViewClient.createWebViewClient`.
       @TargetApi(Build.VERSION_CODES.M)
       @Override
-      public void onReceivedError(WebView view, WebResourceRequest request, WebResourceError error) {
-        FlutterWebViewClient.this.onReceivedError(error.getErrorCode(), error.getDescription().toString());
+      public void onReceivedError(
+          WebView view, WebResourceRequest request, WebResourceError error) {
+        FlutterWebViewClient.this.onReceivedError(
+            error.getErrorCode(), error.getDescription().toString());
       }
 
       @Override
@@ -217,12 +220,15 @@ class FlutterWebViewClient {
       // enabled. The deprecated method is called when a device doesn't support this.
       @SuppressLint("RequiresFeature")
       @Override
-      public void onReceivedError(WebView view, WebResourceRequest request, WebResourceErrorCompat error) {
-        FlutterWebViewClient.this.onReceivedError(error.getErrorCode(), error.getDescription().toString());
+      public void onReceivedError(
+          WebView view, WebResourceRequest request, WebResourceErrorCompat error) {
+        FlutterWebViewClient.this.onReceivedError(
+            error.getErrorCode(), error.getDescription().toString());
       }
 
       @Override
-      public void onReceivedError(WebView view, int errorCode, String description, String failingUrl) {
+      public void onReceivedError(
+          WebView view, int errorCode, String description, String failingUrl) {
         FlutterWebViewClient.this.onReceivedError(errorCode, description);
       }
 

--- a/packages/webview_flutter/example/test_driver/webview_flutter_e2e.dart
+++ b/packages/webview_flutter/example/test_driver/webview_flutter_e2e.dart
@@ -578,7 +578,7 @@ void main() {
       expect(currentUrl, 'https://www.google.com/');
     });
 
-    testWidgets('onReceivedError', (WidgetTester tester) async {
+    testWidgets('onWebResourceError', (WidgetTester tester) async {
       final Completer<WebResourceError> errorCompleter =
           Completer<WebResourceError>();
 
@@ -602,7 +602,7 @@ void main() {
       if (Platform.isAndroid) expect(error.errorType, isNotNull);
     });
 
-    testWidgets('onReceivedError is not called with valid url',
+    testWidgets('onWebResourceError is not called with valid url',
         (WidgetTester tester) async {
       final Completer<WebResourceError> errorCompleter =
           Completer<WebResourceError>();

--- a/packages/webview_flutter/example/test_driver/webview_flutter_e2e.dart
+++ b/packages/webview_flutter/example/test_driver/webview_flutter_e2e.dart
@@ -621,7 +621,7 @@ void main() {
         ),
       );
 
-      expect(errorCompleter, doesNotComplete);
+      expect(errorCompleter.future, doesNotComplete);
     });
 
     testWidgets('can block requests', (WidgetTester tester) async {

--- a/packages/webview_flutter/example/test_driver/webview_flutter_e2e.dart
+++ b/packages/webview_flutter/example/test_driver/webview_flutter_e2e.dart
@@ -576,6 +576,31 @@ void main() {
       expect(currentUrl, 'https://www.google.com/');
     });
 
+    testWidgets('onReceivedError', (WidgetTester tester) async {
+      final Completer<Map<String, String>> errorCompleter =
+          Completer<Map<String, String>>();
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: WebView(
+            key: GlobalKey(),
+            initialUrl: 'https://www.notawebsite..com',
+            onReceivedError: (String errorCode, String description) {
+              errorCompleter.complete(<String, String>{
+                'errorCode': errorCode,
+                'description': description,
+              });
+            },
+          ),
+        ),
+      );
+
+      final Map<String, String> errorResult = await errorCompleter.future;
+      expect(errorResult['errorCode'], isNotNull);
+      expect(errorResult['description'], isNotNull);
+    });
+
     testWidgets('can block requests', (WidgetTester tester) async {
       final Completer<WebViewController> controllerCompleter =
           Completer<WebViewController>();

--- a/packages/webview_flutter/ios/Classes/FLTWKNavigationDelegate.m
+++ b/packages/webview_flutter/ios/Classes/FLTWKNavigationDelegate.m
@@ -5,10 +5,10 @@
 #import "FLTWKNavigationDelegate.h"
 
 @implementation FLTWKNavigationDelegate {
-  FlutterMethodChannel* _methodChannel;
+  FlutterMethodChannel *_methodChannel;
 }
 
-- (instancetype)initWithChannel:(FlutterMethodChannel*)channel {
+- (instancetype)initWithChannel:(FlutterMethodChannel *)channel {
   self = [super init];
   if (self) {
     _methodChannel = channel;
@@ -18,18 +18,18 @@
 
 #pragma mark - WKNavigationDelegate conformance
 
-- (void)webView:(WKWebView*)webView didStartProvisionalNavigation:(WKNavigation*)navigation {
+- (void)webView:(WKWebView *)webView didStartProvisionalNavigation:(WKNavigation *)navigation {
   [_methodChannel invokeMethod:@"onPageStarted" arguments:@{@"url" : webView.URL.absoluteString}];
 }
 
-- (void)webView:(WKWebView*)webView
-    decidePolicyForNavigationAction:(WKNavigationAction*)navigationAction
+- (void)webView:(WKWebView *)webView
+    decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction
                     decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler {
   if (!self.hasDartNavigationDelegate) {
     decisionHandler(WKNavigationActionPolicyAllow);
     return;
   }
-  NSDictionary* arguments = @{
+  NSDictionary *arguments = @{
     @"url" : navigationAction.request.URL.absoluteString,
     @"isForMainFrame" : @(navigationAction.targetFrame.isMainFrame)
   };
@@ -56,33 +56,34 @@
                             decisionHandler(WKNavigationActionPolicyAllow);
                             return;
                           }
-                          NSNumber* typedResult = result;
+                          NSNumber *typedResult = result;
                           decisionHandler([typedResult boolValue] ? WKNavigationActionPolicyAllow
                                                                   : WKNavigationActionPolicyCancel);
                         }];
 }
 
-- (void)webView:(WKWebView*)webView didFinishNavigation:(WKNavigation*)navigation {
+- (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation {
   [_methodChannel invokeMethod:@"onPageFinished" arguments:@{@"url" : webView.URL.absoluteString}];
 }
 
 - (void)onReceivedError:(NSError *)error {
   NSString *errorCode = [NSString stringWithFormat:@"%@: %ld", error.domain, (long)error.code];
-  [_methodChannel invokeMethod:@"onReceivedError" arguments:@{
-    @"errorCode": errorCode,
-    @"description" : error.description,
-  }];
+  [_methodChannel invokeMethod:@"onReceivedError"
+                     arguments:@{
+                       @"errorCode" : errorCode,
+                       @"description" : error.description,
+                     }];
 }
 
 - (void)webView:(WKWebView *)webView
-didFailNavigation:(WKNavigation *)navigation
-      withError:(NSError *)error {
+    didFailNavigation:(WKNavigation *)navigation
+            withError:(NSError *)error {
   [self onReceivedError:error];
 }
 
 - (void)webView:(WKWebView *)webView
-didFailProvisionalNavigation:(WKNavigation *)navigation
-      withError:(NSError *)error {
+    didFailProvisionalNavigation:(WKNavigation *)navigation
+                       withError:(NSError *)error {
   [self onReceivedError:error];
 }
 @end

--- a/packages/webview_flutter/ios/Classes/FLTWKNavigationDelegate.m
+++ b/packages/webview_flutter/ios/Classes/FLTWKNavigationDelegate.m
@@ -70,7 +70,7 @@
   [_methodChannel invokeMethod:@"onReceivedError"
                      arguments:@{
                        @"errorCode" : @(error.code),
-                       @"domain": error.domain,
+                       @"domain" : error.domain,
                        @"description" : error.description,
                      }];
 }

--- a/packages/webview_flutter/ios/Classes/FLTWKNavigationDelegate.m
+++ b/packages/webview_flutter/ios/Classes/FLTWKNavigationDelegate.m
@@ -83,8 +83,8 @@
   return [NSNull null];
 }
 
-- (void)onReceivedError:(NSError *)error {
-  [_methodChannel invokeMethod:@"onReceivedError"
+- (void)onWebResourceError:(NSError *)error {
+  [_methodChannel invokeMethod:@"onWebResourceError"
                      arguments:@{
                        @"errorCode" : @(error.code),
                        @"domain" : error.domain,
@@ -96,12 +96,12 @@
 - (void)webView:(WKWebView *)webView
     didFailNavigation:(WKNavigation *)navigation
             withError:(NSError *)error {
-  [self onReceivedError:error];
+  [self onWebResourceError:error];
 }
 
 - (void)webView:(WKWebView *)webView
     didFailProvisionalNavigation:(WKNavigation *)navigation
                        withError:(NSError *)error {
-  [self onReceivedError:error];
+  [self onWebResourceError:error];
 }
 @end

--- a/packages/webview_flutter/ios/Classes/FLTWKNavigationDelegate.m
+++ b/packages/webview_flutter/ios/Classes/FLTWKNavigationDelegate.m
@@ -66,12 +66,30 @@
   [_methodChannel invokeMethod:@"onPageFinished" arguments:@{@"url" : webView.URL.absoluteString}];
 }
 
++ (id)errorCodeToString:(NSUInteger)code {
+  switch (code) {
+    case WKErrorUnknown:
+      return @"unknown";
+    case WKErrorWebContentProcessTerminated:
+      return @"webContentProcessTerminated";
+    case WKErrorWebViewInvalidated:
+      return @"webViewInvalidated";
+    case WKErrorJavaScriptExceptionOccurred:
+      return @"javaScriptExceptionOccurred";
+    case WKErrorJavaScriptResultTypeIsUnsupported:
+      return @"javaScriptResultTypeIsUnsupported";
+  }
+
+  return [NSNull null];
+}
+
 - (void)onReceivedError:(NSError *)error {
   [_methodChannel invokeMethod:@"onReceivedError"
                      arguments:@{
                        @"errorCode" : @(error.code),
                        @"domain" : error.domain,
                        @"description" : error.description,
+                       @"errorType" : [FLTWKNavigationDelegate errorCodeToString:error.code],
                      }];
 }
 

--- a/packages/webview_flutter/ios/Classes/FLTWKNavigationDelegate.m
+++ b/packages/webview_flutter/ios/Classes/FLTWKNavigationDelegate.m
@@ -67,10 +67,10 @@
 }
 
 - (void)onReceivedError:(NSError *)error {
-  NSString *errorCode = [NSString stringWithFormat:@"%@: %ld", error.domain, (long)error.code];
   [_methodChannel invokeMethod:@"onReceivedError"
                      arguments:@{
-                       @"errorCode" : errorCode,
+                       @"errorCode" : @(error.code),
+                       @"domain": error.domain,
                        @"description" : error.description,
                      }];
 }

--- a/packages/webview_flutter/ios/Classes/FLTWKNavigationDelegate.m
+++ b/packages/webview_flutter/ios/Classes/FLTWKNavigationDelegate.m
@@ -65,4 +65,24 @@
 - (void)webView:(WKWebView*)webView didFinishNavigation:(WKNavigation*)navigation {
   [_methodChannel invokeMethod:@"onPageFinished" arguments:@{@"url" : webView.URL.absoluteString}];
 }
+
+- (void)onReceivedError:(NSError *)error {
+  NSString *errorCode = [NSString stringWithFormat:@"%@: %ld", error.domain, (long)error.code];
+  [_methodChannel invokeMethod:@"onReceivedError" arguments:@{
+    @"errorCode": errorCode,
+    @"description" : error.description,
+  }];
+}
+
+- (void)webView:(WKWebView *)webView
+didFailNavigation:(WKNavigation *)navigation
+      withError:(NSError *)error {
+  [self onReceivedError:error];
+}
+
+- (void)webView:(WKWebView *)webView
+didFailProvisionalNavigation:(WKNavigation *)navigation
+      withError:(NSError *)error {
+  [self onReceivedError:error];
+}
 @end

--- a/packages/webview_flutter/lib/platform_interface.dart
+++ b/packages/webview_flutter/lib/platform_interface.dart
@@ -97,14 +97,6 @@ enum WebResourceErrorType {
 }
 
 /// Error returned in `WebView.onWebResourceError` when a web resource loading error has occurred.
-///
-/// On Android, the error code will be a constant from
-/// [WebViewClient](https://developer.android.com/reference/android/webkit/WebViewClient#summary).
-///
-/// On iOS, the error code will be a constant from a "code" for an
-/// `NSError` in Objective-C. The format will be `$domain: $code`. See
-/// https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ErrorHandlingCocoa/ErrorObjectsDomains/ErrorObjectsDomains.html
-/// for more information on error handling on iOS.
 class WebResourceError {
   /// Creates a new [WebResourceError]
   ///
@@ -118,7 +110,7 @@ class WebResourceError {
   })  : assert(errorCode != null),
         assert(description != null);
 
-  /// Error code of the error.
+  /// Raw code of the error from the respective platform.
   ///
   /// On Android, the error code will be a constant from a
   /// [WebViewClient](https://developer.android.com/reference/android/webkit/WebViewClient#summary) and
@@ -143,9 +135,9 @@ class WebResourceError {
   /// Description of the error that can be used to communicate the problem to the user.
   final String description;
 
-  /// The type of error this error can be categorized as.
+  /// The type this error can be categorized as.
   ///
-  /// This will never be null on Android, but can be null on iOS.
+  /// This will never be `null` on Android, but can be `null` on iOS.
   final WebResourceErrorType errorType;
 }
 

--- a/packages/webview_flutter/lib/platform_interface.dart
+++ b/packages/webview_flutter/lib/platform_interface.dart
@@ -37,34 +37,49 @@ abstract class WebViewPlatformCallbacksHandler {
 enum WebResourceErrorType {
   /// User authentication failed on server.
   authentication,
+
   /// Malformed URL.
   badUrl,
+
   /// Failed to connect to the server.
   connect,
+
   /// Failed to perform SSL handshake.
   failedSslHandshake,
+
   /// Generic file error.
   file,
+
   /// File not found.
   fileNotFound,
+
   /// Server or proxy hostname lookup failed.
   hostLookup,
+
   /// Failed to read or write to the server.
   io,
+
   /// User authentication failed on proxy.
   proxyAuthentication,
+
   /// Too many redirects.
   redirectLoop,
+
   /// Connection timed out.
   timeout,
+
   /// Too many requests during this load.
   tooManyRequests,
+
   /// Generic error.
   unknown,
+
   /// Resource load was canceled by Safe Browsing.
   unsafeResource,
+
   /// Unsupported authentication scheme (not basic or digest).
   unsupportedAuthScheme,
+
   /// Unsupported URI scheme.
   unsupportedScheme,
 }

--- a/packages/webview_flutter/lib/platform_interface.dart
+++ b/packages/webview_flutter/lib/platform_interface.dart
@@ -100,7 +100,7 @@ enum WebResourceErrorType {
 class WebResourceError {
   /// Creates a new [WebResourceError]
   ///
-  /// A user should not need to use this, but can receive on in
+  /// A user should not need to instantiate this class, but will receive one in
   /// [WebResourceErrorCallback].
   WebResourceError({
     @required this.errorCode,

--- a/packages/webview_flutter/lib/platform_interface.dart
+++ b/packages/webview_flutter/lib/platform_interface.dart
@@ -33,7 +33,7 @@ abstract class WebViewPlatformCallbacksHandler {
   void onWebResourceError(WebResourceError error);
 }
 
-/// Error types used by [WebResourceError].
+/// Possible error type categorizations used by [WebResourceError].
 enum WebResourceErrorType {
   /// User authentication failed on server.
   authentication,
@@ -96,6 +96,8 @@ enum WebResourceErrorType {
   javaScriptResultTypeIsUnsupported,
 }
 
+/// Error returned in `WebView.onWebResourceError` when a web resource loading error has occurred.
+///
 /// On Android, the error code will be a constant from
 /// [WebViewClient](https://developer.android.com/reference/android/webkit/WebViewClient#summary).
 ///
@@ -138,12 +140,12 @@ class WebResourceError {
   /// for more information on error handling on iOS.
   final String domain;
 
-  /// Describes the error.
+  /// Description of the error that can be used to communicate the problem to the user.
   final String description;
 
-  /// The type of error.
+  /// The type of error this error can be categorized as.
   ///
-  /// This is will never be null on Android, but can be null on iOS.
+  /// This will never be null on Android, but can be null on iOS.
   final WebResourceErrorType errorType;
 }
 

--- a/packages/webview_flutter/lib/platform_interface.dart
+++ b/packages/webview_flutter/lib/platform_interface.dart
@@ -33,7 +33,7 @@ abstract class WebViewPlatformCallbacksHandler {
   void onWebResourceError(WebResourceError error);
 }
 
-/// Error types used by [WebResourceError] on Android.
+/// Error types used by [WebResourceError].
 enum WebResourceErrorType {
   /// User authentication failed on server.
   authentication,
@@ -82,6 +82,18 @@ enum WebResourceErrorType {
 
   /// Unsupported URI scheme.
   unsupportedScheme,
+
+  /// The web content process was terminated.
+  webContentProcessTerminated,
+
+  /// The web view was invalidated.
+  webViewInvalidated,
+
+  /// A JavaScript exception occurred.
+  javaScriptExceptionOccurred,
+
+  /// The result of JavaScript execution could not be returned.
+  javaScriptResultTypeIsUnsupported,
 }
 
 /// On Android, the error code will be a constant from
@@ -113,7 +125,8 @@ class WebResourceError {
   /// On iOS, the error code will be a constant from `NSError.code` in
   /// Objective-C. See
   /// https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ErrorHandlingCocoa/ErrorObjectsDomains/ErrorObjectsDomains.html
-  /// for more information on error handling on iOS.
+  /// for more information on error handling on iOS. Some possible error codes
+  /// can be found at https://developer.apple.com/documentation/webkit/wkerrorcode?language=objc.
   final int errorCode;
 
   /// The domain of where to find the error code.
@@ -128,9 +141,9 @@ class WebResourceError {
   /// Describes the error.
   final String description;
 
-  /// The type of error when using an Android device.
+  /// The type of error.
   ///
-  /// This is only available on Android and will be null on iOS.
+  /// This is will never be null on Android, but can be null on iOS.
   final WebResourceErrorType errorType;
 }
 

--- a/packages/webview_flutter/lib/platform_interface.dart
+++ b/packages/webview_flutter/lib/platform_interface.dart
@@ -28,6 +28,9 @@ abstract class WebViewPlatformCallbacksHandler {
 
   /// Invoked by [WebViewPlatformController] when a page has finished loading.
   void onPageFinished(String url);
+
+  /// Report web resource loading error to the host application.
+  void onReceivedError(String errorCode, String description);
 }
 
 /// Interface for talking to the webview's platform implementation.

--- a/packages/webview_flutter/lib/platform_interface.dart
+++ b/packages/webview_flutter/lib/platform_interface.dart
@@ -30,7 +30,93 @@ abstract class WebViewPlatformCallbacksHandler {
   void onPageFinished(String url);
 
   /// Report web resource loading error to the host application.
-  void onReceivedError(String errorCode, String description);
+  void onWebResourceError(WebResourceError error);
+}
+
+/// Error types used by [WebResourceError] on Android.
+enum WebResourceErrorType {
+  /// User authentication failed on server.
+  authentication,
+  /// Malformed URL.
+  badUrl,
+  /// Failed to connect to the server.
+  connect,
+  /// Failed to perform SSL handshake.
+  failedSslHandshake,
+  /// Generic file error.
+  file,
+  /// File not found.
+  fileNotFound,
+  /// Server or proxy hostname lookup failed.
+  hostLookup,
+  /// Failed to read or write to the server.
+  io,
+  /// User authentication failed on proxy.
+  proxyAuthentication,
+  /// Too many redirects.
+  redirectLoop,
+  /// Connection timed out.
+  timeout,
+  /// Too many requests during this load.
+  tooManyRequests,
+  /// Generic error.
+  unknown,
+  /// Resource load was canceled by Safe Browsing.
+  unsafeResource,
+  /// Unsupported authentication scheme (not basic or digest).
+  unsupportedAuthScheme,
+  /// Unsupported URI scheme.
+  unsupportedScheme,
+}
+
+/// On Android, the error code will be a constant from
+/// [WebViewClient](https://developer.android.com/reference/android/webkit/WebViewClient#summary).
+///
+/// On iOS, the error code will be a constant from a "code" for an
+/// `NSError` in Objective-C. The format will be `$domain: $code`. See
+/// https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ErrorHandlingCocoa/ErrorObjectsDomains/ErrorObjectsDomains.html
+/// for more information on error handling on iOS.
+class WebResourceError {
+  /// Creates a new [WebResourceError]
+  ///
+  /// A user should not need to use this, but can receive on in
+  /// [WebResourceErrorCallback].
+  WebResourceError({
+    @required this.errorCode,
+    @required this.description,
+    this.domain,
+    this.errorType,
+  })  : assert(errorCode != null),
+        assert(description != null);
+
+  /// Error code of the error.
+  ///
+  /// On Android, the error code will be a constant from a
+  /// [WebViewClient](https://developer.android.com/reference/android/webkit/WebViewClient#summary) and
+  /// will have a corresponding [errorType].
+  ///
+  /// On iOS, the error code will be a constant from `NSError.code` in
+  /// Objective-C. See
+  /// https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ErrorHandlingCocoa/ErrorObjectsDomains/ErrorObjectsDomains.html
+  /// for more information on error handling on iOS.
+  final int errorCode;
+
+  /// The domain of where to find the error code.
+  ///
+  /// This field is only available on iOS and represents a "domain" from where
+  /// the [errorCode] is from. This value is taken directly from an `NSError`
+  /// in Objective-C. See
+  /// https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ErrorHandlingCocoa/ErrorObjectsDomains/ErrorObjectsDomains.html
+  /// for more information on error handling on iOS.
+  final String domain;
+
+  /// Describes the error.
+  final String description;
+
+  /// The type of error when using an Android device.
+  ///
+  /// This is only available on Android and will be null on iOS.
+  final WebResourceErrorType errorType;
 }
 
 /// Interface for talking to the webview's platform implementation.

--- a/packages/webview_flutter/lib/src/webview_method_channel.dart
+++ b/packages/webview_flutter/lib/src/webview_method_channel.dart
@@ -43,13 +43,13 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
       case 'onPageStarted':
         _platformCallbacksHandler.onPageStarted(call.arguments['url']);
         return null;
-      case 'onReceivedError':
+      case 'onWebResourceError':
         _platformCallbacksHandler.onWebResourceError(
           WebResourceError(
             errorCode: call.arguments['errorCode'],
             description: call.arguments['description'],
             domain: call.arguments['domain'],
-            errorType: call.arguments['domain'] == null
+            errorType: call.arguments['errorType'] == null
                 ? null
                 : WebResourceErrorType.values.firstWhere(
                     (WebResourceErrorType type) {

--- a/packages/webview_flutter/lib/src/webview_method_channel.dart
+++ b/packages/webview_flutter/lib/src/webview_method_channel.dart
@@ -53,11 +53,8 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
                 ? null
                 : WebResourceErrorType.values.firstWhere(
                     (WebResourceErrorType type) {
-                      final String enumName = type.toString().replaceFirst(
-                            '$WebResourceErrorType.',
-                            '',
-                          );
-                      return enumName == call.arguments['errorType'];
+                      return type.toString() ==
+                          '$WebResourceErrorType.${call.arguments['errorType']}';
                     },
                   ),
           ),

--- a/packages/webview_flutter/lib/src/webview_method_channel.dart
+++ b/packages/webview_flutter/lib/src/webview_method_channel.dart
@@ -43,6 +43,12 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
       case 'onPageStarted':
         _platformCallbacksHandler.onPageStarted(call.arguments['url']);
         return null;
+      case 'onReceivedError':
+        _platformCallbacksHandler.onReceivedError(
+          call.arguments['errorCode'],
+          call.arguments['description'],
+        );
+        return null;
     }
     throw MissingPluginException(
         '${call.method} was invoked but has no handler');

--- a/packages/webview_flutter/lib/src/webview_method_channel.dart
+++ b/packages/webview_flutter/lib/src/webview_method_channel.dart
@@ -44,14 +44,30 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
         _platformCallbacksHandler.onPageStarted(call.arguments['url']);
         return null;
       case 'onReceivedError':
-        _platformCallbacksHandler.onReceivedError(
-          call.arguments['errorCode'],
-          call.arguments['description'],
+        _platformCallbacksHandler.onWebResourceError(
+          WebResourceError(
+            errorCode: call.arguments['errorCode'],
+            description: call.arguments['description'],
+            domain: call.arguments['domain'],
+            errorType: call.arguments['domain'] == null
+                ? null
+                : WebResourceErrorType.values.firstWhere(
+                    (WebResourceErrorType type) {
+                      final String enumName = type.toString().replaceFirst(
+                            '$WebResourceErrorType.',
+                            '',
+                          );
+                      return enumName == call.arguments['errorType'];
+                    },
+                  ),
+          ),
         );
         return null;
     }
+
     throw MissingPluginException(
-        '${call.method} was invoked but has no handler');
+      '${call.method} was invoked but has no handler',
+    );
   }
 
   @override

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -79,6 +79,9 @@ typedef void PageStartedCallback(String url);
 /// Signature for when a [WebView] has finished loading a page.
 typedef void PageFinishedCallback(String url);
 
+/// Signature for when a [WebView] has failed to load a resource.
+typedef void ReceivedErrorCallback(String errorCode, String description);
+
 /// Specifies possible restrictions on automatic media playback.
 ///
 /// This is typically used in [WebView.initialMediaPlaybackPolicy].
@@ -147,6 +150,7 @@ class WebView extends StatefulWidget {
     this.gestureRecognizers,
     this.onPageStarted,
     this.onPageFinished,
+    this.onReceivedError,
     this.debuggingEnabled = false,
     this.gestureNavigationEnabled = false,
     this.userAgent,
@@ -276,6 +280,12 @@ class WebView extends StatefulWidget {
   /// directly in the HTML has been loaded and code injected with
   /// [WebViewController.evaluateJavascript] can assume this.
   final PageFinishedCallback onPageFinished;
+
+  /// Invoked when a web resource has failed to load.
+  ///
+  /// This can be called for any resource (iframe, image, etc.), not just for
+  /// the main page.
+  final ReceivedErrorCallback onReceivedError;
 
   /// Controls whether WebView debugging is enabled.
   ///
@@ -480,6 +490,11 @@ class _PlatformCallbacksHandler implements WebViewPlatformCallbacksHandler {
     if (_widget.onPageFinished != null) {
       _widget.onPageFinished(url);
     }
+  }
+
+  @override
+  void onReceivedError(String errorCode, String description) {
+    _widget?.onReceivedError(errorCode, description);
   }
 
   void _updateJavascriptChannelsFromSet(Set<JavascriptChannel> channels) {

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -285,6 +285,16 @@ class WebView extends StatefulWidget {
   ///
   /// This can be called for any resource (iframe, image, etc.), not just for
   /// the main page.
+  ///
+  /// On Android, the error code will be a constant from
+  /// [WebViewClient](https://developer.android.com/reference/android/webkit/WebViewClient#summary).
+  /// (e.g. The error code of `WebViewClient.ERROR_AUTHENTICATION` on Android
+  /// translates to `AUTHENTICATION` in Dart.
+  ///
+  /// On iOS, the error code will represent the "domain" and the "code" for an
+  /// `NSError` in Objective-C. The format will be `$domain: $code`. See
+  /// https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ErrorHandlingCocoa/ErrorObjectsDomains/ErrorObjectsDomains.html
+  /// for more information on error handling on iOS.
   final ReceivedErrorCallback onReceivedError;
 
   /// Controls whether WebView debugging is enabled.

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -504,7 +504,9 @@ class _PlatformCallbacksHandler implements WebViewPlatformCallbacksHandler {
 
   @override
   void onReceivedError(String errorCode, String description) {
-    _widget?.onReceivedError(errorCode, description);
+    if (_widget.onReceivedError != null) {
+      _widget.onReceivedError(errorCode, description);
+    }
   }
 
   void _updateJavascriptChannelsFromSet(Set<JavascriptChannel> channels) {

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -80,7 +80,7 @@ typedef void PageStartedCallback(String url);
 typedef void PageFinishedCallback(String url);
 
 /// Signature for when a [WebView] has failed to load a resource.
-typedef void ReceivedErrorCallback(String errorCode, String description);
+typedef void WebResourceErrorCallback(WebResourceError error);
 
 /// Specifies possible restrictions on automatic media playback.
 ///
@@ -150,7 +150,7 @@ class WebView extends StatefulWidget {
     this.gestureRecognizers,
     this.onPageStarted,
     this.onPageFinished,
-    this.onReceivedError,
+    this.onWebResourceError,
     this.debuggingEnabled = false,
     this.gestureNavigationEnabled = false,
     this.userAgent,
@@ -285,17 +285,7 @@ class WebView extends StatefulWidget {
   ///
   /// This can be called for any resource (iframe, image, etc.), not just for
   /// the main page.
-  ///
-  /// On Android, the error code will be a constant from
-  /// [WebViewClient](https://developer.android.com/reference/android/webkit/WebViewClient#summary).
-  /// (e.g. The error code of `WebViewClient.ERROR_AUTHENTICATION` on Android
-  /// translates to `AUTHENTICATION` in Dart.
-  ///
-  /// On iOS, the error code will represent the "domain" and the "code" for an
-  /// `NSError` in Objective-C. The format will be `$domain: $code`. See
-  /// https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ErrorHandlingCocoa/ErrorObjectsDomains/ErrorObjectsDomains.html
-  /// for more information on error handling on iOS.
-  final ReceivedErrorCallback onReceivedError;
+  final WebResourceErrorCallback onWebResourceError;
 
   /// Controls whether WebView debugging is enabled.
   ///
@@ -503,9 +493,9 @@ class _PlatformCallbacksHandler implements WebViewPlatformCallbacksHandler {
   }
 
   @override
-  void onReceivedError(String errorCode, String description) {
-    if (_widget.onReceivedError != null) {
-      _widget.onReceivedError(errorCode, description);
+  void onWebResourceError(WebResourceError error) {
+    if (_widget.onWebResourceError != null) {
+      _widget.onWebResourceError(error);
     }
   }
 

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
-version: 0.3.19+9
+version: 0.3.20
 homepage: https://github.com/flutter/plugins/tree/master/packages/webview_flutter
 
 environment:


### PR DESCRIPTION
## Description

This adds the feature where the webview can report an error when loading page resources. 

After looking for error reporting in the `Webview` implementation of each platform I found Android uses [onReceivedError](https://developer.android.com/reference/android/webkit/WebViewClient#onReceivedError(android.webkit.WebView,%20android.webkit.WebResourceRequest,%20android.webkit.WebResourceError)) in its `WebviewClient` and iOS uses [webView:didFailNavigation:withError:](https://developer.apple.com/documentation/webkit/wknavigationdelegate/1455623-webview?language=objc) and [webView:didFailProvisionalNavigation:withError:](https://developer.apple.com/documentation/webkit/wknavigationdelegate/1455637-webview?language=objc) in its `WKNavigationDelegate`. 

However, each platform handles error codes differently. Android provides a `WebResourceError` which has an `int` code that is defined as a constant in `WebViewClient`. iOS uses a generic `NSError` and doesn't specify the possible values for the error code.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/53023

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
