### PR TITLE
[e2e] Use CompletableFuture from package for lower API level support

### DIFF
--- a/packages/e2e/CHANGELOG.md
+++ b/packages/e2e/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.3
+
+* Uses CompletableFuture from android-retrofuture allow compatibility with API < 24.
+
 ## 0.4.2
 
 * Adds support for Android E2E tests that utilize other @Rule's, like GrantPermissionRule.

--- a/packages/e2e/android/build.gradle
+++ b/packages/e2e/android/build.gradle
@@ -33,6 +33,7 @@ android {
     }
     dependencies {
         api 'junit:junit:4.12'
+        compile 'net.sourceforge.streamsupport:android-retrofuture:1.7.2'
 
         // https://developer.android.com/jetpack/androidx/releases/test/#1.2.0
         api 'androidx.test:runner:1.2.0'

--- a/packages/e2e/android/src/main/java/dev/flutter/plugins/e2e/E2EPlugin.java
+++ b/packages/e2e/android/src/main/java/dev/flutter/plugins/e2e/E2EPlugin.java
@@ -13,7 +13,7 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
+import java9.util.concurrent.CompletableFuture;
 
 /** E2EPlugin */
 public class E2EPlugin implements MethodCallHandler, FlutterPlugin {

--- a/packages/e2e/pubspec.yaml
+++ b/packages/e2e/pubspec.yaml
@@ -1,6 +1,6 @@
 name: e2e
 description: Runs tests that use the flutter_test API as integration tests.
-version: 0.4.2
+version: 0.4.3
 homepage: https://github.com/flutter/plugins/tree/master/packages/e2e
 
 environment:


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/48701

ConcurrentFuture is only available in API24 and above. This imports a support package with an implementation compatible down to our lowest supported API level, 16.