### PR TITLE
[url_launcher] Open url in same window when browser is in standalone mode.

### DIFF
--- a/packages/url_launcher/url_launcher_web/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_web/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.1.1+2
 
-- Open urls with target "_top" (instead of default "_blank") on iOS PWAs.
+- Open urls with target "_top" on iOS PWAs.
 
 # 0.1.1+1
 

--- a/packages/url_launcher/url_launcher_web/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.1+2
+
+- Open urls with "_top" (instead of "_blank") as target on iOS PWAs.
+
 # 0.1.1+1
 
 - Make the pedantic dev_dependency explicit.

--- a/packages/url_launcher/url_launcher_web/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_web/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.1.1+2
 
-- Open urls with "_top" (instead of "_blank") as target on iOS PWAs.
+- Open urls with target "_top" (instead of default "_blank") on iOS PWAs.
 
 # 0.1.1+1
 

--- a/packages/url_launcher/url_launcher_web/lib/navigator.dart
+++ b/packages/url_launcher/url_launcher_web/lib/navigator.dart
@@ -2,12 +2,14 @@
 library navigator.dart;
 
 import 'package:js/js.dart';
+import 'package:meta/meta.dart';
 
 @JS('window.navigator.standalone')
 external bool get _standalone;
 
-/// Utility class to access the window.navigator DOM property.
-class Navigator {
-  /// The window.navigator.standalone DOM property.
-  bool get standalone => _standalone ?? false;
-}
+/// The window.navigator.standalone DOM property.
+bool get standalone => _standalone ?? false;
+
+@visibleForTesting
+@JS('window.navigator.standalone')
+external set standalone(bool enabled);

--- a/packages/url_launcher/url_launcher_web/lib/navigator.dart
+++ b/packages/url_launcher/url_launcher_web/lib/navigator.dart
@@ -6,6 +6,8 @@ import 'package:js/js.dart';
 @JS('window.navigator.standalone')
 external bool get _standalone;
 
+/// Utility class to access the window.navigator DOM property.
 class Navigator {
+  /// The window.navigator.standalone DOM property.
   bool get standalone => _standalone ?? false;
 }

--- a/packages/url_launcher/url_launcher_web/lib/navigator.dart
+++ b/packages/url_launcher/url_launcher_web/lib/navigator.dart
@@ -1,0 +1,11 @@
+@JS()
+library navigator.dart;
+
+import 'package:js/js.dart';
+
+@JS('window.navigator.standalone')
+external bool get _standalone;
+
+class Navigator {
+  bool get standalone => _standalone ?? false;
+}

--- a/packages/url_launcher/url_launcher_web/lib/src/navigator.dart
+++ b/packages/url_launcher/url_launcher_web/lib/src/navigator.dart
@@ -1,5 +1,5 @@
 @JS()
-library navigator.dart;
+library navigator;
 
 import 'package:js/js.dart';
 import 'package:meta/meta.dart';

--- a/packages/url_launcher/url_launcher_web/lib/url_launcher_web.dart
+++ b/packages/url_launcher/url_launcher_web/lib/url_launcher_web.dart
@@ -4,22 +4,31 @@ import 'dart:html' as html;
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:meta/meta.dart';
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
+import 'navigator.dart';
 
 /// The web implementation of [UrlLauncherPlatform].
 ///
 /// This class implements the `package:url_launcher` functionality for the web.
 class UrlLauncherPlugin extends UrlLauncherPlatform {
+  final Navigator _navigator;
+
+  UrlLauncherPlugin({Navigator navigator})
+      : _navigator = navigator ?? Navigator();
+
   /// Registers this class as the default instance of [UrlLauncherPlatform].
   static void registerWith(Registrar registrar) {
     UrlLauncherPlatform.instance = UrlLauncherPlugin();
   }
 
-  /// Opens the given [url] in a new window.
-  ///
+  /// Opens the given [url].
+  /// The url will be opened in a new window unless the browser is in standalone.
   /// Returns the newly created window.
   @visibleForTesting
-  html.WindowBase openNewWindow(String url) {
-    return html.window.open(url, '');
+  html.WindowBase openUrl(String url) {
+    // We need to open on _top in ios browsers in standalone mode.
+    // See https://github.com/flutter/flutter/issues/51461 for reference.
+    final target = _navigator.standalone ? '_top' : '';
+    return html.window.open(url, target);
   }
 
   @override
@@ -42,6 +51,6 @@ class UrlLauncherPlugin extends UrlLauncherPlatform {
     @required bool universalLinksOnly,
     @required Map<String, String> headers,
   }) {
-    return Future<bool>.value(openNewWindow(url) != null);
+    return Future<bool>.value(openUrl(url) != null);
   }
 }

