### PR TITLE
[image_picker] Do not copy a static field into another static field

### DIFF
--- a/packages/image_picker/image_picker/CHANGELOG.md
+++ b/packages/image_picker/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.7+19
+
+* Do not copy static field to another static field.
+
 ## 0.6.7+18
 
 * Fix outdated links across a number of markdown files ([#3276](https://github.com/flutter/plugins/pull/3276))

--- a/packages/image_picker/image_picker/lib/image_picker.dart
+++ b/packages/image_picker/image_picker/lib/image_picker.dart
@@ -27,7 +27,7 @@ export 'package:image_picker_platform_interface/image_picker_platform_interface.
 class ImagePicker {
   /// The platform interface that drives this plugin
   @visibleForTesting
-  static ImagePickerPlatform platform = ImagePickerPlatform.instance;
+  static ImagePickerPlatform get platform => ImagePickerPlatform.instance;
 
   /// Returns a [File] object pointing to the image that was picked.
   ///

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker
 description: Flutter plugin for selecting images from the Android and iOS image
   library, and taking new pictures with the camera.
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker/image_picker
-version: 0.6.7+18
+version: 0.6.7+19
 
 flutter:
   plugin:

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -25,7 +25,9 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     path: ../../integration_test
+  mockito: ^4.1.3
   pedantic: ^1.8.0
+  plugin_platform_interface: ^1.0.3
 
 environment:
   sdk: ">=2.1.0 <3.0.0"

--- a/packages/image_picker/image_picker/test/image_picker_test.dart
+++ b/packages/image_picker/image_picker/test/image_picker_test.dart
@@ -5,6 +5,9 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:image_picker_platform_interface/image_picker_platform_interface.dart';
+import 'package:mockito/mockito.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -24,6 +27,14 @@ void main() {
       });
 
       log.clear();
+    });
+
+    test('ImagePicker platform instance overrides the actual platform used', () {
+      final ImagePickerPlatform savedPlatform = ImagePickerPlatform.instance;
+      final MockPlatform mockPlatform = MockPlatform();
+      ImagePickerPlatform.instance = mockPlatform;
+      expect(ImagePicker.platform, mockPlatform);
+      ImagePickerPlatform.instance = savedPlatform;
     });
 
     group('#pickImage', () {
@@ -336,3 +347,6 @@ void main() {
     });
   });
 }
+
+class MockPlatform extends Mock with MockPlatformInterfaceMixin
+    implements ImagePickerPlatform {}

--- a/packages/image_picker/image_picker/test/image_picker_test.dart
+++ b/packages/image_picker/image_picker/test/image_picker_test.dart
@@ -29,7 +29,8 @@ void main() {
       log.clear();
     });
 
-    test('ImagePicker platform instance overrides the actual platform used', () {
+    test('ImagePicker platform instance overrides the actual platform used',
+        () {
       final ImagePickerPlatform savedPlatform = ImagePickerPlatform.instance;
       final MockPlatform mockPlatform = MockPlatform();
       ImagePickerPlatform.instance = mockPlatform;
@@ -348,5 +349,6 @@ void main() {
   });
 }
 
-class MockPlatform extends Mock with MockPlatformInterfaceMixin
+class MockPlatform extends Mock
+    with MockPlatformInterfaceMixin
     implements ImagePickerPlatform {}


### PR DESCRIPTION
## Description

We fixed this in g3 but forgot to push upstream.

We encourage overriding the platform implementation in google3 for tests. The pattern `image_picker` is currently using makes this difficult since there are two sources of truth for the platform instance where there should be one.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
