### PR TITLE
[video_player] Migrate deprecated api

### DIFF
--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-nullsafety.8
+
+* Migrated from deprecated `defaultBinaryMessenger`.
+
 ## 2.0.0-nullsafety.7
 
 * Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for displaying inline video with other Flutter
 # 0.10.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 2.0.0-nullsafety.7
+version: 2.0.0-nullsafety.8
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player
 
 flutter:

--- a/packages/video_player/video_player/test/video_player_test.dart
+++ b/packages/video_player/video_player/test/video_player_test.dart
@@ -795,11 +795,7 @@ class FakeEventsChannel {
   }
 
   void _sendMessage(ByteData data) {
-    // TODO(jackson): This has been deprecated and should be replaced
-    // with `ServicesBinding.instance.defaultBinaryMessenger` when it's
-    // available on all the versions of Flutter that we test.
-    // ignore: deprecated_member_use
-    defaultBinaryMessenger.handlePlatformMessage(
+    ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
         eventsMethodChannel.name, data, (ByteData? data) {});
   }
 }

--- a/packages/video_player/video_player/test/video_player_test.dart
+++ b/packages/video_player/video_player/test/video_player_test.dart
@@ -795,7 +795,7 @@ class FakeEventsChannel {
   }
 
   void _sendMessage(ByteData data) {
-    ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
+    ServicesBinding.instance!.defaultBinaryMessenger.handlePlatformMessage(
         eventsMethodChannel.name, data, (ByteData? data) {});
   }
 }

--- a/packages/video_player/video_player_platform_interface/test/method_channel_video_player_test.dart
+++ b/packages/video_player/video_player_platform_interface/test/method_channel_video_player_test.dart
@@ -240,52 +240,57 @@ void main() {
           final MethodCall methodCall =
               const StandardMethodCodec().decodeMethodCall(message);
           if (methodCall.method == 'listen') {
-            await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
-                "flutter.io/videoPlayer/videoEvents123",
-                const StandardMethodCodec()
-                    .encodeSuccessEnvelope(<String, dynamic>{
-                  'event': 'initialized',
-                  'duration': 98765,
-                  'width': 1920,
-                  'height': 1080,
-                }),
-                (ByteData data) {});
+            await ServicesBinding.instance.defaultBinaryMessenger
+                .handlePlatformMessage(
+                    "flutter.io/videoPlayer/videoEvents123",
+                    const StandardMethodCodec()
+                        .encodeSuccessEnvelope(<String, dynamic>{
+                      'event': 'initialized',
+                      'duration': 98765,
+                      'width': 1920,
+                      'height': 1080,
+                    }),
+                    (ByteData data) {});
 
-            await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
-                "flutter.io/videoPlayer/videoEvents123",
-                const StandardMethodCodec()
-                    .encodeSuccessEnvelope(<String, dynamic>{
-                  'event': 'completed',
-                }),
-                (ByteData data) {});
+            await ServicesBinding.instance.defaultBinaryMessenger
+                .handlePlatformMessage(
+                    "flutter.io/videoPlayer/videoEvents123",
+                    const StandardMethodCodec()
+                        .encodeSuccessEnvelope(<String, dynamic>{
+                      'event': 'completed',
+                    }),
+                    (ByteData data) {});
 
-            await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
-                "flutter.io/videoPlayer/videoEvents123",
-                const StandardMethodCodec()
-                    .encodeSuccessEnvelope(<String, dynamic>{
-                  'event': 'bufferingUpdate',
-                  'values': <List<dynamic>>[
-                    <int>[0, 1234],
-                    <int>[1235, 4000],
-                  ],
-                }),
-                (ByteData data) {});
+            await ServicesBinding.instance.defaultBinaryMessenger
+                .handlePlatformMessage(
+                    "flutter.io/videoPlayer/videoEvents123",
+                    const StandardMethodCodec()
+                        .encodeSuccessEnvelope(<String, dynamic>{
+                      'event': 'bufferingUpdate',
+                      'values': <List<dynamic>>[
+                        <int>[0, 1234],
+                        <int>[1235, 4000],
+                      ],
+                    }),
+                    (ByteData data) {});
 
-            await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
-                "flutter.io/videoPlayer/videoEvents123",
-                const StandardMethodCodec()
-                    .encodeSuccessEnvelope(<String, dynamic>{
-                  'event': 'bufferingStart',
-                }),
-                (ByteData data) {});
+            await ServicesBinding.instance.defaultBinaryMessenger
+                .handlePlatformMessage(
+                    "flutter.io/videoPlayer/videoEvents123",
+                    const StandardMethodCodec()
+                        .encodeSuccessEnvelope(<String, dynamic>{
+                      'event': 'bufferingStart',
+                    }),
+                    (ByteData data) {});
 
