### PR TITLE
[image_picker] Fixes an issue where videos could be wrongly picked with .jpg extension

### DIFF
--- a/packages/image_picker/image_picker/CHANGELOG.md
+++ b/packages/image_picker/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.7+13
+
+* Android: fixes an issue where videos could be wrongly picked with `.jpg` extension.
+
 ## 0.6.7+12
 
 * Update android compileSdkVersion to 29.

--- a/packages/image_picker/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
+++ b/packages/image_picker/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
@@ -23,8 +23,10 @@
 
 package io.flutter.plugins.imagepicker;
 
+import android.content.ContentResolver;
 import android.content.Context;
 import android.net.Uri;
+import android.webkit.MimeTypeMap;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -39,7 +41,7 @@ class FileUtils {
     OutputStream outputStream = null;
     boolean success = false;
     try {
-      String extension = getImageExtension(uri);
+      String extension = getImageExtension(context, uri);
       inputStream = context.getContentResolver().openInputStream(uri);
       file = File.createTempFile("image_picker", extension, context.getCacheDir());
       file.deleteOnExit();
@@ -67,13 +69,17 @@ class FileUtils {
   }
 
   /** @return extension of image with dot, or default .jpg if it none. */
-  private static String getImageExtension(Uri uriImage) {
+  private static String getImageExtension(Context context, Uri uriImage) {
     String extension = null;
 
     try {
-      String imagePath = uriImage.getPath();
-      if (imagePath != null && imagePath.lastIndexOf(".") != -1) {
-        extension = imagePath.substring(imagePath.lastIndexOf(".") + 1);
+      if (uriImage.getScheme().equals(ContentResolver.SCHEME_CONTENT)) {
+        final MimeTypeMap mime = MimeTypeMap.getSingleton();
+        extension = mime.getExtensionFromMimeType(context.getContentResolver().getType(uriImage));
+      } else {
+        extension =
+            MimeTypeMap.getFileExtensionFromUrl(
+                Uri.fromFile(new File(uriImage.getPath())).toString());
       }
     } catch (Exception e) {
       extension = null;

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker
 description: Flutter plugin for selecting images from the Android and iOS image
   library, and taking new pictures with the camera.
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker/image_picker
-version: 0.6.7+12
+version: 0.6.7+13
 
 flutter:
   plugin:


### PR DESCRIPTION
Fixes an issue where videos could be wrongly picked with `.jpg` extension.

## Description

When picking videos on Android devices, it will return file names ended with `.jpg` extension, regardless of the file being actually a video. This requires a workaround implementation, such as opening a File descriptor on Flutter side and rename it to `.mp4` again.

The issue happens because some URI paths doesn't have an extension and it was being extracted just by splitting the file name from `.` and getting the last part, which make it not quite reliable for some scenarios. Right now, I've updated the source to retrieve the extension based on the URI content.

As a note, this doesn't happen with all Android devices, but I can see it easily replicable with Samsung phones.

## Related Issues

Fixes [#52419](https://github.com/flutter/flutter/issues/52419)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
