### PR TITLE
[flutter_plugin_android_lifecycle] Fix pod lint warnings

### DIFF
--- a/packages/flutter_plugin_android_lifecycle/CHANGELOG.md
+++ b/packages/flutter_plugin_android_lifecycle/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.0.7
 
 * Update Gradle version. Fixes https://github.com/flutter/flutter/issues/48724.
+* Fix CocoaPods podspec lint warnings.
 
 ## 1.0.6
 

--- a/packages/flutter_plugin_android_lifecycle/ios/flutter_plugin_android_lifecycle.podspec
+++ b/packages/flutter_plugin_android_lifecycle/ios/flutter_plugin_android_lifecycle.podspec
@@ -5,14 +5,17 @@
 Pod::Spec.new do |s|
   s.name             = 'flutter_plugin_android_lifecycle'
   s.version          = '0.0.1'
-  s.summary          = 'A new flutter plugin project.'
+  s.summary          = 'Flutter Android Lifecycle Plugin'
   s.description      = <<-DESC
-A new flutter plugin project.
+A Flutter plugin for Android to allow other Flutter plugins to access Android Lifecycle objects in the plugin's binding.
+This plugin a no-op on iOS.
+Downloaded by pub (not CocoaPods).
                        DESC
-  s.homepage         = 'http://example.com'
-  s.license          = { :file => '../LICENSE' }
-  s.author           = { 'Your Company' => 'email@example.com' }
-  s.source           = { :path => '.' }
+  s.homepage         = 'https://github.com/flutter/plugins'
+  s.license          = { :type => 'BSD', :file => '../LICENSE' }
+  s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
+  s.source           = { :http => 'https://github.com/flutter/plugins/tree/master/packages/flutter_plugin_android_lifecycle' }
+  s.documentation_url = 'https://pub.dev/packages/flutter_plugin_android_lifecycle'
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'


### PR DESCRIPTION
## Description

Fix flutter_plugin_android_lifecycle pod lib lint warnings:
```
 -> flutter_plugin_android_lifecycle (0.0.1)
    - WARN  | license: Missing license type.
    - WARN  | description: The description is equal to the summary.
    - WARN  | [iOS] keys: Missing primary key for `source` attribute. The acceptable ones are: `git, hg, http, svn`.
...
[!] flutter_plugin_android_lifecycle did not pass validation, due to 3 warnings (but you can use `--allow-warnings` to ignore them).
```

## Related Issues

https://github.com/flutter/flutter/issues/55245
Dependency to merge https://github.com/flutter/plugin_tools/pull/97

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.