### PR TITLE
[path_provider] Fix pod lint warnings

### DIFF
--- a/packages/path_provider/path_provider/CHANGELOG.md
+++ b/packages/path_provider/path_provider/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Remove Android dependencies fallback.
 * Require Flutter SDK 1.12.13+hotfix.5 or greater.
+* Fix CocoaPods podspec lint warnings.
 
 ## 1.6.6
 

--- a/packages/path_provider/path_provider/ios/path_provider.podspec
+++ b/packages/path_provider/path_provider/ios/path_provider.podspec
@@ -4,14 +4,16 @@
 Pod::Spec.new do |s|
   s.name             = 'path_provider'
   s.version          = '0.0.1'
-  s.summary          = 'A Flutter plugin for getting commonly used locations on the filesystem.'
+  s.summary          = 'Flutter Path Provider'
   s.description      = <<-DESC
 A Flutter plugin for getting commonly used locations on the filesystem.
+Downloaded by pub (not CocoaPods).
                        DESC
-  s.homepage         = 'https://github.com/flutter/plugins/tree/master/packages/path_provider'
-  s.license          = { :file => '../LICENSE' }
-  s.author           = { 'Flutter Team' => 'flutter-dev@googlegroups.com' }
-  s.source           = { :path => '.' }
+  s.homepage         = 'https://github.com/flutter/plugins'
+  s.license          = { :type => 'BSD', :file => '../LICENSE' }
+  s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
+  s.source           = { :http => 'https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider' }
+  s.documentation_url = 'https://pub.dev/packages/path_provider'
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'

--- a/packages/path_provider/path_provider_macos/CHANGELOG.md
+++ b/packages/path_provider/path_provider_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.4+1
+
+* Fix CocoaPods podspec lint warnings.
+
 ## 0.0.4
 
 * Adds an example app to run integration tests.

--- a/packages/path_provider/path_provider_macos/macos/path_provider_macos.podspec
+++ b/packages/path_provider/path_provider_macos/macos/path_provider_macos.podspec
@@ -6,12 +6,12 @@ Pod::Spec.new do |s|
   s.version          = '0.0.1'
   s.summary          = 'A macOS implementation of the path_provider plugin.'
   s.description      = <<-DESC
-  A macOS implementation of the path_provider plugin.
+  A macOS implementation of the Flutter plugin for getting commonly used locations on the filesystem.
                        DESC
   s.homepage         = 'https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider_macos'
-  s.license          = { :file => '../LICENSE' }
-  s.author           = { 'Flutter Team' => 'flutter-dev@googlegroups.com' }
-  s.source           = { :path => '.' }
+  s.license          = { :type => 'BSD', :file => '../LICENSE' }
+  s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
+  s.source           = { :http => 'https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider_macos' }
   s.source_files = 'Classes/**/*'
   s.dependency 'FlutterMacOS'
 

--- a/packages/path_provider/path_provider_macos/pubspec.yaml
+++ b/packages/path_provider/path_provider_macos/pubspec.yaml
@@ -1,6 +1,6 @@
 name: path_provider_macos
 description: macOS implementation of the path_provider plugin
-version: 0.0.4
+version: 0.0.4+1
 homepage: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider_macos
 
 flutter:


### PR DESCRIPTION
## Description

Fix path_provider pod lib lint warnings:
```
 -> path_provider_macos (0.0.1)
    - WARN  | license: Missing license type.
    - WARN  | description: The description is equal to the summary.
    - WARN  | [OSX] keys: Missing primary key for `source` attribute. The acceptable ones are: `git, hg, http, svn`.
...
[!] path_provider_macos did not pass validation, due to 4 warnings (but you can use `--allow-warnings` to ignore them).
```
```
 -> path_provider (0.0.1)
    - WARN  | license: Missing license type.
    - WARN  | description: The description is equal to the summary.
    - WARN  | [iOS] keys: Missing primary key for `source` attribute. The acceptable ones are: `git, hg, http, svn`.
...
[!] path_provider did not pass validation, due to 3 warnings (but you can use `--allow-warnings` to ignore them).
```

## Related Issues

https://github.com/flutter/flutter/issues/55245
Dependency to merge https://github.com/flutter/plugin_tools/pull/97

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.