### PR TITLE
[video_player] VideoPlayerPlugin.java uses or overrides a deprecated API

### DIFF
--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.12+3
+
+* Avoiding uses or overrides a deprecated API in `VideoPlayerPlugin` class.
+
 ## 0.10.12+2
 
 * Fix `setMixWithOthers` test.

--- a/packages/video_player/video_player/android/build.gradle
+++ b/packages/video_player/video_player/android/build.gradle
@@ -1,5 +1,6 @@
 group 'io.flutter.plugins.videoplayer'
 version '1.0-SNAPSHOT'
+def args = ["-Xlint:deprecation","-Xlint:unchecked","-Werror"]
 
 buildscript {
     repositories {
@@ -17,6 +18,10 @@ rootProject.allprojects {
         google()
         jcenter()
     }
+}
+
+project.getTasks().withType(JavaCompile){
+    options.compilerArgs.addAll(args)
 }
 
 apply plugin: 'com.android.library'

--- a/packages/video_player/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -54,13 +54,14 @@ public class VideoPlayerPlugin implements FlutterPlugin, VideoPlayerApi {
 
   @Override
   public void onAttachedToEngine(FlutterPluginBinding binding) {
+    /// getFlutterEngine() is deprecated
     this.flutterState =
         new FlutterState(
             binding.getApplicationContext(),
             binding.getBinaryMessenger(),
             FlutterMain::getLookupKeyForAsset,
             FlutterMain::getLookupKeyForAsset,
-            binding.getFlutterEngine().getRenderer());
+            binding.getTextureRegistry());
     flutterState.startListening(this, binding.getBinaryMessenger());
   }
 

--- a/packages/video_player/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -54,7 +54,6 @@ public class VideoPlayerPlugin implements FlutterPlugin, VideoPlayerApi {
 
   @Override
   public void onAttachedToEngine(FlutterPluginBinding binding) {
-    /// getFlutterEngine() is deprecated
     this.flutterState =
         new FlutterState(
             binding.getApplicationContext(),

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for displaying inline video with other Flutter
 # 0.10.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.10.12+2
+version: 0.10.12+3
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player
 
 flutter:


### PR DESCRIPTION
## Description

- Handle deprecation & unchecked warning as error


- Avoiding uses or overrides a deprecated API in VideoPlayerPlugin.java


A message is displayed when building for android: 

```
flutter build apk
You are building a fat APK that includes binaries for android-arm, android-arm64, android-x64.
If you are deploying the app to the Play Store, it's recommended to use app bundles or split the APK to reduce the APK
size.
    To generate an app bundle, run:
        flutter build appbundle --target-platform android-arm,android-arm64,android-x64
        Learn more on: https://developer.android.com/guide/app-bundle
    To split the APKs per ABI, run:
        flutter build apk --target-platform android-arm,android-arm64,android-x64 --split-per-abi
        Learn more on:  https://developer.android.com/studio/build/configure-apk-splits#configure-abi-split
Note: C:\Users\hamdi\Downloads\plugins-master\packages\video_player\video_player\android\src\main\java\io\flutter\plugins\videoplayer\VideoPlayerPlugin.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Removed unused resources: Binary resource data reduced from 46KB to 37KB: Removed 20%
Running Gradle task 'assembleRelease'...
Running Gradle task 'assembleRelease'... Done                      62,1s
√ Built build\app\outputs\flutter-apk\app-release.apk (18.7MB).
```

```
flutter build appbundle
Running "flutter pub get" in example...                             1,0s
Note: C:\Users\hamdi\Downloads\plugins-master\packages\video_player\video_player\android\src\main\java\io\flutter\plugins\videoplayer\VideoPlayerPlugin.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Removed unused resources: Binary resource data reduced from 36KB to 22KB: Removed 39%
Running Gradle task 'bundleRelease'...
Running Gradle task 'bundleRelease'... Done                        59,5s
√ Built build\app\outputs\bundle\release\app.aab (19.0MB).
```

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
