### PR TITLE
[google_maps_flutter_web] show only single info window 

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0+5
+
+* Show only single info window
+
 ## 0.1.0+4
 
 * Update `package:sanitize_html` to `^1.4.1` to prevent [a crash](https://github.com/flutter/flutter/issues/67854) when InfoWindow title/snippet have links.

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/markers.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/markers.dart
@@ -97,12 +97,15 @@ class MarkersController extends GeometryController {
 
   // InfoWindow...
 
+  MarkerController _markerController;
+
   /// Shows the [InfoWindow] of a [MarkerId].
   ///
   /// See also [hideMarkerInfoWindow] and [isInfoWindowShown].
   void showMarkerInfoWindow(MarkerId markerId) {
-    MarkerController markerController = _markerIdToController[markerId];
-    markerController?.showInfoWindow();
+    _markerController?.hideInfoWindow();
+    _markerController = _markerIdToController[markerId];
+    _markerController?.showInfoWindow();
   }
 
   /// Hides the [InfoWindow] of a [MarkerId].

--- a/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: google_maps_flutter_web
 description: Web platform implementation of google_maps_flutter
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter
-version: 0.1.0+4
+version: 0.1.0+5
 
 flutter:
   plugin:

--- a/packages/google_maps_flutter/google_maps_flutter_web/test/test_driver/markers_integration.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/test/test_driver/markers_integration.dart
@@ -99,6 +99,34 @@ void main() {
       expect(controller.markers[MarkerId('1')].infoWindowShown, isFalse);
     });
 
+    testWidgets('only single InfoWindow is visible',
+        (WidgetTester tester) async {
+      final markers = {
+        Marker(
+          markerId: MarkerId('1'),
+          infoWindow: InfoWindow(title: "Title", snippet: "Snippet"),
+        ),
+        Marker(
+          markerId: MarkerId('2'),
+          infoWindow: InfoWindow(title: "Title", snippet: "Snippet"),
+        ),
+      };
+      controller.addMarkers(markers);
+
+      expect(controller.markers[MarkerId('1')].infoWindowShown, isFalse);
+
+      controller.showMarkerInfoWindow(MarkerId('1'));
+
+      expect(controller.markers[MarkerId('1')].infoWindowShown, isTrue);
+
+      controller.showMarkerInfoWindow(MarkerId('2'));
+
+      expect(controller.markers[MarkerId('2')].infoWindowShown, isTrue);
+
+      expect(controller.markers[MarkerId('1')].infoWindowShown, isFalse);
+
+    });
+
     // https://github.com/flutter/flutter/issues/64938
     testWidgets('markers with icon:null work', (WidgetTester tester) async {
       final markers = {

--- a/packages/google_maps_flutter/google_maps_flutter_web/test/test_driver/markers_integration.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/test/test_driver/markers_integration.dart
@@ -124,7 +124,6 @@ void main() {
       expect(controller.markers[MarkerId('2')].infoWindowShown, isTrue);
 
       expect(controller.markers[MarkerId('1')].infoWindowShown, isFalse);
-
     });
 
     // https://github.com/flutter/flutter/issues/64938


### PR DESCRIPTION
## Description

Currently google_maps_flutter_web shows multiple info window . This pr will make it only show single info window.

## Related Issues

https://github.com/flutter/flutter/issues/67380

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
