### PR TITLE
[google_maps_flutter] Wrap main widget with a SingleChildScrollView

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/padding.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/padding.dart
@@ -66,10 +66,12 @@ class MarkerIconsBodyState extends State<MarkerIconsBody> {
 
     columnChildren.addAll(<Widget>[_paddingInput(), _buttons()]);
 
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.start,
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: columnChildren,
+    return SingleChildScrollView(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: columnChildren,
+      ),
     );
   }
 


### PR DESCRIPTION
## Description

Avoids the widget overflowing the available screen space when the virtual keyboard is brought up.

## Related Issues

None

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [ x] I read and followed the [Flutter Style Guide].
- [ x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x ] I signed the [CLA].
- [ x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
