### PR TITLE
[camera] Added maxVideoDuration to startVideoRecording

### DIFF
--- a/packages/camera/camera_platform_interface/CHANGELOG.md
+++ b/packages/camera/camera_platform_interface/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.1.0
 
-- Added maxVideoDuration to startVideoRecording for implementation of a limitation to the duration of a video recording
+- Added an optional `maxVideoDuration` parameter to the `startVideoRecording` method, which allows implementations to limit the duration of a video recording.
 
 ## 1.0.4
 

--- a/packages/camera/camera_platform_interface/CHANGELOG.md
+++ b/packages/camera/camera_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+
+- Added maxVideoDuration to startVideoRecording for implementation of a limitation to the duration of a video recording
+
 ## 1.0.4
 
 - Added the torch option to the FlashMode enum, which when implemented indicates the flash light should be turned on continuously.

--- a/packages/camera/camera_platform_interface/lib/src/method_channel/method_channel_camera.dart
+++ b/packages/camera/camera_platform_interface/lib/src/method_channel/method_channel_camera.dart
@@ -146,7 +146,8 @@ class MethodChannelCamera extends CameraPlatform {
       _channel.invokeMethod<void>('prepareForVideoRecording');
 
   @override
-  Future<void> startVideoRecording(int cameraId, {Duration maxVideoDuration}) async {
+  Future<void> startVideoRecording(int cameraId,
+      {Duration maxVideoDuration}) async {
     await _channel.invokeMethod<void>(
       'startVideoRecording',
       <String, dynamic>{

--- a/packages/camera/camera_platform_interface/lib/src/method_channel/method_channel_camera.dart
+++ b/packages/camera/camera_platform_interface/lib/src/method_channel/method_channel_camera.dart
@@ -146,10 +146,13 @@ class MethodChannelCamera extends CameraPlatform {
       _channel.invokeMethod<void>('prepareForVideoRecording');
 
   @override
-  Future<void> startVideoRecording(int cameraId) async {
+  Future<void> startVideoRecording(int cameraId, {Duration maxVideoDuration}) async {
     await _channel.invokeMethod<void>(
       'startVideoRecording',
-      <String, dynamic>{'cameraId': cameraId},
+      <String, dynamic>{
+        'cameraId': cameraId,
+        'maxVideoDuration': maxVideoDuration?.inMilliseconds,
+      },
     );
   }
 

--- a/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
+++ b/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
@@ -88,7 +88,9 @@ abstract class CameraPlatform extends PlatformInterface {
 
   /// Starts a video recording.
   ///
-  /// The length of the recording can be limited by specifying the [maxVideoDuration]. By default no maximum duration is specified, meaning the recording will continue until manually stopped.
+  /// The length of the recording can be limited by specifying the [maxVideoDuration].
+  /// By default no maximum duration is specified,
+  /// meaning the recording will continue until manually stopped.
   /// The video is returned as a [XFile] after calling [stopVideoRecording].
   Future<void> startVideoRecording(int cameraId, {Duration maxVideoDuration}) {
     throw UnimplementedError('startVideoRecording() is not implemented.');

--- a/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
+++ b/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
@@ -88,8 +88,9 @@ abstract class CameraPlatform extends PlatformInterface {
 
   /// Starts a video recording.
   ///
+  /// The length of the recording can be limited by defining the [maxVideoDuration]
   /// The video is returned as a [XFile] after calling [stopVideoRecording].
-  Future<void> startVideoRecording(int cameraId) {
+  Future<void> startVideoRecording(int cameraId, {Duration maxVideoDuration}) {
     throw UnimplementedError('startVideoRecording() is not implemented.');
   }
 

--- a/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
+++ b/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
@@ -88,7 +88,7 @@ abstract class CameraPlatform extends PlatformInterface {
 
   /// Starts a video recording.
   ///
-  /// The length of the recording can be limited by defining the [maxVideoDuration]
+  /// The length of the recording can be limited by specifying the [maxVideoDuration]. By default no maximum duration is specified, meaning the recording will continue until manually stopped.
   /// The video is returned as a [XFile] after calling [stopVideoRecording].
   Future<void> startVideoRecording(int cameraId, {Duration maxVideoDuration}) {
     throw UnimplementedError('startVideoRecording() is not implemented.');

--- a/packages/camera/camera_platform_interface/pubspec.yaml
+++ b/packages/camera/camera_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the camera plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/camera/camera_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.0.4
+version: 1.1.0
 
 dependencies:
   flutter:

--- a/packages/camera/camera_platform_interface/test/method_channel/method_channel_camera_test.dart
+++ b/packages/camera/camera_platform_interface/test/method_channel/method_channel_camera_test.dart
@@ -411,12 +411,13 @@ void main() {
         expect(channel.log, <Matcher>[
           isMethodCall('startVideoRecording', arguments: {
             'cameraId': cameraId,
-              'maxVideoDuration': null,
+            'maxVideoDuration': null,
           }),
         ]);
       });
 
-      test('Should pass maxVideoDuration when starting recording a video', () async {
+      test('Should pass maxVideoDuration when starting recording a video',
+          () async {
         // Arrange
         MethodChannelMock channel = MethodChannelMock(
           channelName: 'plugins.flutter.io/camera',
@@ -431,10 +432,8 @@ void main() {
 
         // Assert
         expect(channel.log, <Matcher>[
-          isMethodCall('startVideoRecording', arguments: {
-            'cameraId': cameraId,
-            'maxVideoDuration': 10000
-          }),
+          isMethodCall('startVideoRecording',
+              arguments: {'cameraId': cameraId, 'maxVideoDuration': 10000}),
         ]);
       });
 

--- a/packages/camera/camera_platform_interface/test/method_channel/method_channel_camera_test.dart
+++ b/packages/camera/camera_platform_interface/test/method_channel/method_channel_camera_test.dart
@@ -411,6 +411,29 @@ void main() {
         expect(channel.log, <Matcher>[
           isMethodCall('startVideoRecording', arguments: {
             'cameraId': cameraId,
+              'maxVideoDuration': null,
+          }),
+        ]);
+      });
+
+      test('Should pass maxVideoDuration when starting recording a video', () async {
+        // Arrange
+        MethodChannelMock channel = MethodChannelMock(
+          channelName: 'plugins.flutter.io/camera',
+          methods: {'startVideoRecording': null},
+        );
+
+        // Act
+        await camera.startVideoRecording(
+          cameraId,
+          maxVideoDuration: Duration(seconds: 10),
+        );
+
+        // Assert
+        expect(channel.log, <Matcher>[
+          isMethodCall('startVideoRecording', arguments: {
+            'cameraId': cameraId,
+            'maxVideoDuration': 10000
           }),
         ]);
       });


### PR DESCRIPTION
## Description

Adds maxVideoDuration to startVideoRecording for implementation of a maximum video recording length. 

## Related Issues

[#23414](https://github.com/flutter/flutter/issues/23414)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
