### PR TITLE
[image_picker_for_web] Return filename with file extension

### DIFF
--- a/packages/image_picker/image_picker_for_web/CHANGELOG.md
+++ b/packages/image_picker/image_picker_for_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.0+2
+
+* Update `_handleOnChangeEvent` to return the filename with file extension.
+
 # 0.1.0+1
 
 * Remove `android` directory.

--- a/packages/image_picker/image_picker_for_web/lib/image_picker_for_web.dart
+++ b/packages/image_picker/image_picker_for_web/lib/image_picker_for_web.dart
@@ -89,13 +89,13 @@ class ImagePickerPlugin extends ImagePickerPlatform {
   }
 
   /// Handles the OnChange event from a FileUploadInputElement object
-  /// Returns the objectURL of the selected file.
+  /// Returns the filename with file extension of the selected file.
   String _handleOnChangeEvent(html.Event event) {
     final html.FileUploadInputElement input = event?.target;
     final html.File file = _getFileFromInput(input);
 
     if (file != null) {
-      return html.Url.createObjectUrl(file);
+      return file.name;
     }
     return null;
   }
@@ -105,9 +105,9 @@ class ImagePickerPlugin extends ImagePickerPlatform {
     final Completer<PickedFile> _completer = Completer<PickedFile>();
     // Observe the input until we can return something
     input.onChange.first.then((event) {
-      final objectUrl = _handleOnChangeEvent(event);
+      final objectName = _handleOnChangeEvent(event);
       if (!_completer.isCompleted) {
-        _completer.complete(PickedFile(objectUrl));
+        _completer.complete(PickedFile(objectName));
       }
     });
     input.onError.first.then((event) {

--- a/packages/image_picker/image_picker_for_web/pubspec.yaml
+++ b/packages/image_picker/image_picker_for_web/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker/i
 # 0.1.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.1.0+1
+version: 0.1.0+2
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Modified `_handleOnChangeEvent` to return the filename with file extension.
According to this change, I also modified the variable name `objectUrl` to `objectName` in `_getSelectedFile` since `_handleOnChangeEvent` returns the filename.

`PickedFile.path` previously returned an UUID like `blob:http://localhost:54500/a7ef4437-666b-42d4-a507-c4f91f96d902`, but now it will return the filename with file extension like `profile.png`. (I wonder if this is a breaking change...)

It's my first time contributing to flutter plugins, so I would appreciate any feedback or reviews. Thank you! :-) 

## Related Issues

Fixes https://github.com/flutter/flutter/issues/59308

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