-            await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
-                "flutter.io/videoPlayer/videoEvents123",
-                const StandardMethodCodec()
-                    .encodeSuccessEnvelope(<String, dynamic>{
-                  'event': 'bufferingEnd',
-                }),
-                (ByteData data) {});
+            await ServicesBinding.instance.defaultBinaryMessenger
+                .handlePlatformMessage(
+                    "flutter.io/videoPlayer/videoEvents123",
+                    const StandardMethodCodec()
+                        .encodeSuccessEnvelope(<String, dynamic>{
+                      'event': 'bufferingEnd',
+                    }),
+                    (ByteData data) {});
 
             return const StandardMethodCodec().encodeSuccessEnvelope(null);
           } else if (methodCall.method == 'cancel') {

--- a/packages/video_player/video_player_platform_interface/test/method_channel_video_player_test.dart
+++ b/packages/video_player/video_player_platform_interface/test/method_channel_video_player_test.dart
@@ -234,21 +234,13 @@ void main() {
     });
 
     test('videoEventsFor', () async {
-      // TODO(cbenhagen): This has been deprecated and should be replaced
-      // with `ServicesBinding.instance.defaultBinaryMessenger` when it's
-      // available on all the versions of Flutter that we test.
-      // ignore: deprecated_member_use
-      defaultBinaryMessenger.setMockMessageHandler(
+      ServicesBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
         "flutter.io/videoPlayer/videoEvents123",
         (ByteData message) async {
           final MethodCall methodCall =
               const StandardMethodCodec().decodeMethodCall(message);
           if (methodCall.method == 'listen') {
-            // TODO(cbenhagen): This has been deprecated and should be replaced
-            // with `ServicesBinding.instance.defaultBinaryMessenger` when it's
-            // available on all the versions of Flutter that we test.
-            // ignore: deprecated_member_use
-            await defaultBinaryMessenger.handlePlatformMessage(
+            await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
                 "flutter.io/videoPlayer/videoEvents123",
                 const StandardMethodCodec()
                     .encodeSuccessEnvelope(<String, dynamic>{
@@ -259,11 +251,7 @@ void main() {
                 }),
                 (ByteData data) {});
 
-            // TODO(cbenhagen): This has been deprecated and should be replaced
-            // with `ServicesBinding.instance.defaultBinaryMessenger` when it's
-            // available on all the versions of Flutter that we test.
-            // ignore: deprecated_member_use
-            await defaultBinaryMessenger.handlePlatformMessage(
+            await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
                 "flutter.io/videoPlayer/videoEvents123",
                 const StandardMethodCodec()
                     .encodeSuccessEnvelope(<String, dynamic>{
@@ -271,11 +259,7 @@ void main() {
                 }),
                 (ByteData data) {});
 
-            // TODO(cbenhagen): This has been deprecated and should be replaced
-            // with `ServicesBinding.instance.defaultBinaryMessenger` when it's
-            // available on all the versions of Flutter that we test.
-            // ignore: deprecated_member_use
-            await defaultBinaryMessenger.handlePlatformMessage(
+            await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
                 "flutter.io/videoPlayer/videoEvents123",
                 const StandardMethodCodec()
                     .encodeSuccessEnvelope(<String, dynamic>{
@@ -287,11 +271,7 @@ void main() {
                 }),
                 (ByteData data) {});
 
-            // TODO(cbenhagen): This has been deprecated and should be replaced
-            // with `ServicesBinding.instance.defaultBinaryMessenger` when it's
-            // available on all the versions of Flutter that we test.
-            // ignore: deprecated_member_use
-            await defaultBinaryMessenger.handlePlatformMessage(
+            await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
                 "flutter.io/videoPlayer/videoEvents123",
                 const StandardMethodCodec()
                     .encodeSuccessEnvelope(<String, dynamic>{
@@ -299,11 +279,7 @@ void main() {
                 }),
                 (ByteData data) {});
 
-            // TODO(cbenhagen): This has been deprecated and should be replaced
-            // with `ServicesBinding.instance.defaultBinaryMessenger` when it's
-            // available on all the versions of Flutter that we test.
-            // ignore: deprecated_member_use
-            await defaultBinaryMessenger.handlePlatformMessage(
+            await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
                 "flutter.io/videoPlayer/videoEvents123",
                 const StandardMethodCodec()
                     .encodeSuccessEnvelope(<String, dynamic>{


### PR DESCRIPTION
This migrates calls to `defaultBinaryMessenger` to use `ServicesBinding.instance.defaultBinaryMessenger`
The deprecated `defaultBinaryMessenger` is scheduled to be removed in https://github.com/flutter/flutter/pull/73750

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
