### PR TITLE
[battery] Bump to 1.0.0

### DIFF
--- a/packages/battery/CHANGELOG.md
+++ b/packages/battery/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0
+
+* Bump the package version to 1.0.0 following ecosystem pre-migration (https://github.com/amirh/bump_to_1.0/projects/1).
+
 ## 0.3.1+10
 
 * Update minimum Flutter version to 1.12.13+hotfix.5

--- a/packages/battery/README.md
+++ b/packages/battery/README.md
@@ -1,12 +1,5 @@
 # Battery
 
-**Please set your constraint to `battery: '>=0.3.y+x <2.0.0'`**
-
-## Backward compatible 1.0.0 version is coming
-The battery plugin has reached a stable API, we guarantee that version `1.0.0` will be backward compatible with `0.3.y+z`.
-Please use `battery: '>=0.3.y+x <2.0.0'` as your dependency constraint to allow a smoother ecosystem migration.
-For more details see: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-
 [![pub package](https://img.shields.io/pub/v/battery.svg)](https://pub.dartlang.org/packages/battery)
 
 A Flutter plugin to access various information about the battery of the device the app is running on.

--- a/packages/battery/pubspec.yaml
+++ b/packages/battery/pubspec.yaml
@@ -2,10 +2,7 @@ name: battery
 description: Flutter plugin for accessing information about the battery state
   (full, charging, discharging) on Android and iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/battery
-# 0.3.y+z is compatible with 1.0.0, if you land a breaking change bump
-# the version to 2.0.0.
-# See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.3.1+10
+version: 1.0.0
 
 flutter:
   plugin:


### PR DESCRIPTION
An [ecosystem pre-migration](https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0) has been performed (https://github.com/amirh/bump_to_1.0/projects/1).