### PR TITLE
[e2e] Fix e2e pixel ratio

### DIFF
--- a/packages/e2e/CHANGELOG.md
+++ b/packages/e2e/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.0+1
+
+* Fixed the device pixel ratio problem.
+
 ## 0.5.0
 
 * **Breaking change** by default, tests will use the device window size.

--- a/packages/e2e/lib/e2e.dart
+++ b/packages/e2e/lib/e2e.dart
@@ -52,8 +52,8 @@ class E2EWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding {
   bool get registerTestTextInput => false;
 
   @override
-  ViewConfiguration createViewConfiguration() =>
-      TestViewConfiguration(size: window.physicalSize/window.devicePixelRatio);
+  ViewConfiguration createViewConfiguration() => TestViewConfiguration(
+      size: window.physicalSize / window.devicePixelRatio);
 
   final Completer<bool> _allTestsPassed = Completer<bool>();
 

--- a/packages/e2e/lib/e2e.dart
+++ b/packages/e2e/lib/e2e.dart
@@ -53,7 +53,7 @@ class E2EWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding {
 
   @override
   ViewConfiguration createViewConfiguration() =>
-      TestViewConfiguration(size: window.physicalSize);
+      TestViewConfiguration(size: window.physicalSize/window.devicePixelRatio);
 
   final Completer<bool> _allTestsPassed = Completer<bool>();
 

--- a/packages/e2e/pubspec.yaml
+++ b/packages/e2e/pubspec.yaml
@@ -1,6 +1,6 @@
 name: e2e
 description: Runs tests that use the flutter_test API as integration tests.
-version: 0.5.0
+version: 0.5.0+1
 homepage: https://github.com/flutter/plugins/tree/master/packages/e2e
 
 environment:


### PR DESCRIPTION
## Description

Fix the device pixel ratio for e2e. 

According to https://api.flutter.dev/flutter/flutter_test/TestViewConfiguration-class.html the size of `TestViewConfiguration` constructor is  in logical pixels. 

## Related Issues

flutter/flutter#59880

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
