### PR TITLE
[local_auth] The alert should be called in the main thread.

### DIFF
--- a/packages/local_auth/ios/Classes/FLTLocalAuthPlugin.m
+++ b/packages/local_auth/ios/Classes/FLTLocalAuthPlugin.m
@@ -62,9 +62,15 @@
                 }];
     [alert addAction:additionalAction];
   }
-  [[UIApplication sharedApplication].delegate.window.rootViewController presentViewController:alert
-                                                                                     animated:YES
-                                                                                   completion:nil];
+
+  @try {
+      dispatch_async(dispatch_get_main_queue(), ^{
+          [[UIApplication sharedApplication].delegate.window.rootViewController presentViewController:alert  animated:YES  completion:nil];
+      });
+  } @catch (NSException *exception) {
+      NSLog(@"Exception presentViewController: %@", exception);
+  } @finally {
+  }
 }
 
 - (void)getAvailableBiometrics:(FlutterResult)result {


### PR DESCRIPTION
This fix resolves:
(NSException *) exception = 0x0000000280f86df0 name: "NSInternalInconsistencyException" - reason: "Modifications to the layout engine must not be performed from a background thread after it has been accessed from the main thread."

## Description

This PR resolves an issue for a complete app crash when the biometric lockout happens in the app. The alert throws an error claiming the UI modification should happen in the main thread instead of the background process. Therefore, I run the function in the main thread and wrap it on try catch block for any failure. 

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?
- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
