### PR TITLE
Use testWidgets instead of test to fix failures not surfacing on CI

### DIFF
--- a/packages/integration_test/CHANGELOG.md
+++ b/packages/integration_test/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.9.2+3
+## 0.9.3
 
 * Update README to mention that only `testWidgets` is supported for declaring tests.
 

--- a/packages/integration_test/CHANGELOG.md
+++ b/packages/integration_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.2+3
+
+* Update README to mention that only `testWidgets` is supported for declaring tests.
+
 ## 0.9.2+2
 
 * Broaden the constraint on vm_service.

--- a/packages/integration_test/README.md
+++ b/packages/integration_test/README.md
@@ -14,6 +14,8 @@ Create a `integration_test/` directory for your package. In this directory,
 create a `<name>_test.dart`, using the following as a starting point to make
 assertions.
 
+Note: You should only use `testWidgets` to declare your tests, or errors will not be reported correctly.
+
 ```dart
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';

--- a/packages/integration_test/pubspec.yaml
+++ b/packages/integration_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: integration_test
 description: Runs tests that use the flutter_test API as integration tests.
-version: 0.9.2+2
+version: 0.9.2+3
 homepage: https://github.com/flutter/plugins/tree/master/packages/integration_test
 
 environment:

--- a/packages/integration_test/pubspec.yaml
+++ b/packages/integration_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: integration_test
 description: Runs tests that use the flutter_test API as integration tests.
-version: 0.9.2+3
+version: 0.9.3
 homepage: https://github.com/flutter/plugins/tree/master/packages/integration_test
 
 environment:

--- a/packages/shared_preferences/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.5.12+5
+## 0.5.13
 
 * Update integration test examples to use `testWidgets` instead of `test`.
 

--- a/packages/shared_preferences/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.12+5
+
+* Update integration test examples to use `testWidgets` instead of `test`.
+
 ## 0.5.12+4
 
 * Remove unused `test` dependency.

--- a/packages/shared_preferences/shared_preferences/example/integration_test/shared_preferences_test.dart
+++ b/packages/shared_preferences/shared_preferences/example/integration_test/shared_preferences_test.dart
@@ -33,7 +33,7 @@ void main() {
       preferences.clear();
     });
 
-    test('reading', () async {
+    testWidgets('reading', (WidgetTester _) async {
       expect(preferences.get('String'), isNull);
       expect(preferences.get('bool'), isNull);
       expect(preferences.get('int'), isNull);
@@ -46,7 +46,7 @@ void main() {
       expect(preferences.getStringList('List'), isNull);
     });
 
-    test('writing', () async {
+    testWidgets('writing', (WidgetTester _) async {
       await Future.wait(<Future<bool>>[
         preferences.setString('String', kTestValues2['flutter.String']),
         preferences.setBool('bool', kTestValues2['flutter.bool']),
@@ -61,7 +61,7 @@ void main() {
       expect(preferences.getStringList('List'), kTestValues2['flutter.List']);
     });
 
-    test('removing', () async {
+    testWidgets('removing', (WidgetTester _) async {
       const String key = 'testKey';
       await preferences.setString(key, kTestValues['flutter.String']);
       await preferences.setBool(key, kTestValues['flutter.bool']);
@@ -72,7 +72,7 @@ void main() {
       expect(preferences.get('testKey'), isNull);
     });
 
-    test('clearing', () async {
+    testWidgets('clearing', (WidgetTester _) async {
       await preferences.setString('String', kTestValues['flutter.String']);
       await preferences.setBool('bool', kTestValues['flutter.bool']);
       await preferences.setInt('int', kTestValues['flutter.int']);

--- a/packages/shared_preferences/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/flutter/plugins/tree/master/packages/shared_prefere
 # 0.5.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.5.12+4
+version: 0.5.12+5
 
 flutter:
   plugin:

--- a/packages/shared_preferences/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/flutter/plugins/tree/master/packages/shared_prefere
 # 0.5.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.5.12+5
+version: 0.5.13
 
 flutter:
   plugin:

--- a/packages/shared_preferences/shared_preferences_linux/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.2+5
+
+* Update integration test examples to use `testWidgets` instead of `test`.
+
 ## 0.0.2+4
 
 * Remove unused `test` dependency.

--- a/packages/shared_preferences/shared_preferences_linux/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_linux/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.0.2+5
+## 0.0.3
 
 * Update integration test examples to use `testWidgets` instead of `test`.
 

--- a/packages/shared_preferences/shared_preferences_linux/example/integration_test/shared_preferences_test.dart
+++ b/packages/shared_preferences/shared_preferences_linux/example/integration_test/shared_preferences_test.dart
@@ -33,7 +33,7 @@ void main() {
       preferences.clear();
     });
 
-    test('reading', () async {
+    testWidgets('reading', (WidgetTester _) async {
       expect(preferences.get('String'), isNull);
       expect(preferences.get('bool'), isNull);
       expect(preferences.get('int'), isNull);
@@ -46,7 +46,7 @@ void main() {
       expect(preferences.getStringList('List'), isNull);
     });
 
-    test('writing', () async {
+    testWidgets('writing', (WidgetTester _) async {
       await Future.wait(<Future<bool>>[
         preferences.setString('String', kTestValues2['flutter.String']),
         preferences.setBool('bool', kTestValues2['flutter.bool']),
@@ -61,7 +61,7 @@ void main() {
       expect(preferences.getStringList('List'), kTestValues2['flutter.List']);
     });
 
-    test('removing', () async {
+    testWidgets('removing', (WidgetTester _) async {
       const String key = 'testKey';
       await preferences.setString(key, kTestValues['flutter.String']);
       await preferences.setBool(key, kTestValues['flutter.bool']);
@@ -72,7 +72,7 @@ void main() {
       expect(preferences.get('testKey'), isNull);
     });
 
-    test('clearing', () async {
+    testWidgets('clearing', (WidgetTester _) async {
       await preferences.setString('String', kTestValues['flutter.String']);
       await preferences.setBool('bool', kTestValues['flutter.bool']);
       await preferences.setInt('int', kTestValues['flutter.int']);

--- a/packages/shared_preferences/shared_preferences_linux/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_linux/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shared_preferences_linux
 description: Linux implementation of the shared_preferences plugin
-version: 0.0.2+5
+version: 0.0.3
 homepage: https://github.com/flutter/plugins/tree/master/packages/shared_preferences/shared_preferences_linux
 
 flutter:

--- a/packages/shared_preferences/shared_preferences_linux/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_linux/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shared_preferences_linux
 description: Linux implementation of the shared_preferences plugin
-version: 0.0.2+4
+version: 0.0.2+5
 homepage: https://github.com/flutter/plugins/tree/master/packages/shared_preferences/shared_preferences_linux
 
 flutter:

--- a/packages/shared_preferences/shared_preferences_windows/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.1+4
+
+* Update integration test examples to use `testWidgets` instead of `test`.
+
 ## 0.0.1+3
 
 * Remove unused `test` dependency.

--- a/packages/shared_preferences/shared_preferences_windows/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_windows/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.0.1+4
+## 0.0.2
 
 * Update integration test examples to use `testWidgets` instead of `test`.
 

--- a/packages/shared_preferences/shared_preferences_windows/example/integration_test/shared_preferences_test.dart
+++ b/packages/shared_preferences/shared_preferences_windows/example/integration_test/shared_preferences_test.dart
@@ -37,7 +37,7 @@ void main() {
       preferences.clear();
     });
 
-    test('reading', () async {
+    testWidgets('reading', (WidgetTester _) async {
       final Map<String, Object> values = await preferences.getAll();
       expect(values['String'], isNull);
       expect(values['bool'], isNull);
@@ -46,7 +46,7 @@ void main() {
       expect(values['List'], isNull);
     });
 
-    test('writing', () async {
+    testWidgets('writing', (WidgetTester _) async {
       await Future.wait(<Future<bool>>[
         preferences.setValue(
             'String', 'String', kTestValues2['flutter.String']),
@@ -64,7 +64,7 @@ void main() {
       expect(values['List'], kTestValues2['flutter.List']);
     });
 
-    test('removing', () async {
+    testWidgets('removing', (WidgetTester _) async {
       const String key = 'testKey';
       await preferences.setValue('String', key, kTestValues['flutter.String']);
       await preferences.setValue('Bool', key, kTestValues['flutter.bool']);
@@ -77,7 +77,7 @@ void main() {
       expect(values[key], isNull);
     });
 
-    test('clearing', () async {
+    testWidgets('clearing', (WidgetTester _) async {
       await preferences.setValue(
           'String', 'String', kTestValues['flutter.String']);
       await preferences.setValue('Bool', 'bool', kTestValues['flutter.bool']);

--- a/packages/shared_preferences/shared_preferences_windows/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_windows/pubspec.yaml
@@ -1,7 +1,7 @@
 name: shared_preferences_windows
 description: Windows implementation of shared_preferences
 homepage: https://github.com/flutter/plugins/tree/master/packages/shared_preferences/shared_preferences_windows
-version: 0.0.1+3
+version: 0.0.1+4
 
 flutter:
   plugin:

--- a/packages/shared_preferences/shared_preferences_windows/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_windows/pubspec.yaml
@@ -1,7 +1,7 @@
 name: shared_preferences_windows
 description: Windows implementation of shared_preferences
 homepage: https://github.com/flutter/plugins/tree/master/packages/shared_preferences/shared_preferences_windows
-version: 0.0.1+4
+version: 0.0.2
 
 flutter:
   plugin:

--- a/packages/url_launcher/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 5.7.10+1
+## 5.7.11
 
 * Update integration test examples to use `testWidgets` instead of `test`.
 

--- a/packages/url_launcher/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.7.10+1
+
+* Update integration test examples to use `testWidgets` instead of `test`.
+
 ## 5.7.10
 
 * Update Dart SDK constraint in example.

--- a/packages/url_launcher/url_launcher/example/integration_test/url_launcher_test.dart
+++ b/packages/url_launcher/url_launcher/example/integration_test/url_launcher_test.dart
@@ -12,7 +12,7 @@ import 'package:url_launcher/url_launcher.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  test('canLaunch', () async {
+  testWidgets('canLaunch', (WidgetTester _) async {
     expect(await canLaunch('randomstring'), false);
 
     // Generally all devices should have some default browser.

--- a/packages/url_launcher/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher
 description: Flutter plugin for launching a URL on Android and iOS. Supports
   web, phone, SMS, and email schemes.
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher
-version: 5.7.10
+version: 5.7.10+1
 
 flutter:
   plugin:

--- a/packages/url_launcher/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher
 description: Flutter plugin for launching a URL on Android and iOS. Supports
   web, phone, SMS, and email schemes.
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher
-version: 5.7.10+1
+version: 5.7.11
 
 flutter:
   plugin:

--- a/packages/url_launcher/url_launcher_linux/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.1+5
+
+* Update integration test examples to use `testWidgets` instead of `test`.
+
 ## 0.0.1+4
 
 * Update Dart SDK constraint in example.

--- a/packages/url_launcher/url_launcher_linux/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_linux/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.0.1+5
+## 0.0.2
 
 * Update integration test examples to use `testWidgets` instead of `test`.
 

--- a/packages/url_launcher/url_launcher_linux/example/integration_test/url_launcher_test.dart
+++ b/packages/url_launcher/url_launcher_linux/example/integration_test/url_launcher_test.dart
@@ -9,7 +9,7 @@ import 'package:url_launcher/url_launcher.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  test('canLaunch', () async {
+  testWidgets('canLaunch', (WidgetTester _) async {
     expect(await canLaunch('randomstring'), false);
 
     // Generally all devices should have some default browser.

--- a/packages/url_launcher/url_launcher_linux/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_linux/pubspec.yaml
@@ -1,6 +1,6 @@
 name: url_launcher_linux
 description: Linux implementation of the url_launcher plugin.
-version: 0.0.1+5
+version: 0.0.2
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher_linux
 
 flutter:

--- a/packages/url_launcher/url_launcher_linux/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_linux/pubspec.yaml
@@ -1,6 +1,6 @@
 name: url_launcher_linux
 description: Linux implementation of the url_launcher plugin.
-version: 0.0.1+4
+version: 0.0.1+5
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher_linux
 
 flutter:

--- a/packages/url_launcher/url_launcher_macos/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.1+10
+
+* Update integration test examples to use `testWidgets` instead of `test`.
+
 # 0.0.1+9
 
 * Update Dart SDK constraint in example.

--- a/packages/url_launcher/url_launcher_macos/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_macos/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.0.1+10
+## 0.0.2
 
 * Update integration test examples to use `testWidgets` instead of `test`.
 

--- a/packages/url_launcher/url_launcher_macos/example/integration_test/url_launcher_test.dart
+++ b/packages/url_launcher/url_launcher_macos/example/integration_test/url_launcher_test.dart
@@ -9,7 +9,7 @@ import 'package:url_launcher/url_launcher.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  test('canLaunch', () async {
+  testWidgets('canLaunch', (WidgetTester _) async {
     expect(await canLaunch('randomstring'), false);
 
     // Generally all devices should have some default browser.

--- a/packages/url_launcher/url_launcher_macos/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_macos/pubspec.yaml
@@ -3,7 +3,7 @@ description: macOS implementation of the url_launcher plugin.
 # 0.0.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.0.1+9
+version: 0.0.1+10
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher_macos
 
 flutter:

--- a/packages/url_launcher/url_launcher_macos/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_macos/pubspec.yaml
@@ -3,7 +3,7 @@ description: macOS implementation of the url_launcher plugin.
 # 0.0.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.0.1+10
+version: 0.0.2
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher_macos
 
 flutter:

--- a/packages/url_launcher/url_launcher_windows/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.1+4
+
+* Update integration test examples to use `testWidgets` instead of `test`.
+
 ## 0.0.1+3
 
 * Update Dart SDK constraint in example.

--- a/packages/url_launcher/url_launcher_windows/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_windows/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.0.1+4
+## 0.0.2
 
 * Update integration test examples to use `testWidgets` instead of `test`.
 

--- a/packages/url_launcher/url_launcher_windows/example/integration_test/url_launcher_test.dart
+++ b/packages/url_launcher/url_launcher_windows/example/integration_test/url_launcher_test.dart
@@ -9,7 +9,7 @@ import 'package:url_launcher_platform_interface/url_launcher_platform_interface.
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  test('canLaunch', () async {
+  testWidgets('canLaunch', (WidgetTester _) async {
     UrlLauncherPlatform launcher = UrlLauncherPlatform.instance;
 
     expect(await launcher.canLaunch('randomstring'), false);

--- a/packages/url_launcher/url_launcher_windows/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_windows/pubspec.yaml
@@ -3,7 +3,7 @@ description: Windows implementation of the url_launcher plugin.
 # 0.0.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.0.1+3
+version: 0.0.1+4
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher_windows
 
 flutter:

--- a/packages/url_launcher/url_launcher_windows/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_windows/pubspec.yaml
@@ -3,7 +3,7 @@ description: Windows implementation of the url_launcher plugin.
 # 0.0.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.0.1+4
+version: 0.0.2
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher_windows
 
 flutter:


### PR DESCRIPTION
## Description

Only `testWidgets` is supported for testing for `package:integration_test`. Errors thrown in other declarers will not be caught and reported.

Also added a note to mention this in the README for `package:integration_test`

## Related Issues

flutter/flutter#60943

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.
