### PR TITLE
Update obsolete button refs in plugin examples

### DIFF
--- a/packages/android_alarm_manager/CHANGELOG.md
+++ b/packages/android_alarm_manager/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.5+20
+
+* Update the example app: remove the depreciated `RaisedButton` and `FlatButton` widgets.
+
 ## 0.4.5+19
 
 * Fix outdated links across a number of markdown files ([#3276](https://github.com/flutter/plugins/pull/3276))

--- a/packages/android_alarm_manager/CHANGELOG.md
+++ b/packages/android_alarm_manager/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.4.5+20
 
-* Update the example app: remove the depreciated `RaisedButton` and `FlatButton` widgets.
+* Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.
 
 ## 0.4.5+19
 

--- a/packages/android_alarm_manager/example/lib/main.dart
+++ b/packages/android_alarm_manager/example/lib/main.dart
@@ -131,7 +131,7 @@ class _AlarmHomePageState extends State<_AlarmHomePage> {
                 ),
               ],
             ),
-            RaisedButton(
+            ElevatedButton(
               child: Text(
                 'Schedule OneShot Alarm',
               ),

--- a/packages/android_alarm_manager/pubspec.yaml
+++ b/packages/android_alarm_manager/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for accessing the Android AlarmManager service, and
 # 0.4.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.4.5+19
+version: 0.4.5+20
 homepage: https://github.com/flutter/plugins/tree/master/packages/android_alarm_manager
 
 dependencies:

--- a/packages/android_intent/CHANGELOG.md
+++ b/packages/android_intent/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.0.0-nullsafety.2
 
-* Update the example app: remove the depreciated `RaisedButton` and `FlatButton` widgets.
+* Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.
 
 ## 2.0.0-nullsafety.1
 

--- a/packages/android_intent/CHANGELOG.md
+++ b/packages/android_intent/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-nullsafety.2
+
+* Update the example app: remove the depreciated `RaisedButton` and `FlatButton` widgets.
+
 ## 2.0.0-nullsafety.1
 
 * Fix outdated links across a number of markdown files ([#3276](https://github.com/flutter/plugins/pull/3276))

--- a/packages/android_intent/example/lib/main.dart
+++ b/packages/android_intent/example/lib/main.dart
@@ -59,12 +59,12 @@ class MyHomePage extends StatelessWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
           children: <Widget>[
-            RaisedButton(
+            ElevatedButton(
               child: const Text(
                   'Tap here to set an alarm\non weekdays at 9:30pm.'),
               onPressed: _createAlarm,
             ),
-            RaisedButton(
+            ElevatedButton(
                 child: const Text('Tap here to test explicit intents.'),
                 onPressed: () => _openExplicitIntentsView(context)),
           ],
@@ -166,40 +166,40 @@ class ExplicitIntentsWidget extends StatelessWidget {
           child: Column(
             mainAxisAlignment: MainAxisAlignment.spaceEvenly,
             children: <Widget>[
-              RaisedButton(
+              ElevatedButton(
                 child: const Text(
                     'Tap here to display panorama\nimagery in Google Street View.'),
                 onPressed: _openGoogleMapsStreetView,
               ),
-              RaisedButton(
+              ElevatedButton(
                 child: const Text('Tap here to display\na map in Google Maps.'),
                 onPressed: _displayMapInGoogleMaps,
               ),
-              RaisedButton(
+              ElevatedButton(
                 child: const Text(
                     'Tap here to launch turn-by-turn\nnavigation in Google Maps.'),
                 onPressed: _launchTurnByTurnNavigationInGoogleMaps,
               ),
-              RaisedButton(
+              ElevatedButton(
                 child: const Text('Tap here to open link in Google Chrome.'),
                 onPressed: _openLinkInGoogleChrome,
               ),
-              RaisedButton(
+              ElevatedButton(
                 child: const Text('Tap here to start activity in new task.'),
                 onPressed: _startActivityInNewTask,
               ),
-              RaisedButton(
+              ElevatedButton(
                 child: const Text(
                     'Tap here to test explicit intent fallback to implicit.'),
                 onPressed: _testExplicitIntentFallback,
               ),
-              RaisedButton(
+              ElevatedButton(
                 child: const Text(
                   'Tap here to open Location Settings Configuration',
                 ),
                 onPressed: _openLocationSettingsConfiguration,
               ),
-              RaisedButton(
+              ElevatedButton(
                 child: const Text(
                   'Tap here to open Application Details',
                 ),

--- a/packages/android_intent/pubspec.yaml
+++ b/packages/android_intent/pubspec.yaml
@@ -1,7 +1,7 @@
 name: android_intent
 description: Flutter plugin for launching Android Intents. Not supported on iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/android_intent
-version: 2.0.0-nullsafety.1
+version: 2.0.0-nullsafety.2
 
 flutter:
   plugin:

--- a/packages/battery/battery/CHANGELOG.md
+++ b/packages/battery/battery/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.0.11
 
-* Update the example app: remove the depreciated `RaisedButton` and `FlatButton` widgets.
+* Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.
 
 ## 1.0.10
 

--- a/packages/battery/battery/CHANGELOG.md
+++ b/packages/battery/battery/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.11
+
+* Update the example app: remove the depreciated `RaisedButton` and `FlatButton` widgets.
+
 ## 1.0.10
 
 * Fix outdated links across a number of markdown files ([#3276](https://github.com/flutter/plugins/pull/3276))

--- a/packages/battery/battery/example/lib/main.dart
+++ b/packages/battery/battery/example/lib/main.dart
@@ -71,7 +71,7 @@ class _MyHomePageState extends State<MyHomePage> {
             builder: (_) => AlertDialog(
               content: Text('Battery: $batteryLevel%'),
               actions: <Widget>[
-                FlatButton(
+                TextButton(
                   child: const Text('OK'),
                   onPressed: () {
                     Navigator.pop(context);

--- a/packages/battery/battery/pubspec.yaml
+++ b/packages/battery/battery/pubspec.yaml
@@ -2,7 +2,7 @@ name: battery
 description: Flutter plugin for accessing information about the battery state
   (full, charging, discharging) on Android and iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/battery/battery
-version: 1.0.10
+version: 1.0.11
 
 flutter:
   plugin:

--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.6.4+5
 
-* Update the example app: remove the depreciated `RaisedButton` and `FlatButton` widgets.
+* Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.
 
 ## 0.6.4+4
 

--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.4+4
+
+* Update the example app: remove the depreciated `RaisedButton` and `FlatButton` widgets.
+
 ## 0.6.4+3
 
 * Detect if selected camera supports auto focus and act accordingly on Android. This solves a problem where front facing cameras are not capturing the picture because auto focus is not supported.

--- a/packages/camera/camera/example/lib/main.dart
+++ b/packages/camera/camera/example/lib/main.dart
@@ -330,9 +330,10 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
                   TextButton(
                     child: Text('AUTO'),
                     style: TextButton.styleFrom(
-                      primary: controller?.value?.exposureMode == ExposureMode.auto
-                          ? Colors.orange
-                          : Colors.blue,
+                      primary:
+                          controller?.value?.exposureMode == ExposureMode.auto
+                              ? Colors.orange
+                              : Colors.blue,
                     ),
                     onPressed: controller != null
                         ? () =>
@@ -346,9 +347,10 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
                   TextButton(
                     child: Text('LOCKED'),
                     style: TextButton.styleFrom(
-                      primary: controller?.value?.exposureMode == ExposureMode.auto
-                          ? Colors.orange
-                          : Colors.blue,
+                      primary:
+                          controller?.value?.exposureMode == ExposureMode.auto
+                              ? Colors.orange
+                              : Colors.blue,
                     ),
                     onPressed: controller != null
                         ? () =>

--- a/packages/camera/camera/example/lib/main.dart
+++ b/packages/camera/camera/example/lib/main.dart
@@ -313,6 +313,9 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
   }
 
   Widget _exposureModeControlRowWidget() {
+    final ButtonStyle style = TextButton.styleFrom(
+      primary: controller?.value?.exposureMode == ExposureMode.auto ? Colors.orange : Colors.blue,
+    );
     return SizeTransition(
       sizeFactor: _exposureModeControlRowAnimation,
       child: ClipRect(
@@ -329,12 +332,7 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
                 children: [
                   TextButton(
                     child: Text('AUTO'),
-                    style: TextButton.styleFrom(
-                      primary:
-                          controller?.value?.exposureMode == ExposureMode.auto
-                              ? Colors.orange
-                              : Colors.blue,
-                    ),
+                    style: style,
                     onPressed: controller != null
                         ? () =>
                             onSetExposureModeButtonPressed(ExposureMode.auto)
@@ -346,12 +344,7 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
                   ),
                   TextButton(
                     child: Text('LOCKED'),
-                    style: TextButton.styleFrom(
-                      primary:
-                          controller?.value?.exposureMode == ExposureMode.auto
-                              ? Colors.orange
-                              : Colors.blue,
-                    ),
+                    style: style,
                     onPressed: controller != null
                         ? () =>
                             onSetExposureModeButtonPressed(ExposureMode.locked)

--- a/packages/camera/camera/example/lib/main.dart
+++ b/packages/camera/camera/example/lib/main.dart
@@ -327,12 +327,13 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                 mainAxisSize: MainAxisSize.max,
                 children: [
-                  FlatButton(
+                  TextButton(
                     child: Text('AUTO'),
-                    textColor:
-                        controller?.value?.exposureMode == ExposureMode.auto
-                            ? Colors.orange
-                            : Colors.blue,
+                    style: TextButton.styleFrom(
+                      primary: controller?.value?.exposureMode == ExposureMode.auto
+                          ? Colors.orange
+                          : Colors.blue,
+                    ),
                     onPressed: controller != null
                         ? () =>
                             onSetExposureModeButtonPressed(ExposureMode.auto)
@@ -342,12 +343,13 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
                       showInSnackBar('Resetting exposure point');
                     },
                   ),
-                  FlatButton(
+                  TextButton(
                     child: Text('LOCKED'),
-                    textColor:
-                        controller?.value?.exposureMode == ExposureMode.locked
-                            ? Colors.orange
-                            : Colors.blue,
+                    style: TextButton.styleFrom(
+                      primary: controller?.value?.exposureMode == ExposureMode.auto
+                          ? Colors.orange
+                          : Colors.blue,
+                    ),
                     onPressed: controller != null
                         ? () =>
                             onSetExposureModeButtonPressed(ExposureMode.locked)

--- a/packages/camera/camera/example/lib/main.dart
+++ b/packages/camera/camera/example/lib/main.dart
@@ -313,8 +313,13 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
   }
 
   Widget _exposureModeControlRowWidget() {
-    final ButtonStyle style = TextButton.styleFrom(
+    final ButtonStyle styleAuto = TextButton.styleFrom(
       primary: controller?.value?.exposureMode == ExposureMode.auto
+          ? Colors.orange
+          : Colors.blue,
+    );
+    final ButtonStyle styleLocked = TextButton.styleFrom(
+      primary: controller?.value?.exposureMode == ExposureMode.locked
           ? Colors.orange
           : Colors.blue,
     );
@@ -334,7 +339,7 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
                 children: [
                   TextButton(
                     child: Text('AUTO'),
-                    style: style,
+                    style: styleAuto,
                     onPressed: controller != null
                         ? () =>
                             onSetExposureModeButtonPressed(ExposureMode.auto)
@@ -346,7 +351,7 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
                   ),
                   TextButton(
                     child: Text('LOCKED'),
-                    style: style,
+                    style: styleLocked,
                     onPressed: controller != null
                         ? () =>
                             onSetExposureModeButtonPressed(ExposureMode.locked)

--- a/packages/camera/camera/example/lib/main.dart
+++ b/packages/camera/camera/example/lib/main.dart
@@ -314,7 +314,9 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
 
   Widget _exposureModeControlRowWidget() {
     final ButtonStyle style = TextButton.styleFrom(
-      primary: controller?.value?.exposureMode == ExposureMode.auto ? Colors.orange : Colors.blue,
+      primary: controller?.value?.exposureMode == ExposureMode.auto
+          ? Colors.orange
+          : Colors.blue,
     );
     return SizeTransition(
       sizeFactor: _exposureModeControlRowAnimation,

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera
 description: A Flutter plugin for getting information about and controlling the
   camera on Android and iOS. Supports previewing the camera feed, capturing images, capturing video,
   and streaming image buffers to dart.
-version: 0.6.4+3
+version: 0.6.4+4
 homepage: https://github.com/flutter/plugins/tree/master/packages/camera/camera
 
 dependencies:

--- a/packages/file_selector/file_selector/CHANGELOG.md
+++ b/packages/file_selector/file_selector/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.7.0+2
 
-* Update the example app: remove the depreciated `RaisedButton` and `FlatButton` widgets.
+* Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.
 
 ## 0.7.0+1
 

--- a/packages/file_selector/file_selector/CHANGELOG.md
+++ b/packages/file_selector/file_selector/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.0+2
+
+* Update the example app: remove the depreciated `RaisedButton` and `FlatButton` widgets.
+
 ## 0.7.0+1
 
 * Update Flutter SDK constraint.

--- a/packages/file_selector/file_selector/example/lib/get_directory_page.dart
+++ b/packages/file_selector/file_selector/example/lib/get_directory_page.dart
@@ -25,8 +25,10 @@ class GetDirectoryPage extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
             ElevatedButton(
-              color: Colors.blue,
-              textColor: Colors.white,
+              style: ElevatedButton.styleFrom(
+                primary: Colors.blue,
+                onPrimary: Colors.white,
+              ),
               child: Text('Press to ask user to choose a directory'),
               onPressed: () => _getDirectoryPath(context),
             ),

--- a/packages/file_selector/file_selector/example/lib/get_directory_page.dart
+++ b/packages/file_selector/file_selector/example/lib/get_directory_page.dart
@@ -24,7 +24,7 @@ class GetDirectoryPage extends StatelessWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
-            RaisedButton(
+            ElevatedButton(
               color: Colors.blue,
               textColor: Colors.white,
               child: Text('Press to ask user to choose a directory'),
@@ -55,7 +55,7 @@ class TextDisplay extends StatelessWidget {
         ),
       ),
       actions: [
-        FlatButton(
+        TextButton(
           child: const Text('Close'),
           onPressed: () => Navigator.pop(context),
         ),

--- a/packages/file_selector/file_selector/example/lib/home_page.dart
+++ b/packages/file_selector/file_selector/example/lib/home_page.dart
@@ -4,6 +4,10 @@ import 'package:flutter/material.dart';
 class HomePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
+    final ButtonStyle style = ElevatedButton.styleFrom(
+      primary: Colors.blue,
+      onPrimary: Colors.white,
+    );
     return Scaffold(
       appBar: AppBar(
         title: Text('File Selector Demo Home Page'),
@@ -13,36 +17,31 @@ class HomePage extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
             ElevatedButton(
-              color: Colors.blue,
-              textColor: Colors.white,
+              style: style,
               child: Text('Open a text file'),
               onPressed: () => Navigator.pushNamed(context, '/open/text'),
             ),
             SizedBox(height: 10),
             ElevatedButton(
-              color: Colors.blue,
-              textColor: Colors.white,
+              style: style,
               child: Text('Open an image'),
               onPressed: () => Navigator.pushNamed(context, '/open/image'),
             ),
             SizedBox(height: 10),
             ElevatedButton(
-              color: Colors.blue,
-              textColor: Colors.white,
+              style: style,
               child: Text('Open multiple images'),
               onPressed: () => Navigator.pushNamed(context, '/open/images'),
             ),
             SizedBox(height: 10),
             ElevatedButton(
-              color: Colors.blue,
-              textColor: Colors.white,
+              style: style,
               child: Text('Save a file'),
               onPressed: () => Navigator.pushNamed(context, '/save/text'),
             ),
             SizedBox(height: 10),
             ElevatedButton(
-              color: Colors.blue,
-              textColor: Colors.white,
+              style: style,
               child: Text('Open a get directory dialog'),
               onPressed: () => Navigator.pushNamed(context, '/directory'),
             ),

--- a/packages/file_selector/file_selector/example/lib/home_page.dart
+++ b/packages/file_selector/file_selector/example/lib/home_page.dart
@@ -12,35 +12,35 @@ class HomePage extends StatelessWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
-            RaisedButton(
+            ElevatedButton(
               color: Colors.blue,
               textColor: Colors.white,
               child: Text('Open a text file'),
               onPressed: () => Navigator.pushNamed(context, '/open/text'),
             ),
             SizedBox(height: 10),
-            RaisedButton(
+            ElevatedButton(
               color: Colors.blue,
               textColor: Colors.white,
               child: Text('Open an image'),
               onPressed: () => Navigator.pushNamed(context, '/open/image'),
             ),
             SizedBox(height: 10),
-            RaisedButton(
+            ElevatedButton(
               color: Colors.blue,
               textColor: Colors.white,
               child: Text('Open multiple images'),
               onPressed: () => Navigator.pushNamed(context, '/open/images'),
             ),
             SizedBox(height: 10),
-            RaisedButton(
+            ElevatedButton(
               color: Colors.blue,
               textColor: Colors.white,
               child: Text('Save a file'),
               onPressed: () => Navigator.pushNamed(context, '/save/text'),
             ),
             SizedBox(height: 10),
-            RaisedButton(
+            ElevatedButton(
               color: Colors.blue,
               textColor: Colors.white,
               child: Text('Open a get directory dialog'),

--- a/packages/file_selector/file_selector/example/lib/open_image_page.dart
+++ b/packages/file_selector/file_selector/example/lib/open_image_page.dart
@@ -32,8 +32,10 @@ class OpenImagePage extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
             ElevatedButton(
-              color: Colors.blue,
-              textColor: Colors.white,
+              style: ElevatedButton.styleFrom(
+                primary: Colors.blue,
+                onPrimary: Colors.white,
+              ),
               child: Text('Press to open an image file(png, jpg)'),
               onPressed: () => _openImageFile(context),
             ),

--- a/packages/file_selector/file_selector/example/lib/open_image_page.dart
+++ b/packages/file_selector/file_selector/example/lib/open_image_page.dart
@@ -31,7 +31,7 @@ class OpenImagePage extends StatelessWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
-            RaisedButton(
+            ElevatedButton(
               color: Colors.blue,
               textColor: Colors.white,
               child: Text('Press to open an image file(png, jpg)'),
@@ -63,7 +63,7 @@ class ImageDisplay extends StatelessWidget {
       // while on other platforms it is a system path.
       content: kIsWeb ? Image.network(filePath) : Image.file(File(filePath)),
       actions: [
-        FlatButton(
+        TextButton(
           child: const Text('Close'),
           onPressed: () {
             Navigator.pop(context);

--- a/packages/file_selector/file_selector/example/lib/open_multiple_images_page.dart
+++ b/packages/file_selector/file_selector/example/lib/open_multiple_images_page.dart
@@ -35,8 +35,10 @@ class OpenMultipleImagesPage extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
             ElevatedButton(
-              color: Colors.blue,
-              textColor: Colors.white,
+              style: ElevatedButton.styleFrom(
+                primary: Colors.blue,
+                onPrimary: Colors.white,
+              ),
               child: Text('Press to open multiple images (png, jpg)'),
               onPressed: () => _openImageFile(context),
             ),

--- a/packages/file_selector/file_selector/example/lib/open_multiple_images_page.dart
+++ b/packages/file_selector/file_selector/example/lib/open_multiple_images_page.dart
@@ -34,7 +34,7 @@ class OpenMultipleImagesPage extends StatelessWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
-            RaisedButton(
+            ElevatedButton(
               color: Colors.blue,
               textColor: Colors.white,
               child: Text('Press to open multiple images (png, jpg)'),
@@ -74,7 +74,7 @@ class MultipleImagesDisplay extends StatelessWidget {
         ),
       ),
       actions: [
-        FlatButton(
+        TextButton(
           child: const Text('Close'),
           onPressed: () {
             Navigator.pop(context);

--- a/packages/file_selector/file_selector/example/lib/open_text_page.dart
+++ b/packages/file_selector/file_selector/example/lib/open_text_page.dart
@@ -29,8 +29,10 @@ class OpenTextPage extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
             ElevatedButton(
-              color: Colors.blue,
-              textColor: Colors.white,
+              style: ElevatedButton.styleFrom(
+                primary: Colors.blue,
+                onPrimary: Colors.white,
+              ),
               child: Text('Press to open a text file (json, txt)'),
               onPressed: () => _openTextFile(context),
             ),

--- a/packages/file_selector/file_selector/example/lib/open_text_page.dart
+++ b/packages/file_selector/file_selector/example/lib/open_text_page.dart
@@ -28,7 +28,7 @@ class OpenTextPage extends StatelessWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
-            RaisedButton(
+            ElevatedButton(
               color: Colors.blue,
               textColor: Colors.white,
               child: Text('Press to open a text file (json, txt)'),
@@ -62,7 +62,7 @@ class TextDisplay extends StatelessWidget {
         ),
       ),
       actions: [
-        FlatButton(
+        TextButton(
           child: const Text('Close'),
           onPressed: () => Navigator.pop(context),
         ),

--- a/packages/file_selector/file_selector/example/lib/save_text_page.dart
+++ b/packages/file_selector/file_selector/example/lib/save_text_page.dart
@@ -52,8 +52,10 @@ class SaveTextPage extends StatelessWidget {
             ),
             SizedBox(height: 10),
             ElevatedButton(
-              color: Colors.blue,
-              textColor: Colors.white,
+              style: ElevatedButton.styleFrom(
+                primary: Colors.blue,
+                onPrimary: Colors.white,
+              ),
               child: Text('Press to save a text file'),
               onPressed: () => _saveFile(),
             ),

--- a/packages/file_selector/file_selector/example/lib/save_text_page.dart
+++ b/packages/file_selector/file_selector/example/lib/save_text_page.dart
@@ -51,7 +51,7 @@ class SaveTextPage extends StatelessWidget {
               ),
             ),
             SizedBox(height: 10),
-            RaisedButton(
+            ElevatedButton(
               color: Colors.blue,
               textColor: Colors.white,
               child: Text('Press to save a text file'),

--- a/packages/file_selector/file_selector/pubspec.yaml
+++ b/packages/file_selector/file_selector/pubspec.yaml
@@ -1,7 +1,7 @@
 name: file_selector
 description: Flutter plugin for opening and saving files.
 homepage: https://github.com/flutter/plugins/tree/master/packages/file_selector/file_selector
-version: 0.7.0+1
+version: 0.7.0+2
 
 dependencies:
   flutter:

--- a/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.0.10
 
-* Update the example app: remove the depreciated `RaisedButton` and `FlatButton` widgets.
+* Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.
 
 ## 1.0.9
 

--- a/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.10
+
+* Update the example app: remove the depreciated `RaisedButton` and `FlatButton` widgets.
+
 ## 1.0.9
 
 * Fix outdated links across a number of markdown files ([#3276](https://github.com/flutter/plugins/pull/3276))

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/animate_camera.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/animate_camera.dart
@@ -54,7 +54,7 @@ class AnimateCameraState extends State<AnimateCamera> {
           children: <Widget>[
             Column(
               children: <Widget>[
-                FlatButton(
+                TextButton(
                   onPressed: () {
                     mapController.animateCamera(
                       CameraUpdate.newCameraPosition(
@@ -69,7 +69,7 @@ class AnimateCameraState extends State<AnimateCamera> {
                   },
                   child: const Text('newCameraPosition'),
                 ),
-                FlatButton(
+                TextButton(
                   onPressed: () {
                     mapController.animateCamera(
                       CameraUpdate.newLatLng(
@@ -79,7 +79,7 @@ class AnimateCameraState extends State<AnimateCamera> {
                   },
                   child: const Text('newLatLng'),
                 ),
-                FlatButton(
+                TextButton(
                   onPressed: () {
                     mapController.animateCamera(
                       CameraUpdate.newLatLngBounds(
@@ -93,7 +93,7 @@ class AnimateCameraState extends State<AnimateCamera> {
                   },
                   child: const Text('newLatLngBounds'),
                 ),
-                FlatButton(
+                TextButton(
                   onPressed: () {
                     mapController.animateCamera(
                       CameraUpdate.newLatLngZoom(
@@ -104,7 +104,7 @@ class AnimateCameraState extends State<AnimateCamera> {
                   },
                   child: const Text('newLatLngZoom'),
                 ),
-                FlatButton(
+                TextButton(
                   onPressed: () {
                     mapController.animateCamera(
                       CameraUpdate.scrollBy(150.0, -225.0),
@@ -116,7 +116,7 @@ class AnimateCameraState extends State<AnimateCamera> {
             ),
             Column(
               children: <Widget>[
-                FlatButton(
+                TextButton(
                   onPressed: () {
                     mapController.animateCamera(
                       CameraUpdate.zoomBy(
@@ -127,7 +127,7 @@ class AnimateCameraState extends State<AnimateCamera> {
                   },
                   child: const Text('zoomBy with focus'),
                 ),
-                FlatButton(
+                TextButton(
                   onPressed: () {
                     mapController.animateCamera(
                       CameraUpdate.zoomBy(-0.5),
@@ -135,7 +135,7 @@ class AnimateCameraState extends State<AnimateCamera> {
                   },
                   child: const Text('zoomBy'),
                 ),
-                FlatButton(
+                TextButton(
                   onPressed: () {
                     mapController.animateCamera(
                       CameraUpdate.zoomIn(),
@@ -143,7 +143,7 @@ class AnimateCameraState extends State<AnimateCamera> {
                   },
                   child: const Text('zoomIn'),
                 ),
-                FlatButton(
+                TextButton(
                   onPressed: () {
                     mapController.animateCamera(
                       CameraUpdate.zoomOut(),
@@ -151,7 +151,7 @@ class AnimateCameraState extends State<AnimateCamera> {
                   },
                   child: const Text('zoomOut'),
                 ),
-                FlatButton(
+                TextButton(
                   onPressed: () {
                     mapController.animateCamera(
                       CameraUpdate.zoomTo(16.0),

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/map_coordinates.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/map_coordinates.dart
@@ -83,7 +83,7 @@ class _MapCoordinatesBodyState extends State<_MapCoordinatesBody> {
   Widget _getVisibleRegionButton() {
     return Padding(
       padding: const EdgeInsets.all(8.0),
-      child: RaisedButton(
+      child: ElevatedButton(
         child: const Text('Get Visible Region Bounds'),
         onPressed: () async {
           final LatLngBounds visibleRegion =

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/map_ui.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/map_ui.dart
@@ -70,7 +70,7 @@ class MapUiBodyState extends State<MapUiBody> {
   }
 
   Widget _compassToggler() {
-    return FlatButton(
+    return TextButton(
       child: Text('${_compassEnabled ? 'disable' : 'enable'} compass'),
       onPressed: () {
         setState(() {
@@ -81,7 +81,7 @@ class MapUiBodyState extends State<MapUiBody> {
   }
 
   Widget _mapToolbarToggler() {
-    return FlatButton(
+    return TextButton(
       child: Text('${_mapToolbarEnabled ? 'disable' : 'enable'} map toolbar'),
       onPressed: () {
         setState(() {
@@ -92,7 +92,7 @@ class MapUiBodyState extends State<MapUiBody> {
   }
 
   Widget _latLngBoundsToggler() {
-    return FlatButton(
+    return TextButton(
       child: Text(
         _cameraTargetBounds.bounds == null
             ? 'bound camera target'
@@ -109,7 +109,7 @@ class MapUiBodyState extends State<MapUiBody> {
   }
 
   Widget _zoomBoundsToggler() {
-    return FlatButton(
+    return TextButton(
       child: Text(_minMaxZoomPreference.minZoom == null
           ? 'bound zoom'
           : 'release zoom'),
@@ -126,7 +126,7 @@ class MapUiBodyState extends State<MapUiBody> {
   Widget _mapTypeCycler() {
     final MapType nextType =
         MapType.values[(_mapType.index + 1) % MapType.values.length];
-    return FlatButton(
+    return TextButton(
       child: Text('change map type to $nextType'),
       onPressed: () {
         setState(() {
@@ -137,7 +137,7 @@ class MapUiBodyState extends State<MapUiBody> {
   }
 
   Widget _rotateToggler() {
-    return FlatButton(
+    return TextButton(
       child: Text('${_rotateGesturesEnabled ? 'disable' : 'enable'} rotate'),
       onPressed: () {
         setState(() {
@@ -148,7 +148,7 @@ class MapUiBodyState extends State<MapUiBody> {
   }
 
   Widget _scrollToggler() {
-    return FlatButton(
+    return TextButton(
       child: Text('${_scrollGesturesEnabled ? 'disable' : 'enable'} scroll'),
       onPressed: () {
         setState(() {
@@ -159,7 +159,7 @@ class MapUiBodyState extends State<MapUiBody> {
   }
 
   Widget _tiltToggler() {
-    return FlatButton(
+    return TextButton(
       child: Text('${_tiltGesturesEnabled ? 'disable' : 'enable'} tilt'),
       onPressed: () {
         setState(() {
@@ -170,7 +170,7 @@ class MapUiBodyState extends State<MapUiBody> {
   }
 
   Widget _zoomToggler() {
-    return FlatButton(
+    return TextButton(
       child: Text('${_zoomGesturesEnabled ? 'disable' : 'enable'} zoom'),
       onPressed: () {
         setState(() {
@@ -181,7 +181,7 @@ class MapUiBodyState extends State<MapUiBody> {
   }
 
   Widget _zoomControlsToggler() {
-    return FlatButton(
+    return TextButton(
       child:
           Text('${_zoomControlsEnabled ? 'disable' : 'enable'} zoom controls'),
       onPressed: () {
@@ -193,7 +193,7 @@ class MapUiBodyState extends State<MapUiBody> {
   }
 
   Widget _indoorViewToggler() {
-    return FlatButton(
+    return TextButton(
       child: Text('${_indoorViewEnabled ? 'disable' : 'enable'} indoor'),
       onPressed: () {
         setState(() {
@@ -204,7 +204,7 @@ class MapUiBodyState extends State<MapUiBody> {
   }
 
   Widget _myLocationToggler() {
-    return FlatButton(
+    return TextButton(
       child: Text(
           '${_myLocationEnabled ? 'disable' : 'enable'} my location marker'),
       onPressed: () {
@@ -216,7 +216,7 @@ class MapUiBodyState extends State<MapUiBody> {
   }
 
   Widget _myLocationButtonToggler() {
-    return FlatButton(
+    return TextButton(
       child: Text(
           '${_myLocationButtonEnabled ? 'disable' : 'enable'} my location button'),
       onPressed: () {
@@ -228,7 +228,7 @@ class MapUiBodyState extends State<MapUiBody> {
   }
 
   Widget _myTrafficToggler() {
-    return FlatButton(
+    return TextButton(
       child: Text('${_myTrafficEnabled ? 'disable' : 'enable'} my traffic'),
       onPressed: () {
         setState(() {
@@ -253,7 +253,7 @@ class MapUiBodyState extends State<MapUiBody> {
     if (!_isMapCreated) {
       return null;
     }
-    return FlatButton(
+    return TextButton(
       child: Text('${_nightMode ? 'disable' : 'enable'} night mode'),
       onPressed: () {
         if (_nightMode) {

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/move_camera.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/move_camera.dart
@@ -53,7 +53,7 @@ class MoveCameraState extends State<MoveCamera> {
           children: <Widget>[
             Column(
               children: <Widget>[
-                FlatButton(
+                TextButton(
                   onPressed: () {
                     mapController.moveCamera(
                       CameraUpdate.newCameraPosition(
@@ -68,7 +68,7 @@ class MoveCameraState extends State<MoveCamera> {
                   },
                   child: const Text('newCameraPosition'),
                 ),
-                FlatButton(
+                TextButton(
                   onPressed: () {
                     mapController.moveCamera(
                       CameraUpdate.newLatLng(
@@ -78,7 +78,7 @@ class MoveCameraState extends State<MoveCamera> {
                   },
                   child: const Text('newLatLng'),
                 ),
-                FlatButton(
+                TextButton(
                   onPressed: () {
                     mapController.moveCamera(
                       CameraUpdate.newLatLngBounds(
@@ -92,7 +92,7 @@ class MoveCameraState extends State<MoveCamera> {
                   },
                   child: const Text('newLatLngBounds'),
                 ),
-                FlatButton(
+                TextButton(
                   onPressed: () {
                     mapController.moveCamera(
                       CameraUpdate.newLatLngZoom(
@@ -103,7 +103,7 @@ class MoveCameraState extends State<MoveCamera> {
                   },
                   child: const Text('newLatLngZoom'),
                 ),
-                FlatButton(
+                TextButton(
                   onPressed: () {
                     mapController.moveCamera(
                       CameraUpdate.scrollBy(150.0, -225.0),
@@ -115,7 +115,7 @@ class MoveCameraState extends State<MoveCamera> {
             ),
             Column(
               children: <Widget>[
-                FlatButton(
+                TextButton(
                   onPressed: () {
                     mapController.moveCamera(
                       CameraUpdate.zoomBy(
@@ -126,7 +126,7 @@ class MoveCameraState extends State<MoveCamera> {
                   },
                   child: const Text('zoomBy with focus'),
                 ),
-                FlatButton(
+                TextButton(
                   onPressed: () {
                     mapController.moveCamera(
                       CameraUpdate.zoomBy(-0.5),
@@ -134,7 +134,7 @@ class MoveCameraState extends State<MoveCamera> {
                   },
                   child: const Text('zoomBy'),
                 ),
-                FlatButton(
+                TextButton(
                   onPressed: () {
                     mapController.moveCamera(
                       CameraUpdate.zoomIn(),
@@ -142,7 +142,7 @@ class MoveCameraState extends State<MoveCamera> {
                   },
                   child: const Text('zoomIn'),
                 ),
-                FlatButton(
+                TextButton(
                   onPressed: () {
                     mapController.moveCamera(
                       CameraUpdate.zoomOut(),
@@ -150,7 +150,7 @@ class MoveCameraState extends State<MoveCamera> {
                   },
                   child: const Text('zoomOut'),
                 ),
-                FlatButton(
+                TextButton(
                   onPressed: () {
                     mapController.moveCamera(
                       CameraUpdate.zoomTo(16.0),

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/padding.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/padding.dart
@@ -147,7 +147,7 @@ class MarkerIconsBodyState extends State<MarkerIconsBody> {
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         children: <Widget>[
-          FlatButton(
+          TextButton(
             child: const Text("Set Padding"),
             onPressed: () {
               setState(() {
@@ -159,7 +159,7 @@ class MarkerIconsBodyState extends State<MarkerIconsBody> {
               });
             },
           ),
-          FlatButton(
+          TextButton(
             child: const Text("Reset Padding"),
             onPressed: () {
               setState(() {

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/place_circle.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/place_circle.dart
@@ -165,15 +165,15 @@ class PlaceCircleBodyState extends State<PlaceCircleBody> {
                   children: <Widget>[
                     Column(
                       children: <Widget>[
-                        FlatButton(
+                        TextButton(
                           child: const Text('add'),
                           onPressed: _add,
                         ),
-                        FlatButton(
+                        TextButton(
                           child: const Text('remove'),
                           onPressed: (selectedCircle == null) ? null : _remove,
                         ),
-                        FlatButton(
+                        TextButton(
                           child: const Text('toggle visible'),
                           onPressed:
                               (selectedCircle == null) ? null : _toggleVisible,
@@ -182,19 +182,19 @@ class PlaceCircleBodyState extends State<PlaceCircleBody> {
                     ),
                     Column(
                       children: <Widget>[
-                        FlatButton(
+                        TextButton(
                           child: const Text('change stroke width'),
                           onPressed: (selectedCircle == null)
                               ? null
                               : _changeStrokeWidth,
                         ),
-                        FlatButton(
+                        TextButton(
                           child: const Text('change stroke color'),
                           onPressed: (selectedCircle == null)
                               ? null
                               : _changeStrokeColor,
                         ),
-                        FlatButton(
+                        TextButton(
                           child: const Text('change fill color'),
                           onPressed: (selectedCircle == null)
                               ? null

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/place_marker.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/place_marker.dart
@@ -77,7 +77,7 @@ class PlaceMarkerBodyState extends State<PlaceMarkerBody> {
           builder: (BuildContext context) {
             return AlertDialog(
                 actions: <Widget>[
-                  FlatButton(
+                  TextButton(
                     child: const Text('OK'),
                     onPressed: () => Navigator.of(context).pop(),
                   )
@@ -313,19 +313,19 @@ class PlaceMarkerBodyState extends State<PlaceMarkerBody> {
                   children: <Widget>[
                     Column(
                       children: <Widget>[
-                        FlatButton(
+                        TextButton(
                           child: const Text('add'),
                           onPressed: _add,
                         ),
-                        FlatButton(
+                        TextButton(
                           child: const Text('remove'),
                           onPressed: _remove,
                         ),
-                        FlatButton(
+                        TextButton(
                           child: const Text('change info'),
                           onPressed: _changeInfo,
                         ),
-                        FlatButton(
+                        TextButton(
                           child: const Text('change info anchor'),
                           onPressed: _changeInfoAnchor,
                         ),
@@ -333,35 +333,35 @@ class PlaceMarkerBodyState extends State<PlaceMarkerBody> {
                     ),
                     Column(
                       children: <Widget>[
-                        FlatButton(
+                        TextButton(
                           child: const Text('change alpha'),
                           onPressed: _changeAlpha,
                         ),
-                        FlatButton(
+                        TextButton(
                           child: const Text('change anchor'),
                           onPressed: _changeAnchor,
                         ),
-                        FlatButton(
+                        TextButton(
                           child: const Text('toggle draggable'),
                           onPressed: _toggleDraggable,
                         ),
-                        FlatButton(
+                        TextButton(
                           child: const Text('toggle flat'),
                           onPressed: _toggleFlat,
                         ),
-                        FlatButton(
+                        TextButton(
                           child: const Text('change position'),
                           onPressed: _changePosition,
                         ),
-                        FlatButton(
+                        TextButton(
                           child: const Text('change rotation'),
                           onPressed: _changeRotation,
                         ),
-                        FlatButton(
+                        TextButton(
                           child: const Text('toggle visible'),
                           onPressed: _toggleVisible,
                         ),
-                        FlatButton(
+                        TextButton(
                           child: const Text('change zIndex'),
                           onPressed: _changeZIndex,
                         ),
@@ -371,7 +371,7 @@ class PlaceMarkerBodyState extends State<PlaceMarkerBody> {
                         // TODO(amirh): uncomment this one the ImageStream API change makes it to stable.
                         // https://github.com/flutter/flutter/issues/33438
                         //
-                        // FlatButton(
+                        // TextButton(
                         //   child: const Text('set marker icon'),
                         //   onPressed: () {
                         //     _getAssetIcon(context).then(

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/place_polygon.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/place_polygon.dart
@@ -173,20 +173,20 @@ class PlacePolygonBodyState extends State<PlacePolygonBody> {
                   children: <Widget>[
                     Column(
                       children: <Widget>[
-                        FlatButton(
+                        TextButton(
                           child: const Text('add'),
                           onPressed: _add,
                         ),
-                        FlatButton(
+                        TextButton(
                           child: const Text('remove'),
                           onPressed: (selectedPolygon == null) ? null : _remove,
                         ),
-                        FlatButton(
+                        TextButton(
                           child: const Text('toggle visible'),
                           onPressed:
                               (selectedPolygon == null) ? null : _toggleVisible,
                         ),
-                        FlatButton(
+                        TextButton(
                           child: const Text('toggle geodesic'),
                           onPressed: (selectedPolygon == null)
                               ? null
@@ -196,18 +196,18 @@ class PlacePolygonBodyState extends State<PlacePolygonBody> {
                     ),
                     Column(
                       children: <Widget>[
-                        FlatButton(
+                        TextButton(
                           child: const Text('change stroke width'),
                           onPressed:
                               (selectedPolygon == null) ? null : _changeWidth,
                         ),
-                        FlatButton(
+                        TextButton(
                           child: const Text('change stroke color'),
                           onPressed: (selectedPolygon == null)
                               ? null
                               : _changeStrokeColor,
                         ),
-                        FlatButton(
+                        TextButton(
                           child: const Text('change fill color'),
                           onPressed: (selectedPolygon == null)
                               ? null

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/place_polyline.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/place_polyline.dart
@@ -232,22 +232,22 @@ class PlacePolylineBodyState extends State<PlacePolylineBody> {
                   children: <Widget>[
                     Column(
                       children: <Widget>[
-                        FlatButton(
+                        TextButton(
                           child: const Text('add'),
                           onPressed: _add,
                         ),
-                        FlatButton(
+                        TextButton(
                           child: const Text('remove'),
                           onPressed:
                               (selectedPolyline == null) ? null : _remove,
                         ),
-                        FlatButton(
+                        TextButton(
                           child: const Text('toggle visible'),
                           onPressed: (selectedPolyline == null)
                               ? null
                               : _toggleVisible,
                         ),
-                        FlatButton(
+                        TextButton(
                           child: const Text('toggle geodesic'),
                           onPressed: (selectedPolyline == null)
                               ? null
@@ -257,29 +257,29 @@ class PlacePolylineBodyState extends State<PlacePolylineBody> {
                     ),
                     Column(
                       children: <Widget>[
-                        FlatButton(
+                        TextButton(
                           child: const Text('change width'),
                           onPressed:
                               (selectedPolyline == null) ? null : _changeWidth,
                         ),
-                        FlatButton(
+                        TextButton(
                           child: const Text('change color'),
                           onPressed:
                               (selectedPolyline == null) ? null : _changeColor,
                         ),
-                        FlatButton(
+                        TextButton(
                           child: const Text('change start cap [Android only]'),
                           onPressed: iOSorNotSelected ? null : _changeStartCap,
                         ),
-                        FlatButton(
+                        TextButton(
                           child: const Text('change end cap [Android only]'),
                           onPressed: iOSorNotSelected ? null : _changeEndCap,
                         ),
-                        FlatButton(
+                        TextButton(
                           child: const Text('change joint type [Android only]'),
                           onPressed: iOSorNotSelected ? null : _changeJointType,
                         ),
-                        FlatButton(
+                        TextButton(
                           child: const Text('change pattern [Android only]'),
                           onPressed: iOSorNotSelected ? null : _changePattern,
                         ),

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/snapshot.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/snapshot.dart
@@ -47,7 +47,7 @@ class _SnapshotBodyState extends State<_SnapshotBody> {
               initialCameraPosition: _kInitialPosition,
             ),
           ),
-          FlatButton(
+          TextButton(
             child: Text('Take a snapshot'),
             onPressed: () async {
               final imageBytes = await _mapController?.takeSnapshot();

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter/google_maps_flutter
-version: 1.0.9
+version: 1.0.10
 
 dependencies:
   flutter:

--- a/packages/google_sign_in/extension_google_sign_in_as_googleapis_auth/CHANGELOG.md
+++ b/packages/google_sign_in/extension_google_sign_in_as_googleapis_auth/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.0.4
 
-* Update the example app: remove the depreciated `RaisedButton` and `FlatButton` widgets.
+* Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.
 
 ## 1.0.3
 

--- a/packages/google_sign_in/extension_google_sign_in_as_googleapis_auth/CHANGELOG.md
+++ b/packages/google_sign_in/extension_google_sign_in_as_googleapis_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.4
+
+* Update the example app: remove the depreciated `RaisedButton` and `FlatButton` widgets.
+
 ## 1.0.3
 
 * Fix outdated links across a number of markdown files ([#3276](https://github.com/flutter/plugins/pull/3276))

--- a/packages/google_sign_in/extension_google_sign_in_as_googleapis_auth/example/lib/main.dart
+++ b/packages/google_sign_in/extension_google_sign_in_as_googleapis_auth/example/lib/main.dart
@@ -111,11 +111,11 @@ class SignInDemoState extends State<SignInDemo> {
           ),
           const Text('Signed in successfully.'),
           Text(_contactText ?? ''),
-          RaisedButton(
+          ElevatedButton(
             child: const Text('SIGN OUT'),
             onPressed: _handleSignOut,
           ),
-          RaisedButton(
+          ElevatedButton(
             child: const Text('REFRESH'),
             onPressed: _handleGetContact,
           ),
@@ -126,7 +126,7 @@ class SignInDemoState extends State<SignInDemo> {
         mainAxisAlignment: MainAxisAlignment.spaceAround,
         children: <Widget>[
           const Text('You are not currently signed in.'),
-          RaisedButton(
+          ElevatedButton(
             child: const Text('SIGN IN'),
             onPressed: _handleSignIn,
           ),

--- a/packages/google_sign_in/extension_google_sign_in_as_googleapis_auth/pubspec.yaml
+++ b/packages/google_sign_in/extension_google_sign_in_as_googleapis_auth/pubspec.yaml
@@ -6,7 +6,7 @@
 
 name: extension_google_sign_in_as_googleapis_auth
 description: A bridge package between google_sign_in and googleapis_auth, to create Authenticated Clients from google_sign_in user credentials.
-version: 1.0.3
+version: 1.0.4
 homepage: https://github.com/flutter/plugins/google_sign_in/extension_google_sign_in_as_googleapis_auth
 
 dependencies:

--- a/packages/google_sign_in/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.5.9
+
+* Update the example app: remove the depreciated `RaisedButton` and `FlatButton` widgets.
+
 ## 4.5.8
 
 * Fix outdated links across a number of markdown files ([#3276](https://github.com/flutter/plugins/pull/3276))

--- a/packages/google_sign_in/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 4.5.9
 
-* Update the example app: remove the depreciated `RaisedButton` and `FlatButton` widgets.
+* Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.
 
 ## 4.5.8
 

--- a/packages/google_sign_in/google_sign_in/example/lib/main.dart
+++ b/packages/google_sign_in/google_sign_in/example/lib/main.dart
@@ -120,11 +120,11 @@ class SignInDemoState extends State<SignInDemo> {
           ),
           const Text("Signed in successfully."),
           Text(_contactText ?? ''),
-          RaisedButton(
+          ElevatedButton(
             child: const Text('SIGN OUT'),
             onPressed: _handleSignOut,
           ),
-          RaisedButton(
+          ElevatedButton(
             child: const Text('REFRESH'),
             onPressed: _handleGetContact,
           ),
@@ -135,7 +135,7 @@ class SignInDemoState extends State<SignInDemo> {
         mainAxisAlignment: MainAxisAlignment.spaceAround,
         children: <Widget>[
           const Text("You are not currently signed in."),
-          RaisedButton(
+          ElevatedButton(
             child: const Text('SIGN IN'),
             onPressed: _handleSignIn,
           ),

--- a/packages/google_sign_in/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_sign_in
 description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android and iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_sign_in/google_sign_in
-version: 4.5.8
+version: 4.5.9
 
 flutter:
   plugin:

--- a/packages/image_picker/image_picker/CHANGELOG.md
+++ b/packages/image_picker/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.7+20
+
+* Update the example app: remove the depreciated `RaisedButton` and `FlatButton` widgets.
+
 ## 0.6.7+19
 
 * Do not copy static field to another static field.

--- a/packages/image_picker/image_picker/CHANGELOG.md
+++ b/packages/image_picker/image_picker/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.6.7+21
 
-* Update the example app: remove the depreciated `RaisedButton` and `FlatButton` widgets.
+* Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.
 
 ## 0.6.7+20
 

--- a/packages/image_picker/image_picker/example/lib/main.dart
+++ b/packages/image_picker/image_picker/example/lib/main.dart
@@ -327,13 +327,13 @@ class _MyHomePageState extends State<MyHomePage> {
               ],
             ),
             actions: <Widget>[
-              FlatButton(
+              TextButton(
                 child: const Text('CANCEL'),
                 onPressed: () {
                   Navigator.of(context).pop();
                 },
               ),
-              FlatButton(
+              TextButton(
                   child: const Text('PICK'),
                   onPressed: () {
                     double width = maxWidthController.text.isNotEmpty

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker
 description: Flutter plugin for selecting images from the Android and iOS image
   library, and taking new pictures with the camera.
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker/image_picker
-version: 0.6.7+19
+version: 0.6.7+20
 
 flutter:
   plugin:

--- a/packages/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.4+19
+
+* Update the example app: remove the depreciated `RaisedButton` and `FlatButton` widgets.
+
 ## 0.3.4+18
 
 * Fix outdated links across a number of markdown files ([#3276](https://github.com/flutter/plugins/pull/3276))

--- a/packages/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.3.5+1
 
-* Update the example app: remove the depreciated `RaisedButton` and `FlatButton` widgets.
+* Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.
 
 ## 0.3.5
 

--- a/packages/in_app_purchase/example/lib/main.dart
+++ b/packages/in_app_purchase/example/lib/main.dart
@@ -245,10 +245,12 @@ class _MyAppState extends State<_MyApp> {
             ),
             trailing: previousPurchase != null
                 ? Icon(Icons.check)
-                : FlatButton(
+                : TextButton(
                     child: Text(productDetails.price),
-                    color: Colors.green[800],
-                    textColor: Colors.white,
+                    style: TextButton.styleFrom(
+                      backgroundColor: Colors.green[800],
+                      primary: Colors.white,
+                    ),
                     onPressed: () {
                       PurchaseParam purchaseParam = PurchaseParam(
                           productDetails: productDetails,

--- a/packages/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/pubspec.yaml
@@ -1,7 +1,7 @@
 name: in_app_purchase
 description: A Flutter plugin for in-app purchases. Exposes APIs for making in-app purchases through the App Store and Google Play.
 homepage: https://github.com/flutter/plugins/tree/master/packages/in_app_purchase
-version: 0.3.4+18
+version: 0.3.4+19
 
 dependencies:
   async: ^2.0.8

--- a/packages/local_auth/CHANGELOG.md
+++ b/packages/local_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-nullsafety.3
+
+* Update the example app: remove the depreciated `RaisedButton` and `FlatButton` widgets.
+
 ## 1.0.0-nullsafety.2
 
 * Fix outdated links across a number of markdown files ([#3276](https://github.com/flutter/plugins/pull/3276))

--- a/packages/local_auth/CHANGELOG.md
+++ b/packages/local_auth/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.0.0-nullsafety.3
 
-* Update the example app: remove the depreciated `RaisedButton` and `FlatButton` widgets.
+* Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.
 
 ## 1.0.0-nullsafety.2
 

--- a/packages/local_auth/example/lib/main.dart
+++ b/packages/local_auth/example/lib/main.dart
@@ -99,17 +99,17 @@ class _MyAppState extends State<MyApp> {
               mainAxisAlignment: MainAxisAlignment.spaceAround,
               children: <Widget>[
                 Text('Can check biometrics: $_canCheckBiometrics\n'),
-                RaisedButton(
+                ElevatedButton(
                   child: const Text('Check biometrics'),
                   onPressed: _checkBiometrics,
                 ),
                 Text('Available biometrics: $_availableBiometrics\n'),
-                RaisedButton(
+                ElevatedButton(
                   child: const Text('Get available biometrics'),
                   onPressed: _getAvailableBiometrics,
                 ),
                 Text('Current State: $_authorized\n'),
-                RaisedButton(
+                ElevatedButton(
                   child: Text(_isAuthenticating ? 'Cancel' : 'Authenticate'),
                   onPressed:
                       _isAuthenticating ? _cancelAuthentication : _authenticate,

--- a/packages/local_auth/pubspec.yaml
+++ b/packages/local_auth/pubspec.yaml
@@ -2,7 +2,7 @@ name: local_auth
 description: Flutter plugin for Android and iOS device authentication sensors
   such as Fingerprint Reader and Touch ID.
 homepage: https://github.com/flutter/plugins/tree/master/packages/local_auth
-version: 1.0.0-nullsafety.2
+version: 1.0.0-nullsafety.3
 
 flutter:
   plugin:

--- a/packages/path_provider/path_provider/CHANGELOG.md
+++ b/packages/path_provider/path_provider/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.6.27
 
-* Update the example app: remove the depreciated `RaisedButton` and `FlatButton` widgets.
+* Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.
 
 ## 1.6.26
 

--- a/packages/path_provider/path_provider/CHANGELOG.md
+++ b/packages/path_provider/path_provider/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.6.27
+
+* Update the example app: remove the depreciated `RaisedButton` and `FlatButton` widgets.
+
 ## 1.6.26
 
 * Fix outdated links across a number of markdown files ([#3276](https://github.com/flutter/plugins/pull/3276))

--- a/packages/path_provider/path_provider/example/lib/main.dart
+++ b/packages/path_provider/path_provider/example/lib/main.dart
@@ -129,7 +129,7 @@ class _MyHomePageState extends State<MyHomePage> {
           children: <Widget>[
             Padding(
               padding: const EdgeInsets.all(16.0),
-              child: RaisedButton(
+              child: ElevatedButton(
                 child: const Text('Get Temporary Directory'),
                 onPressed: _requestTempDirectory,
               ),
@@ -138,7 +138,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 future: _tempDirectory, builder: _buildDirectory),
             Padding(
               padding: const EdgeInsets.all(16.0),
-              child: RaisedButton(
+              child: ElevatedButton(
                 child: const Text('Get Application Documents Directory'),
                 onPressed: _requestAppDocumentsDirectory,
               ),
@@ -147,7 +147,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 future: _appDocumentsDirectory, builder: _buildDirectory),
             Padding(
               padding: const EdgeInsets.all(16.0),
-              child: RaisedButton(
+              child: ElevatedButton(
                 child: const Text('Get Application Support Directory'),
                 onPressed: _requestAppSupportDirectory,
               ),
@@ -156,7 +156,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 future: _appSupportDirectory, builder: _buildDirectory),
             Padding(
               padding: const EdgeInsets.all(16.0),
-              child: RaisedButton(
+              child: ElevatedButton(
                 child: const Text('Get Application Library Directory'),
                 onPressed: _requestAppLibraryDirectory,
               ),
@@ -165,7 +165,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 future: _appLibraryDirectory, builder: _buildDirectory),
             Padding(
               padding: const EdgeInsets.all(16.0),
-              child: RaisedButton(
+              child: ElevatedButton(
                 child: Text(
                     '${Platform.isIOS ? "External directories are unavailable " "on iOS" : "Get External Storage Directory"}'),
                 onPressed:
@@ -177,7 +177,7 @@ class _MyHomePageState extends State<MyHomePage> {
             Column(children: <Widget>[
               Padding(
                 padding: const EdgeInsets.all(16.0),
-                child: RaisedButton(
+                child: ElevatedButton(
                   child: Text(
                       '${Platform.isIOS ? "External directories are unavailable " "on iOS" : "Get External Storage Directories"}'),
                   onPressed: Platform.isIOS
@@ -196,7 +196,7 @@ class _MyHomePageState extends State<MyHomePage> {
             Column(children: <Widget>[
               Padding(
                 padding: const EdgeInsets.all(16.0),
-                child: RaisedButton(
+                child: ElevatedButton(
                   child: Text(
                       '${Platform.isIOS ? "External directories are unavailable " "on iOS" : "Get External Cache Directories"}'),
                   onPressed:

--- a/packages/path_provider/path_provider/pubspec.yaml
+++ b/packages/path_provider/path_provider/pubspec.yaml
@@ -1,7 +1,7 @@
 name: path_provider
 description: Flutter plugin for getting commonly used locations on host platform file systems, such as the temp and app data directories.
 homepage: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider
-version: 1.6.26
+version: 1.6.27
 
 flutter:
   plugin:

--- a/packages/path_provider/path_provider_macos/CHANGELOG.md
+++ b/packages/path_provider/path_provider_macos/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.0.4+8
 
-* Update the example app: remove the depreciated `RaisedButton` and `FlatButton` widgets.
+* Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.
 
 ## 0.0.4+7
 

--- a/packages/path_provider/path_provider_macos/CHANGELOG.md
+++ b/packages/path_provider/path_provider_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.4+8
+
+* Update the example app: remove the depreciated `RaisedButton` and `FlatButton` widgets.
+
 ## 0.0.4+7
 
 * Update Flutter SDK constraint.

--- a/packages/path_provider/path_provider_macos/example/lib/main.dart
+++ b/packages/path_provider/path_provider_macos/example/lib/main.dart
@@ -1,5 +1,5 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
+// Copyright 2019 The Flutter Authors. All rights reserved.  Use of
+// this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
 // ignore_for_file: public_member_api_docs
@@ -98,7 +98,7 @@ class _MyHomePageState extends State<MyHomePage> {
           children: <Widget>[
             Padding(
               padding: const EdgeInsets.all(16.0),
-              child: RaisedButton(
+              child: ElevatedButton(
                 child: const Text('Get Temporary Directory'),
                 onPressed: _requestTempDirectory,
               ),
@@ -107,7 +107,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 future: _tempDirectory, builder: _buildDirectory),
             Padding(
               padding: const EdgeInsets.all(16.0),
-              child: RaisedButton(
+              child: ElevatedButton(
                 child: const Text('Get Application Documents Directory'),
                 onPressed: _requestAppDocumentsDirectory,
               ),
@@ -116,7 +116,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 future: _appDocumentsDirectory, builder: _buildDirectory),
             Padding(
               padding: const EdgeInsets.all(16.0),
-              child: RaisedButton(
+              child: ElevatedButton(
                 child: const Text('Get Application Support Directory'),
                 onPressed: _requestAppSupportDirectory,
               ),
@@ -125,7 +125,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 future: _appSupportDirectory, builder: _buildDirectory),
             Padding(
               padding: const EdgeInsets.all(16.0),
-              child: RaisedButton(
+              child: ElevatedButton(
                 child: const Text('Get Application Library Directory'),
                 onPressed: _requestAppLibraryDirectory,
               ),
@@ -134,7 +134,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 future: _appLibraryDirectory, builder: _buildDirectory),
             Padding(
               padding: const EdgeInsets.all(16.0),
-              child: RaisedButton(
+              child: ElevatedButton(
                 child: const Text('Get Downlads Directory'),
                 onPressed: _requestDownloadsDirectory,
               ),

--- a/packages/path_provider/path_provider_macos/example/lib/main.dart
+++ b/packages/path_provider/path_provider_macos/example/lib/main.dart
@@ -1,5 +1,5 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.  Use of
-// this source code is governed by a BSD-style license that can be
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
 // ignore_for_file: public_member_api_docs

--- a/packages/path_provider/path_provider_macos/pubspec.yaml
+++ b/packages/path_provider/path_provider_macos/pubspec.yaml
@@ -3,7 +3,7 @@ description: macOS implementation of the path_provider plugin
 # 0.0.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.0.4+7
+version: 0.0.4+8
 homepage: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider_macos
 
 flutter:

--- a/packages/share/CHANGELOG.md
+++ b/packages/share/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.0.0-nullsafety.2
 
-* Update the example app: remove the depreciated `RaisedButton` and `FlatButton` widgets.
+* Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.
 
 ## 2.0.0-nullsafety.1
 

--- a/packages/share/CHANGELOG.md
+++ b/packages/share/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-nullsafety.2
+
+* Update the example app: remove the depreciated `RaisedButton` and `FlatButton` widgets.
+
 ## 2.0.0-nullsafety.1
 
 * Fix outdated links across a number of markdown files ([#3276](https://github.com/flutter/plugins/pull/3276))

--- a/packages/share/example/lib/main.dart
+++ b/packages/share/example/lib/main.dart
@@ -78,7 +78,7 @@ class DemoAppState extends State<DemoApp> {
                   const Padding(padding: EdgeInsets.only(top: 12.0)),
                   Builder(
                     builder: (BuildContext context) {
-                      return RaisedButton(
+                      return ElevatedButton(
                         child: const Text('Share'),
                         onPressed: text.isEmpty && imagePaths.isEmpty
                             ? null
@@ -89,7 +89,7 @@ class DemoAppState extends State<DemoApp> {
                   const Padding(padding: EdgeInsets.only(top: 12.0)),
                   Builder(
                     builder: (BuildContext context) {
-                      return RaisedButton(
+                      return ElevatedButton(
                         child: const Text('Share With Empty Origin'),
                         onPressed: () => _onShareWithEmptyOrigin(context),
                       );
@@ -110,11 +110,11 @@ class DemoAppState extends State<DemoApp> {
 
   _onShare(BuildContext context) async {
     // A builder is used to retrieve the context immediately
-    // surrounding the RaisedButton.
+    // surrounding the ElevatedButton.
     //
     // The context's `findRenderObject` returns the first
     // RenderObject in its descendent tree when it's not
-    // a RenderObjectWidget. The RaisedButton's RenderObject
+    // a RenderObjectWidget. The ElevatedButton's RenderObject
     // has its position and size after it's built.
     final RenderBox box = context.findRenderObject();
 

--- a/packages/share/pubspec.yaml
+++ b/packages/share/pubspec.yaml
@@ -2,7 +2,7 @@ name: share
 description: Flutter plugin for sharing content via the platform share UI, using
   the ACTION_SEND intent on Android and UIActivityViewController on iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/share
-version: 2.0.0-nullsafety.1
+version: 2.0.0-nullsafety.2
 
 flutter:
   plugin:

--- a/packages/url_launcher/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.0-nullsafety.4
+
+* Update the example app: remove the depreciated `RaisedButton` and `FlatButton` widgets.
+
 ## 6.0.0-nullsafety.3
 
 * forceSafariVC should be nullable.

--- a/packages/url_launcher/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 6.0.0-nullsafety.4
 
-* Update the example app: remove the depreciated `RaisedButton` and `FlatButton` widgets.
+* Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.
 
 ## 6.0.0-nullsafety.3
 

--- a/packages/url_launcher/url_launcher/example/lib/main.dart
+++ b/packages/url_launcher/url_launcher/example/lib/main.dart
@@ -141,7 +141,7 @@ class _MyHomePageState extends State<MyHomePage> {
                     decoration: const InputDecoration(
                         hintText: 'Input the phone number to launch')),
               ),
-              RaisedButton(
+              ElevatedButton(
                 onPressed: () => setState(() {
                   _launched = _makePhoneCall('tel:$_phone');
                 }),
@@ -151,33 +151,33 @@ class _MyHomePageState extends State<MyHomePage> {
                 padding: EdgeInsets.all(16.0),
                 child: Text(toLaunch),
               ),
-              RaisedButton(
+              ElevatedButton(
                 onPressed: () => setState(() {
                   _launched = _launchInBrowser(toLaunch);
                 }),
                 child: const Text('Launch in browser'),
               ),
               const Padding(padding: EdgeInsets.all(16.0)),
-              RaisedButton(
+              ElevatedButton(
                 onPressed: () => setState(() {
                   _launched = _launchInWebViewOrVC(toLaunch);
                 }),
                 child: const Text('Launch in app'),
               ),
-              RaisedButton(
+              ElevatedButton(
                 onPressed: () => setState(() {
                   _launched = _launchInWebViewWithJavaScript(toLaunch);
                 }),
                 child: const Text('Launch in app(JavaScript ON)'),
               ),
-              RaisedButton(
+              ElevatedButton(
                 onPressed: () => setState(() {
                   _launched = _launchInWebViewWithDomStorage(toLaunch);
                 }),
                 child: const Text('Launch in app(DOM storage ON)'),
               ),
               const Padding(padding: EdgeInsets.all(16.0)),
-              RaisedButton(
+              ElevatedButton(
                 onPressed: () => setState(() {
                   _launched = _launchUniversalLinkIos(toLaunch);
                 }),
@@ -185,7 +185,7 @@ class _MyHomePageState extends State<MyHomePage> {
                     'Launch a universal link in a native app, fallback to Safari.(Youtube)'),
               ),
               const Padding(padding: EdgeInsets.all(16.0)),
-              RaisedButton(
+              ElevatedButton(
                 onPressed: () => setState(() {
                   _launched = _launchInWebViewOrVC(toLaunch);
                   Timer(const Duration(seconds: 5), () {

--- a/packages/url_launcher/url_launcher/example/test/url_launcher_example_test.dart
+++ b/packages/url_launcher/url_launcher/example/test/url_launcher_example_test.dart
@@ -32,7 +32,7 @@ void main() {
         headers: defaultHeaders));
 
     Finder browserlaunchBtn =
-        find.widgetWithText(RaisedButton, 'Launch in browser');
+        find.widgetWithText(ElevatedButton, 'Launch in browser');
     expect(browserlaunchBtn, findsOneWidget);
     await tester.tap(browserlaunchBtn);
 

--- a/packages/url_launcher/url_launcher/lib/src/link.dart
+++ b/packages/url_launcher/url_launcher/lib/src/link.dart
@@ -17,7 +17,7 @@ import 'package:url_launcher_platform_interface/url_launcher_platform_interface.
 /// ```dart
 /// Link(
 ///   uri: Uri.parse('https://flutter.dev'),
-///   builder: (BuildContext context, FollowLink followLink) => RaisedButton(
+///   builder: (BuildContext context, FollowLink followLink) => ElevatedButton(
 ///     onPressed: followLink,
 ///     // ... other properties here ...
 ///   )},
@@ -29,7 +29,7 @@ import 'package:url_launcher_platform_interface/url_launcher_platform_interface.
 /// ```dart
 /// Link(
 ///   uri: Uri.parse('/home'),
-///   builder: (BuildContext context, FollowLink followLink) => RaisedButton(
+///   builder: (BuildContext context, FollowLink followLink) => ElevatedButton(
 ///     onPressed: followLink,
 ///     // ... other properties here ...
 ///   )},

--- a/packages/url_launcher/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher
 description: Flutter plugin for launching a URL on Android and iOS. Supports
   web, phone, SMS, and email schemes.
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher
-version: 6.0.0-nullsafety.3
+version: 6.0.0-nullsafety.4
 
 flutter:
   plugin:

--- a/packages/url_launcher/url_launcher_linux/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_linux/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.1.0-nullsafety.3
 
-* Update the example app: remove the depreciated `RaisedButton` and `FlatButton` widgets.
+* Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.
 
 ## 0.1.0-nullsafety.2
 

--- a/packages/url_launcher/url_launcher_linux/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0-nullsafety.3
+
+* Update the example app: remove the depreciated `RaisedButton` and `FlatButton` widgets.
+
 ## 0.1.0-nullsafety.2
 
 * Fix outdated links across a number of markdown files ([#3276](https://github.com/flutter/plugins/pull/3276))

--- a/packages/url_launcher/url_launcher_linux/example/lib/main.dart
+++ b/packages/url_launcher/url_launcher_linux/example/lib/main.dart
@@ -140,7 +140,7 @@ class _MyHomePageState extends State<MyHomePage> {
                     decoration: const InputDecoration(
                         hintText: 'Input the phone number to launch')),
               ),
-              RaisedButton(
+              ElevatedButton(
                 onPressed: () => setState(() {
                   _launched = _makePhoneCall('tel:$_phone');
                 }),
@@ -150,33 +150,33 @@ class _MyHomePageState extends State<MyHomePage> {
                 padding: EdgeInsets.all(16.0),
                 child: Text(toLaunch),
               ),
-              RaisedButton(
+              ElevatedButton(
                 onPressed: () => setState(() {
                   _launched = _launchInBrowser(toLaunch);
                 }),
                 child: const Text('Launch in browser'),
               ),
               const Padding(padding: EdgeInsets.all(16.0)),
-              RaisedButton(
+              ElevatedButton(
                 onPressed: () => setState(() {
                   _launched = _launchInWebViewOrVC(toLaunch);
                 }),
                 child: const Text('Launch in app'),
               ),
-              RaisedButton(
+              ElevatedButton(
                 onPressed: () => setState(() {
                   _launched = _launchInWebViewWithJavaScript(toLaunch);
                 }),
                 child: const Text('Launch in app(JavaScript ON)'),
               ),
-              RaisedButton(
+              ElevatedButton(
                 onPressed: () => setState(() {
                   _launched = _launchInWebViewWithDomStorage(toLaunch);
                 }),
                 child: const Text('Launch in app(DOM storage ON)'),
               ),
               const Padding(padding: EdgeInsets.all(16.0)),
-              RaisedButton(
+              ElevatedButton(
                 onPressed: () => setState(() {
                   _launched = _launchUniversalLinkIos(toLaunch);
                 }),

--- a/packages/url_launcher/url_launcher_linux/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_linux/pubspec.yaml
@@ -1,6 +1,6 @@
 name: url_launcher_linux
 description: Linux implementation of the url_launcher plugin.
-version: 0.1.0-nullsafety.2
+version: 0.1.0-nullsafety.3
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher_linux
 
 flutter:

--- a/packages/url_launcher/url_launcher_macos/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.0-nullsafety.2
+
+* Update the example app: remove the depreciated `RaisedButton` and `FlatButton` widgets.
+
 # 0.1.0-nullsafety.1
 
 * Bump SDK to support null safety.

--- a/packages/url_launcher/url_launcher_macos/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_macos/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.1.0-nullsafety.2
 
-* Update the example app: remove the depreciated `RaisedButton` and `FlatButton` widgets.
+* Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.
 
 # 0.1.0-nullsafety.1
 

--- a/packages/url_launcher/url_launcher_macos/example/lib/main.dart
+++ b/packages/url_launcher/url_launcher_macos/example/lib/main.dart
@@ -140,7 +140,7 @@ class _MyHomePageState extends State<MyHomePage> {
                     decoration: const InputDecoration(
                         hintText: 'Input the phone number to launch')),
               ),
-              RaisedButton(
+              ElevatedButton(
                 onPressed: () => setState(() {
                   _launched = _makePhoneCall('tel:$_phone');
                 }),
@@ -150,33 +150,33 @@ class _MyHomePageState extends State<MyHomePage> {
                 padding: EdgeInsets.all(16.0),
                 child: Text(toLaunch),
               ),
-              RaisedButton(
+              ElevatedButton(
                 onPressed: () => setState(() {
                   _launched = _launchInBrowser(toLaunch);
                 }),
                 child: const Text('Launch in browser'),
               ),
               const Padding(padding: EdgeInsets.all(16.0)),
-              RaisedButton(
+              ElevatedButton(
                 onPressed: () => setState(() {
                   _launched = _launchInWebViewOrVC(toLaunch);
                 }),
                 child: const Text('Launch in app'),
               ),
-              RaisedButton(
+              ElevatedButton(
                 onPressed: () => setState(() {
                   _launched = _launchInWebViewWithJavaScript(toLaunch);
                 }),
                 child: const Text('Launch in app(JavaScript ON)'),
               ),
-              RaisedButton(
+              ElevatedButton(
                 onPressed: () => setState(() {
                   _launched = _launchInWebViewWithDomStorage(toLaunch);
                 }),
                 child: const Text('Launch in app(DOM storage ON)'),
               ),
               const Padding(padding: EdgeInsets.all(16.0)),
-              RaisedButton(
+              ElevatedButton(
                 onPressed: () => setState(() {
                   _launched = _launchUniversalLinkIos(toLaunch);
                 }),

--- a/packages/url_launcher/url_launcher_macos/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_macos/pubspec.yaml
@@ -3,7 +3,7 @@ description: macOS implementation of the url_launcher plugin.
 # 0.0.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.1.0-nullsafety.1
+version: 0.1.0-nullsafety.2
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher_macos
 
 flutter:

--- a/packages/url_launcher/url_launcher_windows/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0-nullsafety.2
+
+* Update the example app: remove the depreciated `RaisedButton` and `FlatButton` widgets.
+
 ## 0.1.0-nullsafety.1
 
 * Bump Dart SDK to support null safety.

--- a/packages/url_launcher/url_launcher_windows/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_windows/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.1.0-nullsafety.2
 
-* Update the example app: remove the depreciated `RaisedButton` and `FlatButton` widgets.
+* Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.
 
 ## 0.1.0-nullsafety.1
 

--- a/packages/url_launcher/url_launcher_windows/example/lib/main.dart
+++ b/packages/url_launcher/url_launcher_windows/example/lib/main.dart
@@ -76,7 +76,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 padding: EdgeInsets.all(16.0),
                 child: Text(toLaunch),
               ),
-              RaisedButton(
+              ElevatedButton(
                 onPressed: () => setState(() {
                   _launched = _launchInBrowser(toLaunch);
                 }),

--- a/packages/url_launcher/url_launcher_windows/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_windows/pubspec.yaml
@@ -3,7 +3,7 @@ description: Windows implementation of the url_launcher plugin.
 # 0.0.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.1.0-nullsafety.1
+version: 0.1.0-nullsafety.2
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher_windows
 
 flutter:

--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.0.0-nullsafety.7
 
-* Update the example app: remove the depreciated `RaisedButton` and `FlatButton` widgets.
+* Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.
 
 ## 2.0.0-nullsafety.6
 

--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-nullsafety.7
+
+* Update the example app: remove the depreciated `RaisedButton` and `FlatButton` widgets.
+
 ## 2.0.0-nullsafety.6
 
 * Fix `VideoPlayerValue toString()` test.

--- a/packages/video_player/video_player/example/lib/main.dart
+++ b/packages/video_player/video_player/example/lib/main.dart
@@ -124,13 +124,13 @@ class _ExampleCard extends StatelessWidget {
           ),
           ButtonBar(
             children: <Widget>[
-              FlatButton(
+              TextButton(
                 child: const Text('BUY TICKETS'),
                 onPressed: () {
                   /* ... */
                 },
               ),
-              FlatButton(
+              TextButton(
                 child: const Text('SELL TICKETS'),
                 onPressed: () {
                   /* ... */

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for displaying inline video with other Flutter
 # 0.10.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 2.0.0-nullsafety.6
+version: 2.0.0-nullsafety.7
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player
 
 flutter:


### PR DESCRIPTION
Updated references to the obsolete Material button widgets:

- FlatButton becomes TextButton
- RaisedButton becomes ElevatedButton
- (OutlineButton becomes OutlinedButton)

These changes will enable the obsolete widgets to be deprecated: https://github.com/flutter/flutter/pull/73352

More information about the evolution of these classes:

- flutter.dev/go/material-button-migration-guide
- flutter.dev/go/material-button-system-updates