### PR TITLE
Expose AppStoreConnection and getTransactions method from the payment…

### DIFF
--- a/packages/in_app_purchase/lib/in_app_purchase.dart
+++ b/packages/in_app_purchase/lib/in_app_purchase.dart
@@ -5,3 +5,5 @@
 export 'src/in_app_purchase/in_app_purchase_connection.dart';
 export 'src/in_app_purchase/product_details.dart';
 export 'src/in_app_purchase/purchase_details.dart';
+export 'src/in_app_purchase/app_store_connection.dart';
+export 'src/in_app_purchase/google_play_connection.dart';

--- a/packages/in_app_purchase/lib/src/in_app_purchase/app_store_connection.dart
+++ b/packages/in_app_purchase/lib/src/in_app_purchase/app_store_connection.dart
@@ -173,6 +173,8 @@ class AppStoreConnection implements InAppPurchaseConnection {
     );
     return productDetailsResponse;
   }
+
+  Future<List<SKPaymentTransactionWrapper>> getTransactions() => _skPaymentQueueWrapper.transactions();
 }
 
 class _TransactionObserver implements SKTransactionObserverWrapper {


### PR DESCRIPTION
… queue wrapper so that "hanging" transactions can be dealt with.

## Description

It isn't currently possible to do anything about AppStore transactions which for some reason were not completed, meaning they just hang around and cannot be changed. The underlying plugin code actually exposes a list of transactions already, which can simply be exposed and from that, create PurchaseDetails and run completePurchase on each of them.

Example code:

if (Platform.isIOS) {
      AppStoreConnection appStoreConnection = _connection as AppStoreConnection;
      var transactions = await appStoreConnection.getTransactions();
      // print(transactions);
      for (var transaction in transactions) {
        var purchaseDetails = PurchaseDetails.fromSKTransaction(transaction, null);
        if (purchaseDetails.status != PurchaseStatus.pending) {
          try {
            var billingResult = await appStoreConnection.completePurchase(purchaseDetails);
            // print(billingResult);
          }
          on Exception catch(e) {
            // print(e);
          }
        }
      }
    }

## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
