### PR TITLE
Revert "[share] Migrate to null-safety"

### DIFF
--- a/packages/share/CHANGELOG.md
+++ b/packages/share/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 2.0.0-nullsafety
-
-* Migrate to null safety.
-
 ## 0.6.5+5
 
 * Update Flutter SDK constraint.

--- a/packages/share/lib/share.dart
+++ b/packages/share/lib/share.dart
@@ -33,8 +33,8 @@ class Share {
   /// from [MethodChannel].
   static Future<void> share(
     String text, {
-    String? subject,
-    Rect? sharePositionOrigin,
+    String subject,
+    Rect sharePositionOrigin,
   }) {
     assert(text != null);
     assert(text.isNotEmpty);
@@ -67,10 +67,10 @@ class Share {
   /// from [MethodChannel].
   static Future<void> shareFiles(
     List<String> paths, {
-    List<String>? mimeTypes,
-    String? subject,
-    String? text,
-    Rect? sharePositionOrigin,
+    List<String> mimeTypes,
+    String subject,
+    String text,
+    Rect sharePositionOrigin,
   }) {
     assert(paths != null);
     assert(paths.isNotEmpty);

--- a/packages/share/pubspec.yaml
+++ b/packages/share/pubspec.yaml
@@ -2,7 +2,10 @@ name: share
 description: Flutter plugin for sharing content via the platform share UI, using
   the ACTION_SEND intent on Android and UIActivityViewController on iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/share
-version: 2.0.0-nullsafety
+# 0.6.y+z is compatible with 1.0.0, if you land a breaking change bump
+# the version to 2.0.0.
+# See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
+version: 0.6.5+5
 
 flutter:
   plugin:
@@ -14,20 +17,20 @@ flutter:
         pluginClass: FLTSharePlugin
 
 dependencies:
-  meta: ^1.3.0-nullsafety.6
-  mime: ^1.0.0-nullsafety.0
+  meta: ^1.0.5
+  mime: ^0.9.7
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  test: ^1.16.0-nullsafety.13
-  mockito: ^4.1.3
+  test: ^1.3.0
+  mockito: ^3.0.0
   flutter_test:
     sdk: flutter
   integration_test:
     path: ../integration_test
-  pedantic: ^1.10.0-nullsafety.3
+  pedantic: ^1.8.0
 
 environment:
+  sdk: ">=2.1.0 <3.0.0"
   flutter: ">=1.12.13+hotfix.5"
-  sdk: ">=2.12.0-0 <3.0.0"

--- a/packages/share/test/share_test.dart
+++ b/packages/share/test/share_test.dart
@@ -15,7 +15,7 @@ import 'package:flutter/services.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  late MockMethodChannel mockChannel;
+  MockMethodChannel mockChannel;
 
   setUp(() {
     mockChannel = MockMethodChannel();
@@ -24,6 +24,14 @@ void main() {
       // The explicit type can be void as the only method call has a return type of void.
       await mockChannel.invokeMethod<void>(call.method, call.arguments);
     });
+  });
+
+  test('sharing null fails', () {
+    expect(
+      () => Share.share(null),
+      throwsA(const TypeMatcher<AssertionError>()),
+    );
+    verifyZeroInteractions(mockChannel);
   });
 
   test('sharing empty fails', () {
@@ -48,6 +56,14 @@ void main() {
       'originWidth': 3.0,
       'originHeight': 4.0,
     }));
+  });
+
+  test('sharing null file fails', () {
+    expect(
+      () => Share.shareFiles([null]),
+      throwsA(const TypeMatcher<AssertionError>()),
+    );
+    verifyZeroInteractions(mockChannel);
   });
 
   test('sharing empty file fails', () {

--- a/script/nnbd_plugins.sh
+++ b/script/nnbd_plugins.sh
@@ -14,7 +14,6 @@ readonly NNBD_PLUGINS_LIST=(
   "local_auth"
   "path_provider"
   "plugin_platform_interface"
-  "share"
   "url_launcher"
   "video_player"
   "webview_flutter"


### PR DESCRIPTION
`flutter pub get` is causing:

```
The current Dart SDK version is 2.12.0-125.0.dev.

Because shelf_static >=0.2.8 depends on mime ^0.9.0 and shelf_static >=0.1.0+1 <0.2.8 requires SDK version >=1.0.0 <2.0.0 or >=2.0.0-dev.55.0 <2.0.0, shelf_static >=0.1.0+1 requires mime ^0.9.0.
And because test >=1.16.0-nullsafety.7 depends on shelf_static ^0.2.6, test >=1.16.0-nullsafety.7 requires mime ^0.9.0.
So, because share depends on both mime ^1.0.0-nullsafety.0 and test ^1.16.0-nullsafety.13, version solving failed.
```
Unfortunately, there is a bug in the script, and the tests never ran. https://cirrus-ci.com/task/5395059044515840

Reverts flutter/plugins#3311