### PR TITLE
[video_player] Update README to mention web support.

### DIFF
--- a/packages/video_player/video_player/README.md
+++ b/packages/video_player/video_player/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/video_player.svg)](https://pub.dartlang.org/packages/video_player)
 
-A Flutter plugin for iOS and Android for playing back video on a Widget surface.
+A Flutter plugin for iOS, Android and Web for playing back video on a Widget surface.
 
 ![The example app running in iOS](https://github.com/flutter/plugins/blob/master/packages/video_player/video_player/doc/demo_ipod.gif?raw=true)
 
@@ -44,7 +44,7 @@ The Flutter project template adds it, so it may already be there.
 
 This plugin compiles for the web platform since version `0.10.5`, in recent enough versions of Flutter (`>=1.12.13+hotfix.4`).
 
-> The Web platform does **not** suppport `dart:io`, so attempts to create a `VideoPlayerController.file` will throw an `UnimplementedError`.
+> The Web platform does **not** suppport `dart:io`, so avoid using the `VideoPlayerController.file` constructor for the plugin. Using the constructor attempts to create a `VideoPlayerController.file` that will throw an `UnimplementedError`.
 
 Different web browsers may have different video-playback capabilities (supported formats, autoplay...). Check [package:video_player_web](https://pub.dev/packages/video_player_web) for more web-specific information.
 


### PR DESCRIPTION
updates to call out web is also supported for this plugin.
Explicitly tells users not to use the constructor when using the plugin for web.

## Related Issues
flutter/flutter#55340


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [≈ ] No, this is *not* a breaking change.

