### PR TITLE
[google_maps_flutter_web] Fix InfoWindow snippets.

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0+4
+
+* Fix crash when InfoWindow title/snippet has links. [Issue](https://github.com/flutter/flutter/issues/67854).
+
 ## 0.1.0+3
 
 * Fix crash when converting initial polylines and polygons. [Issue](https://github.com/flutter/flutter/issues/65152).

--- a/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.1.0+4
 
-* Fix crash when InfoWindow title/snippet has links. [Issue](https://github.com/flutter/flutter/issues/67854).
+* Update `package:sanitize_html` to `^1.4.1` to prevent [a crash](https://github.com/flutter/flutter/issues/67854) when InfoWindow title/snippet have links.
 
 ## 0.1.0+3
 

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/convert.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/convert.dart
@@ -379,9 +379,9 @@ gmaps.InfoWindowOptions _infoWindowOptionsFromMarker(Marker marker) {
   }
 
   final content = '<h3 class="infowindow-title">' +
-      _doSanitizeHtml(marker.infoWindow.title ?? "") +
+      sanitizeHtml(marker.infoWindow.title ?? "") +
       '</h3>' +
-      _doSanitizeHtml(marker.infoWindow.snippet ?? "");
+      sanitizeHtml(marker.infoWindow.snippet ?? "");
 
   return gmaps.InfoWindowOptions()
     ..content = content
@@ -424,7 +424,7 @@ gmaps.MarkerOptions _markerOptionsFromMarker(
           marker.position.latitude,
           marker.position.longitude,
         )
-    ..title = _doSanitizeHtml(marker.infoWindow?.title ?? "")
+    ..title = sanitizeHtml(marker.infoWindow?.title ?? "")
     ..zIndex = marker.zIndex
     ..visible = marker.visible
     ..opacity = marker.alpha
@@ -545,12 +545,6 @@ void _applyCameraUpdate(gmaps.GMap map, CameraUpdate update) {
     default:
       throw UnimplementedError('Unimplemented CameraMove: ${json[0]}.');
   }
-}
-
-// Pass a noop `adLinkRel` callback to sanitizeHtml.
-// This is required until this is fixed: https://github.com/google/dart-neats/issues/71
-String _doSanitizeHtml(String text) {
-  return sanitizeHtml(text, addLinkRel: (_) => []);
 }
 
 // original JS by: Byron Singh (https://stackoverflow.com/a/30541162)

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/convert.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/convert.dart
@@ -379,9 +379,9 @@ gmaps.InfoWindowOptions _infoWindowOptionsFromMarker(Marker marker) {
   }
 
   final content = '<h3 class="infowindow-title">' +
-      sanitizeHtml(marker.infoWindow.title ?? "") +
+      _doSanitizeHtml(marker.infoWindow.title ?? "") +
       '</h3>' +
-      sanitizeHtml(marker.infoWindow.snippet ?? "");
+      _doSanitizeHtml(marker.infoWindow.snippet ?? "");
 
   return gmaps.InfoWindowOptions()
     ..content = content
@@ -424,7 +424,7 @@ gmaps.MarkerOptions _markerOptionsFromMarker(
           marker.position.latitude,
           marker.position.longitude,
         )
-    ..title = sanitizeHtml(marker.infoWindow?.title ?? "")
+    ..title = _doSanitizeHtml(marker.infoWindow?.title ?? "")
     ..zIndex = marker.zIndex
     ..visible = marker.visible
     ..opacity = marker.alpha
@@ -545,6 +545,12 @@ void _applyCameraUpdate(gmaps.GMap map, CameraUpdate update) {
     default:
       throw UnimplementedError('Unimplemented CameraMove: ${json[0]}.');
   }
+}
+
+// Pass a noop `adLinkRel` callback to sanitizeHtml.
+// This is required until this is fixed: https://github.com/google/dart-neats/issues/71
+String _doSanitizeHtml(String text) {
+  return sanitizeHtml(text, addLinkRel: (_) => []);
 }
 
 // original JS by: Byron Singh (https://stackoverflow.com/a/30541162)

--- a/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   google_maps_flutter_platform_interface: ^1.0.4
   google_maps: ^3.0.0
   stream_transform: ^1.2.0
-  sanitize_html: ^1.4.0
+  sanitize_html: ^1.4.1
 
 dev_dependencies:
   flutter_test:

--- a/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: google_maps_flutter_web
 description: Web platform implementation of google_maps_flutter
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter
-version: 0.1.0+3
+version: 0.1.0+4
 
 flutter:
   plugin:
@@ -19,7 +19,7 @@ dependencies:
   google_maps_flutter_platform_interface: ^1.0.4
   google_maps: ^3.0.0
   stream_transform: ^1.2.0
-  sanitize_html: ^1.3.0
+  sanitize_html: ^1.4.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/google_maps_flutter/google_maps_flutter_web/test/test_driver/markers_integration.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/test/test_driver/markers_integration.dart
@@ -110,5 +110,25 @@ void main() {
       expect(controller.markers.length, 1);
       expect(controller.markers[MarkerId('1')].marker.icon, isNull);
     });
+
+    // https://github.com/flutter/flutter/issues/67854
+    testWidgets('InfoWindow snippet can have links',
+        (WidgetTester tester) async {
+      final markers = {
+        Marker(
+          markerId: MarkerId('1'),
+          infoWindow: InfoWindow(
+            title: 'title for test',
+            snippet: '<a href="https://www.google.com">Go to Google >>></a>',
+          ),
+        ),
+      };
+
+      controller.addMarkers(markers);
+
+      expect(controller.markers.length, 1);
+      expect(controller.markers[MarkerId('1')].marker.title,
+          equals('title for test'));
+    });
   });
 }


### PR DESCRIPTION
## Description

This change wraps the `sanitizeHtml` call in a helper function that provides a default implementation for a new parameter that was recently added to its API.

## Related Issues

* Fixes: https://github.com/flutter/flutter/issues/67854
* Root cause: https://github.com/google/dart-neats/issues/71

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
