### PR TITLE
https://github.com/flutter/flutter/issues/47755

### DIFF
--- a/packages/image_picker/image_picker/ios/Classes/FLTImagePickerPhotoAssetUtil.m
+++ b/packages/image_picker/image_picker/ios/Classes/FLTImagePickerPhotoAssetUtil.m
@@ -79,7 +79,7 @@
   NSData *data = [FLTImagePickerMetaDataUtil convertImage:image
                                                 usingType:type
                                                   quality:imageQuality];
-  if (metaData) {
+  if (metaData && data) {
     data = [FLTImagePickerMetaDataUtil updateMetaData:metaData toImage:data];
   }
 


### PR DESCRIPTION
## Description

There are some scenarios where the image returned from imagePickerControler. didFinishPickingMediaWithInfo  is null when picked. The original and edit images are null. UIImagePickerControllerPHAsset is present, however.
We believe that, in this scenario, the phone has not downloaded the full image, and just has a handle to a networked image. We found an apple developer thread that indicated the following: https://developer.apple.com/forums/thread/88147
Applying the fix suggested in the thread above seems to fix this scenario. Our pull request has the fix for your review.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues/47755

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
