### PR TITLE
[e2e] Add customizable `flutter_driver` adaptor

### DIFF
--- a/packages/e2e/CHANGELOG.md
+++ b/packages/e2e/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.3
+
+* Add customizable `flutter_driver` adaptor.
+
 ## 0.6.2+1
 
 * Fix incorrect test results when one test passes then another fails

--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -10,7 +10,7 @@ iOS support is not available yet, but is planned in the future.
 
 Add a dependency on the `e2e` package in the
 `dev_dependencies` section of pubspec.yaml. For plugins, do this in the
-pubspec.yaml of the example app.
+`pubspec.yaml` of the example app.
 
 Invoke `E2EWidgetsFlutterBinding.ensureInitialized()` at the start
 of a test file, e.g.
@@ -45,7 +45,7 @@ import 'dart:async';
 
 import 'package:e2e/e2e_driver.dart' as e2e;
 
-Future<void> main() async => e2e.main();
+Future<void> main() async => e2e.e2eDriver();
 
 ```
 

--- a/packages/e2e/example/test_driver/example_e2e_test.dart
+++ b/packages/e2e/example/test_driver/example_e2e_test.dart
@@ -2,4 +2,4 @@ import 'dart:async';
 
 import 'package:e2e/e2e_driver.dart' as e2e;
 
-Future<void> main() async => e2e.main();
+Future<void> main() async => e2e.e2eDriver();

--- a/packages/e2e/lib/e2e_driver.dart
+++ b/packages/e2e/lib/e2e_driver.dart
@@ -19,12 +19,20 @@ Future<void> main() async => e2eDriver();
 /// Future<void> main() async => e2e.e2eDriver();
 ///
 /// ```
