### PR TITLE
[versions] increase package:platform constraint

### DIFF
--- a/packages/local_auth/CHANGELOG.md
+++ b/packages/local_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.3
+
+* Increase upper range of `package:platform` constraint to allow 3.X versions.
+
 ## 0.6.2+4
 
 * Update package:e2e reference to use the local version in the flutter/plugins

--- a/packages/local_auth/pubspec.yaml
+++ b/packages/local_auth/pubspec.yaml
@@ -2,7 +2,7 @@ name: local_auth
 description: Flutter plugin for Android and iOS device authentication sensors
   such as Fingerprint Reader and Touch ID.
 homepage: https://github.com/flutter/plugins/tree/master/packages/local_auth
-version: 0.6.2+4
+version: 0.6.3
 
 flutter:
   plugin:
@@ -18,7 +18,7 @@ dependencies:
     sdk: flutter
   meta: ^1.0.5
   intl: ">=0.15.1 <0.17.0"
-  platform: ^2.0.0
+  platform: ">=2.0.0 <4.0.0"
   flutter_plugin_android_lifecycle: ^1.0.2
 
 dev_dependencies:

--- a/packages/path_provider/path_provider_platform_interface/CHANGELOG.md
+++ b/packages/path_provider/path_provider_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.3
+
+* Increase upper range of `package:platform` constraint to allow 3.X versions.
+
 ## 1.0.2
 
 * Update lower bound of dart dependency to 2.1.0.

--- a/packages/path_provider/path_provider_platform_interface/pubspec.yaml
+++ b/packages/path_provider/path_provider_platform_interface/pubspec.yaml
@@ -3,13 +3,13 @@ description: A common platform interface for the path_provider plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.0.2
+version: 1.0.3
 
 dependencies:
   flutter:
     sdk: flutter
   meta: ^1.0.5
-  platform: ^2.0.0
+  platform: ">=2.0.0 <4.0.0"
   plugin_platform_interface: ^1.0.1
 
 dev_dependencies:


### PR DESCRIPTION
## Description

Fixes https://github.com/flutter/flutter/issues/63441

package:platform required a breaking change in the behavior of FakePlatform in order to enable null safety, but there will be no other breaking changes in 3.X Since this does not affect path provider or local_auth, the pubspec constraint can be increased.
