### PR TITLE
[google_maps_flutter] Wrap main widget with a SingleChildScrollView

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/padding.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/padding.dart
@@ -66,10 +66,12 @@ class MarkerIconsBodyState extends State<MarkerIconsBody> {
 
     columnChildren.addAll(<Widget>[_paddingInput(), _buttons()]);
 
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.start,
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: columnChildren,
+    return SingleChildScrollView(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: columnChildren,
+      ),
     );
   }
 


### PR DESCRIPTION
## Description
Avoids the widget overflowing the available screen space when the virtual keyboard is brought up.




