### PR TITLE
[device_info_platform_interface] Remove default types and correct nullable types

### DIFF
--- a/packages/device_info/device_info_platform_interface/CHANGELOG.md
+++ b/packages/device_info/device_info_platform_interface/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.0-nullsafety.2
+
+* Make `baseOS`, `previewSdkInt`, and `securityPatch` nullable types.
+* Remove default values for non-nullable types.
+
 ## 2.0.0-nullsafety.1
 
 * Bump Dart SDK to support null safety.

--- a/packages/device_info/device_info_platform_interface/lib/model/android_device_info.dart
+++ b/packages/device_info/device_info_platform_interface/lib/model/android_device_info.dart
@@ -114,27 +114,27 @@ class AndroidDeviceInfo {
   static AndroidDeviceInfo fromMap(Map<String, dynamic> map) {
     return AndroidDeviceInfo(
       version: AndroidBuildVersion._fromMap(
-          map['version']?.cast<String, dynamic>() ?? {}),
-      board: map['board'] ?? '',
-      bootloader: map['bootloader'] ?? '',
-      brand: map['brand'] ?? '',
-      device: map['device'] ?? '',
-      display: map['display'] ?? '',
-      fingerprint: map['fingerprint'] ?? '',
-      hardware: map['hardware'] ?? '',
-      host: map['host'] ?? '',
-      id: map['id'] ?? '',
-      manufacturer: map['manufacturer'] ?? '',
-      model: map['model'] ?? '',
-      product: map['product'] ?? '',
-      supported32BitAbis: _fromList(map['supported32BitAbis'] ?? []),
-      supported64BitAbis: _fromList(map['supported64BitAbis'] ?? []),
-      supportedAbis: _fromList(map['supportedAbis'] ?? []),
-      tags: map['tags'] ?? '',
-      type: map['type'] ?? '',
-      isPhysicalDevice: map['isPhysicalDevice'] ?? false,
-      androidId: map['androidId'] ?? '',
-      systemFeatures: _fromList(map['systemFeatures'] ?? []),
+          map['version']!.cast<String, dynamic>()),
+      board: map['board']!,
+      bootloader: map['bootloader']!,
+      brand: map['brand']!,
+      device: map['device']!,
+      display: map['display']!,
+      fingerprint: map['fingerprint']!,
+      hardware: map['hardware']!,
+      host: map['host']!,
+      id: map['id']!,
+      manufacturer: map['manufacturer']!,
+      model: map['model']!,
+      product: map['product']!,
+      supported32BitAbis: _fromList(map['supported32BitAbis']!),
+      supported64BitAbis: _fromList(map['supported64BitAbis']!),
+      supportedAbis: _fromList(map['supportedAbis']!),
+      tags: map['tags']!,
+      type: map['type']!,
+      isPhysicalDevice: map['isPhysicalDevice']!,
+      androidId: map['androidId']!,
+      systemFeatures: _fromList(map['systemFeatures']!),
     );
   }
 
