### PR TITLE
[device_info] Add toString future

### DIFF
--- a/packages/device_info/CHANGELOG.md
+++ b/packages/device_info/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.3
+
+* Add toString futures
+
 ## 0.4.2+4
 
 Update lower bound of dart dependency to 2.1.0.

--- a/packages/device_info/lib/device_info.dart
+++ b/packages/device_info/lib/device_info.dart
@@ -26,6 +26,41 @@ class DeviceInfoPlugin {
       _cachedAndroidDeviceInfo ??= AndroidDeviceInfo._fromMap(await channel
           .invokeMapMethod<String, dynamic>('getAndroidDeviceInfo'));
 
+  /// A future giving information on the system, string formatted.
+  Future<String> androidInfoString() async {
+    AndroidDeviceInfo _androidInfos =
+        _cachedAndroidDeviceInfo ?? await androidInfo;
+    return '''
+version.securityPatch: ${_androidInfos.version.securityPatch}
+version.sdkInt: ${_androidInfos.version.sdkInt}
+version.release: ${_androidInfos.version.release}
+version.previewSdkInt: ${_androidInfos.version.previewSdkInt}
+version.incremental: ${_androidInfos.version.incremental}
+version.codename: ${_androidInfos.version.codename}
+version.baseOS: ${_androidInfos.version.baseOS}
+board: ${_androidInfos.board}
+bootloader: ${_androidInfos.bootloader}
+brand: ${_androidInfos.brand}
+device: ${_androidInfos.device}
+display: ${_androidInfos.display}
+fingerprint: ${_androidInfos.fingerprint}
+hardware: ${_androidInfos.hardware}
+host: ${_androidInfos.host}
+id: ${_androidInfos.id}
+manufacturer: ${_androidInfos.manufacturer}
+model: ${_androidInfos.model}
+product: ${_androidInfos.product}
+supported32BitAbis: ${_androidInfos.supported32BitAbis}
+supported64BitAbis: ${_androidInfos.supported64BitAbis}
+supportedAbis: ${_androidInfos.supportedAbis}
+tags: ${_androidInfos.tags}
+type: ${_androidInfos.type}
+isPhysicalDevice: ${_androidInfos.isPhysicalDevice}
+androidId: ${_androidInfos.androidId}
+systemFeatures: ${_androidInfos.systemFeatures}
+    ''';
+  }
+
   /// This information does not change from call to call. Cache it.
   IosDeviceInfo _cachedIosDeviceInfo;
 
@@ -35,6 +70,25 @@ class DeviceInfoPlugin {
   Future<IosDeviceInfo> get iosInfo async =>
       _cachedIosDeviceInfo ??= IosDeviceInfo._fromMap(
           await channel.invokeMapMethod<String, dynamic>('getIosDeviceInfo'));
+
+  /// A future giving information on the system, string formatted.
+  Future iosInfoString() async {
+    IosDeviceInfo _iosInfos = _cachedIosDeviceInfo ?? await iosInfo;
+    return '''
+name: ${_iosInfos.name}
+systemName: ${_iosInfos.systemName}
+systemVersion: ${_iosInfos.systemVersion}
+model: ${_iosInfos.model}
+localizedModel: ${_iosInfos.localizedModel}
+identifierForVendor: ${_iosInfos.identifierForVendor}
+isPhysicalDevice: ${_iosInfos.isPhysicalDevice}
+utsname.sysname: ${_iosInfos.utsname.sysname}
+utsname.nodename: ${_iosInfos.utsname.nodename}
+utsname.release: ${_iosInfos.utsname.release}
+utsname.version: ${_iosInfos.utsname.version}
+utsname.machine: ${_iosInfos.utsname.machine}
+    ''';
+  }
 }
 
 /// Information derived from `android.os.Build`.

--- a/packages/device_info/pubspec.yaml
+++ b/packages/device_info/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/flutter/plugins/tree/master/packages/device_info
 # 0.4.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.4.2+4
+version: 0.4.3
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Add a future that returns a string containing all available infos on the device

## Related Issues

Resolve [flutter/flutter#54430](https://github.com/flutter/flutter/issues/54430)

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.