### PR TITLE
Test if files not under example/ are covered by CI

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_web/test/test_driver/google_maps_controller_integration.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/test/test_driver/google_maps_controller_integration.dart
@@ -65,6 +65,7 @@ void main() {
       });
 
       testWidgets('constructor creates widget', (WidgetTester tester) async {
+        expect(false, true);
         expect(controller.widget, isNotNull);
         expect(controller.widget.viewType, endsWith('$mapId'));
       });

--- a/packages/google_maps_flutter/google_maps_flutter_web/test/test_driver/google_maps_controller_integration_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/test/test_driver/google_maps_controller_integration_test.dart
@@ -4,4 +4,9 @@
 
 import 'package:integration_test/integration_test_driver.dart';
 
-Future<void> main() async => integrationDriver();
+Future<void> main() async {
+  notTested();
+  return integrationDriver();
+}
+
+void notTested() => throw StateError('NOT TESTED');

--- a/packages/google_sign_in/google_sign_in/test_driver/google_sign_in_e2e_test.dart
+++ b/packages/google_sign_in/google_sign_in/test_driver/google_sign_in_e2e_test.dart
@@ -8,10 +8,14 @@ import 'dart:io';
 import 'package:flutter_driver/flutter_driver.dart';
 
 Future<void> main() async {
+  notTested();
   final FlutterDriver driver = await FlutterDriver.connect();
   final String data =
       await driver.requestData(null, timeout: const Duration(minutes: 1));
   await driver.close();
   final Map<String, dynamic> result = jsonDecode(data);
+
   exit(result['result'] == 'true' ? 0 : 1);
 }
+
+void notTested() => throw StateError('NOT TESTED');

--- a/packages/google_sign_in/google_sign_in_web/test/test_driver/auth2_integration.dart
+++ b/packages/google_sign_in/google_sign_in_web/test/test_driver/auth2_integration.dart
@@ -35,6 +35,7 @@ void main() {
     });
 
     testWidgets('init throws PlatformException', (WidgetTester tester) async {
+      expect(false, true);
       await expectLater(
           plugin.init(
             hostedDomain: 'foo',

--- a/packages/google_sign_in/google_sign_in_web/test/test_driver/auth2_integration_test.dart
+++ b/packages/google_sign_in/google_sign_in_web/test/test_driver/auth2_integration_test.dart
@@ -4,4 +4,9 @@
 
 import 'package:integration_test/integration_test_driver.dart';
 
-Future<void> main() async => integrationDriver();
+Future<void> main() async {
+  notTested();
+  return integrationDriver();
+}
+
+void notTested() => throw StateError('NOT TESTED');


### PR DESCRIPTION
Driver tests that are not in the example directory are not covered by CI

Source: https://github.com/flutter/plugin_tools/blob/093a2a5346498fcea29350fdbe01e895330a4a40/lib/src/drive_examples_command.dart#L85-L91

This PR changes a subset of the below files to make them fail, but the checks in this PR still show a passing result.

Heuristic of affected files:

```sh
$ git ls-files | grep test_driver  | grep -v example

packages/google_maps_flutter/google_maps_flutter_web/test/test_driver/google_maps_controller_integration.dart
packages/google_maps_flutter/google_maps_flutter_web/test/test_driver/google_maps_controller_integration_test.dart
packages/google_maps_flutter/google_maps_flutter_web/test/test_driver/google_maps_plugin_integration.dart
packages/google_maps_flutter/google_maps_flutter_web/test/test_driver/google_maps_plugin_integration_test.dart
packages/google_maps_flutter/google_maps_flutter_web/test/test_driver/marker_integration.dart
packages/google_maps_flutter/google_maps_flutter_web/test/test_driver/marker_integration_test.dart
packages/google_maps_flutter/google_maps_flutter_web/test/test_driver/markers_integration.dart
packages/google_maps_flutter/google_maps_flutter_web/test/test_driver/markers_integration_test.dart
packages/google_maps_flutter/google_maps_flutter_web/test/test_driver/shape_integration.dart
packages/google_maps_flutter/google_maps_flutter_web/test/test_driver/shape_integration_test.dart
packages/google_maps_flutter/google_maps_flutter_web/test/test_driver/shapes_integration.dart
packages/google_maps_flutter/google_maps_flutter_web/test/test_driver/shapes_integration_test.dart
packages/google_sign_in/google_sign_in/test_driver/google_sign_in_e2e_test.dart
packages/google_sign_in/google_sign_in_web/test/test_driver/auth2_integration.dart
packages/google_sign_in/google_sign_in_web/test/test_driver/auth2_integration_test.dart
packages/google_sign_in/google_sign_in_web/test/test_driver/gapi_load_integration.dart
packages/google_sign_in/google_sign_in_web/test/test_driver/gapi_load_integration_test.dart
packages/google_sign_in/google_sign_in_web/test/test_driver/gapi_mocks/gapi_mocks.dart
packages/google_sign_in/google_sign_in_web/test/test_driver/gapi_mocks/src/auth2_init.dart
packages/google_sign_in/google_sign_in_web/test/test_driver/gapi_mocks/src/gapi.dart
packages/google_sign_in/google_sign_in_web/test/test_driver/gapi_mocks/src/google_user.dart
packages/google_sign_in/google_sign_in_web/test/test_driver/gapi_mocks/src/test_iife.dart
packages/google_sign_in/google_sign_in_web/test/test_driver/gapi_utils_integration.dart
packages/google_sign_in/google_sign_in_web/test/test_driver/gapi_utils_integration_test.dart
packages/google_sign_in/google_sign_in_web/test/test_driver/src/test_utils.dart
packages/integration_test/lib/integration_test_driver.dart
packages/integration_test/lib/integration_test_driver_extended.dart
```