--- a/packages/url_launcher/url_launcher_web/lib/url_launcher_web.dart
+++ b/packages/url_launcher/url_launcher_web/lib/url_launcher_web.dart
@@ -4,7 +4,7 @@ import 'dart:html' as html;
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:meta/meta.dart';
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
-import 'navigator.dart' as navigator;
+import 'src/navigator.dart' as navigator;
 
 /// The web implementation of [UrlLauncherPlatform].
 ///

--- a/packages/url_launcher/url_launcher_web/lib/url_launcher_web.dart
+++ b/packages/url_launcher/url_launcher_web/lib/url_launcher_web.dart
@@ -4,32 +4,25 @@ import 'dart:html' as html;
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:meta/meta.dart';
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
-import 'navigator.dart';
+import 'navigator.dart' as navigator;
 
 /// The web implementation of [UrlLauncherPlatform].
 ///
 /// This class implements the `package:url_launcher` functionality for the web.
 class UrlLauncherPlugin extends UrlLauncherPlatform {
-  final Navigator _navigator;
-
-  /// [UrlLauncherPlugin] constructor.
-  @visibleForTesting
-  UrlLauncherPlugin({Navigator navigator})
-      : _navigator = navigator ?? Navigator();
-
   /// Registers this class as the default instance of [UrlLauncherPlatform].
   static void registerWith(Registrar registrar) {
     UrlLauncherPlatform.instance = UrlLauncherPlugin();
   }
 
-  /// Opens the given [url].
-  /// The url will be opened in a new window unless the browser is in standalone.
+  /// Opens the given [url] in a new window.
+  ///
   /// Returns the newly created window.
   @visibleForTesting
-  html.WindowBase openUrl(String url) {
+  html.WindowBase openNewWindow(String url) {
     // We need to open on _top in ios browsers in standalone mode.
     // See https://github.com/flutter/flutter/issues/51461 for reference.
-    final target = _navigator.standalone ? '_top' : '';
+    final target = navigator.standalone ? '_top' : '';
     return html.window.open(url, target);
   }
 
@@ -53,6 +46,6 @@ class UrlLauncherPlugin extends UrlLauncherPlatform {
     @required bool universalLinksOnly,
     @required Map<String, String> headers,
   }) {
-    return Future<bool>.value(openUrl(url) != null);
+    return Future<bool>.value(openNewWindow(url) != null);
   }
 }

