### PR TITLE
wifi_info_flutter - fix documentation (class name)

### DIFF
--- a/packages/wifi_info_flutter/wifi_info_flutter/README.md
+++ b/packages/wifi_info_flutter/wifi_info_flutter/README.md
@@ -24,9 +24,9 @@ You can get wi-fi related information using:
 ```dart
 import 'package:wifi_info_flutter/wifi_info_flutter.dart';
 
-var wifiBSSID = await WifiFlutter().getWifiBSSID();
-var wifiIP = await WifiFlutter().getWifiIP();
-var wifiName = await WifiFlutter().getWifiName();
+var wifiBSSID = await WifiInfo().getWifiBSSID();
+var wifiIP = await WifiInfo().getWifiIP();
+var wifiName = await WifiInfo().getWifiName();
 ```
 
 ### iOS 12


### PR DESCRIPTION
## Description

The documentation (readme) of the wifi_info_flutter is incorrect, the class name is `WifiInfo()` and not `WifiFlutter()`

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/