### PR TITLE
[camera] Improving handling when camera permissions are not granted.

### DIFF
--- a/packages/camera/CHANGELOG.md
+++ b/packages/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.8+4
+
+* Improved error handling on Android when camera permissions are not granted.
+
 ## 0.5.8+3
 
 * Fix bug in usage example in README.md 

--- a/packages/camera/CHANGELOG.md
+++ b/packages/camera/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.5.8+4
 
-* Improved error handling on Android when camera permissions are not granted.
+* Fixed bug caused by casting a `CameraAccessException` on Android.
 
 ## 0.5.8+3
 

--- a/packages/camera/android/src/main/java/io/flutter/plugins/camera/MethodCallHandlerImpl.java
+++ b/packages/camera/android/src/main/java/io/flutter/plugins/camera/MethodCallHandlerImpl.java
@@ -167,8 +167,10 @@ final class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
   private void handleException(Exception exception, Result result) {
     if (exception instanceof CameraAccessException) {
       result.error("CameraAccess", exception.getMessage(), null);
+      return;
     }
 
+    // CameraAccessException can not be cast to a RuntimeException.
     throw (RuntimeException) exception;
   }
 }

--- a/packages/camera/pubspec.yaml
+++ b/packages/camera/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera
 description: A Flutter plugin for getting information about and controlling the
   camera on Android and iOS. Supports previewing the camera feed, capturing images, capturing video,
   and streaming image buffers to dart.
-version: 0.5.8+3
+version: 0.5.8+4
 
 homepage: https://github.com/flutter/plugins/tree/master/packages/camera
 


### PR DESCRIPTION
## Description

If camera permissions are not granted, the plugin currently throws an exception in Java:

```
E/MethodChannel#plugins.flutter.io/camera(22476): Failed to handle method call
E/MethodChannel#plugins.flutter.io/camera(22476): java.lang.ClassCastException: android.hardware.camera2.CameraAccessException cannot be cast to java.lang.RuntimeException
E/MethodChannel#plugins.flutter.io/camera(22476): 	at io.flutter.plugins.camera.MethodCallHandlerImpl.handleException(MethodCallHandlerImpl.java:172)
E/MethodChannel#plugins.flutter.io/camera(22476): 	at io.flutter.plugins.camera.MethodCallHandlerImpl.lambda$onMethodCall$0$MethodCallHandlerImpl(MethodCallHandlerImpl.java:66)
E/MethodChannel#plugins.flutter.io/camera(22476): 	at io.flutter.plugins.camera.-$$Lambda$MethodCallHandlerImpl$OMU5dV7VCKXKBT37_ThIybqlHuo.onResult(Unknown Source:6)
E/MethodChannel#plugins.flutter.io/camera(22476): 	at io.flutter.plugins.camera.CameraPermissions.requestPermissions(CameraPermissions.java:49)
E/MethodChannel#plugins.flutter.io/camera(22476): 	at io.flutter.plugins.camera.MethodCallHandlerImpl.onMethodCall(MethodCallHandlerImpl.java:57)
E/MethodChannel#plugins.flutter.io/camera(22476): 	at io.flutter.plugin.common.MethodChannel$IncomingMethodCallHandler.onMessage(MethodChannel.java:226)
E/MethodChannel#plugins.flutter.io/camera(22476): 	at io.flutter.embedding.engine.dart.DartMessenger.handleMessageFromDart(DartMessenger.java:85)
E/MethodChannel#plugins.flutter.io/camera(22476): 	at io.flutter.embedding.engine.FlutterJNI.handlePlatformMessage(FlutterJNI.java:631)
E/MethodChannel#plugins.flutter.io/camera(22476): 	at android.os.MessageQueue.nativePollOnce(Native Method)
E/MethodChannel#plugins.flutter.io/camera(22476): 	at android.os.MessageQueue.next(MessageQueue.java:336)
E/MethodChannel#plugins.flutter.io/camera(22476): 	at android.os.Looper.loop(Looper.java:174)
E/MethodChannel#plugins.flutter.io/camera(22476): 	at android.app.ActivityThread.main(ActivityThread.java:7356)
E/MethodChannel#plugins.flutter.io/camera(22476): 	at java.lang.reflect.Method.invoke(Native Method)
E/MethodChannel#plugins.flutter.io/camera(22476): 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
E/MethodChannel#plugins.flutter.io/camera(22476): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:930)
```

That's because the code attempts to cast a `CameraAccessException` to a `RuntimeException`. I think that part of the code is executed unintentionally: what's desired at this point is to fully handle the exception in Java and pass it to dart, i.e. don't throw it again.

## Related Issues

-
## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
