### PR TITLE
[cross_file] Make sure saveTo returns a Future

### DIFF
--- a/packages/cross_file/CHANGELOG.md
+++ b/packages/cross_file/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0
+
+* **breaking change** Make sure the `saveTo` method returns a `Future` so it can be awaited and users are sure the file has been written to disk.
+
 ## 0.1.0+2
 
 * Fix outdated links across a number of markdown files ([#3276](https://github.com/flutter/plugins/pull/3276))

--- a/packages/cross_file/lib/src/types/base.dart
+++ b/packages/cross_file/lib/src/types/base.dart
@@ -18,7 +18,7 @@ abstract class XFileBase {
   XFileBase(String path);
 
   /// Save the CrossFile at the indicated file path.
-  void saveTo(String path) async {
+  Future<void> saveTo(String path) {
     throw UnimplementedError('saveTo has not been implemented.');
   }
 

--- a/packages/cross_file/lib/src/types/html.dart
+++ b/packages/cross_file/lib/src/types/html.dart
@@ -108,7 +108,7 @@ class XFile extends XFileBase {
 
   /// Saves the data of this CrossFile at the location indicated by path.
   /// For the web implementation, the path variable is ignored.
-  void saveTo(String path) async {
+  Future<void> saveTo(String path) async {
     // Create a DOM container where we can host the anchor.
     _target = ensureInitialized('__x_file_dom_element');
 

--- a/packages/cross_file/lib/src/types/io.dart
+++ b/packages/cross_file/lib/src/types/io.dart
@@ -57,7 +57,7 @@ class XFile extends XFileBase {
   }
 
   @override
-  void saveTo(String path) async {
+  Future<void> saveTo(String path) async {
     File fileToSave = File(path);
     await fileToSave.writeAsBytes(_bytes ?? (await readAsBytes()));
     await fileToSave.create();

--- a/packages/cross_file/pubspec.yaml
+++ b/packages/cross_file/pubspec.yaml
@@ -1,7 +1,7 @@
 name: cross_file
 description: An abstraction to allow working with files across multiple platforms.
 homepage: https://github.com/flutter/plugins/tree/master/packages/cross_file
-version: 0.1.0+2
+version: 0.2.0
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Description

Make sure the `saveTo` method returns a `Future` making it clear to users that the method can be awaited. Previous version was marked `async` only which could still be awaited but this is not clear to most users.

## Related Issues

Resolves flutter/flutter#72652

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
