### PR TITLE
[webview_flutter] Android getContentHeight added

### DIFF
--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -219,6 +219,9 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
       case "getScrollY":
         getScrollY(result);
         break;
+      case "getContentHeight":
+        getContentHeight(result);
+        break;    
       default:
         result.notImplemented();
     }
@@ -340,6 +343,10 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
 
   private void getScrollY(Result result) {
     result.success(webView.getScrollY());
+  }
+
+  private void getContentHeight(Result result) {
+    result.success(webView.getContentHeight());
   }
 
   private void applySettings(Map<String, Object> settings) {

--- a/packages/webview_flutter/lib/platform_interface.dart
+++ b/packages/webview_flutter/lib/platform_interface.dart
@@ -317,6 +317,12 @@ abstract class WebViewPlatformController {
     throw UnimplementedError(
         "WebView getScrollY is not implemented on the current platform");
   }
+
+  /// Return the height of WebView content pixels
+  Future<int> getContentHeight() {
+    throw UnimplementedError(
+        "WebView getContentHeight is not implemented on the current platform");
+  }
 }
 
 /// A single setting for configuring a WebViewPlatform which may be absent.

--- a/packages/webview_flutter/lib/src/webview_method_channel.dart
+++ b/packages/webview_flutter/lib/src/webview_method_channel.dart
@@ -153,6 +153,9 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
   @override
   Future<int> getScrollY() => _channel.invokeMethod<int>("getScrollY");
 
+  @override
+  Future<int> getContentHeight() => _channel.invokeMethod<int>("getContentHeight");
+
   /// Method channel implementation for [WebViewPlatform.clearCookies].
   static Future<bool> clearCookies() {
     return _cookieManagerChannel

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -765,6 +765,11 @@ class WebViewController {
   Future<int> getScrollY() {
     return _webViewPlatformController.getScrollY();
   }
+
+  /// Return the height of WebView content pixels
+  Future<int> getContentHeight() {
+    return _webViewPlatformController.getContentHeight();
+  }
 }
 
 /// Manages cookies pertaining to all [WebView]s.


### PR DESCRIPTION
## Description

Added new method `getContentHeigh`, to get WebView inner content height. Functionality currently added only for Android.
