### PR TITLE
[url_launcher] Url launcher platform interface null safety

### DIFF
--- a/packages/url_launcher/url_launcher_platform_interface/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-nullsafety
+
+* Migrate to null safety.
+
 ## 1.0.8
 
 * Added webOnlyWindowName parameter

--- a/packages/url_launcher/url_launcher_platform_interface/analysis_options.yaml
+++ b/packages/url_launcher/url_launcher_platform_interface/analysis_options.yaml
@@ -1,0 +1,4 @@
+include: ../../../analysis_options.yaml
+analyzer:
+  enable-experiment:
+    - non-nullable

--- a/packages/url_launcher/url_launcher_platform_interface/lib/method_channel_url_launcher.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/lib/method_channel_url_launcher.dart
@@ -14,7 +14,7 @@ const MethodChannel _channel = MethodChannel('plugins.flutter.io/url_launcher');
 /// An implementation of [UrlLauncherPlatform] that uses method channels.
 class MethodChannelUrlLauncher extends UrlLauncherPlatform {
   @override
-  Future<bool> canLaunch(String url) {
+  Future<bool?> canLaunch(String url) {
     return _channel.invokeMethod<bool>(
       'canLaunch',
       <String, Object>{'url': url},
@@ -27,15 +27,15 @@ class MethodChannelUrlLauncher extends UrlLauncherPlatform {
   }
 
   @override
-  Future<bool> launch(
+  Future<bool?> launch(
     String url, {
-    @required bool useSafariVC,
-    @required bool useWebView,
-    @required bool enableJavaScript,
-    @required bool enableDomStorage,
-    @required bool universalLinksOnly,
-    @required Map<String, String> headers,
-    String webOnlyWindowName,
+    required bool useSafariVC,
+    required bool useWebView,
+    required bool enableJavaScript,
+    required bool enableDomStorage,
+    required bool universalLinksOnly,
+    required Map<String, String> headers,
+    String? webOnlyWindowName,
   }) {
     return _channel.invokeMethod<bool>(
       'launch',

--- a/packages/url_launcher/url_launcher_platform_interface/lib/method_channel_url_launcher.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/lib/method_channel_url_launcher.dart
@@ -13,11 +13,11 @@ const MethodChannel _channel = MethodChannel('plugins.flutter.io/url_launcher');
 /// An implementation of [UrlLauncherPlatform] that uses method channels.
 class MethodChannelUrlLauncher extends UrlLauncherPlatform {
   @override
-  Future<bool?> canLaunch(String url) {
+  Future<bool> canLaunch(String url) {
     return _channel.invokeMethod<bool>(
       'canLaunch',
       <String, Object>{'url': url},
-    );
+    ).then((value) => value ?? false);
   }
 
   @override
@@ -26,7 +26,7 @@ class MethodChannelUrlLauncher extends UrlLauncherPlatform {
   }
 
   @override
-  Future<bool?> launch(
+  Future<bool> launch(
     String url, {
     required bool useSafariVC,
     required bool useWebView,
@@ -47,6 +47,6 @@ class MethodChannelUrlLauncher extends UrlLauncherPlatform {
         'universalLinksOnly': universalLinksOnly,
         'headers': headers,
       },
-    );
+    ).then((value) => value ?? false);
   }
 }

--- a/packages/url_launcher/url_launcher_platform_interface/lib/method_channel_url_launcher.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/lib/method_channel_url_launcher.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 
 import 'package:flutter/services.dart';
-import 'package:meta/meta.dart' show required;
 
 import 'url_launcher_platform_interface.dart';
 

--- a/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
@@ -39,7 +39,7 @@ abstract class UrlLauncherPlatform extends PlatformInterface {
   }
 
   /// Returns `true` if this platform is able to launch [url].
-  Future<bool> canLaunch(String url) {
+  Future<bool?> canLaunch(String url) {
     throw UnimplementedError('canLaunch() has not been implemented.');
   }
 
@@ -47,15 +47,15 @@ abstract class UrlLauncherPlatform extends PlatformInterface {
   ///
   /// For documentation on the other arguments, see the `launch` documentation
   /// in `package:url_launcher/url_launcher.dart`.
-  Future<bool> launch(
+  Future<bool?> launch(
     String url, {
-    @required bool useSafariVC,
-    @required bool useWebView,
-    @required bool enableJavaScript,
-    @required bool enableDomStorage,
-    @required bool universalLinksOnly,
-    @required Map<String, String> headers,
-    String webOnlyWindowName,
+    required bool useSafariVC,
+    required bool useWebView,
+    required bool enableJavaScript,
+    required bool enableDomStorage,
+    required bool universalLinksOnly,
+    required Map<String, String> headers,
+    String? webOnlyWindowName,
   }) {
     throw UnimplementedError('launch() has not been implemented.');
   }

--- a/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
@@ -38,7 +38,7 @@ abstract class UrlLauncherPlatform extends PlatformInterface {
   }
 
   /// Returns `true` if this platform is able to launch [url].
-  Future<bool?> canLaunch(String url) {
+  Future<bool> canLaunch(String url) {
     throw UnimplementedError('canLaunch() has not been implemented.');
   }
 
@@ -46,7 +46,7 @@ abstract class UrlLauncherPlatform extends PlatformInterface {
   ///
   /// For documentation on the other arguments, see the `launch` documentation
   /// in `package:url_launcher/url_launcher.dart`.
-  Future<bool?> launch(
+  Future<bool> launch(
     String url, {
     required bool useSafariVC,
     required bool useWebView,

--- a/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 
-import 'package:meta/meta.dart' show required;
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 import 'method_channel_url_launcher.dart';

--- a/packages/url_launcher/url_launcher_platform_interface/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_platform_interface/pubspec.yaml
@@ -10,10 +10,7 @@ dependencies:
     sdk: flutter
   # TODO (mvanbeusekom): use pub.dev once 1.10.0-nullsafety released.
   plugin_platform_interface:
-    git: 
-      url: https://github.com/flutter/plugins.git
-      ref: nnbd
-      path: packages/plugin_platform_interface
+      path: ../../plugin_platform_interface
 
 dev_dependencies:
   flutter_test:

--- a/packages/url_launcher/url_launcher_platform_interface/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_platform_interface/pubspec.yaml
@@ -3,20 +3,24 @@ description: A common platform interface for the url_launcher plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.0.8
+version: 2.0.0-nullsafety
 
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.0.5
-  plugin_platform_interface: ^1.0.1
+  # TODO (mvanbeusekom): use pub.dev once 1.10.0-nullsafety released.
+  plugin_platform_interface:
+    git: 
+      url: https://github.com/flutter/plugins.git
+      ref: nnbd
+      path: packages/plugin_platform_interface
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   mockito: ^4.1.1
-  pedantic: ^1.8.0
+  pedantic: ^1.10.0-nullsafety.1
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: '>=2.10.0-56.0.dev <3.0.0'
   flutter: ">=1.9.1+hotfix.4 <2.0.0"

--- a/packages/url_launcher/url_launcher_platform_interface/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_platform_interface/pubspec.yaml
@@ -10,7 +10,10 @@ dependencies:
     sdk: flutter
   # TODO (mvanbeusekom): use pub.dev once 1.10.0-nullsafety released.
   plugin_platform_interface:
-      path: ../../plugin_platform_interface
+    git:
+      url: https://github.com/flutter/plugins.git
+      ref: nnbd
+      path: packages/plugin_platform_interface
 
 dev_dependencies:
   flutter_test:

--- a/packages/url_launcher/url_launcher_platform_interface/test/method_channel_url_launcher_test.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/test/method_channel_url_launcher_test.dart
@@ -43,6 +43,18 @@ void main() {
     final List<MethodCall> log = <MethodCall>[];
     channel.setMockMethodCallHandler((MethodCall methodCall) async {
       log.add(methodCall);
+
+      if (methodCall.method == 'canLaunch') {
+        if (methodCall.arguments['url'] == 'http://example.com/null') {
+          return null;
+        }
+      }
+
+      if (methodCall.method == 'launch') {
+        if (methodCall.arguments['url'] == 'http://example.com/null') {
+          return null;
+        }
+      }
     });
 
     final MethodChannelUrlLauncher launcher = MethodChannelUrlLauncher();
@@ -61,6 +73,12 @@ void main() {
           })
         ],
       );
+    });
+
+    test('canLaunch should return false if platform returns null', () async {
+      final canLaunch = await launcher.canLaunch('http://example.com/null');
+
+      expect(canLaunch, false);
     });
 
     test('launch', () async {
@@ -269,6 +287,20 @@ void main() {
           })
         ],
       );
+    });
+
+    test('launch should return false if platform returns null', () async {
+      final launched = await launcher.launch(
+        'http://example.com/',
+        useSafariVC: true,
+        useWebView: false,
+        enableJavaScript: false,
+        enableDomStorage: false,
+        universalLinksOnly: false,
+        headers: const <String, String>{},
+      );
+
+      expect(launched, false);
     });
 
     test('closeWebView default behavior', () async {

--- a/packages/url_launcher/url_launcher_platform_interface/test/method_channel_url_launcher_test.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/test/method_channel_url_launcher_test.dart
@@ -44,17 +44,9 @@ void main() {
     channel.setMockMethodCallHandler((MethodCall methodCall) async {
       log.add(methodCall);
 
-      if (methodCall.method == 'canLaunch') {
-        if (methodCall.arguments['url'] == 'http://example.com/null') {
-          return null;
-        }
-      }
-
-      if (methodCall.method == 'launch') {
-        if (methodCall.arguments['url'] == 'http://example.com/null') {
-          return null;
-        }
-      }
+      // Return null explicitly instead of relying on the implicit null
+      // returned by the method channel if no return statement is specified.
+      return null;
     });
 
     final MethodChannelUrlLauncher launcher = MethodChannelUrlLauncher();
@@ -76,7 +68,7 @@ void main() {
     });
 
     test('canLaunch should return false if platform returns null', () async {
-      final canLaunch = await launcher.canLaunch('http://example.com/null');
+      final canLaunch = await launcher.canLaunch('http://example.com/');
 
       expect(canLaunch, false);
     });

--- a/packages/url_launcher/url_launcher_platform_interface/test/method_channel_url_launcher_test.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/test/method_channel_url_launcher_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// TODO(mvanbeusekom): Remove once Mockito is migrated to null safety.
+// @dart = 2.9
 import 'package:mockito/mockito.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/script/incremental_build.sh
+++ b/script/incremental_build.sh
@@ -25,6 +25,7 @@ CUSTOM_ANALYSIS_PLUGINS=(
   "plugin_platform_interface"
   "video_player/video_player_web"
   "google_maps_flutter/google_maps_flutter_web"
+  "url_launcher/url_launcher_platform_interface"
 )
 # Comma-separated string of the list above
 readonly CUSTOM_FLAG=$(IFS=, ; echo "${CUSTOM_ANALYSIS_PLUGINS[*]}")


### PR DESCRIPTION
## Description

Migration of "url_launcher_platform_interface" to null safety.

Note: I had to pin the "plugin_platform_interface" package to the git repo since version 1.1.0-nullsafety is not yet released (see companion PR #3115). I have decorated the line with a `# TODO (mvanbeusekom):` comment. Please let me know if I should solve this in a different way.

## Related Issues

flutter/flutter#66395

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
