### PR TITLE
[url_launcher] Add note that `canLaunch` only works for some schemes

### DIFF
--- a/packages/url_launcher/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/url_launcher/lib/url_launcher.dart
@@ -101,6 +101,11 @@ Future<bool> launch(
 
 /// Checks whether the specified URL can be handled by some app installed on the
 /// device.
+///
+/// On iOS 9.0 and later this only works for non-standard URL schemes if those are
+/// declared in your app's `Info.plist` file under the `LSApplicationQueriesSchemes` key
+/// For more details see:
+/// https://developer.apple.com/documentation/uikiAndt/uiapplication/1622952-canopenurl
 Future<bool> canLaunch(String urlString) async {
   if (urlString == null) {
     return false;


### PR DESCRIPTION
And that some configuration is necessary to support custom schemes.

## Description

Document that iOS apps need to be configured to allow querying for non-standard URL schemes.

## Related Issues

- https://github.com/flutter/flutter/issues/42311 (hopefully would have been clearer to the OP)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
