### PR TITLE
[video_player] Clarify the use of NSAllowsArbitraryLoads

### DIFF
--- a/packages/video_player/video_player/README.md
+++ b/packages/video_player/video_player/README.md
@@ -25,7 +25,8 @@ First, add `video_player` as a [dependency in your pubspec.yaml file](https://fl
 
 Warning: The video player is not functional on iOS simulators. An iOS device must be used during development/testing.
 
-Add the following entry to your _Info.plist_ file, located in `<project root>/ios/Runner/Info.plist`:
+If you want to play videos over an insecure HTTP connection add the following entry to your _Info.plist_ file, 
+located in `<project root>/ios/Runner/Info.plist`:
 
 ```xml
 <key>NSAppTransportSecurity</key>
@@ -35,7 +36,7 @@ Add the following entry to your _Info.plist_ file, located in `<project root>/io
 </dict>
 ```
 
-This entry allows your app to access video files by URL.
+This entry allows your app to access video files by a HTTP URL, this is not needed if you always load your videos over HTTPS.
 
 ### Android
 


### PR DESCRIPTION
## Description

As stated by Apple's documentation [App Transport Security (ATS)](https://developer.apple.com/documentation/bundleresources/information_property_list/nsapptransportsecurity) enforces that any request must be encrypted. So HTTP would be disallowed by default.

The documentation in the README implied that the setting is required for ALL cases, not only if you want to use HTTP video URLs. Due to this unclear documentation the setting almost ended up in our app, where we do want to enforce the use of HTTPS.

I've scanned through the repo of video_player and it does not seem like that there are any HTTP requests made that would require this setting to be used by everyone. I would be happy to be proven otherwise 😊.

If I could I would remove the part about ATS completely, but it seems like that there is still issues where this is helpful to some. flutter/flutter#29502

## Related Issues

flutter/flutter#54955

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
