### PR TITLE
[video_player_platform_interface] fix `setMixIWithOthers` test channel

### DIFF
--- a/packages/video_player/video_player_platform_interface/CHANGELOG.md
+++ b/packages/video_player/video_player_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.1
+
+* Fix mixWithOthers test channel.
+
 ## 2.1.0
 
 * Add VideoPlayerOptions with audo mix mode

--- a/packages/video_player/video_player_platform_interface/lib/messages.dart
+++ b/packages/video_player/video_player_platform_interface/lib/messages.dart
@@ -134,6 +134,7 @@ abstract class VideoPlayerApiTest {
   PositionMessage position(TextureMessage arg);
   void seekTo(PositionMessage arg);
   void pause(TextureMessage arg);
+  void setMixWithOthers(MixWithOthersMessage arg);
 }
 
 void VideoPlayerApiTestSetup(VideoPlayerApiTest api) {
@@ -222,6 +223,18 @@ void VideoPlayerApiTestSetup(VideoPlayerApiTest api) {
       final Map<dynamic, dynamic> mapMessage = message as Map<dynamic, dynamic>;
       final TextureMessage input = TextureMessage._fromMap(mapMessage);
       api.pause(input);
+      return {};
+    });
+  }
+  {
+    const BasicMessageChannel<dynamic> channel = BasicMessageChannel<dynamic>(
+        'dev.flutter.pigeon.VideoPlayerApi.setMixWithOthers',
+        StandardMessageCodec());
+    channel.setMockMessageHandler((dynamic message) async {
+      final Map<dynamic, dynamic> mapMessage = message as Map<dynamic, dynamic>;
+      final MixWithOthersMessage input =
+          MixWithOthersMessage._fromMap(mapMessage);
+      api.setMixWithOthers(input);
       return {};
     });
   }

--- a/packages/video_player/video_player_platform_interface/pubspec.yaml
+++ b/packages/video_player/video_player_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the video_player plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.1.0
+version: 2.1.1
 
 dependencies:
   flutter:

--- a/packages/video_player/video_player_platform_interface/test/method_channel_video_player_test.dart
+++ b/packages/video_player/video_player_platform_interface/test/method_channel_video_player_test.dart
@@ -19,6 +19,7 @@ class _ApiLogger implements VideoPlayerApiTest {
   PositionMessage positionMessage;
   LoopingMessage loopingMessage;
   VolumeMessage volumeMessage;
+  MixWithOthersMessage mixWithOthersMessage;
 
   @override
   TextureMessage create(CreateMessage arg) {
@@ -48,6 +49,12 @@ class _ApiLogger implements VideoPlayerApiTest {
   void play(TextureMessage arg) {
     log.add('play');
     textureMessage = arg;
+  }
+
+  @override
+  void setMixWithOthers(MixWithOthersMessage arg) {
+    log.add('setMixWithOthers');
+    mixWithOthersMessage = arg;
   }
 
   @override
@@ -177,6 +184,16 @@ void main() {
       await player.pause(1);
       expect(log.log.last, 'pause');
       expect(log.textureMessage.textureId, 1);
+    });
+
+    test('setMixWithOthers', () async {
+      await player.setMixWithOthers(true);
+      expect(log.log.last, 'setMixWithOthers');
+      expect(log.mixWithOthersMessage.mixWithOthers, true);
+
+      await player.setMixWithOthers(false);
+      expect(log.log.last, 'setMixWithOthers');
+      expect(log.mixWithOthersMessage.mixWithOthers, false);
     });
 
     test('setVolume', () async {


### PR DESCRIPTION
## Description

The test api method channel was not set, which causes test failures

## Related Issues


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
