### PR TITLE
Reland: [e2e] Replaces the check for ActivityTestRule (#2633)

### DIFF
--- a/packages/e2e/CHANGELOG.md
+++ b/packages/e2e/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.2
+
+* Adds support for Android E2E tests that utilize other @Rule's, like GrantPermissionRule.
+
 ## 0.4.1
 
 * Remove Android dependencies fallback.

--- a/packages/e2e/example/android/app/src/androidTest/java/com/example/e2e_example/MainActivityWithPermissionTest.java
+++ b/packages/e2e/example/android/app/src/androidTest/java/com/example/e2e_example/MainActivityWithPermissionTest.java
@@ -1,0 +1,25 @@
+package com.example.e2e_example;
+
+import android.Manifest.permission;
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.rule.GrantPermissionRule;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+
+/**
+ * Demonstrates how a E2E test on Android can be run with permissions already granted. This is
+ * helpful if developers want to test native App behavior that depends on certain system service
+ * results which are guarded with permissions.
+ */
+@RunWith(FlutterTestRunner.class)
+public class MainActivityWithPermissionTest {
+
+  @Rule
+  public GrantPermissionRule permissionRule =
+      GrantPermissionRule.grant(permission.ACCESS_COARSE_LOCATION);
+
+  @Rule
+  public ActivityTestRule<MainActivity> rule =
+      new ActivityTestRule<>(MainActivity.class, true, false);
+}

--- a/packages/e2e/pubspec.yaml
+++ b/packages/e2e/pubspec.yaml
@@ -1,6 +1,6 @@
 name: e2e
 description: Runs tests that use the flutter_test API as integration tests.
-version: 0.4.1
+version: 0.4.2
 homepage: https://github.com/flutter/plugins/tree/master/packages/e2e
 
 environment:


### PR DESCRIPTION
This relands #2633.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
