### PR TITLE
[video_player] Fix tests

### DIFF
--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.10.12+5
+
+* Depend on `video_player_platform_interface` version that contains the new `TestHostVideoPlayerApi`
+  in order for tests to pass using the latest dependency.
+
 ## 0.10.12+4
 
 * Keep handling deprecated Android v1 classes for backward compatibility.

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for displaying inline video with other Flutter
 # 0.10.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.10.12+4
+version: 0.10.12+5
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player
 
 flutter:
@@ -20,7 +20,7 @@ flutter:
 
 dependencies:
   meta: ^1.0.5
-  video_player_platform_interface: ^2.1.0
+  video_player_platform_interface: ^2.2.0
   # The design on https://flutter.dev/go/federated-plugins was to leave
   # this constraint as "any". We cannot do it right now as it fails pub publish
   # validation, so we set a ^ constraint.

--- a/packages/video_player/video_player/test/video_player_test.dart
+++ b/packages/video_player/video_player/test/video_player_test.dart
@@ -588,9 +588,9 @@ void main() {
   });
 }
 
-class FakeVideoPlayerPlatform extends VideoPlayerApiTest {
+class FakeVideoPlayerPlatform extends TestHostVideoPlayerApi {
   FakeVideoPlayerPlatform() {
-    VideoPlayerApiTestSetup(this);
+    TestHostVideoPlayerApi.setup(this);
   }
 
   Completer<bool> initialized = Completer<bool>();
@@ -655,6 +655,11 @@ class FakeVideoPlayerPlatform extends VideoPlayerApiTest {
   @override
   void setVolume(VolumeMessage arg) {
     calls.add('setVolume');
+  }
+
+  @override
+  void setPlaybackSpeed(PlaybackSpeedMessage arg) {
+    // todo: implement as part of completing https://github.com/flutter/plugins/pull/3031
   }
 
   @override


### PR DESCRIPTION
## Description

This should just have been part of https://github.com/flutter/plugins/pull/3031 instead, my bad!

cc @ditman 

## Related Issues

* https://github.com/flutter/plugins/pull/3081#discussion_r495296875
* https://github.com/flutter/plugins/pull/3032#issuecomment-699199586

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, this is *not* a breaking change.

### Actually

This prepares a smooth transition for an upcoming PR instead of locking to an older version 👍 

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
