### PR TITLE
[e2e] Avoid overriding http, textinput, window size

### DIFF
--- a/packages/e2e/lib/e2e.dart
+++ b/packages/e2e/lib/e2e.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
@@ -35,6 +36,20 @@ class E2EWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding {
       if (!_allTestsPassed.isCompleted) _allTestsPassed.complete(true);
     });
   }
+
+  // TODO(dnfield): Remove the ignore once we bump the minimum Flutter version
+  // ignore: override_on_non_overriding_member
+  @override
+  bool get overrideHttpClient => false;
+
+  // TODO(dnfield): Remove the ignore once we bump the minimum Flutter version
+  // ignore: override_on_non_overriding_member
+  @override
+  bool get registerTestTextInput => false;
+
+  @override
+  ViewConfiguration createViewConfiguration() =>
+      TestViewConfiguration(size: window.physicalSize);
 
   final Completer<bool> _allTestsPassed = Completer<bool>();
 


### PR DESCRIPTION
Fixes flutter/flutter#51885
Fixes flutter/flutter#57623

On versions of Flutter containing https://github.com/flutter/flutter/pull/58210, this will make sure we don't automatically register the test text input and httpoverrides.

This will also default the window size to whatever the device or browser actually thinks it should be, rather than forcing it to start at 800x600. We can, if needed, still alter the size in a test using the binding's `setSurfaceSize` from within a test.

/cc @chunhtai since you helped review the upstream PR related to this.