### PR TITLE
[file_selector] Allow empty type groups

### DIFF
--- a/packages/file_selector/file_selector_platform_interface/CHANGELOG.md
+++ b/packages/file_selector/file_selector_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+* Allow type groups that allow any file.
+
 ## 1.0.0
 
 * Initial release.

--- a/packages/file_selector/file_selector_platform_interface/lib/src/types/x_type_group/x_type_group.dart
+++ b/packages/file_selector/file_selector_platform_interface/lib/src/types/x_type_group/x_type_group.dart
@@ -5,18 +5,16 @@
 /// A set of allowed XTypes
 class XTypeGroup {
   /// Creates a new group with the given label and file extensions.
+  ///
+  /// A group with none of the type options provided indicates that any type is
+  /// allowed.
   XTypeGroup({
     this.label,
     this.extensions,
     this.mimeTypes,
     this.macUTIs,
     this.webWildCards,
-  }) : assert(
-            !((extensions == null || extensions.isEmpty) &&
-                (mimeTypes == null || mimeTypes.isEmpty) &&
-                (macUTIs == null || macUTIs.isEmpty) &&
-                (webWildCards == null || webWildCards.isEmpty)),
-            "At least one type must be provided for an XTypeGroup.");
+  });
 
   /// The 'name' or reference to this group of types
   final String label;

--- a/packages/file_selector/file_selector_platform_interface/pubspec.yaml
+++ b/packages/file_selector/file_selector_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the file_selector plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/file_selector/file_selector_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.0.0
+version: 1.0.1
 
 dependencies:
   flutter:

--- a/packages/file_selector/file_selector_platform_interface/test/x_type_group_test.dart
+++ b/packages/file_selector/file_selector_platform_interface/test/x_type_group_test.dart
@@ -7,10 +7,6 @@ import 'package:file_selector_platform_interface/file_selector_platform_interfac
 
 void main() {
   group('XTypeGroup', () {
-    test('fails assertion with no parameters set', () {
-      expect(() => XTypeGroup(), throwsAssertionError);
-    });
-
     test('toJSON() creates correct map', () {
       final label = 'test group';
       final extensions = ['.txt', '.jpg'];
@@ -32,6 +28,18 @@ void main() {
       expect(jsonMap['mimeTypes'], mimeTypes);
       expect(jsonMap['macUTIs'], macUTIs);
       expect(jsonMap['webWildCards'], webWildCards);
+    });
+
+    test('A wildcard group can be created', () {
+      final group = XTypeGroup(
+        label: 'Any',
+      );
+
+      final jsonMap = group.toJSON();
+      expect(jsonMap['extensions'], null);
+      expect(jsonMap['mimeTypes'], null);
+      expect(jsonMap['macUTIs'], null);
+      expect(jsonMap['webWildCards'], null);
     });
   });
 }


### PR DESCRIPTION
## Description

This was restricted under the assumption that there was no reason for an
empty group to exist, but that's not actually true; on platforms with
selectable groups in the native UI, it may be useful to provide
specific options as well as a fallback option (e.g., "Text files" and
"All files").

## Related Issues

None

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
