### PR TITLE
[in_app_purchase] Bump version

### DIFF
--- a/packages/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.4+16
+
+* Add Dartdocs to all public APIs.
+
 ## 0.3.4+15
 
 * Update android compileSdkVersion to 29.

--- a/packages/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/pubspec.yaml
@@ -1,7 +1,7 @@
 name: in_app_purchase
 description: A Flutter plugin for in-app purchases. Exposes APIs for making in-app purchases through the App Store and Google Play.
 homepage: https://github.com/flutter/plugins/tree/master/packages/in_app_purchase
-version: 0.3.4+15
+version: 0.3.4+16
 
 dependencies:
   async: ^2.0.8


### PR DESCRIPTION
Follow-up for https://github.com/flutter/plugins/pull/3220 (forgot to bump in that PR).