### PR TITLE
[path_provider] Migrate path_provider_windows to nullsafety

### DIFF
--- a/packages/path_provider/path_provider_windows/CHANGELOG.md
+++ b/packages/path_provider/path_provider_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0-nullsafety
+
+* Migrate to null safety
+
 ## 0.0.4+4
 
 * Update Flutter SDK constraint.

--- a/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_real.dart
+++ b/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_real.dart
@@ -116,7 +116,7 @@ class PathProviderWindows extends PathProviderPlatform {
   /// [WindowsKnownFolder].
   Future<String> getPath(String folderID) {
     final pathPtrPtr = allocate<Pointer<Utf16>>();
-    final Pointer<GUID> knownFolderID = calloc<GUID>()..setGUID(folderID);;
+    final Pointer<GUID> knownFolderID = calloc<GUID>()..setGUID(folderID);
 
     try {
       final hr = SHGetKnownFolderPath(

--- a/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_real.dart
+++ b/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_real.dart
@@ -22,7 +22,7 @@ import 'folders.dart';
 class VersionInfoQuerier {
   /// Returns the value for [key] in [versionInfo]s English strings section, or
   /// null if there is no such entry, or if versionInfo is null.
-  getStringValue(Pointer<Uint8> versionInfo, key) {
+  getStringValue(Pointer<Uint8>? versionInfo, key) {
     if (versionInfo == null) {
       return null;
     }
@@ -54,7 +54,7 @@ class PathProviderWindows extends PathProviderPlatform {
 
   /// This is typically the same as the TMP environment variable.
   @override
-  Future<String> getTemporaryPath() async {
+  Future<String?> getTemporaryPath() async {
     final buffer = allocate<Uint16>(count: MAX_PATH + 1).cast<Utf16>();
     String path;
 
@@ -88,7 +88,7 @@ class PathProviderWindows extends PathProviderPlatform {
   }
 
   @override
-  Future<String> getApplicationSupportPath() async {
+  Future<String?> getApplicationSupportPath() async {
     final appDataRoot = await getPath(WindowsKnownFolder.RoamingAppData);
     final directory = Directory(
         path.join(appDataRoot, _getApplicationSpecificSubdirectory()));
@@ -105,11 +105,11 @@ class PathProviderWindows extends PathProviderPlatform {
   }
 
   @override
-  Future<String> getApplicationDocumentsPath() =>
+  Future<String?> getApplicationDocumentsPath() =>
       getPath(WindowsKnownFolder.Documents);
 
   @override
-  Future<String> getDownloadsPath() => getPath(WindowsKnownFolder.Downloads);
+  Future<String?> getDownloadsPath() => getPath(WindowsKnownFolder.Downloads);
 
   /// Retrieve any known folder from Windows.
   ///
@@ -117,7 +117,7 @@ class PathProviderWindows extends PathProviderPlatform {
   /// [WindowsKnownFolder].
   Future<String> getPath(String folderID) {
     final pathPtrPtr = allocate<IntPtr>();
-    Pointer<Utf16> pathPtr;
+    late Pointer<Utf16> pathPtr;
 
     try {
       GUID knownFolderID = GUID.fromString(folderID);
@@ -155,13 +155,13 @@ class PathProviderWindows extends PathProviderPlatform {
   /// - If the product name isn't there, it will use the exe's filename (without
   ///   extension).
   String _getApplicationSpecificSubdirectory() {
-    String companyName;
-    String productName;
+    String? companyName;
+    String? productName;
 
     final Pointer<Utf16> moduleNameBuffer =
         allocate<Uint16>(count: MAX_PATH + 1).cast<Utf16>();
     final Pointer<Uint32> unused = allocate<Uint32>();
-    Pointer<Uint8> infoBuffer;
+    Pointer<Uint8>? infoBuffer;
     try {
       // Get the module name.
       final moduleNameLength = GetModuleFileName(0, moduleNameBuffer, MAX_PATH);
@@ -207,7 +207,7 @@ class PathProviderWindows extends PathProviderPlatform {
   /// https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions
   ///
   /// If after sanitizing the string is empty, returns null.
-  String _sanitizedDirectoryName(String rawString) {
+  String? _sanitizedDirectoryName(String? rawString) {
     if (rawString == null) {
       return null;
     }

--- a/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_stub.dart
+++ b/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_stub.dart
@@ -19,7 +19,7 @@ class PathProviderWindows extends PathProviderPlatform {
   }
 
   /// Stub; see comment on VersionInfoQuerier.
-  VersionInfoQuerier versionInfoQuerier;
+  VersionInfoQuerier versionInfoQuerier = VersionInfoQuerier();
 
   /// Match PathProviderWindows so that the analyzer won't report invalid
   /// overrides if tests provide fake PathProviderWindows implementations.

--- a/packages/path_provider/path_provider_windows/pubspec.yaml
+++ b/packages/path_provider/path_provider_windows/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   flutter:
     sdk: flutter
   ffi: ^0.2.0-nullsafety.1
-  win32: ^2.0.0-nullsafety.7
+  win32: 2.0.0-nullsafety.7
 
 dev_dependencies:
   flutter_test:

--- a/packages/path_provider/path_provider_windows/pubspec.yaml
+++ b/packages/path_provider/path_provider_windows/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   flutter:
     sdk: flutter
   ffi: ^0.2.0-nullsafety.1
-  win32: 2.0.0-nullsafety.7
+  win32: ^2.0.0-nullsafety.8
 
 dev_dependencies:
   flutter_test:

--- a/packages/path_provider/path_provider_windows/pubspec.yaml
+++ b/packages/path_provider/path_provider_windows/pubspec.yaml
@@ -11,19 +11,19 @@ flutter:
         pluginClass: none
 
 dependencies:
-  path_provider_platform_interface: ^1.0.3
-  meta: ^1.0.5
-  path: ^1.6.4
+  path_provider_platform_interface: ^2.0.0-nullsafety
+  meta: ^1.3.0-nullsafety.6
+  path: ^1.8.0-nullsafety.3
   flutter:
     sdk: flutter
-  ffi: ^0.1.3
-  win32: ^1.7.1
+  ffi: ^0.2.0-nullsafety.1
+  win32: ^2.0.0-nullsafety.7
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.8.0
+  pedantic: ^1.10.0-nullsafety.3
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: '>=2.12.0-0 <3.0.0'
   flutter: ">=1.12.13+hotfix.4"

--- a/packages/path_provider/path_provider_windows/pubspec.yaml
+++ b/packages/path_provider/path_provider_windows/pubspec.yaml
@@ -1,7 +1,7 @@
 name: path_provider_windows
 description: Windows implementation of the path_provider plugin
 homepage: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider_windows
-version: 0.0.4+4
+version: 0.1.0-nullsafety
 
 flutter:
   plugin:

--- a/packages/path_provider/path_provider_windows/test/path_provider_windows_test.dart
+++ b/packages/path_provider/path_provider_windows/test/path_provider_windows_test.dart
@@ -13,7 +13,7 @@ class FakeVersionInfoQuerier implements VersionInfoQuerier {
 
   final Map<String, String> responses;
 
-  getStringValue(Pointer<Uint8> versionInfo, key) => responses[key];
+  getStringValue(Pointer<Uint8>? versionInfo, key) => responses[key];
 }
 
 void main() {

--- a/packages/path_provider/path_provider_windows/test/path_provider_windows_test.dart
+++ b/packages/path_provider/path_provider_windows/test/path_provider_windows_test.dart
@@ -40,8 +40,11 @@ void main() {
       'ProductName': 'Amazing App',
     });
     final path = await pathProvider.getApplicationSupportPath();
-    expect(path, endsWith(r'AppData\Roaming\A Company\Amazing App'));
-    expect(Directory(path).existsSync(), isTrue);
+    expect(path, isNotNull);
+    if (path != null) {
+      expect(path, endsWith(r'AppData\Roaming\A Company\Amazing App'));
+      expect(Directory(path).existsSync(), isTrue);
+    }
   }, skip: !Platform.isWindows);
 
   test('getApplicationSupportPath with missing company', () async {
@@ -50,8 +53,11 @@ void main() {
       'ProductName': 'Amazing App',
     });
     final path = await pathProvider.getApplicationSupportPath();
-    expect(path, endsWith(r'AppData\Roaming\Amazing App'));
-    expect(Directory(path).existsSync(), isTrue);
+    expect(path, isNotNull);
+    if (path != null) {
+      expect(path, endsWith(r'AppData\Roaming\Amazing App'));
+      expect(Directory(path).existsSync(), isTrue);
+    }
   }, skip: !Platform.isWindows);
 
   test('getApplicationSupportPath with problematic values', () async {
@@ -61,12 +67,15 @@ void main() {
       'ProductName': r'A"/Terrible\|App?*Name',
     });
     final path = await pathProvider.getApplicationSupportPath();
-    expect(
-        path,
-        endsWith(r'AppData\Roaming\'
-            r'A _Bad_ Company_ Name\'
-            r'A__Terrible__App__Name'));
-    expect(Directory(path).existsSync(), isTrue);
+    expect(path, isNotNull);
+    if (path != null) {
+      expect(
+          path,
+          endsWith(r'AppData\Roaming\'
+              r'A _Bad_ Company_ Name\'
+              r'A__Terrible__App__Name'));
+      expect(Directory(path).existsSync(), isTrue);
+    }
   }, skip: !Platform.isWindows);
 
   test('getApplicationSupportPath with a completely invalid company', () async {
@@ -76,8 +85,11 @@ void main() {
       'ProductName': r'Amazing App',
     });
     final path = await pathProvider.getApplicationSupportPath();
-    expect(path, endsWith(r'AppData\Roaming\Amazing App'));
-    expect(Directory(path).existsSync(), isTrue);
+    expect(path, isNotNull);
+    if (path != null) {
+      expect(path, endsWith(r'AppData\Roaming\Amazing App'));
+      expect(Directory(path).existsSync(), isTrue);
+    }
   }, skip: !Platform.isWindows);
 
   test('getApplicationSupportPath with very long app name', () async {


### PR DESCRIPTION
Migrates path_provider_windows to null-safety.

Part of https://github.com/flutter/flutter/issues/70229

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

