### PR TITLE
[camera] Adding check for null before creating capture session.

### DIFF
--- a/packages/camera/CHANGELOG.md
+++ b/packages/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.9
+
+* Fix rare nullptr exception on Android.
+
 ## 0.5.8+6
 
 * Avoiding uses or overrides a deprecated API in CameraPlugin.java.

--- a/packages/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
+++ b/packages/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
@@ -421,7 +421,9 @@ public class Camera {
   }
 
   public void startPreview() throws CameraAccessException {
-    createCaptureSession(CameraDevice.TEMPLATE_PREVIEW, pictureImageReader.getSurface());
+    if (pictureImageReader != null) {
+      createCaptureSession(CameraDevice.TEMPLATE_PREVIEW, pictureImageReader.getSurface());
+    }
   }
 
   public void startPreviewWithImageStream(EventChannel imageStreamChannel)

--- a/packages/camera/pubspec.yaml
+++ b/packages/camera/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera
 description: A Flutter plugin for getting information about and controlling the
   camera on Android and iOS. Supports previewing the camera feed, capturing images, capturing video,
   and streaming image buffers to dart.
-version: 0.5.8+6
+version: 0.5.9
 
 homepage: https://github.com/flutter/plugins/tree/master/packages/camera
 


### PR DESCRIPTION
## Description

Occasionally leads to NullPointerException (potentially due to some race
condition, hard to reproduce deterministically). This patch makes the error go away. I have an app in prod that has 0 occurences of this behavior after the patch. Example stack trace:

```
E/AndroidRuntime( 5679): java.lang.NullPointerException: Attempt to
invoke virtual method 'android.view.Surface
android.media.ImageReader.getSurface()' on a null object reference
E/AndroidRuntime( 5679): 	at
io.flutter.plugins.camera.Camera.startPreview(Camera.java:424)
E/AndroidRuntime( 5679): 	at
io.flutter.plugins.camera.Camera$2.onOpened(Camera.java:160)
E/AndroidRuntime( 5679): 	at
android.hardware.camera2.impl.CameraDeviceImpl$1.run(CameraDeviceImpl.java:145)
E/AndroidRuntime( 5679): 	at
android.os.Handler.handleCallback(Handler.java:883)
E/AndroidRuntime( 5679): 	at
android.os.Handler.dispatchMessage(Handler.java:100)
E/AndroidRuntime( 5679): 	at
android.os.Looper.loop(Looper.java:214)
E/AndroidRuntime( 5679): 	at
android.app.ActivityThread.main(ActivityThread.java:7356)
E/AndroidRuntime( 5679): 	at
java.lang.reflect.Method.invoke(Native Method)
E/AndroidRuntime( 5679): 	at
com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
E/AndroidRuntime( 5679): 	at
com.android.internal.os.ZygoteInit.main(ZygoteInit.java:930)
```

## Related Issues

* flutter/flutter#19595
* flutter/plugins#2871
* https://github.com/flutter/flutter/issues/39109

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.