### PR TITLE
[url_launcher] Initialize previousAutomaticSystemUiAdjustment in launch

### DIFF
--- a/packages/url_launcher/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.4.8
+
+* Initialize `previousAutomaticSystemUiAdjustment` in launch method.
+
 ## 5.4.7
 
 * Update lower bound of dart dependency to 2.1.0.

--- a/packages/url_launcher/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/url_launcher/lib/url_launcher.dart
@@ -73,8 +73,7 @@ Future<bool> launch(
         message: 'To use webview or safariVC, you need to pass'
             'in a web URL. This $urlString is not a web URL.');
   }
-  bool previousAutomaticSystemUiAdjustment =
-      WidgetsBinding.instance.renderView.automaticSystemUiAdjustment;
+  bool previousAutomaticSystemUiAdjustment = true;
   if (statusBarBrightness != null &&
       defaultTargetPlatform == TargetPlatform.iOS) {
     previousAutomaticSystemUiAdjustment =
@@ -93,11 +92,11 @@ Future<bool> launch(
     universalLinksOnly: universalLinksOnly ?? false,
     headers: headers ?? <String, String>{},
   );
+  assert(previousAutomaticSystemUiAdjustment != null);
   if (statusBarBrightness != null) {
     WidgetsBinding.instance.renderView.automaticSystemUiAdjustment =
         previousAutomaticSystemUiAdjustment;
   }
-  assert(WidgetsBinding.instance.renderView.automaticSystemUiAdjustment != null);
   return result;
 }
 

--- a/packages/url_launcher/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/url_launcher/lib/url_launcher.dart
@@ -73,8 +73,8 @@ Future<bool> launch(
         message: 'To use webview or safariVC, you need to pass'
             'in a web URL. This $urlString is not a web URL.');
   }
-  
-  /// true so that ui is automatically computed if statusBarBrightness is set
+
+  /// [true] so that ui is automatically computed if [statusBarBrightness] is set.
   bool previousAutomaticSystemUiAdjustment = true;
   if (statusBarBrightness != null &&
       defaultTargetPlatform == TargetPlatform.iOS) {

--- a/packages/url_launcher/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/url_launcher/lib/url_launcher.dart
@@ -73,6 +73,8 @@ Future<bool> launch(
         message: 'To use webview or safariVC, you need to pass'
             'in a web URL. This $urlString is not a web URL.');
   }
+  
+  /// true so that ui is automatically computed if statusBarBrightness is set
   bool previousAutomaticSystemUiAdjustment = true;
   if (statusBarBrightness != null &&
       defaultTargetPlatform == TargetPlatform.iOS) {

--- a/packages/url_launcher/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/url_launcher/lib/url_launcher.dart
@@ -73,7 +73,8 @@ Future<bool> launch(
         message: 'To use webview or safariVC, you need to pass'
             'in a web URL. This $urlString is not a web URL.');
   }
-  bool previousAutomaticSystemUiAdjustment;
+  bool previousAutomaticSystemUiAdjustment =
+      WidgetsBinding.instance.renderView.automaticSystemUiAdjustment;
   if (statusBarBrightness != null &&
       defaultTargetPlatform == TargetPlatform.iOS) {
     previousAutomaticSystemUiAdjustment =
@@ -96,6 +97,7 @@ Future<bool> launch(
     WidgetsBinding.instance.renderView.automaticSystemUiAdjustment =
         previousAutomaticSystemUiAdjustment;
   }
+  assert(WidgetsBinding.instance.renderView.automaticSystemUiAdjustment != null);
   return result;
 }
 

--- a/packages/url_launcher/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher
 description: Flutter plugin for launching a URL on Android and iOS. Supports
   web, phone, SMS, and email schemes.
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher
-version: 5.4.7
+version: 5.4.8
 
 flutter:
   plugin:

--- a/packages/url_launcher/url_launcher/test/url_launcher_test.dart
+++ b/packages/url_launcher/url_launcher/test/url_launcher_test.dart
@@ -210,15 +210,15 @@ void main() {
       final TestWidgetsFlutterBinding binding =
           TestWidgetsFlutterBinding.ensureInitialized();
       debugDefaultTargetPlatformOverride = TargetPlatform.android;
-      expect(binding.renderView.automaticSystemUiAdjustment, isNotNull);
+      expect(binding.renderView.automaticSystemUiAdjustment, true);
       final Future<bool> launchResult =
           launch('http://flutter.dev/', statusBarBrightness: Brightness.dark);
 
       // The automaticSystemUiAdjustment should be set before the launch
-      // and not null after the launch result is complete.
-      expect(binding.renderView.automaticSystemUiAdjustment, isNotNull);
+      // and equal to true after the launch result is complete.
+      expect(binding.renderView.automaticSystemUiAdjustment, true);
       await launchResult;
-      expect(binding.renderView.automaticSystemUiAdjustment, isNotNull);
+      expect(binding.renderView.automaticSystemUiAdjustment, true);
     });
   });
 }

--- a/packages/url_launcher/url_launcher/test/url_launcher_test.dart
+++ b/packages/url_launcher/url_launcher/test/url_launcher_test.dart
@@ -205,6 +205,21 @@ void main() {
       await launchResult;
       expect(binding.renderView.automaticSystemUiAdjustment, isTrue);
     });
+
+    test('sets automaticSystemUiAdjustment to not be null', () async {
+      final TestWidgetsFlutterBinding binding =
+          TestWidgetsFlutterBinding.ensureInitialized();
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      expect(binding.renderView.automaticSystemUiAdjustment, isNotNull);
+      final Future<bool> launchResult =
+          launch('http://flutter.dev/', statusBarBrightness: Brightness.dark);
+
+      // The automaticSystemUiAdjustment should be set before the launch
+      // and not null after the launch result is complete.
+      expect(binding.renderView.automaticSystemUiAdjustment, isNotNull);
+      await launchResult;
+      expect(binding.renderView.automaticSystemUiAdjustment, isNotNull);
+    });
   });
 }
 


### PR DESCRIPTION
## Description

The value of previousAutomaticSystemUiAdjustment is set to true in launch method before statusBarBrightness is checked. This change prevents the automaticSystemUiAdjustment of the renderView from being set to null after statusBarBrightness is checked. This ensures that _updateSystemChrome() is called before window rendering.

## Related Issues

Fixes flutter/flutter#43373

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