+///
+/// `timeout` controls the longest time waited before the test ends, not
+/// necessarily the execution time for the test app.
+///
+/// `traceTimeline` flag controls if timeline and timeline summary should be
+/// collected.
+///
+/// `testName` is used as the file name for the output timeline files.
 Future<void> e2eDriver({
   Duration timeout = const Duration(minutes: 1),
-  String testName,
   bool traceTimeline = false,
+  String testName,
 }) async {
-  print(testName);
+  assert(!traceTimeline || testName != null);
   final FlutterDriver driver = await FlutterDriver.connect();
   String jsonResult;
   Timeline timeline;

--- a/packages/e2e/lib/e2e_driver.dart
+++ b/packages/e2e/lib/e2e_driver.dart
@@ -42,6 +42,7 @@ Future<void> e2eDriver({
 
   if (traceTimeline) {
     timeline = await driver.traceAction(runner);
+    // In the traceAction call runner is awaited.
   } else {
     await runner();
   }

--- a/packages/e2e/lib/e2e_driver.dart
+++ b/packages/e2e/lib/e2e_driver.dart
@@ -4,7 +4,7 @@ import 'dart:io';
 import 'package:e2e/common.dart' as e2e;
 import 'package:flutter_driver/flutter_driver.dart';
 
-Future<void> main() async => e2eDriver();
+Future<void> main() => e2eDriver();
 
 /// Adaptor to run E2E test using `flutter drive`.
 ///

--- a/packages/e2e/lib/e2e_driver.dart
+++ b/packages/e2e/lib/e2e_driver.dart
@@ -8,8 +8,16 @@ Future<void> main() async => e2eDriver();
 
 /// Adaptor to run E2E test using `flutter drive`.
 ///
-/// For an E2E test `<test_name>.dart`, put a file named `<test_name>_test.dart`
-/// in the app's `test_driver` directory:
+/// `timeout` controls the longest time waited before the test ends, not
+/// necessarily the execution time for the test app.
+///
+/// `traceTimeline` flag controls if timeline and timeline summary should be
+/// collected.
+///
+/// `testName` is used as the file name for the output timeline files.
+///
+/// To an E2E test `<test_name>.dart` using `flutter drive`, put a file named
+/// `<test_name>_test.dart` in the app's `test_driver` directory:
 ///
 /// ```dart
 /// import 'dart:async';
@@ -19,14 +27,6 @@ Future<void> main() async => e2eDriver();
 /// Future<void> main() async => e2e.e2eDriver();
 ///
 /// ```
-///
-/// `timeout` controls the longest time waited before the test ends, not
-/// necessarily the execution time for the test app.
-///
-/// `traceTimeline` flag controls if timeline and timeline summary should be
-/// collected.
-///
-/// `testName` is used as the file name for the output timeline files.
 Future<void> e2eDriver({
   Duration timeout = const Duration(minutes: 1),
   bool traceTimeline = false,

--- a/packages/e2e/lib/e2e_driver.dart
+++ b/packages/e2e/lib/e2e_driver.dart
@@ -24,7 +24,6 @@ Future<void> e2eDriver({
   String testName,
   bool traceTimeline = false,
 }) async {
-
   print(testName);
   final FlutterDriver driver = await FlutterDriver.connect();
   String jsonResult;
@@ -32,10 +31,10 @@ Future<void> e2eDriver({
   Future<void> runner() async {
     jsonResult = await driver.requestData(null, timeout: timeout);
   }
+
   if (traceTimeline) {
     timeline = await driver.traceAction(runner);
-  }
-  else {
+  } else {
     await runner();
   }
   final e2e.Response response = e2e.Response.fromJson(jsonResult);

--- a/packages/e2e/lib/e2e_driver.dart
+++ b/packages/e2e/lib/e2e_driver.dart
@@ -8,8 +8,9 @@ Future<void> main() async => e2eDriver();
 
 /// Adaptor to run E2E test using `flutter drive`.
 ///
-/// `timeout` controls the longest time waited before the test ends, not
-/// necessarily the execution time for the test app.
+/// `timeout` controls the longest time waited before the test ends.
+/// It is not necessarily the execution time for the test app.
+/// The test can and usually runs for shorter time if the test ends early.
 ///
 /// `traceTimeline` flag controls if timeline and timeline summary should be
 /// collected.

--- a/packages/e2e/lib/e2e_driver.dart
+++ b/packages/e2e/lib/e2e_driver.dart
@@ -9,8 +9,8 @@ Future<void> main() => e2eDriver();
 /// Adaptor to run E2E test using `flutter drive`.
 ///
 /// `timeout` controls the longest time waited before the test ends.
-/// It is not necessarily the execution time for the test app.
-/// The test can and usually runs for shorter time if the test ends early.
+/// It is not necessarily the execution time for the test app: the test may
+/// finish sooner than the `timeout`.
 ///
 /// `traceTimeline` flag controls if timeline and timeline summary should be
 /// collected.
@@ -33,6 +33,7 @@ Future<void> e2eDriver({
   bool traceTimeline = false,
   String testName,
 }) async {
+  assert(timeout != null);
   assert(!traceTimeline || testName != null);
   final FlutterDriver driver = await FlutterDriver.connect();
   String jsonResult;

--- a/packages/e2e/lib/e2e_driver.dart
+++ b/packages/e2e/lib/e2e_driver.dart
@@ -4,15 +4,50 @@ import 'dart:io';
 import 'package:e2e/common.dart' as e2e;
 import 'package:flutter_driver/flutter_driver.dart';
 
-Future<void> main() async {
+Future<void> main() async => e2eDriver();
+
+/// Adaptor to run E2E test using `flutter drive`.
+///
+/// For an E2E test `<test_name>.dart`, put a file named `<test_name>_test.dart`
+/// in the app's `test_driver` directory:
+///
+/// ```dart
+/// import 'dart:async';
+///
+/// import 'package:e2e/e2e_driver.dart' as e2e;
+///
+/// Future<void> main() async => e2e.e2eDriver();
+///
+/// ```
+Future<void> e2eDriver({
+  Duration timeout = const Duration(minutes: 1),
+  String testName,
+  bool traceTimeline = false,
+}) async {
+
+  print(testName);
   final FlutterDriver driver = await FlutterDriver.connect();
-  final String jsonResult =
-      await driver.requestData(null, timeout: const Duration(minutes: 1));
+  String jsonResult;
+  Timeline timeline;
+  Future<void> runner() async {
+    jsonResult = await driver.requestData(null, timeout: timeout);
+  }
+  if (traceTimeline) {
+    timeline = await driver.traceAction(runner);
+  }
+  else {
+    await runner();
+  }
   final e2e.Response response = e2e.Response.fromJson(jsonResult);
   await driver.close();
 
   if (response.allTestsPassed) {
     print('All tests passed.');
+    if (traceTimeline) {
+      final TimelineSummary summary = TimelineSummary.summarize(timeline);
+      await summary.writeTimelineToFile(testName, pretty: true);
+      await summary.writeSummaryToFile(testName, pretty: true);
+    }
     exit(0);
   } else {
     print('Failure Details:\n${response.formattedFailureDetails}');

--- a/packages/e2e/pubspec.yaml
+++ b/packages/e2e/pubspec.yaml
@@ -1,6 +1,6 @@
 name: e2e
 description: Runs tests that use the flutter_test API as integration tests.
-version: 0.6.2+1
+version: 0.6.3
 homepage: https://github.com/flutter/plugins/tree/master/packages/e2e
 
 environment:


### PR DESCRIPTION
## Description

Add a customizable `flutter_driver` adaptor, allowing changing timeout time, flag to enable timeline tracing. 
A use case is [here](https://github.com/CareF/measure_overhead) where I'm using the timeline to estimate overhead of `E2E` and `flutter_driver` (E2E is better!) 

## Related Issues

Not a full implementation but can be considered a work around for flutter/flutter#58789

## Test

It seems that we don't yet have unit test for E2E. I changed the related example. 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
