### PR TITLE
[video_player] Fixed HLS streams on iOS (#48760)

### DIFF
--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.10.12+5
+
+* Added isDurationIndefinite to support indefinite streams
+* Raised video_player_platform_interface in video_player to 2.1.1.
+
 ## 0.10.12+4
 
 * Keep handling deprecated Android v1 classes for backward compatibility.

--- a/packages/video_player/video_player/example/lib/main.dart
+++ b/packages/video_player/video_player/example/lib/main.dart
@@ -218,7 +218,7 @@ class _BumbleBeeRemoteVideoState extends State<_BumbleBeeRemoteVideo> {
   void initState() {
     super.initState();
     _controller = VideoPlayerController.network(
-      'https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4',
+      'https://rtmp.api.rt.com/hls/rtdru.m3u8',
       closedCaptionFile: _loadCaptions(),
       videoPlayerOptions: VideoPlayerOptions(mixWithOthers: true),
     );
@@ -253,7 +253,7 @@ class _BumbleBeeRemoteVideoState extends State<_BumbleBeeRemoteVideo> {
                   VideoPlayer(_controller),
                   ClosedCaption(text: _controller.value.caption.text),
                   _PlayPauseOverlay(controller: _controller),
-                  VideoProgressIndicator(_controller, allowScrubbing: true),
+                  VideoProgressIndicator(_controller, allowScrubbing: false),
                 ],
               ),
             ),

--- a/packages/video_player/video_player/example/lib/main.dart
+++ b/packages/video_player/video_player/example/lib/main.dart
@@ -253,7 +253,7 @@ class _BumbleBeeRemoteVideoState extends State<_BumbleBeeRemoteVideo> {
                   VideoPlayer(_controller),
                   ClosedCaption(text: _controller.value.caption.text),
                   _PlayPauseOverlay(controller: _controller),
-                  VideoProgressIndicator(_controller, allowScrubbing: false),
+                  VideoProgressIndicator(_controller, allowScrubbing: true),
                 ],
               ),
             ),

--- a/packages/video_player/video_player/example/lib/main.dart
+++ b/packages/video_player/video_player/example/lib/main.dart
@@ -218,7 +218,7 @@ class _BumbleBeeRemoteVideoState extends State<_BumbleBeeRemoteVideo> {
   void initState() {
     super.initState();
     _controller = VideoPlayerController.network(
-      'https://rtmp.api.rt.com/hls/rtdru.m3u8',
+      'https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4',
       closedCaptionFile: _loadCaptions(),
       videoPlayerOptions: VideoPlayerOptions(mixWithOthers: true),
     );

--- a/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m
@@ -302,6 +302,10 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
   _displayLink.paused = !_isPlaying;
 }
 
+- (bool)isDurationIndefinite {
+  return CMTIME_IS_INDEFINITE([[_player currentItem] duration]);
+}
+
 - (void)sendInitialized {
   if (_eventSink && !_isInitialized) {
     CGSize size = [self.player currentItem].presentationSize;
@@ -312,8 +316,9 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     if (height == CGSizeZero.height && width == CGSizeZero.width) {
       return;
     }
+
     // The player may be initialized but still needs to determine the duration.
-    if ([self duration] == 0) {
+    if ([self duration] == 0 && ![self isDurationIndefinite]) {
       return;
     }
 

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -757,12 +757,12 @@ class _VideoProgressIndicatorState extends State<VideoProgressIndicator> {
         fit: StackFit.passthrough,
         children: <Widget>[
           LinearProgressIndicator(
-            value: maxBuffering / duration,
+            value: duration > 0 ? maxBuffering / duration : 0,
             valueColor: AlwaysStoppedAnimation<Color>(colors.bufferedColor),
             backgroundColor: colors.backgroundColor,
           ),
           LinearProgressIndicator(
-            value: position / duration,
+            value: duration > 0 ? position / duration : 0,
             valueColor: AlwaysStoppedAnimation<Color>(colors.playedColor),
             backgroundColor: Colors.transparent,
           ),

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for displaying inline video with other Flutter
 # 0.10.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.10.12+4
+version: 0.10.12+5
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player
 
 flutter:

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -20,7 +20,7 @@ flutter:
 
 dependencies:
   meta: ^1.0.5
-  video_player_platform_interface: ^2.1.1
+  video_player_platform_interface: ^2.1.0
   # The design on https://flutter.dev/go/federated-plugins was to leave
   # this constraint as "any". We cannot do it right now as it fails pub publish
   # validation, so we set a ^ constraint.

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -20,7 +20,7 @@ flutter:
 
 dependencies:
   meta: ^1.0.5
-  video_player_platform_interface: ^2.1.0
+  video_player_platform_interface: ^2.1.1
   # The design on https://flutter.dev/go/federated-plugins was to leave
   # this constraint as "any". We cannot do it right now as it fails pub publish
   # validation, so we set a ^ constraint.


### PR DESCRIPTION
## Description

Implements the changes of [#1743](https://github.com/flutter/plugins/pull/1743/files) with the desired changes to the implementation. This makes it possible (again) to stream HLS stream with an indefinite length. 

On an iPhone simulator I only hear the audio when playing a HLS stream, but running it on an iPad everything works. 

I added some checks to the VideoProgressIndicator. On iOS, because the duration is 0, it's going to divide 0 by 0, which results in a crash. This is not an issue in Android. On iOS the ProgressIndicator now just shows no progress, which I believe should be the desired behaviour. 

## Related Issues

#1743  
Fixes [#48670](https://github.com/flutter/flutter/issues/48670)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
