### PR TITLE
[url_launcher_web] Fix a typo in a test name and fix quote consistency

### DIFF
--- a/packages/url_launcher/url_launcher_web/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.3+2
+
+- Fix a typo in a test name and fix some style inconsistencies.
+
 # 0.1.3+1
 
 - Depend explicitly on the `platform_interface` package that adds the `webOnlyWindowName` parameter.

--- a/packages/url_launcher/url_launcher_web/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_web/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/u
 # 0.1.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.1.3+1
+version: 0.1.3+2
 
 flutter:
   plugin:

--- a/packages/url_launcher/url_launcher_web/test/url_launcher_web_test.dart
+++ b/packages/url_launcher/url_launcher_web/test/url_launcher_web_test.dart
@@ -145,17 +145,17 @@ void main() {
 
         verify(mockWindow.open('sms:+19725551212?body=hello%20there', ''));
       });
-      test('setting oOnlyLinkTarget as _self opens the url in the same tab',
+      test('setting webOnlyLinkTarget as _self opens the url in the same tab',
           () {
-        plugin.openNewWindow("https://www.google.com",
-            webOnlyWindowName: "_self");
+        plugin.openNewWindow('https://www.google.com',
+            webOnlyWindowName: '_self');
         verify(mockWindow.open('https://www.google.com', '_self'));
       });
 
       test('setting webOnlyLinkTarget as _blank opens the url in a new tab',
           () {
-        plugin.openNewWindow("https://www.google.com",
-            webOnlyWindowName: "_blank");
+        plugin.openNewWindow('https://www.google.com',
+            webOnlyWindowName: '_blank');
         verify(mockWindow.open('https://www.google.com', '_blank'));
       });
 
@@ -197,9 +197,9 @@ void main() {
         test(
             'mailto urls should use _blank if webOnlyWindowName is set as _blank',
             () {
-          plugin.openNewWindow("mailto:name@mydomain.com",
-              webOnlyWindowName: "_blank");
-          verify(mockWindow.open("mailto:name@mydomain.com", "_blank"));
+          plugin.openNewWindow('mailto:name@mydomain.com',
+              webOnlyWindowName: '_blank');
+          verify(mockWindow.open('mailto:name@mydomain.com', '_blank'));
         });
       });
     });


### PR DESCRIPTION
## Description

Fix a typo in a test name and fix quote consistency.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
