### PR TITLE
Fix broken link

### DIFF
--- a/packages/integration_test/README.md
+++ b/packages/integration_test/README.md
@@ -42,7 +42,7 @@ Future<void> main() => integrationDriver();
 You can also use different driver scripts to customize the behavior of the app
 under test. For example, `FlutterDriver` can also be parameterized with
 different [options](https://api.flutter.dev/flutter/flutter_driver/FlutterDriver/connect.html).
-See the [extended driver](https://github.com/flutter/plugins/tree/master/packages/integration_test/example/test_driver/integration_test_extended_driver.dart) for an example.
+See the [extended driver](https://github.com/flutter/plugins/blob/master/packages/integration_test/example/test_driver/extended_integration_test.dart) for an example.
 
 ### Package Structure
 


### PR DESCRIPTION
This is the correct link: https://github.com/flutter/plugins/blob/master/packages/integration_test/example/test_driver/extended_integration_test.dart