### PR TITLE
[connectivity] Fix pod lint warnings

### DIFF
--- a/packages/connectivity/connectivity/CHANGELOG.md
+++ b/packages/connectivity/connectivity/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Bump the minimum Flutter version to 1.12.13+hotfix.5.
 * Clean up various Android workarounds no longer needed after framework v1.12.
 * Complete v2 embedding support.
+* Fix CocoaPods podspec lint warnings.
 
 ## 0.4.8+3
 

--- a/packages/connectivity/connectivity/ios/connectivity.podspec
+++ b/packages/connectivity/connectivity/ios/connectivity.podspec
@@ -4,14 +4,16 @@
 Pod::Spec.new do |s|
   s.name             = 'connectivity'
   s.version          = '0.0.1'
-  s.summary          = 'A new flutter plugin project.'
+  s.summary          = 'Flutter Connectivity'
   s.description      = <<-DESC
-A new flutter plugin project.
+This plugin allows Flutter apps to discover network connectivity and configure themselves accordingly.
+Downloaded by pub (not CocoaPods).
                        DESC
-  s.homepage         = 'http://example.com'
-  s.license          = { :file => '../LICENSE' }
-  s.author           = { 'Your Company' => 'email@example.com' }
-  s.source           = { :path => '.' }
+  s.homepage         = 'https://github.com/flutter/plugins'
+  s.license          = { :type => 'BSD', :file => '../LICENSE' }
+  s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
+  s.source           = { :http => 'https://github.com/flutter/plugins/tree/master/packages/connectivity/connectivity' }
+  s.documentation_url = 'https://pub.dev/packages/connectivity'
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'

--- a/packages/connectivity/connectivity_macos/CHANGELOG.md
+++ b/packages/connectivity/connectivity_macos/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Bump the minimum Flutter version to 1.12.13+hotfix.5.
 * Clean up various Android workarounds no longer needed after framework v1.12.
 * Complete v2 embedding support.
+* Fix CocoaPods podspec lint warnings.
 
 ## 0.1.0+2
 

--- a/packages/connectivity/connectivity_macos/macos/connectivity_macos.podspec
+++ b/packages/connectivity/connectivity_macos/macos/connectivity_macos.podspec
@@ -9,9 +9,9 @@ Pod::Spec.new do |s|
   Desktop implementation of the connectivity plugin
                        DESC
   s.homepage         = 'https://github.com/flutter/plugins/tree/master/packages/connectivity/connectivity_macos'
-  s.license          = { :file => '../LICENSE' }
+  s.license          = { :type => 'BSD', :file => '../LICENSE' }
   s.author           = { 'Flutter Team' => 'flutter-dev@googlegroups.com' }
-  s.source           = { :path => '.' }
+  s.source           = { :http => 'https://github.com/flutter/plugins/tree/master/packages/connectivity/connectivity_macos' }
   s.source_files     = 'Classes/**/*'
   s.dependency 'FlutterMacOS'
   s.dependency 'Reachability'


### PR DESCRIPTION
## Description

Fix connectivity and connectivity_macos pod lib lint warnings:
```
 -> connectivity (0.0.1)
    - WARN  | license: Missing license type.
    - WARN  | description: The description is equal to the summary.
    - WARN  | [iOS] keys: Missing primary key for `source` attribute. The acceptable ones are: `git, hg, http, svn`.
...
[!] connectivity did not pass validation, due to 3 warnings (but you can use `--allow-warnings` to ignore them).
```
```
 -> connectivity_macos (0.0.1)
    - WARN  | license: Missing license type.
    - WARN  | [OSX] keys: Missing primary key for `source` attribute. The acceptable ones are: `git, hg, http, svn`.
    - WARN  | [OSX] swift: The validator used Swift `4.0` by default because no Swift version was specified. To specify a Swift version during validation, add the `swift_versions` attribute in your podspec. Note that usage of a `.swift-version` file is now deprecated.
...
[!] connectivity_macos did not pass validation, due to 3 warnings (but you can use `--allow-warnings` to ignore them).
```
Note connectivity_macos still has the Swift warning after this change, but mac plugins aren't being linted during CI at the moment.  Do the innocuous bits.

## Related Issues

https://github.com/flutter/flutter/issues/55245
Dependency to merge https://github.com/flutter/plugin_tools/pull/97

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.