### PR TITLE
[e2e] Use SettableFutures instead of CompletableFuture

### DIFF
--- a/packages/e2e/CHANGELOG.md
+++ b/packages/e2e/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.6.0
 
-* **Breaking change** `E2EPlugin` exports a `ListenableFuture` for `testResults`.
+* **Breaking change** `E2EPlugin` exports a `Future` for `testResults`.
 
 ## 0.5.0+1
 

--- a/packages/e2e/CHANGELOG.md
+++ b/packages/e2e/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.0
+
+* **Breaking change** `E2EPlugin` exports a `ListenableFuture` for `testResults`.
+
 ## 0.5.0+1
 
 * Fixed the device pixel ratio problem.

--- a/packages/e2e/android/build.gradle
+++ b/packages/e2e/android/build.gradle
@@ -38,6 +38,7 @@ android {
         api 'androidx.test:runner:1.2.0'
         api 'androidx.test:rules:1.2.0'
         api 'androidx.test.espresso:espresso-core:3.2.0'
-        api 'com.google.guava:guava:28.1-android'
+
+        implementation 'com.google.guava:guava:28.1-android'
     }
 }

--- a/packages/e2e/android/build.gradle
+++ b/packages/e2e/android/build.gradle
@@ -33,11 +33,11 @@ android {
     }
     dependencies {
         api 'junit:junit:4.12'
-        implementation 'net.sourceforge.streamsupport:android-retrofuture:1.7.2'
 
         // https://developer.android.com/jetpack/androidx/releases/test/#1.2.0
         api 'androidx.test:runner:1.2.0'
         api 'androidx.test:rules:1.2.0'
         api 'androidx.test.espresso:espresso-core:3.2.0'
+        api 'com.google.guava:guava:28.1-android'
     }
 }

--- a/packages/e2e/android/src/main/java/dev/flutter/plugins/e2e/E2EPlugin.java
+++ b/packages/e2e/android/src/main/java/dev/flutter/plugins/e2e/E2EPlugin.java
@@ -5,7 +5,6 @@
 package dev.flutter.plugins.e2e;
 
 import android.content.Context;
-import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.plugin.common.BinaryMessenger;
@@ -15,6 +14,7 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
 import java.util.Map;
+import java.util.concurrent.Future;
 
 /** E2EPlugin */
 public class E2EPlugin implements MethodCallHandler, FlutterPlugin {
@@ -22,7 +22,7 @@ public class E2EPlugin implements MethodCallHandler, FlutterPlugin {
 
   private static final SettableFuture<Map<String, String>> testResultsSettable =
       SettableFuture.create();
-  public static final ListenableFuture<Map<String, String>> testResults = testResultsSettable;
+  public static final Future<Map<String, String>> testResults = testResultsSettable;
 
   private static final String CHANNEL = "plugins.flutter.io/e2e";
 

--- a/packages/e2e/android/src/main/java/dev/flutter/plugins/e2e/E2EPlugin.java
+++ b/packages/e2e/android/src/main/java/dev/flutter/plugins/e2e/E2EPlugin.java
@@ -5,6 +5,8 @@
 package dev.flutter.plugins.e2e;
 
 import android.content.Context;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
@@ -13,13 +15,14 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
 import java.util.Map;
-import java9.util.concurrent.CompletableFuture;
 
 /** E2EPlugin */
 public class E2EPlugin implements MethodCallHandler, FlutterPlugin {
   private MethodChannel methodChannel;
 
-  public static CompletableFuture<Map<String, String>> testResults = new CompletableFuture<>();
+  private static final SettableFuture<Map<String, String>> testResultsSettable =
+      SettableFuture.create();
+  public static final ListenableFuture<Map<String, String>> testResults = testResultsSettable;
 
   private static final String CHANNEL = "plugins.flutter.io/e2e";
 
@@ -49,7 +52,7 @@ public class E2EPlugin implements MethodCallHandler, FlutterPlugin {
   public void onMethodCall(MethodCall call, Result result) {
     if (call.method.equals("allTestsFinished")) {
       Map<String, String> results = call.argument("results");
-      testResults.complete(results);
+      testResultsSettable.set(results);
       result.success(null);
     } else {
       result.notImplemented();


### PR DESCRIPTION
## Description

This unblocks the import of the plugin internally.

## Related Issues

b/160208320

## Breaking Change

Breaking change if users depend on `E2EPlugin.testResults` as an instance of `CompletableFuture`.

- [x] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.
