### PR TITLE
Clean up CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,23 +4,12 @@
 # These names are just suggestions. It is fine to have your changes
 # reviewed by someone else.
 
-packages/android_alarm_manager/**              @bkonyi
-packages/android_intent/**                     @mklim @matthew-carroll
-packages/battery/**                            @matthew-carroll
+
 packages/camera/**                             @bparrishMines
-packages/connectivity/**                       @matthew-carroll
 packages/cross_file/**                         @ditman @mvanbeusekom
-packages/device_info/**                        @matthew-carroll
-packages/espresso/**                           @collinjackson @adazh
 packages/file_selector/**                      @ditman
 packages/google_maps_flutter/**                @cyanglaz
-packages/google_sign_in/**                     @mehmetf
 packages/image_picker/**                       @cyanglaz
 packages/integration_test/**                   @dnfield
-packages/in_app_purchase/**                    @mklim @cyanglaz @LHLL
+packages/in_app_purchase/**                    @cyanglaz @LHLL
 packages/ios_platform_images/**                @gaaclarke
-packages/package_info/**                       @matthew-carroll
-packages/path_provider/**                      @matthew-carroll
-packages/shared_preferences/**                 @matthew-carroll
-packages/url_launcher/**                       @mklim
-packages/video_player/**                       @iskakaushik


### PR DESCRIPTION
Now that we are adding GitHub actions to automatically label PRs, it would be easier to filter PRs based on the paths they have modified.

If you would rather keep your name in the owners file, let me know. I'm happy to update accordingly.

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
