### PR TITLE
[share] fix: properly share gif format on IOS platform

### DIFF
--- a/packages/share/CHANGELOG.md
+++ b/packages/share/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.6
+
+* Properly send GIF files as an animated GIF instead of the first frame in PNG
+
 ## 0.6.5
 
 * Added support for sharing files

--- a/packages/share/ios/Classes/FLTSharePlugin.m
+++ b/packages/share/ios/Classes/FLTSharePlugin.m
@@ -206,6 +206,10 @@ static NSString *const PLATFORM_CHANNEL = @"plugins.flutter.io/share";
         [mimeType.lowercaseString isEqualToString:@"image/png"]) {
       UIImage *image = [UIImage imageWithContentsOfFile:path];
       [items addObject:image];
+    } else if ([mimeType.lowercaseString isEqualToString:@"image/gif"]) {
+      // GIF Data should not be shared as image but a NSData object
+      NSData *imageData = [NSData dataWithContentsOfFile:path];
+      [items addObject:imageData];
     } else {
       [items addObject:[[ShareData alloc] initWithFile:path mimeType:mimeType]];
     }

--- a/packages/share/pubspec.yaml
+++ b/packages/share/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/flutter/plugins/tree/master/packages/share
 # 0.6.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.6.5
+version: 0.6.6
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

This PR adds a clause in the if/else which handles specific file type on the `share` plugin for iOS platform.
When sharing GIF data, if you share it as a regular file, or an image, you will end up with only the first frame being shared as a PNG, which is not the intended behavior.

In order to properly share the animated GIF, you must pass it as a NSData object.

## Related Issues

I didn't found any issue linked to it, but I've been tracking this bug for a few days now :) I can create one if required

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [ ] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/