@@ -151,26 +151,29 @@ class AndroidDeviceInfo {
 /// See: https://developer.android.com/reference/android/os/Build.VERSION.html
 class AndroidBuildVersion {
   AndroidBuildVersion._({
-    required this.baseOS,
+    this.baseOS,
+    this.previewSdkInt,
+    this.securityPatch,
     required this.codename,
     required this.incremental,
-    required this.previewSdkInt,
     required this.release,
     required this.sdkInt,
-    required this.securityPatch,
   });
 
   /// The base OS build the product is based on.
-  final String baseOS;
+  String? baseOS;
+
+  /// The developer preview revision of a prerelease SDK.
+  int? previewSdkInt;
+
+  /// The user-visible security patch level.
+  final String? securityPatch;
 
   /// The current development codename, or the string "REL" if this is a release build.
   final String codename;
 
   /// The internal value used by the underlying source control to represent this build.
   final String incremental;
-
-  /// The developer preview revision of a prerelease SDK.
-  final int previewSdkInt;
 
   /// The user-visible version string.
   final String release;
@@ -180,19 +183,16 @@ class AndroidBuildVersion {
   /// Possible values are defined in: https://developer.android.com/reference/android/os/Build.VERSION_CODES.html
   final int sdkInt;
 
-  /// The user-visible security patch level.
-  final String securityPatch;
-
   /// Deserializes from the map message received from [_kChannel].
   static AndroidBuildVersion _fromMap(Map<String, dynamic> map) {
     return AndroidBuildVersion._(
-      baseOS: map['baseOS'] ?? '',
-      codename: map['codename'] ?? '',
-      incremental: map['incremental'] ?? '',
-      previewSdkInt: map['previewSdkInt'] ?? 0,
-      release: map['release'] ?? '',
-      sdkInt: map['sdkInt'] ?? 0,
-      securityPatch: map['securityPatch'] ?? '',
+      baseOS: map['baseOS'],
+      previewSdkInt: map['previewSdkInt'],
+      securityPatch: map['securityPatch'],
+      codename: map['codename']!,
+      incremental: map['incremental']!,
+      release: map['release']!,
+      sdkInt: map['sdkInt']!,
     );
   }
 }

--- a/packages/device_info/device_info_platform_interface/lib/model/android_device_info.dart
+++ b/packages/device_info/device_info_platform_interface/lib/model/android_device_info.dart
@@ -113,8 +113,8 @@ class AndroidDeviceInfo {
   /// Deserializes from the message received from [_kChannel].
   static AndroidDeviceInfo fromMap(Map<String, dynamic> map) {
     return AndroidDeviceInfo(
-      version: AndroidBuildVersion._fromMap(
-          map['version']!.cast<String, dynamic>()),
+      version:
+          AndroidBuildVersion._fromMap(map['version']!.cast<String, dynamic>()),
       board: map['board']!,
       bootloader: map['bootloader']!,
       brand: map['brand']!,

--- a/packages/device_info/device_info_platform_interface/lib/model/android_device_info.dart
+++ b/packages/device_info/device_info_platform_interface/lib/model/android_device_info.dart
@@ -161,12 +161,15 @@ class AndroidBuildVersion {
   });
 
   /// The base OS build the product is based on.
+  /// This is only available on Android 6.0 or above.
   String? baseOS;
 
   /// The developer preview revision of a prerelease SDK.
+  /// This is only available on Android 6.0 or above.
   int? previewSdkInt;
 
   /// The user-visible security patch level.
+  /// This is only available on Android 6.0 or above.
   final String? securityPatch;
 
   /// The current development codename, or the string "REL" if this is a release build.

--- a/packages/device_info/device_info_platform_interface/lib/model/ios_device_info.dart
+++ b/packages/device_info/device_info_platform_interface/lib/model/ios_device_info.dart
@@ -45,15 +45,15 @@ class IosDeviceInfo {
   /// Deserializes from the map message received from [_kChannel].
   static IosDeviceInfo fromMap(Map<String, dynamic> map) {
     return IosDeviceInfo(
-      name: map['name'] ?? '',
-      systemName: map['systemName'] ?? '',
-      systemVersion: map['systemVersion'] ?? '',
-      model: map['model'] ?? '',
-      localizedModel: map['localizedModel'] ?? '',
-      identifierForVendor: map['identifierForVendor'] ?? '',
+      name: map['name']!,
+      systemName: map['systemName']!,
+      systemVersion: map['systemVersion']!,
+      model: map['model']!,
+      localizedModel: map['localizedModel']!,
+      identifierForVendor: map['identifierForVendor']!,
       isPhysicalDevice: map['isPhysicalDevice'] == 'true',
       utsname:
-          IosUtsname._fromMap(map['utsname']?.cast<String, dynamic>() ?? {}),
+          IosUtsname._fromMap(map['utsname']!.cast<String, dynamic>()),
     );
   }
 }
@@ -87,11 +87,11 @@ class IosUtsname {
   /// Deserializes from the map message received from [_kChannel].
   static IosUtsname _fromMap(Map<String, dynamic> map) {
     return IosUtsname._(
-      sysname: map['sysname'] ?? '',
-      nodename: map['nodename'] ?? '',
-      release: map['release'] ?? '',
-      version: map['version'] ?? '',
-      machine: map['machine'] ?? '',
+      sysname: map['sysname']!,
+      nodename: map['nodename']!,
+      release: map['release']!,
+      version: map['version']!,
+      machine: map['machine']!,
     );
   }
 }

--- a/packages/device_info/device_info_platform_interface/lib/model/ios_device_info.dart
+++ b/packages/device_info/device_info_platform_interface/lib/model/ios_device_info.dart
@@ -52,8 +52,7 @@ class IosDeviceInfo {
       localizedModel: map['localizedModel']!,
       identifierForVendor: map['identifierForVendor']!,
       isPhysicalDevice: map['isPhysicalDevice'] == 'true',
-      utsname:
-          IosUtsname._fromMap(map['utsname']!.cast<String, dynamic>()),
+      utsname: IosUtsname._fromMap(map['utsname']!.cast<String, dynamic>()),
     );
   }
 }

--- a/packages/device_info/device_info_platform_interface/pubspec.yaml
+++ b/packages/device_info/device_info_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the device_info plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/device_info
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.0.0-nullsafety.1
+version: 2.0.0-nullsafety.2
 
 dependencies:
   flutter:

--- a/packages/device_info/device_info_platform_interface/test/method_channel_device_info_test.dart
+++ b/packages/device_info/device_info_platform_interface/test/method_channel_device_info_test.dart
@@ -24,11 +24,68 @@ void main() {
         switch (methodCall.method) {
           case 'getAndroidDeviceInfo':
             return ({
-              "brand": "Google",
+              "version": <String, dynamic>{
+                "securityPatch": "2018-09-05",
+                "sdkInt": 28,
+                "release": "9",
+                "previewSdkInt": 0,
+                "incremental": "5124027",
+                "codename": "REL",
+                "baseOS": "",
+              },
+              "board": "goldfish_x86_64",
+              "bootloader": "unknown",
+              "brand": "google",
+              "device": "generic_x86_64",
+              "display": "PSR1.180720.075",
+              "fingerprint":
+                  "google/sdk_gphone_x86_64/generic_x86_64:9/PSR1.180720.075/5124027:user/release-keys",
+              "hardware": "ranchu",
+              "host": "abfarm730",
+              "id": "PSR1.180720.075",
+              "manufacturer": "Google",
+              "model": "Android SDK built for x86_64",
+              "product": "sdk_gphone_x86_64",
+              "supported32BitAbis": <String>[
+                "x86",
+              ],
+              "supported64BitAbis": <String>[
+                "x86_64",
+              ],
+              "supportedAbis": <String>[
+                "x86_64",
+                "x86",
+              ],
+              "tags": "release-keys",
+              "type": "user",
+              "isPhysicalDevice": false,
+              "androidId": "f47571f3b4648f45",
+              "systemFeatures": <String>[
+                "android.hardware.sensor.proximity",
+                "android.software.adoptable_storage",
+                "android.hardware.sensor.accelerometer",
+                "android.hardware.faketouch",
+                "android.software.backup",
+                "android.hardware.touchscreen",
+              ],
             });
           case 'getIosDeviceInfo':
             return ({
-              "name": "iPhone 10",
+              "name": "iPhone 13",
+              "systemName": "iOS",
+              "systemVersion": "13.0",
+              "model": "iPhone",
+              "localizedModel": "iPhone",
+              "identifierForVendor": "88F59280-55AD-402C-B922-3203B4794C06",
+              "isPhysicalDevice": false,
+              "utsname": <String, dynamic>{
+                "sysname": "Darwin",
+                "nodename": "host",
+                "release": "19.6.0",
+                "version":
+                    "Darwin Kernel Version 19.6.0: Thu Jun 18 20:49:00 PDT 2020; root:xnu-6153.141.1~1/RELEASE_X86_64",
+                "machine": "x86_64",
+              }
             });
           default:
             return null;
@@ -39,12 +96,66 @@ void main() {
     test("androidInfo", () async {
       final AndroidDeviceInfo result =
           await methodChannelDeviceInfo.androidInfo();
-      expect(result.brand, "Google");
+
+      expect(result.version.securityPatch, "2018-09-05");
+      expect(result.version.sdkInt, 28);
+      expect(result.version.release, "9");
+      expect(result.version.previewSdkInt, 0);
+      expect(result.version.incremental, "5124027");
+      expect(result.version.codename, "REL");
+      expect(result.board, "goldfish_x86_64");
+      expect(result.bootloader, "unknown");
+      expect(result.brand, "google");
+      expect(result.device, "generic_x86_64");
+      expect(result.display, "PSR1.180720.075");
+      expect(result.fingerprint,
+          "google/sdk_gphone_x86_64/generic_x86_64:9/PSR1.180720.075/5124027:user/release-keys");
+      expect(result.hardware, "ranchu");
+      expect(result.host, "abfarm730");
+      expect(result.id, "PSR1.180720.075");
+      expect(result.manufacturer, "Google");
+      expect(result.model, "Android SDK built for x86_64");
+      expect(result.product, "sdk_gphone_x86_64");
+      expect(result.supported32BitAbis, <String>[
+        "x86",
+      ]);
+      expect(result.supported64BitAbis, <String>[
+        "x86_64",
+      ]);
+      expect(result.supportedAbis, <String>[
+        "x86_64",
+        "x86",
+      ]);
+      expect(result.tags, "release-keys");
+      expect(result.type, "user");
+      expect(result.isPhysicalDevice, false);
+      expect(result.androidId, "f47571f3b4648f45");
+      expect(result.systemFeatures, <String>[
+        "android.hardware.sensor.proximity",
+        "android.software.adoptable_storage",
+        "android.hardware.sensor.accelerometer",
+        "android.hardware.faketouch",
+        "android.software.backup",
+        "android.hardware.touchscreen",
+      ]);
     });
 
     test("iosInfo", () async {
       final IosDeviceInfo result = await methodChannelDeviceInfo.iosInfo();
-      expect(result.name, "iPhone 10");
+      expect(result.name, "iPhone 13");
+      expect(result.systemName, "iOS");
+      expect(result.systemVersion, "13.0");
+      expect(result.model, "iPhone");
+      expect(result.localizedModel, "iPhone");
+      expect(
+          result.identifierForVendor, "88F59280-55AD-402C-B922-3203B4794C06");
+      expect(result.isPhysicalDevice, false);
+      expect(result.utsname.sysname, "Darwin");
+      expect(result.utsname.nodename, "host");
+      expect(result.utsname.release, "19.6.0");
+      expect(result.utsname.version,
+          "Darwin Kernel Version 19.6.0: Thu Jun 18 20:49:00 PDT 2020; root:xnu-6153.141.1~1/RELEASE_X86_64");
+      expect(result.utsname.machine, "x86_64");
     });
   });
 }


### PR DESCRIPTION
## Description

Based on the discussion. `baseOS`, `previewSdkInt`, and `securityPatch` are indeed nullable depending on the Android API level. 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
