### PR TITLE
[path_provider_android] Move Path operations to background thread

### DIFF
--- a/packages/connectivity/connectivity/ios/Classes/FLTConnectivityPlugin.m
+++ b/packages/connectivity/connectivity/ios/Classes/FLTConnectivityPlugin.m
@@ -156,7 +156,9 @@
     case kCLAuthorizationStatusAuthorizedWhenInUse: {
       return @"authorizedWhenInUse";
     }
-    default: { return @"unknown"; }
+    default: {
+      return @"unknown";
+    }
   }
 }
 

--- a/packages/connectivity/connectivity/ios/Classes/FLTConnectivityPlugin.m
+++ b/packages/connectivity/connectivity/ios/Classes/FLTConnectivityPlugin.m
@@ -156,9 +156,7 @@
     case kCLAuthorizationStatusAuthorizedWhenInUse: {
       return @"authorizedWhenInUse";
     }
-    default: {
-      return @"unknown";
-    }
+    default: { return @"unknown"; }
   }
 }
 

--- a/packages/path_provider/path_provider/CHANGELOG.md
+++ b/packages/path_provider/path_provider/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.6.19
+
+* Android implementation does path queries in the background thread rather than UI thread.
+
 ## 1.6.18
 
 * Keep handling deprecated Android v1 classes for backward compatibility.

--- a/packages/path_provider/path_provider/android/build.gradle
+++ b/packages/path_provider/path_provider/android/build.gradle
@@ -31,9 +31,16 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
+    android {
+        compileOptions {
+            sourceCompatibility 1.8
+            targetCompatibility 1.8
+        }
+    }
 }
 
 dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
+    implementation 'com.google.guava:guava:20.0'
     testImplementation 'junit:junit:4.12'
 }

--- a/packages/path_provider/path_provider/android/src/main/java/io/flutter/plugins/pathprovider/PathProviderPlugin.java
+++ b/packages/path_provider/path_provider/android/src/main/java/io/flutter/plugins/pathprovider/PathProviderPlugin.java
@@ -7,7 +7,13 @@ package io.flutter.plugins.pathprovider;
 import android.content.Context;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
+import android.os.Handler;
+import android.os.Looper;
 import androidx.annotation.NonNull;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.SettableFuture;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
@@ -15,6 +21,9 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.util.PathUtils;
 import java.io.File;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -22,6 +31,11 @@ public class PathProviderPlugin implements FlutterPlugin, MethodCallHandler {
 
   private Context context;
   private MethodChannel channel;
+  private final Executor uiThreadExecutor = new UiThreadExecutor();
+  private final Executor executor = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder()
+      .setNameFormat("path-provider-background-%d")
+      .setPriority(Thread.NORM_PRIORITY)
+      .build());
 
   public PathProviderPlugin() {}
 
@@ -46,28 +60,48 @@ public class PathProviderPlugin implements FlutterPlugin, MethodCallHandler {
     channel = null;
   }
 
+  private <T> void executeInBackground(Callable<T> task, Result result) {
+    final SettableFuture<T> future = SettableFuture.create();
+    Futures.addCallback(future,
+      new FutureCallback<T>() {
+       public void onSuccess(T answer) {
+         result.success(answer);
+       }
+       public void onFailure(Throwable t) {
+         result.error(t.getClass().getName(), t.getMessage(), null);
+       }
+     }, uiThreadExecutor);
+    executor.execute(() -> {
+      try {
+        future.set(task.call());
+      } catch (Throwable t) {
+        future.setException(t);
+      }
+    });
+  }
+
   @Override
   public void onMethodCall(MethodCall call, @NonNull Result result) {
     switch (call.method) {
       case "getTemporaryDirectory":
-        result.success(getPathProviderTemporaryDirectory());
+        executeInBackground(() -> getPathProviderTemporaryDirectory(), result);
         break;
       case "getApplicationDocumentsDirectory":
-        result.success(getPathProviderApplicationDocumentsDirectory());
+        executeInBackground(() -> getPathProviderApplicationDocumentsDirectory(), result);
         break;
       case "getStorageDirectory":
-        result.success(getPathProviderStorageDirectory());
+        executeInBackground(() -> getPathProviderStorageDirectory(), result);
         break;
       case "getExternalCacheDirectories":
-        result.success(getPathProviderExternalCacheDirectories());
+        executeInBackground(() -> getPathProviderExternalCacheDirectories(), result);
         break;
       case "getExternalStorageDirectories":
         final Integer type = call.argument("type");
         final String directoryName = StorageDirectoryMapper.androidType(type);
-        result.success(getPathProviderExternalStorageDirectories(directoryName));
+        executeInBackground(() -> getPathProviderExternalStorageDirectories(directoryName), result);
         break;
       case "getApplicationSupportDirectory":
-        result.success(getApplicationSupportDirectory());
+        executeInBackground(() -> getApplicationSupportDirectory(), result);
         break;
       default:
         result.notImplemented();
@@ -130,5 +164,14 @@ public class PathProviderPlugin implements FlutterPlugin, MethodCallHandler {
     }
 
     return paths;
+  }
+
+  private static class UiThreadExecutor implements Executor {
+    private final Handler handler = new Handler(Looper.getMainLooper());
+
+    @Override
+    public void execute(Runnable command) {
+      handler.post(command);
+    }
   }
 }

--- a/packages/path_provider/path_provider/pubspec.yaml
+++ b/packages/path_provider/path_provider/pubspec.yaml
@@ -1,7 +1,7 @@
 name: path_provider
 description: Flutter plugin for getting commonly used locations on host platform file systems, such as the temp and app data directories.
 homepage: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider
-version: 1.6.18
+version: 1.6.19
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

All `path` operations in the Android implementation access disk so they need to be done off the UI thread as per Android best practices.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
