### PR TITLE
Fixed HLS Stream on iOS

### DIFF
--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.11.0+1
+
+* Added isDurationIndefinite to support indefinite streams
+
 ## 0.11.0
 
 * Added option to set the video playback speed on the video controller.

--- a/packages/video_player/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
+++ b/packages/video_player/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
@@ -256,6 +256,7 @@ final class VideoPlayer {
       Map<String, Object> event = new HashMap<>();
       event.put("event", "initialized");
       event.put("duration", exoPlayer.getDuration());
+      event.put("isDurationIndefinite", exoPlayer.isCurrentWindowDynamic());
 
       if (exoPlayer.getVideoFormat() != null) {
         Format videoFormat = exoPlayer.getVideoFormat();

--- a/packages/video_player/video_player/example/lib/main.dart
+++ b/packages/video_player/video_player/example/lib/main.dart
@@ -218,13 +218,16 @@ class _BumbleBeeRemoteVideoState extends State<_BumbleBeeRemoteVideo> {
   void initState() {
     super.initState();
     _controller = VideoPlayerController.network(
-      'https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4',
+      // 'https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4',
+      'https://rtmp.api.rt.com/hls/rtdru.m3u8',
       closedCaptionFile: _loadCaptions(),
       videoPlayerOptions: VideoPlayerOptions(mixWithOthers: true),
     );
 
     _controller.addListener(() {
-      setState(() {});
+      setState(() {
+        debugPrint('Indefinite = ${_controller.value.isDurationIndefinite}');
+      });
     });
     _controller.setLooping(true);
     _controller.initialize();

--- a/packages/video_player/video_player/example/test_driver/video_player_test.dart
+++ b/packages/video_player/video_player/example/test_driver/video_player_test.dart
@@ -3,11 +3,14 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+
 import 'package:flutter_driver/flutter_driver.dart';
 import 'package:test/test.dart';
+import 'package:video_player/video_player.dart';
 
 Future<void> main() async {
   final FlutterDriver driver = await FlutterDriver.connect();
+  VideoPlayerController _controller;
   tearDownAll(() async {
     await driver.close();
   });
@@ -24,4 +27,17 @@ Future<void> main() async {
     final Health health = await driver.checkHealth();
     expect(health.status, HealthStatus.ok);
   }, skip: 'Cirrus CI currently hangs while playing videos');
+
+  group('Livestream should have indefinite duration', () {
+    setUp(() async {
+      _controller = VideoPlayerController.network(
+          'https://rtmp.api.rt.com/hls/rtdru.m3u8');
+    });
+
+    test('Should initialize', () async {
+      await _controller.initialize();
+
+      expect(_controller.value.isDurationIndefinite, true);
+    });
+  });
 }

--- a/packages/video_player/video_player/example/test_driver/video_player_test.dart
+++ b/packages/video_player/video_player/example/test_driver/video_player_test.dart
@@ -6,11 +6,10 @@ import 'dart:async';
 
 import 'package:flutter_driver/flutter_driver.dart';
 import 'package:test/test.dart';
-import 'package:video_player/video_player.dart';
 
 Future<void> main() async {
   final FlutterDriver driver = await FlutterDriver.connect();
-  VideoPlayerController _controller;
+
   tearDownAll(() async {
     await driver.close();
   });
@@ -27,17 +26,4 @@ Future<void> main() async {
     final Health health = await driver.checkHealth();
     expect(health.status, HealthStatus.ok);
   }, skip: 'Cirrus CI currently hangs while playing videos');
-
-  group('Livestream should have indefinite duration', () {
-    setUp(() async {
-      _controller = VideoPlayerController.network(
-          'https://rtmp.api.rt.com/hls/rtdru.m3u8');
-    });
-
-    test('Should initialize', () async {
-      await _controller.initialize();
-
-      expect(_controller.value.isDurationIndefinite, true);
-    });
-  });
 }

--- a/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m
@@ -325,6 +325,7 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     _eventSink(@{
       @"event" : @"initialized",
       @"duration" : @([self duration]),
+      @"isDurationIndefinite": @([self isDurationIndefinite]),
       @"width" : @(width),
       @"height" : @(height)
     });

--- a/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m
@@ -302,6 +302,10 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
   _displayLink.paused = !_isPlaying;
 }
 
+- (bool)isDurationIndefinite {
+  return CMTIME_IS_INDEFINITE([[_player currentItem] duration]);
+}
+
 - (void)sendInitialized {
   if (_eventSink && !_isInitialized) {
     CGSize size = [self.player currentItem].presentationSize;
@@ -313,7 +317,7 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
       return;
     }
     // The player may be initialized but still needs to determine the duration.
-    if ([self duration] == 0) {
+    if ([self duration] == 0 && ![self isDurationIndefinite]) {
       return;
     }
 

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -36,6 +36,7 @@ class VideoPlayerValue {
     this.isPlaying = false,
     this.isLooping = false,
     this.isBuffering = false,
+    this.isDurationIndefinite = false,
     this.volume = 1.0,
     this.playbackSpeed = 1.0,
     this.errorDescription,
@@ -74,6 +75,9 @@ class VideoPlayerValue {
 
   /// True if the video is currently buffering.
   final bool isBuffering;
+
+  /// True if the video has an undetermined duration, eg. a live stream.
+  final bool isDurationIndefinite;
 
   /// The current volume of the playback.
   final double volume;
@@ -122,6 +126,7 @@ class VideoPlayerValue {
     bool isPlaying,
     bool isLooping,
     bool isBuffering,
+    bool isDurationIndefinite,
     double volume,
     double playbackSpeed,
     String errorDescription,
@@ -135,6 +140,7 @@ class VideoPlayerValue {
       isPlaying: isPlaying ?? this.isPlaying,
       isLooping: isLooping ?? this.isLooping,
       isBuffering: isBuffering ?? this.isBuffering,
+      isDurationIndefinite: isDurationIndefinite ?? this.isDurationIndefinite,
       volume: volume ?? this.volume,
       playbackSpeed: playbackSpeed ?? this.playbackSpeed,
       errorDescription: errorDescription ?? this.errorDescription,
@@ -152,6 +158,7 @@ class VideoPlayerValue {
         'isPlaying: $isPlaying, '
         'isLooping: $isLooping, '
         'isBuffering: $isBuffering, '
+        'isDurationIndefinite: $isDurationIndefinite, '
         'volume: $volume, '
         'playbackSpeed: $playbackSpeed, '
         'errorDescription: $errorDescription)';
@@ -292,6 +299,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
         case VideoEventType.initialized:
           value = value.copyWith(
             duration: event.duration,
+            isDurationIndefinite: event.isDurationIndefinite,
             size: event.size,
           );
           initializingCompleter.complete(null);

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -819,12 +819,12 @@ class _VideoProgressIndicatorState extends State<VideoProgressIndicator> {
         fit: StackFit.passthrough,
         children: <Widget>[
           LinearProgressIndicator(
-            value: maxBuffering / duration,
+            value: duration > 0 ? maxBuffering / duration : 0,
             valueColor: AlwaysStoppedAnimation<Color>(colors.bufferedColor),
             backgroundColor: colors.backgroundColor,
           ),
           LinearProgressIndicator(
-            value: position / duration,
+            value: duration > 0 ? position / duration : 0,
             valueColor: AlwaysStoppedAnimation<Color>(colors.playedColor),
             backgroundColor: Colors.transparent,
           ),

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for displaying inline video with other Flutter
 # 0.10.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.11.0
+version: 0.11.0+1
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player
 
 flutter:

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -15,19 +15,20 @@ flutter:
         pluginClass: VideoPlayerPlugin
       ios:
         pluginClass: FLTVideoPlayerPlugin
-      web:
-        default_package: video_player_web
+#      web:
+#        default_package: video_player_web
 
 dependencies:
   meta: ^1.0.5
-  video_player_platform_interface: ^2.2.0
+  video_player_platform_interface: # ^2.2.0
+    path: ../video_player_platform_interface
 
   # The design on https://flutter.dev/go/federated-plugins was to leave
   # this constraint as "any". We cannot do it right now as it fails pub publish
   # validation, so we set a ^ constraint.
   # TODO(amirh): Revisit this (either update this part in the  design or the pub tool).
   # https://github.com/flutter/flutter/issues/46264
-  video_player_web: '>=0.1.4 <2.0.0'
+#  video_player_web: '>=0.1.4 <2.0.0'
 
   flutter:
     sdk: flutter

--- a/packages/video_player/video_player/test/method_channel_video_player_test.dart
+++ b/packages/video_player/video_player/test/method_channel_video_player_test.dart
@@ -1,0 +1,80 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:video_player/video_player.dart';
+import 'package:video_player_platform_interface/method_channel_video_player.dart';
+import 'package:video_player_platform_interface/video_player_platform_interface.dart';
+
+VideoEvent createVideoEvent({
+  bool isIndefiniteStream,
+}) {
+  if (isIndefiniteStream) {
+    return (VideoEvent(
+      eventType: VideoEventType.initialized,
+      duration: Duration(seconds: 0),
+      isDurationIndefinite: true,
+    ));
+  } else {
+    return (VideoEvent(
+      eventType: VideoEventType.unknown,
+      duration: Duration(seconds: 0),
+      isDurationIndefinite: false,
+    ));
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('Mock videoEvent', () {
+    final log = <MethodCall>[];
+
+    MethodChannelVideoPlayer methodChannelVideoPlayer;
+
+    StreamSubscription videoEventStreamSubscription;
+    VideoPlayerController _controller;
+
+    setUp(() async {
+      methodChannelVideoPlayer = MethodChannelVideoPlayer();
+
+      _controller = VideoPlayerController.network('https://127.0.0.1');
+
+      // Configure mock implementation for the EventChannel
+      MethodChannel(methodChannelVideoPlayer
+              .eventChannelFor(_controller.textureId)
+              .name)
+          .setMockMethodCallHandler((methodCall) async {
+        log.add(methodCall);
+        switch (methodCall.method) {
+          case 'listen':
+            await ServicesBinding.instance.defaultBinaryMessenger
+                .handlePlatformMessage(
+                    methodChannelVideoPlayer
+                        .eventChannelFor(_controller.textureId)
+                        .name,
+                    methodChannelVideoPlayer
+                        .eventChannelFor(_controller.textureId)
+                        .codec
+                        .encodeSuccessEnvelope(
+                            createVideoEvent(isIndefiniteStream: true)),
+                    (_) {});
+            break;
+          case 'cancel':
+            break;
+          default:
+            return null;
+        }
+      });
+    });
+
+    tearDownAll(() async {
+      await videoEventStreamSubscription.cancel();
+    });
+
+    test('Indefinite stream', () {
+
+      expect(_controller.value.isDurationIndefinite, true);
+    });
+  });
+}

--- a/packages/video_player/video_player/test/video_player_test.dart
+++ b/packages/video_player/video_player/test/video_player_test.dart
@@ -214,6 +214,15 @@ void main() {
             'dash');
       });
 
+      test('network with stream', () async {
+        final VideoPlayerController controller =
+            VideoPlayerController.network('https://127.0.0.1/indefinite');
+
+        await controller.initialize();
+
+        expect(controller.value.isDurationIndefinite, true);
+      });
+
       test('init errors', () async {
         final VideoPlayerController controller = VideoPlayerController.network(
           'http://testing.com/invalid_url',

--- a/packages/video_player/video_player_platform_interface/lib/method_channel_video_player.dart
+++ b/packages/video_player/video_player_platform_interface/lib/method_channel_video_player.dart
@@ -105,6 +105,7 @@ class MethodChannelVideoPlayer extends VideoPlayerPlatform {
           return VideoEvent(
             eventType: VideoEventType.initialized,
             duration: Duration(milliseconds: map['duration']),
+            isDurationIndefinite: map['isDurationIndefinite'],
             size: Size(map['width']?.toDouble() ?? 0.0,
                 map['height']?.toDouble() ?? 0.0),
           );

--- a/packages/video_player/video_player_platform_interface/lib/method_channel_video_player.dart
+++ b/packages/video_player/video_player_platform_interface/lib/method_channel_video_player.dart
@@ -96,7 +96,7 @@ class MethodChannelVideoPlayer extends VideoPlayerPlatform {
 
   @override
   Stream<VideoEvent> videoEventsFor(int textureId) {
-    return _eventChannelFor(textureId)
+    return eventChannelFor(textureId)
         .receiveBroadcastStream()
         .map((dynamic event) {
       final Map<dynamic, dynamic> map = event;
@@ -142,7 +142,8 @@ class MethodChannelVideoPlayer extends VideoPlayerPlatform {
     );
   }
 
-  EventChannel _eventChannelFor(int textureId) {
+  /// Returns [EventChannel] for a specific texture id
+  EventChannel eventChannelFor(int textureId) {
     return EventChannel('flutter.io/videoPlayer/videoEvents$textureId');
   }
 

--- a/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
+++ b/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
@@ -218,6 +218,7 @@ class VideoEvent {
   VideoEvent({
     @required this.eventType,
     this.duration,
+    this.isDurationIndefinite,
     this.size,
     this.buffered,
   });
@@ -229,6 +230,11 @@ class VideoEvent {
   ///
   /// Only used if [eventType] is [VideoEventType.initialized].
   final Duration duration;
+  
+  /// Determines if the video has a defined duration
+  /// 
+  /// Only used if [eventType] is [VideoEventType.initialized].
+  final bool isDurationIndefinite;
 
   /// Size of the video.
   ///
@@ -247,6 +253,7 @@ class VideoEvent {
             runtimeType == other.runtimeType &&
             eventType == other.eventType &&
             duration == other.duration &&
+            isDurationIndefinite == other.isDurationIndefinite &&
             size == other.size &&
             listEquals(buffered, other.buffered);
   }
@@ -255,6 +262,7 @@ class VideoEvent {
   int get hashCode =>
       eventType.hashCode ^
       duration.hashCode ^
+      isDurationIndefinite.hashCode ^
       size.hashCode ^
       buffered.hashCode;
 }


### PR DESCRIPTION
## Description

Implements the changes of [#1743](https://github.com/flutter/plugins/pull/1743/files) with the desired changes to the implementation. This makes it possible (again) to stream HLS stream with an indefinite length. 

On an iPhone simulator I only hear the audio when playing a HLS stream, but running it on an iPad everything works. 

I added some checks to the VideoProgressIndicator. On iOS, because the duration is 0, it's going to divide 0 by 0, which results in a crash. This is not an issue in Android. On iOS the ProgressIndicator now just shows no progress, which I believe should be the desired behaviour. 

## Related Issues

#1743  
Fixes [#48670](https://github.com/flutter/flutter/issues/48670)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [] I updated CHANGELOG.md to add a description of the change.
- [] I signed the [CLA].
- [] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
