### PR TITLE
[video_player] Migrate video player to null safety

### DIFF
--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.0
+
+* Migration to null safety.
+
 ## 0.11.1+2
 
 * Update android compileSdkVersion to 29.

--- a/packages/video_player/video_player/analysis_options.yaml
+++ b/packages/video_player/video_player/analysis_options.yaml
@@ -1,0 +1,4 @@
+include: ../../../analysis_options.yaml
+analyzer:
+  enable-experiment:
+    - non-nullable

--- a/packages/video_player/video_player/example/integration_test/video_player_test.dart
+++ b/packages/video_player/video_player/example/integration_test/video_player_test.dart
@@ -11,7 +11,7 @@ const Duration _playDuration = Duration(seconds: 1);
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
-  VideoPlayerController _controller;
+  late VideoPlayerController _controller;
   tearDown(() async => _controller.dispose());
 
   group('asset videos', () {
@@ -22,7 +22,7 @@ void main() {
     testWidgets('can be initialized', (WidgetTester tester) async {
       await _controller.initialize();
 
-      expect(_controller.value.initialized, true);
+      expect(_controller.value.isInitialized, true);
       expect(_controller.value.position, const Duration(seconds: 0));
       expect(_controller.value.isPlaying, false);
       expect(_controller.value.duration,

--- a/packages/video_player/video_player/example/lib/main.dart
+++ b/packages/video_player/video_player/example/lib/main.dart
@@ -265,7 +265,8 @@ class _BumbleBeeRemoteVideoState extends State<_BumbleBeeRemoteVideo> {
 }
 
 class _ControlsOverlay extends StatelessWidget {
-  const _ControlsOverlay({Key? key, required this.controller}) : super(key: key);
+  const _ControlsOverlay({Key? key, required this.controller})
+      : super(key: key);
 
   static const _examplePlaybackRates = [
     0.25,

--- a/packages/video_player/video_player/example/lib/main.dart
+++ b/packages/video_player/video_player/example/lib/main.dart
@@ -108,7 +108,7 @@ class _ButterFlyAssetVideoInList extends StatelessWidget {
 
 /// A filler card to show the video in a list of scrolling contents.
 class _ExampleCard extends StatelessWidget {
-  const _ExampleCard({Key key, this.title}) : super(key: key);
+  const _ExampleCard({Key? key, required this.title}) : super(key: key);
 
   final String title;
 
@@ -150,7 +150,7 @@ class _ButterFlyAssetVideo extends StatefulWidget {
 }
 
 class _ButterFlyAssetVideoState extends State<_ButterFlyAssetVideo> {
-  VideoPlayerController _controller;
+  late VideoPlayerController _controller;
 
   @override
   void initState() {
@@ -206,7 +206,7 @@ class _BumbleBeeRemoteVideo extends StatefulWidget {
 }
 
 class _BumbleBeeRemoteVideoState extends State<_BumbleBeeRemoteVideo> {
-  VideoPlayerController _controller;
+  late VideoPlayerController _controller;
 
   Future<ClosedCaptionFile> _loadCaptions() async {
     final String fileContents = await DefaultAssetBundle.of(context)
@@ -265,7 +265,7 @@ class _BumbleBeeRemoteVideoState extends State<_BumbleBeeRemoteVideo> {
 }
 
 class _ControlsOverlay extends StatelessWidget {
-  const _ControlsOverlay({Key key, this.controller}) : super(key: key);
+  const _ControlsOverlay({Key? key, required this.controller}) : super(key: key);
 
   static const _examplePlaybackRates = [
     0.25,
@@ -345,7 +345,7 @@ class _PlayerVideoAndPopPage extends StatefulWidget {
 }
 
 class _PlayerVideoAndPopPageState extends State<_PlayerVideoAndPopPage> {
-  VideoPlayerController _videoPlayerController;
+  late VideoPlayerController _videoPlayerController;
   bool startedPlaying = false;
 
   @override

--- a/packages/video_player/video_player/example/pubspec.yaml
+++ b/packages/video_player/video_player/example/pubspec.yaml
@@ -15,7 +15,7 @@ dev_dependencies:
   integration_test:
     path: ../../../integration_test
   test: any
-  pedantic: ^1.8.0
+  pedantic: ^1.10.0-nullsafety.1
 
 flutter:
   uses-material-design: true

--- a/packages/video_player/video_player/example/test_driver/integration_test.dart
+++ b/packages/video_player/video_player/example/test_driver/integration_test.dart
@@ -2,6 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// TODO(egarciad): Remove once Flutter driver is migrated to null safety.
+// @dart = 2.9
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/packages/video_player/video_player/example/test_driver/video_player.dart
+++ b/packages/video_player/video_player/example/test_driver/video_player.dart
@@ -2,6 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// TODO(egarciad): Remove once Flutter driver is migrated to null safety.
+// @dart = 2.9
+
 import 'package:flutter_driver/driver_extension.dart';
 import 'package:video_player_example/main.dart' as app;
 

--- a/packages/video_player/video_player/example/test_driver/video_player_test.dart
+++ b/packages/video_player/video_player/example/test_driver/video_player_test.dart
@@ -2,6 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// TODO(egarciad): Remove once Flutter driver is migrated to null safety.
+// @dart = 2.9
+
 import 'dart:async';
 import 'package:flutter_driver/flutter_driver.dart';
 import 'package:test/test.dart';

--- a/packages/video_player/video_player/lib/src/closed_caption_file.dart
+++ b/packages/video_player/video_player/lib/src/closed_caption_file.dart
@@ -31,7 +31,7 @@ class Caption {
   ///
   /// This is not recommended for direct use unless you are writing a parser for
   /// a new closed captioning file type.
-  const Caption({this.number, this.start, this.end, this.text});
+  const Caption({required this.number, required this.start, required this.end, required this.text});
 
   /// The number that this caption was assigned.
   final int number;
@@ -45,4 +45,8 @@ class Caption {
   /// The actual text that should appear on screen to be read between [start]
   /// and [end].
   final String text;
+
+  /// A no caption object. This is a caption with [start] and [end] durations of zero,
+  /// and an empty [text] string.
+  static const Caption none = Caption(number: 0, start: Duration.zero, end: Duration.zero, text: '');
 }

--- a/packages/video_player/video_player/lib/src/closed_caption_file.dart
+++ b/packages/video_player/video_player/lib/src/closed_caption_file.dart
@@ -31,7 +31,11 @@ class Caption {
   ///
   /// This is not recommended for direct use unless you are writing a parser for
   /// a new closed captioning file type.
-  const Caption({required this.number, required this.start, required this.end, required this.text});
+  const Caption(
+      {required this.number,
+      required this.start,
+      required this.end,
+      required this.text});
 
   /// The number that this caption was assigned.
   final int number;
@@ -48,5 +52,6 @@ class Caption {
 
   /// A no caption object. This is a caption with [start] and [end] durations of zero,
   /// and an empty [text] string.
-  static const Caption none = Caption(number: 0, start: Duration.zero, end: Duration.zero, text: '');
+  static const Caption none =
+      Caption(number: 0, start: Duration.zero, end: Duration.zero, text: '');
 }

--- a/packages/video_player/video_player/lib/src/sub_rip.dart
+++ b/packages/video_player/video_player/lib/src/sub_rip.dart
@@ -41,8 +41,7 @@ List<Caption> _parseCaptionsFromSubRipString(String file) {
       end: startAndEnd.end,
       text: text,
     );
-
-    if (newCaption.start != null && newCaption.end != null) {
+    if (newCaption.start != newCaption.end) {
       captions.add(newCaption);
     }
   }
@@ -64,7 +63,7 @@ class _StartAndEnd {
         RegExp(_subRipTimeStamp + _subRipArrow + _subRipTimeStamp);
 
     if (!format.hasMatch(line)) {
-      return _StartAndEnd(null, null);
+      return _StartAndEnd(Duration.zero, Duration.zero);
     }
 
     final List<String> times = line.split(_subRipArrow);
@@ -84,7 +83,7 @@ class _StartAndEnd {
 // Duration(hours: 0, minutes: 1, seconds: 59, milliseconds: 084)
 Duration _parseSubRipTimestamp(String timestampString) {
   if (!RegExp(_subRipTimeStamp).hasMatch(timestampString)) {
-    return null;
+    return Duration.zero;
   }
 
   final List<String> commaSections = timestampString.split(',');

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -44,11 +44,14 @@ class VideoPlayerValue {
 
   /// Returns an instance for a video that hasn't been loaded.
   VideoPlayerValue.uninitialized()
-    : this(duration: Duration.zero, isInitialized: false);
+      : this(duration: Duration.zero, isInitialized: false);
 
   /// Returns an instance with the given [errorDescription].
   VideoPlayerValue.erroneous(String errorDescription)
-      : this(duration: Duration.zero, isInitialized: false, errorDescription: errorDescription);
+      : this(
+            duration: Duration.zero,
+            isInitialized: false,
+            errorDescription: errorDescription);
 
   /// The total duration of the video.
   ///
@@ -290,7 +293,8 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
           .setMixWithOthers(videoPlayerOptions!.mixWithOthers);
     }
 
-    _textureId = (await _videoPlayerPlatform.create(dataSourceDescription)) ?? kUninitializedTextureId;
+    _textureId = (await _videoPlayerPlatform.create(dataSourceDescription)) ??
+        kUninitializedTextureId;
     _creatingCompleter!.complete(null);
     final Completer<void> initializingCompleter = Completer<void>();
 
@@ -352,6 +356,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   }
 
   @override
+  // ignore: must_call_super
   Future<void> dispose() async {
     if (_creatingCompleter != null) {
       await _creatingCompleter!.future;

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -55,7 +55,7 @@ class VideoPlayerValue {
 
   /// The total duration of the video.
   ///
-  /// The duration is zero if the video hasn't been initialized.
+  /// The duration is [Duration.zero] if the video hasn't been initialized.
   final Duration duration;
 
   /// The current playback position.
@@ -356,7 +356,6 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   }
 
   @override
-  // ignore: must_call_super
   Future<void> dispose() async {
     if (_creatingCompleter != null) {
       await _creatingCompleter!.future;
@@ -366,8 +365,10 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
         await _eventSubscription?.cancel();
         await _videoPlayerPlatform.dispose(_textureId);
       }
+      _lifeCycleObserver.dispose();
     }
-    _lifeCycleObserver.dispose();
+    _isDisposed = true;
+    super.dispose();
   }
 
   /// Starts playing the video.
@@ -416,10 +417,10 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
             return;
           }
           final Duration? newPosition = await position;
-          if (_isDisposed) {
+          if (newPosition == null) {
             return;
           }
-          _updatePosition(newPosition!);
+          _updatePosition(newPosition);
         },
       );
 

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -357,11 +357,10 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
       await _creatingCompleter!.future;
       if (!_isDisposed) {
         _isDisposed = true;
-
-      _timer?.cancel();
-
-      await _eventSubscription?.cancel();
-      await _videoPlayerPlatform.dispose(_textureId);
+        _timer?.cancel();
+        await _eventSubscription?.cancel();
+        await _videoPlayerPlatform.dispose(_textureId);
+      }
     }
     _lifeCycleObserver.dispose();
   }

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -33,7 +33,7 @@ class VideoPlayerValue {
     this.position = Duration.zero,
     this.caption = Caption.none,
     this.buffered = const <DurationRange>[],
-    this.isInitialized = true,
+    this.isInitialized = false,
     this.isPlaying = false,
     this.isLooping = false,
     this.isBuffering = false,
@@ -105,10 +105,7 @@ class VideoPlayerValue {
   /// Returns [size.width] / [size.height] when size is non-null, or `1.0.` when
   /// size is null or the aspect ratio would be less than or equal to 0.0.
   double get aspectRatio {
-    if (!isInitialized) {
-      return 0.0;
-    }
-    if (size.width == 0 || size.height == 0) {
+    if (!isInitialized || size.width == 0 || size.height == 0) {
       return 1.0;
     }
     final double aspectRatio = size.width / size.height;
@@ -268,7 +265,6 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
       case DataSourceType.asset:
         dataSourceDescription = DataSource(
           sourceType: DataSourceType.asset,
-          uri: '',
           asset: dataSource,
           package: package,
         );

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -28,11 +28,12 @@ class VideoPlayerValue {
   /// Constructs a video with the given values. Only [duration] is required. The
   /// rest will initialize with default values when unset.
   VideoPlayerValue({
-    @required this.duration,
-    this.size,
-    this.position = const Duration(),
-    this.caption = const Caption(),
+    required this.duration,
+    this.size = Size.zero,
+    this.position = Duration.zero,
+    this.caption = Caption.none,
     this.buffered = const <DurationRange>[],
+    this.isInitialized = true,
     this.isPlaying = false,
     this.isLooping = false,
     this.isBuffering = false,
@@ -41,17 +42,17 @@ class VideoPlayerValue {
     this.errorDescription,
   });
 
-  /// Returns an instance with a `null` [Duration].
-  VideoPlayerValue.uninitialized() : this(duration: null);
+  /// Returns an instance for a video that hasn't been loaded.
+  VideoPlayerValue.uninitialized()
+    : this(duration: Duration.zero, isInitialized: false);
 
-  /// Returns an instance with a `null` [Duration] and the given
-  /// [errorDescription].
+  /// Returns an instance with the given [errorDescription].
   VideoPlayerValue.erroneous(String errorDescription)
-      : this(duration: null, errorDescription: errorDescription);
+      : this(duration: Duration.zero, isInitialized: false, errorDescription: errorDescription);
 
   /// The total duration of the video.
   ///
-  /// Is null when [initialized] is false.
+  /// The duration is zero if the video hasn't been initialized.
   final Duration duration;
 
   /// The current playback position.
@@ -60,7 +61,7 @@ class VideoPlayerValue {
   /// The [Caption] that should be displayed based on the current [position].
   ///
   /// This field will never be null. If there is no caption for the current
-  /// [position], this will be an empty [Caption] object.
+  /// [position], this will be a [Caption.none] object.
   final Caption caption;
 
   /// The currently buffered ranges.
@@ -84,7 +85,7 @@ class VideoPlayerValue {
   /// A description of the error if present.
   ///
   /// If [hasError] is false this is [null].
-  final String errorDescription;
+  final String? errorDescription;
 
   /// The [size] of the currently loaded video.
   ///
@@ -92,7 +93,7 @@ class VideoPlayerValue {
   final Size size;
 
   /// Indicates whether or not the video has been loaded and is ready to play.
-  bool get initialized => duration != null;
+  final bool isInitialized;
 
   /// Indicates whether or not the video is in an error state. If this is true
   /// [errorDescription] should have information about the problem.
@@ -101,7 +102,10 @@ class VideoPlayerValue {
   /// Returns [size.width] / [size.height] when size is non-null, or `1.0.` when
   /// size is null or the aspect ratio would be less than or equal to 0.0.
   double get aspectRatio {
-    if (size == null || size.width == 0 || size.height == 0) {
+    if (!isInitialized) {
+      return 0.0;
+    }
+    if (size.width == 0 || size.height == 0) {
       return 1.0;
     }
     final double aspectRatio = size.width / size.height;
@@ -114,17 +118,18 @@ class VideoPlayerValue {
   /// Returns a new instance that has the same values as this current instance,
   /// except for any overrides passed in as arguments to [copyWidth].
   VideoPlayerValue copyWith({
-    Duration duration,
-    Size size,
-    Duration position,
-    Caption caption,
-    List<DurationRange> buffered,
-    bool isPlaying,
-    bool isLooping,
-    bool isBuffering,
-    double volume,
-    double playbackSpeed,
-    String errorDescription,
+    Duration? duration,
+    Size? size,
+    Duration? position,
+    Caption? caption,
+    List<DurationRange>? buffered,
+    bool? isInitialized,
+    bool? isPlaying,
+    bool? isLooping,
+    bool? isBuffering,
+    double? volume,
+    double? playbackSpeed,
+    String? errorDescription,
   }) {
     return VideoPlayerValue(
       duration: duration ?? this.duration,
@@ -132,6 +137,7 @@ class VideoPlayerValue {
       position: position ?? this.position,
       caption: caption ?? this.caption,
       buffered: buffered ?? this.buffered,
+      isInitialized: isInitialized ?? this.isInitialized,
       isPlaying: isPlaying ?? this.isPlaying,
       isLooping: isLooping ?? this.isLooping,
       isBuffering: isBuffering ?? this.isBuffering,
@@ -149,6 +155,7 @@ class VideoPlayerValue {
         'position: $position, '
         'caption: $caption, '
         'buffered: [${buffered.join(', ')}], '
+        'isInitialized: $isInitialized, '
         'isPlaying: $isPlaying, '
         'isLooping: $isLooping, '
         'isBuffering: $isBuffering, '
@@ -178,7 +185,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
       {this.package, this.closedCaptionFile, this.videoPlayerOptions})
       : dataSourceType = DataSourceType.asset,
         formatHint = null,
-        super(VideoPlayerValue(duration: null));
+        super(VideoPlayerValue(duration: Duration.zero));
 
   /// Constructs a [VideoPlayerController] playing a video from obtained from
   /// the network.
@@ -191,7 +198,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
       {this.formatHint, this.closedCaptionFile, this.videoPlayerOptions})
       : dataSourceType = DataSourceType.network,
         package = null,
-        super(VideoPlayerValue(duration: null));
+        super(VideoPlayerValue(duration: Duration.zero));
 
   /// Constructs a [VideoPlayerController] playing a video from a file.
   ///
@@ -203,9 +210,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
         dataSourceType = DataSourceType.file,
         package = null,
         formatHint = null,
-        super(VideoPlayerValue(duration: null));
-
-  int _textureId;
+        super(VideoPlayerValue(duration: Duration.zero));
 
   /// The URI to the video file. This will be in different formats depending on
   /// the [DataSourceType] of the original video.
@@ -213,31 +218,36 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
 
   /// **Android only**. Will override the platform's generic file format
   /// detection with whatever is set here.
-  final VideoFormat formatHint;
+  final VideoFormat? formatHint;
 
   /// Describes the type of data source this [VideoPlayerController]
   /// is constructed with.
   final DataSourceType dataSourceType;
 
   /// Provide additional configuration options (optional). Like setting the audio mode to mix
-  final VideoPlayerOptions videoPlayerOptions;
+  final VideoPlayerOptions? videoPlayerOptions;
 
   /// Only set for [asset] videos. The package that the asset was loaded from.
-  final String package;
+  final String? package;
 
   /// Optional field to specify a file containing the closed
   /// captioning.
   ///
   /// This future will be awaited and the file will be loaded when
   /// [initialize()] is called.
-  final Future<ClosedCaptionFile> closedCaptionFile;
+  final Future<ClosedCaptionFile>? closedCaptionFile;
 
-  ClosedCaptionFile _closedCaptionFile;
-  Timer _timer;
+  ClosedCaptionFile? _closedCaptionFile;
+  Timer? _timer;
   bool _isDisposed = false;
-  Completer<void> _creatingCompleter;
-  StreamSubscription<dynamic> _eventSubscription;
-  _VideoAppLifeCycleObserver _lifeCycleObserver;
+  Completer<void>? _creatingCompleter;
+  StreamSubscription<dynamic>? _eventSubscription;
+  late _VideoAppLifeCycleObserver _lifeCycleObserver;
+
+  /// The id of a texture that hasn't been initialized.
+  @visibleForTesting
+  static const int kUninitializedTextureId = -1;
+  int _textureId = kUninitializedTextureId;
 
   /// This is just exposed for testing. It shouldn't be used by anyone depending
   /// on the plugin.
@@ -250,11 +260,12 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
     _lifeCycleObserver.initialize();
     _creatingCompleter = Completer<void>();
 
-    DataSource dataSourceDescription;
+    late DataSource dataSourceDescription;
     switch (dataSourceType) {
       case DataSourceType.asset:
         dataSourceDescription = DataSource(
           sourceType: DataSourceType.asset,
+          uri: '',
           asset: dataSource,
           package: package,
         );
@@ -276,11 +287,11 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
 
     if (videoPlayerOptions?.mixWithOthers != null) {
       await _videoPlayerPlatform
-          .setMixWithOthers(videoPlayerOptions.mixWithOthers);
+          .setMixWithOthers(videoPlayerOptions!.mixWithOthers);
     }
 
-    _textureId = await _videoPlayerPlatform.create(dataSourceDescription);
-    _creatingCompleter.complete(null);
+    _textureId = (await _videoPlayerPlatform.create(dataSourceDescription)) ?? kUninitializedTextureId;
+    _creatingCompleter!.complete(null);
     final Completer<void> initializingCompleter = Completer<void>();
 
     void eventListener(VideoEvent event) {
@@ -293,6 +304,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
           value = value.copyWith(
             duration: event.duration,
             size: event.size,
+            isInitialized: event.duration != null,
           );
           initializingCompleter.complete(null);
           _applyLooping();
@@ -325,8 +337,8 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
     }
 
     void errorListener(Object obj) {
-      final PlatformException e = obj;
-      value = VideoPlayerValue.erroneous(e.message);
+      final PlatformException e = obj as PlatformException;
+      value = VideoPlayerValue.erroneous(e.message!);
       _timer?.cancel();
       if (!initializingCompleter.isCompleted) {
         initializingCompleter.completeError(obj);
@@ -342,17 +354,16 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   @override
   Future<void> dispose() async {
     if (_creatingCompleter != null) {
-      await _creatingCompleter.future;
+      await _creatingCompleter!.future;
       if (!_isDisposed) {
         _isDisposed = true;
-        _timer?.cancel();
-        await _eventSubscription?.cancel();
-        await _videoPlayerPlatform.dispose(_textureId);
-      }
-      _lifeCycleObserver.dispose();
+
+      _timer?.cancel();
+
+      await _eventSubscription?.cancel();
+      await _videoPlayerPlatform.dispose(_textureId);
     }
-    _isDisposed = true;
-    super.dispose();
+    _lifeCycleObserver.dispose();
   }
 
   /// Starts playing the video.
@@ -379,14 +390,14 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   }
 
   Future<void> _applyLooping() async {
-    if (!value.initialized || _isDisposed) {
+    if (!value.isInitialized || _isDisposed) {
       return;
     }
     await _videoPlayerPlatform.setLooping(_textureId, value.isLooping);
   }
 
   Future<void> _applyPlayPause() async {
-    if (!value.initialized || _isDisposed) {
+    if (!value.isInitialized || _isDisposed) {
       return;
     }
     if (value.isPlaying) {
@@ -400,11 +411,11 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
           if (_isDisposed) {
             return;
           }
-          final Duration newPosition = await position;
+          final Duration? newPosition = await position;
           if (_isDisposed) {
             return;
           }
-          _updatePosition(newPosition);
+          _updatePosition(newPosition!);
         },
       );
 
@@ -419,14 +430,14 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   }
 
   Future<void> _applyVolume() async {
-    if (!value.initialized || _isDisposed) {
+    if (!value.isInitialized || _isDisposed) {
       return;
     }
     await _videoPlayerPlatform.setVolume(_textureId, value.volume);
   }
 
   Future<void> _applyPlaybackSpeed() async {
-    if (!value.initialized || _isDisposed) {
+    if (!value.isInitialized || _isDisposed) {
       return;
     }
 
@@ -442,7 +453,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   }
 
   /// The position in the current video.
-  Future<Duration> get position async {
+  Future<Duration?> get position async {
     if (_isDisposed) {
       return null;
     }
@@ -519,17 +530,17 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   /// [Caption].
   Caption _getCaptionAt(Duration position) {
     if (_closedCaptionFile == null) {
-      return Caption();
+      return Caption.none;
     }
 
     // TODO: This would be more efficient as a binary search.
-    for (final caption in _closedCaptionFile.captions) {
+    for (final caption in _closedCaptionFile!.captions) {
       if (caption.start <= position && caption.end >= position) {
         return caption;
       }
     }
 
-    return Caption();
+    return Caption.none;
   }
 
   void _updatePosition(Duration position) {
@@ -545,7 +556,7 @@ class _VideoAppLifeCycleObserver extends Object with WidgetsBindingObserver {
   final VideoPlayerController _controller;
 
   void initialize() {
-    WidgetsBinding.instance.addObserver(this);
+    WidgetsBinding.instance!.addObserver(this);
   }
 
   @override
@@ -565,7 +576,7 @@ class _VideoAppLifeCycleObserver extends Object with WidgetsBindingObserver {
   }
 
   void dispose() {
-    WidgetsBinding.instance.removeObserver(this);
+    WidgetsBinding.instance!.removeObserver(this);
   }
 }
 
@@ -594,8 +605,9 @@ class _VideoPlayerState extends State<VideoPlayer> {
     };
   }
 
-  VoidCallback _listener;
-  int _textureId;
+  late VoidCallback _listener;
+
+  late int _textureId;
 
   @override
   void initState() {
@@ -622,7 +634,7 @@ class _VideoPlayerState extends State<VideoPlayer> {
 
   @override
   Widget build(BuildContext context) {
-    return _textureId == null
+    return _textureId == VideoPlayerController.kUninitializedTextureId
         ? Container()
         : _videoPlayerPlatform.buildView(_textureId);
   }
@@ -646,7 +658,7 @@ class VideoProgressColors {
   /// [backgroundColor] defaults to gray at 50% opacity. This is the background
   /// color behind both [playedColor] and [bufferedColor] to denote the total
   /// size of the video compared to either of those values.
-  VideoProgressColors({
+  const VideoProgressColors({
     this.playedColor = const Color.fromRGBO(255, 0, 0, 0.7),
     this.bufferedColor = const Color.fromRGBO(50, 50, 200, 0.2),
     this.backgroundColor = const Color.fromRGBO(200, 200, 200, 0.5),
@@ -670,8 +682,8 @@ class VideoProgressColors {
 
 class _VideoScrubber extends StatefulWidget {
   _VideoScrubber({
-    @required this.child,
-    @required this.controller,
+    required this.child,
+    required this.controller,
   });
 
   final Widget child;
@@ -689,7 +701,7 @@ class _VideoScrubberState extends State<_VideoScrubber> {
   @override
   Widget build(BuildContext context) {
     void seekToRelativePosition(Offset globalPosition) {
-      final RenderBox box = context.findRenderObject();
+      final RenderBox box = context.findRenderObject() as RenderBox;
       final Offset tapPos = box.globalToLocal(globalPosition);
       final double relative = tapPos.dx / box.size.width;
       final Duration position = controller.value.duration * relative;
@@ -700,7 +712,7 @@ class _VideoScrubberState extends State<_VideoScrubber> {
       behavior: HitTestBehavior.opaque,
       child: widget.child,
       onHorizontalDragStart: (DragStartDetails details) {
-        if (!controller.value.initialized) {
+        if (!controller.value.isInitialized) {
           return;
         }
         _controllerWasPlaying = controller.value.isPlaying;
@@ -709,7 +721,7 @@ class _VideoScrubberState extends State<_VideoScrubber> {
         }
       },
       onHorizontalDragUpdate: (DragUpdateDetails details) {
-        if (!controller.value.initialized) {
+        if (!controller.value.isInitialized) {
           return;
         }
         seekToRelativePosition(details.globalPosition);
@@ -720,7 +732,7 @@ class _VideoScrubberState extends State<_VideoScrubber> {
         }
       },
       onTapDown: (TapDownDetails details) {
-        if (!controller.value.initialized) {
+        if (!controller.value.isInitialized) {
           return;
         }
         seekToRelativePosition(details.globalPosition);
@@ -745,10 +757,10 @@ class VideoProgressIndicator extends StatefulWidget {
   /// to `top: 5.0`.
   VideoProgressIndicator(
     this.controller, {
-    VideoProgressColors colors,
-    this.allowScrubbing,
+    this.colors = const VideoProgressColors(),
+    required this.allowScrubbing,
     this.padding = const EdgeInsets.only(top: 5.0),
-  }) : colors = colors ?? VideoProgressColors();
+  });
 
   /// The [VideoPlayerController] that actually associates a video with this
   /// widget.
@@ -785,7 +797,7 @@ class _VideoProgressIndicatorState extends State<VideoProgressIndicator> {
     };
   }
 
-  VoidCallback listener;
+  late VoidCallback listener;
 
   VideoPlayerController get controller => widget.controller;
 
@@ -806,7 +818,7 @@ class _VideoProgressIndicatorState extends State<VideoProgressIndicator> {
   @override
   Widget build(BuildContext context) {
     Widget progressIndicator;
-    if (controller.value.initialized) {
+    if (controller.value.isInitialized) {
       final int duration = controller.value.duration.inMilliseconds;
       final int position = controller.value.position.inMilliseconds;
 
@@ -878,17 +890,17 @@ class ClosedCaption extends StatelessWidget {
   /// [VideoPlayerValue.caption].
   ///
   /// If [text] is null, nothing will be displayed.
-  const ClosedCaption({Key key, this.text, this.textStyle}) : super(key: key);
+  const ClosedCaption({Key? key, this.text, this.textStyle}) : super(key: key);
 
   /// The text that will be shown in the closed caption, or null if no caption
   /// should be shown.
-  final String text;
+  final String? text;
 
   /// Specifies how the text in the closed caption should look.
   ///
   /// If null, defaults to [DefaultTextStyle.of(context).style] with size 36
   /// font colored white.
-  final TextStyle textStyle;
+  final TextStyle? textStyle;
 
   @override
   Widget build(BuildContext context) {
@@ -913,7 +925,7 @@ class ClosedCaption extends StatelessWidget {
           ),
           child: Padding(
             padding: EdgeInsets.symmetric(horizontal: 2.0),
-            child: Text(text, style: effectiveTextStyle),
+            child: Text(text!, style: effectiveTextStyle),
           ),
         ),
       ),

--- a/packages/video_player/video_player/pigeons/messages.dart
+++ b/packages/video_player/video_player/pigeons/messages.dart
@@ -1,3 +1,5 @@
+// @dart = 2.9
+
 import 'package:pigeon/pigeon_lib.dart';
 
 class TextureMessage {

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -4,8 +4,11 @@ description: Flutter plugin for displaying inline video with other Flutter
 # 0.10.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.11.1+2
+version: 0.12.0
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player
+
+# Don't publish this package until null safety is stable or the package is in the allow list.
+publish_to: none
 
 flutter:
   plugin:
@@ -19,15 +22,21 @@ flutter:
         default_package: video_player_web
 
 dependencies:
-  meta: ^1.0.5
-  video_player_platform_interface: ^2.2.0
+  meta: ^1.3.0-nullsafety.3
+  video_player_platform_interface:
+    path: ../video_player_platform_interface
+    # git:
+    #   url: https://github.com/flutter/plugins.git
+    #   ref: nnbd
+    #   path: packages/video_player/video_player_platform_interface
 
   # The design on https://flutter.dev/go/federated-plugins was to leave
   # this constraint as "any". We cannot do it right now as it fails pub publish
   # validation, so we set a ^ constraint.
   # TODO(amirh): Revisit this (either update this part in the  design or the pub tool).
   # https://github.com/flutter/flutter/issues/46264
-  video_player_web: '>=0.1.4 <2.0.0'
+  video_player_web:
+    path: ../video_player_web
 
   flutter:
     sdk: flutter
@@ -35,9 +44,9 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.8.0
+  pedantic: ^1.10.0-nullsafety.1
   pigeon: 0.1.7
 
 environment:
-  sdk: ">=2.8.0 <3.0.0"
+  sdk: '>=2.10.0-56.0.dev <3.0.0'
   flutter: ">=1.12.13+hotfix.5 <2.0.0"

--- a/packages/video_player/video_player/test/sub_rip_file_test.dart
+++ b/packages/video_player/video_player/test/sub_rip_file_test.dart
@@ -108,6 +108,6 @@ This one is valid
 
 3
 00:01:54,724 --> 00:01:6,760
-This one should be ignored because the 
+This one should be ignored because the
 ned time is missing a digit.
 ''';

--- a/packages/video_player/video_player/test/video_player_initialization_test.dart
+++ b/packages/video_player/video_player/test/video_player_initialization_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:video_player/video_player.dart';

--- a/packages/video_player/video_player/test/video_player_test.dart
+++ b/packages/video_player/video_player/test/video_player_test.dart
@@ -252,7 +252,7 @@ void main() {
 
       await controller.dispose();
 
-      expect(controller.textureId, 1);
+      expect(controller.textureId, 0);
       expect(await controller.position, isNull);
     });
 

--- a/packages/video_player/video_player/test/video_player_test.dart
+++ b/packages/video_player/video_player/test/video_player_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'dart:async';
 import 'dart:io';
 
@@ -18,7 +16,7 @@ import 'package:video_player_platform_interface/video_player_platform_interface.
 
 class FakeController extends ValueNotifier<VideoPlayerValue>
     implements VideoPlayerController {
-  FakeController() : super(VideoPlayerValue(duration: null));
+  FakeController() : super(VideoPlayerValue(duration: Duration.zero));
 
   @override
   Future<void> dispose() async {
@@ -26,7 +24,7 @@ class FakeController extends ValueNotifier<VideoPlayerValue>
   }
 
   @override
-  int textureId;
+  int textureId = VideoPlayerController.kUninitializedTextureId;
 
   @override
   String get dataSource => '';
@@ -35,7 +33,7 @@ class FakeController extends ValueNotifier<VideoPlayerValue>
   DataSourceType get dataSourceType => DataSourceType.file;
 
   @override
-  String get package => null;
+  String get package => null!;
 
   @override
   Future<Duration> get position async => value.position;
@@ -62,13 +60,13 @@ class FakeController extends ValueNotifier<VideoPlayerValue>
   Future<void> setLooping(bool looping) async {}
 
   @override
-  VideoFormat get formatHint => null;
+  VideoFormat? get formatHint => null;
 
   @override
   Future<ClosedCaptionFile> get closedCaptionFile => _loadClosedCaption();
 
   @override
-  VideoPlayerOptions get videoPlayerOptions => null;
+  VideoPlayerOptions? get videoPlayerOptions => null;
 }
 
 Future<ClosedCaptionFile> _loadClosedCaption() async =>
@@ -80,11 +78,13 @@ class _FakeClosedCaptionFile extends ClosedCaptionFile {
     return <Caption>[
       Caption(
         text: 'one',
+        number: 0,
         start: Duration(milliseconds: 100),
         end: Duration(milliseconds: 200),
       ),
       Caption(
         text: 'two',
+        number: 1,
         start: Duration(milliseconds: 300),
         end: Duration(milliseconds: 400),
       ),
@@ -101,6 +101,7 @@ void main() {
     controller.textureId = 123;
     controller.value = controller.value.copyWith(
       duration: const Duration(milliseconds: 100),
+      isInitialized: true,
     );
 
     await tester.pump();
@@ -133,8 +134,8 @@ void main() {
       await tester.pumpWidget(MaterialApp(home: ClosedCaption(text: text)));
 
       final Text textWidget = tester.widget<Text>(find.text(text));
-      expect(textWidget.style.fontSize, 36.0);
-      expect(textWidget.style.color, Colors.white);
+      expect(textWidget.style!.fontSize, 36.0);
+      expect(textWidget.style!.color, Colors.white);
     });
 
     testWidgets('uses given text and style', (WidgetTester tester) async {
@@ -149,7 +150,7 @@ void main() {
       expect(find.text(text), findsOneWidget);
 
       final Text textWidget = tester.widget<Text>(find.text(text));
-      expect(textWidget.style.fontSize, textStyle.fontSize);
+      expect(textWidget.style!.fontSize, textStyle.fontSize);
     });
 
     testWidgets('handles null text', (WidgetTester tester) async {
@@ -173,7 +174,7 @@ void main() {
   });
 
   group('VideoPlayerController', () {
-    FakeVideoPlayerPlatform fakeVideoPlayerPlatform;
+    late FakeVideoPlayerPlatform fakeVideoPlayerPlatform;
 
     setUp(() {
       fakeVideoPlayerPlatform = FakeVideoPlayerPlatform();
@@ -221,7 +222,7 @@ void main() {
           'http://testing.com/invalid_url',
         );
         try {
-          dynamic error;
+          late dynamic error;
           fakeVideoPlayerPlatform.forceInitError = true;
           await controller.initialize().catchError((dynamic e) => error = e);
           final PlatformException platformEx = error;
@@ -245,13 +246,13 @@ void main() {
       final VideoPlayerController controller = VideoPlayerController.network(
         'https://127.0.0.1',
       );
-      expect(controller.textureId, isNull);
+      expect(controller.textureId, VideoPlayerController.kUninitializedTextureId);
       expect(await controller.position, const Duration(seconds: 0));
       await controller.initialize();
 
       await controller.dispose();
 
-      expect(controller.textureId, isNotNull);
+      expect(controller.textureId, 1);
       expect(await controller.position, isNull);
     });
 
@@ -390,19 +391,19 @@ void main() {
 
         await controller.initialize();
         expect(controller.value.position, const Duration());
-        expect(controller.value.caption.text, isNull);
+        expect(controller.value.caption.text, '');
 
         await controller.seekTo(const Duration(milliseconds: 100));
         expect(controller.value.caption.text, 'one');
 
         await controller.seekTo(const Duration(milliseconds: 250));
-        expect(controller.value.caption.text, isNull);
+        expect(controller.value.caption.text, '');
 
         await controller.seekTo(const Duration(milliseconds: 300));
         expect(controller.value.caption.text, 'two');
 
         await controller.seekTo(const Duration(milliseconds: 500));
-        expect(controller.value.caption.text, isNull);
+        expect(controller.value.caption.text, '');
 
         await controller.seekTo(const Duration(milliseconds: 300));
         expect(controller.value.caption.text, 'two');
@@ -419,8 +420,7 @@ void main() {
         await controller.play();
         expect(controller.value.isPlaying, isTrue);
         final FakeVideoEventStream fakeVideoEventStream =
-            fakeVideoPlayerPlatform.streams[controller.textureId];
-        assert(fakeVideoEventStream != null);
+            fakeVideoPlayerPlatform.streams[controller.textureId]!;
 
         fakeVideoEventStream.eventsChannel
             .sendEvent(<String, dynamic>{'event': 'completed'});
@@ -438,8 +438,7 @@ void main() {
         expect(controller.value.isBuffering, false);
         expect(controller.value.buffered, isEmpty);
         final FakeVideoEventStream fakeVideoEventStream =
-            fakeVideoPlayerPlatform.streams[controller.textureId];
-        assert(fakeVideoEventStream != null);
+            fakeVideoPlayerPlatform.streams[controller.textureId]!;
 
         fakeVideoEventStream.eventsChannel
             .sendEvent(<String, dynamic>{'event': 'bufferingStart'});
@@ -496,9 +495,9 @@ void main() {
     test('uninitialized()', () {
       final VideoPlayerValue uninitialized = VideoPlayerValue.uninitialized();
 
-      expect(uninitialized.duration, isNull);
-      expect(uninitialized.position, equals(const Duration(seconds: 0)));
-      expect(uninitialized.caption, equals(const Caption()));
+      expect(uninitialized.duration, equals(Duration.zero));
+      expect(uninitialized.position, equals(Duration.zero));
+      expect(uninitialized.caption, equals(Caption.none));
       expect(uninitialized.buffered, isEmpty);
       expect(uninitialized.isPlaying, isFalse);
       expect(uninitialized.isLooping, isFalse);
@@ -506,20 +505,19 @@ void main() {
       expect(uninitialized.volume, 1.0);
       expect(uninitialized.playbackSpeed, 1.0);
       expect(uninitialized.errorDescription, isNull);
-      expect(uninitialized.size, isNull);
-      expect(uninitialized.size, isNull);
-      expect(uninitialized.initialized, isFalse);
+      expect(uninitialized.size, equals(Size.zero));
+      expect(uninitialized.isInitialized, isFalse);
       expect(uninitialized.hasError, isFalse);
-      expect(uninitialized.aspectRatio, 1.0);
+      expect(uninitialized.aspectRatio, 0.0);
     });
 
     test('erroneous()', () {
       const String errorMessage = 'foo';
       final VideoPlayerValue error = VideoPlayerValue.erroneous(errorMessage);
 
-      expect(error.duration, isNull);
-      expect(error.position, equals(const Duration(seconds: 0)));
-      expect(error.caption, equals(const Caption()));
+      expect(error.duration, equals(Duration.zero));
+      expect(error.position, equals(Duration.zero));
+      expect(error.caption, equals(Caption.none));
       expect(error.buffered, isEmpty);
       expect(error.isPlaying, isFalse);
       expect(error.isLooping, isFalse);
@@ -527,18 +525,17 @@ void main() {
       expect(error.volume, 1.0);
       expect(error.playbackSpeed, 1.0);
       expect(error.errorDescription, errorMessage);
-      expect(error.size, isNull);
-      expect(error.size, isNull);
-      expect(error.initialized, isFalse);
+      expect(error.size, equals(Size.zero));
+      expect(error.isInitialized, isFalse);
       expect(error.hasError, isTrue);
-      expect(error.aspectRatio, 1.0);
+      expect(error.aspectRatio, 0.0);
     });
 
     test('toString()', () {
       const Duration duration = Duration(seconds: 5);
       const Size size = Size(400, 300);
       const Duration position = Duration(seconds: 1);
-      const Caption caption = Caption(text: 'foo');
+      const Caption caption = Caption(text: 'foo', number: 0, start: Duration.zero, end: Duration.zero);
       final List<DurationRange> buffered = <DurationRange>[
         DurationRange(const Duration(seconds: 0), const Duration(seconds: 4))
       ];
@@ -568,6 +565,7 @@ void main() {
           'position: 0:00:01.000000, '
           'caption: Instance of \'Caption\', '
           'buffered: [DurationRange(start: 0:00:00.000000, end: 0:00:04.000000)], '
+          'isInitialized: true, '
           'isPlaying: true, '
           'isLooping: true, '
           'isBuffering: true, '
@@ -586,15 +584,16 @@ void main() {
     group('aspectRatio', () {
       test('640x480 -> 4:3', () {
         final value = VideoPlayerValue(
+          isInitialized: true,
           size: Size(640, 480),
           duration: Duration(seconds: 1),
         );
         expect(value.aspectRatio, 4 / 3);
       });
 
-      test('null size -> 1.0', () {
+      test('no size -> 1.0', () {
         final value = VideoPlayerValue(
-          size: null,
+          isInitialized: true,
           duration: Duration(seconds: 1),
         );
         expect(value.aspectRatio, 1.0);
@@ -602,6 +601,7 @@ void main() {
 
       test('height = 0 -> 1.0', () {
         final value = VideoPlayerValue(
+          isInitialized: true,
           size: Size(640, 0),
           duration: Duration(seconds: 1),
         );
@@ -610,6 +610,7 @@ void main() {
 
       test('width = 0 -> 1.0', () {
         final value = VideoPlayerValue(
+          isInitialized: true,
           size: Size(0, 480),
           duration: Duration(seconds: 1),
         );
@@ -618,6 +619,7 @@ void main() {
 
       test('negative aspect ratio -> 1.0', () {
         final value = VideoPlayerValue(
+          isInitialized: true,
           size: Size(640, -480),
           duration: Duration(seconds: 1),
         );
@@ -646,7 +648,7 @@ void main() {
         File(''),
         videoPlayerOptions: VideoPlayerOptions(mixWithOthers: true));
     await controller.initialize();
-    expect(controller.videoPlayerOptions.mixWithOthers, true);
+    expect(controller.videoPlayerOptions!.mixWithOthers, true);
   });
 }
 
@@ -706,7 +708,7 @@ class FakeVideoPlayerPlatform extends TestHostVideoPlayerApi {
   @override
   void seekTo(PositionMessage arg) {
     calls.add('seekTo');
-    _positions[arg.textureId] = Duration(milliseconds: arg.position);
+    _positions[arg.textureId!] = Duration(milliseconds: arg.position!);
   }
 
   @override
@@ -742,7 +744,7 @@ class FakeVideoEventStream {
   int height;
   Duration duration;
   bool initWithError;
-  FakeEventsChannel eventsChannel;
+  late FakeEventsChannel eventsChannel;
 
   void onListen() {
     if (!initWithError) {
@@ -764,7 +766,7 @@ class FakeEventsChannel {
     eventsMethodChannel.setMockMethodCallHandler(onMethodCall);
   }
 
-  MethodChannel eventsMethodChannel;
+  late MethodChannel eventsMethodChannel;
   VoidCallback onListen;
 
   Future<dynamic> onMethodCall(MethodCall call) {
@@ -780,7 +782,7 @@ class FakeEventsChannel {
     _sendMessage(const StandardMethodCodec().encodeSuccessEnvelope(event));
   }
 
-  void sendError(String code, [String message, dynamic details]) {
+  void sendError(String code, [String? message, dynamic details]) {
     _sendMessage(const StandardMethodCodec().encodeErrorEnvelope(
       code: code,
       message: message,
@@ -794,6 +796,6 @@ class FakeEventsChannel {
     // available on all the versions of Flutter that we test.
     // ignore: deprecated_member_use
     defaultBinaryMessenger.handlePlatformMessage(
-        eventsMethodChannel.name, data, (ByteData data) {});
+        eventsMethodChannel.name, data, (ByteData? data) {});
   }
 }

--- a/packages/video_player/video_player/test/video_player_test.dart
+++ b/packages/video_player/video_player/test/video_player_test.dart
@@ -246,7 +246,8 @@ void main() {
       final VideoPlayerController controller = VideoPlayerController.network(
         'https://127.0.0.1',
       );
-      expect(controller.textureId, VideoPlayerController.kUninitializedTextureId);
+      expect(
+          controller.textureId, VideoPlayerController.kUninitializedTextureId);
       expect(await controller.position, const Duration(seconds: 0));
       await controller.initialize();
 
@@ -535,7 +536,8 @@ void main() {
       const Duration duration = Duration(seconds: 5);
       const Size size = Size(400, 300);
       const Duration position = Duration(seconds: 1);
-      const Caption caption = Caption(text: 'foo', number: 0, start: Duration.zero, end: Duration.zero);
+      const Caption caption = Caption(
+          text: 'foo', number: 0, start: Duration.zero, end: Duration.zero);
       final List<DurationRange> buffered = <DurationRange>[
         DurationRange(const Duration(seconds: 0), const Duration(seconds: 4))
       ];

--- a/packages/video_player/video_player_platform_interface/CHANGELOG.md
+++ b/packages/video_player/video_player_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.0-nullsafety.1
+
+* Make DataSource's `uri` parameter nullable.
+
 ## 3.0.0-nullsafety
 
 * Migrate to null safety.

--- a/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
+++ b/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
@@ -147,7 +147,7 @@ class DataSource {
   /// package and null otherwise.
   DataSource({
     required this.sourceType,
-    required this.uri,
+    this.uri,
     this.formatHint,
     this.asset,
     this.package,
@@ -163,7 +163,7 @@ class DataSource {
   ///
   /// This will be in different formats depending on the [DataSourceType] of
   /// the original video.
-  final String uri;
+  final String? uri;
 
   /// **Android only**. Will override the platform's generic file format
   /// detection with whatever is set here.

--- a/packages/video_player/video_player_platform_interface/pubspec.yaml
+++ b/packages/video_player/video_player_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the video_player plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 3.0.0-nullsafety
+version: 3.0.0-nullsafety.1
 
 dependencies:
   flutter:

--- a/packages/video_player/video_player_platform_interface/test/method_channel_video_player_test.dart
+++ b/packages/video_player/video_player_platform_interface/test/method_channel_video_player_test.dart
@@ -145,7 +145,6 @@ void main() {
     test('create with asset', () async {
       final int textureId = await player.create(DataSource(
         sourceType: DataSourceType.asset,
-        uri: 'someUri',
         asset: 'someAsset',
         package: 'somePackage',
       ));

--- a/packages/video_player/video_player_web/CHANGELOG.md
+++ b/packages/video_player/video_player_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0
+
+* Migrate to null safety.
+
 ## 0.1.4
 
 * Added option to set the video playback speed on the video controller.

--- a/packages/video_player/video_player_web/analysis_options.yaml
+++ b/packages/video_player/video_player_web/analysis_options.yaml
@@ -6,5 +6,7 @@
 include: ../../../analysis_options.yaml
 
 analyzer:
+  enable-experiment:
+    - non-nullable
   errors:
     undefined_prefixed_name: ignore

--- a/packages/video_player/video_player_web/lib/video_player_web.dart
+++ b/packages/video_player/video_player_web/lib/video_player_web.dart
@@ -80,8 +80,7 @@ class VideoPlayerPlugin extends VideoPlayerPlatform {
         }
         // 'webOnlyAssetManager' is only in the web version of dart:ui
         // ignore: undefined_prefixed_name
-        ui.webOnlyAssetManager.getAssetUrl(assetUrl);
-        assetUrl = '';
+        assetUrl = ui.webOnlyAssetManager.getAssetUrl(assetUrl);
         uri = assetUrl;
         break;
       case DataSourceType.file:

--- a/packages/video_player/video_player_web/lib/video_player_web.dart
+++ b/packages/video_player/video_player_web/lib/video_player_web.dart
@@ -50,7 +50,7 @@ class VideoPlayerPlugin extends VideoPlayerPlatform {
 
   @override
   Future<void> dispose(int textureId) async {
-    _videoPlayers[textureId].dispose();
+    _videoPlayers[textureId]!.dispose();
     _videoPlayers.remove(textureId);
     return null;
   }
@@ -66,7 +66,7 @@ class VideoPlayerPlugin extends VideoPlayerPlatform {
     final int textureId = _textureCounter;
     _textureCounter++;
 
-    String uri;
+    late String uri;
     switch (dataSource.sourceType) {
       case DataSourceType.network:
         // Do NOT modify the incoming uri, it can be a Blob, and Safari doesn't
@@ -74,13 +74,14 @@ class VideoPlayerPlugin extends VideoPlayerPlatform {
         uri = dataSource.uri;
         break;
       case DataSourceType.asset:
-        String assetUrl = dataSource.asset;
-        if (dataSource.package != null && dataSource.package.isNotEmpty) {
+        String assetUrl = dataSource.asset!;
+        if (dataSource.package != null && dataSource.package!.isNotEmpty) {
           assetUrl = 'packages/${dataSource.package}/$assetUrl';
         }
         // 'webOnlyAssetManager' is only in the web version of dart:ui
         // ignore: undefined_prefixed_name
-        assetUrl = ui.webOnlyAssetManager.getAssetUrl(assetUrl);
+        ui.webOnlyAssetManager.getAssetUrl(assetUrl);
+        assetUrl = "";
         uri = assetUrl;
         break;
       case DataSourceType.file:
@@ -101,45 +102,45 @@ class VideoPlayerPlugin extends VideoPlayerPlatform {
 
   @override
   Future<void> setLooping(int textureId, bool looping) async {
-    return _videoPlayers[textureId].setLooping(looping);
+    return _videoPlayers[textureId]!.setLooping(looping);
   }
 
   @override
   Future<void> play(int textureId) async {
-    return _videoPlayers[textureId].play();
+    return _videoPlayers[textureId]!.play();
   }
 
   @override
   Future<void> pause(int textureId) async {
-    return _videoPlayers[textureId].pause();
+    return _videoPlayers[textureId]!.pause();
   }
 
   @override
   Future<void> setVolume(int textureId, double volume) async {
-    return _videoPlayers[textureId].setVolume(volume);
+    return _videoPlayers[textureId]!.setVolume(volume);
   }
 
   @override
   Future<void> setPlaybackSpeed(int textureId, double speed) async {
     assert(speed > 0);
 
-    return _videoPlayers[textureId].setPlaybackSpeed(speed);
+    return _videoPlayers[textureId]!.setPlaybackSpeed(speed);
   }
 
   @override
   Future<void> seekTo(int textureId, Duration position) async {
-    return _videoPlayers[textureId].seekTo(position);
+    return _videoPlayers[textureId]!.seekTo(position);
   }
 
   @override
   Future<Duration> getPosition(int textureId) async {
-    _videoPlayers[textureId].sendBufferingUpdate();
-    return _videoPlayers[textureId].getPosition();
+    _videoPlayers[textureId]!.sendBufferingUpdate();
+    return _videoPlayers[textureId]!.getPosition();
   }
 
   @override
   Stream<VideoEvent> videoEventsFor(int textureId) {
-    return _videoPlayers[textureId].eventController.stream;
+    return _videoPlayers[textureId]!.eventController.stream;
   }
 
   @override
@@ -149,14 +150,14 @@ class VideoPlayerPlugin extends VideoPlayerPlatform {
 }
 
 class _VideoPlayer {
-  _VideoPlayer({this.uri, this.textureId});
+  _VideoPlayer({required this.uri, required this.textureId});
 
   final StreamController<VideoEvent> eventController =
       StreamController<VideoEvent>();
 
   final String uri;
   final int textureId;
-  VideoElement videoElement;
+  late VideoElement videoElement;
   bool isInitialized = false;
 
   void initialize() {
@@ -186,9 +187,9 @@ class _VideoPlayer {
       // The Event itself (_) doesn't contain info about the actual error.
       // We need to look at the HTMLMediaElement.error.
       // See: https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/error
-      MediaError error = videoElement.error;
+      MediaError error = videoElement.error!;
       eventController.addError(PlatformException(
-        code: _kErrorValueToErrorName[error.code],
+        code: _kErrorValueToErrorName[error.code]!,
         message: error.message != '' ? error.message : _kDefaultErrorMessage,
         details: _kErrorValueToErrorDescription[error.code],
       ));
@@ -261,8 +262,8 @@ class _VideoPlayer {
           milliseconds: (videoElement.duration * 1000).round(),
         ),
         size: Size(
-          videoElement.videoWidth.toDouble() ?? 0.0,
-          videoElement.videoHeight.toDouble() ?? 0.0,
+          videoElement.videoWidth.toDouble(),
+          videoElement.videoHeight.toDouble(),
         ),
       ),
     );

--- a/packages/video_player/video_player_web/lib/video_player_web.dart
+++ b/packages/video_player/video_player_web/lib/video_player_web.dart
@@ -81,7 +81,7 @@ class VideoPlayerPlugin extends VideoPlayerPlatform {
         // 'webOnlyAssetManager' is only in the web version of dart:ui
         // ignore: undefined_prefixed_name
         ui.webOnlyAssetManager.getAssetUrl(assetUrl);
-        assetUrl = "";
+        assetUrl = '';
         uri = assetUrl;
         break;
       case DataSourceType.file:

--- a/packages/video_player/video_player_web/lib/video_player_web.dart
+++ b/packages/video_player/video_player_web/lib/video_player_web.dart
@@ -71,7 +71,7 @@ class VideoPlayerPlugin extends VideoPlayerPlatform {
       case DataSourceType.network:
         // Do NOT modify the incoming uri, it can be a Blob, and Safari doesn't
         // like blobs that have changed.
-        uri = dataSource.uri;
+        uri = dataSource.uri ?? '';
         break;
       case DataSourceType.asset:
         String assetUrl = dataSource.asset!;

--- a/packages/video_player/video_player_web/pubspec.yaml
+++ b/packages/video_player/video_player_web/pubspec.yaml
@@ -4,7 +4,10 @@ homepage: https://github.com/flutter/plugins/tree/master/packages/video_player/v
 # 0.1.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.1.4
+version: 0.2.0
+
+# Don't publish this package until null safety is stable or the package is in the allow list.
+publish_to: none
 
 flutter:
   plugin:
@@ -18,16 +21,21 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  meta: ^1.1.7
-  video_player_platform_interface: ^2.2.0
+  meta: ^1.3.0-nullsafety.3
+  video_player_platform_interface:
+    path: ../video_player_platform_interface
+    # git:
+    #   url: https://github.com/flutter/plugins.git
+    #   ref: nnbd
+    #   path: packages/video_player/video_player_platform_interface
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   video_player:
     path: ../video_player
-  pedantic: ^1.8.0
+  pedantic: ^1.10.0-nullsafety.1
 
 environment:
-  sdk: ">=2.8.0 <3.0.0"
-  flutter: ">=1.12.8 <2.0.0"
+  sdk: '>=2.10.0-56.0.dev <3.0.0'
+  flutter: ">=1.12.13+hotfix.5 <2.0.0"

--- a/packages/video_player/video_player_web/test/video_player_web_test.dart
+++ b/packages/video_player/video_player_web/test/video_player_web_test.dart
@@ -52,7 +52,6 @@ void main() {
               sourceType: DataSourceType.asset,
               asset: 'videos/bee.mp4',
               package: 'bee_vids',
-              uri: 'irrelevant',
             ),
           ),
           completion(isNonZero));

--- a/packages/video_player/video_player_web/test/video_player_web_test.dart
+++ b/packages/video_player/video_player_web/test/video_player_web_test.dart
@@ -14,16 +14,16 @@ import 'package:video_player_web/video_player_web.dart';
 
 void main() {
   group('VideoPlayer for Web', () {
-    int textureId;
+    late int textureId;
 
     setUp(() async {
       VideoPlayerPlatform.instance = VideoPlayerPlugin();
-      textureId = await VideoPlayerPlatform.instance.create(
+      textureId = (await VideoPlayerPlatform.instance.create(
         DataSource(
             sourceType: DataSourceType.network,
             uri:
                 'https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4'),
-      );
+      ))!;
     });
 
     test('$VideoPlayerPlugin is the live instance', () {
@@ -52,6 +52,7 @@ void main() {
               sourceType: DataSourceType.asset,
               asset: 'videos/bee.mp4',
               package: 'bee_vids',
+              uri: 'irrelevant',
             ),
           ),
           completion(isNonZero));
@@ -84,12 +85,12 @@ void main() {
     });
 
     test('throws PlatformException when playing bad media', () async {
-      int videoPlayerId = await VideoPlayerPlatform.instance.create(
+      int videoPlayerId = (await VideoPlayerPlatform.instance.create(
         DataSource(
             sourceType: DataSourceType.network,
             uri:
                 'https://flutter.github.io/assets-for-api-docs/assets/videos/_non_existent_video.mp4'),
-      );
+      ))!;
 
       Stream<VideoEvent> eventStream =
           VideoPlayerPlatform.instance.videoEventsFor(videoPlayerId);

--- a/script/incremental_build.sh
+++ b/script/incremental_build.sh
@@ -23,6 +23,7 @@ CUSTOM_ANALYSIS_PLUGINS=(
   "in_app_purchase"
   "camera"
   "plugin_platform_interface"
+  "video_player/video_player"
   "video_player/video_player_platform_interface"
   "video_player/video_player_web"
   "google_maps_flutter/google_maps_flutter_web"


### PR DESCRIPTION
Migrates video player to null safety.

I made some API changes like the use of `Duration.zero`/`Size.zero` instead of `null` for defaults in `VideoPlayerValue` and `Caption`.