### PR TITLE
[image_picker] Fixes crash when an image in the gallery is tapped mor…

### DIFF
--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.6
+
+* Fixes crash when an image in the gallery is tapped more than once.
+
 ## 0.6.5
 
 * Set maximum duration for video recording.

--- a/packages/image_picker/ios/Classes/FLTImagePickerPlugin.m
+++ b/packages/image_picker/ios/Classes/FLTImagePickerPlugin.m
@@ -279,7 +279,7 @@ static const int SOURCE_GALLERY = 1;
     }
     self.result(videoURL.path);
     self.result = nil;
-
+    _arguments = nil;
   } else {
     UIImage *image = [info objectForKey:UIImagePickerControllerEditedImage];
     if (image == nil) {
@@ -322,7 +322,6 @@ static const int SOURCE_GALLERY = 1;
                      }];
     }
   }
-  _arguments = nil;
 }
 
 - (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker {
@@ -357,6 +356,9 @@ static const int SOURCE_GALLERY = 1;
 }
 
 - (void)handleSavedPath:(NSString *)path {
+  if (!self.result) {
+    return;
+  }
   if (path) {
     self.result(path);
   } else {
@@ -365,6 +367,7 @@ static const int SOURCE_GALLERY = 1;
                                     details:nil]);
   }
   self.result = nil;
+  _arguments = nil;
 }
 
 @end

--- a/packages/image_picker/ios/Tests/ImagePickerPluginTests.m
+++ b/packages/image_picker/ios/Tests/ImagePickerPluginTests.m
@@ -7,6 +7,11 @@
 @import image_picker;
 @import XCTest;
 
+@interface FLTImagePickerPlugin (Test)
+@property(copy, nonatomic) FlutterResult result;
+- (void)handleSavedPath:(NSString *)path;
+@end
+
 @interface ImagePickerPluginTests : XCTestCase
 @end
 
@@ -88,6 +93,22 @@
                     result:^(id _Nullable r){
                     }];
   XCTAssertEqual([plugin getImagePickerController].videoMaximumDuration, 95);
+}
+
+- (void)testPluginPickImageSelectMultipleTimes {
+  FLTImagePickerPlugin *plugin =
+      [[FLTImagePickerPlugin alloc] initWithViewController:[UIViewController new]];
+  FlutterMethodCall *call =
+      [FlutterMethodCall methodCallWithMethodName:@"pickImage"
+                                        arguments:@{@"source" : @(0), @"cameraDevice" : @(0)}];
+  [plugin handleMethodCall:call
+                    result:^(id _Nullable r){
+                    }];
+  plugin.result = ^(id result) {
+    
+  };
+  [plugin handleSavedPath:@"test"];
+  [plugin handleSavedPath:@"test"];
 }
 
 @end

--- a/packages/image_picker/ios/Tests/ImagePickerPluginTests.m
+++ b/packages/image_picker/ios/Tests/ImagePickerPluginTests.m
@@ -105,7 +105,7 @@
                     result:^(id _Nullable r){
                     }];
   plugin.result = ^(id result) {
-    
+
   };
   [plugin handleSavedPath:@"test"];
   [plugin handleSavedPath:@"test"];

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker
 description: Flutter plugin for selecting images from the Android and iOS image
   library, and taking new pictures with the camera.
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.6.5
+version: 0.6.6
 
 flutter:
   plugin:


### PR DESCRIPTION
…e than once

## Description

Fixes crash when an image in the gallery is tapped more than once

## Related Issues

https://github.com/flutter/flutter/issues/55063

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
