### PR TITLE
[webview_flutter] Add ability to ignore SSL certificate errors on Android

### DIFF
--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-nullsafety.4
+
+* Added `ignoreSslCertificateErrors` on Android.
+
 ## 2.0.0-nullsafety.3
 
 * Fix `onWebResourceError` on iOS.

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -375,6 +375,10 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
         case "allowsInlineMediaPlayback":
           // no-op inline media playback is always allowed on Android.
           break;
+        case "ignoreSslCertificateErrors":
+          final boolean ignoreSslCertificateErrors = (boolean) settings.get(key);
+          flutterWebViewClient.setIgnoreSslCertificateErrors(ignoreSslCertificateErrors);
+          break;
         default:
           throw new IllegalArgumentException("Unknown WebView setting: " + key);
       }

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewClient.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewClient.java
@@ -7,9 +7,11 @@ package io.flutter.plugins.webviewflutter;
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.graphics.Bitmap;
+import android.net.http.SslError;
 import android.os.Build;
 import android.util.Log;
 import android.view.KeyEvent;
+import android.webkit.SslErrorHandler;
 import android.webkit.WebResourceError;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebView;
@@ -30,9 +32,14 @@ class FlutterWebViewClient {
   private static final String TAG = "FlutterWebViewClient";
   private final MethodChannel methodChannel;
   private boolean hasNavigationDelegate;
+  private boolean ignoreSslCertificateErrors;
 
   FlutterWebViewClient(MethodChannel methodChannel) {
     this.methodChannel = methodChannel;
+  }
+
+  public void setIgnoreSslCertificateErrors(boolean ignoreSslCertificateErrors) {
+    this.ignoreSslCertificateErrors = ignoreSslCertificateErrors;
   }
 
   private static String errorCodeToString(int errorCode) {
@@ -198,6 +205,13 @@ class FlutterWebViewClient {
         // Deliberately empty. Occasionally the webview will mark events as having failed to be
         // handled even though they were handled. We don't want to propagate those as they're not
         // truly lost.
+      }
+
+      @Override
+      public void onReceivedSslError(WebView view, SslErrorHandler handler, SslError er) {
+        if (FlutterWebViewClient.this.ignoreSslCertificateErrors) {
+          handler.proceed();
+        }
       }
     };
   }

--- a/packages/webview_flutter/lib/platform_interface.dart
+++ b/packages/webview_flutter/lib/platform_interface.dart
@@ -391,6 +391,7 @@ class WebSettings {
     this.debuggingEnabled,
     this.gestureNavigationEnabled,
     this.allowsInlineMediaPlayback,
+    this.ignoreSslCertificateErrors,
     required this.userAgent,
   }) : assert(userAgent != null);
 
@@ -425,9 +426,12 @@ class WebSettings {
   /// See also: [WebView.gestureNavigationEnabled]
   final bool? gestureNavigationEnabled;
 
+  /// Whether to ignore SSL certificate errors.
+  final bool? ignoreSslCertificateErrors;
+
   @override
   String toString() {
-    return 'WebSettings(javascriptMode: $javascriptMode, hasNavigationDelegate: $hasNavigationDelegate, debuggingEnabled: $debuggingEnabled, gestureNavigationEnabled: $gestureNavigationEnabled, userAgent: $userAgent, allowsInlineMediaPlayback: $allowsInlineMediaPlayback)';
+    return 'WebSettings(javascriptMode: $javascriptMode, hasNavigationDelegate: $hasNavigationDelegate, debuggingEnabled: $debuggingEnabled, gestureNavigationEnabled: $gestureNavigationEnabled, userAgent: $userAgent, allowsInlineMediaPlayback: $allowsInlineMediaPlayback, ignoreSslCertificateErrors: $ignoreSslCertificateErrors)';
   }
 }
 

