### PR TITLE
[camera] Fix picture capture causing a crash on some Huawei devices.

### DIFF
--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.6+1
+
+* Fixes picture captures causing a crash on some Huawei devices.
+
 ## 0.6.6
 
 * Adds auto focus support for Android and iOS implementations.

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
@@ -464,17 +464,20 @@ public class Camera {
             return;
           }
           String reason;
+          boolean fatalFailure = false;
           switch (failure.getReason()) {
             case CaptureFailure.REASON_ERROR:
               reason = "An error happened in the framework";
               break;
             case CaptureFailure.REASON_FLUSHED:
               reason = "The capture has failed due to an abortCaptures() call";
+              fatalFailure = true;
               break;
             default:
               reason = "Unknown reason";
           }
-          pictureCaptureRequest.error("captureFailure", reason, null);
+          Log.w("Camera", "pictureCaptureCallback.onCaptureFailed(): " + reason);
+          if (fatalFailure) pictureCaptureRequest.error("captureFailure", reason, null);
         }
 
         private void processCapture(CaptureResult result) {

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/PictureCaptureRequest.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/PictureCaptureRequest.java
@@ -6,7 +6,6 @@ package io.flutter.plugins.camera;
 
 import android.os.Handler;
 import android.os.Looper;
-
 import androidx.annotation.Nullable;
 import io.flutter.plugin.common.MethodChannel;
 
@@ -22,24 +21,35 @@ class PictureCaptureRequest {
     error,
   }
 
-  private static final int REQUEST_TIMEOUT = 5000;
-  private final Handler handler;
+  private final Runnable timeoutCallback =
+      new Runnable() {
+        @Override
+        public void run() {
+          error("captureTimeout", "Picture capture request timed out", state.toString());
+        }
+      };
+
   private final MethodChannel.Result result;
+  private final TimeoutHandler timeoutHandler;
   private State state;
 
   public PictureCaptureRequest(MethodChannel.Result result) {
+    this(result, new TimeoutHandler());
+  }
+
+  public PictureCaptureRequest(MethodChannel.Result result, TimeoutHandler timeoutHandler) {
     this.result = result;
-    state = State.idle;
-    this.handler = new Handler(Looper.getMainLooper());
+    this.state = State.idle;
+    this.timeoutHandler = timeoutHandler;
   }
 
   public void setState(State state) {
     if (isFinished()) throw new IllegalStateException("Request has already been finished");
     this.state = state;
     if (state != State.idle && state != State.finished && state != State.error) {
-      this.resetTimeout();
+      this.timeoutHandler.resetTimeout(timeoutCallback);
     } else {
-      clearTimeout();
+      this.timeoutHandler.clearTimeout(timeoutCallback);
     }
   }
 
@@ -53,7 +63,7 @@ class PictureCaptureRequest {
 
   public void finish(String absolutePath) {
     if (isFinished()) throw new IllegalStateException("Request has already been finished");
-    clearTimeout();
+    this.timeoutHandler.clearTimeout(timeoutCallback);
     result.success(absolutePath);
     state = State.finished;
   }
@@ -61,25 +71,26 @@ class PictureCaptureRequest {
   public void error(
       String errorCode, @Nullable String errorMessage, @Nullable Object errorDetails) {
     if (isFinished()) throw new IllegalStateException("Request has already been finished");
-    clearTimeout();
+    this.timeoutHandler.clearTimeout(timeoutCallback);
     result.error(errorCode, errorMessage, errorDetails);
     state = State.error;
   }
 
-  private final Runnable timeoutCallback =
-      new Runnable() {
-        @Override
-        public void run() {
-          error("captureTimeout", "Picture capture request timed out", state.toString());
-        }
-      };
+  static class TimeoutHandler {
+    private static final int REQUEST_TIMEOUT = 5000;
+    private final Handler handler;
 
-  private void resetTimeout() {
-    clearTimeout();
-    handler.postDelayed(timeoutCallback, REQUEST_TIMEOUT);
-  }
+    TimeoutHandler() {
+      this.handler = new Handler(Looper.getMainLooper());
+    }
 
-  private void clearTimeout() {
-    handler.removeCallbacks(timeoutCallback);
+    public void resetTimeout(Runnable runnable) {
+      clearTimeout(runnable);
+      handler.postDelayed(runnable, REQUEST_TIMEOUT);
+    }
+
+    public void clearTimeout(Runnable runnable) {
+      handler.removeCallbacks(runnable);
+    }
   }
 }

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/PictureCaptureRequest.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/PictureCaptureRequest.java
@@ -5,6 +5,8 @@
 package io.flutter.plugins.camera;
 
 import android.os.Handler;
+import android.os.Looper;
+
 import androidx.annotation.Nullable;
 import io.flutter.plugin.common.MethodChannel;
 
@@ -28,7 +30,7 @@ class PictureCaptureRequest {
   public PictureCaptureRequest(MethodChannel.Result result) {
     this.result = result;
     state = State.idle;
-    this.handler = new Handler();
+    this.handler = new Handler(Looper.getMainLooper());
   }
 
   public void setState(State state) {

--- a/packages/camera/camera/android/src/test/java/io/flutter/plugins/camera/PictureCaptureRequestTest.java
+++ b/packages/camera/camera/android/src/test/java/io/flutter/plugins/camera/PictureCaptureRequestTest.java
@@ -7,7 +7,10 @@ package io.flutter.plugins.camera;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.flutter.plugin.common.MethodChannel;
@@ -39,6 +42,32 @@ public class PictureCaptureRequestTest {
   }
 
   @Test
+  public void setState_resets_timeout() {
+    PictureCaptureRequest.TimeoutHandler mockTimeoutHandler =
+        mock(PictureCaptureRequest.TimeoutHandler.class);
+    PictureCaptureRequest req = new PictureCaptureRequest(null, mockTimeoutHandler);
+    req.setState(PictureCaptureRequest.State.focusing);
+    req.setState(PictureCaptureRequest.State.preCapture);
+    req.setState(PictureCaptureRequest.State.waitingPreCaptureReady);
+    req.setState(PictureCaptureRequest.State.capturing);
+    verify(mockTimeoutHandler, times(4)).resetTimeout(any());
+    verify(mockTimeoutHandler, never()).clearTimeout(any());
+  }
+
+  @Test
+  public void setState_clears_timeout() {
+    PictureCaptureRequest.TimeoutHandler mockTimeoutHandler =
+        mock(PictureCaptureRequest.TimeoutHandler.class);
+    PictureCaptureRequest req = new PictureCaptureRequest(null, mockTimeoutHandler);
+    req.setState(PictureCaptureRequest.State.idle);
+    req.setState(PictureCaptureRequest.State.finished);
+    req = new PictureCaptureRequest(null, mockTimeoutHandler);
+    req.setState(PictureCaptureRequest.State.error);
+    verify(mockTimeoutHandler, never()).resetTimeout(any());
+    verify(mockTimeoutHandler, times(3)).clearTimeout(any());
+  }
+
+  @Test
   public void finish_sets_result_and_state() {
     // Setup
     MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
@@ -48,6 +77,17 @@ public class PictureCaptureRequestTest {
     // Test
     verify(mockResult).success("/test/path");
     assertEquals("State is finished", req.getState(), PictureCaptureRequest.State.finished);
+  }
+
+  @Test
+  public void finish_clears_timeout() {
+    PictureCaptureRequest.TimeoutHandler mockTimeoutHandler =
+        mock(PictureCaptureRequest.TimeoutHandler.class);
+    MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
+    PictureCaptureRequest req = new PictureCaptureRequest(mockResult, mockTimeoutHandler);
+    req.finish("/test/path");
+    verify(mockTimeoutHandler, never()).resetTimeout(any());
+    verify(mockTimeoutHandler).clearTimeout(any());
   }
 
   @Test
@@ -88,6 +128,17 @@ public class PictureCaptureRequestTest {
     // Test
     verify(mockResult).error("ERROR_CODE", "Error Message", null);
     assertEquals("State is error", req.getState(), PictureCaptureRequest.State.error);
+  }
+
+  @Test
+  public void error_clears_timeout() {
+    PictureCaptureRequest.TimeoutHandler mockTimeoutHandler =
+        mock(PictureCaptureRequest.TimeoutHandler.class);
+    MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
+    PictureCaptureRequest req = new PictureCaptureRequest(mockResult, mockTimeoutHandler);
+    req.error("ERROR_CODE", "Error Message", null);
+    verify(mockTimeoutHandler, never()).resetTimeout(any());
+    verify(mockTimeoutHandler).clearTimeout(any());
   }
 
   @Test(expected = IllegalStateException.class)

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera
 description: A Flutter plugin for getting information about and controlling the
   camera on Android and iOS. Supports previewing the camera feed, capturing images, capturing video,
   and streaming image buffers to dart.
-version: 0.6.6
+version: 0.6.6+1
 homepage: https://github.com/flutter/plugins/tree/master/packages/camera/camera
 
 dependencies:


### PR DESCRIPTION
Taking a picture with the camera plugin causes the app to crash on some Huawei devices.
This is due to Huawei devices triggering the `onCaptureFailed` callback for seemingly irrelevant frames and the plugin handling this as a failure for capture request, even though `onCaptureCompleted` is called afterwards without a problem.
This PR fixes this by ignoring this particular error ([`CaptureFailure.REASON_ERROR`](https://developer.android.com/reference/android/hardware/camera2/CaptureFailure#REASON_ERROR)) and adding a timeout to the picture request, in the unlikely case `onCaptureCompleted` is never called.

Resolves:
- flutter/flutter#73336

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
