### PR TITLE
Androidx migration

### DIFF
--- a/packages/android_alarm_manager/android/gradle.properties
+++ b/packages/android_alarm_manager/android/gradle.properties
@@ -1,1 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
+android.useAndroidX=true
+android.enableJetifier=true

--- a/packages/android_alarm_manager/pubspec.yaml
+++ b/packages/android_alarm_manager/pubspec.yaml
@@ -6,6 +6,8 @@ description: Flutter plugin for accessing the Android AlarmManager service, and
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
 version: 0.4.5+20
 homepage: https://github.com/flutter/plugins/tree/master/packages/android_alarm_manager
+module:
+   androidX: true
 
 dependencies:
   flutter:

--- a/packages/android_intent/android/gradle.properties
+++ b/packages/android_intent/android/gradle.properties
@@ -1,1 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
+android.useAndroidX=true
+android.enableJetifier=true

--- a/packages/android_intent/pubspec.yaml
+++ b/packages/android_intent/pubspec.yaml
@@ -2,7 +2,8 @@ name: android_intent
 description: Flutter plugin for launching Android Intents. Not supported on iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/android_intent
 version: 2.0.0-nullsafety.2
-
+module:
+   androidX: true
 flutter:
   plugin:
     platforms:

--- a/packages/battery/battery/android/gradle.properties
+++ b/packages/battery/battery/android/gradle.properties
@@ -1,1 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
+android.useAndroidX=true
+android.enableJetifier=true

--- a/packages/battery/battery/pubspec.yaml
+++ b/packages/battery/battery/pubspec.yaml
@@ -3,6 +3,8 @@ description: Flutter plugin for accessing information about the battery state
   (full, charging, discharging) on Android and iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/battery/battery
 version: 1.0.11
+module:
+   androidX: true
 
 flutter:
   plugin:

--- a/packages/camera/camera/android/gradle.properties
+++ b/packages/camera/camera/android/gradle.properties
@@ -1,1 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
+android.useAndroidX=true
+android.enableJetifier=true

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -3,6 +3,8 @@ description: A Flutter plugin for getting information about and controlling the
   camera on Android and iOS. Supports previewing the camera feed, capturing images, capturing video,
   and streaming image buffers to dart.
 version: 0.6.4+5
+module:
+   androidX: true
 homepage: https://github.com/flutter/plugins/tree/master/packages/camera/camera
 
 dependencies:

--- a/packages/connectivity/connectivity/android/gradle.properties
+++ b/packages/connectivity/connectivity/android/gradle.properties
@@ -1,1 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
+android.useAndroidX=true
+android.enableJetifier=true

--- a/packages/connectivity/connectivity/pubspec.yaml
+++ b/packages/connectivity/connectivity/pubspec.yaml
@@ -3,6 +3,9 @@ description: Flutter plugin for discovering the state of the network (WiFi &
   mobile/cellular) connectivity on Android and iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/connectivity/connectivity
 version: 3.0.0-nullsafety.3
+module:
+   androidX: true
+
 
 flutter:
   plugin:

--- a/packages/cross_file/pubspec.yaml
+++ b/packages/cross_file/pubspec.yaml
@@ -2,6 +2,8 @@ name: cross_file
 description: An abstraction to allow working with files across multiple platforms.
 homepage: https://github.com/flutter/plugins/tree/master/packages/cross_file
 version: 0.2.0
+module:
+   androidX: true
 
 dependencies:
   flutter:

--- a/packages/device_info/device_info/android/gradle.properties
+++ b/packages/device_info/device_info/android/gradle.properties
@@ -1,1 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
+android.useAndroidX=true
+android.enableJetifier=true

--- a/packages/device_info/device_info/pubspec.yaml
+++ b/packages/device_info/device_info/pubspec.yaml
@@ -6,6 +6,8 @@ homepage: https://github.com/flutter/plugins/tree/master/packages/device_info
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
 version: 2.0.0-nullsafety.2
+module:
+   androidX: true
 
 flutter:
   plugin:

--- a/packages/package_info/android/gradle.properties
+++ b/packages/package_info/android/gradle.properties
@@ -1,1 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
+android.useAndroidX=true
+android.enableJetifier=true

--- a/packages/package_info/pubspec.yaml
+++ b/packages/package_info/pubspec.yaml
@@ -6,6 +6,8 @@ homepage: https://github.com/flutter/plugins/tree/master/packages/package_info
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
 version: 0.4.3+3
