### PR TITLE
Make package:e2e a relative reference

### DIFF
--- a/packages/android_alarm_manager/CHANGELOG.md
+++ b/packages/android_alarm_manager/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.5+12
+
+* Update package:e2e reference to use the local version in the flutter/plugins
+  repository.
+
 ## 0.4.5+11
 
 * Update lower bound of dart dependency to 2.1.0.

--- a/packages/android_alarm_manager/example/pubspec.yaml
+++ b/packages/android_alarm_manager/example/pubspec.yaml
@@ -7,7 +7,8 @@ dependencies:
   android_alarm_manager:
     path: ../
   shared_preferences: ^0.5.6
-  e2e: 0.3.0
+  e2e:
+    path: ../../e2e
   path_provider: ^1.3.1
 
 dev_dependencies:

--- a/packages/android_alarm_manager/example/test_driver/android_alarm_manager_e2e_test.dart
+++ b/packages/android_alarm_manager/example/test_driver/android_alarm_manager_e2e_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_driver/flutter_driver.dart';
@@ -33,9 +34,12 @@ Future<void> main() async {
   // for this plugin will need to be resumed for the test to pass.
   final StreamSubscription<VMIsolateRef> subscription =
       await resumeIsolatesOnPause(driver);
-  final String result =
-      await driver.requestData(null, timeout: const Duration(minutes: 5));
+  final String data = await driver.requestData(
+    null,
+    timeout: const Duration(minutes: 1),
+  );
   await driver.close();
   await subscription.cancel();
-  exit(result == 'pass' ? 0 : 1);
+  final Map<String, dynamic> result = jsonDecode(data);
+  exit(result['result'] == 'true' ? 0 : 1);
 }

--- a/packages/android_intent/example/android/app/src/androidTestDebug/java/io/flutter/plugins/androidintentexample/EmbeddingV1ActivityTest.java
+++ b/packages/android_intent/example/android/app/src/androidTestDebug/java/io/flutter/plugins/androidintentexample/EmbeddingV1ActivityTest.java
@@ -1,7 +1,7 @@
 package io.flutter.plugins.androidintentexample;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 

--- a/packages/android_intent/example/android/app/src/androidTestDebug/java/io/flutter/plugins/androidintentexample/EmbeddingV1ActivityTest.java
+++ b/packages/android_intent/example/android/app/src/androidTestDebug/java/io/flutter/plugins/androidintentexample/EmbeddingV1ActivityTest.java
@@ -5,7 +5,7 @@ import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class EmbeddingV1ActivityTest {
   @Rule
   public ActivityTestRule<EmbeddingV1Activity> rule =

--- a/packages/android_intent/example/android/app/src/androidTestDebug/java/io/flutter/plugins/androidintentexample/MainActivityTest.java
+++ b/packages/android_intent/example/android/app/src/androidTestDebug/java/io/flutter/plugins/androidintentexample/MainActivityTest.java
@@ -5,7 +5,7 @@ import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class MainActivityTest {
   @Rule public ActivityTestRule<MainActivity> rule = new ActivityTestRule<>(MainActivity.class);
 }

--- a/packages/android_intent/example/android/app/src/androidTestDebug/java/io/flutter/plugins/androidintentexample/MainActivityTest.java
+++ b/packages/android_intent/example/android/app/src/androidTestDebug/java/io/flutter/plugins/androidintentexample/MainActivityTest.java
@@ -1,7 +1,7 @@
 package io.flutter.plugins.androidintentexample;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 

--- a/packages/android_intent/example/pubspec.yaml
+++ b/packages/android_intent/example/pubspec.yaml
@@ -8,7 +8,8 @@ dependencies:
     path: ../
 
 dev_dependencies:
-  e2e: "^0.2.1"
+  e2e:
+    path: ../../e2e
   flutter_driver:
     sdk: flutter
   pedantic: ^1.8.0

--- a/packages/android_intent/example/test_driver/android_intent_e2e_test.dart
+++ b/packages/android_intent/example/test_driver/android_intent_e2e_test.dart
@@ -1,5 +1,3 @@
-
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/packages/android_intent/example/test_driver/android_intent_e2e_test.dart
+++ b/packages/android_intent/example/test_driver/android_intent_e2e_test.dart
@@ -1,12 +1,18 @@
+
+
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_driver/flutter_driver.dart';
 
 Future<void> main() async {
   final FlutterDriver driver = await FlutterDriver.connect();
-  final String result =
-      await driver.requestData(null, timeout: const Duration(minutes: 1));
+  final String data = await driver.requestData(
+    null,
+    timeout: const Duration(minutes: 1),
+  );
   await driver.close();
-  exit(result == 'pass' ? 0 : 1);
+  final Map<String, dynamic> result = jsonDecode(data);
+  exit(result['result'] == 'true' ? 0 : 1);
 }

--- a/packages/battery/CHANGELOG.md
+++ b/packages/battery/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.2
+
+* Update package:e2e reference to use the local version in the flutter/plugins
+  repository.
+
 ## 1.0.1
 
 * Update lower bound of dart dependency to 2.1.0.

--- a/packages/battery/example/android/app/src/androidTest/java/io/flutter/plugins/battery/EmbedderV1ActivityTest.java
+++ b/packages/battery/example/android/app/src/androidTest/java/io/flutter/plugins/battery/EmbedderV1ActivityTest.java
@@ -5,7 +5,7 @@
 package io.flutter.plugins.batteryexample;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 

--- a/packages/battery/example/android/app/src/androidTest/java/io/flutter/plugins/battery/EmbedderV1ActivityTest.java
+++ b/packages/battery/example/android/app/src/androidTest/java/io/flutter/plugins/battery/EmbedderV1ActivityTest.java
@@ -9,7 +9,7 @@ import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class EmbedderV1ActivityTest {
   @Rule
   public ActivityTestRule<EmbedderV1Activity> rule =

--- a/packages/battery/example/android/app/src/androidTest/java/io/flutter/plugins/battery/FlutterActivityTest.java
+++ b/packages/battery/example/android/app/src/androidTest/java/io/flutter/plugins/battery/FlutterActivityTest.java
@@ -10,7 +10,7 @@ import io.flutter.embedding.android.FlutterActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class FlutterActivityTest {
   @Rule
   public ActivityTestRule<FlutterActivity> rule = new ActivityTestRule<>(FlutterActivity.class);

--- a/packages/battery/example/android/app/src/androidTest/java/io/flutter/plugins/battery/FlutterActivityTest.java
+++ b/packages/battery/example/android/app/src/androidTest/java/io/flutter/plugins/battery/FlutterActivityTest.java
@@ -5,7 +5,7 @@
 package io.flutter.plugins.batteryexample;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import io.flutter.embedding.android.FlutterActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;

--- a/packages/battery/example/pubspec.yaml
+++ b/packages/battery/example/pubspec.yaml
@@ -10,7 +10,8 @@ dependencies:
 dev_dependencies:
   flutter_driver:
     sdk: flutter
-  e2e: ^0.2.1
+  e2e:
+    path: ../../e2e
   pedantic: ^1.8.0
 
 flutter:

--- a/packages/battery/pubspec.yaml
+++ b/packages/battery/pubspec.yaml
@@ -2,7 +2,7 @@ name: battery
 description: Flutter plugin for accessing information about the battery state
   (full, charging, discharging) on Android and iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/battery
-version: 1.0.1
+version: 1.0.2
 
 flutter:
   plugin:

--- a/packages/battery/pubspec.yaml
+++ b/packages/battery/pubspec.yaml
@@ -24,7 +24,8 @@ dev_dependencies:
   mockito: 3.0.0
   flutter_test:
     sdk: flutter
-  e2e: ^0.2.1
+  e2e:
+    path: ../e2e
   pedantic: ^1.8.0
 
 environment:

--- a/packages/camera/example/android/app/src/androidTestDebug/java/io/flutter/plugins/cameraexample/EmbeddingV1ActivityTest.java
+++ b/packages/camera/example/android/app/src/androidTestDebug/java/io/flutter/plugins/cameraexample/EmbeddingV1ActivityTest.java
@@ -1,7 +1,7 @@
 package io.flutter.plugins.cameraexample;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 

--- a/packages/camera/example/android/app/src/androidTestDebug/java/io/flutter/plugins/cameraexample/EmbeddingV1ActivityTest.java
+++ b/packages/camera/example/android/app/src/androidTestDebug/java/io/flutter/plugins/cameraexample/EmbeddingV1ActivityTest.java
@@ -5,7 +5,7 @@ import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class EmbeddingV1ActivityTest {
   @Rule
   public ActivityTestRule<EmbeddingV1Activity> rule =

--- a/packages/camera/example/android/app/src/androidTestDebug/java/io/flutter/plugins/cameraexample/FlutterActivityTest.java
+++ b/packages/camera/example/android/app/src/androidTestDebug/java/io/flutter/plugins/cameraexample/FlutterActivityTest.java
@@ -6,7 +6,7 @@ import io.flutter.embedding.android.FlutterActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class FlutterActivityTest {
   @Rule
   public ActivityTestRule<FlutterActivity> rule = new ActivityTestRule<>(FlutterActivity.class);

--- a/packages/camera/example/android/app/src/androidTestDebug/java/io/flutter/plugins/cameraexample/FlutterActivityTest.java
+++ b/packages/camera/example/android/app/src/androidTestDebug/java/io/flutter/plugins/cameraexample/FlutterActivityTest.java
@@ -1,7 +1,7 @@
 package io.flutter.plugins.cameraexample;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import io.flutter.embedding.android.FlutterActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;

--- a/packages/camera/example/pubspec.yaml
+++ b/packages/camera/example/pubspec.yaml
@@ -8,7 +8,8 @@ dependencies:
   flutter:
     sdk: flutter
   video_player: ^0.10.0
-  e2e: "^0.2.0"
+  e2e:
+    path: ../../e2e
 
 dev_dependencies:
   flutter_test:

--- a/packages/camera/example/test_driver/camera_e2e_test.dart
+++ b/packages/camera/example/test_driver/camera_e2e_test.dart
@@ -55,11 +55,6 @@ Future<void> main() async {
     'android.permission.RECORD_AUDIO'
   ]);
 
-  final String data = await driver.requestData(
-    null,
-    timeout: const Duration(minutes: 1),
-  );
-
   final Map<String, dynamic> result = jsonDecode(data);
   exit(result['result'] == 'true' ? 0 : 1);
 }

--- a/packages/camera/example/test_driver/camera_e2e_test.dart
+++ b/packages/camera/example/test_driver/camera_e2e_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_driver/flutter_driver.dart';
@@ -33,8 +34,10 @@ Future<void> main() async {
   ]);
   print('Starting test.');
   final FlutterDriver driver = await FlutterDriver.connect();
-  final String result =
-      await driver.requestData(null, timeout: const Duration(minutes: 1));
+  final String data = await driver.requestData(
+    null,
+    timeout: const Duration(minutes: 1),
+  );
   await driver.close();
   print('Test finished. Revoking camera permissions...');
   Process.runSync('adb', <String>[
@@ -51,5 +54,12 @@ Future<void> main() async {
     _examplePackage,
     'android.permission.RECORD_AUDIO'
   ]);
-  exit(result == 'pass' ? 0 : 1);
+
+    final String data = await driver.requestData(
+    null,
+    timeout: const Duration(minutes: 1),
+  );
+
+  final Map<String, dynamic> result = jsonDecode(data);
+  exit(result['result'] == 'true' ? 0 : 1);
 }

--- a/packages/camera/example/test_driver/camera_e2e_test.dart
+++ b/packages/camera/example/test_driver/camera_e2e_test.dart
@@ -55,7 +55,7 @@ Future<void> main() async {
     'android.permission.RECORD_AUDIO'
   ]);
 
-    final String data = await driver.requestData(
+  final String data = await driver.requestData(
     null,
     timeout: const Duration(minutes: 1),
   );

--- a/packages/connectivity/connectivity/CHANGELOG.md
+++ b/packages/connectivity/connectivity/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.9+1
+
+* Update package:e2e reference to use the local version in the flutter/plugins
+  repository.
+
 ## 0.4.9
 
 * Add support for `web` (by endorsing `connectivity_for_web` 0.3.0)

--- a/packages/connectivity/connectivity/example/android/app/src/main/java/io/flutter/plugins/connectivityexample/EmbeddingV1ActivityTest.java
+++ b/packages/connectivity/connectivity/example/android/app/src/main/java/io/flutter/plugins/connectivityexample/EmbeddingV1ActivityTest.java
@@ -5,7 +5,7 @@
 package io.flutter.plugins.connectivityexample;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 

--- a/packages/connectivity/connectivity/example/android/app/src/main/java/io/flutter/plugins/connectivityexample/EmbeddingV1ActivityTest.java
+++ b/packages/connectivity/connectivity/example/android/app/src/main/java/io/flutter/plugins/connectivityexample/EmbeddingV1ActivityTest.java
@@ -9,7 +9,7 @@ import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class EmbeddingV1ActivityTest {
   @Rule
   public ActivityTestRule<EmbeddingV1Activity> rule =

--- a/packages/connectivity/connectivity/example/android/app/src/main/java/io/flutter/plugins/connectivityexample/FlutterActivityTest.java
+++ b/packages/connectivity/connectivity/example/android/app/src/main/java/io/flutter/plugins/connectivityexample/FlutterActivityTest.java
@@ -10,7 +10,7 @@ import io.flutter.embedding.android.FlutterActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class FlutterActivityTest {
   @Rule
   public ActivityTestRule<FlutterActivity> rule = new ActivityTestRule<>(FlutterActivity.class);

--- a/packages/connectivity/connectivity/example/android/app/src/main/java/io/flutter/plugins/connectivityexample/FlutterActivityTest.java
+++ b/packages/connectivity/connectivity/example/android/app/src/main/java/io/flutter/plugins/connectivityexample/FlutterActivityTest.java
@@ -5,7 +5,7 @@
 package io.flutter.plugins.connectivityexample;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import io.flutter.embedding.android.FlutterActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;

--- a/packages/connectivity/connectivity/example/pubspec.yaml
+++ b/packages/connectivity/connectivity/example/pubspec.yaml
@@ -11,7 +11,8 @@ dev_dependencies:
   flutter_driver:
     sdk: flutter
   test: any
-  e2e: ^0.2.0
+  e2e:
+    path: ../../../e2e
   pedantic: ^1.8.0
 
 flutter:

--- a/packages/connectivity/connectivity/example/test_driver/test/connectivity_e2e_test.dart
+++ b/packages/connectivity/connectivity/example/test_driver/test/connectivity_e2e_test.dart
@@ -11,6 +11,6 @@ Future<void> main() async {
   final String data =
       await driver.requestData(null, timeout: const Duration(minutes: 1));
   await driver.close();
-    final Map<String, dynamic> result = jsonDecode(data);
-    exit(result['result'] == 'true' ? 0 : 1);
+  final Map<String, dynamic> result = jsonDecode(data);
+  exit(result['result'] == 'true' ? 0 : 1);
 }

--- a/packages/connectivity/connectivity/example/test_driver/test/connectivity_e2e_test.dart
+++ b/packages/connectivity/connectivity/example/test_driver/test/connectivity_e2e_test.dart
@@ -2,13 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
 import 'dart:io';
 import 'package:flutter_driver/flutter_driver.dart';
 
 Future<void> main() async {
   final FlutterDriver driver = await FlutterDriver.connect();
-  final String result =
+  final String data =
       await driver.requestData(null, timeout: const Duration(minutes: 1));
   await driver.close();
-  exit(result == 'pass' ? 0 : 1);
+    final Map<String, dynamic> result = jsonDecode(data);
+    exit(result['result'] == 'true' ? 0 : 1);
 }

--- a/packages/connectivity/connectivity/ios/Classes/FLTConnectivityPlugin.m
+++ b/packages/connectivity/connectivity/ios/Classes/FLTConnectivityPlugin.m
@@ -156,7 +156,9 @@
     case kCLAuthorizationStatusAuthorizedWhenInUse: {
       return @"authorizedWhenInUse";
     }
-    default: { return @"unknown"; }
+    default: {
+      return @"unknown";
+    }
   }
 }
 

--- a/packages/connectivity/connectivity/ios/Classes/FLTConnectivityPlugin.m
+++ b/packages/connectivity/connectivity/ios/Classes/FLTConnectivityPlugin.m
@@ -156,9 +156,7 @@
     case kCLAuthorizationStatusAuthorizedWhenInUse: {
       return @"authorizedWhenInUse";
     }
-    default: {
-      return @"unknown";
-    }
+    default: { return @"unknown"; }
   }
 }
 

