### PR TITLE
[image_picker: iOS] Expose allowsEditing field of UIImagePickerController.

### DIFF
--- a/packages/image_picker/image_picker/CHANGELOG.md
+++ b/packages/image_picker/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.7+20
+
+* iOS: Expose allowsEditing field.
+
 ## 0.6.7+19
 
 * Do not copy static field to another static field.

--- a/packages/image_picker/image_picker/ios/Classes/FLTImagePickerPlugin.m
+++ b/packages/image_picker/image_picker/ios/Classes/FLTImagePickerPlugin.m
@@ -72,6 +72,9 @@ static const int SOURCE_GALLERY = 1;
     _imagePickerController.delegate = self;
     _imagePickerController.mediaTypes = @[ (NSString *)kUTTypeImage ];
 
+    BOOL allowsEditing = [[_arguments objectForKey:@"allowsEditing"] isEqual:@YES];
+    _imagePickerController.allowsEditing = allowsEditing;
+
     self.result = result;
     _arguments = call.arguments;
 

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker
 description: Flutter plugin for selecting images from the Android and iOS image
   library, and taking new pictures with the camera.
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker/image_picker
-version: 0.6.7+19
+version: 0.6.7+20
 
 flutter:
   plugin:

--- a/packages/image_picker/image_picker_platform_interface/CHANGELOG.md
+++ b/packages/image_picker/image_picker_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.6
+
+* iOS: Expose allowsEditing field.
+
 ## 1.1.5
 
 * Update Flutter SDK constraint.

--- a/packages/image_picker/image_picker_platform_interface/lib/src/method_channel/method_channel_image_picker.dart
+++ b/packages/image_picker/image_picker_platform_interface/lib/src/method_channel/method_channel_image_picker.dart
@@ -7,9 +7,8 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
-import 'package:meta/meta.dart' show required, visibleForTesting;
-
 import 'package:image_picker_platform_interface/image_picker_platform_interface.dart';
+import 'package:meta/meta.dart' show required, visibleForTesting;
 
 final MethodChannel _channel = MethodChannel('plugins.flutter.io/image_picker');
 
@@ -26,6 +25,7 @@ class MethodChannelImagePicker extends ImagePickerPlatform {
     double maxHeight,
     int imageQuality,
     CameraDevice preferredCameraDevice = CameraDevice.rear,
+    bool allowsEditing = false,
   }) async {
     String path = await pickImagePath(
       source: source,
@@ -33,6 +33,7 @@ class MethodChannelImagePicker extends ImagePickerPlatform {
       maxHeight: maxHeight,
       imageQuality: imageQuality,
       preferredCameraDevice: preferredCameraDevice,
+      allowsEditing: allowsEditing,
     );
     return path != null ? PickedFile(path) : null;
   }
@@ -44,6 +45,7 @@ class MethodChannelImagePicker extends ImagePickerPlatform {
     double maxHeight,
     int imageQuality,
     CameraDevice preferredCameraDevice = CameraDevice.rear,
+    bool allowsEditing = false,
   }) {
     assert(source != null);
     if (imageQuality != null && (imageQuality < 0 || imageQuality > 100)) {
@@ -66,7 +68,8 @@ class MethodChannelImagePicker extends ImagePickerPlatform {
         'maxWidth': maxWidth,
         'maxHeight': maxHeight,
         'imageQuality': imageQuality,
-        'cameraDevice': preferredCameraDevice.index
+        'cameraDevice': preferredCameraDevice.index,
+        'allowsEditing': allowsEditing,
       },
     );
   }

--- a/packages/image_picker/image_picker_platform_interface/pubspec.yaml
+++ b/packages/image_picker/image_picker_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the image_picker plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker/image_picker_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.1.5
+version: 1.1.6
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Description

Currently image picker for iOS doesn't allow user to edit image after they picked one. To add this possibility UIImagePickerController in iOS has a boolean field allowsEditing which is now can be passed from plugin interface. 

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
