### PR TITLE
[image_picker] Add option to retrieve image with thumbnail.

### DIFF
--- a/packages/image_picker/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
+++ b/packages/image_picker/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
@@ -570,7 +570,7 @@ public class ImagePickerDelegate
         new File(path).delete();
       }
     } else {
-      finishWithSuccess(path, null);
+      finishWithSuccess(path);
     }
   }
 
@@ -593,25 +593,25 @@ public class ImagePickerDelegate
     return true;
   }
 
-  private void finishWithSuccess(String imagePath, String thumbnailPath) {
-    if (pendingResult == null) {
-      cache.saveResult(imagePath, null, null);
-      return;
-    }
-    HashMap<String, String> result = new HashMap<>();
-    result.put("image", imagePath);
-    result.put("thumbnail", thumbnailPath);
-    pendingResult.success(result);
-    clearMethodCallAndResult();
+  private void finishWithSuccess(String imagePath){
+    finishWithSuccess(imagePath, null);
   }
 
-  private void finishWithSuccess(String imagePath) {
-    if (pendingResult == null) {
+  private void finishWithSuccess(String imagePath, String thumbnailPath) {
+    if (pendingResult == null || methodCall == null) {
       cache.saveResult(imagePath, null, null);
       return;
     }
-    pendingResult.success(imagePath);
+    if (ImagePickerPlugin.METHOD_CALL_IMAGE_WITH_THUMBNAIL.equals(methodCall.method)) {
+      HashMap<String, String> result = new HashMap<>();
+      result.put("image", imagePath);
+      result.put("thumbnail", thumbnailPath);
+      pendingResult.success(result);
+    } else {
+      pendingResult.success(imagePath);
+    }
     clearMethodCallAndResult();
+
   }
 
   private void finishWithAlreadyActiveError(MethodChannel.Result result) {

--- a/packages/image_picker/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -92,6 +92,7 @@ public class ImagePickerPlugin
   }
 
   static final String METHOD_CALL_IMAGE = "pickImage";
+  static final String METHOD_CALL_IMAGE_WITH_THUMBNAIL = "pickImageWithThumbnail";
   static final String METHOD_CALL_VIDEO = "pickVideo";
   private static final String METHOD_CALL_RETRIEVE = "retrieve";
   private static final int CAMERA_DEVICE_FRONT = 1;
@@ -291,6 +292,7 @@ public class ImagePickerPlugin
     }
     switch (call.method) {
       case METHOD_CALL_IMAGE:
+      case METHOD_CALL_IMAGE_WITH_THUMBNAIL:
         imageSource = call.argument("source");
         switch (imageSource) {
           case SOURCE_GALLERY:
@@ -320,7 +322,7 @@ public class ImagePickerPlugin
         delegate.retrieveLostImage(result);
         break;
       default:
-        throw new IllegalArgumentException("Unknown method " + call.method);
+        result.notImplemented();
     }
   }
 }

--- a/packages/image_picker/image_picker/example/pubspec.yaml
+++ b/packages/image_picker/image_picker/example/pubspec.yaml
@@ -9,7 +9,8 @@ dependencies:
   flutter_plugin_android_lifecycle: ^1.0.2
   image_picker:
     path: ../
-  image_picker_for_web: ^0.1.0
+  image_picker_for_web:
+    path: ../../image_picker_for_web
 
 dev_dependencies:
   flutter_driver:

--- a/packages/image_picker/image_picker/lib/image_picker.dart
+++ b/packages/image_picker/image_picker/lib/image_picker.dart
@@ -70,9 +70,9 @@ class ImagePicker {
     return path == null ? null : File(path);
   }
 
-  /// Returns a [PickedFile] object wrapping the image that was picked.
+  /// Returns a [PickedImage] object wrapping the image that was picked.
   ///
-  /// The returned [PickedFile] is intended to be used within a single APP session. Do not save the file path and use it across sessions.
+  /// The returned [PickedImage] is intended to be used within a single APP session. Do not save the file path and use it across sessions.
   ///
   /// The `source` argument controls where the image comes from. This can
   /// be either [ImageSource.camera] or [ImageSource.gallery].
@@ -94,22 +94,36 @@ class ImagePicker {
   ///
   /// In Android, the MainActivity can be destroyed for various reasons. If that happens, the result will be lost
   /// in this call. You can then call [getLostData] when your app relaunches to retrieve the lost data.
-  Future<PickedFile> getImage({
+  Future<PickedImage> getImage({
     @required ImageSource source,
     double maxWidth,
     double maxHeight,
     int imageQuality,
     bool createThumbnail = false,
     CameraDevice preferredCameraDevice = CameraDevice.rear,
-  }) {
-    return platform.pickImage(
-      source: source,
-      maxWidth: maxWidth,
-      maxHeight: maxHeight,
-      imageQuality: imageQuality,
-      createThumbnail: createThumbnail,
-      preferredCameraDevice: preferredCameraDevice,
-    );
+  }) async {
+    try {
+      return await platform.pickImageWithThumbnail(
+        source: source,
+        maxWidth: maxWidth,
+        maxHeight: maxHeight,
+        imageQuality: imageQuality,
+        createThumbnail: createThumbnail,
+        preferredCameraDevice: preferredCameraDevice,
+      );
+    } on UnimplementedError {
+      if(createThumbnail){
+        print("Creating thumbnails is not supported on this platform");
+      }
+      var pickedFile = await platform.pickImage(
+        source: source,
+        maxWidth: maxWidth,
+        maxHeight: maxHeight,
+        imageQuality: imageQuality,
+        preferredCameraDevice: preferredCameraDevice,
+      );
+      return pickedFile == null ? null : PickedImage.fromFile(pickedFile);
+    }
   }
 
   /// Returns a [File] object pointing to the video that was picked.

--- a/packages/image_picker/image_picker/lib/image_picker.dart
+++ b/packages/image_picker/image_picker/lib/image_picker.dart
@@ -20,6 +20,7 @@ export 'package:image_picker_platform_interface/image_picker_platform_interface.
         LostData,
         LostDataResponse,
         PickedFile,
+        PickedImage,
         RetrieveType;
 
 /// Provides an easy way to pick an image/video from the image library,
@@ -98,6 +99,7 @@ class ImagePicker {
     double maxWidth,
     double maxHeight,
     int imageQuality,
+    bool createThumbnail = false,
     CameraDevice preferredCameraDevice = CameraDevice.rear,
   }) {
     return platform.pickImage(
@@ -105,6 +107,7 @@ class ImagePicker {
       maxWidth: maxWidth,
       maxHeight: maxHeight,
       imageQuality: imageQuality,
+      createThumbnail: createThumbnail,
       preferredCameraDevice: preferredCameraDevice,
     );
   }

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -17,7 +17,8 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_plugin_android_lifecycle: ^1.0.2
-  image_picker_platform_interface: ^1.1.0
+  image_picker_platform_interface:
+    path: ../image_picker_platform_interface
 
 dev_dependencies:
   video_player: ^0.10.3

--- a/packages/image_picker/image_picker_for_web/lib/image_picker_for_web.dart
+++ b/packages/image_picker/image_picker_for_web/lib/image_picker_for_web.dart
@@ -31,12 +31,11 @@ class ImagePickerPlugin extends ImagePickerPlatform {
   }
 
   @override
-  Future<PickedImage> pickImage({
+  Future<PickedFile> pickImage({
     @required ImageSource source,
     double maxWidth,
     double maxHeight,
     int imageQuality,
-    bool createThumbnail = false,
     CameraDevice preferredCameraDevice = CameraDevice.rear,
   }) {
     String capture = computeCaptureAttribute(source, preferredCameraDevice);

--- a/packages/image_picker/image_picker_for_web/lib/image_picker_for_web.dart
+++ b/packages/image_picker/image_picker_for_web/lib/image_picker_for_web.dart
@@ -31,11 +31,12 @@ class ImagePickerPlugin extends ImagePickerPlatform {
   }
 
   @override
-  Future<PickedFile> pickImage({
+  Future<PickedImage> pickImage({
     @required ImageSource source,
     double maxWidth,
     double maxHeight,
     int imageQuality,
+    bool createThumbnail = false,
     CameraDevice preferredCameraDevice = CameraDevice.rear,
   }) {
     String capture = computeCaptureAttribute(source, preferredCameraDevice);

--- a/packages/image_picker/image_picker_for_web/pubspec.yaml
+++ b/packages/image_picker/image_picker_for_web/pubspec.yaml
@@ -14,7 +14,8 @@ flutter:
         fileName: image_picker_for_web.dart
 
 dependencies:
-  image_picker_platform_interface: ^1.1.0
+  image_picker_platform_interface:
+    path: ../image_picker_platform_interface
   flutter:
     sdk: flutter
   flutter_web_plugins:

--- a/packages/image_picker/image_picker_platform_interface/lib/src/method_channel/method_channel_image_picker.dart
+++ b/packages/image_picker/image_picker_platform_interface/lib/src/method_channel/method_channel_image_picker.dart
@@ -71,7 +71,7 @@ class MethodChannelImagePicker extends ImagePickerPlatform {
     int imageQuality,
     bool createThumbnail,
     CameraDevice preferredCameraDevice,
-  }) {
+  }) async {
     assert(source != null);
     if (imageQuality != null && (imageQuality < 0 || imageQuality > 100)) {
       throw ArgumentError.value(
@@ -86,8 +86,8 @@ class MethodChannelImagePicker extends ImagePickerPlatform {
       throw ArgumentError.value(maxHeight, 'maxHeight', 'cannot be negative');
     }
 
-    return _channel.invokeMethod<Map<String, String>>(
-      'pickImagePaths',
+    return _channel.invokeMapMethod<String, String>(
+      'pickImage',
       <String, dynamic>{
         'source': source.index,
         'maxWidth': maxWidth,

--- a/packages/image_picker/image_picker_platform_interface/lib/src/platform_interface/image_picker_platform.dart
+++ b/packages/image_picker/image_picker_platform_interface/lib/src/platform_interface/image_picker_platform.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:image_picker_platform_interface/src/types/picked_image.dart';
 import 'package:meta/meta.dart' show required;
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
@@ -138,11 +139,12 @@ abstract class ImagePickerPlatform extends PlatformInterface {
   ///
   /// In Android, the MainActivity can be destroyed for various reasons. If that happens, the result will be lost
   /// in this call. You can then call [retrieveLostData] when your app relaunches to retrieve the lost data.
-  Future<PickedFile> pickImage({
+  Future<PickedImage> pickImage({
     @required ImageSource source,
     double maxWidth,
     double maxHeight,
     int imageQuality,
+    bool createThumbnail = false,
     CameraDevice preferredCameraDevice = CameraDevice.rear,
   }) {
     throw UnimplementedError('pickImage() has not been implemented.');

--- a/packages/image_picker/image_picker_platform_interface/lib/src/platform_interface/image_picker_platform.dart
+++ b/packages/image_picker/image_picker_platform_interface/lib/src/platform_interface/image_picker_platform.dart
@@ -127,7 +127,7 @@ abstract class ImagePickerPlatform extends PlatformInterface {
   ///
   /// The `imageQuality` argument modifies the quality of the image, ranging from 0-100
   /// where 100 is the original/max quality. If `imageQuality` is null, the image with
-  /// the original quality will be returned. Compression is only supportted for certain
+  /// the original quality will be returned. Compression is only supported for certain
   /// image types such as JPEG. If compression is not supported for the image that is picked,
   /// an warning message will be logged.
   ///
@@ -139,7 +139,41 @@ abstract class ImagePickerPlatform extends PlatformInterface {
   ///
   /// In Android, the MainActivity can be destroyed for various reasons. If that happens, the result will be lost
   /// in this call. You can then call [retrieveLostData] when your app relaunches to retrieve the lost data.
-  Future<PickedImage> pickImage({
+  @Deprecated('Use pickImageWithThumbnail instead.')
+  Future<PickedFile> pickImage({
+    @required ImageSource source,
+    double maxWidth,
+    double maxHeight,
+    int imageQuality,
+    CameraDevice preferredCameraDevice = CameraDevice.rear,
+  }) {
+    throw UnimplementedError('pickImage() has not been implemented.');
+  }
+
+  /// Returns a [PickedImage] with the image that was picked.
+  ///
+  /// The `source` argument controls where the image comes from. This can
+  /// be either [ImageSource.camera] or [ImageSource.gallery].
+  ///
+  /// If specified, the image will be at most `maxWidth` wide and
+  /// `maxHeight` tall. Otherwise the image will be returned at it's
+  /// original width and height.
+  ///
+  /// The `imageQuality` argument modifies the quality of the image, ranging from 0-100
+  /// where 100 is the original/max quality. If `imageQuality` is null, the image with
+  /// the original quality will be returned. Compression is only supported for certain
+  /// image types such as JPEG. If compression is not supported for the image that is picked,
+  /// an warning message will be logged.
+  ///
+  /// Use `preferredCameraDevice` to specify the camera to use when the `source` is [ImageSource.camera].
+  /// The `preferredCameraDevice` is ignored when `source` is [ImageSource.gallery]. It is also ignored if the chosen camera is not supported on the device.
+  /// Defaults to [CameraDevice.rear]. Note that Android has no documented parameter for an intent to specify if
+  /// the front or rear camera should be opened, this function is not guaranteed
+  /// to work on an Android device.
+  ///
+  /// In Android, the MainActivity can be destroyed for various reasons. If that happens, the result will be lost
+  /// in this call. You can then call [retrieveLostData] when your app relaunches to retrieve the lost data.
+  Future<PickedImage> pickImageWithThumbnail({
     @required ImageSource source,
     double maxWidth,
     double maxHeight,
@@ -147,7 +181,7 @@ abstract class ImagePickerPlatform extends PlatformInterface {
     bool createThumbnail = false,
     CameraDevice preferredCameraDevice = CameraDevice.rear,
   }) {
-    throw UnimplementedError('pickImage() has not been implemented.');
+    throw UnimplementedError('pickImageWithThumbnail() has not been implemented.');
   }
 
   /// Returns a [PickedFile] containing the video that was picked.

--- a/packages/image_picker/image_picker_platform_interface/lib/src/types/picked_image.dart
+++ b/packages/image_picker/image_picker_platform_interface/lib/src/types/picked_image.dart
@@ -1,0 +1,15 @@
+import 'picked_file/picked_file.dart';
+
+/// A PickedImage is a [PickedFile] with an optional [thumbnail] variable for
+/// a small sized thumbnail image file.
+class PickedImage extends PickedFile {
+
+  /// Small sized thumbnail image file
+  final PickedFile thumbnail;
+
+  /// Constructs a PickedImage object from the imagePath with optionally the
+  /// path to a thumbnail file.
+  PickedImage(String imagePath, {String thumbnailPath}) :
+      thumbnail = thumbnailPath != null ? PickedFile(thumbnailPath) : null,
+      super(imagePath);
+}

--- a/packages/image_picker/image_picker_platform_interface/lib/src/types/picked_image.dart
+++ b/packages/image_picker/image_picker_platform_interface/lib/src/types/picked_image.dart
@@ -1,15 +1,39 @@
+import 'dart:convert';
+
+import 'dart:typed_data';
+
 import 'picked_file/picked_file.dart';
 
 /// A PickedImage is a [PickedFile] with an optional [thumbnail] variable for
 /// a small sized thumbnail image file.
-class PickedImage extends PickedFile {
-
+class PickedImage implements PickedFile {
   /// Small sized thumbnail image file
   final PickedFile thumbnail;
+  final PickedFile _image;
 
   /// Constructs a PickedImage object from the imagePath with optionally the
   /// path to a thumbnail file.
-  PickedImage(String imagePath, {String thumbnailPath}) :
-      thumbnail = thumbnailPath != null ? PickedFile(thumbnailPath) : null,
-      super(imagePath);
+  PickedImage(String imagePath, {String thumbnailPath})
+      : thumbnail = thumbnailPath != null ? PickedFile(thumbnailPath) : null,
+        _image = PickedFile(imagePath);
+
+  /// Constructs a PickedImage object from a PickedFile object. A thumbnail
+  /// file is optional.
+  PickedImage.fromFile(PickedFile image, {this.thumbnail})
+      : assert(image != null),
+        _image = image;
+
+  @override
+  Stream<Uint8List> openRead([int start, int end]) =>
+      _image.openRead(start, end);
+
+  @override
+  String get path => _image.path;
+
+  @override
+  Future<Uint8List> readAsBytes() => _image.readAsBytes();
+
+  @override
+  Future<String> readAsString({Encoding encoding = utf8}) =>
+      _image.readAsString(encoding: encoding);
 }

--- a/packages/image_picker/image_picker_platform_interface/lib/src/types/types.dart
+++ b/packages/image_picker/image_picker_platform_interface/lib/src/types/types.dart
@@ -3,6 +3,7 @@ export 'image_source.dart';
 export 'lost_data_response.dart';
 export 'retrieve_type.dart';
 export 'picked_file/picked_file.dart';
+export 'picked_image.dart';
 
 /// Denotes that an image is being picked.
 const String kTypeImage = 'image';


### PR DESCRIPTION
WIP Only Flutter and Android part are finished for now.

## Description
Some users are asking for getting both the original image and a thumbnail. 
This proposal let `getImage` return a PickedImage. This PickedImage class extends PickedFile to keep best compatibility.
Only the methodchannel changes a bit.

The thumbnail is always an image of (maximum) 600x600 and uses the existing resize methods.
600x600 was the minimum that still looked decent on my phone, so it is quite random with inspiration from [here](https://www.sitepoint.com/community/t/what-size-are-typical-thumbnail-images-and/4424/2). We could choose to make it configurable.

This is from the example, the top image is the thumbnail, the bottom one is the original.
![Screenshot_20201008-164447_Image_Picker_Example](https://user-images.githubusercontent.com/15101411/95476045-20c5c900-0987-11eb-95a0-3b702c061464.png)

## Related Issues
Fixes flutter/flutter#26191

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
