### PR TITLE
[shared_preferences] Add iOS stub to shared_preferences_windows

### DIFF
--- a/packages/shared_preferences/shared_preferences_windows/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.1+1
+
+* Add iOS stub for compatibility with 1.17 and earlier.
+
 ## 0.0.1
 
 * Initial release to support shared_preferences on Windows.

--- a/packages/shared_preferences/shared_preferences_windows/ios/shared_preferences_windows.podspec
+++ b/packages/shared_preferences/shared_preferences_windows/ios/shared_preferences_windows.podspec
@@ -1,0 +1,22 @@
+#
+# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
+# Run `pod lib lint shared_preferences_windows.podspec' to validate before publishing.
+#
+Pod::Spec.new do |s|
+  s.name             = 'shared_preferences_windows'
+  s.version          = '0.0.1'
+  s.summary          = 'shared_preferences_windows iOS stub'
+  s.description      = <<-DESC
+  No-op implementation of the windows shared_preferences plugin to avoid build issues on iOS
+                       DESC
+  s.homepage         = 'https://github.com/flutter/plugins'
+  s.license          = { :type => 'BSD', :file => '../LICENSE' }
+  s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
+  s.source           = { :http => 'https://github.com/flutter/plugins/tree/master/packages/shared_preferences/shared_preferences_windows' }
+  s.dependency 'Flutter'
+  s.platform = :ios, '8.0'
+
+  # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
+  s.swift_version = '5.0'
+end

--- a/packages/shared_preferences/shared_preferences_windows/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_windows/pubspec.yaml
@@ -1,7 +1,7 @@
 name: shared_preferences_windows
 description: Windows implementation of shared_preferences
 homepage: https://github.com/flutter/plugins/tree/master/packages/shared_preferences/shared_preferences_windows
-version: 0.0.1
+version: 0.0.1+1
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

shared_preferences supports versions older than 1.18, so this plugin
needs the iOS stub to prevent breaking iOS projects via transitive
dependencies when shared_preferences endorses the Windows implementation.

## Related Issues

flutter/flutter#41719

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
