### PR TITLE
[android_alarm_manager] Configuration a background engine in the user's code

### DIFF
--- a/packages/android_alarm_manager/CHANGELOG.md
+++ b/packages/android_alarm_manager/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.5+18
+
+* Add FlutterAlarmManagerInitializer to allow a background flutter engine initialization in the user's code
+
 ## 0.4.5+17
 
 * Update Dart SDK constraint in example.

--- a/packages/android_alarm_manager/README.md
+++ b/packages/android_alarm_manager/README.md
@@ -124,3 +124,36 @@ For help getting started with Flutter, view our online
 [documentation](http://flutter.io/).
 
 For help on editing plugin code, view the [documentation](https://flutter.io/platform-plugins/#edit-code).
+
+## Configuration a background FlutterEngine
+
+`configureFlutterEngine` in `MainActivity` is not called when the alarm manager is started. 
+If you would like to register any channels or pigeons you have to create an application class
+and implement `configureAlarmManagerFlutterEngine` method of `io.flutter.plugins.androidalarmmanager.FlutterAlarmManagerInitializer`
+
+```java
+...
+
+import androidx.annotation.NonNull;
+
+import io.flutter.app.FlutterApplication;
+import io.flutter.embedding.engine.FlutterEngine;
+import io.flutter.plugins.androidalarmmanager.FlutterAlarmManagerInitializer;
+
+public class MyApplication extends FlutterApplication implements FlutterAlarmManagerInitializer {
+    @Override
+    public void configureAlarmManagerFlutterEngine(@NonNull FlutterEngine flutterEngine) {
+        // Initialize your channels and pigeons here to make them available in the isolate
+    }
+}
+```
+
+Also, don't forget to change your application class in `AndroidManifest.xml`
+
+```xml
+...
+
+<application
+        android:name=".MyApplication">
+...
+```

--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/FlutterAlarmManagerInitializer.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/FlutterAlarmManagerInitializer.java
@@ -1,0 +1,9 @@
+package io.flutter.plugins.androidalarmmanager;
+
+import androidx.annotation.NonNull;
+
+import io.flutter.embedding.engine.FlutterEngine;
+
+public interface FlutterAlarmManagerInitializer {
+    void configureAlarmManagerFlutterEngine(@NonNull FlutterEngine flutterEngine);
+}

--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/FlutterBackgroundExecutor.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/FlutterBackgroundExecutor.java
@@ -157,8 +157,15 @@ public class FlutterBackgroundExecutor implements MethodCallHandler {
     @SuppressWarnings("deprecation")
     String appBundlePath = io.flutter.view.FlutterMain.findAppBundlePath();
     AssetManager assets = context.getAssets();
+    Context applicationContext = context.getApplicationContext();
     if (!isRunning()) {
       backgroundFlutterEngine = new FlutterEngine(context);
+
+      if(applicationContext instanceof FlutterAlarmManagerInitializer) {
+        FlutterAlarmManagerInitializer initializer = (FlutterAlarmManagerInitializer)applicationContext;
+
+        initializer.configureAlarmManagerFlutterEngine(backgroundFlutterEngine);
+      }
 
       // We need to create an instance of `FlutterEngine` before looking up the
       // callback. If we don't, the callback cache won't be initialized and the

--- a/packages/android_alarm_manager/example/android/app/src/main/java/io/flutter/plugins/androidalarmmanagerexample/Application.java
+++ b/packages/android_alarm_manager/example/android/app/src/main/java/io/flutter/plugins/androidalarmmanagerexample/Application.java
@@ -1,15 +1,23 @@
 package io.flutter.plugins.androidalarmmanagerexample;
 
+import android.annotation.SuppressLint;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+
 import io.flutter.app.FlutterApplication;
+import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.plugins.androidalarmmanager.AlarmService;
 import io.flutter.plugins.androidalarmmanager.AndroidAlarmManagerPlugin;
+import io.flutter.plugins.androidalarmmanager.FlutterAlarmManagerInitializer;
 
 @SuppressWarnings("deprecation")
 public class Application extends FlutterApplication
-    implements io.flutter.plugin.common.PluginRegistry.PluginRegistrantCallback {
+    implements io.flutter.plugin.common.PluginRegistry.PluginRegistrantCallback, FlutterAlarmManagerInitializer {
   @Override
   public void onCreate() {
     super.onCreate();
+
     AlarmService.setPluginRegistrant(this);
   }
 
@@ -18,5 +26,12 @@ public class Application extends FlutterApplication
   public void registerWith(io.flutter.plugin.common.PluginRegistry registry) {
     AndroidAlarmManagerPlugin.registerWith(
         registry.registrarFor("io.flutter.plugins.androidalarmmanager.AndroidAlarmManagerPlugin"));
+  }
+
+  @SuppressLint("LongLogTag")
+  @Override
+  public void configureAlarmManagerFlutterEngine(@NonNull FlutterEngine flutterEngine) {
+    // Initialize method channels, pigeons and etc here
+    Log.i("FlutterAlarmManagerInitializer", "The engine initialized");
   }
 }

--- a/packages/android_alarm_manager/pubspec.yaml
+++ b/packages/android_alarm_manager/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for accessing the Android AlarmManager service, and
 # 0.4.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.4.5+17
+version: 0.4.5+18
 homepage: https://github.com/flutter/plugins/tree/master/packages/android_alarm_manager
 
 dependencies:


### PR DESCRIPTION
## Description

These changed allows initializing a background flutter engine in the user's code. 

Currently, we can't do that because `GeneratedPluginRegistrant.registerWith` is called to configure a new flutter engine.
`MainActivity.configureFlutterEngine` doesn't allow to initialize a background flutter engine because for background services the main activity is not created.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
