### PR TITLE
[google_maps_flutter] Pin GoogleMaps cocoapod dep to last good known version

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.29+1
+
+* (ios) Pin dependency on GoogleMaps pod to `~>2.7`, to address https://github.com/flutter/flutter/issues/63447
+
 ## 0.5.29
 
 * Pass a constant `_web_only_mapCreationId` to `platform.buildView`, so web can return a cached widget DOM when flutter attempts to repaint there.

--- a/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.5.29+1
 
-* (ios) Pin dependency on GoogleMaps pod to `~>2.7`, to address https://github.com/flutter/flutter/issues/63447
+* (ios) Pin dependency on GoogleMaps pod to `< 3.10`, to address https://github.com/flutter/flutter/issues/63447
 
 ## 0.5.29
 

--- a/packages/google_maps_flutter/google_maps_flutter/ios/google_maps_flutter.podspec
+++ b/packages/google_maps_flutter/google_maps_flutter/ios/google_maps_flutter.podspec
@@ -17,7 +17,7 @@ Downloaded by pub (not CocoaPods).
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'GoogleMaps'
+  s.dependency 'GoogleMaps', '~> 2.7'
   s.static_framework = true
   s.platform = :ios, '8.0'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }

--- a/packages/google_maps_flutter/google_maps_flutter/ios/google_maps_flutter.podspec
+++ b/packages/google_maps_flutter/google_maps_flutter/ios/google_maps_flutter.podspec
@@ -17,7 +17,8 @@ Downloaded by pub (not CocoaPods).
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'GoogleMaps', '~> 2.7'
+  # TODO: Unpin this once the fix for b/163474612 or b/163359804 rolls (avoid v3.10!)
+  s.dependency 'GoogleMaps', '3.9'
   s.static_framework = true
   s.platform = :ios, '8.0'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }

--- a/packages/google_maps_flutter/google_maps_flutter/ios/google_maps_flutter.podspec
+++ b/packages/google_maps_flutter/google_maps_flutter/ios/google_maps_flutter.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'google_maps_flutter'
-  s.version          = '0.0.1'
+  s.version          = '0.0.2'
   s.summary          = 'Google Maps for Flutter'
   s.description      = <<-DESC
 A Flutter plugin that provides a Google Maps widget.

--- a/packages/google_maps_flutter/google_maps_flutter/ios/google_maps_flutter.podspec
+++ b/packages/google_maps_flutter/google_maps_flutter/ios/google_maps_flutter.podspec
@@ -18,7 +18,7 @@ Downloaded by pub (not CocoaPods).
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   # TODO: Unpin this once the fix for b/163474612 or b/163359804 rolls (avoid v3.10!)
-  s.dependency 'GoogleMaps', '3.9'
+  s.dependency 'GoogleMaps', '< 3.10'
   s.static_framework = true
   s.platform = :ios, '8.0'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }

--- a/packages/google_maps_flutter/google_maps_flutter/ios/google_maps_flutter.podspec
+++ b/packages/google_maps_flutter/google_maps_flutter/ios/google_maps_flutter.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'google_maps_flutter'
-  s.version          = '0.0.2'
+  s.version          = '0.0.1'
   s.summary          = 'Google Maps for Flutter'
   s.description      = <<-DESC
 A Flutter plugin that provides a Google Maps widget.

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter/google_maps_flutter
-version: 0.5.29
+version: 0.5.29+1
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Description

GoogleMaps 3.10 seems to have increased the minimum requirement for XCode beyond what our test infra can handle (undocumented?).

This change pins the GoogleMaps podspec to <3.10 until the situation clears, to unblock the build trees of both flutter/plugins and flutter/flutter.

**Why are our apps resolving to 3.10, when our Podspec states that ios 8.0 needs to be supported?** 

Apps were resolving to 3.10 because `flutter create` now creates apps that have a minimum iOS version of 9.0 (instead of 8.0).

**Why did 3.10 break us?**

3.10 breaks us because they're using some APIs only available in XCode 11.4 and our infra is in 11.3.1. (However, as @jmagman pointed out, they should check for the availability of these APIs or a runtime error will happen in devices running iOS < 13.4.)

## Related Issues

* https://github.com/flutter/flutter/issues/63447
* b/163359804
* b/163474612

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
