### PR TITLE
Exclude generated_plugin_registrant.cc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ gradle-wrapper.jar
 generated_plugin_registrant.dart
 GeneratedPluginRegistrant.h
 GeneratedPluginRegistrant.m
+generated_plugin_registrant.cc
 GeneratedPluginRegistrant.java
 GeneratedPluginRegistrant.swift
 build/


### PR DESCRIPTION
This should also be updated in the Flutter tool templates