### PR TITLE
Use Xvfb for Linux desktop tests

### DIFF
--- a/.ci/Dockerfile-LinuxDesktop
+++ b/.ci/Dockerfile-LinuxDesktop
@@ -15,5 +15,7 @@ RUN sudo apt-get update && sudo apt-get install -y google-cloud-sdk && \
     gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true
 
+# Install xvfb to allow running headless
+RUN sudo apt-get install -y xvfb
 # Install Linux desktop requirements.
 RUN sudo apt-get install -y clang make cmake ninja-build rsync pkg-config

--- a/.ci/Dockerfile-LinuxDesktop
+++ b/.ci/Dockerfile-LinuxDesktop
@@ -16,6 +16,6 @@ RUN sudo apt-get update && sudo apt-get install -y google-cloud-sdk && \
     gcloud config set component_manager/disable_update_check true
 
 # Install xvfb to allow running headless
-RUN sudo apt-get install -y xvfb
+RUN sudo apt-get install -y xvfb libegl1-mesa
 # Install Linux desktop requirements.
 RUN sudo apt-get install -y clang make cmake ninja-build rsync pkg-config

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -121,7 +121,7 @@ task:
         # TODO(stuartmorgan): Include stable once Linux is supported on stable.
         - flutter channel master
         - ./script/incremental_build.sh build-examples --linux
-        - ./script/incremental_build.sh drive-examples --linux
+        - xvfb-run ./script/incremental_build.sh drive-examples --linux
 
 task:
   # don't run on release tags since it creates O(n^2) tasks where n is the number of plugins


### PR DESCRIPTION
## Description

Flutter plugin tests don't necessarily run in headless mode; this adds a virtual display when running Linux tests so that they will run in normal mode.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/55327

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
