### PR TITLE
[wifi_info_flutter] Method channel name fixed for android

### DIFF
--- a/packages/wifi_info_flutter/wifi_info_flutter/CHANGELOG.md
+++ b/packages/wifi_info_flutter/wifi_info_flutter/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.0.1
 
-* Fixed method channel name in android implementation.
+* Fixed method channel name in android implementation. [Issue](https://github.com/flutter/flutter/issues/69073).
 
 ## 1.0.0
 

--- a/packages/wifi_info_flutter/wifi_info_flutter/CHANGELOG.md
+++ b/packages/wifi_info_flutter/wifi_info_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+* Fixed method channel name in android implementation.
+
 ## 1.0.0
 
 * Initial release of the plugin. This plugin retrieves information about a device's connection to wifi.

--- a/packages/wifi_info_flutter/wifi_info_flutter/android/src/main/java/io/flutter/plugins/wifi_info_flutter/WifiInfoFlutterPlugin.java
+++ b/packages/wifi_info_flutter/wifi_info_flutter/android/src/main/java/io/flutter/plugins/wifi_info_flutter/WifiInfoFlutterPlugin.java
@@ -33,7 +33,7 @@ public class WifiInfoFlutterPlugin implements FlutterPlugin {
   }
 
   private void setupChannels(BinaryMessenger messenger, Context context) {
-    methodChannel = new MethodChannel(messenger, "plugins.flutter.io/wifi_flutter_info");
+    methodChannel = new MethodChannel(messenger, "plugins.flutter.io/wifi_info_flutter");
     final WifiManager wifiManager =
         (WifiManager) context.getApplicationContext().getSystemService(Context.WIFI_SERVICE);
 

--- a/packages/wifi_info_flutter/wifi_info_flutter/pubspec.yaml
+++ b/packages/wifi_info_flutter/wifi_info_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: wifi_info_flutter
 description: A new flutter plugin project.
-version: 1.0.0
+version: 1.0.1
 homepage: https://github.com/flutter/plugins/tree/master/packages/wifi_info_flutter/wifi_info_flutter
 
 environment:


### PR DESCRIPTION
## Description

In this PR, I have fixed the method channel in the android implementation of the plugin.

In platform interface it is : `plugins.flutter.io/wifi_info_flutter`
In Android implementation it was : `plugins.flutter.io/wifi_flutter_info`
In Android implementation it is now : `plugins.flutter.io/wifi_info_flutter`

## Related Issues

Fixes https://github.com/flutter/flutter/issues/69073

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
