### PR TITLE
Remove out of date pod repo update from Cirrus

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -102,8 +102,6 @@ task:
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   osx_instance:
     image: mojave-xcode-11.3-flutter
-  setup_script:
-    - pod repo update
   upgrade_script:
     - flutter channel stable
     - flutter upgrade
@@ -150,7 +148,6 @@ task:
   osx_instance:
     image: mojave-xcode-11.3-flutter
   setup_script:
-    - pod repo update
     - flutter config --enable-macos-desktop
   upgrade_script:
     - flutter channel master


### PR DESCRIPTION
## Description

`pod repo update` is not needed as of [CocoaPods 1.8](http://blog.cocoapods.org/CocoaPods-1.8.0-beta/).  Remove from Cirrus scripts.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.