### PR TITLE
[connectivity_platform_interface] Remove Platform asserts.

### DIFF
--- a/packages/connectivity/connectivity_platform_interface/CHANGELOG.md
+++ b/packages/connectivity/connectivity_platform_interface/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.5
+
+* Remove dart:io Platform checks from the MethodChannel implementation. This is 
+tripping the analysis of other versions of the plugin.
+
 ## 1.0.4
 
 * Bump the minimum Flutter version to 1.12.13+hotfix.5.

--- a/packages/connectivity/connectivity_platform_interface/lib/src/method_channel_connectivity.dart
+++ b/packages/connectivity/connectivity_platform_interface/lib/src/method_channel_connectivity.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io' show Platform;
 
 import 'package:connectivity_platform_interface/connectivity_platform_interface.dart';
 import 'package:flutter/services.dart';
@@ -68,9 +67,6 @@ class MethodChannelConnectivity extends ConnectivityPlatform {
   Future<LocationAuthorizationStatus> requestLocationServiceAuthorization({
     bool requestAlwaysLocationUsage = false,
   }) {
-    // `assert(Platform.isIOS)` will prevent us from doing dart side unit testing.
-    // TODO: These should noop for non-Android, instead of throwing, so people don't need to rely on dart:io for this.
-    assert(!Platform.isAndroid);
     return methodChannel.invokeMethod<String>(
         'requestLocationServiceAuthorization', <bool>[
       requestAlwaysLocationUsage
@@ -79,8 +75,6 @@ class MethodChannelConnectivity extends ConnectivityPlatform {
 
   @override
   Future<LocationAuthorizationStatus> getLocationServiceAuthorization() {
-    // `assert(Platform.isIOS)` will prevent us from doing dart side unit testing.
-    assert(!Platform.isAndroid);
     return methodChannel
         .invokeMethod<String>('getLocationServiceAuthorization')
         .then(parseLocationAuthorizationStatus);

--- a/packages/connectivity/connectivity_platform_interface/pubspec.yaml
+++ b/packages/connectivity/connectivity_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the connectivity plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/connectivity/connectivity_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.0.4
+version: 1.0.5
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Description

Even though the code path never hits web targets, having `dart:io` imports in the MethodChannel implementation in the platform_interface package breaks the `pana` analysis of federated implementations for platforms where those imports are forbidden (like web), with something similar to this:

```
$~/connectivity/experimental_connectivity_web does not support flutter with runtime: flutter-web because of import violation at: 

package:experimental_connectivity_web/experimental_connectivity_web.dart,
package:experimental_connectivity_web/src/network_information_api_connectivity_plugin.dart,
package:experimental_connectivity_web/src/utils/connectivity_result.dart,
package:connectivity_platform_interface/connectivity_platform_interface.dart,
package:connectivity_platform_interface/src/method_channel_connectivity.dart, 
dart:io
```

This change removes the Platform check assert (if deemed critical, it should be added to the `connectivity` plugin, or maybe hidden behind a conditional import in this package).

All current tests, both in connectivity_platform_interface and connectivity pass.

## Related Issues

n/a

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
