### PR TITLE
Run the publish with the pub version from flutter master

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -18,7 +18,7 @@ task:
   matrix:
     - name: publishable
       script:
-        - flutter channel stable
+        - flutter channel master
         - ./script/check_publish.sh
     - name: format
       install_script:


### PR DESCRIPTION
I believe all the plugins are migrated and can not check publish on master, and the workaround in https://github.com/flutter/plugins/pull/2250 can be reverted.
This will also enable us to catch potential publish issues with newer dart version as early as possible.
