### PR TITLE
[google_sign_in, url_launcher] Document unendorsement of web.

### DIFF
--- a/packages/google_sign_in/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in/CHANGELOG.md
@@ -1,6 +1,11 @@
+## 5.0.0-nullsafety.1
+
+* Document that the web plugin is not endorsed in the `nullsafety` prerelease for now.
+
 ## 5.0.0-nullsafety
 
 * Migrate to nnbd.
+* **Breaking change**: web plugins aren't endorsed in null-safe plugins yet.
 
 ## 4.5.9
 

--- a/packages/google_sign_in/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_sign_in
 description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android and iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_sign_in/google_sign_in
-version: 5.0.0-nullsafety
+version: 5.0.0-nullsafety.1
 
 flutter:
   plugin:
@@ -12,8 +12,8 @@ flutter:
         pluginClass: GoogleSignInPlugin
       ios:
         pluginClass: FLTGoogleSignInPlugin
-      web:
-        default_package: google_sign_in_web
+      #web:
+      #  default_package: google_sign_in_web
 
 dependencies:
   google_sign_in_platform_interface: ^2.0.0-nullsafety

--- a/packages/url_launcher/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.0-nullsafety.5
+
+* Document that the web plugin is not endorsed in the `nullsafety` prerelease for now.
+
 ## 6.0.0-nullsafety.4
 
 * Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.
@@ -17,6 +21,7 @@
 ## 6.0.0-nullsafety
 
 * Migrate to null safety.
+* **Breaking change**: web plugins aren't endorsed in null-safe plugins yet.
 
 ## 5.7.13
 

--- a/packages/url_launcher/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher
 description: Flutter plugin for launching a URL on Android and iOS. Supports
   web, phone, SMS, and email schemes.
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher
-version: 6.0.0-nullsafety.4
+version: 6.0.0-nullsafety.5
 
 flutter:
   plugin:


### PR DESCRIPTION
Add some documentation to the CHANGELOG to mention that the plugin doesn't support web in the current prerelease state.

Fixes https://github.com/flutter/flutter/issues/72239

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
