### PR TITLE
[local_auth] Fix retain self warning and pod lint warnings

### DIFF
--- a/packages/local_auth/CHANGELOG.md
+++ b/packages/local_auth/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Remove Android dependencies fallback.
 * Require Flutter SDK 1.12.13+hotfix.5 or greater.
+* Fix block implicitly retains 'self' warning.
+* Fix CocoaPods podspec lint warnings.
 
 ## 0.6.1+4
 

--- a/packages/local_auth/ios/Classes/FLTLocalAuthPlugin.m
+++ b/packages/local_auth/ios/Classes/FLTLocalAuthPlugin.m
@@ -5,10 +5,13 @@
 
 #import "FLTLocalAuthPlugin.h"
 
-@implementation FLTLocalAuthPlugin {
-  NSDictionary *lastCallArgs;
-  FlutterResult lastResult;
-}
+@interface FLTLocalAuthPlugin ()
+@property (copy, nullable) NSDictionary<NSString *, NSNumber *> *lastCallArgs;
+@property (nullable) FlutterResult lastResult;
+@end
+
+@implementation FLTLocalAuthPlugin
+
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
   FlutterMethodChannel *channel =
       [FlutterMethodChannel methodChannelWithName:@"plugins.flutter.io/local_auth"
@@ -91,8 +94,8 @@
                  withFlutterResult:(FlutterResult)result {
   LAContext *context = [[LAContext alloc] init];
   NSError *authError = nil;
-  lastCallArgs = nil;
-  lastResult = nil;
+  self.lastCallArgs = nil;
+  self.lastResult = nil;
   context.localizedFallbackTitle = @"";
 
   if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics
@@ -114,8 +117,8 @@
                               return;
                             case LAErrorSystemCancel:
                               if ([arguments[@"stickyAuth"] boolValue]) {
-                                lastCallArgs = arguments;
-                                lastResult = result;
+                                self.lastCallArgs = arguments;
+                                self.lastResult = result;
                                 return;
                               }
                           }
@@ -158,8 +161,8 @@
 #pragma mark - AppDelegate
 
 - (void)applicationDidBecomeActive:(UIApplication *)application {
-  if (lastCallArgs != nil && lastResult != nil) {
-    [self authenticateWithBiometrics:lastCallArgs withFlutterResult:lastResult];
+  if (self.lastCallArgs != nil && self.lastResult != nil) {
+    [self authenticateWithBiometrics:_lastCallArgs withFlutterResult:self.lastResult];
   }
 }
 

--- a/packages/local_auth/ios/Classes/FLTLocalAuthPlugin.m
+++ b/packages/local_auth/ios/Classes/FLTLocalAuthPlugin.m
@@ -6,8 +6,8 @@
 #import "FLTLocalAuthPlugin.h"
 
 @interface FLTLocalAuthPlugin ()
-@property (copy, nullable) NSDictionary<NSString *, NSNumber *> *lastCallArgs;
-@property (nullable) FlutterResult lastResult;
+@property(copy, nullable) NSDictionary<NSString *, NSNumber *> *lastCallArgs;
+@property(nullable) FlutterResult lastResult;
 @end
 
 @implementation FLTLocalAuthPlugin

--- a/packages/local_auth/ios/local_auth.podspec
+++ b/packages/local_auth/ios/local_auth.podspec
@@ -4,14 +4,16 @@
 Pod::Spec.new do |s|
   s.name             = 'local_auth'
   s.version          = '0.0.1'
-  s.summary          = 'A new flutter plugin project.'
+  s.summary          = 'Flutter Local Auth'
   s.description      = <<-DESC
-A new flutter plugin project.
+This Flutter plugin provides means to perform local, on-device authentication of the user.
+Downloaded by pub (not CocoaPods).
                        DESC
-  s.homepage         = 'http://example.com'
-  s.license          = { :file => '../LICENSE' }
-  s.author           = { 'Your Company' => 'email@example.com' }
-  s.source           = { :path => '.' }
+  s.homepage         = 'https://github.com/flutter/plugins'
+  s.license          = { :type => 'BSD', :file => '../LICENSE' }
+  s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
+  s.source           = { :http => 'https://github.com/flutter/plugins/tree/master/packages/local_auth' }
+  s.documentation_url = 'https://pub.dev/packages/local_auth'
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'


### PR DESCRIPTION
## Description

Fix in_app_purchase implicit-retain-self warning and pod lib lint warnings:
```
 -> local_auth (0.0.1)
    - WARN  | license: Missing license type.
    - WARN  | description: The description is equal to the summary.
    - WARN  | [iOS] keys: Missing primary key for `source` attribute. The acceptable ones are: `git, hg, http, svn`.
    - WARN  | [iOS] xcodebuild:  /Users/m/Projects/plugins/packages/local_auth/ios/Classes/FLTLocalAuthPlugin.m:117:33: warning: block implicitly retains 'self'; explicitly mention 'self' to indicate this is intended behavior [-Wimplicit-retain-self]
    - WARN  | [iOS] xcodebuild:  /Users/m/Projects/plugins/packages/local_auth/ios/Classes/FLTLocalAuthPlugin.m:118:33: warning: block implicitly retains 'self'; explicitly mention 'self' to indicate this is intended behavior [-Wimplicit-retain-self]
...
[!] local_auth did not pass validation, due to 5 warnings (but you can use `--allow-warnings` to ignore them).
```

## Related Issues

https://github.com/flutter/flutter/issues/55245
Dependency to merge https://github.com/flutter/plugin_tools/pull/97

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.