### PR TITLE
[url_launcher] Improved documentation of the `headers` parameter.

### DIFF
--- a/packages/url_launcher/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.7.5
+
+* Improved documentation of the `headers` parameter.
+
 ## 5.7.4
 
 * Update android compileSdkVersion to 29.

--- a/packages/url_launcher/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher/CHANGELOG.md
@@ -1,4 +1,8 @@
+<<<<<<< HEAD
 ## 5.7.5
+=======
+## 5.7.3
+>>>>>>> a741c59a... Update CHANGELOG.md
 
 * Improved documentation of the `headers` parameter.
 

--- a/packages/url_launcher/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher/CHANGELOG.md
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
 ## 5.7.5
-=======
-## 5.7.3
->>>>>>> a741c59a... Update CHANGELOG.md
 
 * Improved documentation of the `headers` parameter.
 

--- a/packages/url_launcher/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/url_launcher/lib/url_launcher.dart
@@ -44,9 +44,9 @@ import 'package:url_launcher_platform_interface/url_launcher_platform_interface.
 /// [enableDomStorage] is an Android only setting. If true, WebView enable
 /// DOM storage.
 /// [headers] is an Android only setting that adds headers to the WebView.
-/// Adding headers without using a WebView is not fully supported.
-/// Some Browsers do not support adding headers. Some browsers partially
-/// support it, depending on the browser version.
+/// When not using a WebView, the header information is passed to the browser,
+/// some Android browsers do not support the [Browser.EXTRA_HEADERS](https://developer.android.com/reference/android/provider/Browser#EXTRA_HEADERS)
+/// intent extra and the header information will be lost.
 /// [webOnlyWindowName] is an Web only setting . _blank opens the new url in new tab ,
 /// _self opens the new url in current tab.
 /// Default behaviour is to open the url in new tab.

--- a/packages/url_launcher/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/url_launcher/lib/url_launcher.dart
@@ -44,6 +44,9 @@ import 'package:url_launcher_platform_interface/url_launcher_platform_interface.
 /// [enableDomStorage] is an Android only setting. If true, WebView enable
 /// DOM storage.
 /// [headers] is an Android only setting that adds headers to the WebView.
+/// Adding headers without using a WebView is not fully supported.
+/// Some Browsers do not support adding headers. Some browsers partially
+/// support it, depending on the browser version.
 /// [webOnlyWindowName] is an Web only setting . _blank opens the new url in new tab ,
 /// _self opens the new url in current tab.
 /// Default behaviour is to open the url in new tab.

--- a/packages/url_launcher/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher
 description: Flutter plugin for launching a URL on Android and iOS. Supports
   web, phone, SMS, and email schemes.
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher
-version: 5.7.4
+version: 5.7.5
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Added a clear documentation of the fact that the `headers` parameter at the `launch` method is not fully supported when using an external browser.

## Related Issues

[Issue 61332](https://github.com/flutter/flutter/issues/61332). 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
