### PR TITLE
Add onInputFocusEvent to WebViewPlatformCallbacksHandler

### DIFF
--- a/packages/webview_flutter/lib/platform_interface.dart
+++ b/packages/webview_flutter/lib/platform_interface.dart
@@ -32,6 +32,9 @@ abstract class WebViewPlatformCallbacksHandler {
 
   /// Report web resource loading error to the host application.
   void onWebResourceError(WebResourceError error);
+
+  /// Invoked by [WebViewPlatformController] when a page has input focus.
+  void onInputFocusEvent(WebTextInputType type);
 }
 
 /// Possible error type categorizations used by [WebResourceError].
@@ -147,6 +150,45 @@ class WebResourceError {
   /// This value is not provided on iOS. Alternatively, you can keep track of
   /// the last values provided to [WebViewPlatformController.loadUrl].
   final String? failingUrl;
+}
+
+/// Represents the type of a focused text input field.
+/// Corresponds with blink's public/platform/WebTextInputType.h
+/// Reference that source for more extended commentary on meaning of each value.
+enum WebTextInputType {
+  none,
+
+  text,
+
+  password,
+
+  search,
+
+  email,
+
+  number,
+
+  telephone,
+
+  url,
+
+  date,
+
+  dateTime,
+
+  dateTimeLocal,
+
+  month,
+
+  time,
+
+  week,
+
+  textArea,
+
+  contentEditable,
+
+  dateTimeField,
 }
 
 /// Interface for talking to the webview's platform implementation.

--- a/packages/webview_flutter/lib/src/webview_method_channel.dart
+++ b/packages/webview_flutter/lib/src/webview_method_channel.dart
@@ -62,6 +62,9 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
           ),
         );
         return null;
+      case 'inputFocusEvent':
+        _platformCallbacksHandler.onInputFocusEvent(call.arguments['type']);
+        return true;
     }
 
     throw MissingPluginException(

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -577,6 +577,9 @@ class _PlatformCallbacksHandler implements WebViewPlatformCallbacksHandler {
     }
   }
 
+  @override
+  void onInputFocusEvent(WebTextInputType type) {}
+
   void _updateJavascriptChannelsFromSet(Set<JavascriptChannel>? channels) {
     _javascriptChannels.clear();
     if (channels == null) {


### PR DESCRIPTION
Allows subclasses to be notified of input focus
events from a WebView.

Bug: b/169054926
