### PR TITLE
[url_launcher] Fix pod lint warnings

### DIFF
--- a/packages/url_launcher/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Remove Android dependencies fallback.
 * Require Flutter SDK 1.12.13+hotfix.5 or greater.
+* Fix CocoaPods podspec lint warnings.
 
 ## 5.4.4
 

--- a/packages/url_launcher/url_launcher/ios/url_launcher.podspec
+++ b/packages/url_launcher/url_launcher/ios/url_launcher.podspec
@@ -9,9 +9,10 @@ Pod::Spec.new do |s|
 A Flutter plugin for making the underlying platform (Android or iOS) launch a URL.
                        DESC
   s.homepage         = 'https://github.com/flutter/plugins/tree/master/packages/url_launcher'
-  s.license          = { :file => '../LICENSE' }
-  s.author           = { 'Flutter Team' => 'flutter-dev@googlegroups.com' }
-  s.source           = { :path => '.' }
+  s.license          = { :type => 'BSD', :file => '../LICENSE' }
+  s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
+  s.source           = { :http => 'https://github.com/flutter/plugins/tree/master/packages/url_launcher' }
+  s.documentation_url = 'https://pub.dev/packages/url_launcher'
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'

--- a/packages/url_launcher/url_launcher_macos/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_macos/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.0.1+5
 
 * Fixed the launchUniversalLinkIos method.
+* Fix CocoaPods podspec lint warnings.
 
 # 0.0.1+4
 

--- a/packages/url_launcher/url_launcher_macos/macos/url_launcher_macos.podspec
+++ b/packages/url_launcher/url_launcher_macos/macos/url_launcher_macos.podspec
@@ -9,9 +9,9 @@ Pod::Spec.new do |s|
   A macOS implementation of the url_launcher plugin.
                        DESC
   s.homepage         = 'https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher_macos'
-  s.license          = { :file => '../LICENSE' }
+  s.license          = { :type => 'BSD', :file => '../LICENSE' }
   s.author           = { 'Flutter Team' => 'flutter-dev@googlegroups.com' }
-  s.source           = { :path => '.' }
+  s.source           = { :http => 'https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher_macos' }
   s.source_files     = 'Classes/**/*'
   s.dependency 'FlutterMacOS'
 


### PR DESCRIPTION
## Description

Fix url_launcher pod lib lint warnings:
```
 -> url_launcher_macos (0.0.1)
    - WARN  | license: Missing license type.
    - WARN  | [OSX] keys: Missing primary key for `source` attribute. The acceptable ones are: `git, hg, http, svn`.
...
[!] url_launcher_macos did not pass validation, due to 2 warnings (but you can use `--allow-warnings` to ignore them).
```
```
 -> url_launcher (0.0.1)
    - WARN  | license: Missing license type.
    - WARN  | [iOS] keys: Missing primary key for `source` attribute. The acceptable ones are: `git, hg, http, svn`.
...
[!] url_launcher did not pass validation, due to 2 warnings (but you can use `--allow-warnings` to ignore them).
```

## Related Issues

https://github.com/flutter/flutter/issues/55245
Dependency to merge https://github.com/flutter/plugin_tools/pull/97

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.