### PR TITLE
[camera] Added documentation about video not working correctly on Android emulators

### DIFF
--- a/packages/camera/CHANGELOG.md
+++ b/packages/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.8+11
+
+* Added information of video not working correctly on Android emulators to `README.md`.
+
 ## 0.5.8+10
 
 * Suppress the `deprecated_member_use` warning in the example app for `ScaffoldMessenger.showSnackBar`.

--- a/packages/camera/README.md
+++ b/packages/camera/README.md
@@ -41,7 +41,7 @@ Change the minimum Android sdk version to 21 (or higher) in your `android/app/bu
 minSdkVersion 21
 ```
 
-Important to note is that the `MediaRecorder` class is not working properly on emulators, as stated in the documentation: https://developer.android.com/reference/android/media/MediaRecorder. Specifically when recording a video with sound enabled and trying to play it back, the duration won't be correct and you will only see the first frame.
+It's important to note that the `MediaRecorder` class is not working properly on emulators, as stated in the documentation: https://developer.android.com/reference/android/media/MediaRecorder. Specifically, when recording a video with sound enabled and trying to play it back, the duration won't be correct and you will only see the first frame.
 
 ### Handling Lifecycle states
 

--- a/packages/camera/README.md
+++ b/packages/camera/README.md
@@ -41,6 +41,10 @@ Change the minimum Android sdk version to 21 (or higher) in your `android/app/bu
 minSdkVersion 21
 ```
 
+Important to note is that the `MediaRecorder` class is not working properly on emulators. This makes
+that when a video is recorded with sound enabled, the duration won't be correct and you will only
+see the first frame.
+
 ### Example
 
 Here is a small example flutter app displaying a full screen camera preview.

--- a/packages/camera/README.md
+++ b/packages/camera/README.md
@@ -41,9 +41,7 @@ Change the minimum Android sdk version to 21 (or higher) in your `android/app/bu
 minSdkVersion 21
 ```
 
-Important to note is that the `MediaRecorder` class is not working properly on emulators. This makes
-that when a video is recorded with sound enabled, the duration won't be correct and you will only
-see the first frame.
+Important to note is that the `MediaRecorder` class is not working properly on emulators, as stated in the documentation: https://developer.android.com/reference/android/media/MediaRecorder. Specifically when recording a video with sound enabled and try to play it back, the duration won't be correct and you will only see the first frame.
 
 ### Example
 

--- a/packages/camera/README.md
+++ b/packages/camera/README.md
@@ -41,7 +41,7 @@ Change the minimum Android sdk version to 21 (or higher) in your `android/app/bu
 minSdkVersion 21
 ```
 
-Important to note is that the `MediaRecorder` class is not working properly on emulators, as stated in the documentation: https://developer.android.com/reference/android/media/MediaRecorder. Specifically when recording a video with sound enabled and try to play it back, the duration won't be correct and you will only see the first frame.
+Important to note is that the `MediaRecorder` class is not working properly on emulators, as stated in the documentation: https://developer.android.com/reference/android/media/MediaRecorder. Specifically when recording a video with sound enabled and trying to play it back, the duration won't be correct and you will only see the first frame.
 
 ### Handling Lifecycle states
 

--- a/packages/camera/pubspec.yaml
+++ b/packages/camera/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera
 description: A Flutter plugin for getting information about and controlling the
   camera on Android and iOS. Supports previewing the camera feed, capturing images, capturing video,
   and streaming image buffers to dart.
-version: 0.5.8+10
+version: 0.5.8+11
 
 homepage: https://github.com/flutter/plugins/tree/master/packages/camera
 

--- a/packages/camera/pubspec.yaml
+++ b/packages/camera/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera
 description: A Flutter plugin for getting information about and controlling the
   camera on Android and iOS. Supports previewing the camera feed, capturing images, capturing video,
   and streaming image buffers to dart.
-version: 0.5.8+11
+version: 0.5.8+12
 
 homepage: https://github.com/flutter/plugins/tree/master/packages/camera
 


### PR DESCRIPTION
## Description

To make sure no developers try to find out why the a video with audio on an Android emulator isn't working properly, I added it to the README.md.

## Related Issues

[Issue 42309](https://github.com/flutter/flutter/issues/42309#)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
