### PR TITLE
[e2e] Use new FrameTiming constructor.

### DIFF
--- a/packages/e2e/CHANGELOG.md
+++ b/packages/e2e/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.3+1
+
+* Update test to use new `FrameTiming` constructor.
+
 ## 0.6.3
 
 * Add customizable `flutter_driver` adaptor.

--- a/packages/e2e/pubspec.yaml
+++ b/packages/e2e/pubspec.yaml
@@ -1,6 +1,6 @@
 name: e2e
 description: Runs tests that use the flutter_test API as integration tests.
-version: 0.6.3
+version: 0.6.3+1
 homepage: https://github.com/flutter/plugins/tree/master/packages/e2e
 
 environment:

--- a/packages/e2e/test/frame_timing_summarizer_test.dart
+++ b/packages/e2e/test/frame_timing_summarizer_test.dart
@@ -17,7 +17,7 @@ void main() {
     List<FrameTiming> inputData = <FrameTiming>[
       for (int i = 0; i < 100; i += 1)
         FrameTiming(
-          // TODO: Add vsyncStart to the FrameTimingSummarizer (?)
+          // TODO: Add vsyncStart to the FrameTimingSummarizer (https://github.com/flutter/flutter/issues/63415)
           vsyncStart: 0,
           buildStart: 0,
           buildFinish: buildTimes[i],

--- a/packages/e2e/test/frame_timing_summarizer_test.dart
+++ b/packages/e2e/test/frame_timing_summarizer_test.dart
@@ -17,6 +17,8 @@ void main() {
     List<FrameTiming> inputData = <FrameTiming>[
       for (int i = 0; i < 100; i += 1)
         FrameTiming(
+          // TODO: Add vsyncStart to the FrameTimingSummarizer (?)
+          vsyncStart: 0,
           buildStart: 0,
           buildFinish: buildTimes[i],
           rasterStart: 500,

--- a/packages/e2e/test/frame_timing_summarizer_test.dart
+++ b/packages/e2e/test/frame_timing_summarizer_test.dart
@@ -16,7 +16,12 @@ void main() {
     rasterTimes = rasterTimes.reversed.toList();
     List<FrameTiming> inputData = <FrameTiming>[
       for (int i = 0; i < 100; i += 1)
-        FrameTiming(<int>[0, buildTimes[i], 500, rasterTimes[i]]),
+        FrameTiming(
+          buildStart: 0,
+          buildFinish: buildTimes[i],
+          rasterStart: 500,
+          rasterFinish: rasterTimes[i],
+        ),
     ];
     FrameTimingSummarizer summary = FrameTimingSummarizer(inputData);
     expect(summary.averageFrameBuildTime.inMicroseconds, 50500);


### PR DESCRIPTION
## Description

A new FrameTiming constructor was introduced here:
https://github.com/flutter/engine/commit/409a5e5963497ccf5d4b248db26058d9d7111e81, and now one of the tests in the e2e plugin doesn't compile anymore. 

(See [here](https://cirrus-ci.com/task/4961853304471552).)

This change updates the test to use the new API.

## Related Issues

https://github.com/flutter/engine/pull/20229

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
