### PR TITLE
[webview_flutter] Allow config ignoreSslError on Android

### DIFF
--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -352,6 +352,10 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
           Integer mode = (Integer) settings.get(key);
           if (mode != null) updateJsMode(mode);
           break;
+        case "ignoreSslError":
+          final boolean ignoreSslError = (boolean) settings.get(key);
+          flutterWebViewClient.setIgnoreSslError(ignoreSslError);
+          break;
         case "hasNavigationDelegate":
           final boolean hasNavigationDelegate = (boolean) settings.get(key);
 

--- a/packages/webview_flutter/example/lib/main.dart
+++ b/packages/webview_flutter/example/lib/main.dart
@@ -58,6 +58,7 @@ class _WebViewExampleState extends State<WebViewExample> {
       body: Builder(builder: (BuildContext context) {
         return WebView(
           initialUrl: 'https://flutter.dev',
+          ignoreSslError: false,
           javascriptMode: JavascriptMode.unrestricted,
           onWebViewCreated: (WebViewController webViewController) {
             _controller.complete(webViewController);

--- a/packages/webview_flutter/lib/platform_interface.dart
+++ b/packages/webview_flutter/lib/platform_interface.dart
@@ -377,8 +377,9 @@ class WebSettings {
   /// sent with [WebviewPlatform#updateSettings].
   ///
   /// The `userAgent` parameter must not be null.
-  WebSettings({
+  const WebSettings({
     this.javascriptMode,
+    this.ignoreSslError,
     this.hasNavigationDelegate,
     this.debuggingEnabled,
     this.gestureNavigationEnabled,
@@ -387,6 +388,9 @@ class WebSettings {
 
   /// The JavaScript execution mode to be used by the webview.
   final JavascriptMode javascriptMode;
+
+  /// Ignore ssl error
+  final bool ignoreSslError;
 
   /// Whether the [WebView] has a [NavigationDelegate] set.
   final bool hasNavigationDelegate;
@@ -413,7 +417,7 @@ class WebSettings {
 
   @override
   String toString() {
-    return 'WebSettings(javascriptMode: $javascriptMode, hasNavigationDelegate: $hasNavigationDelegate, debuggingEnabled: $debuggingEnabled, gestureNavigationEnabled: $gestureNavigationEnabled, userAgent: $userAgent)';
+    return 'WebSettings(javascriptMode: $javascriptMode, ignoreSslError: $ignoreSslError, hasNavigationDelegate: $hasNavigationDelegate, debuggingEnabled: $debuggingEnabled, gestureNavigationEnabled: $gestureNavigationEnabled, userAgent: $userAgent)';
   }
 }
 
@@ -425,7 +429,7 @@ class CreationParams {
   /// [WebViewPlatformController].
   ///
   /// The `autoMediaPlaybackPolicy` parameter must not be null.
-  CreationParams({
+  const CreationParams({
     this.initialUrl,
     this.webSettings,
     this.javascriptChannelNames,

--- a/packages/webview_flutter/lib/src/webview_method_channel.dart
+++ b/packages/webview_flutter/lib/src/webview_method_channel.dart
@@ -177,6 +177,7 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
     }
 
     _addIfNonNull('jsMode', settings.javascriptMode?.index);
+    _addIfNonNull('ignoreSslError', settings.ignoreSslError);
     _addIfNonNull('hasNavigationDelegate', settings.hasNavigationDelegate);
     _addIfNonNull('debuggingEnabled', settings.debuggingEnabled);
     _addIfNonNull(

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -218,6 +218,7 @@ class WebView extends StatefulWidget {
     this.onPageStarted,
     this.onPageFinished,
     this.onWebResourceError,
+    this.ignoreSslError = false,
     this.debuggingEnabled = false,
     this.gestureNavigationEnabled = false,
     this.userAgent,
@@ -354,6 +355,9 @@ class WebView extends StatefulWidget {
   /// the main page.
   final WebResourceErrorCallback onWebResourceError;
 
+  /// ignore ssl error
+  final bool ignoreSslError;
+
   /// Controls whether WebView debugging is enabled.
   ///
   /// Setting this to true enables [WebView debugging on Android](https://developers.google.com/web/tools/chrome-devtools/remote-debugging/).
@@ -466,6 +470,7 @@ CreationParams _creationParamsfromWidget(WebView widget) {
 WebSettings _webSettingsFromWidget(WebView widget) {
   return WebSettings(
     javascriptMode: widget.javascriptMode,
+    ignoreSslError: widget.ignoreSslError,
     hasNavigationDelegate: widget.navigationDelegate != null,
     debuggingEnabled: widget.debuggingEnabled,
     gestureNavigationEnabled: widget.gestureNavigationEnabled,
@@ -486,11 +491,15 @@ WebSettings _clearUnchangedWebSettings(
   assert(newValue.userAgent.isPresent);
 
   JavascriptMode javascriptMode;
+  bool ignoreSslError;
   bool hasNavigationDelegate;
   bool debuggingEnabled;
   WebSetting<String> userAgent = WebSetting<String>.absent();
   if (currentValue.javascriptMode != newValue.javascriptMode) {
     javascriptMode = newValue.javascriptMode;
+  }
+  if (currentValue.ignoreSslError != newValue.ignoreSslError) {
+    ignoreSslError = newValue.ignoreSslError;
   }
   if (currentValue.hasNavigationDelegate != newValue.hasNavigationDelegate) {
     hasNavigationDelegate = newValue.hasNavigationDelegate;
@@ -504,6 +513,7 @@ WebSettings _clearUnchangedWebSettings(
 
   return WebSettings(
     javascriptMode: javascriptMode,
+    ignoreSslError: ignoreSslError,
     hasNavigationDelegate: hasNavigationDelegate,
     debuggingEnabled: debuggingEnabled,
     userAgent: userAgent,


### PR DESCRIPTION
## Description

Allow config ignoreSslError on Android.
use `ignoreSslError: true`, default is false

This submitted code is just a sample.
But, We really hope could support "ignoreSslError".

## Related Issues

Already closed.

