### PR TITLE
[e2e] Android: Remove warning, bump AGP

### DIFF
--- a/packages/e2e/CHANGELOG.md
+++ b/packages/e2e/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.3+2
+
+* Bumps AGP to 3.6.3
+* Changes android-retrofuture dependency type to "implementation"
+
 ## 0.4.3+1
 
 * Post-v2 Android embedding cleanup.

--- a/packages/e2e/android/build.gradle
+++ b/packages/e2e/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.6.3'
     }
 }
 
@@ -33,7 +33,7 @@ android {
     }
     dependencies {
         api 'junit:junit:4.12'
-        compile 'net.sourceforge.streamsupport:android-retrofuture:1.7.2'
+        implementation 'net.sourceforge.streamsupport:android-retrofuture:1.7.2'
 
         // https://developer.android.com/jetpack/androidx/releases/test/#1.2.0
         api 'androidx.test:runner:1.2.0'

--- a/packages/e2e/example/android/app/src/androidTest/java/com/example/e2e_example/FlutterActivityWithPermissionTest.java
+++ b/packages/e2e/example/android/app/src/androidTest/java/com/example/e2e_example/FlutterActivityWithPermissionTest.java
@@ -4,6 +4,7 @@ import android.Manifest.permission;
 import androidx.test.rule.ActivityTestRule;
 import androidx.test.rule.GrantPermissionRule;
 import dev.flutter.plugins.e2e.FlutterTestRunner;
+import io.flutter.embedding.android.FlutterActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
@@ -13,13 +14,13 @@ import org.junit.runner.RunWith;
  * results which are guarded with permissions.
  */
 @RunWith(FlutterTestRunner.class)
-public class MainActivityWithPermissionTest {
+public class FlutterActivityWithPermissionTest {
 
   @Rule
   public GrantPermissionRule permissionRule =
       GrantPermissionRule.grant(permission.ACCESS_COARSE_LOCATION);
 
   @Rule
-  public ActivityTestRule<MainActivity> rule =
-      new ActivityTestRule<>(MainActivity.class, true, false);
+  public ActivityTestRule<FlutterActivity> rule =
+      new ActivityTestRule<>(FlutterActivity.class, true, false);
 }

--- a/packages/e2e/example/android/build.gradle
+++ b/packages/e2e/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.6.3'
     }
 }
 

--- a/packages/e2e/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/e2e/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/packages/e2e/pubspec.yaml
+++ b/packages/e2e/pubspec.yaml
@@ -1,6 +1,6 @@
 name: e2e
 description: Runs tests that use the flutter_test API as integration tests.
-version: 0.4.3+1
+version: 0.4.3+2
 homepage: https://github.com/flutter/plugins/tree/master/packages/e2e
 
 environment:


### PR DESCRIPTION
## Description

Currently, android build creates the warning message:

<img width="1524" alt="Screenshot 2020-05-28 at 13 18 58" src="https://user-images.githubusercontent.com/269860/83140645-4cd26300-a0e6-11ea-91ec-50011a5e8abb.png">



## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
