### PR TITLE
[video_player] Fix pod lint warnings

### DIFF
--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Remove Android dependencies fallback.
 * Require Flutter SDK 1.12.13+hotfix.5 or greater.
+* Fix CocoaPods podspec lint warnings.
 
 ## 0.10.8+2
 

--- a/packages/video_player/video_player/ios/video_player.podspec
+++ b/packages/video_player/video_player/ios/video_player.podspec
@@ -4,14 +4,16 @@
 Pod::Spec.new do |s|
   s.name             = 'video_player'
   s.version          = '0.0.1'
-  s.summary          = 'A new flutter plugin project.'
+  s.summary          = 'Flutter Video Player'
   s.description      = <<-DESC
-A new flutter plugin project.
+A Flutter plugin for playing back video on a Widget surface.
+Downloaded by pub (not CocoaPods).
                        DESC
-  s.homepage         = 'http://example.com'
-  s.license          = { :file => '../LICENSE' }
-  s.author           = { 'Your Company' => 'email@example.com' }
-  s.source           = { :path => '.' }
+  s.homepage         = 'https://github.com/flutter/plugins'
+  s.license          = { :type => 'BSD', :file => '../LICENSE' }
+  s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
+  s.source           = { :http => 'https://github.com/flutter/plugins/tree/master/packages/video_player/video_player' }
+  s.documentation_url = 'https://pub.dev/packages/video_player'
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'


### PR DESCRIPTION
## Description

Fix video_player pod lib lint warnings:
```
 -> video_player (0.0.1)
    - WARN  | license: Missing license type.
    - WARN  | description: The description is equal to the summary.
    - WARN  | [iOS] keys: Missing primary key for `source` attribute. The acceptable ones are: `git, hg, http, svn`.
...
[!] video_player did not pass validation, due to 3 warnings (but you can use `--allow-warnings` to ignore them).
```

## Related Issues

https://github.com/flutter/flutter/issues/55245
Dependency to merge https://github.com/flutter/plugin_tools/pull/97

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.