### PR TITLE
Configure analyzer for plugins that are migrated to nnbd

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,7 +1,5 @@
 include: package:pedantic/analysis_options.1.8.0.yaml
 analyzer:
-  enable-experiment:
-    - non-nullable
   exclude:
     # Ignore generated files
     - '**/*.g.dart'

--- a/packages/plugin_platform_interface/analysis_options.yaml
+++ b/packages/plugin_platform_interface/analysis_options.yaml
@@ -1,0 +1,4 @@
+include: ../../analysis_options.yaml
+analyzer:
+  enable-experiment:
+    - non-nullable

--- a/script/incremental_build.sh
+++ b/script/incremental_build.sh
@@ -22,6 +22,7 @@ fi
 CUSTOM_ANALYSIS_PLUGINS=(
   "in_app_purchase"
   "camera"
+  "plugin_platform_interface"
   "video_player/video_player_web"
   "google_maps_flutter/google_maps_flutter_web"
 )


### PR DESCRIPTION
This PR reverts the current behavior, which applies the `non-nullable` analysis to all the plugins.