### PR TITLE
[image_picker] Select any file with image_picker.

### DIFF
--- a/packages/image_picker/image_picker/CHANGELOG.md
+++ b/packages/image_picker/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.8
+
+* Add `getFile(allowedExtensions)` method so users can select any type of file (web only).
+
 ## 0.6.7+2
 
 * iOS: Fixes unpresentable album/image picker if window's root view controller is already presenting other view controller.

--- a/packages/image_picker/image_picker/example/lib/main.dart
+++ b/packages/image_picker/image_picker/example/lib/main.dart
@@ -6,6 +6,7 @@
 
 import 'dart:async';
 import 'dart:io';
+import 'package:intl/intl.dart' show NumberFormat;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -63,6 +64,16 @@ class _MyHomePageState extends State<MyHomePage> {
       await _controller.play();
       setState(() {});
     }
+  }
+
+  void _onSelectTextFilePressed({BuildContext context}) async {
+    if (_controller != null) {
+      await _controller.setVolume(0.0);
+    }
+    final PickedFile file = await _picker.getFile(
+      allowedExtensions: ['txt', 'json'],
+    );
+    return _displayTextFileContents(file, context: context);
   }
 
   void _onImageButtonPressed(ImageSource source, {BuildContext context}) async {
@@ -270,6 +281,19 @@ class _MyHomePageState extends State<MyHomePage> {
               child: const Icon(Icons.videocam),
             ),
           ),
+          if (kIsWeb)
+            Padding(
+              padding: const EdgeInsets.only(top: 16.0),
+              child: FloatingActionButton(
+                backgroundColor: Colors.green,
+                onPressed: () {
+                  _onSelectTextFilePressed(context: context);
+                },
+                heroTag: 'file',
+                tooltip: 'Select a file (.txt|.json)',
+                child: const Icon(Icons.picture_as_pdf),
+              ),
+            ),
         ],
       ),
     );
@@ -282,6 +306,38 @@ class _MyHomePageState extends State<MyHomePage> {
       return result;
     }
     return null;
+  }
+
+  Future<void> _displayTextFileContents(
+    PickedFile file, {
+    BuildContext context,
+  }) async {
+    final fileContents = await file.readAsString();
+    final size = NumberFormat.compact().format(await file.length());
+    return showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: Text('${file.name} (${size}B)'),
+          content: Scrollbar(
+            child: SingleChildScrollView(
+              child: Text(
+                fileContents,
+                style: TextStyle(fontFamily: "monospace"),
+              ),
+            ),
+          ),
+          actions: [
+            FlatButton(
+              child: const Text('CLOSE'),
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+            ),
+          ],
+        );
+      },
+    );
   }
 
   Future<void> _displayPickImageDialog(

--- a/packages/image_picker/image_picker/example/pubspec.yaml
+++ b/packages/image_picker/image_picker/example/pubspec.yaml
@@ -3,6 +3,7 @@ description: Demonstrates how to use the image_picker plugin.
 author: Flutter Team <flutter-dev@googlegroups.com>
 
 dependencies:
+  intl: ^0.16.1
   video_player: ^0.10.3
   flutter:
     sdk: flutter
@@ -21,5 +22,5 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.0.0-dev.28.0 <3.0.0"
+  sdk: ">=2.2.2 <3.0.0"
   flutter: ">=1.10.0 <2.0.0"

--- a/packages/image_picker/image_picker/lib/image_picker.dart
+++ b/packages/image_picker/image_picker/lib/image_picker.dart
@@ -165,6 +165,18 @@ class ImagePicker {
     );
   }
 
