### PR TITLE
[google_maps_flutter] Out of developers preview, bump to 1.0.0

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 1.0.0
+## 1.0.0 - Out of developer preview  🎉.
 
-* Bump the minimal Flutter SDK to 1.22 where platform views is out of developers preview.
+* Bump the minimal Flutter SDK to 1.22 where platform views are out of developer preview and performing better on iOS. Flutter 1.22 no longer requires adding the `io.flutter.embedded_views_preview` to `Info.plist` in iOS.
 
 ## 0.5.33
 

--- a/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0
+
+* Bump the minimal Flutter SDK to 1.22 where platform views is out of developers preview.
+
 ## 0.5.33
 
 * Keep handling deprecated Android v1 classes for backward compatibility.

--- a/packages/google_maps_flutter/google_maps_flutter/README.md
+++ b/packages/google_maps_flutter/google_maps_flutter/README.md
@@ -4,20 +4,6 @@
 
 A Flutter plugin that provides a [Google Maps](https://developers.google.com/maps/) widget.
 
-## Developers Preview Status
-The plugin relies on Flutter's new mechanism for embedding Android and iOS views.
-As that mechanism is currently in a developers preview, this plugin should also be
-considered a developers preview.
-
-Known issues are tagged with the [platform-views](https://github.com/flutter/flutter/labels/a%3A%20platform-views) and/or [maps](https://github.com/flutter/flutter/labels/p%3A%20maps) labels.
-
-To use this plugin on iOS you need to opt-in for the embedded views preview by
-adding a boolean property to the app's `Info.plist` file, with the key `io.flutter.embedded_views_preview`
-and the value `YES`.
-
-The API exposed by this plugin is not yet stable, and we expect some breaking changes to land soon.
-
-
 ## Usage
 
 To use this plugin, add `google_maps_flutter` as a [dependency in your pubspec.yaml file](https://flutter.io/platform-plugins/).

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -33,4 +33,4 @@ flutter:
 
 environment:
   sdk: ">=2.1.0 <3.0.0"
-  flutter: ">=1.22 <2.0.0"
+  flutter: ">=1.22.0 <2.0.0"

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter/google_maps_flutter
-version: 0.5.33
+version: 1.0.0
 
 dependencies:
   flutter:
@@ -33,4 +33,4 @@ flutter:
 
 environment:
   sdk: ">=2.1.0 <3.0.0"
-  flutter: ">=1.16.3 <2.0.0"
+  flutter: ">=1.22.0-10.0.pre <2.0.0"

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -33,4 +33,4 @@ flutter:
 
 environment:
   sdk: ">=2.1.0 <3.0.0"
-  flutter: ">=1.22.0-10.0.pre <2.0.0"
+  flutter: ">=1.22 <2.0.0"


### PR DESCRIPTION
Bumps the minimally required Flutter SDK to 1.22, starting this version platform views are no longer in developers preview, so the plugin also gets out of developers preview as well.

We also bump the version to 1.0.0 as API stability has been reached.