### PR TITLE
[battery] Fix pod lint warnings

### DIFF
--- a/packages/battery/CHANGELOG.md
+++ b/packages/battery/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1+11
+
+* Fix CocoaPods podspec lint warnings.
+
 ## 0.3.1+10
 
 * Update minimum Flutter version to 1.12.13+hotfix.5

--- a/packages/battery/CHANGELOG.md
+++ b/packages/battery/CHANGELOG.md
@@ -1,10 +1,7 @@
-## 0.3.1+11
-
-* Fix CocoaPods podspec lint warnings.
-
 ## 0.3.1+10
 
 * Update minimum Flutter version to 1.12.13+hotfix.5
+* Fix CocoaPods podspec lint warnings.
 
 ## 0.3.1+9
 

--- a/packages/battery/ios/battery.podspec
+++ b/packages/battery/ios/battery.podspec
@@ -6,12 +6,14 @@ Pod::Spec.new do |s|
   s.version          = '0.0.1'
   s.summary          = 'Flutter plugin for accessing information about the battery.'
   s.description      = <<-DESC
-Flutter plugin for accessing information about the battery.
+A Flutter plugin to access various information about the battery of the device the app is running on.
+Downloaded by pub (not CocoaPods).
                        DESC
-  s.homepage         = 'https://github.com/flutter/plugins/tree/master/packages/battery'
-  s.license          = { :file => '../LICENSE' }
-  s.author           = { 'Flutter Team' => 'flutter-dev@googlegroups.com' }
-  s.source           = { :path => '.' }
+  s.homepage         = 'https://github.com/flutter/plugins'
+  s.license          = { :type => 'BSD', :file => '../LICENSE' }
+  s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
+  s.source           = { :http => 'https://github.com/flutter/plugins/tree/master/packages/battery' }
+  s.documentation_url = 'https://pub.dev/packages/battery'
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'

--- a/packages/battery/pubspec.yaml
+++ b/packages/battery/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/flutter/plugins/tree/master/packages/battery
 # 0.3.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.3.1+11
+version: 0.3.1+10
 
 flutter:
   plugin:

--- a/packages/battery/pubspec.yaml
+++ b/packages/battery/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/flutter/plugins/tree/master/packages/battery
 # 0.3.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.3.1+10
+version: 0.3.1+11
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Fix battery pod lib lint warnings:
```
 -> battery (0.0.1)
    - WARN  | license: Missing license type.
    - WARN  | description: The description is equal to the summary.
    - WARN  | [iOS] keys: Missing primary key for `source` attribute. The acceptable ones are: `git, hg, http, svn`.
[!] battery did not pass validation, due to 3 warnings (but you can use `--allow-warnings` to ignore them).
```

## Related Issues

https://github.com/flutter/flutter/issues/55245
Dependency to merge https://github.com/flutter/plugin_tools/pull/97

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.