### PR TITLE
[video_player] Android: Dispose video players when app is closed

### DIFF
--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.11.1+6
+
+* Android: Dispose video players when app is closed.
+
 ## 0.11.1+5
 
 * Update Dart SDK constraint in example.

--- a/packages/video_player/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -92,6 +92,7 @@ public class VideoPlayerPlugin implements FlutterPlugin, VideoPlayerApi {
     }
     flutterState.stopListening(binding.getBinaryMessenger());
     flutterState = null;
+    disposeAllPlayers();
   }
 
   private void disposeAllPlayers() {

--- a/packages/video_player/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -6,9 +6,9 @@ package io.flutter.plugins.videoplayer;
 
 import android.content.Context;
 import android.os.Build;
-import android.util.Log;
 import android.util.LongSparseArray;
 import io.flutter.FlutterInjector;
+import io.flutter.Log;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.EventChannel;
@@ -92,7 +92,7 @@ public class VideoPlayerPlugin implements FlutterPlugin, VideoPlayerApi {
     }
     flutterState.stopListening(binding.getBinaryMessenger());
     flutterState = null;
-    disposeAllPlayers();
+    initialize();
   }
 
   private void disposeAllPlayers() {

--- a/packages/video_player/video_player/example/android/app/build.gradle
+++ b/packages/video_player/video_player/example/android/app/build.gradle
@@ -64,4 +64,6 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
+    testImplementation 'org.robolectric:robolectric:3.8'
+    testImplementation 'org.mockito:mockito-core:3.5.13'
 }

--- a/packages/video_player/video_player/example/android/app/src/test/java/io/flutter/plugins/videoplayerexample/FlutterActivityTest.java
+++ b/packages/video_player/video_player/example/android/app/src/test/java/io/flutter/plugins/videoplayerexample/FlutterActivityTest.java
@@ -1,0 +1,47 @@
+package io.flutter.plugins.videoplayerexample;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+import io.flutter.embedding.engine.FlutterEngine;
+import io.flutter.embedding.engine.FlutterEngineCache;
+import io.flutter.embedding.engine.FlutterJNI;
+import io.flutter.embedding.engine.loader.FlutterLoader;
+import io.flutter.embedding.engine.plugins.FlutterPlugin;
+import io.flutter.plugins.videoplayer.VideoPlayerPlugin;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class FlutterActivityTest {
+
+    @Test
+    public void disposeAllPlayers() {
+      VideoPlayerPlugin videoPlayerPlugin = spy(new VideoPlayerPlugin());
+      FlutterLoader flutterLoader = mock(FlutterLoader.class);
+      FlutterJNI flutterJNI = mock(FlutterJNI.class);
+      ArgumentCaptor<FlutterPlugin.FlutterPluginBinding> pluginBindingCaptor =
+          ArgumentCaptor.forClass(FlutterPlugin.FlutterPluginBinding.class);
+
+      when(flutterJNI.isAttached()).thenReturn(true);
+      FlutterEngine engine =
+          spy(new FlutterEngine(RuntimeEnvironment.application, flutterLoader, flutterJNI));
+      FlutterEngineCache.getInstance().put("my_flutter_engine", engine);
+
+      engine.getPlugins().add(videoPlayerPlugin);
+      verify(videoPlayerPlugin, times(1))
+          .onAttachedToEngine(pluginBindingCaptor.capture());
+
+      engine.destroy();
+      verify(videoPlayerPlugin, times(1))
+          .onDetachedFromEngine(pluginBindingCaptor.capture());
+      verify(videoPlayerPlugin, times(1)).initialize();
+    }
+}

--- a/packages/video_player/video_player/example/android/app/src/test/java/io/flutter/plugins/videoplayerexample/FlutterActivityTest.java
+++ b/packages/video_player/video_player/example/android/app/src/test/java/io/flutter/plugins/videoplayerexample/FlutterActivityTest.java
@@ -1,47 +1,48 @@
 package io.flutter.plugins.videoplayerexample;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
