### PR TITLE
[path_provider] Fix mistake in license headers

### DIFF
--- a/packages/path_provider/path_provider_macos/CHANGELOG.md
+++ b/packages/path_provider/path_provider_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.4+5
+
+* Update license header.
+
 ## 0.0.4+4
 
 * Remove no-op android folder in the example app.

--- a/packages/path_provider/path_provider_macos/macos/Classes/PathProviderPlugin.swift
+++ b/packages/path_provider/path_provider_macos/macos/Classes/PathProviderPlugin.swift
@@ -1,16 +1,6 @@
-// Copyright 2019 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 import FlutterMacOS
 import Foundation

--- a/packages/path_provider/path_provider_macos/pubspec.yaml
+++ b/packages/path_provider/path_provider_macos/pubspec.yaml
@@ -3,7 +3,7 @@ description: macOS implementation of the path_provider plugin
 # 0.0.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.0.4+4
+version: 0.0.4+5
 homepage: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider_macos
 
 flutter:


### PR DESCRIPTION
MacOS source headers were mistakenly marked as Apache license rather than BSD.