--- a/packages/connectivity/connectivity/pubspec.yaml
+++ b/packages/connectivity/connectivity/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/flutter/plugins/tree/master/packages/connectivity/c
 # 0.4.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.4.9
+version: 0.4.9+1
 
 flutter:
   plugin:

--- a/packages/connectivity/connectivity/pubspec.yaml
+++ b/packages/connectivity/connectivity/pubspec.yaml
@@ -34,7 +34,8 @@ dev_dependencies:
   flutter_driver:
     sdk: flutter
   test: any
-  e2e: ^0.2.0
+  e2e:
+    path: ../../e2e
   mockito: ^4.1.1
   plugin_platform_interface: ^1.0.0
   pedantic: ^1.8.0

--- a/packages/connectivity/connectivity_for_web/CHANGELOG.md
+++ b/packages/connectivity/connectivity_for_web/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.1+1
+
+* Update package:e2e reference to use the local version in the flutter/plugins
+  repository.
+
 ## 0.3.1
 
 * Use NetworkInformation API from dart:html, instead of the JS-interop version.

--- a/packages/connectivity/connectivity_for_web/pubspec.yaml
+++ b/packages/connectivity/connectivity_for_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_for_web
 description: An implementation for the web platform of the Flutter `connectivity` plugin. This uses the NetworkInformation Web API, with a fallback to Navigator.onLine.
-version: 0.3.1
+version: 0.3.1+1
 homepage: https://github.com/ditman/plugins/tree/connectivity-web/packages/connectivity/experimental_connectivity_web
 
 flutter:

--- a/packages/connectivity/connectivity_for_web/pubspec.yaml
+++ b/packages/connectivity/connectivity_for_web/pubspec.yaml
@@ -23,7 +23,8 @@ dev_dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
-  e2e: ^0.2.4+3
+  e2e:
+    path: ../../e2e
   mockito: ^4.1.1
 
 environment:

--- a/packages/connectivity/connectivity_for_web/test/pubspec.yaml
+++ b/packages/connectivity/connectivity_for_web/test/pubspec.yaml
@@ -1,5 +1,5 @@
 name: connectivity_web_example
-description: Example web app for the connectivity plugin 
+description: Example web app for the connectivity plugin
 version: 0.1.1
 homepage: https://github.com/flutter/plugins/tree/master/packages/connectivity/connectivity_web
 
@@ -17,7 +17,8 @@ dev_dependencies:
     sdk: flutter
   flutter_driver:
     sdk: flutter
-  e2e: ^0.2.4+3
+  e2e:
+    path: ../../../e2e
   mockito: ^4.1.1
 
 environment:

--- a/packages/connectivity/connectivity_for_web/test/pubspec.yaml
+++ b/packages/connectivity/connectivity_for_web/test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_web_example
 description: Example web app for the connectivity plugin
-version: 0.1.1
+version: 0.1.1+1
 homepage: https://github.com/flutter/plugins/tree/master/packages/connectivity/connectivity_web
 
 dependencies:

--- a/packages/connectivity/connectivity_macos/CHANGELOG.md
+++ b/packages/connectivity/connectivity_macos/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.0+5
+
+* Update package:e2e reference to use the local version in the flutter/plugins
+  repository.
+
 ## 0.1.0+4
 
 * Remove Android folder from `connectivity_macos`.

--- a/packages/connectivity/connectivity_macos/example/android/app/src/main/java/io/flutter/plugins/connectivityexample/EmbeddingV1ActivityTest.java
+++ b/packages/connectivity/connectivity_macos/example/android/app/src/main/java/io/flutter/plugins/connectivityexample/EmbeddingV1ActivityTest.java
@@ -5,7 +5,7 @@
 package io.flutter.plugins.connectivityexample;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 

--- a/packages/connectivity/connectivity_macos/example/android/app/src/main/java/io/flutter/plugins/connectivityexample/EmbeddingV1ActivityTest.java
+++ b/packages/connectivity/connectivity_macos/example/android/app/src/main/java/io/flutter/plugins/connectivityexample/EmbeddingV1ActivityTest.java
@@ -9,7 +9,7 @@ import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class EmbeddingV1ActivityTest {
   @Rule
   public ActivityTestRule<EmbeddingV1Activity> rule =

--- a/packages/connectivity/connectivity_macos/example/android/app/src/main/java/io/flutter/plugins/connectivityexample/FlutterActivityTest.java
+++ b/packages/connectivity/connectivity_macos/example/android/app/src/main/java/io/flutter/plugins/connectivityexample/FlutterActivityTest.java
@@ -10,7 +10,7 @@ import io.flutter.embedding.android.FlutterActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class FlutterActivityTest {
   @Rule
   public ActivityTestRule<FlutterActivity> rule = new ActivityTestRule<>(FlutterActivity.class);

--- a/packages/connectivity/connectivity_macos/example/android/app/src/main/java/io/flutter/plugins/connectivityexample/FlutterActivityTest.java
+++ b/packages/connectivity/connectivity_macos/example/android/app/src/main/java/io/flutter/plugins/connectivityexample/FlutterActivityTest.java
@@ -5,7 +5,7 @@
 package io.flutter.plugins.connectivityexample;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import io.flutter.embedding.android.FlutterActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;

--- a/packages/connectivity/connectivity_macos/example/pubspec.yaml
+++ b/packages/connectivity/connectivity_macos/example/pubspec.yaml
@@ -12,7 +12,8 @@ dev_dependencies:
   flutter_driver:
     sdk: flutter
   test: any
-  e2e: ^0.2.0
+  e2e:
+    path: ../../../e2e
   pedantic: ^1.8.0
 
 flutter:

--- a/packages/connectivity/connectivity_macos/example/test_driver/test/connectivity_e2e_test.dart
+++ b/packages/connectivity/connectivity_macos/example/test_driver/test/connectivity_e2e_test.dart
@@ -2,13 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
 import 'dart:io';
 import 'package:flutter_driver/flutter_driver.dart';
 
 Future<void> main() async {
   final FlutterDriver driver = await FlutterDriver.connect();
-  final String result =
+  final String data =
       await driver.requestData(null, timeout: const Duration(minutes: 1));
   await driver.close();
-  exit(result == 'pass' ? 0 : 1);
+  final Map<String, dynamic> result = jsonDecode(data);
+  exit(result['result'] == 'true' ? 0 : 1);
 }

--- a/packages/device_info/CHANGELOG.md
+++ b/packages/device_info/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.2+5
+
+* Update package:e2e reference to use the local version in the flutter/plugins
+  repository.
+
 ## 0.4.2+4
 
 Update lower bound of dart dependency to 2.1.0.

--- a/packages/device_info/example/android/app/src/main/java/io/flutter/plugins/deviceinfoexample/EmbeddingV1ActivityTest.java
+++ b/packages/device_info/example/android/app/src/main/java/io/flutter/plugins/deviceinfoexample/EmbeddingV1ActivityTest.java
@@ -1,7 +1,7 @@
 package io.flutter.plugins.deviceinfoexample;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 

--- a/packages/device_info/example/android/app/src/main/java/io/flutter/plugins/deviceinfoexample/EmbeddingV1ActivityTest.java
+++ b/packages/device_info/example/android/app/src/main/java/io/flutter/plugins/deviceinfoexample/EmbeddingV1ActivityTest.java
@@ -5,7 +5,7 @@ import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class EmbeddingV1ActivityTest {
   @Rule
   public ActivityTestRule<EmbeddingV1Activity> rule =

--- a/packages/device_info/example/pubspec.yaml
+++ b/packages/device_info/example/pubspec.yaml
@@ -10,7 +10,8 @@ dependencies:
 dev_dependencies:
   flutter_driver:
     sdk: flutter
-  e2e: ^0.2.0
+  e2e:
+    path: ../../e2e
   pedantic: ^1.8.0
 
 flutter:

--- a/packages/device_info/example/test_driver/device_info_e2e_test.dart
+++ b/packages/device_info/example/test_driver/device_info_e2e_test.dart
@@ -3,13 +3,15 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 import 'package:flutter_driver/flutter_driver.dart';
 
 Future<void> main() async {
   final FlutterDriver driver = await FlutterDriver.connect();
-  final String result =
+  final String data =
       await driver.requestData(null, timeout: const Duration(minutes: 1));
   await driver.close();
-  exit(result == 'pass' ? 0 : 1);
+  final Map<String, dynamic> result = jsonDecode(data);
+  exit(result['result'] == 'true' ? 0 : 1);
 }

--- a/packages/device_info/pubspec.yaml
+++ b/packages/device_info/pubspec.yaml
@@ -24,7 +24,6 @@ dev_dependencies:
   test: ^1.3.0
   flutter_test:
     sdk: flutter
-  e2e: ^0.2.0
   pedantic: ^1.8.0
 
 environment:

--- a/packages/device_info/pubspec.yaml
+++ b/packages/device_info/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/flutter/plugins/tree/master/packages/device_info
 # 0.4.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.4.2+4
+version: 0.4.2+5
 
 flutter:
   plugin:

--- a/packages/e2e/CHANGELOG.md
+++ b/packages/e2e/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.2
+
+* Fix `setSurfaceSize` for e2e tests.
+
 ## 0.6.1
 
 * Added `data` in the reported json.

--- a/packages/e2e/lib/e2e.dart
+++ b/packages/e2e/lib/e2e.dart
@@ -51,9 +51,32 @@ class E2EWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding {
   @override
   bool get registerTestTextInput => false;
 
+  Size _surfaceSize;
+
+  /// Artificially changes the surface size to `size` on the Widget binding,
+  /// then flushes microtasks.
+  ///
+  /// Set to null to use the default surface size.
   @override
-  ViewConfiguration createViewConfiguration() => TestViewConfiguration(
-      size: window.physicalSize / window.devicePixelRatio);
+  Future<void> setSurfaceSize(Size size) {
+    return TestAsyncUtils.guard<void>(() async {
+      assert(inTest);
+      if (_surfaceSize == size)
+        return;
+      _surfaceSize = size;
+      handleMetricsChanged();
+    });
+  }
+
+  @override
+  ViewConfiguration createViewConfiguration() {
+    final double devicePixelRatio = window.devicePixelRatio;
+    final Size size = _surfaceSize ?? window.physicalSize / devicePixelRatio;
+    return TestViewConfiguration(
+      size: size,
+      window: window,
+    );
+  }
 
   final Completer<bool> _allTestsPassed = Completer<bool>();
 

--- a/packages/e2e/lib/e2e.dart
+++ b/packages/e2e/lib/e2e.dart
@@ -37,6 +37,7 @@ class E2EWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding {
       } on MissingPluginException {
         print('Warning: E2E test plugin was not detected.');
       }
+      print(_results);
       if (!_allTestsPassed.isCompleted) _allTestsPassed.complete(true);
     });
   }

--- a/packages/e2e/lib/e2e.dart
+++ b/packages/e2e/lib/e2e.dart
@@ -37,7 +37,6 @@ class E2EWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding {
       } on MissingPluginException {
         print('Warning: E2E test plugin was not detected.');
       }
-      print(_results);
       if (!_allTestsPassed.isCompleted) _allTestsPassed.complete(true);
     });
   }

