### PR TITLE
Upgrade CocoaPods in Cirrus

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -132,6 +132,7 @@ task:
   osx_instance:
     image: catalina-xcode-11.3.1-flutter
   upgrade_script:
+    - sudo gem install cocoapods
     - flutter channel stable
     - flutter upgrade
     - flutter channel master
@@ -190,6 +191,7 @@ task:
   setup_script:
     - flutter config --enable-macos-desktop
   upgrade_script:
+    - sudo gem install cocoapods
     - flutter channel master
     - flutter upgrade
     - git fetch origin master


### PR DESCRIPTION
## Description

Add `sudo gem install cocoapods` to Cirrus to stay on latest CocoaPods.


## Related Issues

https://github.com/flutter/flutter/pull/71170 caused
```
Warning: CocoaPods minimum required version 1.9.0 or greater not installed. Skipping pod install.
  CocoaPods is used to retrieve the iOS and macOS platform side's plugin code that responds to your plugin usage on the Dart side.
  Without CocoaPods, plugins will not work on iOS or macOS.
  For more info, see https://flutter.dev/platform-plugins
To upgrade see https://guides.cocoapods.org/using/getting-started.html#installation for instructions.
CocoaPods not installed or not in valid state.
```
https://cirrus-ci.com/task/5814750833541120?command=build#L51