### PR TITLE
[google_maps_flutter(_platform_interface)] Make the plugin friendlier to the web implementation.

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.29
+
+* Pass a constant `creationMapId` to `platform.buildView`, so web can return a cached widget DOM when flutter attempts to repaint there.
+* Modify some examples slightly so they're more web-friendly.
+
 ## 0.5.28+2
 
 * Move test introduced in #2449 to its right location.

--- a/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.5.29
 
-* Pass a constant `creationMapId` to `platform.buildView`, so web can return a cached widget DOM when flutter attempts to repaint there.
+* Pass a constant `_web_only_mapCreationId` to `platform.buildView`, so web can return a cached widget DOM when flutter attempts to repaint there.
 * Modify some examples slightly so they're more web-friendly.
 
 ## 0.5.28+2

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/marker_icons.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/marker_icons.dart
@@ -73,7 +73,7 @@ class MarkerIconsBodyState extends State<MarkerIconsBody> {
   Future<void> _createMarkerImageFromAsset(BuildContext context) async {
     if (_markerIcon == null) {
       final ImageConfiguration imageConfiguration =
-          createLocalImageConfiguration(context);
+          createLocalImageConfiguration(context, size: Size.square(48));
       BitmapDescriptor.fromAssetImage(
               imageConfiguration, 'assets/red_square.png')
           .then(_updateBitmap);

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/place_polyline.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/place_polyline.dart
@@ -4,8 +4,7 @@
 
 // ignore_for_file: public_member_api_docs
 
-import 'dart:io' show Platform;
-
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 
@@ -202,7 +201,7 @@ class PlacePolylineBodyState extends State<PlacePolylineBody> {
 
   @override
   Widget build(BuildContext context) {
-    final bool iOSorNotSelected = Platform.isIOS || (selectedPolyline == null);
+    final bool iOSorNotSelected = (!kIsWeb && defaultTargetPlatform == TargetPlatform.iOS) || (selectedPolyline == null);
 
     return Column(
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/place_polyline.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/place_polyline.dart
@@ -201,7 +201,9 @@ class PlacePolylineBodyState extends State<PlacePolylineBody> {
 
   @override
   Widget build(BuildContext context) {
-    final bool iOSorNotSelected = (!kIsWeb && defaultTargetPlatform == TargetPlatform.iOS) || (selectedPolyline == null);
+    final bool iOSorNotSelected =
+        (!kIsWeb && defaultTargetPlatform == TargetPlatform.iOS) ||
+            (selectedPolyline == null);
 
     return Column(
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,

--- a/packages/google_maps_flutter/google_maps_flutter/lib/google_maps_flutter.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/lib/google_maps_flutter.dart
@@ -8,6 +8,7 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 import 'dart:ui';
+import 'dart:math' as math show Random;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';

--- a/packages/google_maps_flutter/google_maps_flutter/lib/google_maps_flutter.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/lib/google_maps_flutter.dart
@@ -8,7 +8,6 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 import 'dart:ui';
-import 'dart:math' as math show Random;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';

--- a/packages/google_maps_flutter/google_maps_flutter/lib/src/google_map.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/lib/src/google_map.dart
@@ -10,6 +10,8 @@ part of google_maps_flutter;
 /// map is created.
 typedef void MapCreatedCallback(GoogleMapController controller);
 
+final _random = math.Random();
+
 /// A widget which displays a map with data obtained from the Google Maps service.
 class GoogleMap extends StatefulWidget {
   /// Creates a widget displaying data from Google Maps services.
@@ -205,6 +207,8 @@ class GoogleMap extends StatefulWidget {
 }
 
 class _GoogleMapState extends State<GoogleMap> {
+  final _creationMapId = _random.nextInt(4294967296); // 1<<32
+
   final Completer<GoogleMapController> _controller =
       Completer<GoogleMapController>();
 
@@ -223,7 +227,10 @@ class _GoogleMapState extends State<GoogleMap> {
       'polygonsToAdd': serializePolygonSet(widget.polygons),
       'polylinesToAdd': serializePolylineSet(widget.polylines),
       'circlesToAdd': serializeCircleSet(widget.circles),
+      'creationMapId': _creationMapId,
     };
+    // TODO: Can this call to buildView be moved to the initState method?
+    // That way we wouldn't need the _creationMapId
     return _googleMapsFlutterPlatform.buildView(
       creationParams,
       widget.gestureRecognizers,

--- a/packages/google_maps_flutter/google_maps_flutter/lib/src/google_map.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/lib/src/google_map.dart
@@ -10,7 +10,11 @@ part of google_maps_flutter;
 /// map is created.
 typedef void MapCreatedCallback(GoogleMapController controller);
 
-final _random = math.Random();
+// This counter is used to provide a stable "constant" initialization id
+// to the buildView function, so the web implementation can use it as a
+// cache key. This needs to be provided from the outside, because web
+// views seem to re-render much more often that mobile platform views.
+int _web_only_platformId = 0;
 
 /// A widget which displays a map with data obtained from the Google Maps service.
 class GoogleMap extends StatefulWidget {
@@ -207,7 +211,7 @@ class GoogleMap extends StatefulWidget {
 }
 
 class _GoogleMapState extends State<GoogleMap> {
-  final _creationMapId = _random.nextInt(4294967296); // 1<<32
+  final _web_only_mapCreationId = _web_only_platformId++;
 
   final Completer<GoogleMapController> _controller =
       Completer<GoogleMapController>();
@@ -227,10 +231,9 @@ class _GoogleMapState extends State<GoogleMap> {
       'polygonsToAdd': serializePolygonSet(widget.polygons),
       'polylinesToAdd': serializePolylineSet(widget.polylines),
       'circlesToAdd': serializeCircleSet(widget.circles),
-      'creationMapId': _creationMapId,
+      '_web_only_mapCreationId': _web_only_mapCreationId,
     };
-    // TODO: Can this call to buildView be moved to the initState method?
-    // That way we wouldn't need the _creationMapId
+
     return _googleMapsFlutterPlatform.buildView(
       creationParams,
       widget.gestureRecognizers,

--- a/packages/google_maps_flutter/google_maps_flutter/lib/src/google_map.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/lib/src/google_map.dart
@@ -14,7 +14,7 @@ typedef void MapCreatedCallback(GoogleMapController controller);
 // to the buildView function, so the web implementation can use it as a
 // cache key. This needs to be provided from the outside, because web
 // views seem to re-render much more often that mobile platform views.
-int _web_only_platformId = 0;
+int _webOnlyMapId = 0;
 
 /// A widget which displays a map with data obtained from the Google Maps service.
 class GoogleMap extends StatefulWidget {
@@ -211,7 +211,7 @@ class GoogleMap extends StatefulWidget {
 }
 
 class _GoogleMapState extends State<GoogleMap> {
-  final _web_only_mapCreationId = _web_only_platformId++;
+  final _webOnlyMapCreationId = _webOnlyMapId++;
 
   final Completer<GoogleMapController> _controller =
       Completer<GoogleMapController>();
@@ -231,7 +231,7 @@ class _GoogleMapState extends State<GoogleMap> {
       'polygonsToAdd': serializePolygonSet(widget.polygons),
       'polylinesToAdd': serializePolylineSet(widget.polylines),
       'circlesToAdd': serializeCircleSet(widget.circles),
-      '_web_only_mapCreationId': _web_only_mapCreationId,
+      '_webOnlyMapCreationId': _webOnlyMapCreationId,
     };
 
     return _googleMapsFlutterPlatform.buildView(

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -19,6 +19,7 @@ dev_dependencies:
     sdk: flutter
   test: ^1.6.0
   pedantic: ^1.8.0
+  plugin_platform_interface: ^1.0.2
   mockito: ^4.1.1
 
 flutter:

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -19,6 +19,7 @@ dev_dependencies:
     sdk: flutter
   test: ^1.6.0
   pedantic: ^1.8.0
+  mockito: ^4.1.1
 
 flutter:
   plugin:

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter/google_maps_flutter
-version: 0.5.28+2
+version: 0.5.29
 
 dependencies:
   flutter:

--- a/packages/google_maps_flutter/google_maps_flutter/test/map_creation_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/test/map_creation_test.dart
@@ -26,7 +26,6 @@ void main() {
   testWidgets('_webOnlyMapCreationId increments with each GoogleMap widget', (
     WidgetTester tester,
   ) async {
-
     // Inject two map widgets...
     await tester.pumpWidget(
       Directionality(
@@ -34,10 +33,14 @@ void main() {
         child: Column(
           children: const [
             GoogleMap(
-              initialCameraPosition: CameraPosition(target: LatLng(43.362, -5.849)),
+              initialCameraPosition: CameraPosition(
+                target: LatLng(43.362, -5.849),
+              ),
             ),
             GoogleMap(
-              initialCameraPosition: CameraPosition(target: LatLng(47.649, -122.350)),
+              initialCameraPosition: CameraPosition(
+                target: LatLng(47.649, -122.350),
+              ),
             ),
           ],
         ),

--- a/packages/google_maps_flutter/google_maps_flutter/test/map_creation_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/test/map_creation_test.dart
@@ -1,0 +1,61 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:google_maps_flutter_platform_interface/google_maps_flutter_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:mockito/mockito.dart';
+
+class MockGoogleMapsFlutterPlatform extends Mock
+    with MockPlatformInterfaceMixin
+    implements GoogleMapsFlutterPlatform {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  final platform = MockGoogleMapsFlutterPlatform();
+
+  setUp(() {
+    // Use a mock platform so we never need to hit the MethodChannel code.
+    GoogleMapsFlutterPlatform.instance = platform;
+    when(platform.buildView(any, any, any)).thenReturn(Container());
+  });
+
+  testWidgets('_webOnlyMapCreationId increments with each GoogleMap widget', (
+    WidgetTester tester,
+  ) async {
+
+    // Inject two map widgets...
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Column(
+          children: const [
+            GoogleMap(
+              initialCameraPosition: CameraPosition(target: LatLng(43.362, -5.849)),
+            ),
+            GoogleMap(
+              initialCameraPosition: CameraPosition(target: LatLng(47.649, -122.350)),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    // Verify that each one was created with a different _webOnlyMapCreationId.
+    verifyInOrder([
+      platform.buildView(
+        argThat(containsPair('_webOnlyMapCreationId', 0)),
+        any,
+        any,
+      ),
+      platform.buildView(
+        argThat(containsPair('_webOnlyMapCreationId', 1)),
+        any,
+        any,
+      ),
+    ]);
+  });
+}

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.3
+
+* Pass icon width/height if present on `fromAssetImage` BitmapDescriptors (web only)
+
 ## 1.0.2
 
 * Update lower bound of dart dependency to 2.1.0.

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/bitmap.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/bitmap.dart
@@ -9,6 +9,8 @@ import 'package:flutter/material.dart'
     show ImageConfiguration, AssetImage, AssetBundleImageKey;
 import 'package:flutter/services.dart' show AssetBundle;
 
+import 'package:flutter/foundation.dart' show kIsWeb;
+
 /// Defines a bitmap image. For a marker, this class can be used to set the
 /// image of the marker icon. For a ground overlay, it can be used to set the
 /// image to place on the surface of the earth.
@@ -100,6 +102,10 @@ class BitmapDescriptor {
       'fromAssetImage',
       assetBundleImageKey.name,
       assetBundleImageKey.scale,
+      if (kIsWeb && configuration?.size != null) [
+        configuration.size.width,
+        configuration.size.height,
+      ],
     ]);
   }
 

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/bitmap.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/bitmap.dart
@@ -102,10 +102,11 @@ class BitmapDescriptor {
       'fromAssetImage',
       assetBundleImageKey.name,
       assetBundleImageKey.scale,
-      if (kIsWeb && configuration?.size != null) [
-        configuration.size.width,
-        configuration.size.height,
-      ],
+      if (kIsWeb && configuration?.size != null)
+        [
+          configuration.size.width,
+          configuration.size.height,
+        ],
     ]);
   }
 

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the google_maps_flutter plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter/google_maps_flutter_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.0.2
+version: 1.0.3
 
 dependencies:
   flutter:
@@ -19,5 +19,5 @@ dev_dependencies:
   pedantic: ^1.8.0
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.3.0 <3.0.0"
   flutter: ">=1.9.1+hotfix.4 <2.0.0"


### PR DESCRIPTION
## Description

This PR adds some small modifications to the core maps plugin and its platform interface, so the web version is doable.

It allows people using the experimental branch of google_maps_flutter_web to keep using it, without having to override many packages (and will also simplify the final merge of google_maps_flutter_web, so it only touches one package!)

This PR touches two packages, but both changes should be independent, and backwards compatible, so test should pass, and they can be merged and published in any order.

### google_maps_flutter

* Pass a constant `creationMapId` to `platform.buildView`, so web can return a cached widget DOM when flutter attempts to repaint there.
* Modify some examples slightly so they're more web-friendly (remove dart:io imports, pass a size to the bitmap used as a custom Icon, so it gets rendered at the correct size in higher DPI screens)

### google_maps_flutter_platform_interface

* Pass icon width/height if present on `fromAssetImage` BitmapDescriptors (web only, because web can't determine the actual size of an asset at run-time as easily as the native side).




## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
