### PR TITLE
[video_player] Add cookie support (3/3)

### DIFF
--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.11.2
+
+* Add cookie support for remote network sources. 
+
 ## 0.11.1
 
 * Enable TLSv1.1 & TLSv1.2 for API 19 and below.

--- a/packages/video_player/video_player/android/src/main/java/io/flutter/plugins/videoplayer/Messages.java
+++ b/packages/video_player/video_player/android/src/main/java/io/flutter/plugins/videoplayer/Messages.java
@@ -6,6 +6,7 @@ package io.flutter.plugins.videoplayer;
 import io.flutter.plugin.common.BasicMessageChannel;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.StandardMessageCodec;
+import java.util.ArrayList;
 import java.util.HashMap;
 
 /** Generated class from Pigeon. */
@@ -15,28 +16,18 @@ public class Messages {
   /** Generated class from Pigeon that represents data sent in messages. */
   public static class TextureMessage {
     private Long textureId;
-
-    public Long getTextureId() {
-      return textureId;
-    }
-
-    public void setTextureId(Long setterArg) {
-      this.textureId = setterArg;
-    }
+    public Long getTextureId() { return textureId; }
+    public void setTextureId(Long setterArg) { this.textureId = setterArg; }
 
     HashMap toMap() {
       HashMap<String, Object> toMapResult = new HashMap<>();
       toMapResult.put("textureId", textureId);
       return toMapResult;
     }
-
     static TextureMessage fromMap(HashMap map) {
       TextureMessage fromMapResult = new TextureMessage();
       Object textureId = map.get("textureId");
-      fromMapResult.textureId =
-          (textureId == null)
-              ? null
-              : ((textureId instanceof Integer) ? (Integer) textureId : (Long) textureId);
+      fromMapResult.textureId = (textureId == null) ? null : ((textureId instanceof Integer) ? (Integer)textureId : (Long)textureId);
       return fromMapResult;
     }
   }
@@ -44,44 +35,24 @@ public class Messages {
   /** Generated class from Pigeon that represents data sent in messages. */
   public static class CreateMessage {
     private String asset;
-
-    public String getAsset() {
-      return asset;
-    }
-
-    public void setAsset(String setterArg) {
-      this.asset = setterArg;
-    }
+    public String getAsset() { return asset; }
+    public void setAsset(String setterArg) { this.asset = setterArg; }
 
     private String uri;
-
-    public String getUri() {
-      return uri;
-    }
-
-    public void setUri(String setterArg) {
-      this.uri = setterArg;
-    }
+    public String getUri() { return uri; }
+    public void setUri(String setterArg) { this.uri = setterArg; }
 
     private String packageName;
-
-    public String getPackageName() {
-      return packageName;
-    }
-
-    public void setPackageName(String setterArg) {
-      this.packageName = setterArg;
-    }
+    public String getPackageName() { return packageName; }
+    public void setPackageName(String setterArg) { this.packageName = setterArg; }
 
     private String formatHint;
+    public String getFormatHint() { return formatHint; }
+    public void setFormatHint(String setterArg) { this.formatHint = setterArg; }
 
-    public String getFormatHint() {
-      return formatHint;
-    }
-
-    public void setFormatHint(String setterArg) {
-      this.formatHint = setterArg;
-    }
+    private ArrayList cookies;
+    public ArrayList getCookies() { return cookies; }
+    public void setCookies(ArrayList setterArg) { this.cookies = setterArg; }
 
     HashMap toMap() {
       HashMap<String, Object> toMapResult = new HashMap<>();
@@ -89,19 +60,21 @@ public class Messages {
       toMapResult.put("uri", uri);
       toMapResult.put("packageName", packageName);
       toMapResult.put("formatHint", formatHint);
+      toMapResult.put("cookies", cookies);
       return toMapResult;
     }
-
     static CreateMessage fromMap(HashMap map) {
       CreateMessage fromMapResult = new CreateMessage();
       Object asset = map.get("asset");
-      fromMapResult.asset = (String) asset;
+      fromMapResult.asset = (String)asset;
       Object uri = map.get("uri");
-      fromMapResult.uri = (String) uri;
+      fromMapResult.uri = (String)uri;
       Object packageName = map.get("packageName");
-      fromMapResult.packageName = (String) packageName;
+      fromMapResult.packageName = (String)packageName;
       Object formatHint = map.get("formatHint");
-      fromMapResult.formatHint = (String) formatHint;
+      fromMapResult.formatHint = (String)formatHint;
+      Object cookies = map.get("cookies");
+      fromMapResult.cookies = (ArrayList)cookies;
       return fromMapResult;
     }
   }
@@ -109,24 +82,12 @@ public class Messages {
   /** Generated class from Pigeon that represents data sent in messages. */
   public static class LoopingMessage {
     private Long textureId;
-
-    public Long getTextureId() {
-      return textureId;
-    }
-
-    public void setTextureId(Long setterArg) {
-      this.textureId = setterArg;
-    }
+    public Long getTextureId() { return textureId; }
+    public void setTextureId(Long setterArg) { this.textureId = setterArg; }
 
     private Boolean isLooping;
-
-    public Boolean getIsLooping() {
-      return isLooping;
-    }
-
-    public void setIsLooping(Boolean setterArg) {
-      this.isLooping = setterArg;
-    }
+    public Boolean getIsLooping() { return isLooping; }
+    public void setIsLooping(Boolean setterArg) { this.isLooping = setterArg; }
 
     HashMap toMap() {
       HashMap<String, Object> toMapResult = new HashMap<>();
@@ -134,16 +95,12 @@ public class Messages {
       toMapResult.put("isLooping", isLooping);
       return toMapResult;
     }
-
     static LoopingMessage fromMap(HashMap map) {
       LoopingMessage fromMapResult = new LoopingMessage();
       Object textureId = map.get("textureId");
-      fromMapResult.textureId =
-          (textureId == null)
-              ? null
-              : ((textureId instanceof Integer) ? (Integer) textureId : (Long) textureId);
+      fromMapResult.textureId = (textureId == null) ? null : ((textureId instanceof Integer) ? (Integer)textureId : (Long)textureId);
       Object isLooping = map.get("isLooping");
-      fromMapResult.isLooping = (Boolean) isLooping;
+      fromMapResult.isLooping = (Boolean)isLooping;
       return fromMapResult;
     }
   }
@@ -151,24 +108,12 @@ public class Messages {
   /** Generated class from Pigeon that represents data sent in messages. */
   public static class VolumeMessage {
     private Long textureId;
-
-    public Long getTextureId() {
-      return textureId;
-    }
-
-    public void setTextureId(Long setterArg) {
-      this.textureId = setterArg;
-    }
+    public Long getTextureId() { return textureId; }
+    public void setTextureId(Long setterArg) { this.textureId = setterArg; }
 
     private Double volume;
-
-    public Double getVolume() {
-      return volume;
-    }
-
-    public void setVolume(Double setterArg) {
-      this.volume = setterArg;
-    }
+    public Double getVolume() { return volume; }
+    public void setVolume(Double setterArg) { this.volume = setterArg; }
 
     HashMap toMap() {
       HashMap<String, Object> toMapResult = new HashMap<>();
@@ -176,16 +121,12 @@ public class Messages {
       toMapResult.put("volume", volume);
       return toMapResult;
     }
-
     static VolumeMessage fromMap(HashMap map) {
       VolumeMessage fromMapResult = new VolumeMessage();
       Object textureId = map.get("textureId");
-      fromMapResult.textureId =
-          (textureId == null)
-              ? null
-              : ((textureId instanceof Integer) ? (Integer) textureId : (Long) textureId);
+      fromMapResult.textureId = (textureId == null) ? null : ((textureId instanceof Integer) ? (Integer)textureId : (Long)textureId);
       Object volume = map.get("volume");
-      fromMapResult.volume = (Double) volume;
+      fromMapResult.volume = (Double)volume;
       return fromMapResult;
     }
   }
@@ -193,24 +134,12 @@ public class Messages {
   /** Generated class from Pigeon that represents data sent in messages. */
   public static class PlaybackSpeedMessage {
     private Long textureId;
-
-    public Long getTextureId() {
-      return textureId;
-    }
-
-    public void setTextureId(Long setterArg) {
-      this.textureId = setterArg;
-    }
+    public Long getTextureId() { return textureId; }
+    public void setTextureId(Long setterArg) { this.textureId = setterArg; }
 
     private Double speed;
-
-    public Double getSpeed() {
-      return speed;
-    }
-
-    public void setSpeed(Double setterArg) {
-      this.speed = setterArg;
-    }
+    public Double getSpeed() { return speed; }
+    public void setSpeed(Double setterArg) { this.speed = setterArg; }
 
     HashMap toMap() {
       HashMap<String, Object> toMapResult = new HashMap<>();
@@ -218,16 +147,12 @@ public class Messages {
       toMapResult.put("speed", speed);
       return toMapResult;
     }
-
     static PlaybackSpeedMessage fromMap(HashMap map) {
       PlaybackSpeedMessage fromMapResult = new PlaybackSpeedMessage();
       Object textureId = map.get("textureId");
-      fromMapResult.textureId =
-          (textureId == null)
-              ? null
-              : ((textureId instanceof Integer) ? (Integer) textureId : (Long) textureId);
+      fromMapResult.textureId = (textureId == null) ? null : ((textureId instanceof Integer) ? (Integer)textureId : (Long)textureId);
       Object speed = map.get("speed");
-      fromMapResult.speed = (Double) speed;
+      fromMapResult.speed = (Double)speed;
       return fromMapResult;
     }
   }
@@ -235,24 +160,12 @@ public class Messages {
   /** Generated class from Pigeon that represents data sent in messages. */
   public static class PositionMessage {
     private Long textureId;
-
-    public Long getTextureId() {
-      return textureId;
-    }
-
-    public void setTextureId(Long setterArg) {
-      this.textureId = setterArg;
-    }
+    public Long getTextureId() { return textureId; }
+    public void setTextureId(Long setterArg) { this.textureId = setterArg; }
 
     private Long position;
-
-    public Long getPosition() {
-      return position;
-    }
-
-    public void setPosition(Long setterArg) {
-      this.position = setterArg;
-    }
+    public Long getPosition() { return position; }
+    public void setPosition(Long setterArg) { this.position = setterArg; }
 
     HashMap toMap() {
       HashMap<String, Object> toMapResult = new HashMap<>();
@@ -260,19 +173,12 @@ public class Messages {
       toMapResult.put("position", position);
       return toMapResult;
     }
-
     static PositionMessage fromMap(HashMap map) {
       PositionMessage fromMapResult = new PositionMessage();
       Object textureId = map.get("textureId");
-      fromMapResult.textureId =
-          (textureId == null)
-              ? null
-              : ((textureId instanceof Integer) ? (Integer) textureId : (Long) textureId);
+      fromMapResult.textureId = (textureId == null) ? null : ((textureId instanceof Integer) ? (Integer)textureId : (Long)textureId);
       Object position = map.get("position");
-      fromMapResult.position =
-          (position == null)
-              ? null
-              : ((position instanceof Integer) ? (Integer) position : (Long) position);
+      fromMapResult.position = (position == null) ? null : ((position instanceof Integer) ? (Integer)position : (Long)position);
       return fromMapResult;
     }
   }
@@ -280,320 +186,269 @@ public class Messages {
   /** Generated class from Pigeon that represents data sent in messages. */
   public static class MixWithOthersMessage {
     private Boolean mixWithOthers;
-
-    public Boolean getMixWithOthers() {
-      return mixWithOthers;
-    }
-
-    public void setMixWithOthers(Boolean setterArg) {
-      this.mixWithOthers = setterArg;
-    }
+    public Boolean getMixWithOthers() { return mixWithOthers; }
+    public void setMixWithOthers(Boolean setterArg) { this.mixWithOthers = setterArg; }
 
     HashMap toMap() {
       HashMap<String, Object> toMapResult = new HashMap<>();
       toMapResult.put("mixWithOthers", mixWithOthers);
       return toMapResult;
     }
-
     static MixWithOthersMessage fromMap(HashMap map) {
       MixWithOthersMessage fromMapResult = new MixWithOthersMessage();
       Object mixWithOthers = map.get("mixWithOthers");
-      fromMapResult.mixWithOthers = (Boolean) mixWithOthers;
+      fromMapResult.mixWithOthers = (Boolean)mixWithOthers;
       return fromMapResult;
     }
   }
 
-  /** Generated interface from Pigeon that represents a handler of messages from Flutter. */
+  /** Generated interface from Pigeon that represents a handler of messages from Flutter.*/
   public interface VideoPlayerApi {
     void initialize();
-
     TextureMessage create(CreateMessage arg);
-
     void dispose(TextureMessage arg);
-
     void setLooping(LoopingMessage arg);
-
     void setVolume(VolumeMessage arg);
-
     void setPlaybackSpeed(PlaybackSpeedMessage arg);
-
     void play(TextureMessage arg);
-
     PositionMessage position(TextureMessage arg);
-
     void seekTo(PositionMessage arg);
-
     void pause(TextureMessage arg);
-
     void setMixWithOthers(MixWithOthersMessage arg);
 
     /** Sets up an instance of `VideoPlayerApi` to handle messages through the `binaryMessenger` */
     static void setup(BinaryMessenger binaryMessenger, VideoPlayerApi api) {
       {
         BasicMessageChannel<Object> channel =
-            new BasicMessageChannel<>(
-                binaryMessenger,
-                "dev.flutter.pigeon.VideoPlayerApi.initialize",
-                new StandardMessageCodec());
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.VideoPlayerApi.initialize", new StandardMessageCodec());
         if (api != null) {
-          channel.setMessageHandler(
-              (message, reply) -> {
-                HashMap<String, HashMap> wrapped = new HashMap<>();
-                try {
-                  api.initialize();
-                  wrapped.put("result", null);
-                } catch (Exception exception) {
-                  wrapped.put("error", wrapError(exception));
-                }
-                reply.reply(wrapped);
-              });
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              api.initialize();
+              wrapped.put("result", null);
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
         } else {
           channel.setMessageHandler(null);
         }
       }
       {
         BasicMessageChannel<Object> channel =
-            new BasicMessageChannel<>(
-                binaryMessenger,
-                "dev.flutter.pigeon.VideoPlayerApi.create",
-                new StandardMessageCodec());
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.VideoPlayerApi.create", new StandardMessageCodec());
         if (api != null) {
-          channel.setMessageHandler(
-              (message, reply) -> {
-                HashMap<String, HashMap> wrapped = new HashMap<>();
-                try {
-                  @SuppressWarnings("ConstantConditions")
-                  CreateMessage input = CreateMessage.fromMap((HashMap) message);
-                  TextureMessage output = api.create(input);
-                  wrapped.put("result", output.toMap());
-                } catch (Exception exception) {
-                  wrapped.put("error", wrapError(exception));
-                }
-                reply.reply(wrapped);
-              });
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              @SuppressWarnings("ConstantConditions")
+              CreateMessage input = CreateMessage.fromMap((HashMap)message);
+              TextureMessage output = api.create(input);
+              wrapped.put("result", output.toMap());
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
         } else {
           channel.setMessageHandler(null);
         }
       }
       {
         BasicMessageChannel<Object> channel =
-            new BasicMessageChannel<>(
-                binaryMessenger,
-                "dev.flutter.pigeon.VideoPlayerApi.dispose",
-                new StandardMessageCodec());
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.VideoPlayerApi.dispose", new StandardMessageCodec());
         if (api != null) {
-          channel.setMessageHandler(
-              (message, reply) -> {
-                HashMap<String, HashMap> wrapped = new HashMap<>();
-                try {
-                  @SuppressWarnings("ConstantConditions")
-                  TextureMessage input = TextureMessage.fromMap((HashMap) message);
-                  api.dispose(input);
-                  wrapped.put("result", null);
-                } catch (Exception exception) {
-                  wrapped.put("error", wrapError(exception));
-                }
-                reply.reply(wrapped);
-              });
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              @SuppressWarnings("ConstantConditions")
+              TextureMessage input = TextureMessage.fromMap((HashMap)message);
+              api.dispose(input);
+              wrapped.put("result", null);
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
         } else {
           channel.setMessageHandler(null);
         }
       }
       {
         BasicMessageChannel<Object> channel =
-            new BasicMessageChannel<>(
-                binaryMessenger,
-                "dev.flutter.pigeon.VideoPlayerApi.setLooping",
-                new StandardMessageCodec());
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.VideoPlayerApi.setLooping", new StandardMessageCodec());
         if (api != null) {
-          channel.setMessageHandler(
-              (message, reply) -> {
-                HashMap<String, HashMap> wrapped = new HashMap<>();
-                try {
-                  @SuppressWarnings("ConstantConditions")
-                  LoopingMessage input = LoopingMessage.fromMap((HashMap) message);
-                  api.setLooping(input);
-                  wrapped.put("result", null);
-                } catch (Exception exception) {
-                  wrapped.put("error", wrapError(exception));
-                }
-                reply.reply(wrapped);
-              });
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              @SuppressWarnings("ConstantConditions")
+              LoopingMessage input = LoopingMessage.fromMap((HashMap)message);
+              api.setLooping(input);
+              wrapped.put("result", null);
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
         } else {
           channel.setMessageHandler(null);
         }
       }
       {
         BasicMessageChannel<Object> channel =
-            new BasicMessageChannel<>(
-                binaryMessenger,
-                "dev.flutter.pigeon.VideoPlayerApi.setVolume",
-                new StandardMessageCodec());
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.VideoPlayerApi.setVolume", new StandardMessageCodec());
         if (api != null) {
-          channel.setMessageHandler(
-              (message, reply) -> {
-                HashMap<String, HashMap> wrapped = new HashMap<>();
-                try {
-                  @SuppressWarnings("ConstantConditions")
-                  VolumeMessage input = VolumeMessage.fromMap((HashMap) message);
-                  api.setVolume(input);
-                  wrapped.put("result", null);
-                } catch (Exception exception) {
-                  wrapped.put("error", wrapError(exception));
-                }
-                reply.reply(wrapped);
-              });
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              @SuppressWarnings("ConstantConditions")
+              VolumeMessage input = VolumeMessage.fromMap((HashMap)message);
+              api.setVolume(input);
+              wrapped.put("result", null);
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
         } else {
           channel.setMessageHandler(null);
         }
       }
       {
         BasicMessageChannel<Object> channel =
-            new BasicMessageChannel<>(
-                binaryMessenger,
-                "dev.flutter.pigeon.VideoPlayerApi.setPlaybackSpeed",
-                new StandardMessageCodec());
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.VideoPlayerApi.setPlaybackSpeed", new StandardMessageCodec());
         if (api != null) {
-          channel.setMessageHandler(
-              (message, reply) -> {
-                HashMap<String, HashMap> wrapped = new HashMap<>();
-                try {
-                  @SuppressWarnings("ConstantConditions")
-                  PlaybackSpeedMessage input = PlaybackSpeedMessage.fromMap((HashMap) message);
-                  api.setPlaybackSpeed(input);
-                  wrapped.put("result", null);
-                } catch (Exception exception) {
-                  wrapped.put("error", wrapError(exception));
-                }
-                reply.reply(wrapped);
-              });
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              @SuppressWarnings("ConstantConditions")
+              PlaybackSpeedMessage input = PlaybackSpeedMessage.fromMap((HashMap)message);
+              api.setPlaybackSpeed(input);
+              wrapped.put("result", null);
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
         } else {
           channel.setMessageHandler(null);
         }
       }
       {
         BasicMessageChannel<Object> channel =
-            new BasicMessageChannel<>(
-                binaryMessenger,
-                "dev.flutter.pigeon.VideoPlayerApi.play",
-                new StandardMessageCodec());
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.VideoPlayerApi.play", new StandardMessageCodec());
         if (api != null) {
-          channel.setMessageHandler(
-              (message, reply) -> {
-                HashMap<String, HashMap> wrapped = new HashMap<>();
-                try {
-                  @SuppressWarnings("ConstantConditions")
-                  TextureMessage input = TextureMessage.fromMap((HashMap) message);
-                  api.play(input);
-                  wrapped.put("result", null);
-                } catch (Exception exception) {
-                  wrapped.put("error", wrapError(exception));
-                }
-                reply.reply(wrapped);
-              });
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              @SuppressWarnings("ConstantConditions")
+              TextureMessage input = TextureMessage.fromMap((HashMap)message);
+              api.play(input);
+              wrapped.put("result", null);
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
         } else {
           channel.setMessageHandler(null);
         }
       }
       {
         BasicMessageChannel<Object> channel =
-            new BasicMessageChannel<>(
-                binaryMessenger,
-                "dev.flutter.pigeon.VideoPlayerApi.position",
-                new StandardMessageCodec());
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.VideoPlayerApi.position", new StandardMessageCodec());
         if (api != null) {
-          channel.setMessageHandler(
-              (message, reply) -> {
-                HashMap<String, HashMap> wrapped = new HashMap<>();
-                try {
-                  @SuppressWarnings("ConstantConditions")
-                  TextureMessage input = TextureMessage.fromMap((HashMap) message);
-                  PositionMessage output = api.position(input);
-                  wrapped.put("result", output.toMap());
-                } catch (Exception exception) {
-                  wrapped.put("error", wrapError(exception));
-                }
-                reply.reply(wrapped);
-              });
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              @SuppressWarnings("ConstantConditions")
+              TextureMessage input = TextureMessage.fromMap((HashMap)message);
+              PositionMessage output = api.position(input);
+              wrapped.put("result", output.toMap());
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
         } else {
           channel.setMessageHandler(null);
         }
       }
       {
         BasicMessageChannel<Object> channel =
-            new BasicMessageChannel<>(
-                binaryMessenger,
-                "dev.flutter.pigeon.VideoPlayerApi.seekTo",
-                new StandardMessageCodec());
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.VideoPlayerApi.seekTo", new StandardMessageCodec());
         if (api != null) {
-          channel.setMessageHandler(
-              (message, reply) -> {
-                HashMap<String, HashMap> wrapped = new HashMap<>();
-                try {
-                  @SuppressWarnings("ConstantConditions")
-                  PositionMessage input = PositionMessage.fromMap((HashMap) message);
-                  api.seekTo(input);
-                  wrapped.put("result", null);
-                } catch (Exception exception) {
-                  wrapped.put("error", wrapError(exception));
-                }
-                reply.reply(wrapped);
-              });
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              @SuppressWarnings("ConstantConditions")
+              PositionMessage input = PositionMessage.fromMap((HashMap)message);
+              api.seekTo(input);
+              wrapped.put("result", null);
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
         } else {
           channel.setMessageHandler(null);
         }
       }
       {
         BasicMessageChannel<Object> channel =
-            new BasicMessageChannel<>(
-                binaryMessenger,
-                "dev.flutter.pigeon.VideoPlayerApi.pause",
-                new StandardMessageCodec());
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.VideoPlayerApi.pause", new StandardMessageCodec());
         if (api != null) {
-          channel.setMessageHandler(
-              (message, reply) -> {
-                HashMap<String, HashMap> wrapped = new HashMap<>();
-                try {
-                  @SuppressWarnings("ConstantConditions")
-                  TextureMessage input = TextureMessage.fromMap((HashMap) message);
-                  api.pause(input);
-                  wrapped.put("result", null);
-                } catch (Exception exception) {
-                  wrapped.put("error", wrapError(exception));
-                }
-                reply.reply(wrapped);
-              });
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              @SuppressWarnings("ConstantConditions")
+              TextureMessage input = TextureMessage.fromMap((HashMap)message);
+              api.pause(input);
+              wrapped.put("result", null);
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
         } else {
           channel.setMessageHandler(null);
         }
       }
       {
         BasicMessageChannel<Object> channel =
-            new BasicMessageChannel<>(
-                binaryMessenger,
-                "dev.flutter.pigeon.VideoPlayerApi.setMixWithOthers",
-                new StandardMessageCodec());
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.VideoPlayerApi.setMixWithOthers", new StandardMessageCodec());
         if (api != null) {
-          channel.setMessageHandler(
-              (message, reply) -> {
-                HashMap<String, HashMap> wrapped = new HashMap<>();
-                try {
-                  @SuppressWarnings("ConstantConditions")
-                  MixWithOthersMessage input = MixWithOthersMessage.fromMap((HashMap) message);
-                  api.setMixWithOthers(input);
-                  wrapped.put("result", null);
-                } catch (Exception exception) {
-                  wrapped.put("error", wrapError(exception));
-                }
-                reply.reply(wrapped);
-              });
+          channel.setMessageHandler((message, reply) -> {
+            HashMap<String, HashMap> wrapped = new HashMap<>();
+            try {
+              @SuppressWarnings("ConstantConditions")
+              MixWithOthersMessage input = MixWithOthersMessage.fromMap((HashMap)message);
+              api.setMixWithOthers(input);
+              wrapped.put("result", null);
+            }
+            catch (Exception exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
         } else {
           channel.setMessageHandler(null);
         }
       }
     }
   }
-
   private static HashMap wrapError(Exception exception) {
     HashMap<String, Object> errorMap = new HashMap<>();
     errorMap.put("message", exception.toString());

--- a/packages/video_player/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -137,7 +137,8 @@ public class VideoPlayerPlugin implements FlutterPlugin, VideoPlayerApi {
               handle,
               "asset:///" + assetLookupKey,
               null,
-              options);
+              options,
+              null);
       videoPlayers.put(handle.id(), player);
     } else {
       player =
@@ -147,7 +148,8 @@ public class VideoPlayerPlugin implements FlutterPlugin, VideoPlayerApi {
               handle,
               arg.getUri(),
               arg.getFormatHint(),
-              options);
+              options,
+              arg.getCookies());
       videoPlayers.put(handle.id(), player);
     }
 

--- a/packages/video_player/video_player/example/lib/main.dart
+++ b/packages/video_player/video_player/example/lib/main.dart
@@ -314,13 +314,13 @@ class _ControlsOverlay extends StatelessWidget {
               controller.setPlaybackSpeed(speed);
             },
             itemBuilder: (context) {
-              return [
-                for (final speed in _examplePlaybackRates)
+              return
+                _examplePlaybackRates.map((speed) =>
                   PopupMenuItem(
                     value: speed,
                     child: Text('${speed}x'),
                   )
-              ];
+                ).toList();
             },
             child: Padding(
               padding: const EdgeInsets.symmetric(

--- a/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m
@@ -46,7 +46,9 @@ int64_t FLTCMTimeToMillis(CMTime time) {
 @property(nonatomic, readonly) bool isPlaying;
 @property(nonatomic) bool isLooping;
 @property(nonatomic, readonly) bool isInitialized;
-- (instancetype)initWithURL:(NSURL*)url frameUpdater:(FLTFrameUpdater*)frameUpdater;
+- (instancetype)initWithURL:(NSURL*)url
+               frameUpdater:(FLTFrameUpdater*)frameUpdater
+                    cookies:(NSArray*)cookies;
 - (void)play;
 - (void)pause;
 - (void)setIsLooping:(bool)isLooping;
@@ -62,7 +64,7 @@ static void* playbackBufferFullContext = &playbackBufferFullContext;
 @implementation FLTVideoPlayer
 - (instancetype)initWithAsset:(NSString*)asset frameUpdater:(FLTFrameUpdater*)frameUpdater {
   NSString* path = [[NSBundle mainBundle] pathForResource:asset ofType:nil];
-  return [self initWithURL:[NSURL fileURLWithPath:path] frameUpdater:frameUpdater];
+    return [self initWithURL:[NSURL fileURLWithPath:path] frameUpdater:frameUpdater cookies: nil];
 }
 
 - (void)addObservers:(AVPlayerItem*)item {
@@ -162,8 +164,20 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
   _displayLink.paused = YES;
 }
 
-- (instancetype)initWithURL:(NSURL*)url frameUpdater:(FLTFrameUpdater*)frameUpdater {
-  AVPlayerItem* item = [AVPlayerItem playerItemWithURL:url];
+- (instancetype)initWithURL:(NSURL*)url frameUpdater:(FLTFrameUpdater*)frameUpdater cookies:(NSArray*)cookies {
+  AVPlayerItem *item;
+  if (cookies == (id)[NSNull null] || cookies == nil) {
+    item = [AVPlayerItem playerItemWithURL:url];
+  } else {
+    NSMutableArray* httpCookies = [NSMutableArray new];
+    for (NSString* cookieString in cookies) {
+      NSArray* parsedCookies = [NSHTTPCookie cookiesWithResponseHeaderFields: @{@"Set-Cookie": cookieString}
+                                                                      forURL: [NSURL URLWithString: @""]];
+      [httpCookies addObjectsFromArray: parsedCookies];
+    }
+    AVURLAsset* asset = [AVURLAsset URLAssetWithURL:url options:@{AVURLAssetHTTPCookiesKey: httpCookies}];
+    item = [AVPlayerItem playerItemWithAsset:asset];
+  }
   return [self initWithPlayerItem:item frameUpdater:frameUpdater];
 }
 
@@ -522,7 +536,9 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     return [self onPlayerSetup:player frameUpdater:frameUpdater];
   } else if (input.uri) {
     player = [[FLTVideoPlayer alloc] initWithURL:[NSURL URLWithString:input.uri]
-                                    frameUpdater:frameUpdater];
+                                    frameUpdater:frameUpdater
+                                         cookies:input.cookies
+    ];
     return [self onPlayerSetup:player frameUpdater:frameUpdater];
   } else {
     *error = [FlutterError errorWithCode:@"video_player" message:@"not implemented" details:nil];

--- a/packages/video_player/video_player/ios/Classes/messages.h
+++ b/packages/video_player/video_player/ios/Classes/messages.h
@@ -16,59 +16,55 @@ NS_ASSUME_NONNULL_BEGIN
 @class FLTMixWithOthersMessage;
 
 @interface FLTTextureMessage : NSObject
-@property(nonatomic, strong, nullable) NSNumber *textureId;
+@property(nonatomic, strong, nullable) NSNumber * textureId;
 @end
 
 @interface FLTCreateMessage : NSObject
-@property(nonatomic, copy, nullable) NSString *asset;
-@property(nonatomic, copy, nullable) NSString *uri;
-@property(nonatomic, copy, nullable) NSString *packageName;
-@property(nonatomic, copy, nullable) NSString *formatHint;
+@property(nonatomic, copy, nullable) NSString * asset;
+@property(nonatomic, copy, nullable) NSString * uri;
+@property(nonatomic, copy, nullable) NSString * packageName;
+@property(nonatomic, copy, nullable) NSString * formatHint;
+@property(nonatomic, strong, nullable) NSArray * cookies;
 @end
 
 @interface FLTLoopingMessage : NSObject
-@property(nonatomic, strong, nullable) NSNumber *textureId;
-@property(nonatomic, strong, nullable) NSNumber *isLooping;
+@property(nonatomic, strong, nullable) NSNumber * textureId;
+@property(nonatomic, strong, nullable) NSNumber * isLooping;
 @end
 
 @interface FLTVolumeMessage : NSObject
-@property(nonatomic, strong, nullable) NSNumber *textureId;
-@property(nonatomic, strong, nullable) NSNumber *volume;
+@property(nonatomic, strong, nullable) NSNumber * textureId;
+@property(nonatomic, strong, nullable) NSNumber * volume;
 @end
 
 @interface FLTPlaybackSpeedMessage : NSObject
-@property(nonatomic, strong, nullable) NSNumber *textureId;
-@property(nonatomic, strong, nullable) NSNumber *speed;
+@property(nonatomic, strong, nullable) NSNumber * textureId;
+@property(nonatomic, strong, nullable) NSNumber * speed;
 @end
 
 @interface FLTPositionMessage : NSObject
-@property(nonatomic, strong, nullable) NSNumber *textureId;
-@property(nonatomic, strong, nullable) NSNumber *position;
+@property(nonatomic, strong, nullable) NSNumber * textureId;
+@property(nonatomic, strong, nullable) NSNumber * position;
 @end
 
 @interface FLTMixWithOthersMessage : NSObject
-@property(nonatomic, strong, nullable) NSNumber *mixWithOthers;
+@property(nonatomic, strong, nullable) NSNumber * mixWithOthers;
 @end
 
 @protocol FLTVideoPlayerApi
-- (void)initialize:(FlutterError *_Nullable *_Nonnull)error;
-- (nullable FLTTextureMessage *)create:(FLTCreateMessage *)input
-                                 error:(FlutterError *_Nullable *_Nonnull)error;
-- (void)dispose:(FLTTextureMessage *)input error:(FlutterError *_Nullable *_Nonnull)error;
-- (void)setLooping:(FLTLoopingMessage *)input error:(FlutterError *_Nullable *_Nonnull)error;
-- (void)setVolume:(FLTVolumeMessage *)input error:(FlutterError *_Nullable *_Nonnull)error;
-- (void)setPlaybackSpeed:(FLTPlaybackSpeedMessage *)input
-                   error:(FlutterError *_Nullable *_Nonnull)error;
-- (void)play:(FLTTextureMessage *)input error:(FlutterError *_Nullable *_Nonnull)error;
-- (nullable FLTPositionMessage *)position:(FLTTextureMessage *)input
-                                    error:(FlutterError *_Nullable *_Nonnull)error;
-- (void)seekTo:(FLTPositionMessage *)input error:(FlutterError *_Nullable *_Nonnull)error;
-- (void)pause:(FLTTextureMessage *)input error:(FlutterError *_Nullable *_Nonnull)error;
-- (void)setMixWithOthers:(FLTMixWithOthersMessage *)input
-                   error:(FlutterError *_Nullable *_Nonnull)error;
+-(void)initialize:(FlutterError *_Nullable *_Nonnull)error;
+-(nullable FLTTextureMessage *)create:(FLTCreateMessage*)input error:(FlutterError *_Nullable *_Nonnull)error;
+-(void)dispose:(FLTTextureMessage*)input error:(FlutterError *_Nullable *_Nonnull)error;
+-(void)setLooping:(FLTLoopingMessage*)input error:(FlutterError *_Nullable *_Nonnull)error;
+-(void)setVolume:(FLTVolumeMessage*)input error:(FlutterError *_Nullable *_Nonnull)error;
+-(void)setPlaybackSpeed:(FLTPlaybackSpeedMessage*)input error:(FlutterError *_Nullable *_Nonnull)error;
+-(void)play:(FLTTextureMessage*)input error:(FlutterError *_Nullable *_Nonnull)error;
+-(nullable FLTPositionMessage *)position:(FLTTextureMessage*)input error:(FlutterError *_Nullable *_Nonnull)error;
+-(void)seekTo:(FLTPositionMessage*)input error:(FlutterError *_Nullable *_Nonnull)error;
+-(void)pause:(FLTTextureMessage*)input error:(FlutterError *_Nullable *_Nonnull)error;
+-(void)setMixWithOthers:(FLTMixWithOthersMessage*)input error:(FlutterError *_Nullable *_Nonnull)error;
 @end
 
-extern void FLTVideoPlayerApiSetup(id<FlutterBinaryMessenger> binaryMessenger,
-                                   id<FLTVideoPlayerApi> _Nullable api);
+extern void FLTVideoPlayerApiSetup(id<FlutterBinaryMessenger> binaryMessenger, id<FLTVideoPlayerApi> _Nullable api);
 
 NS_ASSUME_NONNULL_END

--- a/packages/video_player/video_player/ios/Classes/messages.m
+++ b/packages/video_player/video_player/ios/Classes/messages.m
@@ -7,67 +7,67 @@
 #error File requires ARC to be enabled.
 #endif
 
-static NSDictionary *wrapResult(NSDictionary *result, FlutterError *error) {
+static NSDictionary* wrapResult(NSDictionary *result, FlutterError *error) {
   NSDictionary *errorDict = (NSDictionary *)[NSNull null];
   if (error) {
-    errorDict = [NSDictionary
-        dictionaryWithObjectsAndKeys:(error.code ? error.code : [NSNull null]), @"code",
-                                     (error.message ? error.message : [NSNull null]), @"message",
-                                     (error.details ? error.details : [NSNull null]), @"details",
-                                     nil];
+    errorDict = [NSDictionary dictionaryWithObjectsAndKeys:
+        (error.code ? error.code : [NSNull null]), @"code",
+        (error.message ? error.message : [NSNull null]), @"message",
+        (error.details ? error.details : [NSNull null]), @"details",
+        nil];
   }
-  return [NSDictionary dictionaryWithObjectsAndKeys:(result ? result : [NSNull null]), @"result",
-                                                    errorDict, @"error", nil];
+  return [NSDictionary dictionaryWithObjectsAndKeys:
+      (result ? result : [NSNull null]), @"result",
+      errorDict, @"error",
+      nil];
 }
 
 @interface FLTTextureMessage ()
-+ (FLTTextureMessage *)fromMap:(NSDictionary *)dict;
-- (NSDictionary *)toMap;
++(FLTTextureMessage*)fromMap:(NSDictionary*)dict;
+-(NSDictionary*)toMap;
 @end
 @interface FLTCreateMessage ()
-+ (FLTCreateMessage *)fromMap:(NSDictionary *)dict;
-- (NSDictionary *)toMap;
++(FLTCreateMessage*)fromMap:(NSDictionary*)dict;
+-(NSDictionary*)toMap;
 @end
 @interface FLTLoopingMessage ()
-+ (FLTLoopingMessage *)fromMap:(NSDictionary *)dict;
-- (NSDictionary *)toMap;
++(FLTLoopingMessage*)fromMap:(NSDictionary*)dict;
+-(NSDictionary*)toMap;
 @end
 @interface FLTVolumeMessage ()
-+ (FLTVolumeMessage *)fromMap:(NSDictionary *)dict;
-- (NSDictionary *)toMap;
++(FLTVolumeMessage*)fromMap:(NSDictionary*)dict;
+-(NSDictionary*)toMap;
 @end
 @interface FLTPlaybackSpeedMessage ()
-+ (FLTPlaybackSpeedMessage *)fromMap:(NSDictionary *)dict;
-- (NSDictionary *)toMap;
++(FLTPlaybackSpeedMessage*)fromMap:(NSDictionary*)dict;
+-(NSDictionary*)toMap;
 @end
 @interface FLTPositionMessage ()
-+ (FLTPositionMessage *)fromMap:(NSDictionary *)dict;
-- (NSDictionary *)toMap;
++(FLTPositionMessage*)fromMap:(NSDictionary*)dict;
+-(NSDictionary*)toMap;
 @end
 @interface FLTMixWithOthersMessage ()
-+ (FLTMixWithOthersMessage *)fromMap:(NSDictionary *)dict;
-- (NSDictionary *)toMap;
++(FLTMixWithOthersMessage*)fromMap:(NSDictionary*)dict;
+-(NSDictionary*)toMap;
 @end
 
 @implementation FLTTextureMessage
-+ (FLTTextureMessage *)fromMap:(NSDictionary *)dict {
-  FLTTextureMessage *result = [[FLTTextureMessage alloc] init];
++(FLTTextureMessage*)fromMap:(NSDictionary*)dict {
+  FLTTextureMessage* result = [[FLTTextureMessage alloc] init];
   result.textureId = dict[@"textureId"];
   if ((NSNull *)result.textureId == [NSNull null]) {
     result.textureId = nil;
   }
   return result;
 }
-- (NSDictionary *)toMap {
-  return [NSDictionary
-      dictionaryWithObjectsAndKeys:(self.textureId != nil ? self.textureId : [NSNull null]),
-                                   @"textureId", nil];
+-(NSDictionary*)toMap {
+  return [NSDictionary dictionaryWithObjectsAndKeys:(self.textureId ? self.textureId : [NSNull null]), @"textureId", nil];
 }
 @end
 
 @implementation FLTCreateMessage
-+ (FLTCreateMessage *)fromMap:(NSDictionary *)dict {
-  FLTCreateMessage *result = [[FLTCreateMessage alloc] init];
++(FLTCreateMessage*)fromMap:(NSDictionary*)dict {
+  FLTCreateMessage* result = [[FLTCreateMessage alloc] init];
   result.asset = dict[@"asset"];
   if ((NSNull *)result.asset == [NSNull null]) {
     result.asset = nil;
@@ -84,22 +84,20 @@ static NSDictionary *wrapResult(NSDictionary *result, FlutterError *error) {
   if ((NSNull *)result.formatHint == [NSNull null]) {
     result.formatHint = nil;
   }
+  result.cookies = dict[@"cookies"];
+  if ((NSNull *)result.cookies == [NSNull null]) {
+    result.cookies = nil;
+  }
   return result;
 }
-- (NSDictionary *)toMap {
-  return [NSDictionary
-      dictionaryWithObjectsAndKeys:(self.asset ? self.asset : [NSNull null]), @"asset",
-                                   (self.uri ? self.uri : [NSNull null]), @"uri",
-                                   (self.packageName ? self.packageName : [NSNull null]),
-                                   @"packageName",
-                                   (self.formatHint ? self.formatHint : [NSNull null]),
-                                   @"formatHint", nil];
+-(NSDictionary*)toMap {
+  return [NSDictionary dictionaryWithObjectsAndKeys:(self.asset ? self.asset : [NSNull null]), @"asset", (self.uri ? self.uri : [NSNull null]), @"uri", (self.packageName ? self.packageName : [NSNull null]), @"packageName", (self.formatHint ? self.formatHint : [NSNull null]), @"formatHint", (self.cookies ? self.cookies : [NSNull null]), @"cookies", nil];
 }
 @end
 
 @implementation FLTLoopingMessage
-+ (FLTLoopingMessage *)fromMap:(NSDictionary *)dict {
-  FLTLoopingMessage *result = [[FLTLoopingMessage alloc] init];
++(FLTLoopingMessage*)fromMap:(NSDictionary*)dict {
+  FLTLoopingMessage* result = [[FLTLoopingMessage alloc] init];
   result.textureId = dict[@"textureId"];
   if ((NSNull *)result.textureId == [NSNull null]) {
     result.textureId = nil;
@@ -110,18 +108,14 @@ static NSDictionary *wrapResult(NSDictionary *result, FlutterError *error) {
   }
   return result;
 }
-- (NSDictionary *)toMap {
-  return [NSDictionary
-      dictionaryWithObjectsAndKeys:(self.textureId != nil ? self.textureId : [NSNull null]),
-                                   @"textureId",
-                                   (self.isLooping != nil ? self.isLooping : [NSNull null]),
-                                   @"isLooping", nil];
+-(NSDictionary*)toMap {
+  return [NSDictionary dictionaryWithObjectsAndKeys:(self.textureId ? self.textureId : [NSNull null]), @"textureId", (self.isLooping ? self.isLooping : [NSNull null]), @"isLooping", nil];
 }
 @end
 
 @implementation FLTVolumeMessage
-+ (FLTVolumeMessage *)fromMap:(NSDictionary *)dict {
-  FLTVolumeMessage *result = [[FLTVolumeMessage alloc] init];
++(FLTVolumeMessage*)fromMap:(NSDictionary*)dict {
+  FLTVolumeMessage* result = [[FLTVolumeMessage alloc] init];
   result.textureId = dict[@"textureId"];
   if ((NSNull *)result.textureId == [NSNull null]) {
     result.textureId = nil;
@@ -132,17 +126,14 @@ static NSDictionary *wrapResult(NSDictionary *result, FlutterError *error) {
   }
   return result;
 }
-- (NSDictionary *)toMap {
-  return [NSDictionary
-      dictionaryWithObjectsAndKeys:(self.textureId != nil ? self.textureId : [NSNull null]),
-                                   @"textureId", (self.volume != nil ? self.volume : [NSNull null]),
-                                   @"volume", nil];
+-(NSDictionary*)toMap {
+  return [NSDictionary dictionaryWithObjectsAndKeys:(self.textureId ? self.textureId : [NSNull null]), @"textureId", (self.volume ? self.volume : [NSNull null]), @"volume", nil];
 }
 @end
 
 @implementation FLTPlaybackSpeedMessage
-+ (FLTPlaybackSpeedMessage *)fromMap:(NSDictionary *)dict {
-  FLTPlaybackSpeedMessage *result = [[FLTPlaybackSpeedMessage alloc] init];
++(FLTPlaybackSpeedMessage*)fromMap:(NSDictionary*)dict {
+  FLTPlaybackSpeedMessage* result = [[FLTPlaybackSpeedMessage alloc] init];
   result.textureId = dict[@"textureId"];
   if ((NSNull *)result.textureId == [NSNull null]) {
     result.textureId = nil;
@@ -153,17 +144,14 @@ static NSDictionary *wrapResult(NSDictionary *result, FlutterError *error) {
   }
   return result;
 }
-- (NSDictionary *)toMap {
-  return [NSDictionary
-      dictionaryWithObjectsAndKeys:(self.textureId != nil ? self.textureId : [NSNull null]),
-                                   @"textureId", (self.speed != nil ? self.speed : [NSNull null]),
-                                   @"speed", nil];
+-(NSDictionary*)toMap {
+  return [NSDictionary dictionaryWithObjectsAndKeys:(self.textureId ? self.textureId : [NSNull null]), @"textureId", (self.speed ? self.speed : [NSNull null]), @"speed", nil];
 }
 @end
 
 @implementation FLTPositionMessage
-+ (FLTPositionMessage *)fromMap:(NSDictionary *)dict {
-  FLTPositionMessage *result = [[FLTPositionMessage alloc] init];
++(FLTPositionMessage*)fromMap:(NSDictionary*)dict {
+  FLTPositionMessage* result = [[FLTPositionMessage alloc] init];
   result.textureId = dict[@"textureId"];
   if ((NSNull *)result.textureId == [NSNull null]) {
     result.textureId = nil;
@@ -174,50 +162,47 @@ static NSDictionary *wrapResult(NSDictionary *result, FlutterError *error) {
   }
   return result;
 }
-- (NSDictionary *)toMap {
-  return [NSDictionary
-      dictionaryWithObjectsAndKeys:(self.textureId != nil ? self.textureId : [NSNull null]),
-                                   @"textureId",
-                                   (self.position != nil ? self.position : [NSNull null]),
-                                   @"position", nil];
+-(NSDictionary*)toMap {
+  return [NSDictionary dictionaryWithObjectsAndKeys:(self.textureId ? self.textureId : [NSNull null]), @"textureId", (self.position ? self.position : [NSNull null]), @"position", nil];
 }
 @end
 
 @implementation FLTMixWithOthersMessage
-+ (FLTMixWithOthersMessage *)fromMap:(NSDictionary *)dict {
-  FLTMixWithOthersMessage *result = [[FLTMixWithOthersMessage alloc] init];
++(FLTMixWithOthersMessage*)fromMap:(NSDictionary*)dict {
+  FLTMixWithOthersMessage* result = [[FLTMixWithOthersMessage alloc] init];
   result.mixWithOthers = dict[@"mixWithOthers"];
   if ((NSNull *)result.mixWithOthers == [NSNull null]) {
     result.mixWithOthers = nil;
   }
   return result;
 }
-- (NSDictionary *)toMap {
-  return [NSDictionary
-      dictionaryWithObjectsAndKeys:(self.mixWithOthers != nil ? self.mixWithOthers : [NSNull null]),
-                                   @"mixWithOthers", nil];
+-(NSDictionary*)toMap {
+  return [NSDictionary dictionaryWithObjectsAndKeys:(self.mixWithOthers ? self.mixWithOthers : [NSNull null]), @"mixWithOthers", nil];
 }
 @end
 
 void FLTVideoPlayerApiSetup(id<FlutterBinaryMessenger> binaryMessenger, id<FLTVideoPlayerApi> api) {
   {
-    FlutterBasicMessageChannel *channel = [FlutterBasicMessageChannel
+    FlutterBasicMessageChannel *channel =
+      [FlutterBasicMessageChannel
         messageChannelWithName:@"dev.flutter.pigeon.VideoPlayerApi.initialize"
-               binaryMessenger:binaryMessenger];
+        binaryMessenger:binaryMessenger];
     if (api) {
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         FlutterError *error;
         [api initialize:&error];
         callback(wrapResult(nil, error));
       }];
-    } else {
+    }
+    else {
       [channel setMessageHandler:nil];
     }
   }
   {
-    FlutterBasicMessageChannel *channel = [FlutterBasicMessageChannel
+    FlutterBasicMessageChannel *channel =
+      [FlutterBasicMessageChannel
         messageChannelWithName:@"dev.flutter.pigeon.VideoPlayerApi.create"
-               binaryMessenger:binaryMessenger];
+        binaryMessenger:binaryMessenger];
     if (api) {
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         FlutterError *error;
@@ -225,14 +210,16 @@ void FLTVideoPlayerApiSetup(id<FlutterBinaryMessenger> binaryMessenger, id<FLTVi
         FLTTextureMessage *output = [api create:input error:&error];
         callback(wrapResult([output toMap], error));
       }];
-    } else {
+    }
+    else {
       [channel setMessageHandler:nil];
     }
   }
   {
-    FlutterBasicMessageChannel *channel = [FlutterBasicMessageChannel
+    FlutterBasicMessageChannel *channel =
+      [FlutterBasicMessageChannel
         messageChannelWithName:@"dev.flutter.pigeon.VideoPlayerApi.dispose"
-               binaryMessenger:binaryMessenger];
+        binaryMessenger:binaryMessenger];
     if (api) {
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         FlutterError *error;
@@ -240,14 +227,16 @@ void FLTVideoPlayerApiSetup(id<FlutterBinaryMessenger> binaryMessenger, id<FLTVi
         [api dispose:input error:&error];
         callback(wrapResult(nil, error));
       }];
-    } else {
+    }
+    else {
       [channel setMessageHandler:nil];
     }
   }
   {
-    FlutterBasicMessageChannel *channel = [FlutterBasicMessageChannel
+    FlutterBasicMessageChannel *channel =
+      [FlutterBasicMessageChannel
         messageChannelWithName:@"dev.flutter.pigeon.VideoPlayerApi.setLooping"
-               binaryMessenger:binaryMessenger];
+        binaryMessenger:binaryMessenger];
     if (api) {
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         FlutterError *error;
@@ -255,14 +244,16 @@ void FLTVideoPlayerApiSetup(id<FlutterBinaryMessenger> binaryMessenger, id<FLTVi
         [api setLooping:input error:&error];
         callback(wrapResult(nil, error));
       }];
-    } else {
+    }
+    else {
       [channel setMessageHandler:nil];
     }
   }
   {
-    FlutterBasicMessageChannel *channel = [FlutterBasicMessageChannel
+    FlutterBasicMessageChannel *channel =
+      [FlutterBasicMessageChannel
         messageChannelWithName:@"dev.flutter.pigeon.VideoPlayerApi.setVolume"
-               binaryMessenger:binaryMessenger];
+        binaryMessenger:binaryMessenger];
     if (api) {
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         FlutterError *error;
@@ -270,14 +261,16 @@ void FLTVideoPlayerApiSetup(id<FlutterBinaryMessenger> binaryMessenger, id<FLTVi
         [api setVolume:input error:&error];
         callback(wrapResult(nil, error));
       }];
-    } else {
+    }
+    else {
       [channel setMessageHandler:nil];
     }
   }
   {
-    FlutterBasicMessageChannel *channel = [FlutterBasicMessageChannel
+    FlutterBasicMessageChannel *channel =
+      [FlutterBasicMessageChannel
         messageChannelWithName:@"dev.flutter.pigeon.VideoPlayerApi.setPlaybackSpeed"
-               binaryMessenger:binaryMessenger];
+        binaryMessenger:binaryMessenger];
     if (api) {
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         FlutterError *error;
@@ -285,14 +278,16 @@ void FLTVideoPlayerApiSetup(id<FlutterBinaryMessenger> binaryMessenger, id<FLTVi
         [api setPlaybackSpeed:input error:&error];
         callback(wrapResult(nil, error));
       }];
-    } else {
+    }
+    else {
       [channel setMessageHandler:nil];
     }
   }
   {
     FlutterBasicMessageChannel *channel =
-        [FlutterBasicMessageChannel messageChannelWithName:@"dev.flutter.pigeon.VideoPlayerApi.play"
-                                           binaryMessenger:binaryMessenger];
+      [FlutterBasicMessageChannel
+        messageChannelWithName:@"dev.flutter.pigeon.VideoPlayerApi.play"
+        binaryMessenger:binaryMessenger];
     if (api) {
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         FlutterError *error;
@@ -300,14 +295,16 @@ void FLTVideoPlayerApiSetup(id<FlutterBinaryMessenger> binaryMessenger, id<FLTVi
         [api play:input error:&error];
         callback(wrapResult(nil, error));
       }];
-    } else {
+    }
+    else {
       [channel setMessageHandler:nil];
     }
   }
   {
-    FlutterBasicMessageChannel *channel = [FlutterBasicMessageChannel
+    FlutterBasicMessageChannel *channel =
+      [FlutterBasicMessageChannel
         messageChannelWithName:@"dev.flutter.pigeon.VideoPlayerApi.position"
-               binaryMessenger:binaryMessenger];
+        binaryMessenger:binaryMessenger];
     if (api) {
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         FlutterError *error;
@@ -315,14 +312,16 @@ void FLTVideoPlayerApiSetup(id<FlutterBinaryMessenger> binaryMessenger, id<FLTVi
         FLTPositionMessage *output = [api position:input error:&error];
         callback(wrapResult([output toMap], error));
       }];
-    } else {
+    }
+    else {
       [channel setMessageHandler:nil];
     }
   }
   {
-    FlutterBasicMessageChannel *channel = [FlutterBasicMessageChannel
+    FlutterBasicMessageChannel *channel =
+      [FlutterBasicMessageChannel
         messageChannelWithName:@"dev.flutter.pigeon.VideoPlayerApi.seekTo"
-               binaryMessenger:binaryMessenger];
+        binaryMessenger:binaryMessenger];
     if (api) {
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         FlutterError *error;
@@ -330,14 +329,16 @@ void FLTVideoPlayerApiSetup(id<FlutterBinaryMessenger> binaryMessenger, id<FLTVi
         [api seekTo:input error:&error];
         callback(wrapResult(nil, error));
       }];
-    } else {
+    }
+    else {
       [channel setMessageHandler:nil];
     }
   }
   {
-    FlutterBasicMessageChannel *channel = [FlutterBasicMessageChannel
+    FlutterBasicMessageChannel *channel =
+      [FlutterBasicMessageChannel
         messageChannelWithName:@"dev.flutter.pigeon.VideoPlayerApi.pause"
-               binaryMessenger:binaryMessenger];
+        binaryMessenger:binaryMessenger];
     if (api) {
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         FlutterError *error;
@@ -345,14 +346,16 @@ void FLTVideoPlayerApiSetup(id<FlutterBinaryMessenger> binaryMessenger, id<FLTVi
         [api pause:input error:&error];
         callback(wrapResult(nil, error));
       }];
-    } else {
+    }
+    else {
       [channel setMessageHandler:nil];
     }
   }
   {
-    FlutterBasicMessageChannel *channel = [FlutterBasicMessageChannel
+    FlutterBasicMessageChannel *channel =
+      [FlutterBasicMessageChannel
         messageChannelWithName:@"dev.flutter.pigeon.VideoPlayerApi.setMixWithOthers"
-               binaryMessenger:binaryMessenger];
+        binaryMessenger:binaryMessenger];
     if (api) {
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         FlutterError *error;
@@ -360,7 +363,8 @@ void FLTVideoPlayerApiSetup(id<FlutterBinaryMessenger> binaryMessenger, id<FLTVi
         [api setMixWithOthers:input error:&error];
         callback(wrapResult(nil, error));
       }];
-    } else {
+    }
+    else {
       [channel setMessageHandler:nil];
     }
   }

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -177,6 +177,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   VideoPlayerController.asset(this.dataSource,
       {this.package, this.closedCaptionFile, this.videoPlayerOptions})
       : dataSourceType = DataSourceType.asset,
+        cookies = null,
         formatHint = null,
         super(VideoPlayerValue(duration: null));
 
@@ -188,7 +189,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   /// **Android only**: The [formatHint] option allows the caller to override
   /// the video format detection code.
   VideoPlayerController.network(this.dataSource,
-      {this.formatHint, this.closedCaptionFile, this.videoPlayerOptions})
+      {this.formatHint, this.closedCaptionFile, this.videoPlayerOptions, this.cookies})
       : dataSourceType = DataSourceType.network,
         package = null,
         super(VideoPlayerValue(duration: null));
@@ -201,6 +202,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
       {this.closedCaptionFile, this.videoPlayerOptions})
       : dataSource = 'file://${file.path}',
         dataSourceType = DataSourceType.file,
+        cookies = null,
         package = null,
         formatHint = null,
         super(VideoPlayerValue(duration: null));
@@ -221,6 +223,9 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
 
   /// Provide additional configuration options (optional). Like setting the audio mode to mix
   final VideoPlayerOptions videoPlayerOptions;
+
+  /// Http cookies while building [dataSource] from networks
+  final List<Cookie> cookies;
 
   /// Only set for [asset] videos. The package that the asset was loaded from.
   final String package;
@@ -264,6 +269,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
           sourceType: DataSourceType.network,
           uri: dataSource,
           formatHint: formatHint,
+          cookies: cookies?.map((c) => c.toString())?.toList(),
         );
         break;
       case DataSourceType.file:

--- a/packages/video_player/video_player/pigeons/messages.dart
+++ b/packages/video_player/video_player/pigeons/messages.dart
@@ -29,6 +29,7 @@ class CreateMessage {
   String uri;
   String packageName;
   String formatHint;
+  List<String> cookies;
 }
 
 class MixWithOthersMessage {

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for displaying inline video with other Flutter
 # 0.10.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.11.1
+version: 0.11.2
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player
 
 flutter:
@@ -20,14 +20,14 @@ flutter:
 
 dependencies:
   meta: ^1.0.5
-  video_player_platform_interface: ^2.2.0
+  video_player_platform_interface: ^2.3.0
 
   # The design on https://flutter.dev/go/federated-plugins was to leave
   # this constraint as "any". We cannot do it right now as it fails pub publish
   # validation, so we set a ^ constraint.
   # TODO(amirh): Revisit this (either update this part in the  design or the pub tool).
   # https://github.com/flutter/flutter/issues/46264
-  video_player_web: '>=0.1.4 <2.0.0'
+  video_player_web: '>=0.1.5 <2.0.0'
 
   flutter:
     sdk: flutter

--- a/packages/video_player/video_player/test/video_player_test.dart
+++ b/packages/video_player/video_player/test/video_player_test.dart
@@ -69,6 +69,9 @@ class FakeController extends ValueNotifier<VideoPlayerValue>
 
   @override
   VideoPlayerOptions get videoPlayerOptions => null;
+  
+  @override
+  List<Cookie> get cookies => null;
 }
 
 Future<ClosedCaptionFile> _loadClosedCaption() async =>
@@ -186,9 +189,11 @@ void main() {
         );
         await controller.initialize();
 
-        expect(
-            fakeVideoPlayerPlatform.dataSourceDescriptions[0].asset, 'a.avi');
+        expect(fakeVideoPlayerPlatform.dataSourceDescriptions[0].asset,
+            'a.avi');
         expect(fakeVideoPlayerPlatform.dataSourceDescriptions[0].packageName,
+            null);
+        expect(fakeVideoPlayerPlatform.dataSourceDescriptions[0].uri,
             null);
       });
 
@@ -200,8 +205,13 @@ void main() {
 
         expect(fakeVideoPlayerPlatform.dataSourceDescriptions[0].uri,
             'https://127.0.0.1');
+        expect(fakeVideoPlayerPlatform.dataSourceDescriptions[0].asset,
+            null);
+        expect(fakeVideoPlayerPlatform.dataSourceDescriptions[0].formatHint,
+            null);
         expect(
-            fakeVideoPlayerPlatform.dataSourceDescriptions[0].formatHint, null);
+            fakeVideoPlayerPlatform.dataSourceDescriptions[0].cookies,
+            null);
       });
 
       test('network with hint', () async {
@@ -214,6 +224,20 @@ void main() {
             'https://127.0.0.1');
         expect(fakeVideoPlayerPlatform.dataSourceDescriptions[0].formatHint,
             'dash');
+      });
+
+      test('network with cookies', () async {
+        final cookieStr = 'name=value; Domain=example.com; Path=/';
+
+        final VideoPlayerController controller = VideoPlayerController.network(
+            'https://127.0.0.1',
+            cookies: [Cookie.fromSetCookieValue(cookieStr)]);
+        await controller.initialize();
+
+        expect(fakeVideoPlayerPlatform.dataSourceDescriptions[0].uri,
+            'https://127.0.0.1');
+        expect(fakeVideoPlayerPlatform.dataSourceDescriptions[0].cookies[0],
+            cookieStr);
       });
 
       test('init errors', () async {


### PR DESCRIPTION
**Part 3 of #2882 - see main description there.**

* Add included cookies, if any, to AVPlayer + ExoPlayer 
* Lots of pigeon-generated formatting diffs; still on same version. Hoping to check in exactly what pigeon generates. 
* Fix bug in example/lib/main.dart : collection `for` introduced a dependency on the control-flow-collections experiment
