### PR TITLE
Run camera linter, skip warnings

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -130,7 +130,7 @@ task:
         - find . -name "*.podspec" | xargs grep -l "osx" | xargs rm
         # Skip the dummy podspecs used to placate the tool.
         - find . -name "*_web*.podspec" -o -name "*_mac*.podspec" | xargs rm
-        - ./script/incremental_build.sh podspecs --skip camera --skip google_sign_in
+        - ./script/incremental_build.sh podspecs --no-analyze camera --ignore-warnings camera --skip google_sign_in
     - name: build-ipas+drive-examples
       env:
         PATH: $PATH:/usr/local/bin


### PR DESCRIPTION
## Description

https://github.com/flutter/plugin_tools/pull/97 is published with the new `--ignore-warnings` flag.  Instead of skipping camera, just ignore the [warnings](https://github.com/flutter/flutter/issues/20708).

## Related Issues

Fixes https://github.com/flutter/flutter/issues/55245
https://github.com/flutter/flutter/issues/20708
https://github.com/flutter/plugin_tools/pull/97

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.