### PR TITLE
[google_maps_flutter] Use `onCameraIdle` to determine when map is ready in e2e tests

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.28+3
+
+* Update the e2e tests to use `onCameraIdle` instead of using an arbitrary delay.
+
 ## 0.5.28+2
 
 * Move test introduced in #2449 to its right location.

--- a/packages/google_maps_flutter/google_maps_flutter/example/test_driver/google_maps_e2e.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/test_driver/google_maps_e2e.dart
@@ -447,6 +447,7 @@ void main() {
         await mapControllerCompleter.future;
 
     await tester.pumpAndSettle();
+    await onCameraIdleCompleter.future;
 
     await onCameraIdleCompleter.future;
 

--- a/packages/google_maps_flutter/google_maps_flutter/example/test_driver/google_maps_e2e.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/test_driver/google_maps_e2e.dart
@@ -449,8 +449,6 @@ void main() {
     await tester.pumpAndSettle();
     await onCameraIdleCompleter.future;
 
-    await onCameraIdleCompleter.future;
-
     ScreenCoordinate coordinate =
         await mapController.getScreenCoordinate(_kInitialCameraPosition.target);
     Rect rect = tester.getRect(find.byKey(key));

--- a/packages/google_maps_flutter/google_maps_flutter/example/test_driver/google_maps_e2e.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/test_driver/google_maps_e2e.dart
@@ -426,6 +426,7 @@ void main() {
   testWidgets('testInitialCenterLocationAtCenter', (WidgetTester tester) async {
     final Completer<GoogleMapController> mapControllerCompleter =
         Completer<GoogleMapController>();
+    final Completer<void> onCameraIdleCompleter = Completer<void>();
     final Key key = GlobalKey();
     await tester.pumpWidget(
       Directionality(
@@ -436,6 +437,9 @@ void main() {
           onMapCreated: (GoogleMapController controller) {
             mapControllerCompleter.complete(controller);
           },
+          onCameraIdle: () {
+            onCameraIdleCompleter.complete();
+          },
         ),
       ),
     );
@@ -443,10 +447,8 @@ void main() {
         await mapControllerCompleter.future;
 
     await tester.pumpAndSettle();
-    // TODO(cyanglaz): Remove this after we added `mapRendered` callback, and `mapControllerCompleter.complete(controller)` above should happen
-    // in `mapRendered`.
-    // https://github.com/flutter/flutter/issues/54758
-    await Future.delayed(Duration(seconds: 1));
+
+    await onCameraIdleCompleter.future;
 
     ScreenCoordinate coordinate =
         await mapController.getScreenCoordinate(_kInitialCameraPosition.target);
@@ -775,6 +777,7 @@ void main() {
     final Key key = GlobalKey();
     final Completer<GoogleMapController> controllerCompleter =
         Completer<GoogleMapController>();
+    final Completer<void> onCameraIdleCompleter = Completer<void>();
 
     await tester.pumpWidget(Directionality(
       textDirection: TextDirection.ltr,
@@ -784,16 +787,17 @@ void main() {
         onMapCreated: (GoogleMapController controller) {
           controllerCompleter.complete(controller);
         },
+        onCameraIdle: () {
+          onCameraIdleCompleter.complete();
+        },
       ),
     ));
 
     final GoogleMapController controller = await controllerCompleter.future;
 
     await tester.pumpAndSettle();
-    // TODO(cyanglaz): Remove this after we added `mapRendered` callback, and `mapControllerCompleter.complete(controller)` above should happen
-    // in `mapRendered`.
-    // https://github.com/flutter/flutter/issues/54758
-    await Future.delayed(Duration(seconds: 1));
+
+    await onCameraIdleCompleter.future;
 
     final LatLngBounds visibleRegion = await controller.getVisibleRegion();
     final LatLng topLeft =
@@ -810,6 +814,7 @@ void main() {
     final Key key = GlobalKey();
     final Completer<GoogleMapController> controllerCompleter =
         Completer<GoogleMapController>();
+    Completer<void> onCameraIdleCompleter = Completer<void>();
 
     await tester.pumpWidget(Directionality(
       textDirection: TextDirection.ltr,
@@ -819,22 +824,24 @@ void main() {
         onMapCreated: (GoogleMapController controller) {
           controllerCompleter.complete(controller);
         },
+        onCameraIdle: () {
+          onCameraIdleCompleter.complete();
+        },
       ),
     ));
 
     final GoogleMapController controller = await controllerCompleter.future;
 
     await tester.pumpAndSettle();
-    // TODO(cyanglaz): Remove this after we added `mapRendered` callback, and `mapControllerCompleter.complete(controller)` above should happen
-    // in `mapRendered`.
-    // https://github.com/flutter/flutter/issues/54758
-    await Future.delayed(Duration(seconds: 1));
+    await onCameraIdleCompleter.future;
+    onCameraIdleCompleter = Completer<void>();
 
     double zoom = await controller.getZoomLevel();
     expect(zoom, _kInitialZoomLevel);
 
     await controller.moveCamera(CameraUpdate.zoomTo(7));
     await tester.pumpAndSettle();
+    await onCameraIdleCompleter.future;
     zoom = await controller.getZoomLevel();
     expect(zoom, equals(7));
   });
@@ -843,6 +850,7 @@ void main() {
     final Key key = GlobalKey();
     final Completer<GoogleMapController> controllerCompleter =
         Completer<GoogleMapController>();
+    final Completer<void> onCameraIdleCompleter = Completer<void>();
 
     await tester.pumpWidget(Directionality(
       textDirection: TextDirection.ltr,
@@ -852,15 +860,15 @@ void main() {
         onMapCreated: (GoogleMapController controller) {
           controllerCompleter.complete(controller);
         },
+        onCameraIdle: () {
+          onCameraIdleCompleter.complete();
+        },
       ),
     ));
     final GoogleMapController controller = await controllerCompleter.future;
 
     await tester.pumpAndSettle();
-    // TODO(cyanglaz): Remove this after we added `mapRendered` callback, and `mapControllerCompleter.complete(controller)` above should happen
-    // in `mapRendered`.
-    // https://github.com/flutter/flutter/issues/54758
-    await Future.delayed(Duration(seconds: 1));
+    await onCameraIdleCompleter.future;
 
     final LatLngBounds visibleRegion = await controller.getVisibleRegion();
     final LatLng northWest = LatLng(
@@ -875,10 +883,14 @@ void main() {
   testWidgets('testResizeWidget', (WidgetTester tester) async {
     final Completer<GoogleMapController> controllerCompleter =
         Completer<GoogleMapController>();
+    final Completer<void> onCameraIdleCompleter = Completer<void>();
     final GoogleMap map = GoogleMap(
       initialCameraPosition: _kInitialCameraPosition,
       onMapCreated: (GoogleMapController controller) async {
         controllerCompleter.complete(controller);
+      },
+      onCameraIdle: () {
+        onCameraIdleCompleter.complete();
       },
     );
     await tester.pumpWidget(Directionality(
@@ -895,10 +907,7 @@ void main() {
                 body: SizedBox(height: 400, width: 400, child: map)))));
 
     await tester.pumpAndSettle();
-    // TODO(cyanglaz): Remove this after we added `mapRendered` callback, and `mapControllerCompleter.complete(controller)` above should happen
-    // in `mapRendered`.
-    // https://github.com/flutter/flutter/issues/54758
-    await Future.delayed(Duration(seconds: 1));
+    await onCameraIdleCompleter.future;
 
     // Simple call to make sure that the app hasn't crashed.
     final LatLngBounds bounds1 = await controller.getVisibleRegion();

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter/google_maps_flutter
-version: 0.5.28+2
+version: 0.5.28+3
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Description

We used to use some arbitrary delays on e2e tests, which is bound to be flaky. Updated the tests to use `onCameraIdle` to determine when the maps are ready.

## Related Issues

No issues has been created as we haven't really see the flakiness.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