+  /// Returns an arbitrary [PickedFile].
+  ///
+  /// The [allowedExtensions] argument controls what files may be selected, for example:
+  /// \['pdf', 'doc'] to allow only to pick .pdf or .doc files.
+  ///
+  /// When empty, the plugin lets the user pick any file.
+  Future<PickedFile> getFile({
+    List<String> allowedExtensions = const [],
+  }) {
+    return platform.pickArbitraryFile(allowedExtensions: allowedExtensions);
+  }
+
   /// Retrieve the lost image file when [pickImage] or [pickVideo] failed because the  MainActivity is destroyed. (Android only)
   ///
   /// Image or video can be lost if the MainActivity is destroyed. And there is no guarantee that the MainActivity is always alive.

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker
 description: Flutter plugin for selecting images from the Android and iOS image
   library, and taking new pictures with the camera.
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker/image_picker
-version: 0.6.7+2
+version: 0.6.8
 
 flutter:
   plugin:
@@ -17,7 +17,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_plugin_android_lifecycle: ^1.0.2
-  image_picker_platform_interface: ^1.1.0
+  image_picker_platform_interface: ^1.2.0
 
 dev_dependencies:
   video_player: ^0.10.3

--- a/packages/image_picker/image_picker_for_web/CHANGELOG.md
+++ b/packages/image_picker/image_picker_for_web/CHANGELOG.md
@@ -1,7 +1,12 @@
-# 0.1.0+1
+## 0.1.1
+
+* Implement `pickArbitraryFile` platform method.
+* Initialize `name` and `size` of the picked file.
+
+## 0.1.0+1
 
 * Remove `android` directory.
 
-# 0.1.0
+## 0.1.0
 
 * Initial open-source release.

--- a/packages/image_picker/image_picker_for_web/pubspec.yaml
+++ b/packages/image_picker/image_picker_for_web/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker/i
 # 0.1.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.1.0+1
+version: 0.1.1
 
 flutter:
   plugin:
@@ -14,7 +14,7 @@ flutter:
         fileName: image_picker_for_web.dart
 
 dependencies:
-  image_picker_platform_interface: ^1.1.0
+  image_picker_platform_interface: ^1.2.0
   flutter:
     sdk: flutter
   flutter_web_plugins:

--- a/packages/image_picker/image_picker_platform_interface/CHANGELOG.md
+++ b/packages/image_picker/image_picker_platform_interface/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.2.0
+
+* Add `pickArbitraryFile` method to the platform interface. This allows users to pick any file type, not just images or videos.
+* Add `name` and `length()` methods to PickedFile.
+
 ## 1.1.0
 
 * Introduce PickedFile type for the new API.

--- a/packages/image_picker/image_picker_platform_interface/lib/src/platform_interface/image_picker_platform.dart
+++ b/packages/image_picker/image_picker_platform_interface/lib/src/platform_interface/image_picker_platform.dart
@@ -168,6 +168,18 @@ abstract class ImagePickerPlatform extends PlatformInterface {
     throw UnimplementedError('pickVideo() has not been implemented.');
   }
 
+  /// Returns an arbitrary [PickedFile].
+  ///
+  /// The `allowedExtensions` argument controls what files may be selected, for example:
+  /// \['pdf', 'doc'] to allow only to pick .pdf or .doc files.
+  ///
+  /// When `allowedExtensions` is null/empty, the plugin lets the user pick any file.
+  Future<PickedFile> pickArbitraryFile({
+    List<String> allowedExtensions = const [],
+  }) {
+    throw UnimplementedError('pickArbitraryFile() has not been implemented.');
+  }
+
   /// Retrieve the lost [PickedFile] file when [pickImage] or [pickVideo] failed because the MainActivity is destroyed. (Android only)
   ///
   /// Image or video can be lost if the MainActivity is destroyed. And there is no guarantee that the MainActivity is always alive.

--- a/packages/image_picker/image_picker_platform_interface/lib/src/types/picked_file/base.dart
+++ b/packages/image_picker/image_picker_platform_interface/lib/src/types/picked_file/base.dart
@@ -29,6 +29,18 @@ abstract class PickedFileBase {
     throw UnimplementedError('.path has not been implemented.');
   }
 
