### PR TITLE
[video_player] fix Timer Leak

### DIFF
--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.11.0+1
+
+* Fixed uncanceled timers when calling `play` on the controller multiple times causing value
+  listeners to be called indefinitely (after `pause`) and more often than needed. 
+
 ## 0.11.0
 
 * Added option to set the video playback speed on the video controller.

--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.11.0+1
 
-* Fixed uncanceled timers when calling `play` on the controller multiple times causing value
-  listeners to be called indefinitely (after `pause`) and more often than needed. 
+* Fixed uncanceled timers when calling `play` on the controller multiple times before `pause`, which
+  caused value listeners to be called indefinitely (after `pause`) and more often than needed. 
 
 ## 0.11.0
 

--- a/packages/video_player/video_player/example/integration_test/video_player_test.dart
+++ b/packages/video_player/video_player/example/integration_test/video_player_test.dart
@@ -63,29 +63,5 @@ void main() {
       expect(_controller.value.isPlaying, false);
       expect(_controller.value.position, pausedPosition);
     }, skip: Platform.isIOS);
-
-    testWidgets('cancels timers', (WidgetTester tester) async {
-      await _controller.initialize();
-
-      var eventCount = 0;
-      final listener = () => eventCount++;
-      _controller.addListener(listener);
-
-      // Play for a second, then pause, and then wait a second.
-      await _controller.play();
-      // Call play twice to test if timers leak.
-      await _controller.play();
-      await tester.pumpAndSettle(_playDuration);
-
-      final prePauseEventCount = eventCount;
-      await _controller.pause();
-      await tester.pumpAndSettle(_playDuration);
-
-      // If timers were properly canceled, there should only be one new event
-      // (from pausing). If timers were not canceled, there will be more events.
-      expect(eventCount, prePauseEventCount + 1);
-
-      _controller.removeListener(listener);
-    }, skip: Platform.isIOS);
   });
 }

--- a/packages/video_player/video_player/example/integration_test/video_player_test.dart
+++ b/packages/video_player/video_player/example/integration_test/video_player_test.dart
@@ -3,9 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:io';
-
-import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:video_player/video_player.dart';
 
 const Duration _playDuration = Duration(seconds: 1);

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -391,6 +391,9 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
     }
     if (value.isPlaying) {
       await _videoPlayerPlatform.play(_textureId);
+
+      // Cancel previous timer.
+      _timer?.cancel();
       _timer = Timer.periodic(
         const Duration(milliseconds: 500),
         (Timer timer) async {

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for displaying inline video with other Flutter
 # 0.10.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.11.0
+version: 0.11.0+1
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player
 
 flutter:


### PR DESCRIPTION
## Description

Currently, when `play` is called twice, i.e. `play` is called again before `pause`, the `_timer` leaks, which can create very frequent calls of listener **and** more importantly will never stop notifying, even when the video is paused.

I would say that this is a pretty severe issue as calling `play` on a controller can easily happen more than once and should not have side effects.

## Tests

I tried to add the following integration test:

```dart
testWidgets('cancels timers', (WidgetTester tester) async {
      await _controller.initialize();

      var eventCount = 0;
      final listener = () => eventCount++;
      _controller.addListener(listener);

      // Play for a second, then pause, and then wait a second.
      await _controller.play();
      // Call play twice to test if timers leak.
      await _controller.play();
      await tester.pumpAndSettle(_playDuration);

      final prePauseEventCount = eventCount;
      await _controller.pause();
      await tester.pumpAndSettle(_playDuration);

      // If timers were properly canceled, there should only be one new event
      // (from pausing). If timers were not canceled, there will be more events.
      expect(eventCount, prePauseEventCount + 1);

      _controller.removeListener(listener);
    }, skip: Platform.isIOS);
```

However, I was not able to get the existing integration tests to succeed, which is why I figured that this can do without a regression test for now.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]). (more below)
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
