### PR TITLE
[path_provider] Use the application ID in the application support path

### DIFF
--- a/packages/path_provider/path_provider_linux/CHANGELOG.md
+++ b/packages/path_provider/path_provider_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0
+* This release updaes getApplicationSupportPath to use the application ID instead of the executable name.
+  * Older apps will lose their preferences as they migrate to the new app ID based path.
+
 ## 0.0.1+2
 * This release updates the example to depend on the endorsed plugin rather than relative path
 

--- a/packages/path_provider/path_provider_linux/CHANGELOG.md
+++ b/packages/path_provider/path_provider_linux/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.1.0
-* This release updaes getApplicationSupportPath to use the application ID instead of the executable name.
-  * Older apps will lose their preferences as they migrate to the new app ID based path.
+* This release updates getApplicationSupportPath to use the application ID instead of the executable name.
+  * No migration is provided, so any older apps that were using this path will now have a different directory.
 
 ## 0.0.1+2
 * This release updates the example to depend on the endorsed plugin rather than relative path

--- a/packages/path_provider/path_provider_linux/lib/path_provider_linux.dart
+++ b/packages/path_provider/path_provider_linux/lib/path_provider_linux.dart
@@ -3,10 +3,20 @@
 // found in the LICENSE file.
 import 'dart:io';
 import 'dart:async';
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
 
 import 'package:xdg_directories/xdg_directories.dart' as xdg;
 import 'package:path/path.dart' as path;
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+
+// GApplication* g_application_get_default();
+typedef g_application_get_default_c = IntPtr Function();
+typedef g_application_get_default_dart = int Function();
+
+// const gchar* g_application_get_application_id(GApplication* application);
+typedef g_application_get_application_id_c = Pointer<Utf8> Function(IntPtr);
+typedef g_application_get_application_id_dart = Pointer<Utf8> Function(int);
 
 /// The linux implementation of [PathProviderPlatform]
 ///
@@ -22,11 +32,43 @@ class PathProviderLinux extends PathProviderPlatform {
     return Future.value("/tmp");
   }
 
+  // Gets the application ID set in GApplication.
+  String _getApplicationId() {
+    DynamicLibrary gio;
+    try {
+      gio = DynamicLibrary.open('libgio-2.0.so');
+    } on ArgumentError {
+      return null;
+    }
+    var g_application_get_default = gio.lookupFunction<
+        g_application_get_default_c,
+        g_application_get_default_dart>('g_application_get_default');
+    var app = g_application_get_default();
+    if (app == 0) return null;
+
+    var g_application_get_application_id = gio.lookupFunction<
+            g_application_get_application_id_c,
+            g_application_get_application_id_dart>(
+        'g_application_get_application_id');
+    var app_id = g_application_get_application_id(app);
+    if (app_id == null) return null;
+
+    return Utf8.fromUtf8(app_id);
+  }
+
+  // Gets the unique ID for this application.
+  Future<String> _getId() async {
+    var appId = _getApplicationId();
+    if (appId != null) return appId;
+
+    // Fall back to using the executable name.
+    return path.basenameWithoutExtension(
+        await File('/proc/self/exe').resolveSymbolicLinks());
+  }
+
   @override
   Future<String> getApplicationSupportPath() async {
-    final processName = path.basenameWithoutExtension(
-        await File('/proc/self/exe').resolveSymbolicLinks());
-    final directory = Directory(path.join(xdg.dataHome.path, processName));
+    final directory = Directory(path.join(xdg.dataHome.path, await _getId()));
     // Creating the directory if it doesn't exist, because mobile implementations assume the directory exists
     if (!await directory.exists()) {
       await directory.create(recursive: true);

--- a/packages/path_provider/path_provider_linux/pubspec.yaml
+++ b/packages/path_provider/path_provider_linux/pubspec.yaml
@@ -1,6 +1,6 @@
 name: path_provider_linux
 description: linux implementation of the path_provider plugin
-version: 0.0.1+2
+version: 0.1.0
 homepage: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider_linux
 
 flutter:
@@ -15,6 +15,7 @@ environment:
   flutter: ">=1.10.0 <2.0.0"
 
 dependencies:
+  ffi: ^0.1.3
   path: ^1.6.4
   xdg_directories: ^0.1.0
   path_provider_platform_interface: ^1.0.1


### PR DESCRIPTION
## Description

Use the application ID in the application support path. The existing code uses the binary name, which is not necessarily unique. Application IDs were recently added to the Linux shell.

## Related Issues

https://github.com/flutter/flutter/issues/59234

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