--- a/packages/webview_flutter/lib/src/webview_method_channel.dart
+++ b/packages/webview_flutter/lib/src/webview_method_channel.dart
@@ -188,6 +188,8 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
         'gestureNavigationEnabled', settings.gestureNavigationEnabled);
     _addIfNonNull(
         'allowsInlineMediaPlayback', settings.allowsInlineMediaPlayback);
+    _addIfNonNull(
+        'ignoreSslCertificateErrors', settings.ignoreSslCertificateErrors);
     _addSettingIfPresent('userAgent', settings.userAgent);
     return map;
   }

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -224,9 +224,11 @@ class WebView extends StatefulWidget {
     this.initialMediaPlaybackPolicy =
         AutoMediaPlaybackPolicy.require_user_action_for_all_media_types,
     this.allowsInlineMediaPlayback = false,
+    this.ignoreSslCertificateErrors = false,
   })  : assert(javascriptMode != null),
         assert(initialMediaPlaybackPolicy != null),
         assert(allowsInlineMediaPlayback != null),
+        assert(ignoreSslCertificateErrors != null),
         super(key: key);
 
   static WebViewPlatform? _platform;
@@ -341,6 +343,15 @@ class WebView extends StatefulWidget {
   ///
   /// By default `allowsInlineMediaPlayback` is false.
   final bool allowsInlineMediaPlayback;
+
+  /// Determines whether errors with SSL certificates should be ignored.
+  ///
+  /// If `true`, problems with SSL certificates will be ignored. This is generally useful only in development scenarios
+  /// where self-signed certificates are commonly used. It is strongly recommended to leave this as `false` in
+  /// production scenarios.
+  ///
+  /// This only works on Android.
+  final bool ignoreSslCertificateErrors;
 
   /// Invoked when a page starts loading.
   final PageStartedCallback? onPageStarted;
@@ -480,6 +491,7 @@ WebSettings _webSettingsFromWidget(WebView widget) {
     gestureNavigationEnabled: widget.gestureNavigationEnabled,
     allowsInlineMediaPlayback: widget.allowsInlineMediaPlayback,
     userAgent: WebSetting<String?>.of(widget.userAgent),
+    ignoreSslCertificateErrors: widget.ignoreSslCertificateErrors,
   );
 }
 
@@ -494,10 +506,12 @@ WebSettings _clearUnchangedWebSettings(
   assert(newValue.hasNavigationDelegate != null);
   assert(newValue.debuggingEnabled != null);
   assert(newValue.userAgent != null);
+  assert(newValue.ignoreSslCertificateErrors != null);
 
   JavascriptMode? javascriptMode;
   bool? hasNavigationDelegate;
   bool? debuggingEnabled;
+  bool? ignoreSslCertificateErrors;
   WebSetting<String?> userAgent = WebSetting.absent();
   if (currentValue.javascriptMode != newValue.javascriptMode) {
     javascriptMode = newValue.javascriptMode;
@@ -511,12 +525,17 @@ WebSettings _clearUnchangedWebSettings(
   if (currentValue.userAgent != newValue.userAgent) {
     userAgent = newValue.userAgent;
   }
+  if (currentValue.ignoreSslCertificateErrors !=
+      newValue.ignoreSslCertificateErrors) {
+    ignoreSslCertificateErrors = newValue.ignoreSslCertificateErrors;
+  }
 
   return WebSettings(
     javascriptMode: javascriptMode,
     hasNavigationDelegate: hasNavigationDelegate,
     debuggingEnabled: debuggingEnabled,
     userAgent: userAgent,
+    ignoreSslCertificateErrors: ignoreSslCertificateErrors,
   );
 }
 

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
-version: 2.0.0-nullsafety.3
+version: 2.0.0-nullsafety.4
 homepage: https://github.com/flutter/plugins/tree/master/packages/webview_flutter
 
 environment:

--- a/packages/webview_flutter/test/webview_flutter_test.dart
+++ b/packages/webview_flutter/test/webview_flutter_test.dart
@@ -788,6 +788,50 @@ void main() {
     });
   });
 
