### PR TITLE
Exclude null-safe plugins from testing on stable

### DIFF
--- a/script/build_all_plugins_app.sh
+++ b/script/build_all_plugins_app.sh
@@ -8,6 +8,8 @@ readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null && pwd)"
 readonly REPO_DIR="$(dirname "$SCRIPT_DIR")"
 
 source "$SCRIPT_DIR/common.sh"
+source "$SCRIPT_DIR/nnbd_plugins.sh"
+
 check_changed_packages > /dev/null
 
 readonly EXCLUDED_PLUGINS_LIST=(
@@ -42,7 +44,13 @@ readonly EXCLUDED_PLUGINS_LIST=(
 # Comma-separated string of the list above
 readonly EXCLUDED=$(IFS=, ; echo "${EXCLUDED_PLUGINS_LIST[*]}")
 
-(cd "$REPO_DIR" && pub global run flutter_plugin_tools all-plugins-app --exclude $EXCLUDED)
+ALL_EXCLUDED=($EXCLUDED)
+# Exclude nnbd plugins from stable.
+if [[ "$CHANNEL" -eq "stable" ]]; then
+  ALL_EXCLUDED=("$EXCLUDED,$EXCLUDED_PLUGINS_FROM_STABLE")
+fi
+
+(cd "$REPO_DIR" && pub global run flutter_plugin_tools all-plugins-app --exclude $ALL_EXCLUDED)
 
 function error() {
   echo "$@" 1>&2

--- a/script/build_all_plugins_app.sh
+++ b/script/build_all_plugins_app.sh
@@ -50,6 +50,8 @@ if [[ "$CHANNEL" -eq "stable" ]]; then
   ALL_EXCLUDED=("$EXCLUDED,$EXCLUDED_PLUGINS_FROM_STABLE")
 fi
 
+echo "Excluding the following plugins: $ALL_EXCLUDED"
+
 (cd "$REPO_DIR" && pub global run flutter_plugin_tools all-plugins-app --exclude $ALL_EXCLUDED)
 
 function error() {

--- a/script/incremental_build.sh
+++ b/script/incremental_build.sh
@@ -5,11 +5,19 @@ readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 readonly REPO_DIR="$(dirname "$SCRIPT_DIR")"
 
 source "$SCRIPT_DIR/common.sh"
+source "$SCRIPT_DIR/nnbd_plugins.sh"
 
 if [ "$(expr substr $(uname -s) 1 5)" == "MINGW" ]; then
   PUB=pub.bat
 else
   PUB=pub
+fi
+
+# Plugins that are excluded from this task.
+ALL_EXCLUDED=("")
+# Exclude nnbd plugins from stable.
+if [[ "$CHANNEL" -eq "stable" ]] then
+  ALL_EXCLUDED=($EXCLUDED_PLUGINS_FROM_STABLE)
 fi
 
 # Plugins that deliberately use their own analysis_options.yaml.
@@ -39,7 +47,7 @@ PLUGIN_SHARDING=($PLUGIN_SHARDING)
 
 if [[ "${BRANCH_NAME}" == "master" ]]; then
   echo "Running for all packages"
-  (cd "$REPO_DIR" && $PUB global run flutter_plugin_tools "${ACTIONS[@]}" ${PLUGIN_SHARDING[@]})
+  (cd "$REPO_DIR" && $PUB global run flutter_plugin_tools "${ACTIONS[@]}" --exclude="$ALL_EXCLUDED" ${PLUGIN_SHARDING[@]})
 else
   # Sets CHANGED_PACKAGES
   check_changed_packages
@@ -47,10 +55,10 @@ else
   if [[ "$CHANGED_PACKAGES" == "" ]]; then
     echo "No changes detected in packages."
     echo "Running for all packages"
-    (cd "$REPO_DIR" && $PUB global run flutter_plugin_tools "${ACTIONS[@]}" ${PLUGIN_SHARDING[@]})
+    (cd "$REPO_DIR" && $PUB global run flutter_plugin_tools "${ACTIONS[@]}" --exclude="$ALL_EXCLUDED" ${PLUGIN_SHARDING[@]})
   else
     echo running "${ACTIONS[@]}"
-    (cd "$REPO_DIR" && $PUB global run flutter_plugin_tools "${ACTIONS[@]}" --plugins="$CHANGED_PACKAGES" ${PLUGIN_SHARDING[@]})
+    (cd "$REPO_DIR" && $PUB global run flutter_plugin_tools "${ACTIONS[@]}" --plugins="$CHANGED_PACKAGES" --exclude="$ALL_EXCLUDED" ${PLUGIN_SHARDING[@]})
     echo "Running version check for changed packages"
     (cd "$REPO_DIR" && $PUB global run flutter_plugin_tools version-check --base_sha="$(get_branch_base_sha)")
   fi

--- a/script/incremental_build.sh
+++ b/script/incremental_build.sh
@@ -18,6 +18,7 @@ ALL_EXCLUDED=("")
 # Exclude nnbd plugins from stable.
 if [[ "$CHANNEL" -eq "stable" ]]; then
   ALL_EXCLUDED=($EXCLUDED_PLUGINS_FROM_STABLE)
+  echo "Excluding the following plugins: $ALL_EXCLUDED"
 fi
 
 # Plugins that deliberately use their own analysis_options.yaml.

--- a/script/incremental_build.sh
+++ b/script/incremental_build.sh
@@ -16,7 +16,7 @@ fi
 # Plugins that are excluded from this task.
 ALL_EXCLUDED=("")
 # Exclude nnbd plugins from stable.
-if [[ "$CHANNEL" -eq "stable" ]] then
+if [[ "$CHANNEL" -eq "stable" ]]; then
   ALL_EXCLUDED=($EXCLUDED_PLUGINS_FROM_STABLE)
 fi
 

--- a/script/nnbd_plugins.sh
+++ b/script/nnbd_plugins.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# This script contains the list of plugins migrated to nnbd
+# that should be excluded from testing on Flutter stable until
+# null-safe is available on stable.
+
+readonly NNBD_PLUGINS_LIST=(
+  "flutter_webview"
+)
+
+export EXCLUDED_PLUGINS_FROM_STABLE=$(IFS=, ; echo "${NNBD_PLUGINS_LIST[*]}")


### PR DESCRIPTION
Mechanism for disabling the checks on Flutter stable. This needs a PR to the tool.