### PR TITLE
[share] Migrate to null-safety

### DIFF
--- a/packages/share/CHANGELOG.md
+++ b/packages/share/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-nullsafety
+
+* Migrate to null safety.
+
 ## 0.6.5+5
 
 * Update Flutter SDK constraint.

--- a/packages/share/CHANGELOG.md
+++ b/packages/share/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0-nullsafety
+## 2.0.0-nullsafety
 
 * Migrate to null safety.
 

--- a/packages/share/lib/share.dart
+++ b/packages/share/lib/share.dart
@@ -33,8 +33,8 @@ class Share {
   /// from [MethodChannel].
   static Future<void> share(
     String text, {
-    String subject,
-    Rect sharePositionOrigin,
+    String? subject,
+    Rect? sharePositionOrigin,
   }) {
     assert(text != null);
     assert(text.isNotEmpty);
@@ -67,10 +67,10 @@ class Share {
   /// from [MethodChannel].
   static Future<void> shareFiles(
     List<String> paths, {
-    List<String> mimeTypes,
-    String subject,
-    String text,
-    Rect sharePositionOrigin,
+    List<String>? mimeTypes,
+    String? subject,
+    String? text,
+    Rect? sharePositionOrigin,
   }) {
     assert(paths != null);
     assert(paths.isNotEmpty);

--- a/packages/share/pubspec.yaml
+++ b/packages/share/pubspec.yaml
@@ -2,10 +2,7 @@ name: share
 description: Flutter plugin for sharing content via the platform share UI, using
   the ACTION_SEND intent on Android and UIActivityViewController on iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/share
-# 0.6.y+z is compatible with 1.0.0, if you land a breaking change bump
-# the version to 2.0.0.
-# See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.6.5+5
+version: 2.0.0-nullsafety
 
 flutter:
   plugin:
@@ -17,20 +14,20 @@ flutter:
         pluginClass: FLTSharePlugin
 
 dependencies:
-  meta: ^1.0.5
-  mime: ^0.9.7
+  meta: ^1.3.0-nullsafety.6
+  mime: ^1.0.0-nullsafety.0
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  test: ^1.3.0
-  mockito: ^3.0.0
+  test: ^1.16.0-nullsafety.13
+  mockito: ^4.1.3
   flutter_test:
     sdk: flutter
   integration_test:
     path: ../integration_test
-  pedantic: ^1.8.0
+  pedantic: ^1.10.0-nullsafety.3
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
   flutter: ">=1.12.13+hotfix.5"
+  sdk: ">=2.12.0-0 <3.0.0"

--- a/packages/share/test/share_test.dart
+++ b/packages/share/test/share_test.dart
@@ -15,7 +15,7 @@ import 'package:flutter/services.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  MockMethodChannel mockChannel;
+  late MockMethodChannel mockChannel;
 
   setUp(() {
     mockChannel = MockMethodChannel();
@@ -24,14 +24,6 @@ void main() {
       // The explicit type can be void as the only method call has a return type of void.
       await mockChannel.invokeMethod<void>(call.method, call.arguments);
     });
-  });
-
-  test('sharing null fails', () {
-    expect(
-      () => Share.share(null),
-      throwsA(const TypeMatcher<AssertionError>()),
-    );
-    verifyZeroInteractions(mockChannel);
   });
 
   test('sharing empty fails', () {
@@ -56,14 +48,6 @@ void main() {
       'originWidth': 3.0,
       'originHeight': 4.0,
     }));
-  });
-
-  test('sharing null file fails', () {
-    expect(
-      () => Share.shareFiles([null]),
-      throwsA(const TypeMatcher<AssertionError>()),
-    );
-    verifyZeroInteractions(mockChannel);
   });
 
   test('sharing empty file fails', () {

--- a/script/nnbd_plugins.sh
+++ b/script/nnbd_plugins.sh
@@ -13,6 +13,7 @@ readonly NNBD_PLUGINS_LIST=(
   "local_auth"
   "path_provider"
   "plugin_platform_interface"
+  "share"
   "url_launcher"
   "video_player"
 )


### PR DESCRIPTION
## Description

Migrate share plugin to null safety.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
