### PR TITLE
local html and baseUrl support

### DIFF
--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.21+1
+
+* static html and baseUrl support. 
+
 ## 0.3.21
 
 * Enable programmatic scrolling using Android's WebView.scrollTo & iOS WKWebView.scrollView.contentOffset.

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -28,6 +28,7 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
   private final MethodChannel methodChannel;
   private final FlutterWebViewClient flutterWebViewClient;
   private final Handler platformThreadHandler;
+  private String baseUrl;
 
   @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
   @SuppressWarnings("unchecked")
@@ -68,7 +69,7 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
     if (params.containsKey("html")) {
       String html = (String) params.get("html");
       if (params.containsKey("baseUrl")) {
-        String baseUrl = (String) params.get("baseUrl");
+        baseUrl = (String) params.get("baseUrl");
         webView.loadDataWithBaseURL(baseUrl, html, "text/html", "UTF-8", null);
       } else {
         webView.loadData(html, "text/html", "UTF-8");
@@ -129,6 +130,9 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
     switch (methodCall.method) {
       case "loadUrl":
         loadUrl(methodCall, result);
+        break;
+      case "loadHtml":
+        loadHtml(methodCall, result);
         break;
       case "updateSettings":
         updateSettings(methodCall, result);
@@ -192,6 +196,20 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
       headers = Collections.emptyMap();
     }
     webView.loadUrl(url, headers);
+    result.success(null);
+  }
+
+  @SuppressWarnings("unchecked")
+  private void loadHtml(MethodCall methodCall, Result result) {
+    Map<String, Object> request = (Map<String, Object>) methodCall.arguments;
+    String html = (String) request.get("html");
+    if (html != null) {
+      if (baseUrl != null) {
+        webView.loadDataWithBaseURL(baseUrl, html, "text/html", "UTF-8", null);
+      } else {
+        webView.loadData(html, "text/html", "UTF-8");
+      }
+    }
     result.success(null);
   }
 

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -65,7 +65,15 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
       String userAgent = (String) params.get("userAgent");
       updateUserAgent(userAgent);
     }
