### PR TITLE
fix pointer events by setting TestBindingEventSource

### DIFF
--- a/packages/integration_test/CHANGELOG.md
+++ b/packages/integration_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.3
+
+* Set TestBindingEventSource to test for web integration_tests.
+
 ## 0.9.2+2
 
 * Broaden the constraint on vm_service.

--- a/packages/integration_test/example/integration_test/_example_test_web.dart
+++ b/packages/integration_test/example/integration_test/_example_test_web.dart
@@ -6,7 +6,9 @@
 // tree, read text, and verify that the values of widget properties are correct.
 
 import 'dart:html' as html;
+import 'dart:js_util' as js_util;
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
@@ -21,15 +23,74 @@ void main() {
     // Trigger a frame.
     await tester.pumpAndSettle();
 
+    final Finder finder = find.byKey(const Key('platform'));
+    final Text platformText = tester.widget(finder);
+
     // Verify that platform is retrieved.
-    expect(
-      find.byWidgetPredicate(
-        (Widget widget) =>
-            widget is Text &&
-            widget.data
-                .startsWith('Platform: ${html.window.navigator.platform}\n'),
-      ),
-      findsOneWidget,
-    );
+    expect(finder, findsOneWidget);
+    expect(platformText.data, 'Platform: ${html.window.navigator.platform}\n');
   });
+
+  testWidgets('verify event dispatching works', (WidgetTester tester) async {
+    // Build our app and trigger a frame.
+    app.main();
+
+    // Trigger a frame.
+    await tester.pumpAndSettle();
+
+    final Finder finderButton = find.byKey(const Key('button'));
+    expect(finderButton, findsOneWidget);
+
+    final Offset offset = tester.getCenter(finderButton);
+
+    dispatchEventToMouseLocation((offset.dx).toInt(), (offset.dy).toInt());
+    await tester.pumpAndSettle();
+
+    final Finder finder = find.byKey(const Key('counter'));
+    final Text counter = tester.widget(finder);
+
+    // Verify that counter is clicked.
+    expect(finder, findsOneWidget);
+    expect(counter.data, '1');
+  });
+}
+
+void dispatchEventToMouseLocation(int mouseX, int mouseY) {
+  final html.EventTarget target =
+      html.document.elementFromPoint(mouseX, mouseY);
+
+  dispatchPointerEvent(target, 'pointerdown', <String, dynamic>{
+    'bubbles': true,
+    'cancelable': true,
+    'screenX': mouseX,
+    'screenY': mouseY,
+    'clientX': mouseX,
+    'clientY': mouseY,
+  });
+
+  dispatchPointerEvent(target, 'pointerup', <String, dynamic>{
+    'bubbles': true,
+    'cancelable': true,
+    'screenX': mouseX,
+    'screenY': mouseY,
+    'clientX': mouseX,
+    'clientY': mouseY,
+  });
+}
+
+html.PointerEvent dispatchPointerEvent(
+    html.EventTarget target, String type, Map<String, dynamic> args) {
+  final dynamic jsPointerEvent =
+      js_util.getProperty(html.window, 'PointerEvent');
+  final List<dynamic> eventArgs = <dynamic>[
+    type,
+    args,
+  ];
+
+  final html.PointerEvent event = js_util.callConstructor(
+          jsPointerEvent, js_util.jsify(eventArgs) as List<dynamic>)
+      as html.PointerEvent;
+  target.dispatchEvent(event);
+
+  return event;
 }

