### PR TITLE
[android_intent] Fix pod lint warnings

### DIFF
--- a/packages/android_intent/CHANGELOG.md
+++ b/packages/android_intent/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.7+1
+
+* Fix CocoaPods podspec lint warnings.
+
 ## 0.3.7
 
 * Add a `Future<bool> canResolveActivity` method to the AndroidIntent class. It 

--- a/packages/android_intent/ios/android_intent.podspec
+++ b/packages/android_intent/ios/android_intent.podspec
@@ -3,15 +3,18 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'android_intent'
-  s.version          = '0.3.7'
-  s.summary          = 'A new flutter plugin project.'
+  s.version          = '0.0.1'
+  s.summary          = 'Android Intent Plugin for Flutter'
   s.description      = <<-DESC
-A new flutter plugin project.
+This plugin allows Flutter apps to launch arbitrary intents when the platform is Android.
+If the plugin is invoked on iOS, it will crash your app.
+Downloaded by pub (not CocoaPods).
                        DESC
-  s.homepage         = 'http://example.com'
-  s.license          = { :file => '../LICENSE' }
-  s.author           = { 'Your Company' => 'email@example.com' }
-  s.source           = { :path => '.' }
+  s.homepage         = 'https://github.com/flutter/plugins'
+  s.license          = { :type => 'BSD', :file => '../LICENSE' }
+  s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
+  s.source           = { :http => 'https://github.com/flutter/plugins/tree/master/packages/android_intent' }
+  s.documentation_url = 'https://pub.dev/packages/android_intent'
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'

--- a/packages/android_intent/pubspec.yaml
+++ b/packages/android_intent/pubspec.yaml
@@ -1,7 +1,7 @@
 name: android_intent
 description: Flutter plugin for launching Android Intents. Not supported on iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/android_intent
-version: 0.3.7
+version: 0.3.7+1
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Fix android_intent pod lib lint warnings:
```
 -> android_intent (0.3.7)
    - WARN  | license: Missing license type.
    - WARN  | description: The description is equal to the summary.
    - WARN  | [iOS] keys: Missing primary key for `source` attribute. The acceptable ones are: `git, hg, http, svn`.
...
[!] android_intent did not pass validation, due to 3 warnings (but you can use `--allow-warnings` to ignore them).
```

## Related Issues

https://github.com/flutter/flutter/issues/55245
Dependency to merge https://github.com/flutter/plugin_tools/pull/97

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.