### PR TITLE
[camera] Fix initialization error in camera example on iOS

### DIFF
--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.6+1
+
+* Improved error feedback by differentiating between uninitialized and disposed camera controllers.
+
 ## 0.6.6
 
 * Adds auto focus support for Android and iOS implementations.

--- a/packages/camera/camera/example/lib/main.dart
+++ b/packages/camera/camera/example/lib/main.dart
@@ -572,8 +572,12 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
     try {
       await controller.initialize();
       await Future.wait([
-        controller.getMinExposureOffset().then((value) => _minAvailableExposureOffset = value),
-        controller.getMaxExposureOffset().then((value) => _maxAvailableExposureOffset = value),
+        controller
+            .getMinExposureOffset()
+            .then((value) => _minAvailableExposureOffset = value),
+        controller
+            .getMaxExposureOffset()
+            .then((value) => _maxAvailableExposureOffset = value),
         controller.getMaxZoomLevel().then((value) => _maxAvailableZoom = value),
         controller.getMinZoomLevel().then((value) => _minAvailableZoom = value),
       ]);

--- a/packages/camera/camera/example/lib/main.dart
+++ b/packages/camera/camera/example/lib/main.dart
@@ -571,10 +571,12 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
 
     try {
       await controller.initialize();
-      _minAvailableExposureOffset = await controller.getMinExposureOffset();
-      _maxAvailableExposureOffset = await controller.getMaxExposureOffset();
-      _maxAvailableZoom = await controller.getMaxZoomLevel();
-      _minAvailableZoom = await controller.getMinZoomLevel();
+      await Future.wait([
+        controller.getMinExposureOffset().then((value) => _minAvailableExposureOffset = value),
+        controller.getMaxExposureOffset().then((value) => _maxAvailableExposureOffset = value),
+        controller.getMaxZoomLevel().then((value) => _maxAvailableZoom = value),
+        controller.getMinZoomLevel().then((value) => _minAvailableZoom = value),
+      ]);
     } on CameraException catch (e) {
       _showCameraException(e);
     }

--- a/packages/camera/camera/lib/src/camera_controller.dart
+++ b/packages/camera/camera/lib/src/camera_controller.dart
@@ -285,12 +285,7 @@ class CameraController extends ValueNotifier<CameraValue> {
   ///
   /// Throws a [CameraException] if the capture fails.
   Future<XFile> takePicture() async {
-    if (!value.isInitialized || _isDisposed) {
-      throw CameraException(
-        'Uninitialized CameraController.',
-        'takePicture was called on uninitialized CameraController',
-      );
-    }
+    _throwIfNotInitialized("takePicture");
     if (value.isTakingPicture) {
       throw CameraException(
         'Previous capture has not returned yet.',
@@ -328,13 +323,7 @@ class CameraController extends ValueNotifier<CameraValue> {
   Future<void> startImageStream(onLatestImageAvailable onAvailable) async {
     assert(defaultTargetPlatform == TargetPlatform.android ||
         defaultTargetPlatform == TargetPlatform.iOS);
-
-    if (!value.isInitialized || _isDisposed) {
-      throw CameraException(
-        'Uninitialized CameraController',
-        'startImageStream was called on uninitialized CameraController.',
-      );
-    }
+    _throwIfNotInitialized("startImageStream");
     if (value.isRecordingVideo) {
       throw CameraException(
         'A video recording is already started.',
@@ -374,13 +363,7 @@ class CameraController extends ValueNotifier<CameraValue> {
   Future<void> stopImageStream() async {
     assert(defaultTargetPlatform == TargetPlatform.android ||
         defaultTargetPlatform == TargetPlatform.iOS);
-
-    if (!value.isInitialized || _isDisposed) {
-      throw CameraException(
-        'Uninitialized CameraController',
-        'stopImageStream was called on uninitialized CameraController.',
-      );
-    }
+    _throwIfNotInitialized("stopImageStream");
     if (value.isRecordingVideo) {
       throw CameraException(
         'A video recording is already started.',
@@ -410,12 +393,7 @@ class CameraController extends ValueNotifier<CameraValue> {
   /// The video is returned as a [XFile] after calling [stopVideoRecording].
   /// Throws a [CameraException] if the capture fails.
   Future<void> startVideoRecording() async {
-    if (!value.isInitialized || _isDisposed) {
-      throw CameraException(
-        'Uninitialized CameraController',
-        'startVideoRecording was called on uninitialized CameraController',
-      );
-    }
+    _throwIfNotInitialized("startVideoRecording");
     if (value.isRecordingVideo) {
       throw CameraException(
         'A video recording is already started.',
@@ -441,12 +419,7 @@ class CameraController extends ValueNotifier<CameraValue> {
   ///
   /// Throws a [CameraException] if the capture failed.
   Future<XFile> stopVideoRecording() async {
-    if (!value.isInitialized || _isDisposed) {
-      throw CameraException(
-        'Uninitialized CameraController',
-        'stopVideoRecording was called on uninitialized CameraController',
-      );
-    }
+    _throwIfNotInitialized("stopVideoRecording");
     if (!value.isRecordingVideo) {
       throw CameraException(
         'No video is recording',
@@ -466,12 +439,7 @@ class CameraController extends ValueNotifier<CameraValue> {
   ///
   /// This feature is only available on iOS and Android sdk 24+.
   Future<void> pauseVideoRecording() async {
-    if (!value.isInitialized || _isDisposed) {
-      throw CameraException(
-        'Uninitialized CameraController',
-        'pauseVideoRecording was called on uninitialized CameraController',
-      );
-    }
+    _throwIfNotInitialized("pauseVideoRecording");
     if (!value.isRecordingVideo) {
       throw CameraException(
         'No video is recording',
@@ -490,12 +458,7 @@ class CameraController extends ValueNotifier<CameraValue> {
   ///
   /// This feature is only available on iOS and Android sdk 24+.
   Future<void> resumeVideoRecording() async {
-    if (!value.isInitialized || _isDisposed) {
-      throw CameraException(
-        'Uninitialized CameraController',
-        'resumeVideoRecording was called on uninitialized CameraController',
-      );
-    }
+    _throwIfNotInitialized("resumeVideoRecording");
     if (!value.isRecordingVideo) {
       throw CameraException(
         'No video is recording',
@@ -512,12 +475,7 @@ class CameraController extends ValueNotifier<CameraValue> {
 
   /// Returns a widget showing a live camera preview.
   Widget buildPreview() {
-    if (!value.isInitialized || _isDisposed) {
-      throw CameraException(
-        'Uninitialized CameraController',
-        'buildView() was called on uninitialized CameraController.',
-      );
-    }
+    _throwIfNotInitialized("buildPreview");
     try {
       return CameraPlatform.instance.buildPreview(_cameraId);
     } on PlatformException catch (e) {
@@ -527,13 +485,7 @@ class CameraController extends ValueNotifier<CameraValue> {
 
   /// Gets the maximum supported zoom level for the selected camera.
   Future<double> getMaxZoomLevel() {
-    if (!value.isInitialized || _isDisposed) {
-      throw CameraException(
-        'Uninitialized CameraController',
-        'getMaxZoomLevel was called on uninitialized CameraController',
-      );
-    }
-
+    _throwIfNotInitialized("getMaxZoomLevel");
     try {
       return CameraPlatform.instance.getMaxZoomLevel(_cameraId);
     } on PlatformException catch (e) {
@@ -543,13 +495,7 @@ class CameraController extends ValueNotifier<CameraValue> {
 
   /// Gets the minimum supported zoom level for the selected camera.
   Future<double> getMinZoomLevel() {
-    if (!value.isInitialized || _isDisposed) {
-      throw CameraException(
-        'Uninitialized CameraController',
-        'getMinZoomLevel was called on uninitialized CameraController',
-      );
-    }
-
+    _throwIfNotInitialized("getMinZoomLevel");
     try {
       return CameraPlatform.instance.getMinZoomLevel(_cameraId);
     } on PlatformException catch (e) {
@@ -563,13 +509,7 @@ class CameraController extends ValueNotifier<CameraValue> {
   /// zoom level returned by the `getMaxZoomLevel`. Throws an `CameraException`
   /// when an illegal zoom level is suplied.
   Future<void> setZoomLevel(double zoom) {
-    if (!value.isInitialized || _isDisposed) {
-      throw CameraException(
-        'Uninitialized CameraController',
-        'setZoomLevel was called on uninitialized CameraController',
-      );
-    }
-
+    _throwIfNotInitialized("setZoomLevel");
     try {
       return CameraPlatform.instance.setZoomLevel(_cameraId, zoom);
     } on PlatformException catch (e) {
@@ -621,13 +561,7 @@ class CameraController extends ValueNotifier<CameraValue> {
 
   /// Gets the minimum supported exposure offset for the selected camera in EV units.
   Future<double> getMinExposureOffset() async {
-    if (!value.isInitialized || _isDisposed) {
-      throw CameraException(
-        'Uninitialized CameraController',
-        'getMinExposureOffset was called on uninitialized CameraController',
-      );
-    }
-
+    _throwIfNotInitialized("getMinExposureOffset");
     try {
       return CameraPlatform.instance.getMinExposureOffset(_cameraId);
     } on PlatformException catch (e) {
@@ -637,13 +571,7 @@ class CameraController extends ValueNotifier<CameraValue> {
 
   /// Gets the maximum supported exposure offset for the selected camera in EV units.
   Future<double> getMaxExposureOffset() async {
-    if (!value.isInitialized || _isDisposed) {
-      throw CameraException(
-        'Uninitialized CameraController',
-        'getMaxExposureOffset was called on uninitialized CameraController',
-      );
-    }
-
+    _throwIfNotInitialized("getMaxExposureOffset");
     try {
       return CameraPlatform.instance.getMaxExposureOffset(_cameraId);
     } on PlatformException catch (e) {
@@ -655,13 +583,7 @@ class CameraController extends ValueNotifier<CameraValue> {
   ///
   /// Returns 0 when the camera supports using a free value without stepping.
   Future<double> getExposureOffsetStepSize() async {
-    if (!value.isInitialized || _isDisposed) {
-      throw CameraException(
-        'Uninitialized CameraController',
-        'getExposureOffsetStepSize was called on uninitialized CameraController',
-      );
-    }
-
+    _throwIfNotInitialized("getExposureOffsetStepSize");
     try {
       return CameraPlatform.instance.getExposureOffsetStepSize(_cameraId);
     } on PlatformException catch (e) {
@@ -681,13 +603,7 @@ class CameraController extends ValueNotifier<CameraValue> {
   ///
   /// Returns the (rounded) offset value that was set.
   Future<double> setExposureOffset(double offset) async {
-    if (!value.isInitialized || _isDisposed) {
-      throw CameraException(
-        'Uninitialized CameraController',
-        'setExposureOffset was called on uninitialized CameraController',
-      );
-    }
-
+    _throwIfNotInitialized("setExposureOffset");
     // Check if offset is in range
     List<double> range =
         await Future.wait([getMinExposureOffset(), getMaxExposureOffset()]);
@@ -761,6 +677,21 @@ class CameraController extends ValueNotifier<CameraValue> {
     if (_initCalled != null) {
       await _initCalled;
       await CameraPlatform.instance.dispose(_cameraId);
+    }
+  }
+
+  void _throwIfNotInitialized(String functionName) {
+    if (!value.isInitialized) {
+      throw CameraException(
+        'Uninitialized CameraController',
+        '$functionName() was called on an uninitialized CameraController.',
+      );
+    }
+    if (_isDisposed) {
+      throw CameraException(
+        'Disposed CameraController',
+        '$functionName() was called on a disposed CameraController.',
+      );
     }
   }
 }

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera
 description: A Flutter plugin for getting information about and controlling the
   camera on Android and iOS. Supports previewing the camera feed, capturing images, capturing video,
   and streaming image buffers to dart.
-version: 0.6.6
+version: 0.6.6+1
 homepage: https://github.com/flutter/plugins/tree/master/packages/camera/camera
 
 dependencies:

--- a/packages/camera/camera/test/camera_image_stream_test.dart
+++ b/packages/camera/camera/test/camera_image_stream_test.dart
@@ -22,12 +22,21 @@ void main() {
         ResolutionPreset.max);
 
     expect(
-        () => cameraController.startImageStream((image) => null),
-        throwsA(isA<CameraException>().having(
-          (error) => error.description,
-          'Uninitialized CameraController.',
-          'startImageStream was called on uninitialized CameraController.',
-        )));
+      () => cameraController.startImageStream((image) => null),
+      throwsA(
+        isA<CameraException>()
+            .having(
+              (error) => error.code,
+              'code',
+              'Uninitialized CameraController',
+            )
+            .having(
+              (error) => error.description,
+              'description',
+              'startImageStream() was called on an uninitialized CameraController.',
+            ),
+      ),
+    );
   });
 
   test('startImageStream() throws $CameraException when recording videos',
@@ -107,12 +116,21 @@ void main() {
         ResolutionPreset.max);
 
     expect(
-        cameraController.stopImageStream,
-        throwsA(isA<CameraException>().having(
-          (error) => error.description,
-          'Uninitialized CameraController.',
-          'stopImageStream was called on uninitialized CameraController.',
-        )));
+      cameraController.stopImageStream,
+      throwsA(
+        isA<CameraException>()
+            .having(
+              (error) => error.code,
+              'code',
+              'Uninitialized CameraController',
+            )
+            .having(
+              (error) => error.description,
+              'description',
+              'stopImageStream() was called on an uninitialized CameraController.',
+            ),
+      ),
+    );
   });
 
   test('stopImageStream() throws $CameraException when recording videos',

--- a/packages/camera/camera/test/camera_test.dart
+++ b/packages/camera/camera/test/camera_test.dart
@@ -210,12 +210,21 @@ void main() {
               sensorOrientation: 90),
           ResolutionPreset.max);
       expect(
-          cameraController.takePicture(),
-          throwsA(isA<CameraException>().having(
-            (error) => error.description,
-            'Uninitialized CameraController.',
-            'takePicture was called on uninitialized CameraController',
-          )));
+        cameraController.takePicture(),
+        throwsA(
+          isA<CameraException>()
+              .having(
+                (error) => error.code,
+                'code',
+                'Uninitialized CameraController',
+              )
+              .having(
+                (error) => error.description,
+                'description',
+                'takePicture() was called on an uninitialized CameraController.',
+              ),
+        ),
+      );
     });
 
     test('takePicture() throws $CameraException when takePicture is true',
@@ -283,12 +292,21 @@ void main() {
           ResolutionPreset.max);
 
       expect(
-          cameraController.startVideoRecording(),
-          throwsA(isA<CameraException>().having(
-            (error) => error.description,
-            'Uninitialized CameraController',
-            'startVideoRecording was called on uninitialized CameraController',
-          )));
+        cameraController.startVideoRecording(),
+        throwsA(
+          isA<CameraException>()
+              .having(
+                (error) => error.code,
+                'code',
+                'Uninitialized CameraController',
+              )
+              .having(
+                (error) => error.description,
+                'description',
+                'startVideoRecording() was called on an uninitialized CameraController.',
+              ),
+        ),
+      );
     });
     test('startVideoRecording() throws $CameraException when recording videos',
         () async {
@@ -347,12 +365,21 @@ void main() {
           ResolutionPreset.max);
 
       expect(
-          cameraController.getMaxZoomLevel,
-          throwsA(isA<CameraException>().having(
-            (error) => error.description,
-            'Uninitialized CameraController',
-            'getMaxZoomLevel was called on uninitialized CameraController',
-          )));
+        cameraController.getMaxZoomLevel,
+        throwsA(
+          isA<CameraException>()
+              .having(
+                (error) => error.code,
+                'code',
+                'Uninitialized CameraController',
+              )
+              .having(
+                (error) => error.description,
+                'description',
+                'getMaxZoomLevel() was called on an uninitialized CameraController.',
+              ),
+        ),
+      );
     });
 
     test('getMaxZoomLevel() throws $CameraException when disposed', () async {
@@ -367,12 +394,21 @@ void main() {
       await cameraController.dispose();
 
       expect(
-          cameraController.getMaxZoomLevel,
-          throwsA(isA<CameraException>().having(
-            (error) => error.description,
-            'Uninitialized CameraController',
-            'getMaxZoomLevel was called on uninitialized CameraController',
-          )));
+        cameraController.getMaxZoomLevel,
+        throwsA(
+          isA<CameraException>()
+              .having(
+                (error) => error.code,
+                'code',
+                'Disposed CameraController',
+              )
+              .having(
+                (error) => error.description,
+                'description',
+                'getMaxZoomLevel() was called on a disposed CameraController.',
+              ),
+        ),
+      );
     });
 
     test(
@@ -429,12 +465,21 @@ void main() {
           ResolutionPreset.max);
 
       expect(
-          cameraController.getMinZoomLevel,
-          throwsA(isA<CameraException>().having(
-            (error) => error.description,
-            'Uninitialized CameraController',
-            'getMinZoomLevel was called on uninitialized CameraController',
-          )));
+        cameraController.getMinZoomLevel,
+        throwsA(
+          isA<CameraException>()
+              .having(
+                (error) => error.code,
+                'code',
+                'Uninitialized CameraController',
+              )
+              .having(
+                (error) => error.description,
+                'description',
+                'getMinZoomLevel() was called on an uninitialized CameraController.',
+              ),
+        ),
+      );
     });
 
     test('getMinZoomLevel() throws $CameraException when disposed', () async {
@@ -449,12 +494,21 @@ void main() {
       await cameraController.dispose();
 
       expect(
-          cameraController.getMinZoomLevel,
-          throwsA(isA<CameraException>().having(
-            (error) => error.description,
-            'Uninitialized CameraController',
-            'getMinZoomLevel was called on uninitialized CameraController',
-          )));
+        cameraController.getMinZoomLevel,
+        throwsA(
+          isA<CameraException>()
+              .having(
+                (error) => error.code,
+                'code',
+                'Disposed CameraController',
+              )
+              .having(
+                (error) => error.description,
+                'description',
+                'getMinZoomLevel() was called on a disposed CameraController.',
+              ),
+        ),
+      );
     });
 
     test(
@@ -510,12 +564,21 @@ void main() {
           ResolutionPreset.max);
 
       expect(
-          () => cameraController.setZoomLevel(42.0),
-          throwsA(isA<CameraException>().having(
-            (error) => error.description,
-            'Uninitialized CameraController',
-            'setZoomLevel was called on uninitialized CameraController',
-          )));
+        () => cameraController.setZoomLevel(42.0),
+        throwsA(
+          isA<CameraException>()
+              .having(
+                (error) => error.code,
+                'code',
+                'Uninitialized CameraController',
+              )
+              .having(
+                (error) => error.description,
+                'description',
+                'setZoomLevel() was called on an uninitialized CameraController.',
+              ),
+        ),
+      );
     });
 
     test('setZoomLevel() throws $CameraException when disposed', () async {
@@ -530,12 +593,21 @@ void main() {
       await cameraController.dispose();
 
       expect(
-          () => cameraController.setZoomLevel(42.0),
-          throwsA(isA<CameraException>().having(
-            (error) => error.description,
-            'Uninitialized CameraController',
-            'setZoomLevel was called on uninitialized CameraController',
-          )));
+        () => cameraController.setZoomLevel(42.0),
+        throwsA(
+          isA<CameraException>()
+              .having(
+                (error) => error.code,
+                'code',
+                'Disposed CameraController',
+              )
+              .having(
+                (error) => error.description,
+                'description',
+                'setZoomLevel() was called on a disposed CameraController.',
+              ),
+        ),
+      );
     });
 
     test(


### PR DESCRIPTION
Currently, when starting a camera in the camera example app on iOS, the user's permission is asked the first time.
This causes the app to become inactive during camera initialization, causing the camera controller to be disposed.
As the camera controller is disposed during initialization, some properties cannot be fetched, resulting in an error being shown to the user.

This PR fixes this issue in the example app, and slightly improves the error feedback given by the camera controller.

## Related issues:
 
- flutter/flutter#73783

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
