### PR TITLE
[connectivity_for_web] Fix homepage in pubspec.yaml

### DIFF
--- a/packages/connectivity/connectivity_for_web/CHANGELOG.md
+++ b/packages/connectivity/connectivity_for_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1+3
+
+* Fix homepage in `pubspec.yaml`.
+
 ## 0.3.1+2
 
 * Update package:e2e to use package:integration_test

--- a/packages/connectivity/connectivity_for_web/pubspec.yaml
+++ b/packages/connectivity/connectivity_for_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: connectivity_for_web
 description: An implementation for the web platform of the Flutter `connectivity` plugin. This uses the NetworkInformation Web API, with a fallback to Navigator.onLine.
-version: 0.3.1+2
-homepage: https://github.com/ditman/plugins/tree/connectivity-web/packages/connectivity/experimental_connectivity_web
+version: 0.3.1+3
+repository: https://github.com/flutter/plugins/tree/master/packages/connectivity/connectivity_for_web
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Fix broken homepage URI in pubspec. Also switches from using `homepage` to `repository` – a bit more accurate.

## Related Issues

Similar to https://github.com/flutter/flutter/issues/66844

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
