### PR TITLE
[path_provider] Update endorsed Windows version

### DIFF
--- a/packages/path_provider/path_provider/CHANGELOG.md
+++ b/packages/path_provider/path_provider/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.6.17
+
+* Update Windows endorsement verison again, to pick up the fix for
+  web compilation in projects that include path_provider.
+
 ## 1.6.16
 
 * Update Windows endorsement verison

--- a/packages/path_provider/path_provider/pubspec.yaml
+++ b/packages/path_provider/path_provider/pubspec.yaml
@@ -1,7 +1,7 @@
 name: path_provider
 description: Flutter plugin for getting commonly used locations on host platform file systems, such as the temp and app data directories.
 homepage: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider
-version: 1.6.16
+version: 1.6.17
 
 flutter:
   plugin:
@@ -24,7 +24,7 @@ dependencies:
   path_provider_platform_interface: ^1.0.1
   path_provider_macos: ^0.0.4
   path_provider_linux: ^0.0.1
-  path_provider_windows: ^0.0.2
+  path_provider_windows: ^0.0.4
 
 dev_dependencies:
   integration_test:


### PR DESCRIPTION
## Description

path_provider_windows 0.0.2 causes issues both for web projects and for
projects built with Flutter 1.17 or earlier. This requires 0.0.4+ to
ensure fixes for both issues are included.

## Related Issues

https://github.com/flutter/flutter/issues/66158
https://github.com/flutter/flutter/issues/66143

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
