### PR TITLE
[path_provider] Updated documentation reflecting changes needed for testing

### DIFF
--- a/packages/path_provider/path_provider/CHANGELOG.md
+++ b/packages/path_provider/path_provider/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.6.11
+* Updated documentation to reflect the need for changes in testing for federated plugins
+
 ## 1.6.10
 * Linux implementation endorsement
 

--- a/packages/path_provider/path_provider/CHANGELOG.md
+++ b/packages/path_provider/path_provider/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.6.11
+## 1.6.10+1
 * Updated documentation to reflect the need for changes in testing for federated plugins
 
 ## 1.6.10

--- a/packages/path_provider/path_provider/CHANGELOG.md
+++ b/packages/path_provider/path_provider/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.6.10+1
+## 1.6.11
 * Updated documentation to reflect the need for changes in testing for federated plugins
 
 ## 1.6.10

--- a/packages/path_provider/path_provider/README.md
+++ b/packages/path_provider/path_provider/README.md
@@ -2,7 +2,8 @@
 
 [![pub package](https://img.shields.io/pub/v/path_provider.svg)](https://pub.dartlang.org/packages/path_provider)
 
-A Flutter plugin for finding commonly used locations on the filesystem. Supports iOS and Android.
+A Flutter plugin for finding commonly used locations on the filesystem. Supports iOS, Android, Linux and MacOS.
+Not all methods are supported on all platforms.
 
 ## Usage
 
@@ -19,3 +20,18 @@ String appDocPath = appDocDir.path;
 ```
 
 Please see the example app of this plugin for a full example.
+
+### Usage in tests
+
+Recently `path_provider` was updated to be a federated plugin. 
+
+With that change, tests should be updated to mock `PathProviderPlatform` rather than `PlatformChannel`. 
+
+See this `path_provider` [test](https://github.com/flutter/plugins/blob/master/packages/path_provider/path_provider/test/path_provider_test.dart) for an example.
+
+You will also have to temporarily add the following line to the setup of your test.
+```dart
+disablePathProviderPlatformOverride = true;
+```
+
+See this [issue](https://github.com/flutter/flutter/issues/52267), and these comments [1](https://github.com/flutter/plugins/pull/2789#issuecomment-632354400), [2](https://github.com/flutter/plugins/pull/2789#discussion_r430634873) for details on why this is needed.

--- a/packages/path_provider/path_provider/README.md
+++ b/packages/path_provider/path_provider/README.md
@@ -23,9 +23,8 @@ Please see the example app of this plugin for a full example.
 
 ### Usage in tests
 
-Recently `path_provider` was updated to be a federated plugin. 
-
-With that change, tests should be updated to mock `PathProviderPlatform` rather than `PlatformChannel`. 
+`path_provider` now uses a `PlatformInterface`, meaning that not all platforms share the a single `PlatformChannel`-based implementation. 
+With that change, tests should be updated to mock `PathProviderPlatform` rather than `PlatformChannel`.
 
 See this `path_provider` [test](https://github.com/flutter/plugins/blob/master/packages/path_provider/path_provider/test/path_provider_test.dart) for an example.
 
@@ -34,4 +33,4 @@ You will also have to temporarily add the following line to the setup of your te
 disablePathProviderPlatformOverride = true;
 ```
 
-See this [issue](https://github.com/flutter/flutter/issues/52267), and these comments [1](https://github.com/flutter/plugins/pull/2789#issuecomment-632354400), [2](https://github.com/flutter/plugins/pull/2789#discussion_r430634873) for details on why this is needed.
+See this [issue](https://github.com/flutter/flutter/issues/52267), for more details on why this is needed.

--- a/packages/path_provider/path_provider/pubspec.yaml
+++ b/packages/path_provider/path_provider/pubspec.yaml
@@ -2,7 +2,7 @@ name: path_provider
 description: Flutter plugin for getting commonly used locations on the Android &
   iOS file systems, such as the temp and app data directories.
 homepage: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider
-version: 1.6.10
+version: 1.6.11
 
 flutter:
   plugin:

--- a/packages/path_provider/path_provider/pubspec.yaml
+++ b/packages/path_provider/path_provider/pubspec.yaml
@@ -2,7 +2,7 @@ name: path_provider
 description: Flutter plugin for getting commonly used locations on the Android &
   iOS file systems, such as the temp and app data directories.
 homepage: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider
-version: 1.6.11
+version: 1.6.10+1
 
 flutter:
   plugin:

--- a/packages/path_provider/path_provider/pubspec.yaml
+++ b/packages/path_provider/path_provider/pubspec.yaml
@@ -2,7 +2,7 @@ name: path_provider
 description: Flutter plugin for getting commonly used locations on the Android &
   iOS file systems, such as the temp and app data directories.
 homepage: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider
-version: 1.6.10+1
+version: 1.6.11
 
 flutter:
   plugin:


### PR DESCRIPTION
 Updated documentation reflecting changes needed for testing federated plugins

## Description

This PR addresses this [comment](https://github.com/flutter/plugins/pull/2789#issuecomment-638949311)
The recent federation of the Linux path provider might break tests, this updates the README.md to address those changes and direct the users how to mock the plugin in their tests.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