-import org.robolectric.annotation.Config;
-import io.flutter.embedding.engine.FlutterEngine;
-import io.flutter.embedding.engine.FlutterEngineCache;
-import io.flutter.embedding.engine.FlutterJNI;
-import io.flutter.embedding.engine.loader.FlutterLoader;
-import io.flutter.embedding.engine.plugins.FlutterPlugin;
-import io.flutter.plugins.videoplayer.VideoPlayerPlugin;
+
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.flutter.embedding.engine.FlutterEngine;
+import io.flutter.embedding.engine.FlutterEngineCache;
+import io.flutter.embedding.engine.FlutterJNI;
+import io.flutter.embedding.engine.loader.FlutterLoader;
+import io.flutter.embedding.engine.plugins.FlutterPlugin;
+import io.flutter.plugins.videoplayer.VideoPlayerPlugin;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE)
 public class FlutterActivityTest {
 
-    @Test
-    public void disposeAllPlayers() {
-      VideoPlayerPlugin videoPlayerPlugin = spy(new VideoPlayerPlugin());
-      FlutterLoader flutterLoader = mock(FlutterLoader.class);
-      FlutterJNI flutterJNI = mock(FlutterJNI.class);
-      ArgumentCaptor<FlutterPlugin.FlutterPluginBinding> pluginBindingCaptor =
-          ArgumentCaptor.forClass(FlutterPlugin.FlutterPluginBinding.class);
+  @Test
+  public void disposeAllPlayers() {
+    VideoPlayerPlugin videoPlayerPlugin = spy(new VideoPlayerPlugin());
+    FlutterLoader flutterLoader = mock(FlutterLoader.class);
+    FlutterJNI flutterJNI = mock(FlutterJNI.class);
+    ArgumentCaptor<FlutterPlugin.FlutterPluginBinding> pluginBindingCaptor =
+        ArgumentCaptor.forClass(FlutterPlugin.FlutterPluginBinding.class);
 
-      when(flutterJNI.isAttached()).thenReturn(true);
-      FlutterEngine engine =
-          spy(new FlutterEngine(RuntimeEnvironment.application, flutterLoader, flutterJNI));
-      FlutterEngineCache.getInstance().put("my_flutter_engine", engine);
+    when(flutterJNI.isAttached()).thenReturn(true);
+    FlutterEngine engine =
+        spy(new FlutterEngine(RuntimeEnvironment.application, flutterLoader, flutterJNI));
+    FlutterEngineCache.getInstance().put("my_flutter_engine", engine);
 
-      engine.getPlugins().add(videoPlayerPlugin);
-      verify(videoPlayerPlugin, times(1))
-          .onAttachedToEngine(pluginBindingCaptor.capture());
+    engine.getPlugins().add(videoPlayerPlugin);
+    verify(videoPlayerPlugin, times(1))
+        .onAttachedToEngine(pluginBindingCaptor.capture());
 
-      engine.destroy();
-      verify(videoPlayerPlugin, times(1))
-          .onDetachedFromEngine(pluginBindingCaptor.capture());
-      verify(videoPlayerPlugin, times(1)).initialize();
-    }
+    engine.destroy();
+    verify(videoPlayerPlugin, times(1))
+        .onDetachedFromEngine(pluginBindingCaptor.capture());
+    verify(videoPlayerPlugin, times(1)).initialize();
+  }
 }

--- a/packages/video_player/video_player/example/android/app/src/test/java/io/flutter/plugins/videoplayerexample/FlutterActivityTest.java
+++ b/packages/video_player/video_player/example/android/app/src/test/java/io/flutter/plugins/videoplayerexample/FlutterActivityTest.java
@@ -1,6 +1,5 @@
 package io.flutter.plugins.videoplayerexample;
 
-
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -19,6 +18,7 @@ import org.mockito.ArgumentCaptor;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
+
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE)
 public class FlutterActivityTest {
@@ -37,12 +37,10 @@ public class FlutterActivityTest {
     FlutterEngineCache.getInstance().put("my_flutter_engine", engine);
 
     engine.getPlugins().add(videoPlayerPlugin);
-    verify(videoPlayerPlugin, times(1))
-        .onAttachedToEngine(pluginBindingCaptor.capture());
+    verify(videoPlayerPlugin, times(1)).onAttachedToEngine(pluginBindingCaptor.capture());
 
     engine.destroy();
-    verify(videoPlayerPlugin, times(1))
-        .onDetachedFromEngine(pluginBindingCaptor.capture());
+    verify(videoPlayerPlugin, times(1)).onDetachedFromEngine(pluginBindingCaptor.capture());
     verify(videoPlayerPlugin, times(1)).initialize();
   }
 }

--- a/packages/video_player/video_player/example/integration_test/video_player_test.dart
+++ b/packages/video_player/video_player/example/integration_test/video_player_test.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:video_player/video_player.dart';
@@ -106,25 +105,5 @@ void main() {
       await tester.pumpAndSettle();
       expect(_controller.value.isPlaying, true);
     });
-  });
-
-  group('android', () {
-    setUp(() {
-      _controller = VideoPlayerController.asset('assets/Butterfly-209.mp4');
-    });
-
-    testWidgets(
-      'can be played',
-          (WidgetTester tester) async {
-        await _controller.initialize();
-
-        await _controller.play();
-        await tester.pumpAndSettle(Duration(seconds: 3));
-
-        expect(_controller.value.isPlaying, true);
-
-        await SystemNavigator.pop(animated: false);
-      },
-    );
   });
 }

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for displaying inline video with other Flutter
 # 0.10.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.11.1+5
+version: 0.11.1+6
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player
 
 flutter:


### PR DESCRIPTION
## Description

- Android: Dispose video players when app is closed.

## Related Issues

https://github.com/flutter/flutter/issues/69605

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
