### PR TITLE
Fix unguarded availability in Camera plugin

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -157,7 +157,7 @@ task:
         - find . -name "*.podspec" | xargs grep -l "osx" | xargs rm
         # Skip the dummy podspecs used to placate the tool.
         - find . -name "*_web*.podspec" -o -name "*_mac*.podspec" | xargs rm
-        - ./script/incremental_build.sh podspecs --no-analyze camera --ignore-warnings camera
+        - ./script/incremental_build.sh podspecs
     - name: build-ipas+drive-examples
       env:
         PATH: $PATH:/usr/local/bin

--- a/packages/camera/CHANGELOG.md
+++ b/packages/camera/CHANGELOG.md
@@ -1,10 +1,14 @@
+## 0.5.8+5
+
+* Fix compilation/availability issues on iOS.
+
 ## 0.5.8+4
 
 * Fixed bug caused by casting a `CameraAccessException` on Android.
 
 ## 0.5.8+3
 
-* Fix bug in usage example in README.md 
+* Fix bug in usage example in README.md
 
 ## 0.5.8+2
 

--- a/packages/camera/ios/Classes/CameraPlugin.m
+++ b/packages/camera/ios/Classes/CameraPlugin.m
@@ -837,7 +837,7 @@ FourCharCode const videoFormat = kCVPixelFormatType_32BGRA;
       }
       int64_t textureId = [_registry registerTexture:cam];
       _camera = cam;
-      __weak CameraPlugin* weakSelf = self;
+      __weak CameraPlugin *weakSelf = self;
       cam.onFrameAvailable = ^{
         [weakSelf.registry textureFrameAvailable:textureId];
       };

--- a/packages/camera/ios/Classes/CameraPlugin.m
+++ b/packages/camera/ios/Classes/CameraPlugin.m
@@ -837,8 +837,9 @@ FourCharCode const videoFormat = kCVPixelFormatType_32BGRA;
       }
       int64_t textureId = [_registry registerTexture:cam];
       _camera = cam;
