### PR TITLE
[camera_platform_interface] Add torch definition to the FlashModes enum 

### DIFF
--- a/packages/camera/camera_platform_interface/CHANGELOG.md
+++ b/packages/camera/camera_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.4
+
+- Added the torch option to the FlashMode enum, which when implemented indicates the flash light should be turned on continuously.
+
 ## 1.0.3
 
 - Update Flutter SDK constraint.

--- a/packages/camera/camera_platform_interface/lib/src/method_channel/method_channel_camera.dart
+++ b/packages/camera/camera_platform_interface/lib/src/method_channel/method_channel_camera.dart
@@ -226,6 +226,8 @@ class MethodChannelCamera extends CameraPlatform {
         return 'auto';
       case FlashMode.always:
         return 'always';
+      case FlashMode.torch:
+        return 'torch';
       default:
         throw ArgumentError('Unknown FlashMode value');
     }

--- a/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
+++ b/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
@@ -108,7 +108,7 @@ abstract class CameraPlatform extends PlatformInterface {
     throw UnimplementedError('resumeVideoRecording() is not implemented.');
   }
 
-  /// Sets the flash mode for taking pictures.
+  /// Sets the flash mode for the selected camera.
   Future<void> setFlashMode(int cameraId, FlashMode mode) {
     throw UnimplementedError('setFlashMode() is not implemented.');
   }

--- a/packages/camera/camera_platform_interface/lib/src/types/flash_mode.dart
+++ b/packages/camera/camera_platform_interface/lib/src/types/flash_mode.dart
@@ -12,4 +12,7 @@ enum FlashMode {
 
   /// Always use the flash when taking a picture.
   always,
+
+  /// Turns on the flash light and keeps it on until switched off.
+  torch,
 }

--- a/packages/camera/camera_platform_interface/pubspec.yaml
+++ b/packages/camera/camera_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the camera plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/camera/camera_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.0.3
+version: 1.0.4
 
 dependencies:
   flutter:

--- a/packages/camera/camera_platform_interface/test/types/flash_mode_test.dart
+++ b/packages/camera/camera_platform_interface/test/types/flash_mode_test.dart
@@ -6,10 +6,10 @@ import 'package:camera_platform_interface/camera_platform_interface.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  test('FlashMode should contain 3 options', () {
+  test('FlashMode should contain 4 options', () {
     final values = FlashMode.values;
 
-    expect(values.length, 3);
+    expect(values.length, 4);
   });
 
   test("FlashMode enum should have items in correct index", () {
@@ -18,5 +18,6 @@ void main() {
     expect(values[0], FlashMode.off);
     expect(values[1], FlashMode.auto);
     expect(values[2], FlashMode.always);
+    expect(values[3], FlashMode.torch);
   });
 }


### PR DESCRIPTION
## Description

This PR adds the additional `torch` value to the `FlashModes` enum, which when implemented should turn on the flash light and keep it on until it is manually turned-off.

## Related Issues

flutter/flutter#19845
flutter/flutter#37853

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
