### PR TITLE
Update analysis options for nnbd

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -4,6 +4,9 @@ analyzer:
     # Ignore generated files
     - '**/*.g.dart'
     - 'lib/src/generated/*.dart'
+  errors:
+    always_require_non_null_named_parameters: false # not needed with nnbd
+    unnecessary_null_comparison: false # Turned as long as nnbd mix-mode is supported.
 linter:
   rules:
     - public_member_api_docs


### PR DESCRIPTION
With NNBD `assert(foo != null)` for a non nullable `foo` generates an analysis error.
However as long as we support mixed-mode we want these asserts it, so disabling the check.