+module:
+   androoidX: true
 
 flutter:
   plugin:

--- a/packages/path_provider/path_provider/android/gradle.properties
+++ b/packages/path_provider/path_provider/android/gradle.properties
@@ -1,1 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
+android.useAndroidX=true
+android.enableJetifier=true

--- a/packages/path_provider/path_provider/pubspec.yaml
+++ b/packages/path_provider/path_provider/pubspec.yaml
@@ -2,6 +2,8 @@ name: path_provider
 description: Flutter plugin for getting commonly used locations on host platform file systems, such as the temp and app data directories.
 homepage: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider
 version: 1.6.27
+module:
+   androidX: true
 
 flutter:
   plugin:

--- a/packages/quick_actions/android/gradle.properties
+++ b/packages/quick_actions/android/gradle.properties
@@ -1,1 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
+android.useAndroidX=true
+android.enableJetifier=true

--- a/packages/quick_actions/pubspec.yaml
+++ b/packages/quick_actions/pubspec.yaml
@@ -3,6 +3,8 @@ description: Flutter plugin for creating shortcuts on home screen, also known as
   Quick Actions on iOS and App Shortcuts on Android.
 homepage: https://github.com/flutter/plugins/tree/master/packages/quick_actions
 version: 0.4.0+12
+module:
+androidX: true
 
 flutter:
   plugin:

--- a/packages/sensors/android/gradle.properties
+++ b/packages/sensors/android/gradle.properties
@@ -1,1 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
+android.useAndroidX=true
+android.enableJetifier=true

--- a/packages/sensors/pubspec.yaml
+++ b/packages/sensors/pubspec.yaml
@@ -6,6 +6,8 @@ homepage: https://github.com/flutter/plugins/tree/master/packages/sensors
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
 version: 0.4.2+8
+module:
+   androidX: true
 
 flutter:
   plugin:

--- a/packages/share/android/gradle.properties
+++ b/packages/share/android/gradle.properties
@@ -1,1 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
+android.useAndroidX=true
+android.enableJetifier=true

--- a/packages/share/pubspec.yaml
+++ b/packages/share/pubspec.yaml
@@ -3,6 +3,8 @@ description: Flutter plugin for sharing content via the platform share UI, using
   the ACTION_SEND intent on Android and UIActivityViewController on iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/share
 version: 2.0.0-nullsafety.2
+module:
+   androidX: true
 
 flutter:
   plugin:

--- a/packages/shared_preferences/shared_preferences/android/gradle.properties
+++ b/packages/shared_preferences/shared_preferences/android/gradle.properties
@@ -1,1 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
+android.useAndroidX=true
+android.enableJetifier=true

--- a/packages/shared_preferences/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences/pubspec.yaml
@@ -6,6 +6,8 @@ homepage: https://github.com/flutter/plugins/tree/master/packages/shared_prefere
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
 version: 0.5.13+2
+module:
+   androidX: true
 
 flutter:
   plugin:

--- a/packages/url_launcher/url_launcher/android/gradle.properties
+++ b/packages/url_launcher/url_launcher/android/gradle.properties
@@ -1,1 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
+android.useAndroidX=true
+android.enableJetifier=true

--- a/packages/url_launcher/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/pubspec.yaml
@@ -3,6 +3,8 @@ description: Flutter plugin for launching a URL on Android and iOS. Supports
   web, phone, SMS, and email schemes.
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher
 version: 6.0.0-nullsafety.4
+module:
+   androidX: true
 
 flutter:
   plugin:

--- a/packages/video_player/video_player/android/gradle.properties
+++ b/packages/video_player/video_player/android/gradle.properties
@@ -1,1 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
+android.useAndroidX=true
+android.enableJetifier=true

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -6,6 +6,8 @@ description: Flutter plugin for displaying inline video with other Flutter
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
 version: 2.0.0-nullsafety.7
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player
+module:
+   androidX: true
 
 flutter:
   plugin:


### PR DESCRIPTION
*some of plugin not migrated to androidX so in this pull request I am migrating some plugin to androidX*

Close issue  `#73664`

## androidX migrated Checklist

- [X] android_alarm_manager
- [X] android_intent
- [X] battery
- [X] camera
- [X] connectivity
- [X] device_info
- [X] cross_file
- [X] espresso
- [X] file_selector
- [X] package_info
- [X] path_provider
- [X] quick_actions
- [X] sensor
- [X] share
- [X] shared_prefrences
- [X] url_launcher
- [X] video_player
