### PR TITLE
[google_sign_in_web] Ensure not-signed-in users are returned as `null`.

### DIFF
--- a/packages/google_sign_in/google_sign_in_web/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.0+1
+
+* Ensure the web code returns `null` when the user is not signed in, instead of a `null-object` User. Fixes [issue 52338](https://github.com/flutter/flutter/issues/52338).
+
 ## 0.9.0
 
 * Add support for methods introduced in `google_sign_in_platform_interface` 1.1.0.

--- a/packages/google_sign_in/google_sign_in_web/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_web/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.9.0+1
+## 0.9.1
 
 * Ensure the web code returns `null` when the user is not signed in, instead of a `null-object` User. Fixes [issue 52338](https://github.com/flutter/flutter/issues/52338).
 

--- a/packages/google_sign_in/google_sign_in_web/lib/src/utils.dart
+++ b/packages/google_sign_in/google_sign_in_web/lib/src/utils.dart
@@ -31,9 +31,13 @@ Future<void> injectJSLibraries(List<String> libraries,
 
 /// Utility method that converts `currentUser` to the equivalent
 /// [GoogleSignInUserData].
+/// This method returns `null` when the currentUser is not signedIn.
 GoogleSignInUserData gapiUserToPluginUserData(auth2.GoogleUser currentUser) {
-  assert(currentUser != null);
-  final auth2.BasicProfile profile = currentUser.getBasicProfile();
+  final bool isSignedIn = currentUser?.isSignedIn() ?? false;
+  final auth2.BasicProfile profile = currentUser?.getBasicProfile();
+  if (!isSignedIn || profile?.getId() == null) {
+    return null;
+  }
   return GoogleSignInUserData(
     displayName: profile?.getName(),
     email: profile?.getEmail(),

--- a/packages/google_sign_in/google_sign_in_web/lib/src/utils.dart
+++ b/packages/google_sign_in/google_sign_in_web/lib/src/utils.dart
@@ -31,7 +31,7 @@ Future<void> injectJSLibraries(List<String> libraries,
 
 /// Utility method that converts `currentUser` to the equivalent
 /// [GoogleSignInUserData].
-/// This method returns `null` when the currentUser is not signedIn.
+/// This method returns `null` when the [currentUser] is not signed in.
 GoogleSignInUserData gapiUserToPluginUserData(auth2.GoogleUser currentUser) {
   final bool isSignedIn = currentUser?.isSignedIn() ?? false;
   final auth2.BasicProfile profile = currentUser?.getBasicProfile();

--- a/packages/google_sign_in/google_sign_in_web/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_sign_in_web
 description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android, iOS and Web.
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_sign_in/google_sign_in_web
-version: 0.9.0
+version: 0.9.1
 
 flutter:
   plugin:

--- a/packages/google_sign_in/google_sign_in_web/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_web/pubspec.yaml
@@ -25,6 +25,7 @@ dev_dependencies:
     sdk: flutter
   google_sign_in: ^4.0.14
   pedantic: ^1.8.0
+  mockito: ^4.1.1
 
 environment:
   sdk: ">=2.6.0 <3.0.0"

--- a/packages/google_sign_in/google_sign_in_web/test/gapi_mocks/src/google_user.dart
+++ b/packages/google_sign_in/google_sign_in_web/test/gapi_mocks/src/google_user.dart
@@ -23,5 +23,8 @@ String googleUser(GoogleSignInUserData data) => '''
   },
   getGrantedScopes: () => 'some scope',
   grant: () => true,
+  isSignedIn: () => {
+    return ${data != null ? 'true' : 'false'};
+  },
 }
 ''';

--- a/packages/google_sign_in/google_sign_in_web/test/gapi_utils_test.dart
+++ b/packages/google_sign_in/google_sign_in_web/test/gapi_utils_test.dart
@@ -1,0 +1,46 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+@TestOn('browser')
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:google_sign_in_web/src/generated/gapiauth2.dart' as gapi;
+import 'package:google_sign_in_web/src/utils.dart';
+import 'package:mockito/mockito.dart';
+
+class MockGoogleUser extends Mock implements gapi.GoogleUser {}
+
+class MockBasicProfile extends Mock implements gapi.BasicProfile {}
+
+void main() {
+  // The non-null use cases are covered by the auth2_test.dart file.
+
+  group('gapiUserToPluginUserData', () {
+    var mockUser;
+
+    setUp(() {
+      mockUser = MockGoogleUser();
+    });
+
+    test('null user -> null response', () {
+      expect(gapiUserToPluginUserData(null), isNull);
+    });
+
+    test('not signed-in user -> null response', () {
+      when(mockUser.isSignedIn()).thenReturn(false);
+      expect(gapiUserToPluginUserData(mockUser), isNull);
+    });
+
+    test('signed-in, but null profile user -> null response', () {
+      when(mockUser.isSignedIn()).thenReturn(true);
+      expect(gapiUserToPluginUserData(mockUser), isNull);
+    });
+
+    test('signed-in, null userId in profile user -> null response', () {
+      when(mockUser.isSignedIn()).thenReturn(true);
+      when(mockUser.getBasicProfile()).thenReturn(MockBasicProfile());
+      expect(gapiUserToPluginUserData(mockUser), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Description

This change ensures that not signed-in users are returned as `null`, **not as an object with all its properties set to null!**

The core plugin assumes that a not-authenticated user is being returned as `null` from the platform code, but the web implementation is currently returning a null-object (as in [the pattern](https://en.wikipedia.org/wiki/Null_object_pattern)).

**WHY did the above prevented creating sign-in popups?**

Because of [this](https://github.com/flutter/plugins/blob/master/packages/google_sign_in/google_sign_in/lib/google_sign_in.dart#L291). The call to signIn is marked as `canSkipCall`, assuming that there's a non-null user known by the plugin, returning that directly.

In some cases, the user would never be properly cleared (or a null-User-object would be returned from the init/silentSignIn), making the proper signIn call to NOT happen!!

_(This PR should fix most of the current open issues with the Google Sign In for web plugin.)_

## Testing

I have deployed a version of Flutter's Google Sign In example app that uses this version of the plugin here:

### https://dit-sign-in-debug.web.app

## Related Issues

Fixes:
* https://github.com/flutter/flutter/issues/49500
* https://github.com/flutter/flutter/issues/52338
* https://github.com/flutter/flutter/issues/54106
* ~~[flutter/flutter#54768](https://github.com/flutter/flutter/issues/54768#issuecomment-613679099)~~
* (Maybe others)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