--- a/packages/url_launcher/url_launcher_web/lib/url_launcher_web.dart
+++ b/packages/url_launcher/url_launcher_web/lib/url_launcher_web.dart
@@ -12,6 +12,8 @@ import 'navigator.dart';
 class UrlLauncherPlugin extends UrlLauncherPlatform {
   final Navigator _navigator;
 
+  /// [UrlLauncherPlugin] constructor.
+  @visibleForTesting
   UrlLauncherPlugin({Navigator navigator})
       : _navigator = navigator ?? Navigator();
 

--- a/packages/url_launcher/url_launcher_web/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: url_launcher_web
 description: Web platform implementation of url_launcher
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher_web
-version: 0.1.1+1
+version: 0.1.1+2
 
 flutter:
   plugin:
@@ -17,6 +17,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   meta: ^1.1.7
+  js: ^0.6.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/url_launcher/url_launcher_web/test/url_launcher_web_test.dart
+++ b/packages/url_launcher/url_launcher_web/test/url_launcher_web_test.dart
@@ -8,7 +8,7 @@ import 'dart:html' as html;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:url_launcher_web/url_launcher_web.dart';
-import 'package:url_launcher_web/navigator.dart' as navigator;
+import 'package:url_launcher_web/src/navigator.dart' as navigator;
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 
 void main() {

--- a/packages/url_launcher/url_launcher_web/test/url_launcher_web_test.dart
+++ b/packages/url_launcher/url_launcher_web/test/url_launcher_web_test.dart
@@ -45,7 +45,7 @@ void main() {
       expect(launch('mailto:name@mydomain.com'), completion(isTrue));
     });
 
-    test('the url is opened in a new window', () {
+    test('the window that is launched is a new window', () {
       final UrlLauncherPlugin urlLauncherPlugin = UrlLauncherPlugin();
       final html.WindowBase newWindow =
           urlLauncherPlugin.openNewWindow('https://www.google.com');
@@ -54,7 +54,7 @@ void main() {
       expect(newWindow.opener, equals(html.window));
     });
 
-    test('the url is opened in the same window', () {
+    test('the window that is launched is in the same window', () {
       // Simulate the navigator is in standalone mode on iOS devices.
       // https://developer.mozilla.org/en-US/docs/Web/API/Navigator
       navigator.standalone = true;

--- a/packages/url_launcher/url_launcher_web/test/url_launcher_web_test.dart
+++ b/packages/url_launcher/url_launcher_web/test/url_launcher_web_test.dart
@@ -8,13 +8,8 @@ import 'dart:html' as html;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:url_launcher_web/url_launcher_web.dart';
-import 'package:url_launcher_web/navigator.dart';
+import 'package:url_launcher_web/navigator.dart' as navigator;
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
-
-class NavigatorStandalone implements Navigator {
-  @override
-  bool get standalone => true;
-}
 
 void main() {
   group('URL Launcher for Web', () {
@@ -53,18 +48,19 @@ void main() {
     test('the url is opened in a new window', () {
       final UrlLauncherPlugin urlLauncherPlugin = UrlLauncherPlugin();
       final html.WindowBase newWindow =
-          urlLauncherPlugin.openUrl('https://www.google.com');
+          urlLauncherPlugin.openNewWindow('https://www.google.com');
       expect(newWindow, isNotNull);
       expect(newWindow, isNot(equals(html.window)));
       expect(newWindow.opener, equals(html.window));
     });
 
     test('the url is opened in the same window', () {
-      final navigator = NavigatorStandalone();
-      final UrlLauncherPlugin urlLauncherPlugin =
-          UrlLauncherPlugin(navigator: navigator);
+      // Simulate the navigator is in standalone mode on iOS devices.
+      // https://developer.mozilla.org/en-US/docs/Web/API/Navigator
+      navigator.standalone = true;
+      final UrlLauncherPlugin urlLauncherPlugin = UrlLauncherPlugin();
       final html.WindowBase window =
-          urlLauncherPlugin.openUrl('https://www.google.com');
+          urlLauncherPlugin.openNewWindow('https://www.google.com');
       expect(window, isNotNull);
       expect(window.opener, isNot(equals(html.window)));
     });

--- a/packages/url_launcher/url_launcher_web/test/url_launcher_web_test.dart
+++ b/packages/url_launcher/url_launcher_web/test/url_launcher_web_test.dart
@@ -55,6 +55,7 @@ void main() {
     });
 
     test('the window that is launched is in the same window', () {
+      final originalStandalone = navigator.standalone;
       // Simulate the navigator is in standalone mode on iOS devices.
       // https://developer.mozilla.org/en-US/docs/Web/API/Navigator
       navigator.standalone = true;
@@ -63,6 +64,7 @@ void main() {
           urlLauncherPlugin.openNewWindow('https://www.google.com');
       expect(window, isNotNull);
       expect(window.opener, isNot(equals(html.window)));
+      navigator.standalone = originalStandalone;
     });
 
     test('does not implement closeWebView()', () {

--- a/packages/url_launcher/url_launcher_web/test/url_launcher_web_test.dart
+++ b/packages/url_launcher/url_launcher_web/test/url_launcher_web_test.dart
@@ -5,11 +5,16 @@
 @TestOn('chrome') // Uses web-only Flutter SDK
 
 import 'dart:html' as html;
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:url_launcher_web/url_launcher_web.dart';
+import 'package:url_launcher_web/navigator.dart';
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
+
+class NavigatorStandalone implements Navigator {
+  @override
+  bool get standalone => true;
+}
 
 void main() {
   group('URL Launcher for Web', () {
@@ -45,13 +50,23 @@ void main() {
       expect(launch('mailto:name@mydomain.com'), completion(isTrue));
     });
 
-    test('the window that is launched is a new window', () {
+    test('the url is opened in a new window', () {
       final UrlLauncherPlugin urlLauncherPlugin = UrlLauncherPlugin();
       final html.WindowBase newWindow =
-          urlLauncherPlugin.openNewWindow('https://www.google.com');
+          urlLauncherPlugin.openUrl('https://www.google.com');
       expect(newWindow, isNotNull);
       expect(newWindow, isNot(equals(html.window)));
       expect(newWindow.opener, equals(html.window));
+    });
+
+    test('the url is opened in the same window', () {
+      final navigator = NavigatorStandalone();
+      final UrlLauncherPlugin urlLauncherPlugin =
+          UrlLauncherPlugin(navigator: navigator);
+      final html.WindowBase window =
+          urlLauncherPlugin.openUrl('https://www.google.com');
+      expect(window, isNotNull);
+      expect(window.opener, isNot(equals(html.window)));
     });
 
     test('does not implement closeWebView()', () {


### PR DESCRIPTION
## Description

Users using this plugin on iOS PWAs are experiencing blank screens when a url is opened on another app and then they try to go back. It seems to be an well known issue on iOS [1] and [2] as reference. In the meantime we can overcome this limitation by modifying the target to "_top" according to [2] (solution manually verified). This PR does exactly that, verifies if the user is running a PWA in iOS and if so it will open the url with "_top" as target.
 
[1] https://stackoverflow.com/questions/55517297/mailto-doesnt-work-when-website-launched-from-ios-home-screen/56153685#56153685
[2] https://stackoverflow.com/questions/56220862/ios-pwa-open-maps-returns-to-blank-screen
## Related Issues

flutter/flutter#51461

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
