### PR TITLE
Error

### DIFF
--- a/packages/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.4
+
+* Expose SKError code to client apps.
+
 ## 0.3.3+2
 
 * Post-v2 Android embedding cleanups.

--- a/packages/in_app_purchase/lib/src/in_app_purchase/app_store_connection.dart
+++ b/packages/in_app_purchase/lib/src/in_app_purchase/app_store_connection.dart
@@ -221,7 +221,7 @@ class _TransactionObserver implements SKTransactionObserverWrapper {
             ..error = transaction.error != null
                 ? IAPError(
                     source: IAPSource.AppStore,
-                    code: kPurchaseErrorCode,
+                    code: '${transaction.error.code}',
                     message: transaction.error.domain,
                     details: transaction.error.userInfo,
                   )

--- a/packages/in_app_purchase/lib/src/in_app_purchase/app_store_connection.dart
+++ b/packages/in_app_purchase/lib/src/in_app_purchase/app_store_connection.dart
@@ -215,17 +215,7 @@ class _TransactionObserver implements SKTransactionObserverWrapper {
     purchaseUpdatedController
         .add(transactions.map((SKPaymentTransactionWrapper transaction) {
       PurchaseDetails purchaseDetails =
-          PurchaseDetails.fromSKTransaction(transaction, receiptData)
-            ..status = SKTransactionStatusConverter()
-                .toPurchaseStatus(transaction.transactionState)
-            ..error = transaction.error != null
-                ? IAPError(
-                    source: IAPSource.AppStore,
-                    code: '${transaction.error.code}',
-                    message: transaction.error.domain,
-                    details: transaction.error.userInfo,
-                  )
-                : null;
+          PurchaseDetails.fromSKTransaction(transaction, receiptData);
       return purchaseDetails;
     }).toList());
   }

--- a/packages/in_app_purchase/lib/src/in_app_purchase/purchase_details.dart
+++ b/packages/in_app_purchase/lib/src/in_app_purchase/purchase_details.dart
@@ -196,6 +196,14 @@ class PurchaseDetails {
         _platform = _kPlatformIOS {
     status = SKTransactionStatusConverter()
         .toPurchaseStatus(transaction.transactionState);
+            if (status == PurchaseStatus.error) {
+      error = IAPError(
+        source: IAPSource.AppStore,
+        code: kPurchaseErrorCode,
+        message: transaction.error.domain,
+        details: transaction.error.userInfo,
+      );
+    }
   }
 
   /// Generate a [PurchaseDetails] object based on an Android [Purchase] object.
@@ -211,6 +219,13 @@ class PurchaseDetails {
         this.billingClientPurchase = purchase,
         _platform = _kPlatformAndroid {
     status = PurchaseStateConverter().toPurchaseStatus(purchase.purchaseState);
+    if (status == PurchaseStatus.error) {
+      error = IAPError(
+        source: IAPSource.GooglePlay,
+        code: kPurchaseErrorCode,
+        message: null,
+      );
+    }
   }
 }
 

--- a/packages/in_app_purchase/lib/src/in_app_purchase/purchase_details.dart
+++ b/packages/in_app_purchase/lib/src/in_app_purchase/purchase_details.dart
@@ -196,7 +196,7 @@ class PurchaseDetails {
         _platform = _kPlatformIOS {
     status = SKTransactionStatusConverter()
         .toPurchaseStatus(transaction.transactionState);
-            if (status == PurchaseStatus.error) {
+    if (status == PurchaseStatus.error) {
       error = IAPError(
         source: IAPSource.AppStore,
         code: kPurchaseErrorCode,

--- a/packages/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/pubspec.yaml
@@ -1,7 +1,7 @@
 name: in_app_purchase
 description: A Flutter plugin for in-app purchases. Exposes APIs for making in-app purchases through the App Store and Google Play.
 homepage: https://github.com/flutter/plugins/tree/master/packages/in_app_purchase
-version: 0.3.3+2
+version: 0.3.4
 
 dependencies:
   async: ^2.0.8

--- a/packages/in_app_purchase/test/in_app_purchase_connection/app_store_connection_test.dart
+++ b/packages/in_app_purchase/test/in_app_purchase_connection/app_store_connection_test.dart
@@ -228,7 +228,7 @@ void main() {
           .buyNonConsumable(purchaseParam: purchaseParam);
 
       IAPError completerError = await completer.future;
-      expect(completerError.code, '0');
+      expect(completerError.code, 'purchase_error');
       expect(completerError.source, IAPSource.AppStore);
       expect(completerError.message, 'ios_domain');
       expect(completerError.details, {'message': 'an error message'});

--- a/packages/in_app_purchase/test/in_app_purchase_connection/app_store_connection_test.dart
+++ b/packages/in_app_purchase/test/in_app_purchase_connection/app_store_connection_test.dart
@@ -228,7 +228,7 @@ void main() {
           .buyNonConsumable(purchaseParam: purchaseParam);
 
       IAPError completerError = await completer.future;
-      expect(completerError.code, kPurchaseErrorCode);
+      expect(completerError.code, '0');
       expect(completerError.source, IAPSource.AppStore);
       expect(completerError.message, 'ios_domain');
       expect(completerError.details, {'message': 'an error message'});


### PR DESCRIPTION
## Description

Expose SKError code to client apps when a transaction failed.

Currently, platform independent error is populated to `PurchaseDetails.error` and `PurchaseDetails.skPaymentTransaction.error` should contain error details from iOS platform.

## Related Issues

https://github.com/flutter/flutter/issues/47738

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.