### PR TITLE
[e2e] fixed code snippet in readme that referenced a non-existent variable

### DIFF
--- a/packages/e2e/CHANGELOG.md
+++ b/packages/e2e/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Bumps AGP to 3.6.3
 * Changes android-retrofuture dependency type to "implementation"
+* Fixed code snippet in readme that referenced a non-existent `result` variable.
 
 ## 0.4.3+1
 

--- a/packages/e2e/CHANGELOG.md
+++ b/packages/e2e/CHANGELOG.md
@@ -1,8 +1,11 @@
+## 0.4.3+3
+
+* Fixed code snippet in readme that referenced a non-existent `result` variable.
+
 ## 0.4.3+2
 
 * Bumps AGP to 3.6.3
 * Changes android-retrofuture dependency type to "implementation"
-* Fixed code snippet in readme that referenced a non-existent `result` variable.
 
 ## 0.4.3+1
 

--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -23,7 +23,6 @@ void main() {
   testWidgets("failing test example", (WidgetTester tester) async {
     expect(2 + 2, equals(5));
   });
-  exit(result == 'pass' ? 0 : 1);
 }
 ```
 

--- a/packages/e2e/pubspec.yaml
+++ b/packages/e2e/pubspec.yaml
@@ -1,6 +1,6 @@
 name: e2e
 description: Runs tests that use the flutter_test API as integration tests.
-version: 0.4.3+2
+version: 0.4.3+3
 homepage: https://github.com/flutter/plugins/tree/master/packages/e2e
 
 environment:


### PR DESCRIPTION
## Description

The first code snippet for the e2e plugin's readme invokes the `exit` that uses the value of a `result` variable that doesn't exist. I'm assuming there's some confusion where `result` stored the output of calling `request_data` that isn't used in the context of the code snippet. This PR is to remove that line of code.
## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.