### PR TITLE
[google_sign_in] use transparent_image lib

### DIFF
--- a/packages/google_sign_in/google_sign_in/lib/widgets.dart
+++ b/packages/google_sign_in/google_sign_in/lib/widgets.dart
@@ -2,10 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:typed_data';
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:transparent_image/transparent_image.dart';
 
 import 'src/common.dart';
 import 'src/fife.dart' as fife;
@@ -117,9 +116,7 @@ class GoogleUserCircleAvatar extends StatelessWidget {
           child: Stack(fit: StackFit.expand, children: <Widget>[
             placeholder,
             FadeInImage.memoryNetwork(
-              // This creates a transparent placeholder image, so that
-              // [placeholder] shows through.
-              placeholder: Uint8List((size.round() * size.round())),
+              placeholder: kTransparentImage,
               image: sizedPhotoUrl,
             )
           ]),

--- a/packages/google_sign_in/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_sign_in
 description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android and iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_sign_in/google_sign_in
-version: 4.5.1
+version: 4.5.2
 
 flutter:
   plugin:
@@ -16,6 +16,7 @@ flutter:
         default_package: google_sign_in_web
 
 dependencies:
+  transparent_image: ^1.0.0
   google_sign_in_platform_interface: ^1.1.1
   flutter:
     sdk: flutter


### PR DESCRIPTION
## Description

Instead of using an empty Uint8List for placeholder in GoogleUserCircleAvatar, we should use transparent_image

## Related Issues

https://github.com/flutter/flutter/issues/55639

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
