### PR TITLE
[camera] Revert platform interface dependency to lower version

### DIFF
--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.3+4
+
+* Revert previous dependency update: Changed dependency on camera_platform_interface to >=1.04 <1.1.0.
+
 ## 0.6.3+3
 
 * Updated dependency on camera_platform_interface to ^1.2.0.

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -2,13 +2,13 @@ name: camera
 description: A Flutter plugin for getting information about and controlling the
   camera on Android and iOS. Supports previewing the camera feed, capturing images, capturing video,
   and streaming image buffers to dart.
-version: 0.6.3+3
+version: 0.6.3+4
 homepage: https://github.com/flutter/plugins/tree/master/packages/camera/camera
 
 dependencies:
   flutter:
     sdk: flutter
-  camera_platform_interface: ^1.2.0
+  camera_platform_interface: ">=1.0.4 <1.1.0"
 
 dev_dependencies:
   path_provider: ^0.5.0

--- a/packages/camera/camera/test/camera_test.dart
+++ b/packages/camera/camera/test/camera_test.dart
@@ -26,8 +26,7 @@ get mockAvailableCameras => [
 
 get mockInitializeCamera => 13;
 
-get mockOnCameraInitializedEvent =>
-    CameraInitializedEvent(13, 75, 75, ExposureMode.auto, false);
+get mockOnCameraInitializedEvent => CameraInitializedEvent(13, 75, 75);
 
 get mockOnCameraClosingEvent => null;
 
@@ -642,8 +641,7 @@ class MockCameraPlatform extends Mock
       : Future.value(mockTakePicture);
 
   @override
-  Future<XFile> startVideoRecording(int cameraId,
-          {Duration maxVideoDuration}) =>
+  Future<XFile> startVideoRecording(int cameraId) =>
       Future.value(mockVideoRecordingXFile);
 }
 


### PR DESCRIPTION
## Description

Currently, the camera plugin can no longer initialize due to an update to the platform interface. 
This PR fixes this issue by depending on a lower version of the platform interface until the camera plugin itself is updated as well.

## Related Issues

- flutter/flutter#73059
- Resolves flutter/flutter#73088

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
