### PR TITLE
[local_auth] Bump version

### DIFF
--- a/packages/local_auth/CHANGELOG.md
+++ b/packages/local_auth/CHANGELOG.md
@@ -1,9 +1,12 @@
+## 0.6.2+1
+
+* Fix CocoaPods podspec lint warnings.
+
 ## 0.6.2
 
 * Remove Android dependencies fallback.
 * Require Flutter SDK 1.12.13+hotfix.5 or greater.
 * Fix block implicitly retains 'self' warning.
-* Fix CocoaPods podspec lint warnings.
 
 ## 0.6.1+4
 

--- a/packages/local_auth/pubspec.yaml
+++ b/packages/local_auth/pubspec.yaml
@@ -2,7 +2,7 @@ name: local_auth
 description: Flutter plugin for Android and iOS device authentication sensors
   such as Fingerprint Reader and Touch ID.
 homepage: https://github.com/flutter/plugins/tree/master/packages/local_auth
-version: 0.6.2
+version: 0.6.2+1
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

When https://github.com/flutter/plugins/pull/2685 was [merged](https://github.com/flutter/plugins/commit/a0a39103c55ebf0a2d7f87c39f04ce6596774f07) the published version was 0.6.1+3 and the pubspec was 0.6.2, so I added appended to the 0.6.2 CHANGELOG.  However, local_auth was published on the [commit immediately before it](https://github.com/flutter/plugins/releases/tag/local_auth-v0.6.2) and therefore isn't really in 0.6.2.
Bump the version and change the CHANGELOG to reflect this.

## Related Issues

https://github.com/flutter/plugins/pull/2685

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.