### PR TITLE
[video_player_web] Add a custom analysis_options file to video_player_web.

### DIFF
--- a/packages/video_player/video_player_web/CHANGELOG.md
+++ b/packages/video_player/video_player_web/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.1.2+2
 
-* Add `analysis_options.yaml` to the package, so we can ignore `undefined_prefixed_name` errors (temporarily).
+* Add `analysis_options.yaml` to the package, so we can ignore `undefined_prefixed_name` errors. Works around https://github.com/flutter/flutter/issues/41563.
 
 ## 0.1.2+1
 

--- a/packages/video_player/video_player_web/CHANGELOG.md
+++ b/packages/video_player/video_player_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2+2
+
+* Add `analysis_options.yaml` to the package, so we can ignore `undefined_prefixed_name` errors (temporarily).
+
 ## 0.1.2+1
 
 * Make the pedantic dev_dependency explicit.

--- a/packages/video_player/video_player_web/analysis_options.yaml
+++ b/packages/video_player/video_player_web/analysis_options.yaml
@@ -1,7 +1,7 @@
-# This is a temporary file to allow us to land a new set of linter rules in a
-# series of manageable patches instead of one gigantic PR. It disables some of
-# the new lints that are already failing on this plugin, for this plugin. It
-# should be deleted and the failing lints addressed as soon as possible.
+# This is a temporary file to allow us to unblock the flutter/plugins repo CI.
+# It disables some of lints that were disabled inline. Disabling lints inline
+# is no longer possible, so this file is required.
+# TODO(ditman) https://github.com/flutter/flutter/issues/55000 (clean this up)
 
 include: ../../../analysis_options.yaml
 

--- a/packages/video_player/video_player_web/analysis_options.yaml
+++ b/packages/video_player/video_player_web/analysis_options.yaml
@@ -1,0 +1,10 @@
+# This is a temporary file to allow us to land a new set of linter rules in a
+# series of manageable patches instead of one gigantic PR. It disables some of
+# the new lints that are already failing on this plugin, for this plugin. It
+# should be deleted and the failing lints addressed as soon as possible.
+
+include: ../../../analysis_options.yaml
+
+analyzer:
+  errors:
+    undefined_prefixed_name: ignore

--- a/packages/video_player/video_player_web/pubspec.yaml
+++ b/packages/video_player/video_player_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: video_player_web
 description: Web platform implementation of video_player
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player_web
-version: 0.1.2+1
+version: 0.1.2+2
 
 flutter:
   plugin:

--- a/script/incremental_build.sh
+++ b/script/incremental_build.sh
@@ -16,7 +16,7 @@ source "$SCRIPT_DIR/common.sh"
 CUSTOM_ANALYSIS_PLUGINS=(
   "in_app_purchase"
   "camera"
-  "video_player_web"
+  "video_player/video_player_web"
 )
 # Comma-separated string of the list above
 readonly CUSTOM_FLAG=$(IFS=, ; echo "${CUSTOM_ANALYSIS_PLUGINS[*]}")

--- a/script/incremental_build.sh
+++ b/script/incremental_build.sh
@@ -16,6 +16,7 @@ source "$SCRIPT_DIR/common.sh"
 CUSTOM_ANALYSIS_PLUGINS=(
   "in_app_purchase"
   "camera"
+  "video_player_web"
 )
 # Comma-separated string of the list above
 readonly CUSTOM_FLAG=$(IFS=, ; echo "${CUSTOM_ANALYSIS_PLUGINS[*]}")


### PR DESCRIPTION
## Description

flutter/plugins is currently red because inline analysis checks are no longer honored, as described here: https://github.com/flutter/flutter/issues/52899.

`video_player_web` used a web-only API that was being flagged (correctly) by the analyzer, but suppressed inline via `// ignore` comments.

Now that `// ignore` comments don't work, the tree has gone red.

The fix for `video_player_web` will take longer than acceptable to unblock the flutter/plugins tree, so we're putting this mitigation so work can continue normally.

This patch will be removed, once the affected APIs can be accessed without triggering analyzer errors.

## Related Issues

* https://github.com/flutter/flutter/issues/52899
* https://github.com/flutter/flutter/issues/41563

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
