### PR TITLE
[google_sign_in] Fix issue with repeated calls to requestScopes.

### DIFF
--- a/packages/google_sign_in/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.4.5
+
+* Fix requestScopes to allow subsequent calls on Android.
+
 ## 4.4.4
 
 * OCMock module import -> #import, unit tests compile generated as library.

--- a/packages/google_sign_in/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
+++ b/packages/google_sign_in/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
@@ -444,7 +444,7 @@ public class GoogleSignInPlugin implements MethodCallHandler, FlutterPlugin, Act
 
       GoogleSignInAccount account = googleSignInWrapper.getLastSignedInAccount(context);
       if (account == null) {
-        result.error(ERROR_REASON_SIGN_IN_REQUIRED, "No account to grant scopes.", null);
+        finishWithError(ERROR_REASON_SIGN_IN_REQUIRED, "No account to grant scopes.");
         return;
       }
 
@@ -458,7 +458,7 @@ public class GoogleSignInPlugin implements MethodCallHandler, FlutterPlugin, Act
       }
 
       if (wrappedScopes.isEmpty()) {
-        result.success(true);
+        finishWithSuccess(true);
         return;
       }
 

--- a/packages/google_sign_in/google_sign_in/example/android/app/src/test/java/io/flutter/plugins/googlesignin/GoogleSignInPluginTests.java
+++ b/packages/google_sign_in/google_sign_in/example/android/app/src/test/java/io/flutter/plugins/googlesignin/GoogleSignInPluginTests.java
@@ -4,6 +4,7 @@
 
 package io.flutter.plugins.googlesignin;
 
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -134,5 +135,31 @@ public class GoogleSignInPluginTests {
         Delegate.REQUEST_CODE_REQUEST_SCOPE, Activity.RESULT_OK, new Intent());
 
     verify(result).success(true);
+  }
+
+  @Test
+  public void requestScopes_mayBeCalledRepeatedly() {
+    HashMap<String, List<String>> arguments = new HashMap<>();
+    arguments.put("scopes", Collections.singletonList("requestedScope"));
+    MethodCall methodCall = new MethodCall("requestScopes", arguments);
+    Scope requestedScope = new Scope("requestedScope");
+
+    ArgumentCaptor<ActivityResultListener> captor =
+        ArgumentCaptor.forClass(ActivityResultListener.class);
+    verify(mockRegistrar).addActivityResultListener(captor.capture());
+    ActivityResultListener listener = captor.getValue();
+
+    when(mockGoogleSignIn.getLastSignedInAccount(mockContext)).thenReturn(account);
+    when(account.getGrantedScopes()).thenReturn(Collections.singleton(requestedScope));
+    when(mockGoogleSignIn.hasPermissions(account, requestedScope)).thenReturn(false);
+
+    plugin.onMethodCall(methodCall, result);
+    listener.onActivityResult(
+        Delegate.REQUEST_CODE_REQUEST_SCOPE, Activity.RESULT_OK, new Intent());
+    plugin.onMethodCall(methodCall, result);
+    listener.onActivityResult(
+        Delegate.REQUEST_CODE_REQUEST_SCOPE, Activity.RESULT_OK, new Intent());
+
+    verify(result, times(2)).success(true);
   }
 }

--- a/packages/google_sign_in/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_sign_in
 description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android and iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_sign_in/google_sign_in
-version: 4.4.4
+version: 4.4.5
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Make sure the stored `result` field is cleared if `requestScopes` exits early, otherwise subsequent calls to the plugin will get a "concurrent call" `PlatformException`.

## Related Issues

flutter/flutter#55410

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
