### PR TITLE
Remove unnecessary work around from test in prep for vm_service migration

### DIFF
--- a/packages/android_alarm_manager/CHANGELOG.md
+++ b/packages/android_alarm_manager/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.5+16
+
+* Remove unnecessary workaround from test.
+
 ## 0.4.5+15
 
 * Update android compileSdkVersion to 29.

--- a/packages/android_alarm_manager/example/test_driver/integration_test.dart
+++ b/packages/android_alarm_manager/example/test_driver/integration_test.dart
@@ -7,39 +7,14 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_driver/flutter_driver.dart';
-import 'package:vm_service_client/vm_service_client.dart';
-
-Future<StreamSubscription<VMIsolateRef>> resumeIsolatesOnPause(
-    FlutterDriver driver) async {
-  final VM vm = await driver.serviceClient.getVM();
-  for (VMIsolateRef isolateRef in vm.isolates) {
-    final VMIsolate isolate = await isolateRef.load();
-    if (isolate.isPaused) {
-      await isolate.resume();
-    }
-  }
-  return driver.serviceClient.onIsolateRunnable
-      .asBroadcastStream()
-      .listen((VMIsolateRef isolateRef) async {
-    final VMIsolate isolate = await isolateRef.load();
-    if (isolate.isPaused) {
-      await isolate.resume();
-    }
-  });
-}
 
 Future<void> main() async {
   final FlutterDriver driver = await FlutterDriver.connect();
-  // flutter drive causes isolates to be paused on spawn. The background isolate
-  // for this plugin will need to be resumed for the test to pass.
-  final StreamSubscription<VMIsolateRef> subscription =
-      await resumeIsolatesOnPause(driver);
   final String data = await driver.requestData(
     null,
     timeout: const Duration(minutes: 1),
   );
   await driver.close();
-  await subscription.cancel();
   final Map<String, dynamic> result = jsonDecode(data);
   exit(result['result'] == 'true' ? 0 : 1);
 }

--- a/packages/android_alarm_manager/pubspec.yaml
+++ b/packages/android_alarm_manager/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for accessing the Android AlarmManager service, and
 # 0.4.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.4.5+15
+version: 0.4.5+16
 homepage: https://github.com/flutter/plugins/tree/master/packages/android_alarm_manager
 
 dependencies:


### PR DESCRIPTION
This workaround is no longer necessary after https://github.com/flutter/flutter/pull/65703