### PR TITLE
[share] Fix NPE when start chooserIntent and the activity is null

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -57,3 +57,4 @@ Ryo Miyake <ryo@miyake.id>
 Théo Champion <contact.theochampion@gmail.com>
 Kazuki Yamaguchi <y.kazuki0614n@gmail.com>
 Eitan Schwartz <eshvartz@gmail.com>
+Balázs Varga <warnyul@gmail.com>

--- a/packages/share/CHANGELOG.md
+++ b/packages/share/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.4+1
+
+* Fix potential NPE when activity is not set
+
 ## 0.6.4
 
 * Remove Android dependencies fallback.

--- a/packages/share/android/src/main/java/io/flutter/plugins/share/Share.java
+++ b/packages/share/android/src/main/java/io/flutter/plugins/share/Share.java
@@ -5,12 +5,14 @@
 package io.flutter.plugins.share;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 
 /** Handles share intent. */
 class Share {
 
   private Activity activity;
+  private Context applicationContext;
 
   /**
    * Constructs a Share object. The {@code activity} is used to start the share intent. It might be
@@ -19,6 +21,7 @@ class Share {
    */
   Share(Activity activity) {
     this.activity = activity;
+    this.applicationContext = activity.getApplicationContext();
   }
 
   /**
@@ -44,7 +47,7 @@ class Share {
       activity.startActivity(chooserIntent);
     } else {
       chooserIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-      activity.startActivity(chooserIntent);
+      applicationContext.startActivity(chooserIntent);
     }
   }
 }

--- a/packages/share/pubspec.yaml
+++ b/packages/share/pubspec.yaml
@@ -2,7 +2,7 @@ name: share
 description: Flutter plugin for sharing content via the platform share UI, using
   the ACTION_SEND intent on Android and UIActivityViewController on iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/share
-version: 0.6.4
+version: 0.6.4+1
 
 flutter:
   plugin:


### PR DESCRIPTION
* Save applicationContext on the constructor to start chooserIntent as a new task when activity is null.
* Version bump
* Update CHANGELOG.md
* Update AUTHORS

## Description

I have find a possible NPE in the Share class. This PR solve this issue. I guess, it is very rare case, when activity is null, so not a big deal.

## Related Issues

There is no related issue in this topic

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