+  /// The name of the file as it was selected by the user in their device.
+  ///
+  /// Use only for cosmetic reasons, do not try to use this as a path.
+  String get name {
+    throw UnimplementedError('.name has not been implemented.');
+  }
+
+  /// Get the length of the file. Returns a `Future<int>` that completes with the length in bytes.
+  Future<int> length() {
+    throw UnimplementedError('.length() has not been implemented.');
+  }
+
   /// Synchronously read the entire file contents as a string using the given [Encoding].
   ///
   /// By default, `encoding` is [utf8].

--- a/packages/image_picker/image_picker_platform_interface/lib/src/types/picked_file/html.dart
+++ b/packages/image_picker/image_picker_platform_interface/lib/src/types/picked_file/html.dart
@@ -11,13 +11,24 @@ import './base.dart';
 class PickedFile extends PickedFileBase {
   final String path;
   final Uint8List _initBytes;
+  final int _length;
+  @override
+  final String name;
 
   /// Construct a PickedFile object from its ObjectUrl.
   ///
-  /// Optionally, this can be initialized with `bytes`
+  /// Optionally, this can be initialized with `bytes` and `length`
   /// so no http requests are performed to retrieve files later.
-  PickedFile(this.path, {Uint8List bytes})
-      : _initBytes = bytes,
+  ///
+  /// `name` needs to be passed from the outside, since we only have
+  /// access to it while we create the ObjectUrl.
+  PickedFile(
+    this.path, {
+    this.name,
+    int length,
+    Uint8List bytes,
+  })  : _initBytes = bytes,
+        _length = length,
         super(path);
 
   Future<Uint8List> get _bytes async {
@@ -25,6 +36,11 @@ class PickedFile extends PickedFileBase {
       return Future.value(UnmodifiableUint8ListView(_initBytes));
     }
     return http.readBytes(path);
+  }
+
+  @override
+  Future<int> length() async {
+    return _length ?? (await _bytes).length;
   }
 
   @override

--- a/packages/image_picker/image_picker_platform_interface/lib/src/types/picked_file/io.dart
+++ b/packages/image_picker/image_picker_platform_interface/lib/src/types/picked_file/io.dart
@@ -19,6 +19,16 @@ class PickedFile extends PickedFileBase {
   }
 
   @override
+  String get name {
+    return _file.path.split(Platform.pathSeparator).last;
+  }
+
+  @override
+  Future<int> length() {
+    return _file.length();
+  }
+
+  @override
   Future<String> readAsString({Encoding encoding = utf8}) {
     return _file.readAsString(encoding: encoding);
   }

--- a/packages/image_picker/image_picker_platform_interface/lib/src/types/picked_file/unsupported.dart
+++ b/packages/image_picker/image_picker_platform_interface/lib/src/types/picked_file/unsupported.dart
@@ -1,13 +1,25 @@
+import 'dart:typed_data';
+
 import './base.dart';
 
 /// A PickedFile is a cross-platform, simplified File abstraction.
 ///
 /// It wraps the bytes of a selected file, and its (platform-dependant) path.
 class PickedFile extends PickedFileBase {
-  /// Construct a PickedFile object, from its `bytes`.
+  /// Construct a PickedFile object from its path.
   ///
-  /// Optionally, you may pass a `path`. See caveats in [PickedFileBase.path].
-  PickedFile(String path) : super(path) {
+  /// Optionally, this can be initialized with `bytes` and `length`
+  /// so no http requests are performed to retrieve data later.
+  ///
+  /// `name` may be passed from the outside, for those cases where the effective
+  /// `path` of the file doesn't match what the user sees when selecting it
+  /// (like in web)
+  PickedFile(
+    String path, {
+    String name,
+    int length,
+    Uint8List bytes,
+  }) : super(path) {
     throw UnimplementedError(
         'PickedFile is not available in your current platform.');
   }

--- a/packages/image_picker/image_picker_platform_interface/pubspec.yaml
+++ b/packages/image_picker/image_picker_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the image_picker plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker/image_picker_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.1.0
+version: 1.2.0
 
 dependencies:
   flutter:

--- a/packages/image_picker/image_picker_platform_interface/test/picked_file_html_test.dart
+++ b/packages/image_picker/image_picker_platform_interface/test/picked_file_html_test.dart
@@ -12,17 +12,33 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:image_picker_platform_interface/image_picker_platform_interface.dart';
 
 final String expectedStringContents = 'Hello, world!';
+final int expectedSize = expectedStringContents.length;
 final Uint8List bytes = utf8.encode(expectedStringContents);
 final html.File textFile = html.File([bytes], 'hello.txt');
 final String textFileUrl = html.Url.createObjectUrl(textFile);
 
 void main() {
   group('Create with an objectUrl', () {
-    final pickedFile = PickedFile(textFileUrl);
+    final pickedFile =
+        PickedFile(textFileUrl, length: expectedSize, name: 'hello.txt');
+
+    test('Can get length', () async {
+      expect(await pickedFile.length(), equals(expectedSize));
+    });
+
+    test('Can get length from bytes', () async {
+      final pickedFile = PickedFile(textFileUrl);
+      expect(await pickedFile.length(), equals(expectedSize));
+    });
+
+    test('Extracts the filename', () async {
+      expect(pickedFile.name, equals('hello.txt'));
+    });
 
     test('Can be read as a string', () async {
       expect(await pickedFile.readAsString(), equals(expectedStringContents));
     });
+
     test('Can be read as bytes', () async {
       expect(await pickedFile.readAsBytes(), equals(bytes));
     });

--- a/packages/image_picker/image_picker_platform_interface/test/picked_file_io_test.dart
+++ b/packages/image_picker/image_picker_platform_interface/test/picked_file_io_test.dart
@@ -12,6 +12,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:image_picker_platform_interface/image_picker_platform_interface.dart';
 
 final String expectedStringContents = 'Hello, world!';
+final int expectedSize = expectedStringContents.length;
 final Uint8List bytes = utf8.encode(expectedStringContents);
 final File textFile = File('./assets/hello.txt');
 final String textFilePath = textFile.path;
@@ -20,9 +21,18 @@ void main() {
   group('Create with an objectUrl', () {
     final pickedFile = PickedFile(textFilePath);
 
+    test('Can get length', () async {
+      expect(await pickedFile.length(), equals(expectedSize));
+    });
+
+    test('Extracts the filename', () async {
+      expect(pickedFile.name, equals('hello.txt'));
+    });
+
     test('Can be read as a string', () async {
       expect(await pickedFile.readAsString(), equals(expectedStringContents));
     });
+
     test('Can be read as bytes', () async {
       expect(await pickedFile.readAsBytes(), equals(bytes));
     });


### PR DESCRIPTION
## Description

This PR adds a `Future<PickedFile> getFile({List<String> allowedExtensions})` method to the image_picker plugin, so users can select any arbitrary file from their device (not just images or videos).

This is the full PoC PR. In order for this to be merged, it needs to be split in 3 PRs: platform_interface, web version and finally, core plugin.

You can see a deployed version of this PR here:

* ### https://dit-picker-tests.web.app

This also adds a few extra fields to the `PickedFile` object: `name` and `length()`, to retrieve the file name and size (in bytes) of the picked file.

## Related Issues

* [\[web\] How to select files?](https://github.com/flutter/flutter/issues/35671)
* [image_picker PickedFile should have a "length" method similar to File](https://github.com/flutter/flutter/issues/58764)
* [Add file picker to DevTools](https://github.com/flutter/devtools/issues/2149)

## Other platforms

This seems doable in other platforms (but this PR only covers the web version).

* Linux: https://github.com/mlabbe/nativefiledialog
* Windows: https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.openfiledialog?view=netcore-3.1
* MacOS: https://stackoverflow.com/questions/4289511/nsopenpanel-set-file-type
* iOS: https://pspdfkit.com/blog/2019/the-bittersweet-ios-document-browser/
* Android: https://stackoverflow.com/questions/46491433/android-limit-intent-action-get-content-to-a-specific-file-extension (needs converting extensions to the correct mime-type)
...

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
