### PR TITLE
[e2e] Fix pod lint warnings

### DIFF
--- a/packages/e2e/CHANGELOG.md
+++ b/packages/e2e/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.4.2
 
 * Adds support for Android E2E tests that utilize other @Rule's, like GrantPermissionRule.
+* Fix CocoaPods podspec lint warnings.
 
 ## 0.4.1
 

--- a/packages/e2e/e2e_macos/macos/e2e_macos.podspec
+++ b/packages/e2e/e2e_macos/macos/e2e_macos.podspec
@@ -9,11 +9,10 @@ Pod::Spec.new do |s|
 Runs tests that use the flutter_test API as integration tests on macOS.
                        DESC
   s.homepage         = 'https://github.com/flutter/plugins/tree/master/packages/e2e/e2e_macos'
-  s.license          = { :file => '../LICENSE' }
+  s.license          = { :type => 'BSD', :file => '../LICENSE' }
   s.author           = { 'Flutter Team' => 'flutter-dev@googlegroups.com' }
-  s.source           = { :path => '.' }
+  s.source           = { :http => 'https://github.com/flutter/plugins/tree/master/packages/e2e' }
   s.source_files = 'Classes/**/*'
-  s.public_header_files = 'Classes/**/*.h'
   s.dependency 'FlutterMacOS'
 
   s.platform = :osx, '10.11'

--- a/packages/e2e/ios/e2e.podspec
+++ b/packages/e2e/ios/e2e.podspec
@@ -9,9 +9,9 @@ Pod::Spec.new do |s|
 Runs tests that use the flutter_test API as integration tests.
                        DESC
   s.homepage         = 'https://github.com/flutter/plugins/tree/master/packages/e2e'
-  s.license          = { :file => '../LICENSE' }
+  s.license          = { :type => 'BSD', :file => '../LICENSE' }
   s.author           = { 'Flutter Team' => 'flutter-dev@googlegroups.com' }
-  s.source           = { :path => '.' }
+  s.source           = { :http => 'https://github.com/flutter/plugins/tree/master/packages/e2e' }
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'


### PR DESCRIPTION
## Description

Fix e2e pod lib lint warnings:
```
 -> e2e (0.0.1)
    - WARN  | license: Missing license type.
    - WARN  | [iOS] keys: Missing primary key for `source` attribute. The acceptable ones are: `git, hg, http, svn`.
...
[!] e2e did not pass validation, due to 2 warnings (but you can use `--allow-warnings` to ignore them).
```
```
 -> e2e_macos (0.0.1)
    - WARN  | license: Missing license type.
    - WARN  | [OSX] keys: Missing primary key for `source` attribute. The acceptable ones are: `git, hg, http, svn`.
    - WARN  | [OSX] file patterns: The `public_header_files` pattern did not match any file.
    - WARN  | [OSX] swift: The validator used Swift `4.0` by default because no Swift version was specified. To specify a Swift version during validation, add the `swift_versions` attribute in your podspec. Note that usage of a `.swift-version` file is now deprecated.
...
[!] e2e_macos did not pass validation, due to 4 warnings (but you can use `--allow-warnings` to ignore them).
```
Note e2e_macos still has the Swift warning after this change, but mac plugins aren't being linted during CI at the moment. Do the innocuous bits.

## Related Issues

https://github.com/flutter/flutter/issues/55245
Dependency to merge https://github.com/flutter/plugin_tools/pull/97

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.