--- a/packages/e2e/lib/e2e.dart
+++ b/packages/e2e/lib/e2e.dart
@@ -61,8 +61,9 @@ class E2EWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding {
   Future<void> setSurfaceSize(Size size) {
     return TestAsyncUtils.guard<void>(() async {
       assert(inTest);
-      if (_surfaceSize == size)
+      if (_surfaceSize == size) {
         return;
+      }
       _surfaceSize = size;
       handleMetricsChanged();
     });

--- a/packages/e2e/pubspec.yaml
+++ b/packages/e2e/pubspec.yaml
@@ -1,6 +1,6 @@
 name: e2e
 description: Runs tests that use the flutter_test API as integration tests.
-version: 0.6.1
+version: 0.6.2
 homepage: https://github.com/flutter/plugins/tree/master/packages/e2e
 
 environment:

--- a/packages/e2e/test/binding_test.dart
+++ b/packages/e2e/test/binding_test.dart
@@ -10,11 +10,11 @@ void main() async {
   group('Test E2E binding', () {
     final WidgetsBinding binding = E2EWidgetsFlutterBinding.ensureInitialized();
     assert(binding is E2EWidgetsFlutterBinding);
-    final E2EWidgetsFlutterBinding e2ebinding =
+    final E2EWidgetsFlutterBinding e2eBinding =
         binding as E2EWidgetsFlutterBinding;
 
     setUp(() {
-      request = e2ebinding.callback(<String, String>{
+      request = e2eBinding.callback(<String, String>{
         'command': 'request_data',
       });
     });
@@ -23,8 +23,34 @@ void main() async {
       runApp(MaterialApp(
         home: Text('Test'),
       ));
-      expect(tester.binding, e2ebinding);
-      e2ebinding.reportData = <String, dynamic>{'answer': 42};
+      expect(tester.binding, e2eBinding);
+      e2eBinding.reportData = <String, dynamic>{'answer': 42};
+    });
+
+    testWidgets('setSurfaceSize works', (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(home: Center(child: Text('Test'))));
+
+      final Size windowCenter = tester.binding.window.physicalSize /
+          tester.binding.window.devicePixelRatio /
+          2;
+      final double windowCenterX = windowCenter.width;
+      final double windowCenterY = windowCenter.height;
+
+      Offset widgetCenter = tester.getRect(find.byType(Text)).center;
+      expect(widgetCenter.dx, windowCenterX);
+      expect(widgetCenter.dy, windowCenterY);
+
+      await tester.binding.setSurfaceSize(const Size(200, 300));
+      await tester.pump();
+      widgetCenter = tester.getRect(find.byType(Text)).center;
+      expect(widgetCenter.dx, 100);
+      expect(widgetCenter.dy, 150);
+
+      await tester.binding.setSurfaceSize(null);
+      await tester.pump();
+      widgetCenter = tester.getRect(find.byType(Text)).center;
+      expect(widgetCenter.dx, windowCenterX);
+      expect(widgetCenter.dy, windowCenterY);
     });
   });
 

--- a/packages/flutter_plugin_android_lifecycle/example/android/app/src/androidTest/java/io/flutter/plugins/flutter_plugin_android_lifecycle/EmbeddingV1ActivityTest.java
+++ b/packages/flutter_plugin_android_lifecycle/example/android/app/src/androidTest/java/io/flutter/plugins/flutter_plugin_android_lifecycle/EmbeddingV1ActivityTest.java
@@ -5,7 +5,7 @@
 package io.flutter.plugins.flutter_plugin_android_lifecycle_example;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 

--- a/packages/flutter_plugin_android_lifecycle/example/android/app/src/androidTest/java/io/flutter/plugins/flutter_plugin_android_lifecycle/EmbeddingV1ActivityTest.java
+++ b/packages/flutter_plugin_android_lifecycle/example/android/app/src/androidTest/java/io/flutter/plugins/flutter_plugin_android_lifecycle/EmbeddingV1ActivityTest.java
@@ -9,7 +9,7 @@ import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class EmbeddingV1ActivityTest {
   @Rule
   public ActivityTestRule<EmbeddingV1Activity> rule =

--- a/packages/flutter_plugin_android_lifecycle/example/android/app/src/androidTest/java/io/flutter/plugins/flutter_plugin_android_lifecycle/MainActivityTest.java
+++ b/packages/flutter_plugin_android_lifecycle/example/android/app/src/androidTest/java/io/flutter/plugins/flutter_plugin_android_lifecycle/MainActivityTest.java
@@ -9,7 +9,7 @@ import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class MainActivityTest {
   @Rule public ActivityTestRule<MainActivity> rule = new ActivityTestRule<>(MainActivity.class);
 }

--- a/packages/flutter_plugin_android_lifecycle/example/android/app/src/androidTest/java/io/flutter/plugins/flutter_plugin_android_lifecycle/MainActivityTest.java
+++ b/packages/flutter_plugin_android_lifecycle/example/android/app/src/androidTest/java/io/flutter/plugins/flutter_plugin_android_lifecycle/MainActivityTest.java
@@ -5,7 +5,7 @@
 package io.flutter.plugins.flutter_plugin_android_lifecycle_example;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 

--- a/packages/flutter_plugin_android_lifecycle/example/pubspec.yaml
+++ b/packages/flutter_plugin_android_lifecycle/example/pubspec.yaml
@@ -8,7 +8,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  e2e: "^0.2.1"
+  e2e:
+    path: ../../e2e
 
 dev_dependencies:
   flutter_test:

--- a/packages/google_maps_flutter/google_maps_flutter/example/android/app/src/androidTest/java/io/flutter/plugins/googlemaps/EmbeddingV1ActivityTest.java
+++ b/packages/google_maps_flutter/google_maps_flutter/example/android/app/src/androidTest/java/io/flutter/plugins/googlemaps/EmbeddingV1ActivityTest.java
@@ -6,7 +6,7 @@ import io.flutter.plugins.googlemapsexample.*;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class EmbeddingV1ActivityTest {
   @Rule
   public ActivityTestRule<EmbeddingV1Activity> rule =

--- a/packages/google_maps_flutter/google_maps_flutter/example/android/app/src/androidTest/java/io/flutter/plugins/googlemaps/EmbeddingV1ActivityTest.java
+++ b/packages/google_maps_flutter/google_maps_flutter/example/android/app/src/androidTest/java/io/flutter/plugins/googlemaps/EmbeddingV1ActivityTest.java
@@ -1,7 +1,7 @@
 package io.flutter.plugins.googlemaps;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import io.flutter.plugins.googlemapsexample.*;
 import org.junit.Rule;
 import org.junit.runner.RunWith;

--- a/packages/google_maps_flutter/google_maps_flutter/example/android/app/src/androidTest/java/io/flutter/plugins/googlemaps/MainActivityTest.java
+++ b/packages/google_maps_flutter/google_maps_flutter/example/android/app/src/androidTest/java/io/flutter/plugins/googlemaps/MainActivityTest.java
@@ -6,7 +6,7 @@ import io.flutter.embedding.android.FlutterActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class MainActivityTest {
   @Rule
   public ActivityTestRule<FlutterActivity> rule = new ActivityTestRule<>(FlutterActivity.class);

--- a/packages/google_maps_flutter/google_maps_flutter/example/android/app/src/androidTest/java/io/flutter/plugins/googlemaps/MainActivityTest.java
+++ b/packages/google_maps_flutter/google_maps_flutter/example/android/app/src/androidTest/java/io/flutter/plugins/googlemaps/MainActivityTest.java
@@ -1,7 +1,7 @@
 package io.flutter.plugins.googlemaps;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import io.flutter.embedding.android.FlutterActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;

--- a/packages/google_maps_flutter/google_maps_flutter/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/example/pubspec.yaml
@@ -16,7 +16,8 @@ dev_dependencies:
   flutter_driver:
     sdk: flutter
   test: ^1.6.0
-  e2e: ^0.2.1
+  e2e:
+    path: ../../../e2e
   pedantic: ^1.8.0
 
 # For information on the generic Dart part of this file, see the
@@ -58,5 +59,5 @@ flutter:
   #       - asset: fonts/TrajanPro_Bold.ttf
   #         weight: 700
   #
-  # For details regarding fonts from package dependencies, 
+  # For details regarding fonts from package dependencies,
   # see https://flutter.io/custom-fonts/#from-packages

--- a/packages/google_maps_flutter/google_maps_flutter/example/test_driver/google_maps_e2e.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/test_driver/google_maps_e2e.dart
@@ -443,14 +443,11 @@ void main() {
         await mapControllerCompleter.future;
 
     await tester.pumpAndSettle();
-    // TODO(cyanglaz): Remove this after we added `mapRendered` callback, and `mapControllerCompleter.complete(controller)` above should happen
-    // in `mapRendered`.
-    // https://github.com/flutter/flutter/issues/54758
-    await Future.delayed(Duration(seconds: 1));
 
     ScreenCoordinate coordinate =
         await mapController.getScreenCoordinate(_kInitialCameraPosition.target);
     Rect rect = tester.getRect(find.byKey(key));
+    print(coordinate);
     if (Platform.isIOS) {
       // On iOS, the coordinate value from the GoogleMapSdk doesn't include the devicePixelRatio`.
       // So we don't need to do the conversion like we did below for other platforms.
@@ -468,7 +465,7 @@ void main() {
                   tester.binding.window.devicePixelRatio)
               .round());
     }
-  });
+  }, skip: true); // https://github.com/flutter/flutter/issues/54758
 
   testWidgets('testGetVisibleRegion', (WidgetTester tester) async {
     final Key key = GlobalKey();

--- a/packages/google_maps_flutter/google_maps_flutter/example/test_driver/google_maps_e2e.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/test_driver/google_maps_e2e.dart
@@ -424,6 +424,7 @@ void main() {
   });
 
   testWidgets('testInitialCenterLocationAtCenter', (WidgetTester tester) async {
+    await tester.binding.setSurfaceSize(const Size(800.0, 600.0));
     final Completer<GoogleMapController> mapControllerCompleter =
         Completer<GoogleMapController>();
     final Key key = GlobalKey();
@@ -444,10 +445,14 @@ void main() {
 
     await tester.pumpAndSettle();
 
+    // TODO(cyanglaz): Remove this after we added `mapRendered` callback, and `mapControllerCompleter.complete(controller)` above should happen
+    // in `mapRendered`.
+    // https://github.com/flutter/flutter/issues/54758
+    await Future.delayed(Duration(seconds: 1));
+
     ScreenCoordinate coordinate =
         await mapController.getScreenCoordinate(_kInitialCameraPosition.target);
     Rect rect = tester.getRect(find.byKey(key));
-    print(coordinate);
     if (Platform.isIOS) {
       // On iOS, the coordinate value from the GoogleMapSdk doesn't include the devicePixelRatio`.
       // So we don't need to do the conversion like we did below for other platforms.
@@ -465,7 +470,8 @@ void main() {
                   tester.binding.window.devicePixelRatio)
               .round());
     }
-  }, skip: true); // https://github.com/flutter/flutter/issues/54758
+    await tester.binding.setSurfaceSize(null);
+  });
 
   testWidgets('testGetVisibleRegion', (WidgetTester tester) async {
     final Key key = GlobalKey();

--- a/packages/google_maps_flutter/google_maps_flutter/example/test_driver/google_maps_e2e_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/test_driver/google_maps_e2e_test.dart
@@ -3,13 +3,15 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 import 'package:flutter_driver/flutter_driver.dart';
 
 Future<void> main() async {
   final FlutterDriver driver = await FlutterDriver.connect();
-  final String result =
+  final String data =
       await driver.requestData(null, timeout: const Duration(minutes: 1));
   await driver.close();
-  exit(result == 'pass' ? 0 : 1);
+  final Map<String, dynamic> result = jsonDecode(data);
+  exit(result['result'] == 'true' ? 0 : 1);
 }

--- a/packages/google_sign_in/extension_google_sign_in_as_googleapis_auth/example/android/app/src/main/java/io/flutter/plugins/googlesigninexample/EmbeddingV1ActivityTest.java
+++ b/packages/google_sign_in/extension_google_sign_in_as_googleapis_auth/example/android/app/src/main/java/io/flutter/plugins/googlesigninexample/EmbeddingV1ActivityTest.java
@@ -5,7 +5,7 @@
 package io.flutter.plugins.googlesigninexample;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 

--- a/packages/google_sign_in/extension_google_sign_in_as_googleapis_auth/example/android/app/src/main/java/io/flutter/plugins/googlesigninexample/EmbeddingV1ActivityTest.java
+++ b/packages/google_sign_in/extension_google_sign_in_as_googleapis_auth/example/android/app/src/main/java/io/flutter/plugins/googlesigninexample/EmbeddingV1ActivityTest.java
@@ -9,7 +9,7 @@ import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class EmbeddingV1ActivityTest {
   @Rule
   public ActivityTestRule<EmbeddingV1Activity> rule =

--- a/packages/google_sign_in/extension_google_sign_in_as_googleapis_auth/example/android/app/src/main/java/io/flutter/plugins/googlesigninexample/FlutterActivityTest.java
+++ b/packages/google_sign_in/extension_google_sign_in_as_googleapis_auth/example/android/app/src/main/java/io/flutter/plugins/googlesigninexample/FlutterActivityTest.java
@@ -10,7 +10,7 @@ import io.flutter.embedding.android.FlutterActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class FlutterActivityTest {
   @Rule
   public ActivityTestRule<FlutterActivity> rule = new ActivityTestRule<>(FlutterActivity.class);

--- a/packages/google_sign_in/extension_google_sign_in_as_googleapis_auth/example/android/app/src/main/java/io/flutter/plugins/googlesigninexample/FlutterActivityTest.java
+++ b/packages/google_sign_in/extension_google_sign_in_as_googleapis_auth/example/android/app/src/main/java/io/flutter/plugins/googlesigninexample/FlutterActivityTest.java
@@ -5,7 +5,7 @@
 package io.flutter.plugins.googlesigninexample;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import io.flutter.embedding.android.FlutterActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;

--- a/packages/google_sign_in/extension_google_sign_in_as_googleapis_auth/example/pubspec.yaml
+++ b/packages/google_sign_in/extension_google_sign_in_as_googleapis_auth/example/pubspec.yaml
@@ -11,7 +11,8 @@ dependencies:
 
 dev_dependencies:
   pedantic: ^1.8.0
-  e2e:  ^0.2.1
+  e2e:
+    path: ../../../e2e
   flutter_driver:
     sdk: flutter
 

--- a/packages/google_sign_in/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.5.2
+
+* Update package:e2e reference to use the local version in the flutter/plugins
+  repository.
+
 ## 4.5.1
 
 * Add note on Apple sign in requirement in README.

--- a/packages/google_sign_in/google_sign_in/example/android/app/src/main/java/io/flutter/plugins/googlesigninexample/EmbeddingV1ActivityTest.java
+++ b/packages/google_sign_in/google_sign_in/example/android/app/src/main/java/io/flutter/plugins/googlesigninexample/EmbeddingV1ActivityTest.java
@@ -5,7 +5,7 @@
 package io.flutter.plugins.googlesigninexample;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 

--- a/packages/google_sign_in/google_sign_in/example/android/app/src/main/java/io/flutter/plugins/googlesigninexample/EmbeddingV1ActivityTest.java
+++ b/packages/google_sign_in/google_sign_in/example/android/app/src/main/java/io/flutter/plugins/googlesigninexample/EmbeddingV1ActivityTest.java
@@ -9,7 +9,7 @@ import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class EmbeddingV1ActivityTest {
   @Rule
   public ActivityTestRule<EmbeddingV1Activity> rule =

--- a/packages/google_sign_in/google_sign_in/example/android/app/src/main/java/io/flutter/plugins/googlesigninexample/FlutterActivityTest.java
+++ b/packages/google_sign_in/google_sign_in/example/android/app/src/main/java/io/flutter/plugins/googlesigninexample/FlutterActivityTest.java
@@ -10,7 +10,7 @@ import io.flutter.embedding.android.FlutterActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class FlutterActivityTest {
   @Rule
   public ActivityTestRule<FlutterActivity> rule = new ActivityTestRule<>(FlutterActivity.class);

--- a/packages/google_sign_in/google_sign_in/example/android/app/src/main/java/io/flutter/plugins/googlesigninexample/FlutterActivityTest.java
+++ b/packages/google_sign_in/google_sign_in/example/android/app/src/main/java/io/flutter/plugins/googlesigninexample/FlutterActivityTest.java
@@ -5,7 +5,7 @@
 package io.flutter.plugins.googlesigninexample;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import io.flutter.embedding.android.FlutterActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;

--- a/packages/google_sign_in/google_sign_in/example/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in/example/pubspec.yaml
@@ -10,7 +10,8 @@ dependencies:
 
 dev_dependencies:
   pedantic: ^1.8.0
-  e2e:  ^0.2.1
+  e2e:
+    path: ../../../e2e
   flutter_driver:
     sdk: flutter
 

--- a/packages/google_sign_in/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_sign_in
 description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android and iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_sign_in/google_sign_in
-version: 4.5.1
+version: 4.5.2
 
 flutter:
   plugin:

--- a/packages/google_sign_in/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in/pubspec.yaml
@@ -34,7 +34,8 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   pedantic: ^1.8.0
-  e2e: ^0.2.1
+  e2e:
+    path: ../../e2e
 
 environment:
   sdk: ">=2.1.0 <3.0.0"

--- a/packages/google_sign_in/google_sign_in/test_driver/google_sign_in_e2e_test.dart
+++ b/packages/google_sign_in/google_sign_in/test_driver/google_sign_in_e2e_test.dart
@@ -3,13 +3,15 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 import 'package:flutter_driver/flutter_driver.dart';
 
 Future<void> main() async {
   final FlutterDriver driver = await FlutterDriver.connect();
-  final String result =
+  final String data =
       await driver.requestData(null, timeout: const Duration(minutes: 1));
   await driver.close();
-  exit(result == 'pass' ? 0 : 1);
+  final Map<String, dynamic> result = jsonDecode(data);
+  exit(result['result'] == 'true' ? 0 : 1);
 }

--- a/packages/google_sign_in/google_sign_in_web/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_web/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.9.1+2
+
+* Update package:e2e reference to use the local version in the flutter/plugins
+  repository.
+
 ## 0.9.1+1
 
 * Remove Android folder from `google_sign_in_web`.

--- a/packages/google_sign_in/google_sign_in_web/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_sign_in_web
 description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android, iOS and Web.
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_sign_in/google_sign_in_web
-version: 0.9.1+1
+version: 0.9.1+2
 
 flutter:
   plugin:

--- a/packages/image_picker/image_picker/CHANGELOG.md
+++ b/packages/image_picker/image_picker/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.6.7+5
+
+* Update package:e2e reference to use the local version in the flutter/plugins
+  repository.
+
+
 ## 0.6.7+4
 
 * Support iOS simulator x86_64 architecture.

--- a/packages/image_picker/image_picker/example/android/app/src/main/java/io/flutter/plugins/imagepickerexample/EmbeddingV1ActivityTest.java
+++ b/packages/image_picker/image_picker/example/android/app/src/main/java/io/flutter/plugins/imagepickerexample/EmbeddingV1ActivityTest.java
@@ -9,7 +9,7 @@ import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class EmbeddingV1ActivityTest {
   @Rule
   public ActivityTestRule<EmbeddingV1Activity> rule =

--- a/packages/image_picker/image_picker/example/android/app/src/main/java/io/flutter/plugins/imagepickerexample/EmbeddingV1ActivityTest.java
+++ b/packages/image_picker/image_picker/example/android/app/src/main/java/io/flutter/plugins/imagepickerexample/EmbeddingV1ActivityTest.java
@@ -5,7 +5,7 @@
 package io.flutter.plugins.imagepickerexample;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 

--- a/packages/image_picker/image_picker/example/android/app/src/main/java/io/flutter/plugins/imagepickerexample/FlutterActivityTest.java
+++ b/packages/image_picker/image_picker/example/android/app/src/main/java/io/flutter/plugins/imagepickerexample/FlutterActivityTest.java
@@ -6,7 +6,7 @@ import io.flutter.embedding.android.FlutterActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class FlutterActivityTest {
   @Rule
   public ActivityTestRule<FlutterActivity> rule = new ActivityTestRule<>(FlutterActivity.class);

--- a/packages/image_picker/image_picker/example/android/app/src/main/java/io/flutter/plugins/imagepickerexample/FlutterActivityTest.java
+++ b/packages/image_picker/image_picker/example/android/app/src/main/java/io/flutter/plugins/imagepickerexample/FlutterActivityTest.java
@@ -1,7 +1,7 @@
 package io.flutter.plugins.imagepickerexample;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import io.flutter.embedding.android.FlutterActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;

--- a/packages/image_picker/image_picker/example/pubspec.yaml
+++ b/packages/image_picker/image_picker/example/pubspec.yaml
@@ -14,7 +14,8 @@ dependencies:
 dev_dependencies:
   flutter_driver:
     sdk: flutter
-  e2e:  ^0.2.1
+  e2e:
+    path: ../../../e2e
   pedantic: ^1.8.0
 
 flutter:

--- a/packages/image_picker/image_picker/example/test_driver/test/image_picker_e2e_test.dart
+++ b/packages/image_picker/image_picker/example/test_driver/test/image_picker_e2e_test.dart
@@ -3,13 +3,15 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 import 'package:flutter_driver/flutter_driver.dart';
 
 Future<void> main() async {
   final FlutterDriver driver = await FlutterDriver.connect();
-  final String result =
+  final String data =
       await driver.requestData(null, timeout: const Duration(minutes: 1));
   await driver.close();
-  exit(result == 'pass' ? 0 : 1);
+  final Map<String, dynamic> result = jsonDecode(data);
+  exit(result['result'] == 'true' ? 0 : 1);
 }

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker
 description: Flutter plugin for selecting images from the Android and iOS image
   library, and taking new pictures with the camera.
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker/image_picker
-version: 0.6.7+4
+version: 0.6.7+5
 
 flutter:
   plugin:

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -23,7 +23,8 @@ dev_dependencies:
   video_player: ^0.10.3
   flutter_test:
     sdk: flutter
-  e2e: ^0.2.1
+  e2e:
+    path: ../../e2e
   pedantic: ^1.8.0
 
 environment:

--- a/packages/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.4+2
+
+* Update package:e2e reference to use the local version in the flutter/plugins
+  repository.
+
 ## 0.3.4+1
 
 * iOS: Fix the bug that `SKPaymentQueueWrapper.transactions` doesn't return all transactions.

--- a/packages/in_app_purchase/example/android/app/src/main/java/io/flutter/plugins/inapppurchaseexample/EmbeddingV1ActivityTest.java
+++ b/packages/in_app_purchase/example/android/app/src/main/java/io/flutter/plugins/inapppurchaseexample/EmbeddingV1ActivityTest.java
@@ -5,7 +5,7 @@
 package io.flutter.plugins.inapppurchaseexample;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 

--- a/packages/in_app_purchase/example/android/app/src/main/java/io/flutter/plugins/inapppurchaseexample/EmbeddingV1ActivityTest.java
+++ b/packages/in_app_purchase/example/android/app/src/main/java/io/flutter/plugins/inapppurchaseexample/EmbeddingV1ActivityTest.java
@@ -9,7 +9,7 @@ import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class EmbeddingV1ActivityTest {
   @Rule
   public ActivityTestRule<EmbeddingV1Activity> rule =

--- a/packages/in_app_purchase/example/android/app/src/main/java/io/flutter/plugins/inapppurchaseexample/FlutterActivityTest.java
+++ b/packages/in_app_purchase/example/android/app/src/main/java/io/flutter/plugins/inapppurchaseexample/FlutterActivityTest.java
@@ -10,7 +10,7 @@ import io.flutter.embedding.android.FlutterActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class FlutterActivityTest {
   @Rule
   public ActivityTestRule<FlutterActivity> rule = new ActivityTestRule<>(FlutterActivity.class);

--- a/packages/in_app_purchase/example/android/app/src/main/java/io/flutter/plugins/inapppurchaseexample/FlutterActivityTest.java
+++ b/packages/in_app_purchase/example/android/app/src/main/java/io/flutter/plugins/inapppurchaseexample/FlutterActivityTest.java
@@ -5,7 +5,7 @@
 package io.flutter.plugins.inapppurchaseexample;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import io.flutter.embedding.android.FlutterActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;

--- a/packages/in_app_purchase/example/pubspec.yaml
+++ b/packages/in_app_purchase/example/pubspec.yaml
@@ -14,7 +14,8 @@ dev_dependencies:
     sdk: flutter
   in_app_purchase:
     path: ../
-  e2e: ^0.2.0
+  e2e:
+    path: ../../e2e
   pedantic: ^1.8.0
 
 flutter:

--- a/packages/in_app_purchase/example/test_driver/test/in_app_purchase_e2e_test.dart
+++ b/packages/in_app_purchase/example/test_driver/test/in_app_purchase_e2e_test.dart
@@ -2,14 +2,16 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:io';
 import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
 import 'package:flutter_driver/flutter_driver.dart';
 
 Future<void> main() async {
   final FlutterDriver driver = await FlutterDriver.connect();
-  final String result =
+  final String data =
       await driver.requestData(null, timeout: const Duration(minutes: 1));
   await driver.close();
-  exit(result == 'pass' ? 0 : 1);
+  final Map<String, dynamic> result = jsonDecode(data);
+  exit(result['result'] == 'true' ? 0 : 1);
 }

--- a/packages/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/pubspec.yaml
@@ -1,7 +1,7 @@
 name: in_app_purchase
 description: A Flutter plugin for in-app purchases. Exposes APIs for making in-app purchases through the App Store and Google Play.
 homepage: https://github.com/flutter/plugins/tree/master/packages/in_app_purchase
-version: 0.3.4+1
+version: 0.3.4+2
 
 dependencies:
   async: ^2.0.8

--- a/packages/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/pubspec.yaml
@@ -22,7 +22,8 @@ dev_dependencies:
     path: example/
   test: ^1.5.2
   shared_preferences: ^0.5.2
-  e2e: ^0.2.0
+  e2e:
+    path: ../e2e
   pedantic: ^1.8.0
 
 flutter:

--- a/packages/local_auth/CHANGELOG.md
+++ b/packages/local_auth/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.2+4
+
+* Update package:e2e reference to use the local version in the flutter/plugins
+  repository.
+
 ## 0.6.2+3
 
 * Post-v2 Android embedding cleanup.

--- a/packages/local_auth/example/android/app/src/androidTest/java/io/flutter/plugins/localauth/EmbeddingV1ActivityTest.java
+++ b/packages/local_auth/example/android/app/src/androidTest/java/io/flutter/plugins/localauth/EmbeddingV1ActivityTest.java
@@ -1,7 +1,7 @@
 package io.flutter.plugins.localauth;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import io.flutter.plugins.localauthexample.EmbeddingV1Activity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;

--- a/packages/local_auth/example/android/app/src/androidTest/java/io/flutter/plugins/localauth/EmbeddingV1ActivityTest.java
+++ b/packages/local_auth/example/android/app/src/androidTest/java/io/flutter/plugins/localauth/EmbeddingV1ActivityTest.java
@@ -6,7 +6,7 @@ import io.flutter.plugins.localauthexample.EmbeddingV1Activity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class EmbeddingV1ActivityTest {
   @Rule
   public ActivityTestRule<EmbeddingV1Activity> rule =

--- a/packages/local_auth/example/android/app/src/androidTest/java/io/flutter/plugins/localauth/MainActivityTest.java
+++ b/packages/local_auth/example/android/app/src/androidTest/java/io/flutter/plugins/localauth/MainActivityTest.java
@@ -1,7 +1,7 @@
 package io.flutter.plugins.localauth;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import io.flutter.embedding.android.FlutterFragmentActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;

--- a/packages/local_auth/example/android/app/src/androidTest/java/io/flutter/plugins/localauth/MainActivityTest.java
+++ b/packages/local_auth/example/android/app/src/androidTest/java/io/flutter/plugins/localauth/MainActivityTest.java
@@ -6,7 +6,7 @@ import io.flutter.embedding.android.FlutterFragmentActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class FlutterFragmentActivityTest {
   @Rule
   public ActivityTestRule<FlutterFragmentActivity> rule =

--- a/packages/local_auth/example/pubspec.yaml
+++ b/packages/local_auth/example/pubspec.yaml
@@ -8,7 +8,8 @@ dependencies:
     path: ../
 
 dev_dependencies:
-  e2e: ^0.2.1
+  e2e:
+    path: ../../e2e
   flutter_driver:
     sdk: flutter
   pedantic: ^1.8.0

--- a/packages/local_auth/pubspec.yaml
+++ b/packages/local_auth/pubspec.yaml
@@ -2,7 +2,7 @@ name: local_auth
 description: Flutter plugin for Android and iOS device authentication sensors
   such as Fingerprint Reader and Touch ID.
 homepage: https://github.com/flutter/plugins/tree/master/packages/local_auth
-version: 0.6.2+3
+version: 0.6.2+4
 
 flutter:
   plugin:

--- a/packages/local_auth/pubspec.yaml
+++ b/packages/local_auth/pubspec.yaml
@@ -22,7 +22,8 @@ dependencies:
   flutter_plugin_android_lifecycle: ^1.0.2
 
 dev_dependencies:
-  e2e: ^0.2.1
+  e2e:
+    path: ../e2e
   flutter_driver:
     sdk: flutter
   flutter_test:

--- a/packages/package_info/CHANGELOG.md
+++ b/packages/package_info/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.2
+
+* Update package:e2e reference to use the local version in the flutter/plugins
+  repository.
+
 ## 0.4.1
 
 * Add support for macOS.

--- a/packages/package_info/example/android/app/src/androidTest/java/io/flutter/plugins/packageinfoexample/EmbedderV1ActivityTest.java
+++ b/packages/package_info/example/android/app/src/androidTest/java/io/flutter/plugins/packageinfoexample/EmbedderV1ActivityTest.java
@@ -9,7 +9,7 @@ import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class EmbedderV1ActivityTest {
   @Rule
   public ActivityTestRule<EmbedderV1Activity> rule =

--- a/packages/package_info/example/android/app/src/androidTest/java/io/flutter/plugins/packageinfoexample/EmbedderV1ActivityTest.java
+++ b/packages/package_info/example/android/app/src/androidTest/java/io/flutter/plugins/packageinfoexample/EmbedderV1ActivityTest.java
@@ -5,7 +5,7 @@
 package io.flutter.plugins.packageinfoexample;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 

--- a/packages/package_info/example/android/app/src/androidTest/java/io/flutter/plugins/packageinfoexample/MainActivityTest.java
+++ b/packages/package_info/example/android/app/src/androidTest/java/io/flutter/plugins/packageinfoexample/MainActivityTest.java
@@ -5,7 +5,7 @@
 package io.flutter.plugins.packageinfoexample;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import io.flutter.embedding.android.FlutterActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;

--- a/packages/package_info/example/android/app/src/androidTest/java/io/flutter/plugins/packageinfoexample/MainActivityTest.java
+++ b/packages/package_info/example/android/app/src/androidTest/java/io/flutter/plugins/packageinfoexample/MainActivityTest.java
@@ -10,7 +10,7 @@ import io.flutter.embedding.android.FlutterActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class MainActivityTest {
   @Rule
   public ActivityTestRule<FlutterActivity> rule = new ActivityTestRule<>(FlutterActivity.class);

--- a/packages/package_info/example/pubspec.yaml
+++ b/packages/package_info/example/pubspec.yaml
@@ -6,7 +6,8 @@ dependencies:
     sdk: flutter
   package_info:
     path: ../
-  e2e: "^0.2.1"
+  e2e:
+    path: ../../e2e
 
 dev_dependencies:
   flutter_driver:

--- a/packages/package_info/example/test_driver/package_info_e2e_test.dart
+++ b/packages/package_info/example/test_driver/package_info_e2e_test.dart
@@ -2,14 +2,18 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_driver/flutter_driver.dart';
 
 Future<void> main() async {
   final FlutterDriver driver = await FlutterDriver.connect();
-  final String result =
-      await driver.requestData(null, timeout: const Duration(minutes: 1));
+  final String data = await driver.requestData(
+    null,
+    timeout: const Duration(minutes: 1),
+  );
   await driver.close();
-  exit(result == 'pass' ? 0 : 1);
+  final Map<String, dynamic> result = jsonDecode(data);
+  exit(result['result'] == 'true' ? 0 : 1);
 }

--- a/packages/package_info/pubspec.yaml
+++ b/packages/package_info/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/flutter/plugins/tree/master/packages/package_info
 # 0.4.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.4.1
+version: 0.4.2
 
 flutter:
   plugin:

--- a/packages/package_info/pubspec.yaml
+++ b/packages/package_info/pubspec.yaml
@@ -28,7 +28,8 @@ dev_dependencies:
   flutter_driver:
     sdk: flutter
   test: any
-  e2e: "^0.2.1"
+  e2e:
+    path: ../e2e
   pedantic: ^1.8.0
 
 environment:

--- a/packages/path_provider/path_provider/CHANGELOG.md
+++ b/packages/path_provider/path_provider/CHANGELOG.md
@@ -1,7 +1,14 @@
+## 1.6.12
+
+* Update package:e2e reference to use the local version in the flutter/plugins
+  repository.
+
 ## 1.6.11
+
 * Updated documentation to reflect the need for changes in testing for federated plugins
 
 ## 1.6.10
+
 * Linux implementation endorsement
 
 ## 1.6.9

--- a/packages/path_provider/path_provider/example/android/app/src/androidTest/java/EmbeddingV1ActivityTest.java
+++ b/packages/path_provider/path_provider/example/android/app/src/androidTest/java/EmbeddingV1ActivityTest.java
@@ -2,7 +2,7 @@
 package io.flutter.plugins.pathprovider;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import io.flutter.plugins.pathproviderexample.EmbeddingV1Activity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;

--- a/packages/path_provider/path_provider/example/android/app/src/androidTest/java/EmbeddingV1ActivityTest.java
+++ b/packages/path_provider/path_provider/example/android/app/src/androidTest/java/EmbeddingV1ActivityTest.java
@@ -7,7 +7,7 @@ import io.flutter.plugins.pathproviderexample.EmbeddingV1Activity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class EmbeddingV1ActivityTest {
   @Rule
   public ActivityTestRule<EmbeddingV1Activity> rule =

--- a/packages/path_provider/path_provider/example/android/app/src/androidTest/java/MainActivityTest.java
+++ b/packages/path_provider/path_provider/example/android/app/src/androidTest/java/MainActivityTest.java
@@ -7,7 +7,7 @@ import io.flutter.embedding.android.FlutterActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class FlutterActivityTest {
   @Rule
   public ActivityTestRule<FlutterActivity> rule = new ActivityTestRule<>(FlutterActivity.class);

--- a/packages/path_provider/path_provider/example/android/app/src/androidTest/java/MainActivityTest.java
+++ b/packages/path_provider/path_provider/example/android/app/src/androidTest/java/MainActivityTest.java
@@ -2,7 +2,7 @@
 package io.flutter.plugins.pathprovider;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import io.flutter.embedding.android.FlutterActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;

--- a/packages/path_provider/path_provider/example/pubspec.yaml
+++ b/packages/path_provider/path_provider/example/pubspec.yaml
@@ -8,7 +8,8 @@ dependencies:
     path: ../
 
 dev_dependencies:
-  e2e: ^0.2.1
+  e2e:
+    path: ../../../e2e
   flutter_driver:
     sdk: flutter
   test: any

--- a/packages/path_provider/path_provider/example/test_driver/path_provider_e2e_test.dart
+++ b/packages/path_provider/path_provider/example/test_driver/path_provider_e2e_test.dart
@@ -3,13 +3,15 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 import 'package:flutter_driver/flutter_driver.dart';
 
 Future<void> main() async {
   final FlutterDriver driver = await FlutterDriver.connect();
-  final String result =
+  final String data =
       await driver.requestData(null, timeout: const Duration(minutes: 1));
   await driver.close();
-  exit(result == 'pass' ? 0 : 1);
+  final Map<String, dynamic> result = jsonDecode(data);
+  exit(result['result'] == 'true' ? 0 : 1);
 }

--- a/packages/path_provider/path_provider/pubspec.yaml
+++ b/packages/path_provider/path_provider/pubspec.yaml
@@ -2,7 +2,7 @@ name: path_provider
 description: Flutter plugin for getting commonly used locations on the Android &
   iOS file systems, such as the temp and app data directories.
 homepage: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider
-version: 1.6.11
+version: 1.6.12
 
 flutter:
   plugin:

--- a/packages/path_provider/path_provider/pubspec.yaml
+++ b/packages/path_provider/path_provider/pubspec.yaml
@@ -25,7 +25,8 @@ dependencies:
   path_provider_linux: ^0.0.1
 
 dev_dependencies:
-  e2e: ^0.2.1
+  e2e:
+    path: ../../e2e
   flutter_test:
     sdk: flutter
   flutter_driver:

--- a/packages/path_provider/path_provider_linux/example/pubspec.yaml
+++ b/packages/path_provider/path_provider_linux/example/pubspec.yaml
@@ -24,7 +24,8 @@ dev_dependencies:
     sdk: flutter
   flutter_driver:
     sdk: flutter
-  e2e: ^0.2.1
+  e2e:
+    path: ../../../e2e
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/packages/path_provider/path_provider_linux/example/test_driver/path_provider_e2e_test.dart
+++ b/packages/path_provider/path_provider_linux/example/test_driver/path_provider_e2e_test.dart
@@ -3,13 +3,15 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 import 'package:flutter_driver/flutter_driver.dart';
 
 Future<void> main() async {
   final FlutterDriver driver = await FlutterDriver.connect();
-  final String result =
+  final String data =
       await driver.requestData(null, timeout: const Duration(minutes: 1));
   await driver.close();
-  exit(result == 'pass' ? 0 : 1);
+  final Map<String, dynamic> result = jsonDecode(data);
+  exit(result['result'] == 'true' ? 0 : 1);
 }

--- a/packages/path_provider/path_provider_macos/example/android/app/src/androidTest/java/EmbeddingV1ActivityTest.java
+++ b/packages/path_provider/path_provider_macos/example/android/app/src/androidTest/java/EmbeddingV1ActivityTest.java
@@ -2,7 +2,7 @@
 package io.flutter.plugins.pathprovider;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import io.flutter.plugins.pathproviderexample.EmbeddingV1Activity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;

--- a/packages/path_provider/path_provider_macos/example/android/app/src/androidTest/java/EmbeddingV1ActivityTest.java
+++ b/packages/path_provider/path_provider_macos/example/android/app/src/androidTest/java/EmbeddingV1ActivityTest.java
@@ -7,7 +7,7 @@ import io.flutter.plugins.pathproviderexample.EmbeddingV1Activity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class EmbeddingV1ActivityTest {
   @Rule
   public ActivityTestRule<EmbeddingV1Activity> rule =

--- a/packages/path_provider/path_provider_macos/example/android/app/src/androidTest/java/MainActivityTest.java
+++ b/packages/path_provider/path_provider_macos/example/android/app/src/androidTest/java/MainActivityTest.java
@@ -7,7 +7,7 @@ import io.flutter.plugins.pathproviderexample.MainActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class MainActivityTest {
   @Rule public ActivityTestRule<MainActivity> rule = new ActivityTestRule<>(MainActivity.class);
 }

--- a/packages/path_provider/path_provider_macos/example/android/app/src/androidTest/java/MainActivityTest.java
+++ b/packages/path_provider/path_provider_macos/example/android/app/src/androidTest/java/MainActivityTest.java
@@ -2,7 +2,7 @@
 package io.flutter.plugins.pathprovider;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import io.flutter.plugins.pathproviderexample.MainActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;

--- a/packages/path_provider/path_provider_macos/example/pubspec.yaml
+++ b/packages/path_provider/path_provider_macos/example/pubspec.yaml
@@ -9,7 +9,8 @@ dependencies:
     path: ../
 
 dev_dependencies:
-  e2e: ^0.2.1
+  e2e:
+    path: ../../../e2e
   flutter_driver:
     sdk: flutter
   test: any

--- a/packages/path_provider/path_provider_macos/example/test_driver/path_provider_e2e_test.dart
+++ b/packages/path_provider/path_provider_macos/example/test_driver/path_provider_e2e_test.dart
@@ -3,13 +3,15 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 import 'package:flutter_driver/flutter_driver.dart';
 
 Future<void> main() async {
   final FlutterDriver driver = await FlutterDriver.connect();
-  final String result =
+  final String data =
       await driver.requestData(null, timeout: const Duration(minutes: 1));
   await driver.close();
-  exit(result == 'pass' ? 0 : 1);
+  final Map<String, dynamic> result = jsonDecode(data);
+  exit(result['result'] == 'true' ? 0 : 1);
 }

--- a/packages/quick_actions/CHANGELOG.md
+++ b/packages/quick_actions/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.0+7
+
+* Update package:e2e reference to use the local version in the flutter/plugins
+  repository.
+
 ## 0.4.0+6
 
 * Post-v2 Android embedding cleanup.

--- a/packages/quick_actions/example/android/app/src/main/java/io/flutter/plugins/quickactionsexample/EmbeddingV1ActivityTest.java
+++ b/packages/quick_actions/example/android/app/src/main/java/io/flutter/plugins/quickactionsexample/EmbeddingV1ActivityTest.java
@@ -5,7 +5,7 @@
 package io.flutter.plugins.quickactionsexample;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 

--- a/packages/quick_actions/example/android/app/src/main/java/io/flutter/plugins/quickactionsexample/EmbeddingV1ActivityTest.java
+++ b/packages/quick_actions/example/android/app/src/main/java/io/flutter/plugins/quickactionsexample/EmbeddingV1ActivityTest.java
@@ -9,7 +9,7 @@ import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class EmbeddingV1ActivityTest {
   @Rule
   public ActivityTestRule<EmbeddingV1Activity> rule =

--- a/packages/quick_actions/example/android/app/src/main/java/io/flutter/plugins/quickactionsexample/FlutterActivityTest.java
+++ b/packages/quick_actions/example/android/app/src/main/java/io/flutter/plugins/quickactionsexample/FlutterActivityTest.java
@@ -10,7 +10,7 @@ import io.flutter.embedding.android.FlutterActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class FlutterActivityTest {
   @Rule
   public ActivityTestRule<FlutterActivity> rule = new ActivityTestRule<>(FlutterActivity.class);

--- a/packages/quick_actions/example/android/app/src/main/java/io/flutter/plugins/quickactionsexample/FlutterActivityTest.java
+++ b/packages/quick_actions/example/android/app/src/main/java/io/flutter/plugins/quickactionsexample/FlutterActivityTest.java
@@ -5,7 +5,7 @@
 package io.flutter.plugins.quickactionsexample;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import io.flutter.embedding.android.FlutterActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;

--- a/packages/quick_actions/example/pubspec.yaml
+++ b/packages/quick_actions/example/pubspec.yaml
@@ -10,7 +10,8 @@ dependencies:
 dev_dependencies:
   flutter_driver:
     sdk: flutter
-  e2e: ^0.2.0
+  e2e:
+    path: ../../e2e
   pedantic: ^1.8.0
 
 flutter:

--- a/packages/quick_actions/example/test_driver/quick_actions_e2e_test.dart
+++ b/packages/quick_actions/example/test_driver/quick_actions_e2e_test.dart
@@ -3,13 +3,15 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 import 'package:flutter_driver/flutter_driver.dart';
 
 Future<void> main() async {
   final FlutterDriver driver = await FlutterDriver.connect();
-  final String result =
+  final String data =
       await driver.requestData(null, timeout: const Duration(minutes: 1));
   await driver.close();
-  exit(result == 'pass' ? 0 : 1);
+  final Map<String, dynamic> result = jsonDecode(data);
+  exit(result['result'] == 'true' ? 0 : 1);
 }

--- a/packages/quick_actions/pubspec.yaml
+++ b/packages/quick_actions/pubspec.yaml
@@ -2,7 +2,7 @@ name: quick_actions
 description: Flutter plugin for creating shortcuts on home screen, also known as
   Quick Actions on iOS and App Shortcuts on Android.
 homepage: https://github.com/flutter/plugins/tree/master/packages/quick_actions
-version: 0.4.0+6
+version: 0.4.0+7
 
 flutter:
   plugin:

--- a/packages/quick_actions/pubspec.yaml
+++ b/packages/quick_actions/pubspec.yaml
@@ -23,7 +23,8 @@ dev_dependencies:
   mockito: ^3.0.0
   flutter_test:
     sdk: flutter
-  e2e: ^0.2.0
+  e2e:
+    path: ../e2e
   pedantic: ^1.8.0
 
 environment:

--- a/packages/sensors/CHANGELOG.md
+++ b/packages/sensors/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.2+3
+
+* Update package:e2e reference to use the local version in the flutter/plugins
+  repository.
+
 ## 0.4.2+2
 
 * Post-v2 Android embedding cleanup.

--- a/packages/sensors/example/android/app/src/main/java/io/flutter/plugins/sensorsexample/EmbeddingV1ActivityTest.java
+++ b/packages/sensors/example/android/app/src/main/java/io/flutter/plugins/sensorsexample/EmbeddingV1ActivityTest.java
@@ -1,7 +1,7 @@
 package io.flutter.plugins.sensorsexample;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 

--- a/packages/sensors/example/android/app/src/main/java/io/flutter/plugins/sensorsexample/EmbeddingV1ActivityTest.java
+++ b/packages/sensors/example/android/app/src/main/java/io/flutter/plugins/sensorsexample/EmbeddingV1ActivityTest.java
@@ -5,7 +5,7 @@ import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class EmbeddingV1ActivityTest {
   @Rule
   public ActivityTestRule<EmbeddingV1Activity> rule =

--- a/packages/sensors/example/android/app/src/main/java/io/flutter/plugins/sensorsexample/FlutterActivityTest.java
+++ b/packages/sensors/example/android/app/src/main/java/io/flutter/plugins/sensorsexample/FlutterActivityTest.java
@@ -10,7 +10,7 @@ import io.flutter.embedding.android.FlutterActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class FlutterActivityTest {
   @Rule
   public ActivityTestRule<FlutterActivity> rule = new ActivityTestRule<>(FlutterActivity.class);

--- a/packages/sensors/example/android/app/src/main/java/io/flutter/plugins/sensorsexample/FlutterActivityTest.java
+++ b/packages/sensors/example/android/app/src/main/java/io/flutter/plugins/sensorsexample/FlutterActivityTest.java
@@ -5,7 +5,7 @@
 package io.flutter.plugins.sensorsexample;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import io.flutter.embedding.android.FlutterActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;

--- a/packages/sensors/example/pubspec.yaml
+++ b/packages/sensors/example/pubspec.yaml
@@ -10,7 +10,8 @@ dependencies:
 dev_dependencies:
   flutter_driver:
     sdk: flutter
-  e2e: ^0.2.0
+  e2e:
+    path: ../../e2e
   pedantic: ^1.8.0
 
 flutter:

--- a/packages/sensors/example/test_driver/test/sensors_e2e_test.dart
+++ b/packages/sensors/example/test_driver/test/sensors_e2e_test.dart
@@ -3,13 +3,15 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 import 'package:flutter_driver/flutter_driver.dart';
 
 Future<void> main() async {
   final FlutterDriver driver = await FlutterDriver.connect();
-  final String result =
+  final String data =
       await driver.requestData(null, timeout: const Duration(minutes: 1));
   await driver.close();
-  exit(result == 'pass' ? 0 : 1);
+  final Map<String, dynamic> result = jsonDecode(data);
+  exit(result['result'] == 'true' ? 0 : 1);
 }

--- a/packages/sensors/pubspec.yaml
+++ b/packages/sensors/pubspec.yaml
@@ -24,7 +24,8 @@ dev_dependencies:
   test: ^1.3.0
   flutter_test:
     sdk: flutter
-  e2e: ^0.2.0
+  e2e:
+    path: ../e2e
   mockito: ^4.1.1
   pedantic: ^1.8.0
 

--- a/packages/sensors/pubspec.yaml
+++ b/packages/sensors/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/flutter/plugins/tree/master/packages/sensors
 # 0.4.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.4.2+2
+version: 0.4.2+3
 
 flutter:
   plugin:

--- a/packages/share/CHANGELOG.md
+++ b/packages/share/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.4+4
+
+* Update package:e2e reference to use the local version in the flutter/plugins
+  repository.
+
 ## 0.6.4+3
 
 * Post-v2 Android embedding cleanup.

--- a/packages/share/example/android/app/src/main/java/io/flutter/plugins/shareexample/EmbeddingV1ActivityTest.java
+++ b/packages/share/example/android/app/src/main/java/io/flutter/plugins/shareexample/EmbeddingV1ActivityTest.java
@@ -1,7 +1,7 @@
 package io.flutter.plugins.shareexample;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 

--- a/packages/share/example/android/app/src/main/java/io/flutter/plugins/shareexample/EmbeddingV1ActivityTest.java
+++ b/packages/share/example/android/app/src/main/java/io/flutter/plugins/shareexample/EmbeddingV1ActivityTest.java
@@ -5,7 +5,7 @@ import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class EmbeddingV1ActivityTest {
   @Rule
   public ActivityTestRule<EmbeddingV1Activity> rule =

--- a/packages/share/example/android/app/src/main/java/io/flutter/plugins/shareexample/FlutterActivityTest.java
+++ b/packages/share/example/android/app/src/main/java/io/flutter/plugins/shareexample/FlutterActivityTest.java
@@ -10,7 +10,7 @@ import io.flutter.embedding.android.FlutterActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class FlutterActivityTest {
   @Rule
   public ActivityTestRule<FlutterActivity> rule = new ActivityTestRule<>(FlutterActivity.class);

--- a/packages/share/example/android/app/src/main/java/io/flutter/plugins/shareexample/FlutterActivityTest.java
+++ b/packages/share/example/android/app/src/main/java/io/flutter/plugins/shareexample/FlutterActivityTest.java
@@ -5,7 +5,7 @@
 package io.flutter.plugins.shareexample;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import io.flutter.embedding.android.FlutterActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;

--- a/packages/share/example/pubspec.yaml
+++ b/packages/share/example/pubspec.yaml
@@ -10,7 +10,8 @@ dependencies:
 dev_dependencies:
   flutter_driver:
     sdk: flutter
-  e2e: ^0.2.0
+  e2e:
+    path: ../../e2e
   pedantic: ^1.8.0
 
 flutter:
@@ -19,4 +20,4 @@ flutter:
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
   flutter: ">=1.9.1+hotfix.2 <2.0.0"
-  
+

--- a/packages/share/example/test_driver/test/share_e2e_test.dart
+++ b/packages/share/example/test_driver/test/share_e2e_test.dart
@@ -3,13 +3,15 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 import 'package:flutter_driver/flutter_driver.dart';
 
 Future<void> main() async {
   final FlutterDriver driver = await FlutterDriver.connect();
-  final String result =
+  final String data =
       await driver.requestData(null, timeout: const Duration(minutes: 1));
   await driver.close();
-  exit(result == 'pass' ? 0 : 1);
+  final Map<String, dynamic> result = jsonDecode(data);
+  exit(result['result'] == 'true' ? 0 : 1);
 }

--- a/packages/share/pubspec.yaml
+++ b/packages/share/pubspec.yaml
@@ -26,7 +26,8 @@ dev_dependencies:
   mockito: ^3.0.0
   flutter_test:
     sdk: flutter
-  e2e: ^0.2.0
+  e2e:
+    path: ../e2e
   pedantic: ^1.8.0
 
 environment:

--- a/packages/share/pubspec.yaml
+++ b/packages/share/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/flutter/plugins/tree/master/packages/share
 # 0.6.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.6.4+3
+version: 0.6.4+4
 
 flutter:
   plugin:

--- a/packages/shared_preferences/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.9
+
+* Update package:e2e reference to use the local version in the flutter/plugins
+  repository.
+
 ## 0.5.8
 
 * Support Linux by default.

--- a/packages/shared_preferences/shared_preferences/example/android/app/src/main/java/io/flutter/plugins/sharedpreferencesexample/EmbeddingV1ActivityTest.java
+++ b/packages/shared_preferences/shared_preferences/example/android/app/src/main/java/io/flutter/plugins/sharedpreferencesexample/EmbeddingV1ActivityTest.java
@@ -6,7 +6,7 @@ import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class EmbeddingV1ActivityTest {
   @Rule
   public ActivityTestRule<EmbeddingV1Activity> rule =

--- a/packages/shared_preferences/shared_preferences/example/android/app/src/main/java/io/flutter/plugins/sharedpreferencesexample/EmbeddingV1ActivityTest.java
+++ b/packages/shared_preferences/shared_preferences/example/android/app/src/main/java/io/flutter/plugins/sharedpreferencesexample/EmbeddingV1ActivityTest.java
@@ -2,7 +2,7 @@
 package io.flutter.plugins.sharedpreferencesexample;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 

--- a/packages/shared_preferences/shared_preferences/example/android/app/src/main/java/io/flutter/plugins/sharedpreferencesexample/FlutterActivityTest.java
+++ b/packages/shared_preferences/shared_preferences/example/android/app/src/main/java/io/flutter/plugins/sharedpreferencesexample/FlutterActivityTest.java
@@ -10,7 +10,7 @@ import io.flutter.embedding.android.FlutterActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class FlutterActivityTest {
   @Rule
   public ActivityTestRule<FlutterActivity> rule = new ActivityTestRule<>(FlutterActivity.class);

--- a/packages/shared_preferences/shared_preferences/example/android/app/src/main/java/io/flutter/plugins/sharedpreferencesexample/FlutterActivityTest.java
+++ b/packages/shared_preferences/shared_preferences/example/android/app/src/main/java/io/flutter/plugins/sharedpreferencesexample/FlutterActivityTest.java
@@ -5,7 +5,7 @@
 package io.flutter.plugins.sharedpreferencesexample;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import io.flutter.embedding.android.FlutterActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;

--- a/packages/shared_preferences/shared_preferences/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences/example/pubspec.yaml
@@ -11,7 +11,8 @@ dev_dependencies:
   flutter_driver:
     sdk: flutter
   test: any
-  e2e: ^0.2.0
+  e2e:
+    path: ../../../e2e
   pedantic: ^1.8.0
 
 flutter:

--- a/packages/shared_preferences/shared_preferences/example/test_driver/shared_preferences_e2e_test.dart
+++ b/packages/shared_preferences/shared_preferences/example/test_driver/shared_preferences_e2e_test.dart
@@ -3,13 +3,15 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 import 'package:flutter_driver/flutter_driver.dart';
 
 Future<void> main() async {
   final FlutterDriver driver = await FlutterDriver.connect();
-  final String result =
+  final String data =
       await driver.requestData(null, timeout: const Duration(minutes: 1));
   await driver.close();
-  exit(result == 'pass' ? 0 : 1);
+  final Map<String, dynamic> result = jsonDecode(data);
+  exit(result['result'] == 'true' ? 0 : 1);
 }

--- a/packages/shared_preferences/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/flutter/plugins/tree/master/packages/shared_prefere
 # 0.5.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.5.8
+version: 0.5.9
 
 flutter:
   plugin:

--- a/packages/shared_preferences/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences/pubspec.yaml
@@ -42,7 +42,8 @@ dev_dependencies:
   flutter_driver:
     sdk: flutter
   test: any
-  e2e: ^0.2.0
+  e2e:
+    path: ../../e2e
   pedantic: ^1.8.0
 
 environment:

--- a/packages/shared_preferences/shared_preferences_linux/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_linux/example/pubspec.yaml
@@ -18,7 +18,8 @@ dev_dependencies:
   flutter_driver:
     sdk: flutter
   test: any
-  e2e: ^0.2.0
+  e2e:
+    path: ../../../e2e
   pedantic: ^1.8.0
 
 flutter:

--- a/packages/shared_preferences/shared_preferences_linux/example/test_driver/shared_preferences_e2e_test.dart
+++ b/packages/shared_preferences/shared_preferences_linux/example/test_driver/shared_preferences_e2e_test.dart
@@ -3,13 +3,15 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 import 'package:flutter_driver/flutter_driver.dart';
 
 Future<void> main() async {
   final FlutterDriver driver = await FlutterDriver.connect();
-  final String result =
+  final String data =
       await driver.requestData(null, timeout: const Duration(minutes: 1));
   await driver.close();
-  exit(result == 'pass' ? 0 : 1);
+  final Map<String, dynamic> result = jsonDecode(data);
+  exit(result['result'] == 'true' ? 0 : 1);
 }

--- a/packages/shared_preferences/shared_preferences_macos/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_macos/example/pubspec.yaml
@@ -12,7 +12,8 @@ dev_dependencies:
   flutter_driver:
     sdk: flutter
   test: any
-  e2e: ^0.2.0
+  e2e:
+    path: ../../../e2e
   pedantic: ^1.8.0
 
 flutter:

--- a/packages/shared_preferences/shared_preferences_macos/example/test_driver/shared_preferences_e2e_test.dart
+++ b/packages/shared_preferences/shared_preferences_macos/example/test_driver/shared_preferences_e2e_test.dart
@@ -3,13 +3,15 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 import 'package:flutter_driver/flutter_driver.dart';
 
 Future<void> main() async {
   final FlutterDriver driver = await FlutterDriver.connect();
-  final String result =
+  final String data =
       await driver.requestData(null, timeout: const Duration(minutes: 1));
   await driver.close();
-  exit(result == 'pass' ? 0 : 1);
+  final Map<String, dynamic> result = jsonDecode(data);
+  exit(result['result'] == 'true' ? 0 : 1);
 }

--- a/packages/url_launcher/url_launcher/example/android/app/src/androidTestDebug/java/io/flutter/plugins/urllauncherexample/EmbeddingV1ActivityTest.java
+++ b/packages/url_launcher/url_launcher/example/android/app/src/androidTestDebug/java/io/flutter/plugins/urllauncherexample/EmbeddingV1ActivityTest.java
@@ -1,7 +1,7 @@
 package io.flutter.plugins.urllauncherexample;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 

--- a/packages/url_launcher/url_launcher/example/android/app/src/androidTestDebug/java/io/flutter/plugins/urllauncherexample/EmbeddingV1ActivityTest.java
+++ b/packages/url_launcher/url_launcher/example/android/app/src/androidTestDebug/java/io/flutter/plugins/urllauncherexample/EmbeddingV1ActivityTest.java
@@ -5,7 +5,7 @@ import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class EmbeddingV1ActivityTest {
   @Rule
   public ActivityTestRule<EmbeddingV1Activity> rule =

--- a/packages/url_launcher/url_launcher/example/android/app/src/androidTestDebug/java/io/flutter/plugins/urllauncherexample/MainActivityTest.java
+++ b/packages/url_launcher/url_launcher/example/android/app/src/androidTestDebug/java/io/flutter/plugins/urllauncherexample/MainActivityTest.java
@@ -1,7 +1,7 @@
 package io.flutter.plugins.urllauncherexample;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import io.flutter.embedding.android.FlutterActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;

--- a/packages/url_launcher/url_launcher/example/android/app/src/androidTestDebug/java/io/flutter/plugins/urllauncherexample/MainActivityTest.java
+++ b/packages/url_launcher/url_launcher/example/android/app/src/androidTestDebug/java/io/flutter/plugins/urllauncherexample/MainActivityTest.java
@@ -6,7 +6,7 @@ import io.flutter.embedding.android.FlutterActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class FlutterActivityTest {
   @Rule
   public ActivityTestRule<FlutterActivity> rule = new ActivityTestRule<>(FlutterActivity.class);

--- a/packages/url_launcher/url_launcher/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/example/pubspec.yaml
@@ -8,7 +8,8 @@ dependencies:
     path: ../
 
 dev_dependencies:
-  e2e: "^0.2.0"
+  e2e:
+    path: ../../../e2e
   flutter_driver:
     sdk: flutter
   pedantic: ^1.8.0

--- a/packages/url_launcher/url_launcher/example/test_driver/url_launcher_e2e_test.dart
+++ b/packages/url_launcher/url_launcher/example/test_driver/url_launcher_e2e_test.dart
@@ -2,14 +2,16 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
-
 import 'package:flutter_driver/flutter_driver.dart';
 
 Future<void> main() async {
   final FlutterDriver driver = await FlutterDriver.connect();
-  final String result =
+  final String data =
       await driver.requestData(null, timeout: const Duration(minutes: 1));
   await driver.close();
-  exit(result == 'pass' ? 0 : 1);
+  final Map<String, dynamic> result = jsonDecode(data);
+  exit(result['result'] == 'true' ? 0 : 1);
 }

--- a/packages/url_launcher/url_launcher_linux/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_linux/example/pubspec.yaml
@@ -9,7 +9,8 @@ dependencies:
     path: ../
 
 dev_dependencies:
-  e2e: "^0.2.0"
+  e2e:
+    path: ../../../e2e
   flutter_driver:
     sdk: flutter
   pedantic: ^1.8.0

--- a/packages/url_launcher/url_launcher_linux/example/test_driver/url_launcher_e2e_test.dart
+++ b/packages/url_launcher/url_launcher_linux/example/test_driver/url_launcher_e2e_test.dart
@@ -2,14 +2,16 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
-
 import 'package:flutter_driver/flutter_driver.dart';
 
 Future<void> main() async {
   final FlutterDriver driver = await FlutterDriver.connect();
-  final String result =
+  final String data =
       await driver.requestData(null, timeout: const Duration(minutes: 1));
   await driver.close();
-  exit(result == 'pass' ? 0 : 1);
+  final Map<String, dynamic> result = jsonDecode(data);
+  exit(result['result'] == 'true' ? 0 : 1);
 }

--- a/packages/url_launcher/url_launcher_macos/example/android/app/src/androidTestDebug/java/io/flutter/plugins/urllauncherexample/EmbeddingV1ActivityTest.java
+++ b/packages/url_launcher/url_launcher_macos/example/android/app/src/androidTestDebug/java/io/flutter/plugins/urllauncherexample/EmbeddingV1ActivityTest.java
@@ -1,7 +1,7 @@
 package io.flutter.plugins.urllauncherexample;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 

--- a/packages/url_launcher/url_launcher_macos/example/android/app/src/androidTestDebug/java/io/flutter/plugins/urllauncherexample/EmbeddingV1ActivityTest.java
+++ b/packages/url_launcher/url_launcher_macos/example/android/app/src/androidTestDebug/java/io/flutter/plugins/urllauncherexample/EmbeddingV1ActivityTest.java
@@ -5,7 +5,7 @@ import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class EmbeddingV1ActivityTest {
   @Rule
   public ActivityTestRule<EmbeddingV1Activity> rule =

--- a/packages/url_launcher/url_launcher_macos/example/android/app/src/androidTestDebug/java/io/flutter/plugins/urllauncherexample/FlutterActivityTest.java
+++ b/packages/url_launcher/url_launcher_macos/example/android/app/src/androidTestDebug/java/io/flutter/plugins/urllauncherexample/FlutterActivityTest.java
@@ -1,7 +1,7 @@
 package io.flutter.plugins.urllauncherexample;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import io.flutter.embedding.android.FlutterActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;

--- a/packages/url_launcher/url_launcher_macos/example/android/app/src/androidTestDebug/java/io/flutter/plugins/urllauncherexample/FlutterActivityTest.java
+++ b/packages/url_launcher/url_launcher_macos/example/android/app/src/androidTestDebug/java/io/flutter/plugins/urllauncherexample/FlutterActivityTest.java
@@ -6,7 +6,7 @@ import io.flutter.embedding.android.FlutterActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class FlutterActivityTest {
   @Rule
   public ActivityTestRule<FlutterActivity> rule = new ActivityTestRule<>(FlutterActivity.class);

--- a/packages/url_launcher/url_launcher_macos/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_macos/example/pubspec.yaml
@@ -9,7 +9,8 @@ dependencies:
     path: ../
 
 dev_dependencies:
-  e2e: "^0.2.0"
+  e2e:
+    path: ../../../e2e
   flutter_driver:
     sdk: flutter
   pedantic: ^1.8.0

--- a/packages/url_launcher/url_launcher_macos/example/test_driver/url_launcher_e2e_test.dart
+++ b/packages/url_launcher/url_launcher_macos/example/test_driver/url_launcher_e2e_test.dart
@@ -2,14 +2,16 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
-
 import 'package:flutter_driver/flutter_driver.dart';
 
 Future<void> main() async {
   final FlutterDriver driver = await FlutterDriver.connect();
-  final String result =
+  final String data =
       await driver.requestData(null, timeout: const Duration(minutes: 1));
   await driver.close();
-  exit(result == 'pass' ? 0 : 1);
+  final Map<String, dynamic> result = jsonDecode(data);
+  exit(result['result'] == 'true' ? 0 : 1);
 }

--- a/packages/video_player/video_player/example/pubspec.yaml
+++ b/packages/video_player/video_player/example/pubspec.yaml
@@ -12,7 +12,8 @@ dev_dependencies:
     sdk: flutter
   flutter_driver:
     sdk: flutter
-  e2e: "^0.2.0"
+  e2e:
+    path: ../../../e2e
   test: any
   pedantic: ^1.8.0
 

--- a/packages/video_player/video_player/example/test_driver/video_player_e2e_test.dart
+++ b/packages/video_player/video_player/example/test_driver/video_player_e2e_test.dart
@@ -3,13 +3,15 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 import 'package:flutter_driver/flutter_driver.dart';
 
 Future<void> main() async {
   final FlutterDriver driver = await FlutterDriver.connect();
-  final String result =
+  final String data =
       await driver.requestData(null, timeout: const Duration(minutes: 1));
   await driver.close();
-  exit(result == 'pass' ? 0 : 1);
+  final Map<String, dynamic> result = jsonDecode(data);
+  exit(result['result'] == 'true' ? 0 : 1);
 }

--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.22+2
+
+* Update package:e2e reference to use the local version in the flutter/plugins
+  repository.
+
 ## 0.3.22+1
 
 * Update the `setAndGetScrollPosition` to use hard coded values and add a `pumpAndSettle` call.

--- a/packages/webview_flutter/example/android/app/src/androidTestDebug/java/io/flutter/plugins/webviewflutterexample/EmbeddingV1ActivityTest.java
+++ b/packages/webview_flutter/example/android/app/src/androidTestDebug/java/io/flutter/plugins/webviewflutterexample/EmbeddingV1ActivityTest.java
@@ -1,7 +1,7 @@
 package io.flutter.plugins.webviewflutterexample;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 

--- a/packages/webview_flutter/example/android/app/src/androidTestDebug/java/io/flutter/plugins/webviewflutterexample/EmbeddingV1ActivityTest.java
+++ b/packages/webview_flutter/example/android/app/src/androidTestDebug/java/io/flutter/plugins/webviewflutterexample/EmbeddingV1ActivityTest.java
@@ -5,7 +5,7 @@ import dev.flutter.plugins.e2e.FlutterTestRunner;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class EmbeddingV1ActivityTest {
   @Rule
   public ActivityTestRule<EmbeddingV1Activity> rule =

--- a/packages/webview_flutter/example/android/app/src/androidTestDebug/java/io/flutter/plugins/webviewflutterexample/MainActivityTest.java
+++ b/packages/webview_flutter/example/android/app/src/androidTestDebug/java/io/flutter/plugins/webviewflutterexample/MainActivityTest.java
@@ -6,7 +6,7 @@ import io.flutter.embedding.android.FlutterActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-@RunWith(FlutterRunner.class)
+@RunWith(FlutterTestRunner.class)
 public class MainActivityTest {
   @Rule
   public ActivityTestRule<FlutterActivity> rule = new ActivityTestRule<>(FlutterActivity.class);

--- a/packages/webview_flutter/example/android/app/src/androidTestDebug/java/io/flutter/plugins/webviewflutterexample/MainActivityTest.java
+++ b/packages/webview_flutter/example/android/app/src/androidTestDebug/java/io/flutter/plugins/webviewflutterexample/MainActivityTest.java
@@ -1,7 +1,7 @@
 package io.flutter.plugins.webviewflutterexample;
 
 import androidx.test.rule.ActivityTestRule;
-import dev.flutter.plugins.e2e.FlutterRunner;
+import dev.flutter.plugins.e2e.FlutterTestRunner;
 import io.flutter.embedding.android.FlutterActivity;
 import org.junit.Rule;
 import org.junit.runner.RunWith;

--- a/packages/webview_flutter/example/pubspec.yaml
+++ b/packages/webview_flutter/example/pubspec.yaml
@@ -15,7 +15,8 @@ dev_dependencies:
     sdk: flutter
   flutter_driver:
     sdk: flutter
-  e2e: "^0.2.0"
+  e2e:
+    path: ../../e2e
   pedantic: ^1.8.0
 
 flutter:

--- a/packages/webview_flutter/example/test_driver/webview_flutter_e2e_test.dart
+++ b/packages/webview_flutter/example/test_driver/webview_flutter_e2e_test.dart
@@ -3,14 +3,15 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
-
 import 'package:flutter_driver/flutter_driver.dart';
 
 Future<void> main() async {
   final FlutterDriver driver = await FlutterDriver.connect();
-  final String result =
+  final String data =
       await driver.requestData(null, timeout: const Duration(minutes: 1));
   await driver.close();
-  exit(result == 'pass' ? 0 : 1);
+  final Map<String, dynamic> result = jsonDecode(data);
+  exit(result['result'] == 'true' ? 0 : 1);
 }

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
-version: 0.3.22+1
+version: 0.3.22+2
 homepage: https://github.com/flutter/plugins/tree/master/packages/webview_flutter
 
 environment:


### PR DESCRIPTION
Make sure that we pick up the package as it exists in this repo, rather than whatever happens to be published on pub.

This also meant updating some outdated/deprecated references (FlutterRunner -> FlutterTestRunner) in older usages.

/cc @caref @digiter 