### PR TITLE
[path_provider_windows] Add missing method to fake

### DIFF
--- a/packages/path_provider/path_provider_windows/CHANGELOG.md
+++ b/packages/path_provider/path_provider_windows/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.0.4+1
+
+* Add getPath to the stub, so that the analyzer won't complain about
+  fakes that override it.
+* export 'folders.dart' rather than importing it, since it's intended to be
+  public.
+
 ## 0.0.4
 
 * Move the actual implementation behind a conditional import, exporting

--- a/packages/path_provider/path_provider_windows/lib/path_provider_windows.dart
+++ b/packages/path_provider/path_provider_windows/lib/path_provider_windows.dart
@@ -5,7 +5,6 @@
 // path_provider_windows is implemented using FFI; export a stub for platforms
 // that don't support FFI (e.g., web) to avoid having transitive dependencies
 // break web compilation.
-export 'src/folders_stub.dart'
-    if (dart.library.ffi) 'src/folders.dart';
+export 'src/folders_stub.dart' if (dart.library.ffi) 'src/folders.dart';
 export 'src/path_provider_windows_stub.dart'
     if (dart.library.ffi) 'src/path_provider_windows_real.dart';

--- a/packages/path_provider/path_provider_windows/lib/path_provider_windows.dart
+++ b/packages/path_provider/path_provider_windows/lib/path_provider_windows.dart
@@ -5,5 +5,7 @@
 // path_provider_windows is implemented using FFI; export a stub for platforms
 // that don't support FFI (e.g., web) to avoid having transitive dependencies
 // break web compilation.
+export 'src/folders_stub.dart'
+    if (dart.library.ffi) 'src/folders.dart';
 export 'src/path_provider_windows_stub.dart'
     if (dart.library.ffi) 'src/path_provider_windows_real.dart';

--- a/packages/path_provider/path_provider_windows/lib/src/folders_stub.dart
+++ b/packages/path_provider/path_provider_windows/lib/src/folders_stub.dart
@@ -1,0 +1,6 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// Stub version of the actual class.
+class WindowsKnownFolder {}

--- a/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_real.dart
+++ b/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_real.dart
@@ -12,7 +12,7 @@ import 'package:path/path.dart' as path;
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:win32/win32.dart';
 
-import 'folders.dart';
+export 'folders.dart';
 
 /// Wraps the Win32 VerQueryValue API call.
 ///

--- a/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_real.dart
+++ b/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_real.dart
@@ -12,7 +12,7 @@ import 'package:path/path.dart' as path;
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:win32/win32.dart';
 
-export 'folders.dart';
+import 'folders.dart';
 
 /// Wraps the Win32 VerQueryValue API call.
 ///

--- a/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_stub.dart
+++ b/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_stub.dart
@@ -20,6 +20,10 @@ class PathProviderWindows extends PathProviderPlatform {
 
   /// Stub; see comment on VersionInfoQuerier.
   VersionInfoQuerier versionInfoQuerier;
+
+  /// Match PathProviderWindows so that the analyzer won't report invalid
+  /// overrides if tests provide fake PathProviderWindows implementations.
+  Future<String> getPath(String folderID) async => '';
 }
 
 /// Stub to satisfy the analyzer, which doesn't seem to handle conditional

--- a/packages/path_provider/path_provider_windows/pubspec.yaml
+++ b/packages/path_provider/path_provider_windows/pubspec.yaml
@@ -1,7 +1,7 @@
 name: path_provider_windows
 description: Windows implementation of the path_provider plugin
 homepage: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider_windows
-version: 0.0.4
+version: 0.0.4+1
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

The fake didn't have getFolder, so if a test of something using
path_provider_windows (such as shared_preferences_windows) had a fake
that overrode getFolder, the analyzer would complain about overriding a
non-existent method. This adds it to avoid that analyzer warning.

It also fixes a minor issue introduced in the previous change, where
folder.dart was accidentally made internal rather than public.

## Related Issues

None

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
