### PR TITLE
[google_maps_flutter_web] show only single infoWindow

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.1.0+6
 
-* Show only single infoWindow
+* Ensure a single `InfoWindow` is shown at a time. [Issue](https://github.com/flutter/flutter/issues/67380).
 
 ## 0.1.0+5
 

--- a/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0+6
+
+* Show only single infoWindow
+
 ## 0.1.0+5
 
 * Update `package:google_maps` to `^3.4.5`.

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/markers.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/markers.dart
@@ -100,13 +100,15 @@ class MarkersController extends GeometryController {
   }
 
   // InfoWindow...
+  MarkerController _markerController;
 
   /// Shows the [InfoWindow] of a [MarkerId].
   ///
   /// See also [hideMarkerInfoWindow] and [isInfoWindowShown].
   void showMarkerInfoWindow(MarkerId markerId) {
-    MarkerController markerController = _markerIdToController[markerId];
-    markerController?.showInfoWindow();
+    _markerController?.hideInfoWindow();
+    _markerController = _markerIdToController[markerId];
+    _markerController?.showInfoWindow();
   }
 
   /// Hides the [InfoWindow] of a [MarkerId].

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/markers.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/markers.dart
@@ -100,7 +100,6 @@ class MarkersController extends GeometryController {
   }
 
   // InfoWindow...
-  MarkerController _markerController;
 
   /// Shows the [InfoWindow] of a [MarkerId].
   ///

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/markers.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/markers.dart
@@ -150,7 +150,8 @@ class MarkersController extends GeometryController {
 
   void _hideAllMarkerInfoWindow() {
     _markerIdToController.values
-        .where((controller) => controller == null ? false : controller.infoWindowShown)
+        .where((controller) =>
+            controller == null ? false : controller.infoWindowShown)
         .forEach((controller) => controller.hideInfoWindow());
   }
 }

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/markers.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/markers.dart
@@ -106,9 +106,9 @@ class MarkersController extends GeometryController {
   ///
   /// See also [hideMarkerInfoWindow] and [isInfoWindowShown].
   void showMarkerInfoWindow(MarkerId markerId) {
-    _markerController?.hideInfoWindow();
-    _markerController = _markerIdToController[markerId];
-    _markerController?.showInfoWindow();
+    _hideAllMarkerInfoWindow();
+    MarkerController markerController = _markerIdToController[markerId];
+    markerController?.showInfoWindow();
   }
 
   /// Hides the [InfoWindow] of a [MarkerId].
@@ -146,5 +146,11 @@ class MarkersController extends GeometryController {
       _gmLatLngToLatLng(latLng),
       markerId,
     ));
+  }
+
+  void _hideAllMarkerInfoWindow() {
+    _markerIdToController.values
+        .where((controller) => controller?.infoWindowShown)
+        .forEach((controller) => controller.hideInfoWindow());
   }
 }

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/markers.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/markers.dart
@@ -150,7 +150,7 @@ class MarkersController extends GeometryController {
 
   void _hideAllMarkerInfoWindow() {
     _markerIdToController.values
-        .where((controller) => controller?.infoWindowShown)
+        .where((controller) => controller == null ? false : controller.infoWindowShown)
         .forEach((controller) => controller.hideInfoWindow());
   }
 }

--- a/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: google_maps_flutter_web
 description: Web platform implementation of google_maps_flutter
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter
-version: 0.1.0+5
+version: 0.1.0+6
 
 flutter:
   plugin:

--- a/packages/google_maps_flutter/google_maps_flutter_web/test/test_driver/markers_integration.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/test/test_driver/markers_integration.dart
@@ -100,6 +100,7 @@ void main() {
       expect(controller.markers[MarkerId('1')].infoWindowShown, isFalse);
     });
 
+    // https://github.com/flutter/flutter/issues/67380
     testWidgets('only single InfoWindow is visible',
         (WidgetTester tester) async {
       final markers = {
@@ -115,16 +116,17 @@ void main() {
       controller.addMarkers(markers);
 
       expect(controller.markers[MarkerId('1')].infoWindowShown, isFalse);
+      expect(controller.markers[MarkerId('2')].infoWindowShown, isFalse);
 
       controller.showMarkerInfoWindow(MarkerId('1'));
 
       expect(controller.markers[MarkerId('1')].infoWindowShown, isTrue);
+      expect(controller.markers[MarkerId('2')].infoWindowShown, isFalse);
 
       controller.showMarkerInfoWindow(MarkerId('2'));
 
-      expect(controller.markers[MarkerId('2')].infoWindowShown, isTrue);
-
       expect(controller.markers[MarkerId('1')].infoWindowShown, isFalse);
+      expect(controller.markers[MarkerId('2')].infoWindowShown, isTrue);
     });
 
     // https://github.com/flutter/flutter/issues/64938

--- a/packages/google_maps_flutter/google_maps_flutter_web/test/test_driver/markers_integration.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/test/test_driver/markers_integration.dart
@@ -100,6 +100,33 @@ void main() {
       expect(controller.markers[MarkerId('1')].infoWindowShown, isFalse);
     });
 
+    testWidgets('only single InfoWindow is visible',
+        (WidgetTester tester) async {
+      final markers = {
+        Marker(
+          markerId: MarkerId('1'),
+          infoWindow: InfoWindow(title: "Title", snippet: "Snippet"),
+        ),
+        Marker(
+          markerId: MarkerId('2'),
+          infoWindow: InfoWindow(title: "Title", snippet: "Snippet"),
+        ),
+      };
+      controller.addMarkers(markers);
+
+      expect(controller.markers[MarkerId('1')].infoWindowShown, isFalse);
+
+      controller.showMarkerInfoWindow(MarkerId('1'));
+
+      expect(controller.markers[MarkerId('1')].infoWindowShown, isTrue);
+
+      controller.showMarkerInfoWindow(MarkerId('2'));
+
+      expect(controller.markers[MarkerId('2')].infoWindowShown, isTrue);
+
+      expect(controller.markers[MarkerId('1')].infoWindowShown, isFalse);
+    });
+
     // https://github.com/flutter/flutter/issues/64938
     testWidgets('markers with icon:null work', (WidgetTester tester) async {
       final markers = {


### PR DESCRIPTION
## Description

Currently google_maps_flutter_web shows multiple infoWindow . This PR will make it show only single infoWindow.


## Related Issues

Fixes flutter/flutter#67380

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
