### PR TITLE
[path_provider] Path provider windows updates

### DIFF
--- a/packages/path_provider/path_provider/CHANGELOG.md
+++ b/packages/path_provider/path_provider/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.6.16
+
+* Update Windows endorsement verison
+
 ## 1.6.15
 
 * Endorse Windows implementation.

--- a/packages/path_provider/path_provider/pubspec.yaml
+++ b/packages/path_provider/path_provider/pubspec.yaml
@@ -1,7 +1,7 @@
 name: path_provider
 description: Flutter plugin for getting commonly used locations on host platform file systems, such as the temp and app data directories.
 homepage: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider
-version: 1.6.15
+version: 1.6.16
 
 flutter:
   plugin:

--- a/packages/path_provider/path_provider/pubspec.yaml
+++ b/packages/path_provider/path_provider/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   path_provider_platform_interface: ^1.0.1
   path_provider_macos: ^0.0.4
   path_provider_linux: ^0.0.1
-  path_provider_windows: ^0.0.1
+  path_provider_windows: ^0.0.2
 
 dev_dependencies:
   integration_test:

--- a/packages/path_provider/path_provider_windows/ios/path_provider_windows.podspec
+++ b/packages/path_provider/path_provider_windows/ios/path_provider_windows.podspec
@@ -1,0 +1,22 @@
+#
+# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
+# Run `pod lib lint path_provider_windows.podspec' to validate before publishing.
+#
+Pod::Spec.new do |s|
+  s.name             = 'path_provider_windows'
+  s.version          = '0.0.1'
+  s.summary          = 'path_provider_windows iOS stub'
+  s.description      = <<-DESC
+  No-op implementation of the windows path_provider plugin to avoid build issues on iOS
+                       DESC
+  s.homepage         = 'https://github.com/flutter/plugins'
+  s.license          = { :type => 'BSD', :file => '../LICENSE' }
+  s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
+  s.source           = { :http => 'https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider_windows' }
+  s.dependency 'Flutter'
+  s.platform = :ios, '8.0'
+
+  # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
+  s.swift_version = '5.0'
+end


### PR DESCRIPTION
## Description

- Adds missing iOS podspec to path_provider_windows, which was necessary to publish it (since path_provider doesn't require 1.20+)
- Requires path_provider_windows 0.0.2, not 0.0.1, in path_provider endorsement.

## Related Issues

flutter/flutter#41715

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
