### PR TITLE
[in_app_purchase] Add support to cross-grade a subscription on Android

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -57,3 +57,4 @@ Ryo Miyake <ryo@miyake.id>
 Théo Champion <contact.theochampion@gmail.com>
 Kazuki Yamaguchi <y.kazuki0614n@gmail.com>
 Eitan Schwartz <eshvartz@gmail.com>
+Alessandro Agosto <agosto.alessandro@gmail.com>

--- a/packages/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.4
+
+* Android: Add support for subscription cross-grades
+
 ## 0.3.3
 
 * Introduce `SKPaymentQueueWrapper.transactions`.
@@ -9,7 +13,7 @@
 ## 0.3.2+1
 
 * iOS: Fix only transactions with SKPaymentTransactionStatePurchased and SKPaymentTransactionStateFailed can be finished.
-* iOS: Only one pending transaction of a given product is allowed.  
+* iOS: Only one pending transaction of a given product is allowed.
 
 ## 0.3.2
 

--- a/packages/in_app_purchase/lib/src/billing_client_wrappers/billing_client_wrapper.dart
+++ b/packages/in_app_purchase/lib/src/billing_client_wrappers/billing_client_wrapper.dart
@@ -168,11 +168,12 @@ class BillingClient {
   /// and [the given
   /// accountId](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.Builder.html#setAccountId(java.lang.String)).
   Future<BillingResultWrapper> launchBillingFlow(
-      {@required String sku, String accountId}) async {
+      {@required String sku, String accountId, String oldSku}) async {
     assert(sku != null);
     final Map<String, dynamic> arguments = <String, dynamic>{
       'sku': sku,
       'accountId': accountId,
+      'oldSku': oldSku,
     };
     return BillingResultWrapper.fromJson(
         await channel.invokeMapMethod<String, dynamic>(

--- a/packages/in_app_purchase/lib/src/in_app_purchase/google_play_connection.dart
+++ b/packages/in_app_purchase/lib/src/in_app_purchase/google_play_connection.dart
@@ -56,7 +56,8 @@ class GooglePlayConnection
     BillingResultWrapper billingResultWrapper =
         await billingClient.launchBillingFlow(
             sku: purchaseParam.productDetails.id,
-            accountId: purchaseParam.applicationUserName);
+            accountId: purchaseParam.applicationUserName,
+            oldSku: purchaseParam.oldProduct?.id);
     return billingResultWrapper.responseCode == BillingResponse.ok;
   }
 

--- a/packages/in_app_purchase/lib/src/in_app_purchase/purchase_details.dart
+++ b/packages/in_app_purchase/lib/src/in_app_purchase/purchase_details.dart
@@ -79,7 +79,8 @@ class PurchaseParam {
   PurchaseParam(
       {@required this.productDetails,
       this.applicationUserName,
-      this.sandboxTesting});
+      this.sandboxTesting,
+      this.oldProduct});
 
   /// The product to create payment for.
   ///
@@ -96,6 +97,10 @@ class PurchaseParam {
 
   /// The 'sandboxTesting' is only available on iOS, set it to `true` for testing in AppStore's sandbox environment. The default value is `false`.
   final bool sandboxTesting;
+
+  /// The 'oldProduct' is only available on Android for non-consumable resources and is meant to allow subscription cross-grades.
+  /// By setting this you will replace the subscription represented by `oldProduct`. On iOS this is ignored.
+  final ProductDetails oldProduct;
 }
 
 /// Represents the transaction details of a purchase.

--- a/packages/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/pubspec.yaml
@@ -1,7 +1,7 @@
 name: in_app_purchase
 description: A Flutter plugin for in-app purchases. Exposes APIs for making in-app purchases through the App Store and Google Play.
 homepage: https://github.com/flutter/plugins/tree/master/packages/in_app_purchase
-version: 0.3.3
+version: 0.3.4
 
 dependencies:
   async: ^2.0.8

--- a/packages/in_app_purchase/test/billing_client_wrappers/billing_client_wrapper_test.dart
+++ b/packages/in_app_purchase/test/billing_client_wrappers/billing_client_wrapper_test.dart
@@ -159,6 +159,7 @@ void main() {
           stubPlatform.previousCallMatching(launchMethodName).arguments;
       expect(arguments['sku'], equals(skuDetails.sku));
       expect(arguments['accountId'], equals(accountId));
+      expect(arguments['oldSku'], isNull);
     });
 
     test('handles null accountId', () async {
@@ -178,6 +179,32 @@ void main() {
           stubPlatform.previousCallMatching(launchMethodName).arguments;
       expect(arguments['sku'], equals(skuDetails.sku));
       expect(arguments['accountId'], isNull);
+      expect(arguments['oldSku'], isNull);
+    });
+
+    test('handles oldSku', () async {
+      const String debugMessage = 'dummy message';
+      final BillingResponse responseCode = BillingResponse.ok;
+      final BillingResultWrapper expectedBillingResult = BillingResultWrapper(
+          responseCode: responseCode, debugMessage: debugMessage);
+      stubPlatform.addResponse(
+        name: launchMethodName,
+        value: buildBillingResultMap(expectedBillingResult),
+      );
+      final SkuDetailsWrapper skuDetails = dummySkuDetails;
+      final String accountId = "hashedAccountId";
+
+      expect(
+          await billingClient.launchBillingFlow(
+              sku: skuDetails.sku,
+              accountId: accountId,
+              oldSku: skuDetails.sku),
+          equals(expectedBillingResult));
+      Map<dynamic, dynamic> arguments =
+          stubPlatform.previousCallMatching(launchMethodName).arguments;
+      expect(arguments['sku'], equals(skuDetails.sku));
+      expect(arguments['accountId'], equals(accountId));
+      expect(arguments['oldSku'], equals(skuDetails.sku));
     });
   });
 


### PR DESCRIPTION
This change introduces basic support to replace an old subscription on
Android. On iOS passing the added parameter will have no effect.

Please note that the current implementation is basic, in that it misses
a way to contextually change the proration mode.

It also uses `setOldSku(string)` rather than `setOldSku(string, string)`
which also requires the old purchaseToken to be provided.

Ref: https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.Builder#setoldsku

## Description

Hi, I’ve done a basic implementation to support Android subscription cross grades.

Note that this is a basic implementation in that it doesn’t support customizing the proration mode while changing the subscription. It also uses the deprecated method `setOldSku(string)`. In order to use the new `setOldSku(string, string)` method we should add another parameter to accept the "purchaseToken", which seemed too invasive with regards to the iOS counterpart which doesn’t need that information as cross-grades are managed by the storefront through the concept of groups. I'm open to suggestions to add support for custom proration mode and to use the new suggested `setSku(string, string)` method.

I preferred the deprecated method in order to keep the change as simple as possible while achieving what most apps need. On iOS passing the added `oldProduct` parameter will have no effect.

## Related Issues

* https://github.com/flutter/flutter/issues/32395
* https://github.com/flutter/flutter/issues/51535

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
