### PR TITLE
[shared_preferences] Fix pod lint warnings

### DIFF
--- a/packages/shared_preferences/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Remove Android dependencies fallback.
 * Require Flutter SDK 1.12.13+hotfix.5 or greater.
+* Fix CocoaPods podspec lint warnings.
 
 ## 0.5.6+3
 

--- a/packages/shared_preferences/shared_preferences/ios/shared_preferences.podspec
+++ b/packages/shared_preferences/shared_preferences/ios/shared_preferences.podspec
@@ -4,14 +4,15 @@
 Pod::Spec.new do |s|
   s.name             = 'shared_preferences'
   s.version          = '0.0.1'
-  s.summary          = 'A Flutter plugin for reading and writing simple key-value pairs.'
+  s.summary          = 'Flutter Shared Preferences'
   s.description      = <<-DESC
-A Flutter plugin for reading and writing simple key-value pairs.
+Wraps NSUserDefaults, providing a persistent store for simple key-value pairs.
                        DESC
-  s.homepage         = 'https://github.com/flutter/plugins/tree/master/packages/shared_preferences'
-  s.license          = { :file => '../LICENSE' }
-  s.author           = { 'Flutter Team' => 'flutter-dev@googlegroups.com' }
-  s.source           = { :path => '.' }
+  s.homepage         = 'https://github.com/flutter/plugins'
+  s.license          = { :type => 'BSD', :file => '../LICENSE' }
+  s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
+  s.source           = { :http => 'https://github.com/flutter/plugins/tree/master/packages/shared_preferences/shared_preferences' }
+  s.documentation_url = 'https://pub.dev/packages/shared_preferences'
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'

--- a/packages/shared_preferences/shared_preferences_macos/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.1+7
+
+* Fix CocoaPods podspec lint warnings.
+
 ## 0.0.1+6
 
 * Make the pedantic dev_dependency explicit.

--- a/packages/shared_preferences/shared_preferences_macos/macos/shared_preferences_macos.podspec
+++ b/packages/shared_preferences/shared_preferences_macos/macos/shared_preferences_macos.podspec
@@ -4,14 +4,14 @@
 Pod::Spec.new do |s|
   s.name             = 'shared_preferences_macos'
   s.version          = '0.0.1'
-  s.summary          = 'macOS implementation of the shared_preferences plugin for reading and writing simple key-value pairs.'
+  s.summary          = 'macOS implementation of the shared_preferences plugin.'
   s.description      = <<-DESC
-  macOS implementation of the shared_preferences plugin for reading and writing simple key-value pairs.
+Wraps NSUserDefaults, providing a persistent store for simple key-value pairs.
                        DESC
   s.homepage         = 'https://github.com/flutter/plugins/tree/master/packages/shared_preferences/shared_preferences_macos'
-  s.license          = { :file => '../LICENSE' }
+  s.license          = { :type => 'BSD', :file => '../LICENSE' }
   s.author           = { 'Flutter Team' => 'flutter-dev@googlegroups.com' }
-  s.source           = { :path => '.' }
+  s.source           = { :http => 'https://github.com/flutter/plugins/tree/master/packages/shared_preferences/shared_preferences_macos' }
   s.source_files = 'Classes/**/*'
   s.dependency 'FlutterMacOS'
 

--- a/packages/shared_preferences/shared_preferences_macos/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_macos/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shared_preferences_macos
 description: macOS implementation of the shared_preferences plugin.
-version: 0.0.1+6
+version: 0.0.1+7
 homepage: https://github.com/flutter/plugins/tree/master/packages/shared_preferences/shared_preferences_macos
 
 flutter:


### PR DESCRIPTION
## Description

Fix shared_preferences pod lib lint warnings:
```
 -> shared_preferences_macos (0.0.1)
    - WARN  | license: Missing license type.
    - WARN  | description: The description is equal to the summary.
    - WARN  | [OSX] keys: Missing primary key for `source` attribute. The acceptable ones are: `git, hg, http, svn`.
...
[!] shared_preferences_macos did not pass validation, due to 3 warnings (but you can use `--allow-warnings` to ignore them).
```
```
 -> shared_preferences (0.0.1)
    - WARN  | license: Missing license type.
    - WARN  | description: The description is equal to the summary.
    - WARN  | [iOS] keys: Missing primary key for `source` attribute. The acceptable ones are: `git, hg, http, svn`.
...
[!] shared_preferences did not pass validation, due to 3 warnings (but you can use `--allow-warnings` to ignore them).
```

## Related Issues

https://github.com/flutter/flutter/issues/55245
Dependency to merge https://github.com/flutter/plugin_tools/pull/97

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.