### PR TITLE
[image_picker] deprecate `retrieveLostData`

### DIFF
--- a/packages/image_picker/image_picker/CHANGELOG.md
+++ b/packages/image_picker/image_picker/CHANGELOG.md
@@ -1,8 +1,11 @@
+## 0.6.7+6
+
+* Deprecate method `retrieveLostData`.
+
 ## 0.6.7+5
 
 * Update package:e2e reference to use the local version in the flutter/plugins
   repository.
-
 
 ## 0.6.7+4
 

--- a/packages/image_picker/image_picker/lib/image_picker.dart
+++ b/packages/image_picker/image_picker/lib/image_picker.dart
@@ -178,6 +178,7 @@ class ImagePicker {
   /// See also:
   /// * [LostDataResponse], for what's included in the response.
   /// * [Android Activity Lifecycle](https://developer.android.com/reference/android/app/Activity.html), for more information on MainActivity destruction.
+  @Deprecated('Use imagePicker.getLostData() method instead.')
   static Future<LostDataResponse> retrieveLostData() {
     return platform.retrieveLostDataAsDartIoFile();
   }

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker
 description: Flutter plugin for selecting images from the Android and iOS image
   library, and taking new pictures with the camera.
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker/image_picker
-version: 0.6.7+5
+version: 0.6.7+6
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

As method `ImagePicker.retrieveLostData()` returns a deprecated class (`LostDataResponse`), the method should also be annotated `@Deprecated`.
Advise using `getLostData` method instead (`retrieveLostData` -> `getLostData`), this is consistent with `pick_video` -> `get_video`, and `pick_image` -> `get_image`.