+  group('ignoreSslCertificateErrors', () {
+    testWidgets('enable', (WidgetTester tester) async {
+      await tester.pumpWidget(const WebView(
+        ignoreSslCertificateErrors: true,
+      ));
+
+      final FakePlatformWebView platformWebView =
+          fakePlatformViewsController.lastCreatedView!;
+
+      expect(platformWebView.ignoreSslCertificateErrors, true);
+    });
+
+    testWidgets('defaults to false', (WidgetTester tester) async {
+      await tester.pumpWidget(const WebView());
+
+      final FakePlatformWebView platformWebView =
+          fakePlatformViewsController.lastCreatedView!;
+
+      expect(platformWebView.ignoreSslCertificateErrors, false);
+    });
+
+    testWidgets('can be changed', (WidgetTester tester) async {
+      final GlobalKey key = GlobalKey();
+      await tester.pumpWidget(WebView(key: key));
+
+      final FakePlatformWebView platformWebView =
+          fakePlatformViewsController.lastCreatedView!;
+
+      await tester.pumpWidget(WebView(
+        key: key,
+        ignoreSslCertificateErrors: true,
+      ));
+
+      expect(platformWebView.ignoreSslCertificateErrors, true);
+
+      await tester.pumpWidget(WebView(
+        key: key,
+        ignoreSslCertificateErrors: false,
+      ));
+
+      expect(platformWebView.ignoreSslCertificateErrors, false);
+    });
+  });
+
   group('Custom platform implementation', () {
     setUpAll(() {
       WebView.platform = MyWebViewPlatform();
@@ -801,6 +845,7 @@ void main() {
         const WebView(
           initialUrl: 'https://youtube.com',
           gestureNavigationEnabled: true,
+          ignoreSslCertificateErrors: true,
         ),
       );
 
@@ -817,6 +862,7 @@ void main() {
               debuggingEnabled: false,
               userAgent: WebSetting<String?>.of(null),
               gestureNavigationEnabled: true,
+              ignoreSslCertificateErrors: true,
             ),
           )));
     });
@@ -883,6 +929,8 @@ class FakePlatformWebView {
     hasNavigationDelegate =
         params['settings']['hasNavigationDelegate'] ?? false;
     debuggingEnabled = params['settings']['debuggingEnabled'];
+    ignoreSslCertificateErrors =
+        params['settings']['ignoreSslCertificateErrors'];
     userAgent = params['settings']['userAgent'];
     channel = MethodChannel(
         'plugins.flutter.io/webview_$id', const StandardMethodCodec());
@@ -902,6 +950,7 @@ class FakePlatformWebView {
 
   bool? hasNavigationDelegate;
   bool? debuggingEnabled;
+  bool? ignoreSslCertificateErrors;
   String? userAgent;
 
   Future<dynamic> onMethodCall(MethodCall call) {
@@ -919,6 +968,10 @@ class FakePlatformWebView {
         }
         if (call.arguments['debuggingEnabled'] != null) {
           debuggingEnabled = call.arguments['debuggingEnabled'];
+        }
+        if (call.arguments['ignoreSslCertificateErrors'] != null) {
+          ignoreSslCertificateErrors =
+              call.arguments['ignoreSslCertificateErrors'];
         }
         userAgent = call.arguments['userAgent'];
         break;


### PR DESCRIPTION
Adds an `ignoreSslCertificateErrors` flag to `WebView` (default to `false` for safety) primarily to support development scenarios with self-signed certificates.

![zsSuWOCgSO](https://user-images.githubusercontent.com/1901832/104682410-575a6f00-5740-11eb-9694-2f415eda2df4.gif)

Note that I have added only Android support because I'm not currently set up for iOS development.

*List which issues are fixed by this PR. You must list at least one issue.*

* https://github.com/flutter/flutter/issues/36925 (I don't believe this should have been closed because the problem was the specific implementation, not the request itself)

## Pre-launch Checklist

- [X] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
