### PR TITLE
[integration_test] Add watchPerformance

### DIFF
--- a/packages/integration_test/CHANGELOG.md
+++ b/packages/integration_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.2
+
+* Add `watchPerformance` for performance test.
+
 ## 0.9.1
 
 * Keep handling deprecated Android v1 classes for backward compatibility.

--- a/packages/integration_test/lib/integration_test.dart
+++ b/packages/integration_test/lib/integration_test.dart
@@ -309,7 +309,8 @@ class IntegrationTestWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding
     addTimingsCallback(watcher);
     await action();
     removeTimingsCallback(watcher);
-    final FrameTimingSummarizer frameTimes = FrameTimingSummarizer(frameTimings);
+    final FrameTimingSummarizer frameTimes =
+        FrameTimingSummarizer(frameTimings);
     reportData ??= <String, dynamic>{};
     reportData[reportKey] = frameTimes.summary;
   }

--- a/packages/integration_test/lib/integration_test.dart
+++ b/packages/integration_test/lib/integration_test.dart
@@ -304,10 +304,19 @@ class IntegrationTestWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding
       }
       return true;
     }());
+
+    // The engine could batch FrameTimings and send them only once per second.
+    // Delay for a sufficient time so either old FrameTimings are flushed and not
+    // interfering our measurements here, or new FrameTimings are all reported.
+    Future<void> delayForFrameTimings() =>
+      Future<void>.delayed(const Duration(seconds: 2));
+
+    await delayForFrameTimings(); // flush old FrameTimings
     final List<FrameTiming> frameTimings = <FrameTiming>[];
     final TimingsCallback watcher = frameTimings.addAll;
     addTimingsCallback(watcher);
     await action();
+    await delayForFrameTimings(); // make sure all FrameTimings are reported
     removeTimingsCallback(watcher);
     final FrameTimingSummarizer frameTimes =
         FrameTimingSummarizer(frameTimings);

--- a/packages/integration_test/lib/integration_test.dart
+++ b/packages/integration_test/lib/integration_test.dart
@@ -308,6 +308,9 @@ class IntegrationTestWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding
     // The engine could batch FrameTimings and send them only once per second.
     // Delay for a sufficient time so either old FrameTimings are flushed and not
     // interfering our measurements here, or new FrameTimings are all reported.
+    // TODO(CareF): remove this when flush FrameTiming is readly in engine.
+    //              See https://github.com/flutter/flutter/issues/64808
+    //              and https://github.com/flutter/flutter/issues/67593
     Future<void> delayForFrameTimings() =>
       Future<void>.delayed(const Duration(seconds: 2));
 

--- a/packages/integration_test/lib/integration_test.dart
+++ b/packages/integration_test/lib/integration_test.dart
@@ -312,7 +312,7 @@ class IntegrationTestWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding
     //              See https://github.com/flutter/flutter/issues/64808
     //              and https://github.com/flutter/flutter/issues/67593
     Future<void> delayForFrameTimings() =>
-      Future<void>.delayed(const Duration(seconds: 2));
+        Future<void>.delayed(const Duration(seconds: 2));
 
     await delayForFrameTimings(); // flush old FrameTimings
     final List<FrameTiming> frameTimings = <FrameTiming>[];

--- a/packages/integration_test/pubspec.yaml
+++ b/packages/integration_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: integration_test
 description: Runs tests that use the flutter_test API as integration tests.
-version: 0.9.1
+version: 0.9.2
 homepage: https://github.com/flutter/plugins/tree/master/packages/integration_test
 
 environment:


### PR DESCRIPTION
## Description

Add a `watchPerformance` method to `IntegrationTestWidgetsFlutterBinding` to implement performance metric collection as we do on `flutter_driver` test by `traceAction` and `TimelineSummary`. This is also to reland #2906 (revert #2917)

## Related Issues

This is the first step of flutter/flutter#63537

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
