### PR TITLE
[in_app_purchase] Add support for InApp subscription upgrade/downgrade

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -62,3 +62,4 @@ Juan Alvarez <juan.alvarez@resideo.com>
 Aleksandr Yurkovskiy <sanekyy@gmail.com>
 Anton Borries <mail@antonborri.es>
 Alex Li <google@alexv525.com>
+Rahul Raj <64.rahulraj@gmail.com>

--- a/packages/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1
+
+* Support InApp subscription upgrade/downgrade.
+
 ## 0.4.0
 
 * Migrate to nullsafety.

--- a/packages/in_app_purchase/README.md
+++ b/packages/in_app_purchase/README.md
@@ -178,6 +178,30 @@ and `AppStore` that the purchase has been finished.
 
 WARNING! Failure to call `InAppPurchaseConnection.completePurchase` and get a successful response within 3 days of the purchase will result a refund.
 
+### Upgrading or Downgrading an existing InApp Subscription
+
+In order to upgrade/downgrade an existing InApp subscription on `PlayStore`, 
+you need to provide an instance of `ChangeSubscriptionParam` with the old 
+`PurchaseDetails` that the user needs to migrate from, and an optional `ProrationMode`
+with the `PurchaseParam` object while calling `InAppPurchaseConnection.buyNonConsumable`.
+`AppStore` does not require this since they provides a subscription grouping mechanism. 
+Each subscription you offer must be assigned to a subscription group. 
+So the developers can group related subscriptions together to prevents users from 
+accidentally purchasing multiple subscriptions.
+Please refer to the 'Creating a Subscription Group' sections of [Apple's subscription guide](https://developer.apple.com/app-store/subscriptions/)
+
+
+```dart
+final PurchaseDetails oldPurchaseDetails = ...;
+PurchaseParam purchaseParam = PurchaseParam(
+    productDetails: productDetails,
+    changeSubscriptionParam: ChangeSubscriptionParam(
+        oldPurchaseDetails: oldPurchaseDetails,
+        prorationMode: ProrationMode.immediateWithTimeProration));
+InAppPurchaseConnection.instance
+    .buyNonConsumable(purchaseParam: purchaseParam);
+```
+
 ## Development
 
 This plugin uses

--- a/packages/in_app_purchase/example/README.md
+++ b/packages/in_app_purchase/example/README.md
@@ -30,7 +30,8 @@ below.
 
    - `consumable`: A managed product.
    - `upgrade`: A managed product.
-   - `subscription`: A subscription.
+   - `subscription_silver`: A lower level subscription.
+   - `subscription_gold`: A higher level subscription.
 
    Make sure that all of the products are set to `ACTIVE`.
 

--- a/packages/in_app_purchase/example/android/app/src/test/java/io/flutter/plugins/inapppurchase/MethodCallHandlerTest.java
+++ b/packages/in_app_purchase/example/android/app/src/test/java/io/flutter/plugins/inapppurchase/MethodCallHandlerTest.java
@@ -18,6 +18,7 @@ import static io.flutter.plugins.inapppurchase.Translator.fromPurchasesResult;
 import static io.flutter.plugins.inapppurchase.Translator.fromSkuDetailsList;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
+import static java.util.Collections.unmodifiableList;
 import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -261,7 +262,7 @@ public class MethodCallHandlerTest {
   }
 
   @Test
-  public void launchBillingFlow_ok_nullAccountId() {
+  public void launchBillingFlow_ok_null_AccountId() {
     // Fetch the sku details first and then prepare the launch billing flow call
     String skuId = "foo";
     queryForSkus(singletonList(skuId));
@@ -293,6 +294,40 @@ public class MethodCallHandlerTest {
   }
 
   @Test
+  public void launchBillingFlow_ok_null_OldSku() {
+    // Fetch the sku details first and then prepare the launch billing flow call
+    String skuId = "foo";
+    String accountId = "account";
+    queryForSkus(singletonList(skuId));
+    HashMap<String, Object> arguments = new HashMap<>();
+    arguments.put("sku", skuId);
+    arguments.put("accountId", accountId);
+    arguments.put("oldSku", null);
+    MethodCall launchCall = new MethodCall(LAUNCH_BILLING_FLOW, arguments);
+
+    // Launch the billing flow
+    BillingResult billingResult =
+        BillingResult.newBuilder()
+            .setResponseCode(100)
+            .setDebugMessage("dummy debug message")
+            .build();
+    when(mockBillingClient.launchBillingFlow(any(), any())).thenReturn(billingResult);
+    methodChannelHandler.onMethodCall(launchCall, result);
+
+    // Verify we pass the arguments to the billing flow
+    ArgumentCaptor<BillingFlowParams> billingFlowParamsCaptor =
+        ArgumentCaptor.forClass(BillingFlowParams.class);
+    verify(mockBillingClient).launchBillingFlow(any(), billingFlowParamsCaptor.capture());
+    BillingFlowParams params = billingFlowParamsCaptor.getValue();
+    assertEquals(params.getSku(), skuId);
+    assertEquals(params.getAccountId(), accountId);
+    assertNull(params.getOldSku());
+    // Verify we pass the response code to result
+    verify(result, never()).error(any(), any(), any());
+    verify(result, times(1)).success(fromBillingResult(billingResult));
+  }
+
+  @Test
   public void launchBillingFlow_ok_null_Activity() {
     methodChannelHandler.setActivity(null);
 
@@ -309,6 +344,42 @@ public class MethodCallHandlerTest {
     // Verify we pass the response code to result
     verify(result).error(contains("ACTIVITY_UNAVAILABLE"), contains("foreground"), any());
     verify(result, never()).success(any());
+  }
+
+  @Test
+  public void launchBillingFlow_ok_oldSku() {
+    // Fetch the sku details first and query the method call
+    String skuId = "foo";
+    String accountId = "account";
+    String oldSkuId = "oldFoo";
+    queryForSkus(unmodifiableList(asList(skuId, oldSkuId)));
+    HashMap<String, Object> arguments = new HashMap<>();
+    arguments.put("sku", skuId);
+    arguments.put("accountId", accountId);
+    arguments.put("oldSku", oldSkuId);
+    MethodCall launchCall = new MethodCall(LAUNCH_BILLING_FLOW, arguments);
+
+    // Launch the billing flow
+    BillingResult billingResult =
+        BillingResult.newBuilder()
+            .setResponseCode(100)
+            .setDebugMessage("dummy debug message")
+            .build();
+    when(mockBillingClient.launchBillingFlow(any(), any())).thenReturn(billingResult);
+    methodChannelHandler.onMethodCall(launchCall, result);
+
+    // Verify we pass the arguments to the billing flow
+    ArgumentCaptor<BillingFlowParams> billingFlowParamsCaptor =
+        ArgumentCaptor.forClass(BillingFlowParams.class);
+    verify(mockBillingClient).launchBillingFlow(any(), billingFlowParamsCaptor.capture());
+    BillingFlowParams params = billingFlowParamsCaptor.getValue();
+    assertEquals(params.getSku(), skuId);
+    assertEquals(params.getAccountId(), accountId);
+    assertEquals(params.getOldSku(), oldSkuId);
+
+    // Verify we pass the response code to result
+    verify(result, never()).error(any(), any(), any());
+    verify(result, times(1)).success(fromBillingResult(billingResult));
   }
 
   @Test
@@ -345,6 +416,79 @@ public class MethodCallHandlerTest {
   }
 
   @Test
+  public void launchBillingFlow_ok_Proration() {
+    // Fetch the sku details first and query the method call
+    String skuId = "foo";
+    String oldSkuId = "oldFoo";
+    String accountId = "account";
+    int prorationMode = BillingFlowParams.ProrationMode.IMMEDIATE_AND_CHARGE_PRORATED_PRICE;
+    queryForSkus(unmodifiableList(asList(skuId, oldSkuId)));
+    HashMap<String, Object> arguments = new HashMap<>();
+    arguments.put("sku", skuId);
+    arguments.put("accountId", accountId);
+    arguments.put("oldSku", oldSkuId);
+    arguments.put("prorationMode", prorationMode);
+    MethodCall launchCall = new MethodCall(LAUNCH_BILLING_FLOW, arguments);
+
+    // Launch the billing flow
+    BillingResult billingResult =
+        BillingResult.newBuilder()
+            .setResponseCode(100)
+            .setDebugMessage("dummy debug message")
+            .build();
+    when(mockBillingClient.launchBillingFlow(any(), any())).thenReturn(billingResult);
+    methodChannelHandler.onMethodCall(launchCall, result);
+
+    // Verify we pass the arguments to the billing flow
+    ArgumentCaptor<BillingFlowParams> billingFlowParamsCaptor =
+        ArgumentCaptor.forClass(BillingFlowParams.class);
+    verify(mockBillingClient).launchBillingFlow(any(), billingFlowParamsCaptor.capture());
+    BillingFlowParams params = billingFlowParamsCaptor.getValue();
+    assertEquals(params.getSku(), skuId);
+    assertEquals(params.getAccountId(), accountId);
+    assertEquals(params.getOldSku(), oldSkuId);
+    assertEquals(params.getReplaceSkusProrationMode(), prorationMode);
+
+    // Verify we pass the response code to result
+    verify(result, never()).error(any(), any(), any());
+    verify(result, times(1)).success(fromBillingResult(billingResult));
+  }
+
+  @Test
+  public void launchBillingFlow_ok_Proration_with_null_OldSku() {
+    // Fetch the sku details first and query the method call
+    String skuId = "foo";
+    String accountId = "account";
+    String queryOldSkuId = "oldFoo";
+    String oldSkuId = null;
+    int prorationMode = BillingFlowParams.ProrationMode.IMMEDIATE_AND_CHARGE_PRORATED_PRICE;
+    queryForSkus(unmodifiableList(asList(skuId, queryOldSkuId)));
+    HashMap<String, Object> arguments = new HashMap<>();
+    arguments.put("sku", skuId);
+    arguments.put("accountId", accountId);
+    arguments.put("oldSku", oldSkuId);
+    arguments.put("prorationMode", prorationMode);
+    MethodCall launchCall = new MethodCall(LAUNCH_BILLING_FLOW, arguments);
+
+    // Launch the billing flow
+    BillingResult billingResult =
+        BillingResult.newBuilder()
+            .setResponseCode(100)
+            .setDebugMessage("dummy debug message")
+            .build();
+    when(mockBillingClient.launchBillingFlow(any(), any())).thenReturn(billingResult);
+    methodChannelHandler.onMethodCall(launchCall, result);
+
+    // Assert that we sent an error back.
+    verify(result)
+        .error(
+            contains("IN_APP_PURCHASE_REQUIRE_OLD_SKU"),
+            contains("launchBillingFlow failed because oldSku is null"),
+            any());
+    verify(result, never()).success(any());
+  }
+
+  @Test
   public void launchBillingFlow_clientDisconnected() {
     // Prepare the launch call after disconnecting the client
     MethodCall disconnectCall = new MethodCall(END_CONNECTION, null);
@@ -378,6 +522,27 @@ public class MethodCallHandlerTest {
 
     // Assert that we sent an error back.
     verify(result).error(contains("NOT_FOUND"), contains(skuId), any());
+    verify(result, never()).success(any());
+  }
+
+  @Test
+  public void launchBillingFlow_oldSkuNotFound() {
+    // Try to launch the billing flow for a random sku ID
+    establishConnectedBillingClient(null, null);
+    String skuId = "foo";
+    String accountId = "account";
+    String oldSkuId = "oldSku";
+    queryForSkus(singletonList(skuId));
+    HashMap<String, Object> arguments = new HashMap<>();
+    arguments.put("sku", skuId);
+    arguments.put("accountId", accountId);
+    arguments.put("oldSku", oldSkuId);
+    MethodCall launchCall = new MethodCall(LAUNCH_BILLING_FLOW, arguments);
+
+    methodChannelHandler.onMethodCall(launchCall, result);
+
+    // Assert that we sent an error back.
+    verify(result).error(contains("IN_APP_PURCHASE_INVALID_OLD_SKU"), contains(oldSkuId), any());
     verify(result, never()).success(any());
   }
 

--- a/packages/in_app_purchase/example/lib/main.dart
+++ b/packages/in_app_purchase/example/lib/main.dart
@@ -19,10 +19,14 @@ void main() {
 const bool _kAutoConsume = true;
 
 const String _kConsumableId = 'consumable';
+const String _kUpgradeId = 'upgrade';
+const String _kSilverSubscriptionId = 'subscription_silver';
+const String _kGoldSubscriptionId = 'subscription_gold';
 const List<String> _kProductIds = <String>[
   _kConsumableId,
-  'upgrade',
-  'subscription'
+  _kUpgradeId,
+  _kSilverSubscriptionId,
+  _kGoldSubscriptionId,
 ];
 
 class _MyApp extends StatefulWidget {
@@ -252,9 +256,22 @@ class _MyAppState extends State<_MyApp> {
                       primary: Colors.white,
                     ),
                     onPressed: () {
+                      // NOTE: If you are making a subscription purchase/upgrade/downgrade, we recommend you to
+                      // verify the latest status of you your subscription by using server side receipt validation
+                      // and update the UI accordingly. The subscription purchase status shown
+                      // inside the app may not be accurate.
+                      final oldSubscription =
+                          _getOldSubscription(productDetails, purchases);
                       PurchaseParam purchaseParam = PurchaseParam(
                           productDetails: productDetails,
-                          applicationUserName: null);
+                          applicationUserName: null,
+                          changeSubscriptionParam: Platform.isAndroid &&
+                                  oldSubscription != null
+                              ? ChangeSubscriptionParam(
+                                  oldPurchaseDetails: oldSubscription,
+                                  prorationMode:
+                                      ProrationMode.immediateWithTimeProration)
+                              : null);
                       if (productDetails.id == _kConsumableId) {
                         _connection.buyConsumable(
                             purchaseParam: purchaseParam,
@@ -386,5 +403,25 @@ class _MyAppState extends State<_MyApp> {
         }
       }
     });
+  }
+
+  PurchaseDetails? _getOldSubscription(
+      ProductDetails productDetails, Map<String, PurchaseDetails> purchases) {
+    // This is just to demonstrate a subscription upgrade or downgrade.
+    // This method assumes that you have only 2 subscriptions under a group, 'subscription_silver' & 'subscription_gold'.
+    // The 'subscription_silver' subscription can be upgraded to 'subscription_gold' and
+    // the 'subscription_gold' subscription can be downgraded to 'subscription_silver'.
+    // Please remember to replace the logic of finding the old subscription Id as per your app.
+    // The old subscription is only required on Android since Apple handles this internally
+    // by using the subscription group feature in iTunesConnect.
+    PurchaseDetails? oldSubscription;
+    if (productDetails.id == _kSilverSubscriptionId &&
+        purchases[_kGoldSubscriptionId] != null) {
+      oldSubscription = purchases[_kGoldSubscriptionId];
+    } else if (productDetails.id == _kGoldSubscriptionId &&
+        purchases[_kSilverSubscriptionId] != null) {
+      oldSubscription = purchases[_kSilverSubscriptionId];
+    }
+    return oldSubscription;
   }
 }

--- a/packages/in_app_purchase/lib/src/billing_client_wrappers/enum_converters.dart
+++ b/packages/in_app_purchase/lib/src/billing_client_wrappers/enum_converters.dart
@@ -50,12 +50,34 @@ class SkuTypeConverter implements JsonConverter<SkuType, String?> {
   String toJson(SkuType object) => _$SkuTypeEnumMap[object]!;
 }
 
+/// Serializer for [ProrationMode].
+///
+/// Use these in `@JsonSerializable()` classes by annotating them with
+/// `@ProrationModeConverter()`.
+class ProrationModeConverter implements JsonConverter<ProrationMode, int?> {
+  /// Default const constructor.
+  const ProrationModeConverter();
+
+  @override
+  ProrationMode fromJson(int? json) {
+    if (json == null) {
+      return ProrationMode.unknownSubscriptionUpgradeDowngradePolicy;
+    }
+    return _$enumDecode<ProrationMode, dynamic>(
+        _$ProrationModeEnumMap.cast<ProrationMode, dynamic>(), json);
+  }
+
+  @override
+  int toJson(ProrationMode object) => _$ProrationModeEnumMap[object]!;
+}
+
 // Define a class so we generate serializer helper methods for the enums
 @JsonSerializable()
 class _SerializedEnums {
   late BillingResponse response;
   late SkuType type;
   late PurchaseStateWrapper purchaseState;
+  late ProrationMode prorationMode;
 }
 
 /// Serializer for [PurchaseStateWrapper].

--- a/packages/in_app_purchase/lib/src/billing_client_wrappers/enum_converters.g.dart
+++ b/packages/in_app_purchase/lib/src/billing_client_wrappers/enum_converters.g.dart
@@ -11,7 +11,9 @@ _SerializedEnums _$_SerializedEnumsFromJson(Map json) {
     ..response = _$enumDecode(_$BillingResponseEnumMap, json['response'])
     ..type = _$enumDecode(_$SkuTypeEnumMap, json['type'])
     ..purchaseState =
-        _$enumDecode(_$PurchaseStateWrapperEnumMap, json['purchaseState']);
+        _$enumDecode(_$PurchaseStateWrapperEnumMap, json['purchaseState'])
+    ..prorationMode =
+        _$enumDecode(_$ProrationModeEnumMap, json['prorationMode']);
 }
 
 Map<String, dynamic> _$_SerializedEnumsToJson(_SerializedEnums instance) =>
@@ -19,6 +21,7 @@ Map<String, dynamic> _$_SerializedEnumsToJson(_SerializedEnums instance) =>
       'response': _$BillingResponseEnumMap[instance.response],
       'type': _$SkuTypeEnumMap[instance.type],
       'purchaseState': _$PurchaseStateWrapperEnumMap[instance.purchaseState],
+      'prorationMode': _$ProrationModeEnumMap[instance.prorationMode],
     };
 
 K _$enumDecode<K, V>(
@@ -71,4 +74,12 @@ const _$PurchaseStateWrapperEnumMap = {
   PurchaseStateWrapper.unspecified_state: 0,
   PurchaseStateWrapper.purchased: 1,
   PurchaseStateWrapper.pending: 2,
+};
+
+const _$ProrationModeEnumMap = {
+  ProrationMode.unknownSubscriptionUpgradeDowngradePolicy: 0,
+  ProrationMode.immediateWithTimeProration: 1,
+  ProrationMode.immediateAndChargeProratedPrice: 2,
+  ProrationMode.immediateWithoutProration: 3,
+  ProrationMode.deferred: 4,
 };

--- a/packages/in_app_purchase/lib/src/in_app_purchase/app_store_connection.dart
+++ b/packages/in_app_purchase/lib/src/in_app_purchase/app_store_connection.dart
@@ -56,6 +56,15 @@ class AppStoreConnection implements InAppPurchaseConnection {
 
   @override
   Future<bool> buyNonConsumable({required PurchaseParam purchaseParam}) async {
+    assert(
+        purchaseParam.changeSubscriptionParam == null,
+        "`purchaseParam.changeSubscriptionParam` must be null. It is not supported on iOS "
+        "as Apple provides a subscription grouping mechanism. "
+        "Each subscription you offer must be assigned to a subscription group. "
+        "So the developers can group related subscriptions together to prevents users "
+        "from accidentally purchasing multiple subscriptions. "
+        "Please refer to the 'Creating a Subscription Group' sections of "
+        "Apple's subscription guide (https://developer.apple.com/app-store/subscriptions/)");
     await _skPaymentQueueWrapper.addPayment(SKPaymentWrapper(
         productIdentifier: purchaseParam.productDetails.id,
         quantity: 1,

--- a/packages/in_app_purchase/lib/src/in_app_purchase/google_play_connection.dart
+++ b/packages/in_app_purchase/lib/src/in_app_purchase/google_play_connection.dart
@@ -63,7 +63,11 @@ class GooglePlayConnection
     BillingResultWrapper billingResultWrapper =
         await billingClient.launchBillingFlow(
             sku: purchaseParam.productDetails.id,
-            accountId: purchaseParam.applicationUserName);
+            accountId: purchaseParam.applicationUserName,
+            oldSku: purchaseParam
+                .changeSubscriptionParam?.oldPurchaseDetails.productID,
+            prorationMode:
+                purchaseParam.changeSubscriptionParam?.prorationMode);
     return billingResultWrapper.responseCode == BillingResponse.ok;
   }
 

--- a/packages/in_app_purchase/lib/src/in_app_purchase/purchase_details.dart
+++ b/packages/in_app_purchase/lib/src/in_app_purchase/purchase_details.dart
@@ -90,7 +90,8 @@ class PurchaseParam {
       {required this.productDetails,
       this.applicationUserName,
       this.sandboxTesting = false,
-      this.simulatesAskToBuyInSandbox = false});
+      this.simulatesAskToBuyInSandbox = false,
+      this.changeSubscriptionParam});
 
   /// The product to create payment for.
   ///
@@ -117,6 +118,38 @@ class PurchaseParam {
   ///
   /// See also [SKPaymentWrapper.simulatesAskToBuyInSandbox].
   final bool simulatesAskToBuyInSandbox;
+
+  /// The 'changeSubscriptionParam' is only available on Android, for upgrading or
+  /// downgrading an existing subscription.
+  ///
+  /// This does not require on iOS since Apple provides a way to group related subscriptions
+  /// together in iTunesConnect. So when a subscription upgrade or downgrade is requested,
+  /// Apple finds the old subscription details from the group and handle it automatically.
+  final ChangeSubscriptionParam? changeSubscriptionParam;
+}
+
+/// This parameter object which is only applicable on Android for upgrading or downgrading an existing subscription.
+///
+/// This does not require on iOS since iTunesConnect provides a subscription grouping mechanism.
+/// Each subscription you offer must be assigned to a subscription group.
+/// So the developers can group related subscriptions together to prevent users from
+/// accidentally purchasing multiple subscriptions.
+///
+/// Please refer to the 'Creating a Subscription Group' sections of [Apple's subscription guide](https://developer.apple.com/app-store/subscriptions/)
+class ChangeSubscriptionParam {
+  /// Creates a new change subscription param object with given data
+  ChangeSubscriptionParam(
+      {required this.oldPurchaseDetails, this.prorationMode});
+
+  /// The purchase object of the existing subscription that the user needs to
+  /// upgrade/downgrade from.
+  final PurchaseDetails oldPurchaseDetails;
+
+  /// The proration mode.
+  ///
+  /// This is an optional parameter that indicates how to handle the existing
+  /// subscription when the new subscription comes into effect.
+  final ProrationMode? prorationMode;
 }
 
 /// Represents the transaction details of a purchase.

--- a/packages/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/pubspec.yaml
@@ -1,7 +1,7 @@
 name: in_app_purchase
 description: A Flutter plugin for in-app purchases. Exposes APIs for making in-app purchases through the App Store and Google Play.
 homepage: https://github.com/flutter/plugins/tree/master/packages/in_app_purchase
-version: 0.4.0
+version: 0.4.1
 
 dependencies:
   flutter:

--- a/packages/in_app_purchase/test/billing_client_wrappers/billing_client_wrapper_test.dart
+++ b/packages/in_app_purchase/test/billing_client_wrappers/billing_client_wrapper_test.dart
@@ -207,6 +207,64 @@ void main() {
       expect(arguments['accountId'], equals(accountId));
     });
 
+    test(
+        'serializes and deserializes data on change subscription without proration',
+        () async {
+      const String debugMessage = 'dummy message';
+      final BillingResponse responseCode = BillingResponse.ok;
+      final BillingResultWrapper expectedBillingResult = BillingResultWrapper(
+          responseCode: responseCode, debugMessage: debugMessage);
+      stubPlatform.addResponse(
+        name: launchMethodName,
+        value: buildBillingResultMap(expectedBillingResult),
+      );
+      final SkuDetailsWrapper skuDetails = dummySkuDetails;
+      final String accountId = "hashedAccountId";
+
+      expect(
+          await billingClient.launchBillingFlow(
+              sku: skuDetails.sku,
+              accountId: accountId,
+              oldSku: dummyOldPurchase.sku),
+          equals(expectedBillingResult));
+      Map<dynamic, dynamic> arguments =
+          stubPlatform.previousCallMatching(launchMethodName).arguments;
+      expect(arguments['sku'], equals(skuDetails.sku));
+      expect(arguments['accountId'], equals(accountId));
+      expect(arguments['oldSku'], equals(dummyOldPurchase.sku));
+    });
+
+    test(
+        'serializes and deserializes data on change subscription with proration',
+        () async {
+      const String debugMessage = 'dummy message';
+      final BillingResponse responseCode = BillingResponse.ok;
+      final BillingResultWrapper expectedBillingResult = BillingResultWrapper(
+          responseCode: responseCode, debugMessage: debugMessage);
+      stubPlatform.addResponse(
+        name: launchMethodName,
+        value: buildBillingResultMap(expectedBillingResult),
+      );
+      final SkuDetailsWrapper skuDetails = dummySkuDetails;
+      final String accountId = "hashedAccountId";
+      final prorationMode = ProrationMode.immediateAndChargeProratedPrice;
+
+      expect(
+          await billingClient.launchBillingFlow(
+              sku: skuDetails.sku,
+              accountId: accountId,
+              oldSku: dummyOldPurchase.sku,
+              prorationMode: prorationMode),
+          equals(expectedBillingResult));
+      Map<dynamic, dynamic> arguments =
+          stubPlatform.previousCallMatching(launchMethodName).arguments;
+      expect(arguments['sku'], equals(skuDetails.sku));
+      expect(arguments['accountId'], equals(accountId));
+      expect(arguments['oldSku'], equals(dummyOldPurchase.sku));
+      expect(arguments['prorationMode'],
+          ProrationModeConverter().toJson(prorationMode));
+    });
+
     test('handles null accountId', () async {
       const String debugMessage = 'dummy message';
       final BillingResponse responseCode = BillingResponse.ok;

--- a/packages/in_app_purchase/test/billing_client_wrappers/purchase_wrapper_test.dart
+++ b/packages/in_app_purchase/test/billing_client_wrappers/purchase_wrapper_test.dart
@@ -46,6 +46,20 @@ final PurchaseHistoryRecordWrapper dummyPurchaseHistoryRecord =
   developerPayload: 'dummy payload',
 );
 
+final PurchaseWrapper dummyOldPurchase = PurchaseWrapper(
+  orderId: 'oldOrderId',
+  packageName: 'oldPackageName',
+  purchaseTime: 0,
+  signature: 'oldSignature',
+  sku: 'oldSku',
+  purchaseToken: 'oldPurchaseToken',
+  isAutoRenewing: false,
+  originalJson: '',
+  developerPayload: 'old dummy payload',
+  isAcknowledged: true,
+  purchaseState: PurchaseStateWrapper.purchased,
+);
+
 void main() {
   group('PurchaseWrapper', () {
     test('converts from map', () {


### PR DESCRIPTION
## Description

This pull request adds support for Upgrading/Downgrading an existing InApp subscription on Android. This does not require any changes on iOS since iTunesConnect provides a way to create a 'subscription group'.
Ref: https://developer.android.com/google/play/billing/billing_subscriptions#Allow-upgrade

Also, this supports Proration Mode that handles the user's existing subscription.
Ref: https://developer.android.com/google/play/billing/billing_subscriptions#set-proration-mode

While changing the subscription, this uses the old 'PurchaseDetails' object, rather than using 'ProductDetails' or just the 'oldSku' id itself, because, In the latest versions of the Play Billing Library, setOldSku() is deprecated (https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.Builder#setoldsku)
and the new method uses the old purchase token. So it is better to use the 'PurchaseDetails' object here since it contains the 'VerificationData' to prepare for the next releases.

Also, for simplicity, I just skipped updating the example project to make use of this change. Also because this is not a common use case.  

I am excited and looking forward to closing the issue that I reported.
## Related Issues
flutter/flutter#32395

#support

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
