### PR TITLE
[package_info] add override to toString method

### DIFF
--- a/packages/package_info/CHANGELOG.md
+++ b/packages/package_info/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.2+1
+
+* Add override to `toString` method.
+
 ## 0.4.2
 
 * Update package:e2e reference to use the local version in the flutter/plugins

--- a/packages/package_info/lib/package_info.dart
+++ b/packages/package_info/lib/package_info.dart
@@ -61,4 +61,13 @@ class PackageInfo {
 
   /// The build number. `CFBundleVersion` on iOS, `versionCode` on Android.
   final String buildNumber;
+
+  @override
+  String toString() {
+    return '$runtimeType('
+        'appName: $appName, '
+        'buildNumber: $buildNumber, '
+        'packageName: $packageName, '
+        'version: $version)';
+  }
 }

--- a/packages/package_info/pubspec.yaml
+++ b/packages/package_info/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/flutter/plugins/tree/master/packages/package_info
 # 0.4.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.4.2
+version: 0.4.2+1
 
 flutter:
   plugin:

--- a/packages/package_info/test/package_info_test.dart
+++ b/packages/package_info/test/package_info_test.dart
@@ -46,4 +46,12 @@ void main() {
       ],
     );
   });
+
+  test('toString', () async {
+    final PackageInfo info = await PackageInfo.fromPlatform();
+    expect(
+      info.toString(),
+      'PackageInfo(appName: package_info_example, buildNumber: 1, packageName: io.flutter.plugins.packageinfoexample, version: 1.0)',
+    );
+  });
 }


### PR DESCRIPTION
## Description

Currently, the `PackageInfo` class doesn't override the `toString` method, so if one use it in a `print` statement, it only sees `Instance of 'PackageInfo'`.

With these proposed changes, one would see, e.g. `PackageInfo(appName: package_info_example, buildNumber: 1, packageName: io.flutter.plugins.packageinfoexample, version: 1.0)`.

## Related Issues

I didn't find an issue about this.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
