### PR TITLE
[file_selector_web] Add dummy ios directory.

### DIFF
--- a/packages/file_selector/file_selector_web/CHANGELOG.md
+++ b/packages/file_selector/file_selector_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.7.0+1
+
+- Add dummy `ios` dir, so flutter sdk can be lower than 1.20
+
 # 0.7.0
 
 - Initial open-source release.

--- a/packages/file_selector/file_selector_web/ios/file_selector_web.podspec
+++ b/packages/file_selector/file_selector_web/ios/file_selector_web.podspec
@@ -1,0 +1,21 @@
+#
+# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
+#
+Pod::Spec.new do |s|
+    s.name             = 'file_selector_web'
+    s.version          = '0.0.1'
+    s.summary          = 'No-op implementation of file_selector_web web plugin to avoid build issues on iOS'
+    s.description      = <<-DESC
+  temp fake file_selector_web plugin
+                         DESC
+    s.homepage         = 'https://github.com/flutter/plugins/tree/master/packages/file_selector/file_selector_web'
+    s.license          = { :file => '../LICENSE' }
+    s.author           = { 'Flutter Team' => 'flutter-dev@googlegroups.com' }
+    s.source           = { :path => '.' }
+    s.source_files = 'Classes/**/*'
+    s.public_header_files = 'Classes/**/*.h'
+    s.dependency 'Flutter'
+  
+    s.ios.deployment_target = '8.0'
+  end
+  

--- a/packages/file_selector/file_selector_web/pubspec.yaml
+++ b/packages/file_selector/file_selector_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: file_selector_web
 description: Web platform implementation of file_selector
 homepage: https://github.com/flutter/plugins/tree/master/packages/file_selector/file_selector_web
-version: 0.7.0
+version: 0.7.0+1
 
 flutter:
   plugin:


### PR DESCRIPTION
When attempting to publish the `file_selector_web` plugin, the tool complained that it didn't have an `ios` directory (or a much more recent version of the flutter sdk as a minimum bound):

```
pubspec.yaml allows Flutter SDK version prior to 1.20.0, which does not support having no `ios/` folder.
Please consider increasing the Flutter SDK requirement to ^1.20.0 or higher (environment.sdk.flutter) or create an `ios/` folder.

See https://flutter.dev/docs/development/packages-and-plugins/developing-packages#plugin

pub finished with exit code 1

Publish failed. Exiting.
```

This PR adds the `ios` directory, so the plugin is publishable.

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
