### PR TITLE
Added WAKE_LOCK permission instructions

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/README.md
+++ b/packages/google_maps_flutter/google_maps_flutter/README.md
@@ -39,6 +39,15 @@ To use this plugin, add `google_maps_flutter` as a [dependency in your pubspec.y
 
 ### Android
 
+Add WAKE_LOCK permission in the application manifest `android/app/src/main/AndroidManifest.xml`:
+
+```xml
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.android.application">
+ 
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+```
+
 Specify your API key in the application manifest `android/app/src/main/AndroidManifest.xml`:
 
 ```xml


### PR DESCRIPTION
The package needs WAKE_LOCK permission sometimes when GoogleMap widget resizes for any reason.
Update google_maps_flutter with instructions on setting WAKE_LOCK permissions.
