### PR TITLE
pictureImageReader null check

### DIFF
--- a/packages/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
+++ b/packages/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
@@ -421,7 +421,11 @@ public class Camera {
   }
 
   public void startPreview() throws CameraAccessException {
-    createCaptureSession(CameraDevice.TEMPLATE_PREVIEW, pictureImageReader.getSurface());
+    if(pictureImageReader!=null){
+      createCaptureSession(CameraDevice.TEMPLATE_PREVIEW, pictureImageReader.getSurface());
+    }
+
+
   }
 
   public void startPreviewWithImageStream(EventChannel imageStreamChannel)


### PR DESCRIPTION
On some android devices,  I got an error because of Camera plugin. When we checked the error , we found it in this path : plugins\packages\camera\android\src\main\java\io\flutter\plugins\camera\camera.java

In the camera.java file startPreview caused an error because of pictureImageReader. We made null check for pictureImageReader , after that we never got that error. 

I send a commit to check null for pictureImageReader.