### PR TITLE
[webview_flutter] Workaround old Android tablets select drop down crash

### DIFF
--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.3.20+1
 
 * OCMock module import -> #import, unit tests compile generated as library.
+* Fix select drop down crash on old Android tablets (https://github.com/flutter/flutter/issues/54164).
 
 ## 0.3.20
 

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/InputAwareWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/InputAwareWebView.java
@@ -7,10 +7,13 @@ package io.flutter.plugins.webviewflutter;
 import static android.content.Context.INPUT_METHOD_SERVICE;
 
 import android.content.Context;
+import android.graphics.Rect;
+import android.os.Build;
 import android.util.Log;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
 import android.webkit.WebView;
+import android.widget.ListPopupWindow;
 
 /**
  * A WebView subclass that mirrors the same implementation hacks that the system WebView does in
@@ -185,5 +188,46 @@ final class InputAwareWebView extends WebView {
             imm.isActive(containerView);
           }
         });
+  }
+
+  @Override
+  protected void onFocusChanged(boolean focused, int direction, Rect previouslyFocusedRect) {
+    // This works around a crash when old (<67.0.3367.0) Chromium versions are used.
+
+    // Prior to Chromium 67.0.3367 the following sequence happens when a select drop down is shown
+    // on tablets:
+    //
+    //  - WebView is callingListPopupWindow#show
+    //  - buildDropDown is invoked, which sets mDropDownList to a DropDownListView.
+    //  - showAsDropDown is invoked - resulting in mDropDownList being added to the window and is
+    //    also synchronously performing the following sequence:
+    //    - WebView's focus change listener is loosing focus (as mDropDownList got it)
+    //    - WebView is hiding all popups (as it lost focus)
+    //    - WebView's SelectPopupDropDown#hide is invoked.
+    //    - DropDownPopupWindow#dismiss is invoked setting mDropDownList to null.
+    //  - mDropDownList#setSelection is invoked and is throwing a NullPointerException (as we just set mDropDownList to null).
+    //
+    // To workaround this, we drop the problematic focus lost call.
+    // See more details on: https://github.com/flutter/flutter/issues/54164
+    //
+    // We don't do this after Android P as it shipped with a new enough WebView version, and it's
+    // better to not do this on all future Android versions in case DropDownListView's code changes.
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P
+        && isCalledFromListPopupWindowShow()
+        && !focused) {
+      return;
+    }
+    super.onFocusChanged(focused, direction, previouslyFocusedRect);
+  }
+
+  private boolean isCalledFromListPopupWindowShow() {
+    StackTraceElement[] stackTraceElements = Thread.currentThread().getStackTrace();
+    for (int i = 0; i < stackTraceElements.length; i++) {
+      if (stackTraceElements[i].getClassName().equals(ListPopupWindow.class.getCanonicalName())
+          && stackTraceElements[i].getMethodName().equals("show")) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/InputAwareWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/InputAwareWebView.java
@@ -197,7 +197,7 @@ final class InputAwareWebView extends WebView {
     // Prior to Chromium 67.0.3367 the following sequence happens when a select drop down is shown
     // on tablets:
     //
-    //  - WebView is callingListPopupWindow#show
+    //  - WebView is calling ListPopupWindow#show
     //  - buildDropDown is invoked, which sets mDropDownList to a DropDownListView.
     //  - showAsDropDown is invoked - resulting in mDropDownList being added to the window and is
     //    also synchronously performing the following sequence:


### PR DESCRIPTION
Works around a crash in Android tablets running a Chromium version older than `67.0.3367.0`

Before [afb450](https://source.chromium.org/chromium/chromium/src/+/afb450fc02dfef4995a87c62b82d6cc0ed27be84?originalUrl=https%2F%2F:%2F%2F%2F%2Fcs.chromium.org%2F), on tablets Chromium used a `ListPopupWindow` to show select drop downs. `ListPoupWindow` is using `DropDownListView` which internally is using a [ListDropDownWindow](https://android.googlesource.com/platform/frameworks/base/+/oreo-mr1-release/core/java/android/widget/DropDownListView.java#28), which partially hijacks view focus (most importantly it [overrides isFocused](https://android.googlesource.com/platform/frameworks/base/+/oreo-mr1-release/core/java/android/widget/DropDownListView.java#337) to return true, which causes `requestChildFocus` to be invoked [here](https://android.googlesource.com/platform/frameworks/base/+/oreo-mr1-release/core/java/android/view/ViewGroup.java#4970)) .

With Android WebView versions prior to [afb450](https://source.chromium.org/chromium/chromium/src/+/afb450fc02dfef4995a87c62b82d6cc0ed27be84?originalUrl=https%2F%2F:%2F%2F%2F%2Fcs.chromium.org%2F), the following sequence happens when a select drop down is shown:

1. WebView is calling`ListPopupWindow#show`
1. [buildDropDown](https://android.googlesource.com/platform/frameworks/base/+/oreo-mr1-release/core/java/android/widget/ListPopupWindow.java#613) is invoked, which sets `mDropDownList` to a `DropDownListView`.
1. [`showAsDropDown` is invoked](https://android.googlesource.com/platform/frameworks/base/+/oreo-mr1-release/core/java/android/widget/ListPopupWindow.java#695) - resulting in `mDropDownList` being added to the window and is also synchronously performing the following sequence:
    1. WebView's focus change listener is loosing focus (as mDropDownList got it)
    1. WebView is hiding all popups (as it lost focus)
    1. WebView's [`SelectPopupDropDown#hide`](https://source.chromium.org/chromium/chromium/src/+/master:content/public/android/java/src/org/chromium/content/browser/input/SelectPopupDropdown.java;l=79;drc=c4070b691ec0b1ce6a523ed1c2f26d08afa2110d?originalUrl=https:%2F%2Fcs.chromium.org%2F) is invoked.
    1. [`DropDownPopupWindow#dismiss`](https://android.googlesource.com/platform/frameworks/base/+/oreo-mr1-release/core/java/android/widget/ListPopupWindow.java#716) is invoked setting `mDropDownList` to null.
1. [`mDropDownList#setSelection`](https://android.googlesource.com/platform/frameworks/base/+/oreo-mr1-release/core/java/android/widget/ListPopupWindow.java#697) is invoked and is throwing a NullPointerException (as we just set `mDropDownList` to null).

This is an unfortunate case where a combination of grey area behaviors by Flutter, Chromium, and Android, each work on their own, crash when they are combined together.

We workaround by dropping `onFocusChanged` calls that originated from `ListPopupWindow`,

Fixes: https://github.com/flutter/flutter/issues/54164

## Testing exemption
This is impractical to test, got a testing exemption in: https://github.com/flutter/flutter/issues/54164#issuecomment-613645157