--- a/packages/integration_test/example/integration_test/_extended_test_web.dart
+++ b/packages/integration_test/example/integration_test/_extended_test_web.dart
@@ -26,16 +26,12 @@ void main() {
     // Take a screenshot.
     await binding.takeScreenshot('platform_name');
 
+    final Finder finder = find.byKey(const Key('platform'));
+    final Text platformText = tester.widget(finder);
+
     // Verify that platform is retrieved.
-    expect(
-      find.byWidgetPredicate(
-        (Widget widget) =>
-            widget is Text &&
-            widget.data
-                .startsWith('Platform: ${html.window.navigator.platform}\n'),
-      ),
-      findsOneWidget,
-    );
+    expect(finder, findsOneWidget);
+    expect(platformText, 'Platform: ${html.window.navigator.platform}\n');
   });
 
   testWidgets('verify screenshot', (WidgetTester tester) async {

--- a/packages/integration_test/example/lib/my_web_app.dart
+++ b/packages/integration_test/example/lib/my_web_app.dart
@@ -11,6 +11,14 @@ class MyWebApp extends StatefulWidget {
 }
 
 class _MyWebAppState extends State<MyWebApp> {
+  int _counter = 0;
+
+  void _increment() {
+    setState(() {
+      _counter++;
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -19,8 +27,33 @@ class _MyWebAppState extends State<MyWebApp> {
           title: const Text('Plugin example app'),
         ),
         body: Center(
-          key: Key('mainapp'),
-          child: Text('Platform: ${html.window.navigator.platform}\n'),
+          child: Column(
+            children: [
+              Text(
+                'Platform: ${html.window.navigator.platform}\n',
+                key: Key('platform'),
+              ),
+              Text(
+                '$_counter',
+                key: Key('counter'),
+              ),
+              Expanded(
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: <Widget>[
+                    RaisedButton(
+                      padding: const EdgeInsets.all(10.0),
+                      onPressed: _increment,
+                      key: Key('button'),
+                      child:
+                          const Text('Button!', style: TextStyle(fontSize: 20)),
+                    ),
+                  ],
+                ),
+              )
+            ],
+          ),
         ),
       ),
     );

--- a/packages/integration_test/example/pubspec.yaml
+++ b/packages/integration_test/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 
 environment:
   sdk: ">=2.1.0 <3.0.0"
-  flutter: ">=1.6.7 <2.0.0"
+  flutter: ">=1.12.13+hotfix.5 <2.0.0"
 
 dependencies:
   flutter:

--- a/packages/integration_test/lib/integration_test.dart
+++ b/packages/integration_test/lib/integration_test.dart
@@ -79,7 +79,11 @@ class IntegrationTestWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding
     // vs TestBindingEventSource.test. Test uses RenderBindind.dispatch
     // event. The former does not deliver the gesture but only compare
     // matchers.
-    super.handlePointerEvent(pointerEvent, source: TestBindingEventSource.test);
+    if(this is LiveTestWidgetsFlutterBinding) {
+      super.handlePointerEvent(pointerEvent, source: TestBindingEventSource.test);
+    } else {
+      print('different runtime type: ${this.runtimeType}');
+    }
   }
 
   // TODO(dnfield): Remove the ignore once we bump the minimum Flutter version

--- a/packages/integration_test/lib/integration_test.dart
+++ b/packages/integration_test/lib/integration_test.dart
@@ -75,15 +75,12 @@ class IntegrationTestWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding
     PointerEvent pointerEvent, {
     TestBindingEventSource source = TestBindingEventSource.device,
   }) {
-    Function function = super.handlePointerEvent;
-    // Due to bindings in _binding_io.dart, WidgetBindings can be decendent of
-    // `AutomatedTestWidgetsFlutterBinding` for non-web environments.
-    if (function != null) {
-      // TestBindingEventSource.device uses WidgerTester.dispatchEvent method
-      // vs TestBindingEventSource.test. Test uses RenderBindind.dispatch
-      // event. The former does not deliver the gesture but only compare
-      // matchers.
-      function(pointerEvent,
+    // TestBindingEventSource.device uses WidgerTester.dispatchEvent method
+    // vs TestBindingEventSource.test. Test uses RenderBindind.dispatch
+    // event. The former does not deliver the gesture but only compare
+    // matchers.
+    if (this is LiveTestWidgetsFlutterBinding) {
+      super.handlePointerEvent(pointerEvent,
           source: TestBindingEventSource.test);
     }
   }

--- a/packages/integration_test/lib/integration_test.dart
+++ b/packages/integration_test/lib/integration_test.dart
@@ -70,6 +70,22 @@ class IntegrationTestWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding
     };
   }
 
+  @override
+  void handlePointerEvent(
+    PointerEvent pointerEvent, {
+    TestBindingEventSource source = TestBindingEventSource.device,
+  }) {
+    if (kIsWeb) {
+      // Web driver does not create real device events. Routing web
+      // integration tests' pointer events with source set to `device`,
+      // results in exceptions.
+      super.handlePointerEvent(pointerEvent,
+          source: TestBindingEventSource.test);
+    } else {
+      super.handlePointerEvent(pointerEvent);
+    }
+  }
+
   // TODO(dnfield): Remove the ignore once we bump the minimum Flutter version
   // ignore: override_on_non_overriding_member
   @override

--- a/packages/integration_test/lib/integration_test.dart
+++ b/packages/integration_test/lib/integration_test.dart
@@ -75,15 +75,16 @@ class IntegrationTestWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding
     PointerEvent pointerEvent, {
     TestBindingEventSource source = TestBindingEventSource.device,
   }) {
-    // TestBindingEventSource.device uses WidgerTester.dispatchEvent method
-    // vs TestBindingEventSource.test. Test uses RenderBindind.dispatch
-    // event. The former does not deliver the gesture but only compare
-    // matchers.
-    if (this is LiveTestWidgetsFlutterBinding) {
-      super.handlePointerEvent(pointerEvent,
+    Function function = super.handlePointerEvent;
+    // Due to bindings in _binding_io.dart, WidgetBindings can be decendent of
+    // `AutomatedTestWidgetsFlutterBinding` for non-web environments.
+    if (function != null) {
+      // TestBindingEventSource.device uses WidgerTester.dispatchEvent method
+      // vs TestBindingEventSource.test. Test uses RenderBindind.dispatch
+      // event. The former does not deliver the gesture but only compare
+      // matchers.
+      function(pointerEvent,
           source: TestBindingEventSource.test);
-    } else {
-      print('different runtime type: ${this.runtimeType}');
     }
   }
 

--- a/packages/integration_test/lib/integration_test.dart
+++ b/packages/integration_test/lib/integration_test.dart
@@ -79,10 +79,7 @@ class IntegrationTestWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding
     // vs TestBindingEventSource.test. Test uses RenderBindind.dispatch
     // event. The former does not deliver the gesture but only compare
     // matchers.
-    if (this is LiveTestWidgetsFlutterBinding) {
-      super.handlePointerEvent(pointerEvent,
-          source: TestBindingEventSource.test);
-    }
+    super.handlePointerEvent(pointerEvent, source: TestBindingEventSource.test);
   }
 
   // TODO(dnfield): Remove the ignore once we bump the minimum Flutter version

--- a/packages/integration_test/lib/integration_test.dart
+++ b/packages/integration_test/lib/integration_test.dart
@@ -75,15 +75,12 @@ class IntegrationTestWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding
     PointerEvent pointerEvent, {
     TestBindingEventSource source = TestBindingEventSource.device,
   }) {
-    if (kIsWeb) {
-      // Web driver does not create real device events. Routing web
-      // integration tests' pointer events with source set to `device`,
-      // results in exceptions.
-      super.handlePointerEvent(pointerEvent,
+    // TestBindingEventSource.device uses WidgerTester.dispatchEvent method
+    // vs TestBindingEventSource.test. Test uses RenderBindind.dispatch
+    // event. The former does not deliver the gesture but only compare
+    // matchers.
+    super.handlePointerEvent(pointerEvent,
           source: TestBindingEventSource.test);
-    } else {
-      super.handlePointerEvent(pointerEvent);
-    }
   }
 
   // TODO(dnfield): Remove the ignore once we bump the minimum Flutter version

--- a/packages/integration_test/lib/integration_test.dart
+++ b/packages/integration_test/lib/integration_test.dart
@@ -79,8 +79,7 @@ class IntegrationTestWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding
     // vs TestBindingEventSource.test. Test uses RenderBindind.dispatch
     // event. The former does not deliver the gesture but only compare
     // matchers.
-    super.handlePointerEvent(pointerEvent,
-          source: TestBindingEventSource.test);
+    super.handlePointerEvent(pointerEvent, source: TestBindingEventSource.test);
   }
 
   // TODO(dnfield): Remove the ignore once we bump the minimum Flutter version

