### PR TITLE
serious bug：native project textfeild's content will be lost after pickImg

### DIFF
--- a/packages/image_picker/CHANGELOG.md
+++ b/packages/image_picker/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 0.6.6
-
-* Fixes crash when an image in the gallery is tapped more than once.
-
 ## 0.6.5+1
 
 * Fix CocoaPods podspec lint warnings.

--- a/packages/image_picker/ios/Classes/FLTImagePickerPlugin.m
+++ b/packages/image_picker/ios/Classes/FLTImagePickerPlugin.m
@@ -279,7 +279,7 @@ static const int SOURCE_GALLERY = 1;
     }
     self.result(videoURL.path);
     self.result = nil;
-    _arguments = nil;
+
   } else {
     UIImage *image = [info objectForKey:UIImagePickerControllerEditedImage];
     if (image == nil) {
@@ -322,6 +322,7 @@ static const int SOURCE_GALLERY = 1;
                      }];
     }
   }
+  _arguments = nil;
 }
 
 - (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker {
@@ -356,9 +357,6 @@ static const int SOURCE_GALLERY = 1;
 }
 
 - (void)handleSavedPath:(NSString *)path {
-  if (!self.result) {
-    return;
-  }
   if (path) {
     self.result(path);
   } else {
@@ -367,7 +365,6 @@ static const int SOURCE_GALLERY = 1;
                                     details:nil]);
   }
   self.result = nil;
-  _arguments = nil;
 }
 
 @end

--- a/packages/image_picker/ios/Tests/ImagePickerPluginTests.m
+++ b/packages/image_picker/ios/Tests/ImagePickerPluginTests.m
@@ -7,11 +7,6 @@
 @import image_picker;
 @import XCTest;
 
-@interface FLTImagePickerPlugin (Test)
-@property(copy, nonatomic) FlutterResult result;
-- (void)handleSavedPath:(NSString *)path;
-@end
-
 @interface ImagePickerPluginTests : XCTestCase
 @end
 
@@ -93,22 +88,6 @@
                     result:^(id _Nullable r){
                     }];
   XCTAssertEqual([plugin getImagePickerController].videoMaximumDuration, 95);
-}
-
-- (void)testPluginPickImageSelectMultipleTimes {
-  FLTImagePickerPlugin *plugin =
-      [[FLTImagePickerPlugin alloc] initWithViewController:[UIViewController new]];
-  FlutterMethodCall *call =
-      [FlutterMethodCall methodCallWithMethodName:@"pickImage"
-                                        arguments:@{@"source" : @(0), @"cameraDevice" : @(0)}];
-  [plugin handleMethodCall:call
-                    result:^(id _Nullable r){
-                    }];
-  plugin.result = ^(id result) {
-
-  };
-  [plugin handleSavedPath:@"test"];
-  [plugin handleSavedPath:@"test"];
 }
 
 @end

--- a/packages/image_picker/pubspec.yaml
+++ b/packages/image_picker/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker
 description: Flutter plugin for selecting images from the Android and iOS image
   library, and taking new pictures with the camera.
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker
-version: 0.6.6
+version: 0.6.5+1
 
 flutter:
   plugin:


### PR DESCRIPTION
This package does not have any problems in the flutter project, but in the native project, if the page contains TextFeild, after the image is selected, the content entered by textfeild will be lost, which is a very serious bug.

Below is my environment
`Flutter 1.12.13+hotfix.8 • channel stable • https://github.com/flutter/flutter.git
Framework • revision 0b8abb4724 (4 months ago) • 2020-02-11 11:44:36 -0800
Engine • revision e1e6ced81d
Tools • Dart 2.7.0`