### PR TITLE
added disclaimer for missing web support in readme of url_launcher.

### DIFF
--- a/packages/url_launcher/url_launcher/README.md
+++ b/packages/url_launcher/url_launcher/README.md
@@ -94,3 +94,9 @@ If you do this for a URL of a page containing JavaScript, make sure to pass in
 `enableJavaScript: true`, or else the launch method will not work properly. On
 iOS, the default behavior is to open all web URLs within the app. Everything
 else is redirected to the app handler.
+
+## Disclaimer
+The `url_launcher: 6.0.0-nullsafety.1` plugin is missing web support. 
+The web suppport is temporary disabled until web is migrated to nnbd.
+See comments in [`pubspec.yaml`](https://github.com/flutter/plugins/blob/34667d44cc1f8668e24058f02f823f119214e2ee/
+packages/url_launcher/url_launcher/pubspec.yaml#L37) file.

--- a/packages/url_launcher/url_launcher/README.md
+++ b/packages/url_launcher/url_launcher/README.md
@@ -94,3 +94,9 @@ If you do this for a URL of a page containing JavaScript, make sure to pass in
 `enableJavaScript: true`, or else the launch method will not work properly. On
 iOS, the default behavior is to open all web URLs within the app. Everything
 else is redirected to the app handler.
+
+## Disclaimer
+The `url_launcher: 6.0.0-nullsafety.1` plugin does not have web support. 
+The web support is temporarily disabled until the web is migrated to nnbd.
+See comments in [`pubspec.yaml`](https://github.com/flutter/plugins/blob/34667d44cc1f8668e24058f02f823f119214e2ee/
+packages/url_launcher/url_launcher/pubspec.yaml#L37) file.

--- a/packages/url_launcher/url_launcher/README.md
+++ b/packages/url_launcher/url_launcher/README.md
@@ -94,9 +94,3 @@ If you do this for a URL of a page containing JavaScript, make sure to pass in
 `enableJavaScript: true`, or else the launch method will not work properly. On
 iOS, the default behavior is to open all web URLs within the app. Everything
 else is redirected to the app handler.
-
-## Disclaimer
-The `url_launcher: 6.0.0-nullsafety.1` plugin is missing web support. 
-The web suppport is temporary disabled until web is migrated to nnbd.
-See comments in [`pubspec.yaml`](https://github.com/flutter/plugins/blob/34667d44cc1f8668e24058f02f823f119214e2ee/
-packages/url_launcher/url_launcher/pubspec.yaml#L37) file.


### PR DESCRIPTION
## Description
Added disclaimer for missing web support in the readme file of url_launcher: 6.0.0-nullsafety.1.

## Related Issues
Fixes #72239

##Tests

I added the following tests: N/A because only docs are changed.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
