### PR TITLE
[battery] Migrate battery_plugin_interface to null safety

### DIFF
--- a/packages/battery/battery_platform_interface/CHANGELOG.md
+++ b/packages/battery/battery_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-nullsafety
+
+* Migrate to null safety.
+
 ## 1.0.1
 
 - Update Flutter SDK constraint.

--- a/packages/battery/battery_platform_interface/lib/method_channel/method_channel_battery.dart
+++ b/packages/battery/battery_platform_interface/lib/method_channel/method_channel_battery.dart
@@ -23,15 +23,17 @@ class MethodChannelBattery extends BatteryPlatform {
   }
 
   /// Stream variable for storing battery state.
-  late final Stream<BatteryState> _onBatteryStateChanged;
+  Stream<BatteryState>? _onBatteryStateChanged;
 
   /// Event channel for getting battery change state.
   Stream<BatteryState> onBatteryStateChanged() {
-    _onBatteryStateChanged = eventChannel
-        .receiveBroadcastStream()
-        .map((dynamic event) => _parseBatteryState(event));
+    if (_onBatteryStateChanged == null) {
+      _onBatteryStateChanged = eventChannel
+          .receiveBroadcastStream()
+          .map((dynamic event) => _parseBatteryState(event));
+    }
 
-    return _onBatteryStateChanged;
+    return _onBatteryStateChanged!;
   }
 }
 

--- a/packages/battery/battery_platform_interface/lib/method_channel/method_channel_battery.dart
+++ b/packages/battery/battery_platform_interface/lib/method_channel/method_channel_battery.dart
@@ -11,11 +11,11 @@ import '../battery_platform_interface.dart';
 class MethodChannelBattery extends BatteryPlatform {
   /// The method channel used to interact with the native platform.
   @visibleForTesting
-  MethodChannel channel = MethodChannel('plugins.flutter.io/battery');
+  final MethodChannel channel = MethodChannel('plugins.flutter.io/battery');
 
   /// The event channel used to interact with the native platform.
   @visibleForTesting
-  EventChannel eventChannel = EventChannel('plugins.flutter.io/charging');
+  final EventChannel eventChannel = EventChannel('plugins.flutter.io/charging');
 
   /// Method channel for getting battery level.
   Future<int> batteryLevel() async {
@@ -23,15 +23,14 @@ class MethodChannelBattery extends BatteryPlatform {
   }
 
   /// Stream variable for storing battery state.
-  Stream<BatteryState> _onBatteryStateChanged;
+  late final Stream<BatteryState> _onBatteryStateChanged;
 
   /// Event channel for getting battery change state.
   Stream<BatteryState> onBatteryStateChanged() {
-    if (_onBatteryStateChanged == null) {
-      _onBatteryStateChanged = eventChannel
-          .receiveBroadcastStream()
-          .map((dynamic event) => _parseBatteryState(event));
-    }
+    _onBatteryStateChanged = eventChannel
+        .receiveBroadcastStream()
+        .map((dynamic event) => _parseBatteryState(event));
+
     return _onBatteryStateChanged;
   }
 }

--- a/packages/battery/battery_platform_interface/pubspec.yaml
+++ b/packages/battery/battery_platform_interface/pubspec.yaml
@@ -3,20 +3,20 @@ description: A common platform interface for the battery plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/battery
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.0.1
+version: 2.0.0-nullsafety
 
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.1.8
-  plugin_platform_interface: ^1.0.2
+  meta: ^1.3.0-nullsafety.6
+  plugin_platform_interface: ^1.1.0-nullsafety.1
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: ^4.1.1
-  pedantic: ^1.8.0
+  mockito: ^5.0.0-nullsafety.0
+  pedantic: ^1.10.0-nullsafety.3
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"
   flutter: ">=1.9.1+hotfix.4"

--- a/packages/battery/battery_platform_interface/pubspec.yaml
+++ b/packages/battery/battery_platform_interface/pubspec.yaml
@@ -8,14 +8,14 @@ version: 2.0.0-nullsafety
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.3.0-nullsafety.6
+  meta: ^1.3.0-nullsafety
   plugin_platform_interface: ^1.1.0-nullsafety.1
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0-nullsafety.0
-  pedantic: ^1.10.0-nullsafety.3
+  pedantic: ^1.10.0-nullsafety
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"

--- a/packages/battery/battery_platform_interface/test/method_channel_battery_test.dart
+++ b/packages/battery/battery_platform_interface/test/method_channel_battery_test.dart
@@ -12,8 +12,8 @@ import 'package:battery_platform_interface/method_channel/method_channel_battery
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  group("$MethodChannelBattery", () {
-    MethodChannelBattery methodChannelBattery;
+  group('$MethodChannelBattery', () {
+    late MethodChannelBattery methodChannelBattery;
 
     setUp(() async {
       methodChannelBattery = MethodChannelBattery();
@@ -32,7 +32,7 @@ void main() {
           .setMockMethodCallHandler((MethodCall methodCall) async {
         switch (methodCall.method) {
           case 'listen':
-            await ServicesBinding.instance.defaultBinaryMessenger
+            await ServicesBinding.instance!.defaultBinaryMessenger
                 .handlePlatformMessage(
               methodChannelBattery.eventChannel.name,
               methodChannelBattery.eventChannel.codec
@@ -48,13 +48,13 @@ void main() {
     });
 
     /// Test for batetry level call.
-    test("getBatteryLevel", () async {
+    test('getBatteryLevel', () async {
       final int result = await methodChannelBattery.batteryLevel();
       expect(result, 90);
     });
 
     /// Test for battery changed state call.
-    test("onBatteryChanged", () async {
+    test('onBatteryChanged', () async {
       final BatteryState result =
           await methodChannelBattery.onBatteryStateChanged().first;
       expect(result, BatteryState.full);

--- a/script/nnbd_plugins.sh
+++ b/script/nnbd_plugins.sh
@@ -6,6 +6,7 @@
 
 readonly NNBD_PLUGINS_LIST=(
   "android_intent"
+  "battery"
   "connectivity"
   "device_info"
   "flutter_plugin_android_lifecycle"


### PR DESCRIPTION
## Description

Migrate battery_plugin_interface to null safety.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