-    if (params.containsKey("initialUrl")) {
+    if (params.containsKey("html")) {
+      String html = (String) params.get("html");
+      if (params.containsKey("baseUrl")) {
+        String baseUrl = (String) params.get("baseUrl");
+        webView.loadDataWithBaseURL(baseUrl, html, "text/html", "UTF-8", null);
+      } else {
+        webView.loadData(html, "text/html", "UTF-8");
+      }
+    } else if (params.containsKey("initialUrl")) {
       String url = (String) params.get("initialUrl");
       webView.loadUrl(url);
     }

--- a/packages/webview_flutter/ios/Classes/FlutterWebView.m
+++ b/packages/webview_flutter/ios/Classes/FlutterWebView.m
@@ -110,10 +110,19 @@
     [self applySettings:settings];
     // TODO(amirh): return an error if apply settings failed once it's possible to do so.
     // https://github.com/flutter/flutter/issues/36228
-
-    NSString* initialUrl = args[@"initialUrl"];
-    if ([initialUrl isKindOfClass:[NSString class]]) {
-      [self loadUrl:initialUrl];
+    
+    NSString* html = args[@"html"];
+    if ([html isKindOfClass:[NSString class]]) {
+      NSURL* baseURL = args[@"baseUrl"];
+      if (!baseURL) {
+        baseURL = [NSURL URLWithString:@"about:blank"];
+      }
+      [_webView loadHTMLString:html baseURL:baseURL];
+    } else {
+      NSString* initialUrl = args[@"initialUrl"];
+      if ([initialUrl isKindOfClass:[NSString class]]) {
+        [self loadUrl:initialUrl];
+      }
     }
   }
   return self;

--- a/packages/webview_flutter/ios/Classes/FlutterWebView.m
+++ b/packages/webview_flutter/ios/Classes/FlutterWebView.m
@@ -113,11 +113,13 @@
     
     NSString* html = args[@"html"];
     if ([html isKindOfClass:[NSString class]]) {
-      NSURL* baseURL = args[@"baseUrl"];
-      if (!baseURL) {
-        baseURL = [NSURL URLWithString:@"about:blank"];
+      NSString* baseURLString = args[@"baseUrl"];
+      if ([baseURLString isKindOfClass:[NSString class]]) {
+        NSURL *baseURL = [NSURL URLWithString:baseURLString];
+        [_webView loadHTMLString:html baseURL: baseURL];
+      } else {
+        [_webView loadHTMLString:html baseURL: nil];
       }
-      [_webView loadHTMLString:html baseURL:baseURL];
     } else {
       NSString* initialUrl = args[@"initialUrl"];
       if ([initialUrl isKindOfClass:[NSString class]]) {

--- a/packages/webview_flutter/ios/Classes/FlutterWebView.m
+++ b/packages/webview_flutter/ios/Classes/FlutterWebView.m
@@ -115,7 +115,7 @@
     if ([html isKindOfClass:[NSString class]]) {
       NSString* baseURLString = args[@"baseUrl"];
       if ([baseURLString isKindOfClass:[NSString class]]) {
-        NSURL *baseURL = [NSURL URLWithString:baseURLString];
+        baseURL = [NSURL URLWithString:baseURLString];
         [_webView loadHTMLString:html baseURL: baseURL];
       } else {
         [_webView loadHTMLString:html baseURL: nil];
@@ -130,6 +130,8 @@
   return self;
 }
 
+NSURL *baseURL = nil;
+
 - (UIView*)view {
   return _webView;
 }
@@ -139,6 +141,8 @@
     [self onUpdateSettings:call result:result];
   } else if ([[call method] isEqualToString:@"loadUrl"]) {
     [self onLoadUrl:call result:result];
+  } else if ([[call method] isEqualToString:@"loadHtml"]) {
+    [self onLoadHtml:call result:result];
   } else if ([[call method] isEqualToString:@"canGoBack"]) {
     [self onCanGoBack:call result:result];
   } else if ([[call method] isEqualToString:@"canGoForward"]) {
@@ -192,6 +196,18 @@
   } else {
     result(nil);
   }
+}
+
+- (void)onLoadHtml:(FlutterMethodCall*)call result:(FlutterResult)result {
+    NSString* html = [call arguments][@"html"];
+    if ([html isKindOfClass:[NSString class]]) {
+      if (baseURL != nil) {
+        [_webView loadHTMLString:html baseURL: baseURL];
+      } else {
+        [_webView loadHTMLString:html baseURL: nil];
+      }
+    }
+    result(nil);
 }
 
 - (void)onCanGoBack:(FlutterMethodCall*)call result:(FlutterResult)result {

--- a/packages/webview_flutter/ios/Classes/FlutterWebView.m
+++ b/packages/webview_flutter/ios/Classes/FlutterWebView.m
@@ -110,15 +110,15 @@
     [self applySettings:settings];
     // TODO(amirh): return an error if apply settings failed once it's possible to do so.
     // https://github.com/flutter/flutter/issues/36228
-    
+
     NSString* html = args[@"html"];
     if ([html isKindOfClass:[NSString class]]) {
       NSString* baseURLString = args[@"baseUrl"];
       if ([baseURLString isKindOfClass:[NSString class]]) {
         baseURL = [NSURL URLWithString:baseURLString];
-        [_webView loadHTMLString:html baseURL: baseURL];
+        [_webView loadHTMLString:html baseURL:baseURL];
       } else {
-        [_webView loadHTMLString:html baseURL: nil];
+        [_webView loadHTMLString:html baseURL:nil];
       }
     } else {
       NSString* initialUrl = args[@"initialUrl"];
@@ -130,7 +130,7 @@
   return self;
 }
 
-NSURL *baseURL = nil;
+NSURL* baseURL = nil;
 
 - (UIView*)view {
   return _webView;
@@ -199,15 +199,15 @@ NSURL *baseURL = nil;
 }
 
 - (void)onLoadHtml:(FlutterMethodCall*)call result:(FlutterResult)result {
-    NSString* html = [call arguments][@"html"];
-    if ([html isKindOfClass:[NSString class]]) {
-      if (baseURL != nil) {
-        [_webView loadHTMLString:html baseURL: baseURL];
-      } else {
-        [_webView loadHTMLString:html baseURL: nil];
-      }
+  NSString* html = [call arguments][@"html"];
+  if ([html isKindOfClass:[NSString class]]) {
+    if (baseURL != nil) {
+      [_webView loadHTMLString:html baseURL:baseURL];
+    } else {
+      [_webView loadHTMLString:html baseURL:nil];
     }
-    result(nil);
+  }
+  result(nil);
 }
 
 - (void)onCanGoBack:(FlutterMethodCall*)call result:(FlutterResult)result {

--- a/packages/webview_flutter/lib/platform_interface.dart
+++ b/packages/webview_flutter/lib/platform_interface.dart
@@ -174,7 +174,7 @@ abstract class WebViewPlatformController {
     throw UnimplementedError(
         "WebView loadUrl is not implemented on the current platform");
   }
-  
+
   /// Loads the specified html.
   ///
   /// `html` must not be null.
@@ -441,12 +441,13 @@ class CreationParams {
   ///
   /// When null the webview will be created without loading any page.
   final String initialUrl;
-  
+
   /// The initial baseUrl to load in the webview. It will work with html only.
   final String baseUrl;
-  
+
   /// The initial html to load in the webview. This will be preferred over initialUrl if it exists.
   final String html;
+
   /// The initial [WebSettings] for the new webview.
   ///
   /// This can later be updated with [WebViewPlatformController.updateSettings].

--- a/packages/webview_flutter/lib/platform_interface.dart
+++ b/packages/webview_flutter/lib/platform_interface.dart
@@ -420,6 +420,8 @@ class CreationParams {
   /// The `autoMediaPlaybackPolicy` parameter must not be null.
   CreationParams({
     this.initialUrl,
+    this.html,
+    this.baseUrl,
     this.webSettings,
     this.javascriptChannelNames,
     this.userAgent,
@@ -431,7 +433,8 @@ class CreationParams {
   ///
   /// When null the webview will be created without loading any page.
   final String initialUrl;
-
+  final String baseUrl;
+  final String html;
   /// The initial [WebSettings] for the new webview.
   ///
   /// This can later be updated with [WebViewPlatformController.updateSettings].

--- a/packages/webview_flutter/lib/platform_interface.dart
+++ b/packages/webview_flutter/lib/platform_interface.dart
@@ -175,6 +175,9 @@ abstract class WebViewPlatformController {
         "WebView loadUrl is not implemented on the current platform");
   }
   
+  /// Loads the specified html.
+  ///
+  /// `html` must not be null.
   Future<void> loadHtml(String html) {
     throw UnimplementedError(
         "WebView loadHtml is not implemented on the current platform");
@@ -438,7 +441,11 @@ class CreationParams {
   ///
   /// When null the webview will be created without loading any page.
   final String initialUrl;
+  
+  /// The initial baseUrl to load in the webview. It will work with html only.
   final String baseUrl;
+  
+  /// The initial html to load in the webview. This will be preferred over initialUrl if it exists.
   final String html;
   /// The initial [WebSettings] for the new webview.
   ///

--- a/packages/webview_flutter/lib/platform_interface.dart
+++ b/packages/webview_flutter/lib/platform_interface.dart
@@ -174,6 +174,11 @@ abstract class WebViewPlatformController {
     throw UnimplementedError(
         "WebView loadUrl is not implemented on the current platform");
   }
+  
+  Future<void> loadHtml(String html) {
+    throw UnimplementedError(
+        "WebView loadUrl is not implemented on the current platform");
+  }
 
   /// Updates the webview settings.
   ///

--- a/packages/webview_flutter/lib/platform_interface.dart
+++ b/packages/webview_flutter/lib/platform_interface.dart
@@ -177,7 +177,7 @@ abstract class WebViewPlatformController {
   
   Future<void> loadHtml(String html) {
     throw UnimplementedError(
-        "WebView loadUrl is not implemented on the current platform");
+        "WebView loadHtml is not implemented on the current platform");
   }
 
   /// Updates the webview settings.

--- a/packages/webview_flutter/lib/src/webview_method_channel.dart
+++ b/packages/webview_flutter/lib/src/webview_method_channel.dart
@@ -190,14 +190,20 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
   /// [AndroidWebViewBuilder] and [CupertinoWebViewBuilder].
   static Map<String, dynamic> creationParamsToMap(
       CreationParams creationParams) {
-    return <String, dynamic>{
+    var creationParamMap = <String, dynamic>{
       'initialUrl': creationParams.initialUrl,
-      'html': creationParams.html,
-      'baseUrl': creationParams.baseUrl,
       'settings': _webSettingsToMap(creationParams.webSettings),
       'javascriptChannelNames': creationParams.javascriptChannelNames.toList(),
       'userAgent': creationParams.userAgent,
       'autoMediaPlaybackPolicy': creationParams.autoMediaPlaybackPolicy.index,
     };
+
+    if (creationParams.html != null) {
+      creationParamMap['html'] = creationParams.html;
+    }
+    if (creationParams.baseUrl != null) {
+      creationParamMap['baseUrl'] = creationParams.baseUrl;
+    }
+    return creationParamMap;
   }
 }

--- a/packages/webview_flutter/lib/src/webview_method_channel.dart
+++ b/packages/webview_flutter/lib/src/webview_method_channel.dart
@@ -192,6 +192,8 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
       CreationParams creationParams) {
     return <String, dynamic>{
       'initialUrl': creationParams.initialUrl,
+      'html': creationParams.html,
+      'baseUrl': creationParams.baseUrl,
       'settings': _webSettingsToMap(creationParams.webSettings),
       'javascriptChannelNames': creationParams.javascriptChannelNames.toList(),
       'userAgent': creationParams.userAgent,

--- a/packages/webview_flutter/lib/src/webview_method_channel.dart
+++ b/packages/webview_flutter/lib/src/webview_method_channel.dart
@@ -78,7 +78,7 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
       'headers': headers,
     });
   }
-  
+
   @override
   Future<void> loadHtml(String html) async {
     return _channel.invokeMethod<void>('loadHtml', <String, dynamic>{

--- a/packages/webview_flutter/lib/src/webview_method_channel.dart
+++ b/packages/webview_flutter/lib/src/webview_method_channel.dart
@@ -78,6 +78,13 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
       'headers': headers,
     });
   }
+  
+  @override
+  Future<void> loadHtml(String html) async {
+    return _channel.invokeMethod<void>('loadHtml', <String, dynamic>{
+      'html': html,
+    });
+  }
 
   @override
   Future<String> currentUrl() => _channel.invokeMethod<String>('currentUrl');

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -211,7 +211,11 @@ class WebView extends StatefulWidget {
 
   /// The initial URL to load.
   final String initialUrl;
+  
+  /// The initial baseURL to load.
   final String baseUrl;
+  
+  /// The initial static html to load.
   final String html;
 
   /// Whether Javascript execution is enabled.
@@ -554,7 +558,12 @@ class WebViewController {
     return _webViewPlatformController.loadUrl(url, headers);
   }
   
+  /// Loads the specified html.
+  ///
+  /// `html` must not be null.
+  ///
   Future<void> loadHtml(String html) async {
+    assert(html != null);
     return _webViewPlatformController.loadHtml(html);
   }
 

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -553,6 +553,10 @@ class WebViewController {
     _validateUrlString(url);
     return _webViewPlatformController.loadUrl(url, headers);
   }
+  
+  Future<void> loadHtml(String html) async {
+    return _webViewPlatformController.loadHtml(html);
+  }
 
   /// Accessor to the current URL that the WebView is displaying.
   ///

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -211,10 +211,10 @@ class WebView extends StatefulWidget {
 
   /// The initial URL to load.
   final String initialUrl;
-  
+
   /// The initial baseURL to load.
   final String baseUrl;
-  
+
   /// The initial static html to load.
   final String html;
 
@@ -557,7 +557,7 @@ class WebViewController {
     _validateUrlString(url);
     return _webViewPlatformController.loadUrl(url, headers);
   }
-  
+
   /// Loads the specified html.
   ///
   /// `html` must not be null.

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -144,6 +144,8 @@ class WebView extends StatefulWidget {
     Key key,
     this.onWebViewCreated,
     this.initialUrl,
+    this.html,
+    this.baseUrl,
     this.javascriptMode = JavascriptMode.disabled,
     this.javascriptChannels,
     this.navigationDelegate,
@@ -209,6 +211,8 @@ class WebView extends StatefulWidget {
 
   /// The initial URL to load.
   final String initialUrl;
+  final String baseUrl;
+  final String html;
 
   /// Whether Javascript execution is enabled.
   final JavascriptMode javascriptMode;
@@ -389,6 +393,8 @@ class _WebViewState extends State<WebView> {
 CreationParams _creationParamsfromWidget(WebView widget) {
   return CreationParams(
     initialUrl: widget.initialUrl,
+    html: widget.html,
+    baseUrl: widget.baseUrl,
     webSettings: _webSettingsFromWidget(widget),
     javascriptChannelNames: _extractChannelNames(widget.javascriptChannels),
     userAgent: widget.userAgent,

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
-version: 0.3.21
+version: 0.3.21+1
 homepage: https://github.com/flutter/plugins/tree/master/packages/webview_flutter
 
 environment:


### PR DESCRIPTION
## Description

*This is an enhancement of the current implementation of flutter webview. This addresses the issue of loading static html in webview, alongwith baseUrl support. This works in both ios and android.*

## Related Issues

*Earlier we used to do it through initialUrl, by converting it to base64 string and so on. React native has a proper support for static html and baseUrl.(https://github.com/fluttercommunity/flutter_webview_plugin/issues/23)*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
