### PR TITLE
[quick_actions] Fix UIApplicationShortcutItem availability and pod lint warnings

### DIFF
--- a/packages/quick_actions/CHANGELOG.md
+++ b/packages/quick_actions/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Bump the minimum Flutter version to 1.12.13+hotfix.5.
 * Clean up various Android workarounds no longer needed after framework v1.12.
 * Complete v2 embedding support.
+* Fix UIApplicationShortcutItem availability warnings.
+* Fix CocoaPods podspec lint warnings.
 
 ## 0.4.0+3
 

--- a/packages/quick_actions/ios/Classes/FLTQuickActionsPlugin.m
+++ b/packages/quick_actions/ios/Classes/FLTQuickActionsPlugin.m
@@ -47,13 +47,13 @@ static NSString *const CHANNEL_NAME = @"plugins.flutter.io/quick_actions";
 
 - (BOOL)application:(UIApplication *)application
     performActionForShortcutItem:(UIApplicationShortcutItem *)shortcutItem
-               completionHandler:(void (^)(BOOL succeeded))completionHandler API_AVAILABLE(ios(9.0)) {
+               completionHandler:(void (^)(BOOL succeeded))completionHandler
+    API_AVAILABLE(ios(9.0)) {
   [self.channel invokeMethod:@"launch" arguments:shortcutItem.type];
   return YES;
 }
 
 #pragma mark Private functions
-
 
 NS_INLINE void _setShortcutItems(NSArray *items) API_AVAILABLE(ios(9.0)) {
   NSMutableArray<UIApplicationShortcutItem *> *newShortcuts = [[NSMutableArray alloc] init];
@@ -66,7 +66,8 @@ NS_INLINE void _setShortcutItems(NSArray *items) API_AVAILABLE(ios(9.0)) {
   [UIApplication sharedApplication].shortcutItems = newShortcuts;
 }
 
-NS_INLINE UIApplicationShortcutItem *_deserializeShortcutItem(NSDictionary *serialized) API_AVAILABLE(ios(9.0)) {
+NS_INLINE UIApplicationShortcutItem *_deserializeShortcutItem(NSDictionary *serialized)
+    API_AVAILABLE(ios(9.0)) {
   UIApplicationShortcutIcon *icon =
       [serialized[@"icon"] isKindOfClass:[NSNull class]]
           ? nil

--- a/packages/quick_actions/ios/Classes/FLTQuickActionsPlugin.m
+++ b/packages/quick_actions/ios/Classes/FLTQuickActionsPlugin.m
@@ -22,45 +22,51 @@ static NSString *const CHANNEL_NAME = @"plugins.flutter.io/quick_actions";
 }
 
 - (void)handleMethodCall:(FlutterMethodCall *)call result:(FlutterResult)result {
-  if ([call.method isEqualToString:@"setShortcutItems"]) {
-    setShortcutItems(call.arguments);
-    result(nil);
-  } else if ([call.method isEqualToString:@"clearShortcutItems"]) {
-    [UIApplication sharedApplication].shortcutItems = @[];
-    result(nil);
-  } else if ([call.method isEqualToString:@"getLaunchAction"]) {
-    result(nil);
+  if (@available(iOS 9.0, *)) {
+    if ([call.method isEqualToString:@"setShortcutItems"]) {
+      _setShortcutItems(call.arguments);
+      result(nil);
+    } else if ([call.method isEqualToString:@"clearShortcutItems"]) {
+      [UIApplication sharedApplication].shortcutItems = @[];
+      result(nil);
+    } else if ([call.method isEqualToString:@"getLaunchAction"]) {
+      result(nil);
+    } else {
+      result(FlutterMethodNotImplemented);
+    }
   } else {
-    result(FlutterMethodNotImplemented);
+    NSLog(@"Shortcuts are not supported prior to iOS 9.");
+    result(nil);
   }
 }
 
 - (void)dealloc {
-  [self.channel setMethodCallHandler:nil];
-  self.channel = nil;
+  [_channel setMethodCallHandler:nil];
+  _channel = nil;
 }
 
 - (BOOL)application:(UIApplication *)application
     performActionForShortcutItem:(UIApplicationShortcutItem *)shortcutItem
-               completionHandler:(void (^)(BOOL succeeded))completionHandler {
+               completionHandler:(void (^)(BOOL succeeded))completionHandler API_AVAILABLE(ios(9.0)) {
   [self.channel invokeMethod:@"launch" arguments:shortcutItem.type];
   return YES;
 }
 
 #pragma mark Private functions
 
-static void setShortcutItems(NSArray *items) {
-  NSMutableArray *newShortcuts = [[NSMutableArray alloc] init];
+
+NS_INLINE void _setShortcutItems(NSArray *items) API_AVAILABLE(ios(9.0)) {
+  NSMutableArray<UIApplicationShortcutItem *> *newShortcuts = [[NSMutableArray alloc] init];
 
   for (id item in items) {
-    UIApplicationShortcutItem *shortcut = deserializeShortcutItem(item);
+    UIApplicationShortcutItem *shortcut = _deserializeShortcutItem(item);
     [newShortcuts addObject:shortcut];
   }
 
   [UIApplication sharedApplication].shortcutItems = newShortcuts;
 }
 
-static UIApplicationShortcutItem *deserializeShortcutItem(NSDictionary *serialized) {
+NS_INLINE UIApplicationShortcutItem *_deserializeShortcutItem(NSDictionary *serialized) API_AVAILABLE(ios(9.0)) {
   UIApplicationShortcutIcon *icon =
       [serialized[@"icon"] isKindOfClass:[NSNull class]]
           ? nil

--- a/packages/quick_actions/ios/quick_actions.podspec
+++ b/packages/quick_actions/ios/quick_actions.podspec
@@ -4,14 +4,16 @@
 Pod::Spec.new do |s|
   s.name             = 'quick_actions'
   s.version          = '0.0.1'
-  s.summary          = 'A new flutter plugin project.'
+  s.summary          = 'Flutter Quick Actions'
   s.description      = <<-DESC
-A new flutter plugin project.
+This Flutter plugin allows you to manage and interact with the application's home screen quick actions.
+Downloaded by pub (not CocoaPods).
                        DESC
-  s.homepage         = 'http://example.com'
-  s.license          = { :file => '../LICENSE' }
-  s.author           = { 'Your Company' => 'email@example.com' }
-  s.source           = { :path => '.' }
+  s.homepage         = 'https://github.com/flutter/plugins'
+  s.license          = { :type => 'BSD', :file => '../LICENSE' }
+  s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
+  s.source           = { :http => 'https://github.com/flutter/plugins/tree/master/packages/quick_actions' }
+  s.documentation_url = 'https://pub.dev/packages/quick_actions'
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'


### PR DESCRIPTION
## Description

Fix quick_actions UIApplicationShortcutItem availability warnings, slightly cleaned up FLTQuickActionsPlugin (though [I'm not convinced this plugin is working](https://github.com/flutter/flutter/labels/p%3A%20quick_actions)). 
Also fix pod lib lint warnings:
```
 -> quick_actions (0.0.1)
    - WARN  | license: Missing license type.
    - WARN  | description: The description is equal to the summary.
    - WARN  | [iOS] keys: Missing primary key for `source` attribute. The acceptable ones are: `git, hg, http, svn`.
    - WARN  | [iOS] xcodebuild:  /Users/m/Projects/plugins/packages/quick_actions/ios/Classes/FLTQuickActionsPlugin.m:44:35: warning: 'UIApplicationShortcutItem' is only available on iOS 9.0 or newer [-Wunguarded-availability]
    - WARN  | [iOS] xcodebuild:  /Users/m/Projects/plugins/packages/quick_actions/ios/Classes/FLTQuickActionsPlugin.m:63:8: warning: 'UIApplicationShortcutItem' is only available on iOS 9.0 or newer [-Wunguarded-availability]
    - WARN  | [iOS] xcodebuild:  /Users/m/Projects/plugins/packages/quick_actions/ios/Classes/FLTQuickActionsPlugin.m:29:39: warning: 'setShortcutItems:' is only available on iOS 9.0 or newer [-Wunguarded-availability]
    - WARN  | [iOS] xcodebuild:  /Users/m/Projects/plugins/packages/quick_actions/ios/Classes/FLTQuickActionsPlugin.m:56:5: warning: 'UIApplicationShortcutItem' is only available on iOS 9.0 or newer [-Wunguarded-availability]
    - WARN  | [iOS] xcodebuild:  /Users/m/Projects/plugins/packages/quick_actions/ios/Classes/FLTQuickActionsPlugin.m:60:37: warning: 'setShortcutItems:' is only available on iOS 9.0 or newer [-Wunguarded-availability]
    - WARN  | [iOS] xcodebuild:  /Users/m/Projects/plugins/packages/quick_actions/ios/Classes/FLTQuickActionsPlugin.m:64:3: warning: 'UIApplicationShortcutIcon' is only available on iOS 9.0 or newer [-Wunguarded-availability]
    - WARN  | [iOS] xcodebuild:  /Users/m/Projects/plugins/packages/quick_actions/ios/Classes/FLTQuickActionsPlugin.m:67:14: warning: 'UIApplicationShortcutIcon' is only available on iOS 9.0 or newer [-Wunguarded-availability]
    - WARN  | [iOS] xcodebuild:  /Users/m/Projects/plugins/packages/quick_actions/ios/Classes/FLTQuickActionsPlugin.m:69:12: warning: 'UIApplicationShortcutItem' is only available on iOS 9.0 or newer [-Wunguarded-availability]
...
[!] quick_actions did not pass validation, due to 11 warnings (but you can use `--allow-warnings` to ignore them).
```

## Related Issues
https://github.com/flutter/flutter/issues/55245
Dependency to merge https://github.com/flutter/plugin_tools/pull/97

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.