### PR TITLE
[in_app_purchase] Fix AppStore cancel payment modal

### DIFF
--- a/packages/in_app_purchase/lib/src/store_kit_wrappers/sk_payment_queue_wrapper.dart
+++ b/packages/in_app_purchase/lib/src/store_kit_wrappers/sk_payment_queue_wrapper.dart
@@ -103,9 +103,14 @@ class SKPaymentQueueWrapper {
   /// finishTransaction:]`](https://developer.apple.com/documentation/storekit/skpaymentqueue/1506003-finishtransaction?language=objc).
   Future<void> finishTransaction(
       SKPaymentTransactionWrapper transaction) async {
+    Map requestMap = {
+      "transactionIdentifier": transaction.transactionIdentifier,
+      "productIdentifier": transaction.payment.productIdentifier,
+    };
     await channel.invokeMethod<void>(
-        '-[InAppPurchasePlugin finishTransaction:result:]',
-        transaction.transactionIdentifier);
+      '-[InAppPurchasePlugin finishTransaction:result:]',
+      requestMap,
+    );
   }
 
   /// Restore previously purchased transactions.


### PR DESCRIPTION
## Description

When the user cancels the payment dialog there is no `transactionIdentifier` this means the transaction cannot be finished in the current implementation and therefore not initiated again.

I haven't polished the PR to be included here, but just wanted to give a heads up. Feel free to close it if it does not meet your standards.
