### PR TITLE
[camera] Fixes crash with using inner camera on some Android devices.

### DIFF
--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.0+3
+
+* Fixes crash with using inner camera on some Android devices.
+
 ## 0.7.0+2
 
 * Improved error feedback by differentiating between uninitialized and disposed camera controllers.

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
@@ -216,7 +216,6 @@ public class Camera {
           public void onOpened(@NonNull CameraDevice device) {
             cameraDevice = device;
             try {
-              cameraRegions = new CameraRegions(getRegionBoundaries());
               startPreview();
               dartMessenger.sendCameraInitializedEvent(
                   previewSize.getWidth(),
@@ -299,6 +298,8 @@ public class Camera {
         captureRequestBuilder.addTarget(surface);
       }
     }
+
+    cameraRegions = new CameraRegions(getRegionBoundaries());
 
     // Prepare the callback
     CameraCaptureSession.StateCallback callback =

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera
 description: A Flutter plugin for getting information about and controlling the
   camera on Android and iOS. Supports previewing the camera feed, capturing images, capturing video,
   and streaming image buffers to dart.
-version: 0.7.0+2
+version: 0.7.0+3
 homepage: https://github.com/flutter/plugins/tree/master/packages/camera/camera
 
 dependencies:


### PR DESCRIPTION
Fixes NullPointerException when using inner camera on Android Pixel 3 XL.

* https://github.com/flutter/flutter/issues/73922

Crashes in 0.6.4+3 and later versions. 

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
  - This is crash on actual devices, I did not add tests.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

## Details

NullPointerException on the following line in `Camera.getRegionBoundaries`:

```java
// Get the current distortion correction mode
Integer distortionCorrectionMode =
    captureRequestBuilder.get(CaptureRequest.DISTORTION_CORRECTION_MODE);
```

Does not crash with the outer camera. Probably to return under the previous conditions `supportsDistortionCorrection`.

```java
// No distortion correction support
if (android.os.Build.VERSION.SDK_INT < VERSION_CODES.P || !supportsDistortionCorrection()) {
  return cameraManager
      .getCameraCharacteristics(cameraDevice.getId())
      .get(CameraCharacteristics.SENSOR_INFO_PIXEL_ARRAY_SIZE);
}
```

captureRequestBuilder is created in the middle of `startPreview`'s processing.
For this reason, the position where the cameraRegions are created has been moved.

I think this is related to https://github.com/flutter/plugins/pull/3346
