### PR TITLE
[battery] update dart deps lower bound to 2.1.0

### DIFF
--- a/packages/battery/CHANGELOG.md
+++ b/packages/battery/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+* Update lower bound of dart dependency to 2.1.0.
+
 ## 1.0.0
 
 * Bump the package version to 1.0.0 following ecosystem pre-migration (https://github.com/amirh/bump_to_1.0/projects/1).

--- a/packages/battery/pubspec.yaml
+++ b/packages/battery/pubspec.yaml
@@ -2,7 +2,7 @@ name: battery
 description: Flutter plugin for accessing information about the battery state
   (full, charging, discharging) on Android and iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/battery
-version: 1.0.0
+version: 1.0.1
 
 flutter:
   plugin:
@@ -28,5 +28,5 @@ dev_dependencies:
   pedantic: ^1.8.0
 
 environment:
-  sdk: ">=2.0.0-dev.28.0 <3.0.0"
+  sdk: ">=2.1.0 <3.0.0"
   flutter: ">=1.12.13+hotfix.5 <2.0.0"


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/56930