### PR TITLE
[all] Update CODEOWNERS to properly request reviews

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,22 +4,22 @@
 # These names are just suggestions. It is fine to have your changes
 # reviewed by someone else.
 
-packages/android_alarm_manager/*              @bkonyi
-packages/android_intent/*                     @mklim @matthew-carroll
-packages/battery/*                            @amirh @matthew-carroll
-packages/camera/*                             @bparrishMines
-packages/connectivity/*                       @cyanglaz @matthew-carroll
-packages/device_info/*                        @matthew-carroll
-packages/espresso/*                           @collinjackson @adazh
-packages/google_maps_flutter/*                @cyanglaz
-packages/google_sign_in/*                     @cyanglaz @mehmetf
-packages/image_picker/*                       @cyanglaz
-packages/integration_test/*                   @dnfield
-packages/in_app_purchase/*                    @mklim @cyanglaz @LHLL
-packages/ios_platform_images/*                @gaaclarke
-packages/package_info/*                       @cyanglaz @matthew-carroll
-packages/path_provider/*                      @matthew-carroll
-packages/shared_preferences/*                 @matthew-carroll
-packages/url_launcher/*                       @mklim
-packages/video_player/*                       @iskakaushik @cyanglaz
-packages/webview_flutter/*                    @amirh
+packages/android_alarm_manager/**              @bkonyi
+packages/android_intent/**                     @mklim @matthew-carroll
+packages/battery/**                            @amirh @matthew-carroll
+packages/camera/**                             @bparrishMines
+packages/connectivity/**                       @cyanglaz @matthew-carroll
+packages/device_info/**                        @matthew-carroll
+packages/espresso/**                           @collinjackson @adazh
+packages/google_maps_flutter/**                @cyanglaz
+packages/google_sign_in/**                     @cyanglaz @mehmetf
+packages/image_picker/**                       @cyanglaz
+packages/integration_test/**                   @dnfield
+packages/in_app_purchase/**                    @mklim @cyanglaz @LHLL
+packages/ios_platform_images/**                @gaaclarke
+packages/package_info/**                       @cyanglaz @matthew-carroll
+packages/path_provider/**                      @matthew-carroll
+packages/shared_preferences/**                 @matthew-carroll
+packages/url_launcher/**                       @mklim
+packages/video_player/**                       @iskakaushik @cyanglaz
+packages/webview_flutter/**                    @amirh


### PR DESCRIPTION
## Description

Because of federated plugins, no reviews are requested automatically when opening a PR.

For example, https://github.com/flutter/plugins/pull/3032 should have probably automatically requested @iskakaushik and @cyanglaz, however, that did not happen because the paths for federated plugins are not covered at the moment.

## Checklist


- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] All existing and new tests are passing.
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