+      __weak CameraPlugin* weakSelf = self;
       cam.onFrameAvailable = ^{
-        [self.registry textureFrameAvailable:textureId];
+        [weakSelf.registry textureFrameAvailable:textureId];
       };
       FlutterEventChannel *eventChannel = [FlutterEventChannel
           eventChannelWithName:[NSString

--- a/packages/camera/ios/Classes/CameraPlugin.m
+++ b/packages/camera/ios/Classes/CameraPlugin.m
@@ -872,9 +872,11 @@ FourCharCode const videoFormat = kCVPixelFormatType_32BGRA;
   } else {
     NSDictionary *argsMap = call.arguments;
     NSUInteger textureId = ((NSNumber *)argsMap[@"textureId"]).unsignedIntegerValue;
-    if (@available(iOS 10.0, *)) {
-      if ([@"takePicture" isEqualToString:call.method]) {
+    if ([@"takePicture" isEqualToString:call.method]) {
+      if (@available(iOS 10.0, *)) {
         [_camera captureToFile:call.arguments[@"path"] result:result];
+      } else {
+        result(FlutterMethodNotImplemented);
       }
     } else if ([@"dispose" isEqualToString:call.method]) {
       [_registry unregisterTexture:textureId];

--- a/packages/camera/ios/Classes/CameraPlugin.m
+++ b/packages/camera/ios/Classes/CameraPlugin.m
@@ -265,9 +265,9 @@ FourCharCode const videoFormat = kCVPixelFormatType_32BGRA;
   [_capturePhotoOutput
       capturePhotoWithSettings:settings
                       delegate:[[FLTSavePhotoDelegate alloc] initWithPath:path
-                                                                    result:result
+                                                                   result:result
                                                             motionManager:_motionManager
-                                                            cameraPosition:_captureDevice.position]];
+                                                           cameraPosition:_captureDevice.position]];
 }
 
 - (void)setCaptureSessionPreset:(ResolutionPreset)resolutionPreset {
@@ -787,8 +787,8 @@ FourCharCode const videoFormat = kCVPixelFormatType_32BGRA;
 }
 
 - (void)handleMethodCallAsync:(FlutterMethodCall *)call result:(FlutterResult)result {
-  if (@available(iOS 10.0, *)) {
-    if ([@"availableCameras" isEqualToString:call.method]) {
+  if ([@"availableCameras" isEqualToString:call.method]) {
+    if (@available(iOS 10.0, *)) {
       AVCaptureDeviceDiscoverySession *discoverySession = [AVCaptureDeviceDiscoverySession
           discoverySessionWithDeviceTypes:@[ AVCaptureDeviceTypeBuiltInWideAngleCamera ]
                                 mediaType:AVMediaTypeVideo
@@ -816,6 +816,8 @@ FourCharCode const videoFormat = kCVPixelFormatType_32BGRA;
         }];
       }
       result(reply);
+    } else {
+      result(FlutterMethodNotImplemented);
     }
   } else if ([@"initialize" isEqualToString:call.method]) {
     NSString *cameraName = call.arguments[@"cameraName"];

--- a/packages/camera/ios/Classes/CameraPlugin.m
+++ b/packages/camera/ios/Classes/CameraPlugin.m
@@ -472,7 +472,7 @@ FourCharCode const videoFormat = kCVPixelFormatType_32BGRA;
 
       if (_audioTimeOffset.value != 0) {
         CFRelease(sampleBuffer);
-        sampleBuffer = [self copyAdjustTime:sampleBuffer by:_audioTimeOffset];
+        sampleBuffer = [self adjustTime:sampleBuffer by:_audioTimeOffset];
       }
 
       [self newAudioSample:sampleBuffer];
@@ -482,7 +482,7 @@ FourCharCode const videoFormat = kCVPixelFormatType_32BGRA;
   }
 }
 
-- (CMSampleBufferRef)copyAdjustTime:(CMSampleBufferRef)sample by:(CMTime)offset {
+- (CMSampleBufferRef)adjustTime:(CMSampleBufferRef)sample by:(CMTime)offset CF_RETURNS_RETAINED {
   CMItemCount count;
   CMSampleBufferGetSampleTimingInfoArray(sample, 0, nil, &count);
   CMSampleTimingInfo *pInfo = malloc(sizeof(CMSampleTimingInfo) * count);

--- a/packages/camera/ios/Classes/CameraPlugin.m
+++ b/packages/camera/ios/Classes/CameraPlugin.m
@@ -472,7 +472,7 @@ FourCharCode const videoFormat = kCVPixelFormatType_32BGRA;
 
       if (_audioTimeOffset.value != 0) {
         CFRelease(sampleBuffer);
-        sampleBuffer = [self adjustTime:sampleBuffer by:_audioTimeOffset];
+        sampleBuffer = [self copyAdjustTime:sampleBuffer by:_audioTimeOffset];
       }
 
       [self newAudioSample:sampleBuffer];
@@ -482,7 +482,7 @@ FourCharCode const videoFormat = kCVPixelFormatType_32BGRA;
   }
 }
 
-- (CMSampleBufferRef)adjustTime:(CMSampleBufferRef)sample by:(CMTime)offset {
+- (CMSampleBufferRef)copyAdjustTime:(CMSampleBufferRef)sample by:(CMTime)offset {
   CMItemCount count;
   CMSampleBufferGetSampleTimingInfoArray(sample, 0, nil, &count);
   CMSampleTimingInfo *pInfo = malloc(sizeof(CMSampleTimingInfo) * count);

--- a/packages/camera/ios/Classes/CameraPlugin.m
+++ b/packages/camera/ios/Classes/CameraPlugin.m
@@ -807,7 +807,7 @@ FourCharCode const videoFormat = kCVPixelFormatType_32BGRA;
       AVCaptureDeviceDiscoverySession *discoverySession = [AVCaptureDeviceDiscoverySession
           discoverySessionWithDeviceTypes:@[ AVCaptureDeviceTypeBuiltInWideAngleCamera ]
                                 mediaType:AVMediaTypeVideo
-                                position:AVCaptureDevicePositionUnspecified];
+                                 position:AVCaptureDevicePositionUnspecified];
       NSArray<AVCaptureDevice *> *devices = discoverySession.devices;
       NSMutableArray<NSDictionary<NSString *, NSObject *> *> *reply =
           [[NSMutableArray alloc] initWithCapacity:devices.count];

--- a/packages/camera/ios/camera.podspec
+++ b/packages/camera/ios/camera.podspec
@@ -4,17 +4,19 @@
 Pod::Spec.new do |s|
   s.name             = 'camera'
   s.version          = '0.0.1'
-  s.summary          = 'A new flutter plugin project.'
+  s.summary          = 'Flutter Camera'
   s.description      = <<-DESC
-A new flutter plugin project.
+A Flutter plugin to use the camera from your Flutter app.
                        DESC
-  s.homepage         = 'http://example.com'
-  s.license          = { :file => '../LICENSE' }
-  s.author           = { 'Your Company' => 'email@example.com' }
-  s.source           = { :path => '.' }
+  s.homepage         = 'https://github.com/flutter/plugins'
+  s.license          = { :type => 'BSD', :file => '../LICENSE' }
+  s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
+  s.source           = { :http => 'https://github.com/flutter/plugins/tree/master/packages/camera' }
+  s.documentation_url = 'https://pub.dev/packages/camera'
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
+
   s.platform = :ios, '8.0'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
 

--- a/packages/camera/ios/camera.podspec
+++ b/packages/camera/ios/camera.podspec
@@ -16,7 +16,7 @@ A new flutter plugin project.
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.platform = :ios, '8.0'
-  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS' => 'armv7 arm64 x86_64' }
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
 
   s.test_spec 'Tests' do |test_spec|
     test_spec.source_files = 'Tests/**/*'

--- a/packages/camera/pubspec.yaml
+++ b/packages/camera/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera
 description: A Flutter plugin for getting information about and controlling the
   camera on Android and iOS. Supports previewing the camera feed, capturing images, capturing video,
   and streaming image buffers to dart.
-version: 0.5.8+4
+version: 0.5.8+5
 
 homepage: https://github.com/flutter/plugins/tree/master/packages/camera
 


### PR DESCRIPTION
~~The build is failing on this plugin in an unrelated PR currrently due to these issues.~~ This doesn't fail the build because we're specifically ignoring these warnings, so instead I'm enabling the warnings. This does cause crashes for users on older iOS versions, see linked bug.

This does make me wonder if we really should claim to support this plugin on iOS 8.0.  Currently, you can't take a picture with the camera plugin on anything lower than iOS 10 - it would cause a runtime crash (now it will just result in an exception that should be recoverable).

Fixes https://github.com/flutter/flutter/issues/20708