--- a/packages/integration_test/lib/integration_test.dart
+++ b/packages/integration_test/lib/integration_test.dart
@@ -79,8 +79,9 @@ class IntegrationTestWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding
     // vs TestBindingEventSource.test. Test uses RenderBindind.dispatch
     // event. The former does not deliver the gesture but only compare
     // matchers.
-    if(this is LiveTestWidgetsFlutterBinding) {
-      super.handlePointerEvent(pointerEvent, source: TestBindingEventSource.test);
+    if (this is LiveTestWidgetsFlutterBinding) {
+      super.handlePointerEvent(pointerEvent,
+          source: TestBindingEventSource.test);
     } else {
       print('different runtime type: ${this.runtimeType}');
     }

--- a/packages/integration_test/pubspec.yaml
+++ b/packages/integration_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: integration_test
 description: Runs tests that use the flutter_test API as integration tests.
-version: 0.9.2+2
+version: 0.9.3
 homepage: https://github.com/flutter/plugins/tree/master/packages/integration_test
 
 environment:


### PR DESCRIPTION
## Description

Web integration tests were failing for MousePointer events. This PR is fixing this by setting `TestBindingEventSource` to `TestBindingEventSource.test` for web integration_tests. 

## Related Issues

Fixes https://github.com/flutter/flutter/issues/68502

## Tests

Tests are added to test the pointer gestures.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
