### PR TITLE
fix url == nil creash

### DIFF
--- a/packages/url_launcher/url_launcher/ios/Classes/FLTURLLauncherPlugin.m
+++ b/packages/url_launcher/url_launcher/ios/Classes/FLTURLLauncherPlugin.m
@@ -102,6 +102,7 @@ API_AVAILABLE(ios(9.0))
 
 - (BOOL)canLaunchURL:(NSString *)urlString {
   NSURL *url = [NSURL URLWithString:urlString];
+  if(!url) return NO;
   UIApplication *application = [UIApplication sharedApplication];
   return [application canOpenURL:url];
 }
@@ -110,6 +111,7 @@ API_AVAILABLE(ios(9.0))
              call:(FlutterMethodCall *)call
            result:(FlutterResult)result {
   NSURL *url = [NSURL URLWithString:urlString];
+  if(!url) return;
   UIApplication *application = [UIApplication sharedApplication];
 
   if (@available(iOS 10.0, *)) {


### PR DESCRIPTION
## Description

iOS system objective-c , When using "url_launcher" plugin, if the urlString is illegal or Unusual, [NSURL URLWithString:urlString] = nil, calling the canOpenURL method will crash.

## Related Issues

[issue72704](https://github.com/flutter/flutter/issues/72704)


