### PR TITLE
[Camera] Made CameraController.isDisposed publicly accessible. Added unit Tests for the new implementation.

### DIFF
--- a/packages/camera/CHANGELOG.md
+++ b/packages/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.8+15
+
+* Made `CameraController.isDisposed` publicly accessible.
+
 ## 0.5.8+14
 
 * Changed the order of the setters for `mediaRecorder` in `MediaRecorderBuilder.java` to make it more readable.

--- a/packages/camera/CHANGELOG.md
+++ b/packages/camera/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.5.8+15
 
-* Made `CameraController.isDisposed` publicly accessible.
+* Added the `debugCheckIsDisposed` method which can be used in debug mode to validate if the `CameraController` class has been disposed.
 
 ## 0.5.8+14
 

--- a/packages/camera/lib/camera.dart
+++ b/packages/camera/lib/camera.dart
@@ -307,8 +307,12 @@ class CameraController extends ValueNotifier<CameraValue> {
   StreamSubscription<dynamic> _imageStreamSubscription;
   Completer<void> _creatingCompleter;
 
-  /// True after [CameraController.dispose] has completed successfully.
-  bool get isDisposed => _isDisposed;
+  /// Checks whether [CameraController.dispose] has completed successfully.
+  ///
+  /// This is a no-op when asserts are disabled.
+  void debugCheckIsDisposed() {
+    assert(_isDisposed);
+  }
 
   /// Initializes the camera on the device.
   ///

--- a/packages/camera/lib/camera.dart
+++ b/packages/camera/lib/camera.dart
@@ -307,6 +307,9 @@ class CameraController extends ValueNotifier<CameraValue> {
   StreamSubscription<dynamic> _imageStreamSubscription;
   Completer<void> _creatingCompleter;
 
+  /// True after [CameraController.dispose] has completed successfully.
+  bool get isDisposed => _isDisposed;
+
   /// Initializes the camera on the device.
   ///
   /// Throws a [CameraException] if the initialization fails.

--- a/packages/camera/pubspec.yaml
+++ b/packages/camera/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera
 description: A Flutter plugin for getting information about and controlling the
   camera on Android and iOS. Supports previewing the camera feed, capturing images, capturing video,
   and streaming image buffers to dart.
-version: 0.5.8+14
+version: 0.5.8+15
 homepage: https://github.com/flutter/plugins/tree/master/packages/camera
 
 dependencies:

--- a/packages/camera/pubspec.yaml
+++ b/packages/camera/pubspec.yaml
@@ -17,6 +17,7 @@ dev_dependencies:
   flutter_driver:
     sdk: flutter
   pedantic: ^1.8.0
+  mockito: ^4.1.3
 
 flutter:
   plugin:

--- a/packages/camera/pubspec.yaml
+++ b/packages/camera/pubspec.yaml
@@ -17,7 +17,6 @@ dev_dependencies:
   flutter_driver:
     sdk: flutter
   pedantic: ^1.8.0
-  mockito: ^4.1.3
 
 flutter:
   plugin:

--- a/packages/camera/test/camera_test.dart
+++ b/packages/camera/test/camera_test.dart
@@ -6,7 +6,8 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('camera', () {
-    test('debugCheckIsDisposed should not throw assertion error when disposed', () {
+    test('debugCheckIsDisposed should not throw assertion error when disposed',
+        () {
       final MockCameraDescription description = MockCameraDescription();
       final CameraController controller = CameraController(
         description,
@@ -23,8 +24,7 @@ void main() {
       }
     });
 
-    test(
-        'debugCheckIsDisposed should throw assertion error when not disposed',
+    test('debugCheckIsDisposed should throw assertion error when not disposed',
         () {
       final MockCameraDescription description = MockCameraDescription();
       final CameraController controller = CameraController(

--- a/packages/camera/test/camera_test.dart
+++ b/packages/camera/test/camera_test.dart
@@ -6,7 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('camera', () {
-    test("isDisposed true when disposed", () {
+    test('debugCheckIsDisposed should not throw assertion error when disposed', () {
       final MockCameraDescription description = MockCameraDescription();
       final CameraController controller = CameraController(
         description,
@@ -14,17 +14,28 @@ void main() {
       );
 
       controller.dispose();
-      expect(controller.isDisposed, isTrue);
+
+      try {
+        controller.debugCheckIsDisposed();
+      } on AssertionError {
+        fail(
+            'debugCheckIsDisposed should not throw if the camera controller is not disposed.');
+      }
     });
 
-    test("isDisposed false when not disposed", () {
+    test(
+        'debugCheckIsDisposed should throw assertion error when not disposed',
+        () {
       final MockCameraDescription description = MockCameraDescription();
       final CameraController controller = CameraController(
         description,
         ResolutionPreset.low,
       );
 
-      expect(controller.isDisposed, isFalse);
+      expect(
+        () => controller.debugCheckIsDisposed(),
+        throwsAssertionError,
+      );
     });
   });
 }

--- a/packages/camera/test/camera_test.dart
+++ b/packages/camera/test/camera_test.dart
@@ -1,0 +1,38 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+import 'package:camera/camera.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('camera', () {
+    test("isDisposed true when disposed", () {
+      final MockCameraDescription description = MockCameraDescription();
+      final CameraController controller = CameraController(
+        description,
+        ResolutionPreset.low,
+      );
+
+      controller.dispose();
+      expect(controller.isDisposed, isTrue);
+    });
+
+    test("isDisposed false when not disposed", () {
+      final MockCameraDescription description = MockCameraDescription();
+      final CameraController controller = CameraController(
+        description,
+        ResolutionPreset.low,
+      );
+
+      expect(controller.isDisposed, isFalse);
+    });
+  });
+}
+
+class MockCameraDescription extends CameraDescription {
+  @override
+  CameraLensDirection get lensDirection => CameraLensDirection.back;
+
+  @override
+  String get name => 'back';
+}

--- a/packages/camera/test/camera_test.dart
+++ b/packages/camera/test/camera_test.dart
@@ -16,12 +16,10 @@ void main() {
 
       controller.dispose();
 
-      try {
-        controller.debugCheckIsDisposed();
-      } on AssertionError {
-        fail(
-            'debugCheckIsDisposed should not throw if the camera controller is not disposed.');
-      }
+      expect(
+        controller.debugCheckIsDisposed,
+        returnsNormally
+      );
     });
 
     test('debugCheckIsDisposed should throw assertion error when not disposed',

--- a/packages/camera/test/camera_test.dart
+++ b/packages/camera/test/camera_test.dart
@@ -16,10 +16,7 @@ void main() {
 
       controller.dispose();
 
-      expect(
-        controller.debugCheckIsDisposed,
-        returnsNormally
-      );
+      expect(controller.debugCheckIsDisposed, returnsNormally);
     });
 
     test('debugCheckIsDisposed should throw assertion error when not disposed',


### PR DESCRIPTION
## Description

Currently when you call `CameraController.Dispose()` there is no way of knowing whether you disposed that CameraController.
With this PR, the user can check if that CameraController has been disposed, by getting `CameraController.isDisposed`.

Since the current `test/camera_test.dart` file contains test for the `CameraController` class located in the `lib/new/src/camera_controller.dart` I have moved it into the `test/new/camera_test.dart` sub folder. 

I have added a new `test/camera_test.dart` file which contains the unit tests covering the new `isDisposed` property which was added to the `CameraController` class located in the current `lib/camera.dart` implementation.

Additionally I have added unit tests to the `test/new/camera_test.dart` file to ensure the `isDisposed` property (already) implemented in the `CameraController` class located in the `lib/new/src/camera_controller.dart` file is working properly.

## Related Issues

Fixes [flutter/flutter#51630](https://github.com/flutter/flutter/issues/51630)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
