### PR TITLE
Add support for MacOS to in_app_purchase plugin.

### DIFF
--- a/packages/in_app_purchase/lib/src/in_app_purchase/in_app_purchase_connection.dart
+++ b/packages/in_app_purchase/lib/src/in_app_purchase/in_app_purchase_connection.dart
@@ -50,7 +50,7 @@ abstract class InAppPurchaseConnection {
     if (Platform.isAndroid) {
       _purchaseUpdatedStream =
           GooglePlayConnection.instance.purchaseUpdatedStream;
-    } else if (Platform.isIOS) {
+    } else if (Platform.isIOS | Platform.isMacOS) {
       _purchaseUpdatedStream =
           AppStoreConnection.instance.purchaseUpdatedStream;
     } else {
@@ -258,7 +258,7 @@ abstract class InAppPurchaseConnection {
 
     if (Platform.isAndroid) {
       _instance = GooglePlayConnection.instance;
-    } else if (Platform.isIOS) {
+    } else if (Platform.isIOS | Platform.isMacOS) {
       _instance = AppStoreConnection.instance;
     } else {
       throw UnsupportedError(

--- a/packages/in_app_purchase/macos/Classes/FIAObjectTranslator.h
+++ b/packages/in_app_purchase/macos/Classes/FIAObjectTranslator.h
@@ -1,0 +1,35 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <Foundation/Foundation.h>
+#import <StoreKit/StoreKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface FIAObjectTranslator : NSObject
+
++ (NSDictionary *)getMapFromSKProduct:(SKProduct *)product;
+
++ (NSDictionary *)getMapFromSKProductSubscriptionPeriod:(SKProductSubscriptionPeriod *)period
+    API_AVAILABLE(ios(11.2));
+
++ (NSDictionary *)getMapFromSKProductDiscount:(SKProductDiscount *)discount
+    API_AVAILABLE(ios(11.2));
+
++ (NSDictionary *)getMapFromSKProductsResponse:(SKProductsResponse *)productResponse;
+
++ (NSDictionary *)getMapFromSKPayment:(SKPayment *)payment;
+
++ (NSDictionary *)getMapFromNSLocale:(NSLocale *)locale;
+
++ (SKMutablePayment *)getSKMutablePaymentFromMap:(NSDictionary *)map;
+
++ (NSDictionary *)getMapFromSKPaymentTransaction:(SKPaymentTransaction *)transaction;
+
++ (NSDictionary *)getMapFromNSError:(NSError *)error;
+
+@end
+;
+
+NS_ASSUME_NONNULL_END

--- a/packages/in_app_purchase/macos/Classes/FIAObjectTranslator.m
+++ b/packages/in_app_purchase/macos/Classes/FIAObjectTranslator.m
@@ -1,0 +1,172 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "FIAObjectTranslator.h"
+
+#pragma mark - SKProduct Coders
+
+@implementation FIAObjectTranslator
+
++ (NSDictionary *)getMapFromSKProduct:(SKProduct *)product {
+  if (!product) {
+    return nil;
+  }
+  NSMutableDictionary *map = [[NSMutableDictionary alloc] initWithDictionary:@{
+    @"localizedDescription" : product.localizedDescription ?: [NSNull null],
+    @"localizedTitle" : product.localizedTitle ?: [NSNull null],
+    @"productIdentifier" : product.productIdentifier ?: [NSNull null],
+    @"price" : product.price.description ?: [NSNull null]
+
+  }];
+  // TODO(cyanglaz): NSLocale is a complex object, want to see the actual need of getting this
+  // expanded to a map. Matching android to only get the currencySymbol for now.
+  // https://github.com/flutter/flutter/issues/26610
+  [map setObject:[FIAObjectTranslator getMapFromNSLocale:product.priceLocale] ?: [NSNull null]
+          forKey:@"priceLocale"];
+  if (@available(iOS 11.2, *)) {
+    [map setObject:[FIAObjectTranslator
+                       getMapFromSKProductSubscriptionPeriod:product.subscriptionPeriod]
+                       ?: [NSNull null]
+            forKey:@"subscriptionPeriod"];
+  }
+  if (@available(iOS 11.2, *)) {
+    [map setObject:[FIAObjectTranslator getMapFromSKProductDiscount:product.introductoryPrice]
+                       ?: [NSNull null]
+            forKey:@"introductoryPrice"];
+  }
+  if (@available(iOS 12.0, *)) {
+    [map setObject:product.subscriptionGroupIdentifier ?: [NSNull null]
+            forKey:@"subscriptionGroupIdentifier"];
+  }
+  return map;
+}
+
++ (NSDictionary *)getMapFromSKProductSubscriptionPeriod:(SKProductSubscriptionPeriod *)period {
+  if (!period) {
+    return nil;
+  }
+  return @{@"numberOfUnits" : @(period.numberOfUnits), @"unit" : @(period.unit)};
+}
+
++ (NSDictionary *)getMapFromSKProductDiscount:(SKProductDiscount *)discount {
+  if (!discount) {
+    return nil;
+  }
+  NSMutableDictionary *map = [[NSMutableDictionary alloc] initWithDictionary:@{
+    @"price" : discount.price.description ?: [NSNull null],
+    @"numberOfPeriods" : @(discount.numberOfPeriods),
+    @"subscriptionPeriod" :
+            [FIAObjectTranslator getMapFromSKProductSubscriptionPeriod:discount.subscriptionPeriod]
+        ?: [NSNull null],
+    @"paymentMode" : @(discount.paymentMode)
+  }];
+
+  // TODO(cyanglaz): NSLocale is a complex object, want to see the actual need of getting this
+  // expanded to a map. Matching android to only get the currencySymbol for now.
+  // https://github.com/flutter/flutter/issues/26610
+  [map setObject:[FIAObjectTranslator getMapFromNSLocale:discount.priceLocale] ?: [NSNull null]
+          forKey:@"priceLocale"];
+  return map;
+}
+
++ (NSDictionary *)getMapFromSKProductsResponse:(SKProductsResponse *)productResponse {
+  if (!productResponse) {
+    return nil;
+  }
+  NSMutableArray *productsMapArray = [NSMutableArray new];
+  for (SKProduct *product in productResponse.products) {
+    [productsMapArray addObject:[FIAObjectTranslator getMapFromSKProduct:product]];
+  }
+  return @{
+    @"products" : productsMapArray,
+    @"invalidProductIdentifiers" : productResponse.invalidProductIdentifiers ?: @[]
+  };
+}
+
++ (NSDictionary *)getMapFromSKPayment:(SKPayment *)payment {
+  if (!payment) {
+    return nil;
+  }
+  NSMutableDictionary *map = [[NSMutableDictionary alloc] initWithDictionary:@{
+    @"productIdentifier" : payment.productIdentifier ?: [NSNull null],
+    @"requestData" : payment.requestData ? [[NSString alloc] initWithData:payment.requestData
+                                                                 encoding:NSUTF8StringEncoding]
+                                         : [NSNull null],
+    @"quantity" : @(payment.quantity),
+    @"applicationUsername" : payment.applicationUsername ?: [NSNull null]
+  }];
+  if (@available(iOS 8.3, *)) {
+    [map setObject:@(payment.simulatesAskToBuyInSandbox) forKey:@"simulatesAskToBuyInSandbox"];
+  }
+  return map;
+}
+
++ (NSDictionary *)getMapFromNSLocale:(NSLocale *)locale {
+  if (!locale) {
+    return nil;
+  }
+  NSMutableDictionary *map = [[NSMutableDictionary alloc] init];
+  [map setObject:[locale objectForKey:NSLocaleCurrencySymbol] ?: [NSNull null]
+          forKey:@"currencySymbol"];
+  [map setObject:[locale objectForKey:NSLocaleCurrencyCode] ?: [NSNull null]
+          forKey:@"currencyCode"];
+  return map;
+}
+
++ (SKMutablePayment *)getSKMutablePaymentFromMap:(NSDictionary *)map {
+  if (!map) {
+    return nil;
+  }
+  SKMutablePayment *payment = [[SKMutablePayment alloc] init];
+  payment.productIdentifier = map[@"productIdentifier"];
+  NSString *utf8String = map[@"requestData"];
+  payment.requestData = [utf8String dataUsingEncoding:NSUTF8StringEncoding];
+  payment.quantity = [map[@"quantity"] integerValue];
+  payment.applicationUsername = map[@"applicationUsername"];
+  if (@available(iOS 8.3, *)) {
+    payment.simulatesAskToBuyInSandbox = [map[@"simulatesAskToBuyInSandbox"] boolValue];
+  }
+  return payment;
+}
+
++ (NSDictionary *)getMapFromSKPaymentTransaction:(SKPaymentTransaction *)transaction {
+  if (!transaction) {
+    return nil;
+  }
+  NSMutableDictionary *map = [[NSMutableDictionary alloc] initWithDictionary:@{
+    @"error" : [FIAObjectTranslator getMapFromNSError:transaction.error] ?: [NSNull null],
+    @"payment" : transaction.payment ? [FIAObjectTranslator getMapFromSKPayment:transaction.payment]
+                                     : [NSNull null],
+    @"originalTransaction" : transaction.originalTransaction
+        ? [FIAObjectTranslator getMapFromSKPaymentTransaction:transaction.originalTransaction]
+        : [NSNull null],
+    @"transactionTimeStamp" : transaction.transactionDate
+        ? @(transaction.transactionDate.timeIntervalSince1970)
+        : [NSNull null],
+    @"transactionIdentifier" : transaction.transactionIdentifier ?: [NSNull null],
+    @"transactionState" : @(transaction.transactionState)
+  }];
+
+  return map;
+}
+
++ (NSDictionary *)getMapFromNSError:(NSError *)error {
+  if (!error) {
+    return nil;
+  }
+  NSMutableDictionary *userInfo = [NSMutableDictionary new];
+  for (NSErrorUserInfoKey key in error.userInfo) {
+    id value = error.userInfo[key];
+    if ([value isKindOfClass:[NSError class]]) {
+      userInfo[key] = [FIAObjectTranslator getMapFromNSError:value];
+    } else if ([value isKindOfClass:[NSURL class]]) {
+      userInfo[key] = [value absoluteString];
+    } else {
+      userInfo[key] = value;
+    }
+  }
+  return @{@"code" : @(error.code), @"domain" : error.domain ?: @"", @"userInfo" : userInfo};
+}
+
+@end

--- a/packages/in_app_purchase/macos/Classes/FIAPReceiptManager.h
+++ b/packages/in_app_purchase/macos/Classes/FIAPReceiptManager.h
@@ -1,0 +1,17 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class FlutterError;
+
+@interface FIAPReceiptManager : NSObject
+
+- (nullable NSString *)retrieveReceiptWithError:(FlutterError *_Nullable *_Nullable)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/in_app_purchase/macos/Classes/FIAPReceiptManager.m
+++ b/packages/in_app_purchase/macos/Classes/FIAPReceiptManager.m
@@ -1,0 +1,33 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+//
+//  FIAPReceiptManager.m
+//  in_app_purchase
+//
+//  Created by Chris Yang on 3/2/19.
+//
+
+#import "FIAPReceiptManager.h"
+#import <FlutterMacOS/FlutterMacOS.h>
+
+@implementation FIAPReceiptManager
+
+- (NSString *)retrieveReceiptWithError:(FlutterError **)error {
+  NSURL *receiptURL = [[NSBundle mainBundle] appStoreReceiptURL];
+  NSData *receipt = [self getReceiptData:receiptURL];
+  if (!receipt) {
+    *error = [FlutterError errorWithCode:@"storekit_no_receipt"
+                                 message:@"Cannot find receipt for the current main bundle."
+                                 details:nil];
+    return nil;
+  }
+  return [receipt base64EncodedStringWithOptions:kNilOptions];
+}
+
+- (NSData *)getReceiptData:(NSURL *)url {
+  return [NSData dataWithContentsOfURL:url];
+}
+
+@end

--- a/packages/in_app_purchase/macos/Classes/FIAPRequestHandler.h
+++ b/packages/in_app_purchase/macos/Classes/FIAPRequestHandler.h
@@ -1,0 +1,20 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <Foundation/Foundation.h>
+#import <StoreKit/StoreKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void (^ProductRequestCompletion)(SKProductsResponse *_Nullable response,
+                                         NSError *_Nullable errror);
+
+@interface FIAPRequestHandler : NSObject
+
+- (instancetype)initWithRequest:(SKRequest *)request;
+- (void)startProductRequestWithCompletionHandler:(ProductRequestCompletion)completion;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/in_app_purchase/macos/Classes/FIAPRequestHandler.m
+++ b/packages/in_app_purchase/macos/Classes/FIAPRequestHandler.m
@@ -1,0 +1,55 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "FIAPRequestHandler.h"
+#import <StoreKit/StoreKit.h>
+
+#pragma mark - Main Handler
+
+@interface FIAPRequestHandler () <SKProductsRequestDelegate>
+
+@property(copy, nonatomic) ProductRequestCompletion completion;
+@property(strong, nonatomic) SKRequest *request;
+
+@end
+
+@implementation FIAPRequestHandler
+
+- (instancetype)initWithRequest:(SKRequest *)request {
+  self = [super init];
+  if (self) {
+    self.request = request;
+    request.delegate = self;
+  }
+  return self;
+}
+
+- (void)startProductRequestWithCompletionHandler:(ProductRequestCompletion)completion {
+  self.completion = completion;
+  [self.request start];
+}
+
+- (void)productsRequest:(SKProductsRequest *)request
+     didReceiveResponse:(SKProductsResponse *)response {
+  if (self.completion) {
+    self.completion(response, nil);
+    // set the completion to nil here so self.completion won't be triggered again in
+    // requestDidFinish for SKProductRequest.
+    self.completion = nil;
+  }
+}
+
+- (void)requestDidFinish:(SKRequest *)request {
+  if (self.completion) {
+    self.completion(nil, nil);
+  }
+}
+
+- (void)request:(SKRequest *)request didFailWithError:(NSError *)error {
+  if (self.completion) {
+    self.completion(nil, error);
+  }
+}
+
+@end

--- a/packages/in_app_purchase/macos/Classes/FIAPaymentQueueHandler.h
+++ b/packages/in_app_purchase/macos/Classes/FIAPaymentQueueHandler.h
@@ -1,0 +1,47 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <Foundation/Foundation.h>
+#import <StoreKit/StoreKit.h>
+
+@class SKPaymentTransaction;
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void (^TransactionsUpdated)(NSArray<SKPaymentTransaction *> *transactions);
+typedef void (^TransactionsRemoved)(NSArray<SKPaymentTransaction *> *transactions);
+typedef void (^RestoreTransactionFailed)(NSError *error);
+typedef void (^RestoreCompletedTransactionsFinished)(void);
+typedef BOOL (^ShouldAddStorePayment)(SKPayment *payment, SKProduct *product);
+typedef void (^UpdatedDownloads)(NSArray<SKDownload *> *downloads);
+
+@interface FIAPaymentQueueHandler : NSObject <SKPaymentTransactionObserver>
+
+// Unfinished transactions.
+@property(nonatomic, readonly) NSDictionary<NSString *, SKPaymentTransaction *> *transactions;
+
+- (instancetype)initWithQueue:(nonnull SKPaymentQueue *)queue
+                     transactionsUpdated:(nullable TransactionsUpdated)transactionsUpdated
+                      transactionRemoved:(nullable TransactionsRemoved)transactionsRemoved
+                restoreTransactionFailed:(nullable RestoreTransactionFailed)restoreTransactionFailed
+    restoreCompletedTransactionsFinished:
+        (nullable RestoreCompletedTransactionsFinished)restoreCompletedTransactionsFinished
+                   shouldAddStorePayment:(nullable ShouldAddStorePayment)shouldAddStorePayment
+                        updatedDownloads:(nullable UpdatedDownloads)updatedDownloads;
+// Can throw exceptions if the transaction type is purchasing, should always used in a @try block.
+- (void)finishTransaction:(nonnull SKPaymentTransaction *)transaction;
+- (void)restoreTransactions:(nullable NSString *)applicationName;
+
+// This method needs to be called before any other methods.
+- (void)startObservingPaymentQueue;
+
+// Appends a payment to the SKPaymentQueue.
+//
+// @param payment Payment object to be added to the payment queue.
+// @return whether "addPayment" was successful.
+- (BOOL)addPayment:(SKPayment *)payment;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/in_app_purchase/macos/Classes/FIAPaymentQueueHandler.m
+++ b/packages/in_app_purchase/macos/Classes/FIAPaymentQueueHandler.m
@@ -1,0 +1,133 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "FIAPaymentQueueHandler.h"
+
+@interface FIAPaymentQueueHandler ()
+
+@property(strong, nonatomic) SKPaymentQueue *queue;
+@property(nullable, copy, nonatomic) TransactionsUpdated transactionsUpdated;
+@property(nullable, copy, nonatomic) TransactionsRemoved transactionsRemoved;
+@property(nullable, copy, nonatomic) RestoreTransactionFailed restoreTransactionFailed;
+@property(nullable, copy, nonatomic)
+    RestoreCompletedTransactionsFinished paymentQueueRestoreCompletedTransactionsFinished;
+@property(nullable, copy, nonatomic) ShouldAddStorePayment shouldAddStorePayment;
+@property(nullable, copy, nonatomic) UpdatedDownloads updatedDownloads;
+
+@property(strong, nonatomic)
+    NSMutableDictionary<NSString *, SKPaymentTransaction *> *transactionsSetter;
+
+@end
+
+@implementation FIAPaymentQueueHandler
+
+- (instancetype)initWithQueue:(nonnull SKPaymentQueue *)queue
+                     transactionsUpdated:(nullable TransactionsUpdated)transactionsUpdated
+                      transactionRemoved:(nullable TransactionsRemoved)transactionsRemoved
+                restoreTransactionFailed:(nullable RestoreTransactionFailed)restoreTransactionFailed
+    restoreCompletedTransactionsFinished:
+        (nullable RestoreCompletedTransactionsFinished)restoreCompletedTransactionsFinished
+                   shouldAddStorePayment:(nullable ShouldAddStorePayment)shouldAddStorePayment
+                        updatedDownloads:(nullable UpdatedDownloads)updatedDownloads {
+  self = [super init];
+  if (self) {
+    _queue = queue;
+    _transactionsUpdated = transactionsUpdated;
+    _transactionsRemoved = transactionsRemoved;
+    _restoreTransactionFailed = restoreTransactionFailed;
+    _paymentQueueRestoreCompletedTransactionsFinished = restoreCompletedTransactionsFinished;
+    _shouldAddStorePayment = shouldAddStorePayment;
+    _updatedDownloads = updatedDownloads;
+    _transactionsSetter = [NSMutableDictionary dictionary];
+  }
+  return self;
+}
+
+- (void)startObservingPaymentQueue {
+  [_queue addTransactionObserver:self];
+}
+
+- (BOOL)addPayment:(SKPayment *)payment {
+  if (self.transactionsSetter[payment.productIdentifier]) {
+    return NO;
+  }
+  [self.queue addPayment:payment];
+  return YES;
+}
+
+- (void)finishTransaction:(SKPaymentTransaction *)transaction {
+  [self.queue finishTransaction:transaction];
+}
+
+- (void)restoreTransactions:(nullable NSString *)applicationName {
+  if (applicationName) {
+    [self.queue restoreCompletedTransactionsWithApplicationUsername:applicationName];
+  } else {
+    [self.queue restoreCompletedTransactions];
+  }
+}
+
+#pragma mark - observing
+
+// Sent when the transaction array has changed (additions or state changes).  Client should check
+// state of transactions and finish as appropriate.
+- (void)paymentQueue:(SKPaymentQueue *)queue
+    updatedTransactions:(NSArray<SKPaymentTransaction *> *)transactions {
+  for (SKPaymentTransaction *transaction in transactions) {
+    if (transaction.transactionIdentifier) {
+      // Use product identifier instead of transaction identifier for few reasons:
+      // 1. Only transactions with purchased state and failed state will have a transaction id, it
+      //    will become impossible for clients to finish deferred transactions when needed.
+      // 2. Using product identifiers can help prevent clients from purchasing the same
+      //    subscription more than once by accident.
+      self.transactionsSetter[transaction.payment.productIdentifier] = transaction;
+    }
+  }
+  // notify dart through callbacks.
+  self.transactionsUpdated(transactions);
+}
+
+// Sent when transactions are removed from the queue (via finishTransaction:).
+- (void)paymentQueue:(SKPaymentQueue *)queue
+    removedTransactions:(NSArray<SKPaymentTransaction *> *)transactions {
+  for (SKPaymentTransaction *transaction in transactions) {
+    if (transaction.transactionIdentifier) {
+      [self.transactionsSetter removeObjectForKey:transaction.payment.productIdentifier];
+    }
+  }
+  self.transactionsRemoved(transactions);
+}
+
+// Sent when an error is encountered while adding transactions from the user's purchase history back
+// to the queue.
+- (void)paymentQueue:(SKPaymentQueue *)queue
+    restoreCompletedTransactionsFailedWithError:(NSError *)error {
+  self.restoreTransactionFailed(error);
+}
+
+// Sent when all transactions from the user's purchase history have successfully been added back to
+// the queue.
+- (void)paymentQueueRestoreCompletedTransactionsFinished:(SKPaymentQueue *)queue {
+  self.paymentQueueRestoreCompletedTransactionsFinished();
+}
+
+// Sent when the download state has changed.
+- (void)paymentQueue:(SKPaymentQueue *)queue updatedDownloads:(NSArray<SKDownload *> *)downloads {
+  self.updatedDownloads(downloads);
+}
+
+// Sent when a user initiates an IAP buy from the App Store
+- (BOOL)paymentQueue:(SKPaymentQueue *)queue
+    shouldAddStorePayment:(SKPayment *)payment
+               forProduct:(SKProduct *)product {
+  return (self.shouldAddStorePayment(payment, product));
+}
+
+#pragma mark - getter
+
+- (NSDictionary<NSString *, SKPaymentTransaction *> *)transactions {
+  return [self.transactionsSetter copy];
+}
+
+@end

--- a/packages/in_app_purchase/macos/Classes/InAppPurchasePlugin.h
+++ b/packages/in_app_purchase/macos/Classes/InAppPurchasePlugin.h
@@ -1,0 +1,17 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <FlutterMacOS/FlutterMacOS.h>
+@class FIAPaymentQueueHandler;
+@class FIAPReceiptManager;
+
+@interface InAppPurchasePlugin : NSObject <FlutterPlugin>
+
+@property(strong, nonatomic) FIAPaymentQueueHandler *paymentQueueHandler;
+
+- (instancetype)initWithReceiptManager:(FIAPReceiptManager *)receiptManager
+    NS_DESIGNATED_INITIALIZER;
+- (instancetype)init NS_UNAVAILABLE;
+
+@end

--- a/packages/in_app_purchase/macos/Classes/InAppPurchasePlugin.m
+++ b/packages/in_app_purchase/macos/Classes/InAppPurchasePlugin.m
@@ -1,0 +1,336 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "InAppPurchasePlugin.h"
+#import <StoreKit/StoreKit.h>
+#import "FIAObjectTranslator.h"
+#import "FIAPReceiptManager.h"
+#import "FIAPRequestHandler.h"
+#import "FIAPaymentQueueHandler.h"
+
+@interface InAppPurchasePlugin ()
+
+// Holding strong references to FIAPRequestHandlers. Remove the handlers from the set after
+// the request is finished.
+@property(strong, nonatomic, readonly) NSMutableSet *requestHandlers;
+
+// After querying the product, the available products will be saved in the map to be used
+// for purchase.
+@property(strong, nonatomic, readonly) NSMutableDictionary *productsCache;
+
+// Call back channel to dart used for when a listener function is triggered.
+@property(strong, nonatomic, readonly) FlutterMethodChannel *callbackChannel;
+@property(strong, nonatomic, readonly) NSObject<FlutterTextureRegistry> *registry;
+@property(strong, nonatomic, readonly) NSObject<FlutterBinaryMessenger> *messenger;
+@property(strong, nonatomic, readonly) NSObject<FlutterPluginRegistrar> *registrar;
+
+@property(strong, nonatomic, readonly) FIAPReceiptManager *receiptManager;
+
+@end
+
+@implementation InAppPurchasePlugin
+
++ (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
+  FlutterMethodChannel *channel =
+      [FlutterMethodChannel methodChannelWithName:@"plugins.flutter.io/in_app_purchase"
+                                  binaryMessenger:[registrar messenger]];
+  InAppPurchasePlugin *instance = [[InAppPurchasePlugin alloc] initWithRegistrar:registrar];
+  [registrar addMethodCallDelegate:instance channel:channel];
+}
+
+- (instancetype)initWithReceiptManager:(FIAPReceiptManager *)receiptManager {
+  self = [super init];
+  _receiptManager = receiptManager;
+  _requestHandlers = [NSMutableSet new];
+  _productsCache = [NSMutableDictionary new];
+  return self;
+}
+
+- (instancetype)initWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
+  self = [self initWithReceiptManager:[FIAPReceiptManager new]];
+  _registrar = registrar;
+  _registry = [registrar textures];
+  _messenger = [registrar messenger];
+
+  __weak typeof(self) weakSelf = self;
+  _paymentQueueHandler = [[FIAPaymentQueueHandler alloc] initWithQueue:[SKPaymentQueue defaultQueue]
+      transactionsUpdated:^(NSArray<SKPaymentTransaction *> *_Nonnull transactions) {
+        [weakSelf handleTransactionsUpdated:transactions];
+      }
+      transactionRemoved:^(NSArray<SKPaymentTransaction *> *_Nonnull transactions) {
+        [weakSelf handleTransactionsRemoved:transactions];
+      }
+      restoreTransactionFailed:^(NSError *_Nonnull error) {
+        [weakSelf handleTransactionRestoreFailed:error];
+      }
+      restoreCompletedTransactionsFinished:^{
+        [weakSelf restoreCompletedTransactionsFinished];
+      }
+      shouldAddStorePayment:^BOOL(SKPayment *payment, SKProduct *product) {
+        return [weakSelf shouldAddStorePayment:payment product:product];
+      }
+      updatedDownloads:^void(NSArray<SKDownload *> *_Nonnull downloads) {
+        [weakSelf updatedDownloads:downloads];
+      }];
+  [_paymentQueueHandler startObservingPaymentQueue];
+  _callbackChannel =
+      [FlutterMethodChannel methodChannelWithName:@"plugins.flutter.io/in_app_purchase_callback"
+                                  binaryMessenger:[registrar messenger]];
+  return self;
+}
+
+- (void)handleMethodCall:(FlutterMethodCall *)call result:(FlutterResult)result {
+  if ([@"-[SKPaymentQueue canMakePayments:]" isEqualToString:call.method]) {
+    [self canMakePayments:result];
+  } else if ([@"-[InAppPurchasePlugin startProductRequest:result:]" isEqualToString:call.method]) {
+    [self handleProductRequestMethodCall:call result:result];
+  } else if ([@"-[InAppPurchasePlugin addPayment:result:]" isEqualToString:call.method]) {
+    [self addPayment:call result:result];
+  } else if ([@"-[InAppPurchasePlugin finishTransaction:result:]" isEqualToString:call.method]) {
+    [self finishTransaction:call result:result];
+  } else if ([@"-[InAppPurchasePlugin restoreTransactions:result:]" isEqualToString:call.method]) {
+    [self restoreTransactions:call result:result];
+  } else if ([@"-[InAppPurchasePlugin retrieveReceiptData:result:]" isEqualToString:call.method]) {
+    [self retrieveReceiptData:call result:result];
+  } else if ([@"-[InAppPurchasePlugin refreshReceipt:result:]" isEqualToString:call.method]) {
+    [self refreshReceipt:call result:result];
+  } else {
+    result(FlutterMethodNotImplemented);
+  }
+}
+
+- (void)canMakePayments:(FlutterResult)result {
+  result([NSNumber numberWithBool:[SKPaymentQueue canMakePayments]]);
+}
+
+- (void)handleProductRequestMethodCall:(FlutterMethodCall *)call result:(FlutterResult)result {
+  if (![call.arguments isKindOfClass:[NSArray class]]) {
+    result([FlutterError errorWithCode:@"storekit_invalid_argument"
+                               message:@"Argument type of startRequest is not array"
+                               details:call.arguments]);
+    return;
+  }
+  NSArray *productIdentifiers = (NSArray *)call.arguments;
+  SKProductsRequest *request =
+      [self getProductRequestWithIdentifiers:[NSSet setWithArray:productIdentifiers]];
+  FIAPRequestHandler *handler = [[FIAPRequestHandler alloc] initWithRequest:request];
+  [self.requestHandlers addObject:handler];
+  __weak typeof(self) weakSelf = self;
+  [handler startProductRequestWithCompletionHandler:^(SKProductsResponse *_Nullable response,
+                                                      NSError *_Nullable error) {
+    if (error) {
+      result([FlutterError errorWithCode:@"storekit_getproductrequest_platform_error"
+                                 message:error.localizedDescription
+                                 details:error.description]);
+      return;
+    }
+    if (!response) {
+      result([FlutterError errorWithCode:@"storekit_platform_no_response"
+                                 message:@"Failed to get SKProductResponse in startRequest "
+                                         @"call. Error occured on iOS platform"
+                                 details:call.arguments]);
+      return;
+    }
+    for (SKProduct *product in response.products) {
+      [self.productsCache setObject:product forKey:product.productIdentifier];
+    }
+    result([FIAObjectTranslator getMapFromSKProductsResponse:response]);
+    [weakSelf.requestHandlers removeObject:handler];
+  }];
+}
+
+- (void)addPayment:(FlutterMethodCall *)call result:(FlutterResult)result {
+  if (![call.arguments isKindOfClass:[NSDictionary class]]) {
+    result([FlutterError errorWithCode:@"storekit_invalid_argument"
+                               message:@"Argument type of addPayment is not a Dictionary"
+                               details:call.arguments]);
+    return;
+  }
+  NSDictionary *paymentMap = (NSDictionary *)call.arguments;
+  NSString *productID = [paymentMap objectForKey:@"productIdentifier"];
+  // When a product is already fetched, we create a payment object with
+  // the product to process the payment.
+  SKProduct *product = [self getProduct:productID];
+  if (!product) {
+    result([FlutterError
+        errorWithCode:@"storekit_invalid_payment_object"
+              message:
+                  @"You have requested a payment for an invalid product. Either the "
+                  @"`productIdentifier` of the payment is not valid or the product has not been "
+                  @"fetched before adding the payment to the payment queue."
+              details:call.arguments]);
+    return;
+  }
+  SKMutablePayment *payment = [SKMutablePayment paymentWithProduct:product];
+  payment.applicationUsername = [paymentMap objectForKey:@"applicationUsername"];
+  NSNumber *quantity = [paymentMap objectForKey:@"quantity"];
+  payment.quantity = (quantity != nil) ? quantity.integerValue : 1;
+  if (@available(iOS 8.3, *)) {
+    payment.simulatesAskToBuyInSandbox =
+        [[paymentMap objectForKey:@"simulatesAskToBuyInSandBox"] boolValue];
+  }
+
+  if (![self.paymentQueueHandler addPayment:payment]) {
+    result([FlutterError
+        errorWithCode:@"storekit_duplicate_product_object"
+              message:@"There is a pending transaction for the same product identifier. Please "
+                      @"either wait for it to be finished or finish it manuelly using "
+                      @"`completePurchase` to avoid edge cases."
+
+              details:call.arguments]);
+    return;
+  }
+  result(nil);
+}
+
+- (void)finishTransaction:(FlutterMethodCall *)call result:(FlutterResult)result {
+  if (![call.arguments isKindOfClass:[NSString class]]) {
+    result([FlutterError errorWithCode:@"storekit_invalid_argument"
+                               message:@"Argument type of finishTransaction is not a string."
+                               details:call.arguments]);
+    return;
+  }
+  NSString *identifier = call.arguments;
+  SKPaymentTransaction *transaction =
+      [self.paymentQueueHandler.transactions objectForKey:identifier];
+  if (!transaction) {
+    result([FlutterError
+        errorWithCode:@"storekit_platform_invalid_transaction"
+              message:[NSString
+                          stringWithFormat:@"The transaction with transactionIdentifer:%@ does not "
+                                           @"exist. Note that if the transactionState is "
+                                           @"purchasing, the transactionIdentifier will be "
+                                           @"nil(null).",
+                                           transaction.transactionIdentifier]
+              details:call.arguments]);
+    return;
+  }
+  @try {
+    // finish transaction will throw exception if the transaction type is purchasing. Notify dart
+    // about this exception.
+    [self.paymentQueueHandler finishTransaction:transaction];
+  } @catch (NSException *e) {
+    result([FlutterError errorWithCode:@"storekit_finish_transaction_exception"
+                               message:e.name
+                               details:e.description]);
+    return;
+  }
+  result(nil);
+}
+
+- (void)restoreTransactions:(FlutterMethodCall *)call result:(FlutterResult)result {
+  if (call.arguments && ![call.arguments isKindOfClass:[NSString class]]) {
+    result([FlutterError
+        errorWithCode:@"storekit_invalid_argument"
+              message:@"Argument is not nil and the type of finishTransaction is not a string."
+              details:call.arguments]);
+    return;
+  }
+  [self.paymentQueueHandler restoreTransactions:call.arguments];
+}
+
+- (void)retrieveReceiptData:(FlutterMethodCall *)call result:(FlutterResult)result {
+  FlutterError *error = nil;
+  NSString *receiptData = [self.receiptManager retrieveReceiptWithError:&error];
+  if (error) {
+    result(error);
+    return;
+  }
+  result(receiptData);
+}
+
+- (void)refreshReceipt:(FlutterMethodCall *)call result:(FlutterResult)result {
+  NSDictionary *arguments = call.arguments;
+  SKReceiptRefreshRequest *request;
+  if (arguments) {
+    if (![arguments isKindOfClass:[NSDictionary class]]) {
+      result([FlutterError errorWithCode:@"storekit_invalid_argument"
+                                 message:@"Argument type of startRequest is not array"
+                                 details:call.arguments]);
+      return;
+    }
+    NSMutableDictionary *properties = [NSMutableDictionary new];
+    properties[SKReceiptPropertyIsExpired] = arguments[@"isExpired"];
+    properties[SKReceiptPropertyIsRevoked] = arguments[@"isRevoked"];
+    properties[SKReceiptPropertyIsVolumePurchase] = arguments[@"isVolumePurchase"];
+    request = [self getRefreshReceiptRequest:properties];
+  } else {
+    request = [self getRefreshReceiptRequest:nil];
+  }
+  FIAPRequestHandler *handler = [[FIAPRequestHandler alloc] initWithRequest:request];
+  [self.requestHandlers addObject:handler];
+  __weak typeof(self) weakSelf = self;
+  [handler startProductRequestWithCompletionHandler:^(SKProductsResponse *_Nullable response,
+                                                      NSError *_Nullable error) {
+    if (error) {
+      result([FlutterError errorWithCode:@"storekit_refreshreceiptrequest_platform_error"
+                                 message:error.localizedDescription
+                                 details:error.description]);
+      return;
+    }
+    result(nil);
+    [weakSelf.requestHandlers removeObject:handler];
+  }];
+}
+
+#pragma mark - delegates
+
+- (void)handleTransactionsUpdated:(NSArray<SKPaymentTransaction *> *)transactions {
+  NSMutableArray *maps = [NSMutableArray new];
+  for (SKPaymentTransaction *transaction in transactions) {
+    [maps addObject:[FIAObjectTranslator getMapFromSKPaymentTransaction:transaction]];
+  }
+  [self.callbackChannel invokeMethod:@"updatedTransactions" arguments:maps];
+}
+
+- (void)handleTransactionsRemoved:(NSArray<SKPaymentTransaction *> *)transactions {
+  NSMutableArray *maps = [NSMutableArray new];
+  for (SKPaymentTransaction *transaction in transactions) {
+    [maps addObject:[FIAObjectTranslator getMapFromSKPaymentTransaction:transaction]];
+  }
+  [self.callbackChannel invokeMethod:@"removedTransactions" arguments:maps];
+}
+
+- (void)handleTransactionRestoreFailed:(NSError *)error {
+  [self.callbackChannel invokeMethod:@"restoreCompletedTransactionsFailed"
+                           arguments:[FIAObjectTranslator getMapFromNSError:error]];
+}
+
+- (void)restoreCompletedTransactionsFinished {
+  [self.callbackChannel invokeMethod:@"paymentQueueRestoreCompletedTransactionsFinished"
+                           arguments:nil];
+}
+
+- (void)updatedDownloads:(NSArray<SKDownload *> *)downloads {
+  NSLog(@"Received an updatedDownloads callback, but downloads are not supported.");
+}
+
+- (BOOL)shouldAddStorePayment:(SKPayment *)payment product:(SKProduct *)product {
+  // We always return NO here. And we send the message to dart to process the payment; and we will
+  // have a interception method that deciding if the payment should be processed (implemented by the
+  // programmer).
+  [self.productsCache setObject:product forKey:product.productIdentifier];
+  [self.callbackChannel invokeMethod:@"shouldAddStorePayment"
+                           arguments:@{
+                             @"payment" : [FIAObjectTranslator getMapFromSKPayment:payment],
+                             @"product" : [FIAObjectTranslator getMapFromSKProduct:product]
+                           }];
+  return NO;
+}
+
+#pragma mark - dependency injection (for unit testing)
+
+- (SKProductsRequest *)getProductRequestWithIdentifiers:(NSSet *)identifiers {
+  return [[SKProductsRequest alloc] initWithProductIdentifiers:identifiers];
+}
+
+- (SKProduct *)getProduct:(NSString *)productID {
+  return [self.productsCache objectForKey:productID];
+}
+
+- (SKReceiptRefreshRequest *)getRefreshReceiptRequest:(NSDictionary *)properties {
+  return [[SKReceiptRefreshRequest alloc] initWithReceiptProperties:properties];
+}
+
+@end

--- a/packages/in_app_purchase/macos/in_app_purchase.podspec
+++ b/packages/in_app_purchase/macos/in_app_purchase.podspec
@@ -1,0 +1,25 @@
+#
+# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
+#
+Pod::Spec.new do |s|
+  s.name             = 'in_app_purchase'
+  s.version          = '0.0.1'
+  s.summary          = 'Flutter In App Purchase'
+  s.description      = <<-DESC
+A Flutter plugin for in-app purchases. Exposes APIs for making in-app purchases through the App Store.
+Downloaded by pub (not CocoaPods).
+                       DESC
+  s.homepage         = 'https://github.com/flutter/plugins'
+  s.license          = { :type => 'BSD', :file => '../LICENSE' }
+  s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
+  s.source           = { :http => 'https://github.com/flutter/plugins/tree/master/packages/in_app_purchase' }
+  s.documentation_url = 'https://pub.dev/packages/in_app_purchase'
+  s.source_files = 'Classes/**/*'
+  s.dependency 'FlutterMacOS'
+  s.platform = :osx, '10.11'
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
+
+  s.test_spec 'Tests' do |test_spec|
+    test_spec.source_files = 'Tests/**/*'
+  end
+end

--- a/packages/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/pubspec.yaml
@@ -33,6 +33,8 @@ flutter:
         pluginClass: InAppPurchasePlugin
       ios:
         pluginClass: InAppPurchasePlugin
+      macos:
+        pluginClass: InAppPurchasePlugin
 
 environment:
   sdk: ">=2.3.0 <3.0.0"


### PR DESCRIPTION
## Description

This PR contains the  (almost entirely superficial) changes necessary to enable IAP on MacOS.  The plugin native code is identical to the iOS code with the exception of header file changes.

