### PR TITLE
Updated references to obsolete Material button widgets

### DIFF
--- a/packages/battery/example/lib/main.dart
+++ b/packages/battery/example/lib/main.dart
@@ -67,7 +67,7 @@ class _MyHomePageState extends State<MyHomePage> {
             child: new AlertDialog(
               content: new Text('Battery: ${await _battery.batteryLevel}%'),
               actions: <Widget>[
-                new FlatButton(
+                new TextButton(
                   child: const Text('OK'),
                   onPressed: () {
                     Navigator.pop(context);

--- a/packages/firebase_messaging/example/lib/main.dart
+++ b/packages/firebase_messaging/example/lib/main.dart
@@ -101,12 +101,12 @@ class _PushMessagingExampleState extends State<PushMessagingExample> {
         child: new AlertDialog(
           content: new Text("Item ${item.itemId} has been updated"),
           actions: <Widget>[
-            new FlatButton(
+            new TextButton(
                 child: const Text('CLOSE'),
                 onPressed: () {
                   Navigator.pop(context, false);
                 }),
-            new FlatButton(
+            new TextButton(
                 child: const Text('SHOW'),
                 onPressed: () {
                   Navigator.pop(context, true);
@@ -191,7 +191,7 @@ class _PushMessagingExampleState extends State<PushMessagingExample> {
                         });
                       }),
                 ),
-                new FlatButton(
+                new TextButton(
                   child: const Text("subscribe"),
                   onPressed: _topicButtonsDisabled
                       ? null
@@ -201,7 +201,7 @@ class _PushMessagingExampleState extends State<PushMessagingExample> {
                           _clearTopicText();
                         },
                 ),
-                new FlatButton(
+                new TextButton(
                   child: const Text("unsubscribe"),
                   onPressed: _topicButtonsDisabled
                       ? null

--- a/packages/google_sign_in/example/lib/main.dart
+++ b/packages/google_sign_in/example/lib/main.dart
@@ -118,11 +118,11 @@ class SignInDemoState extends State<SignInDemo> {
           ),
           const Text("Signed in successfully."),
           new Text(_contactText),
-          new RaisedButton(
+          new ElevatedButton(
             child: const Text('SIGN OUT'),
             onPressed: _handleSignOut,
           ),
-          new RaisedButton(
+          new ElevatedButton(
             child: const Text('REFRESH'),
             onPressed: _handleGetContact,
           ),
@@ -133,7 +133,7 @@ class SignInDemoState extends State<SignInDemo> {
         mainAxisAlignment: MainAxisAlignment.spaceAround,
         children: <Widget>[
           const Text("You are not currently signed in."),
-          new RaisedButton(
+          new ElevatedButton(
             child: const Text('SIGN IN'),
             onPressed: _handleSignIn,
           ),

--- a/packages/path_provider/example/lib/main.dart
+++ b/packages/path_provider/example/lib/main.dart
@@ -85,7 +85,7 @@ class _MyHomePageState extends State<MyHomePage> {
               children: <Widget>[
                 new Padding(
                   padding: const EdgeInsets.all(16.0),
-                  child: new RaisedButton(
+                  child: new ElevatedButton(
                     child: const Text('Get Temporary Directory'),
                     onPressed: _requestTempDirectory,
                   ),
@@ -100,7 +100,7 @@ class _MyHomePageState extends State<MyHomePage> {
               children: <Widget>[
                 new Padding(
                   padding: const EdgeInsets.all(16.0),
-                  child: new RaisedButton(
+                  child: new ElevatedButton(
                     child: const Text('Get Application Documents Directory'),
                     onPressed: _requestAppDocumentsDirectory,
                   ),
@@ -114,9 +114,9 @@ class _MyHomePageState extends State<MyHomePage> {
             new Column(children: <Widget>[
               new Padding(
                 padding: const EdgeInsets.all(16.0),
-                child: new RaisedButton(
+                child: new ElevatedButton(
                   child: new Text('${Platform.isIOS ?
-                                    "External directories are unavailable " 
+                                    "External directories are unavailable "
                                     "on iOS":
                                     "Get External Storage Directory" }'),
                   onPressed:

--- a/packages/share/example/lib/main.dart
+++ b/packages/share/example/lib/main.dart
@@ -40,7 +40,7 @@ class DemoAppState extends State<DemoApp> {
                         text = value;
                       }),
                 ),
-                new RaisedButton(
+                new ElevatedButton(
                   child: const Text('Share'),
                   onPressed: text.isNotEmpty
                       ? () {

--- a/packages/url_launcher/example/lib/main.dart
+++ b/packages/url_launcher/example/lib/main.dart
@@ -74,7 +74,7 @@ class _MyHomePageState extends State<MyHomePage> {
                   padding: const EdgeInsets.all(16.0),
                   child: const Text('https://flutter.io'),
                 ),
-                new RaisedButton(
+                new ElevatedButton(
                   onPressed: _launchUrl,
                   child: const Text('Go'),
                 ),


### PR DESCRIPTION
Updated references to the obsolete Material button widgets:

- FlatButton becomes TextButton
- RaisedButton becomes ElevatedButton
- OutlineButton becomes OutlinedButton

These changes will enable the obsolete widgets to be deprecated: https://github.com/flutter/flutter/pull/73352

More information about the evolution of these classes:

- flutter.dev/go/material-button-migration-guide
- flutter.dev/go/material-button-system-updates