### PR TITLE
Ignore deprecated_member_use analysis lint

### DIFF
--- a/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_real.dart
+++ b/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_real.dart
@@ -123,7 +123,11 @@ class PathProviderWindows extends PathProviderPlatform {
       GUID knownFolderID = GUID.fromString(folderID);
 
       final hr = SHGetKnownFolderPath(
-          knownFolderID.addressOf, KF_FLAG_DEFAULT, NULL, pathPtrPtr);
+        knownFolderID.addressOf, // ignore: deprecated_member_use
+        KF_FLAG_DEFAULT,
+        NULL,
+        pathPtrPtr,
+      );
 
       if (FAILED(hr)) {
         if (hr == E_INVALIDARG || hr == E_FAIL) {


### PR DESCRIPTION
This is needed to unblock the engine -> framework roll

```
Checking project path_provider_windows...

  info - 'addressOf' is deprecated and shouldn't be used. Hold on to the pointer backing a struct instead. at lib/src/path_provider_windows_real.dart:126:25 - (deprecated_member_use)

1 issue found; analyzed 11 source files in 6.6s.
```