### PR TITLE
[android_alarm_manager] version fix

### DIFF
--- a/packages/android_alarm_manager/pubspec.yaml
+++ b/packages/android_alarm_manager/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for accessing the Android AlarmManager service, and
 # 0.4.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.4.5+12
+version: 0.4.5+13
 homepage: https://github.com/flutter/plugins/tree/master/packages/android_alarm_manager
 
 dependencies:


### PR DESCRIPTION
https://github.com/flutter/plugins/pull/3020 had a unmatched version between changelog and pubspec.yaml