### PR TITLE
Opt out of null safety

### DIFF
--- a/packages/connectivity/connectivity/CHANGELOG.md
+++ b/packages/connectivity/connectivity/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+* Opt out of null safety.
+
 ## 2.0.0
 
 * [Breaking Change] The `getWifiName`, `getWifiBSSID` and `getWifiIP` are removed to [wifi_info_flutter](https://github.com/flutter/plugins/tree/master/packages/wifi_info_flutter)

--- a/packages/connectivity/connectivity/lib/connectivity.dart
+++ b/packages/connectivity/connectivity/lib/connectivity.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.9
+
 import 'dart:async';
 
 import 'package:connectivity_platform_interface/connectivity_platform_interface.dart';

--- a/packages/connectivity/connectivity/pubspec.yaml
+++ b/packages/connectivity/connectivity/pubspec.yaml
@@ -2,7 +2,7 @@ name: connectivity
 description: Flutter plugin for discovering the state of the network (WiFi &
   mobile/cellular) connectivity on Android and iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/connectivity/connectivity
-version: 2.0.0
+version: 2.0.1
 
 flutter:
   plugin:

--- a/packages/connectivity/connectivity_platform_interface/CHANGELOG.md
+++ b/packages/connectivity/connectivity_platform_interface/CHANGELOG.md
@@ -1,10 +1,14 @@
+## 1.0.7
+
+* Opt out of null safety.
+
 ## 1.0.6
 
 * Update lower bound of dart dependency to 2.1.0.
 
 ## 1.0.5
 
-* Remove dart:io Platform checks from the MethodChannel implementation. This is 
+* Remove dart:io Platform checks from the MethodChannel implementation. This is
 tripping the analysis of other versions of the plugin.
 
 ## 1.0.4

--- a/packages/connectivity/connectivity_platform_interface/lib/connectivity_platform_interface.dart
+++ b/packages/connectivity/connectivity_platform_interface/lib/connectivity_platform_interface.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.9
+
 import 'dart:async';
 
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';

--- a/packages/connectivity/connectivity_platform_interface/pubspec.yaml
+++ b/packages/connectivity/connectivity_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the connectivity plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/connectivity/connectivity_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.0.6
+version: 1.0.7
 
 dependencies:
   flutter:

--- a/packages/device_info/device_info/CHANGELOG.md
+++ b/packages/device_info/device_info/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.2+10
+
+* Opt out of null safety.
+
 ## 0.4.2+9
 
 * Update android compileSdkVersion to 29.

--- a/packages/device_info/device_info/lib/device_info.dart
+++ b/packages/device_info/device_info/lib/device_info.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.9
+
 import 'dart:async';
 import 'package:device_info_platform_interface/device_info_platform_interface.dart';
 

--- a/packages/device_info/device_info/pubspec.yaml
+++ b/packages/device_info/device_info/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/flutter/plugins/tree/master/packages/device_info
 # 0.4.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.4.2+9
+version: 0.4.2+10
 
 flutter:
   plugin:

--- a/packages/device_info/device_info_platform_interface/CHANGELOG.md
+++ b/packages/device_info/device_info_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2
+
+- Opt out of null safety.
+
 ## 1.0.1
 
 - Documentation typo fixed.

--- a/packages/device_info/device_info_platform_interface/lib/device_info_platform_interface.dart
+++ b/packages/device_info/device_info_platform_interface/lib/device_info_platform_interface.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.9
+
 import 'dart:async';
 
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';

--- a/packages/device_info/device_info_platform_interface/pubspec.yaml
+++ b/packages/device_info/device_info_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the device_info plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/device_info
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.0.1
+version: 1.0.2
 
 dependencies:
   flutter:

--- a/packages/plugin_platform_interface/CHANGELOG.md
+++ b/packages/plugin_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.4
+
+* Opt out of null safety.
+
 ## 1.0.3
 
 * Fix homepage in `pubspec.yaml`.

--- a/packages/plugin_platform_interface/lib/plugin_platform_interface.dart
+++ b/packages/plugin_platform_interface/lib/plugin_platform_interface.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.9
+
 library plugin_platform_interface;
 
 import 'package:meta/meta.dart';

--- a/packages/plugin_platform_interface/pubspec.yaml
+++ b/packages/plugin_platform_interface/pubspec.yaml
@@ -12,7 +12,7 @@ description: Reusable base class for Flutter plugin platform interfaces.
 # be done when absolutely necessary and after the ecosystem has already migrated to 1.X.Y version
 # that is forward compatible with 2.0.0 (ideally the ecosystem have migrated to depend on:
 # `plugin_platform_interface: >=1.X.Y <3.0.0`).
-version: 1.0.3
+version: 1.0.4
 
 repository: https://github.com/flutter/plugins/tree/master/packages/plugin_platform_interface
 

--- a/packages/url_launcher/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.7.10
+
+* Opt out of null safety.
+
 ## 5.7.9
 
 * Check in windows/ directory for example/

--- a/packages/url_launcher/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/url_launcher/lib/url_launcher.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.9
+
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';

--- a/packages/url_launcher/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher
 description: Flutter plugin for launching a URL on Android and iOS. Supports
   web, phone, SMS, and email schemes.
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher
-version: 5.7.9
+version: 5.7.10
 
 flutter:
   plugin:

--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.11.1+5
+
+* Opt out of null safety.
+
 ## 0.11.1+4
 
 * Add `toString()` to `Caption`.

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.9
+
 import 'dart:async';
 import 'dart:io';
 

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for displaying inline video with other Flutter
 # 0.10.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.11.1+4
+version: 0.11.1+5
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player
 
 flutter:

--- a/packages/video_player/video_player_platform_interface/CHANGELOG.md
+++ b/packages/video_player/video_player_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.1
+
+* Opt out of null safety.
+
 ## 2.2.0
 
 * Added option to set the video playback speed on the video controller.

--- a/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
+++ b/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.9
+
 import 'dart:async';
 import 'dart:ui';
 

--- a/packages/video_player/video_player_platform_interface/pubspec.yaml
+++ b/packages/video_player/video_player_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the video_player plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.2.0
+version: 2.2.1
 
 dependencies:
   flutter:

--- a/packages/video_player/video_player_web/CHANGELOG.md
+++ b/packages/video_player/video_player_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.5
+
+* Out out of null safety.
+
 ## 0.1.4
 
 * Added option to set the video playback speed on the video controller.

--- a/packages/video_player/video_player_web/lib/video_player_web.dart
+++ b/packages/video_player/video_player_web/lib/video_player_web.dart
@@ -1,3 +1,9 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.9
+
 import 'dart:async';
 import 'dart:html';
 import 'dart:ui' as ui;

--- a/packages/video_player/video_player_web/pubspec.yaml
+++ b/packages/video_player/video_player_web/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/flutter/plugins/tree/master/packages/video_player/v
 # 0.1.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.1.4
+version: 0.1.5
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

These packages have null safety enabled by default.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
