### PR TITLE
[camera] CameraPlugin.java uses or overrides a deprecated API

### DIFF
--- a/packages/camera/CHANGELOG.md
+++ b/packages/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.8+6
+
+* Avoiding uses or overrides a deprecated API in CameraPlugin.java.
+
 ## 0.5.8+5
 
 * Fix compilation/availability issues on iOS.

--- a/packages/camera/android/build.gradle
+++ b/packages/camera/android/build.gradle
@@ -1,5 +1,6 @@
 group 'io.flutter.plugins.camera'
 version '1.0-SNAPSHOT'
+def args = ["-Xlint:deprecation","-Xlint:unchecked","-Werror"]
 
 buildscript {
     repositories {
@@ -17,6 +18,10 @@ rootProject.allprojects {
         google()
         jcenter()
     }
+}
+
+project.getTasks().withType(JavaCompile){
+    options.compilerArgs.addAll(args)
 }
 
 apply plugin: 'com.android.library'

--- a/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
+++ b/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
@@ -70,7 +70,7 @@ public final class CameraPlugin implements FlutterPlugin, ActivityAware {
         binding.getActivity(),
         flutterPluginBinding.getBinaryMessenger(),
         binding::addRequestPermissionsResultListener,
-        flutterPluginBinding.getFlutterEngine().getRenderer());
+        flutterPluginBinding.getTextureRegistry());
   }
 
   @Override

--- a/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
+++ b/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
@@ -66,7 +66,6 @@ public final class CameraPlugin implements FlutterPlugin, ActivityAware {
 
   @Override
   public void onAttachedToActivity(@NonNull ActivityPluginBinding binding) {
-    /// getFlutterEngine() is deprecated
     maybeStartListening(
         binding.getActivity(),
         flutterPluginBinding.getBinaryMessenger(),

--- a/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
+++ b/packages/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
@@ -66,6 +66,7 @@ public final class CameraPlugin implements FlutterPlugin, ActivityAware {
 
   @Override
   public void onAttachedToActivity(@NonNull ActivityPluginBinding binding) {
+    /// getFlutterEngine() is deprecated
     maybeStartListening(
         binding.getActivity(),
         flutterPluginBinding.getBinaryMessenger(),

--- a/packages/camera/pubspec.yaml
+++ b/packages/camera/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera
 description: A Flutter plugin for getting information about and controlling the
   camera on Android and iOS. Supports previewing the camera feed, capturing images, capturing video,
   and streaming image buffers to dart.
-version: 0.5.8+5
+version: 0.5.8+6
 
 homepage: https://github.com/flutter/plugins/tree/master/packages/camera
 


### PR DESCRIPTION
## Description

- Handle deprecation & unchecked warning as error

- Avoiding uses or overrides a deprecated API in CameraPlugin.java

A message is displayed when building for android: 

```
flutter build apk
Running "flutter pub get" in example...                            38,2s
You are building a fat APK that includes binaries for android-arm, android-arm64, android-x64.
If you are deploying the app to the Play Store, it's recommended to use app bundles or split the APK to reduce the APK
size.
    To generate an app bundle, run:
        flutter build appbundle --target-platform android-arm,android-arm64,android-x64
        Learn more on: https://developer.android.com/guide/app-bundle
    To split the APKs per ABI, run:
        flutter build apk --target-platform android-arm,android-arm64,android-x64 --split-per-abi
        Learn more on:  https://developer.android.com/studio/build/configure-apk-splits#configure-abi-split
Note: C:\Users\hamdi\Downloads\plugins-master\packages\camera\android\src\main\java\io\flutter\plugins\camera\CameraPlugin.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: C:\Users\hamdi\AppData\Local\Pub\Cache\hosted\pub.dartlang.org\video_player-0.10.12+2\android\src\main\java\io\flutter\plugins\videoplayer\VideoPlayerPlugin.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Calling mockable JAR artifact transform to create file: C:\Users\hamdi\.gradle\caches\transforms-1\files-1.1\android.jar\c93f5298c0c73f9f1471636f2dd33213\android.jar with input C:\Users\hamdi\AppData\Local\Android\Sdk\platforms\android-28\android.jar
Removed unused resources: Binary resource data reduced from 39KB to 33KB: Removed 14%
Running Gradle task 'assembleRelease'...
Running Gradle task 'assembleRelease'... Done                      90,3s
√ Built build\app\outputs\flutter-apk\app-release.apk (16.1MB).
```

```
flutter build appbundle
Running "flutter pub get" in example...                             0,9s
Note: C:\Users\hamdi\Downloads\plugins-master\packages\camera\android\src\main\java\io\flutter\plugins\camera\CameraPlugin.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: C:\Users\hamdi\AppData\Local\Pub\Cache\hosted\pub.dartlang.org\video_player-0.10.12+2\android\src\main\java\io\flutter\plugins\videoplayer\VideoPlayerPlugin.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Removed unused resources: Binary resource data reduced from 28KB to 20KB: Removed 27%
Running Gradle task 'bundleRelease'...
Running Gradle task 'bundleRelease'... Done                        56,5s
√ Built build\app\outputs\bundle\release\app.aab (16.4MB).
```

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
