### PR TITLE
[google_maps_flutter] Markers to respond based on consumeTapEvents parameter

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.25+4
+
+* Respond to marker tap events based on consumeTapEvents parameter
+
 ## 0.5.25+3
 
 * Rename 'Page' in the example app to avoid type conflict with the Flutter Framework.

--- a/packages/google_maps_flutter/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/MarkersController.java
+++ b/packages/google_maps_flutter/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/MarkersController.java
@@ -97,11 +97,13 @@ class MarkersController {
     if (markerId == null) {
       return false;
     }
-    methodChannel.invokeMethod("marker#onTap", Convert.markerIdToJson(markerId));
-    MarkerController markerController = markerIdToController.get(markerId);
-    if (markerController != null) {
-      return markerController.consumeTapEvents();
+
+    final MarkerController markerController = markerIdToController.get(markerId);
+    if (markerController != null && markerController.consumeTapEvents()) {
+      methodChannel.invokeMethod("marker#onTap", Convert.markerIdToJson(markerId));
+      return true;
     }
+
     return false;
   }
 

--- a/packages/google_maps_flutter/google_maps_flutter/ios/Classes/GoogleMapMarkerController.m
+++ b/packages/google_maps_flutter/google_maps_flutter/ios/Classes/GoogleMapMarkerController.m
@@ -292,8 +292,11 @@ static UIImage* ExtractIcon(NSObject<FlutterPluginRegistrar>* registrar, NSArray
   if (!controller) {
     return NO;
   }
-  [_methodChannel invokeMethod:@"marker#onTap" arguments:@{@"markerId" : markerId}];
-  return controller.consumeTapEvents;
+  if (controller.consumeTapEvents) {
+    [_methodChannel invokeMethod:@"marker#onTap" arguments:@{@"markerId" : markerId}];
+    return YES;
+  }
+  return NO;
 }
 - (void)onMarkerDragEnd:(NSString*)markerId coordinate:(CLLocationCoordinate2D)coordinate {
   if (!markerId) {

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter/google_maps_flutter
-version: 0.5.25+3
+version: 0.5.25+4
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Description

Markers when tapped are showing the info window even if the consumeTapEvents parameter has been set to false

## Related Issues

Fixes https://github.com/flutter/flutter/issues/39868

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [-] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

