### PR TITLE
[in_app_purchase] Added serviceTimeout code for google iab (test)

### DIFF
--- a/packages/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.4+6
+
+* Android: Fixed bug due to code -3 (SERVICE_TIMEOUT) in `BillingResponse`
+
 ## 0.3.4+5
 
 * Added necessary README docs for getting started with Android.

--- a/packages/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/pubspec.yaml
@@ -1,7 +1,7 @@
 name: in_app_purchase
 description: A Flutter plugin for in-app purchases. Exposes APIs for making in-app purchases through the App Store and Google Play.
 homepage: https://github.com/flutter/plugins/tree/master/packages/in_app_purchase
-version: 0.3.4+5
+version: 0.3.4+6
 
 dependencies:
   async: ^2.0.8

--- a/packages/in_app_purchase/test/billing_client_wrappers/enum_converters_test.dart
+++ b/packages/in_app_purchase/test/billing_client_wrappers/enum_converters_test.dart
@@ -1,0 +1,95 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+import 'package:in_app_purchase/billing_client_wrappers.dart';
+import 'package:in_app_purchase/src/billing_client_wrappers/enum_converters.dart';
+
+void main() {
+  group('BillingResponse', () {
+    test('serviceTimeout', () {
+      final BillingResponse parsed = BillingResponse.serviceTimeout;
+      final BillingResponse expected = BillingResponseConverter().fromJson(-3);
+
+      expect(parsed, equals(expected));
+    });
+
+    test('featureNotSupported', () {
+      final BillingResponse parsed = BillingResponse.featureNotSupported;
+      final BillingResponse expected = BillingResponseConverter().fromJson(-2);
+
+      expect(parsed, equals(expected));
+    });
+
+    test('serviceDisconnected', () {
+      final BillingResponse parsed = BillingResponse.serviceDisconnected;
+      final BillingResponse expected = BillingResponseConverter().fromJson(-1);
+
+      expect(parsed, equals(expected));
+    });
+
+    test('ok', () {
+      final BillingResponse parsed = BillingResponse.ok;
+      final BillingResponse expected = BillingResponseConverter().fromJson(0);
+
+      expect(parsed, equals(expected));
+    });
+
+    test('userCanceled', () {
+      final BillingResponse parsed = BillingResponse.userCanceled;
+      final BillingResponse expected = BillingResponseConverter().fromJson(1);
+
+      expect(parsed, equals(expected));
+    });
+
+    test('serviceUnavailable', () {
+      final BillingResponse parsed = BillingResponse.serviceUnavailable;
+      final BillingResponse expected = BillingResponseConverter().fromJson(2);
+
+      expect(parsed, equals(expected));
+    });
+
+    test('billingUnavailable', () {
+      final BillingResponse parsed = BillingResponse.billingUnavailable;
+      final BillingResponse expected = BillingResponseConverter().fromJson(3);
+
+      expect(parsed, equals(expected));
+    });
+
+    test('itemUnavailable', () {
+      final BillingResponse parsed = BillingResponse.itemUnavailable;
+      final BillingResponse expected = BillingResponseConverter().fromJson(4);
+
+      expect(parsed, equals(expected));
+    });
+
+    test('developerError', () {
+      final BillingResponse parsed = BillingResponse.developerError;
+      final BillingResponse expected = BillingResponseConverter().fromJson(5);
+
+      expect(parsed, equals(expected));
+    });
+
+    test('error', () {
+      final BillingResponse parsed = BillingResponse.error;
+      final BillingResponse expected = BillingResponseConverter().fromJson(6);
+
+      expect(parsed, equals(expected));
+    });
+
+    test('itemAlreadyOwned', () {
+      final BillingResponse parsed = BillingResponse.itemAlreadyOwned;
+      final BillingResponse expected = BillingResponseConverter().fromJson(7);
+
+      expect(parsed, equals(expected));
+    });
+
+    test('itemNotOwned', () {
+      final BillingResponse parsed = BillingResponse.itemNotOwned;
+      final BillingResponse expected = BillingResponseConverter().fromJson(8);
+
+      expect(parsed, equals(expected));
+    });
+  });
+}


### PR DESCRIPTION
## Description

Android: Fixed bug due to code -3 (SERVICE_TIMEOUT) in `BillingResponse`
Adding tests

## Related Issues

Fix for issue flutter/flutter#43969
Previous pull request flutter/plugins#2248

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
