### PR TITLE
[google_maps_flutter] Avoid calling onMapCreated when already disposed

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.11
+
+* Fix onMapCreated being called when the platform view is created after `GoogleMap` has already been disposed.
+
 ## 1.0.10
 
 * Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.

--- a/packages/google_maps_flutter/google_maps_flutter/lib/src/google_map.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/lib/src/google_map.dart
@@ -320,7 +320,7 @@ class _GoogleMapState extends State<GoogleMap> {
       this,
     );
     _controller.complete(controller);
-    if (widget.onMapCreated != null) {
+    if (mounted && widget.onMapCreated != null) {
       widget.onMapCreated(controller);
     }
   }

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter/google_maps_flutter
-version: 1.0.10
+version: 1.0.11
 
 dependencies:
   flutter:


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/73876

The following assertion fails if `onMapCreated` is called when a `GoogleMap` widget has already been disposed.

(from `framework.dart`)
```Dart
bool _debugCheckStateIsActiveForAncestorLookup() {
  assert(() {
    if (_debugLifecycleState != _ElementLifecycle.active) {
      throw FlutterError.fromParts(<DiagnosticsNode>[
        ErrorSummary("Looking up a deactivated widget's ancestor is unsafe."),
        ErrorDescription(
          "At this point the state of the widget's element tree is no longer "
          'stable.'
        ),
        ErrorHint(
          "To safely refer to a widget's ancestor in its dispose() method, "
          'save a reference to the ancestor by calling dependOnInheritedWidgetOfExactType() '
          "in the widget's didChangeDependencies() method."
        ),
      ]);
    }
    return true;
  }());
  return true;
}
```

I tried to create a test, but I can't find how to test when a widget has been disposed. The best I could come up with was:

```Dart
testWidgets('onMapCreated not called if disposed',
    (WidgetTester tester) async {
  var completer1 = Completer<GoogleMapController>();
  var completer2 = Completer<GoogleMapController>();

  final map1 = GoogleMap(
    initialCameraPosition: CameraPosition(target: LatLng(10.0, 15.0)),
    onMapCreated: (controller) => completer1.complete(controller),
  );

  var container = Directionality(
    textDirection: TextDirection.ltr,
    child: map1,
  );

  await tester.pumpWidget(
    container,
    null,
    EnginePhase.build,
  );

  container = Directionality(
    textDirection: TextDirection.ltr,
    child: GoogleMap(
      initialCameraPosition: CameraPosition(target: LatLng(10.0, 15.0)),
      onMapCreated: (controller) => completer2.complete(controller),
    ),
  );

  await tester.pumpWidget(container);
  await tester.pumpWidget(map1);

  expect(completer1.isCompleted, false);
  expect(completer2.isCompleted, true);
});
```

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
