### PR TITLE
[google_maps_flutter] Fix UIKit availability and pod lint warnings

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.26+2
+
+* Fix UIKit availability warnings and CocoaPods podspec lint warnings.
+
 ## 0.5.26+1
 
 * Removes a errorneously added method from the GoogleMapController.h header file.

--- a/packages/google_maps_flutter/google_maps_flutter/ios/Classes/GoogleMapController.m
+++ b/packages/google_maps_flutter/google_maps_flutter/ios/Classes/GoogleMapController.m
@@ -190,6 +190,7 @@ static double ToDouble(NSNumber* data) { return [FLTGoogleMapJsonConversions toD
       }
     } else {
       NSLog(@"Taking snapshots is not supported for Flutter Google Maps prior to iOS 10.");
+      result(nil);
     }
   } else if ([call.method isEqualToString:@"markers#update"]) {
     id markersToAdd = call.arguments[@"markersToAdd"];

--- a/packages/google_maps_flutter/google_maps_flutter/ios/Classes/GoogleMapController.m
+++ b/packages/google_maps_flutter/google_maps_flutter/ios/Classes/GoogleMapController.m
@@ -172,20 +172,24 @@ static double ToDouble(NSNumber* data) { return [FLTGoogleMapJsonConversions toD
   } else if ([call.method isEqualToString:@"map#waitForMap"]) {
     result(nil);
   } else if ([call.method isEqualToString:@"map#takeSnapshot"]) {
-    if (_mapView != nil) {
-      UIGraphicsImageRendererFormat* format = [UIGraphicsImageRendererFormat defaultFormat];
-      format.scale = [[UIScreen mainScreen] scale];
-      UIGraphicsImageRenderer* renderer =
-          [[UIGraphicsImageRenderer alloc] initWithSize:_mapView.frame.size format:format];
+    if (@available(iOS 10.0, *)) {
+      if (_mapView != nil) {
+        UIGraphicsImageRendererFormat* format = [UIGraphicsImageRendererFormat defaultFormat];
+        format.scale = [[UIScreen mainScreen] scale];
+        UIGraphicsImageRenderer* renderer =
+            [[UIGraphicsImageRenderer alloc] initWithSize:_mapView.frame.size format:format];
 
-      UIImage* image = [renderer imageWithActions:^(UIGraphicsImageRendererContext* context) {
-        [_mapView.layer renderInContext:context.CGContext];
-      }];
-      result([FlutterStandardTypedData typedDataWithBytes:UIImagePNGRepresentation(image)]);
+        UIImage* image = [renderer imageWithActions:^(UIGraphicsImageRendererContext* context) {
+          [_mapView.layer renderInContext:context.CGContext];
+        }];
+        result([FlutterStandardTypedData typedDataWithBytes:UIImagePNGRepresentation(image)]);
+      } else {
+        result([FlutterError errorWithCode:@"GoogleMap uninitialized"
+                                   message:@"takeSnapshot called prior to map initialization"
+                                   details:nil]);
+      }
     } else {
-      result([FlutterError errorWithCode:@"GoogleMap uninitialized"
-                                 message:@"takeSnapshot called prior to map initialization"
-                                 details:nil]);
+      NSLog(@"Taking snapshots is not supported for Flutter Google Maps prior to iOS 10.");
     }
   } else if ([call.method isEqualToString:@"markers#update"]) {
     id markersToAdd = call.arguments[@"markersToAdd"];

--- a/packages/google_maps_flutter/google_maps_flutter/ios/google_maps_flutter.podspec
+++ b/packages/google_maps_flutter/google_maps_flutter/ios/google_maps_flutter.podspec
@@ -4,14 +4,16 @@
 Pod::Spec.new do |s|
   s.name             = 'google_maps_flutter'
   s.version          = '0.0.1'
-  s.summary          = 'A new flutter plugin project.'
+  s.summary          = 'Google Maps for Flutter'
   s.description      = <<-DESC
-A new flutter plugin project.
+A Flutter plugin that provides a Google Maps widget.
+Downloaded by pub (not CocoaPods).
                        DESC
-  s.homepage         = 'http://example.com'
-  s.license          = { :file => '../LICENSE' }
-  s.author           = { 'Your Company' => 'email@example.com' }
-  s.source           = { :path => '.' }
+  s.homepage         = 'https://github.com/flutter/plugins'
+  s.license          = { :type => 'BSD', :file => '../LICENSE' }
+  s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
+  s.source           = { :http => 'https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter/google_maps_flutter' }
+  s.documentation_url = 'https://pub.dev/packages/google_maps_flutter'
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter/google_maps_flutter
-version: 0.5.26+1
+version: 0.5.26+2
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Description

Fix google_maps_flutter UIKit availability warnings introduced in https://github.com/flutter/plugins/pull/2607.  Also fix pod lib lint warnings:
```
 -> google_maps_flutter (0.0.1)
    - WARN  | license: Missing license type.
    - WARN  | description: The description is equal to the summary.
    - WARN  | [iOS] keys: Missing primary key for `source` attribute. The acceptable ones are: `git, hg, http, svn`.
    - WARN  | [iOS] xcodebuild:  /Users/m/Projects/plugins/packages/google_maps_flutter/google_maps_flutter/ios/Classes/GoogleMapController.m:176:7: warning: 'UIGraphicsImageRendererFormat' is only available on iOS 10.0 or newer [-Wunguarded-availability]
    - WARN  | [iOS] xcodebuild:  /Users/m/Projects/plugins/packages/google_maps_flutter/google_maps_flutter/ios/Classes/GoogleMapController.m:176:78: warning: 'defaultFormat' is only available on iOS 10.0 or newer [-Wunguarded-availability]
    - WARN  | [iOS] xcodebuild:  /Users/m/Projects/plugins/packages/google_maps_flutter/google_maps_flutter/ios/Classes/GoogleMapController.m:176:48: warning: 'UIGraphicsImageRendererFormat' is only available on iOS 10.0 or newer [-Wunguarded-availability]
    - WARN  | [iOS] xcodebuild:  /Users/m/Projects/plugins/packages/google_maps_flutter/google_maps_flutter/ios/Classes/GoogleMapController.m:178:7: warning: 'UIGraphicsImageRenderer' is only available on iOS 10.0 or newer [-Wunguarded-availability]
    - WARN  | [iOS] xcodebuild:  /Users/m/Projects/plugins/packages/google_maps_flutter/google_maps_flutter/ios/Classes/GoogleMapController.m:179:13: warning: 'UIGraphicsImageRenderer' is only available on iOS 10.0 or newer [-Wunguarded-availability]
    - WARN  | [iOS] xcodebuild:  /Users/m/Projects/plugins/packages/google_maps_flutter/google_maps_flutter/ios/Classes/GoogleMapController.m:181:53: warning: 'UIGraphicsImageRendererContext' is only available on iOS 10.0 or newer [-Wunguarded-availability]
...
[!] google_maps_flutter did not pass validation, due to 9 warnings (but you can use `--allow-warnings` to ignore them).
```

## Related Issues
Fixes https://github.com/flutter/flutter/issues/55258
https://github.com/flutter/flutter/issues/55245
Dependency to merge https://github.com/flutter/plugin_tools/pull/97

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.