### PR TITLE
[camera] Ensure that channel.invokeMethod runs on the main thread

### DIFF
--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.7.0+1
 
-* Fix issue: [camera] [crash] Methods marked with @UiThread must be executed on the main thread #72340
+* Ensure communication from JAVA to Dart is done on the main UI thread.
 
 ## 0.7.0
 

--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.0+1
+
+* Fix issue: [camera] [crash] Methods marked with @UiThread must be executed on the main thread #72340
+
 ## 0.7.0
 
 * BREAKING CHANGE: `CameraValue.aspectRatio` now returns `width / height` rather than `height / width`. [(commit)](https://github.com/flutter/plugins/commit/100c7470d4066b1d0f8f7e4ec6d7c943e736f970)

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/DartMessenger.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/DartMessenger.java
@@ -1,5 +1,7 @@
 package io.flutter.plugins.camera;
 
+import android.os.Handler;
+import android.os.Looper;
 import android.text.TextUtils;
 import androidx.annotation.Nullable;
 import io.flutter.plugin.common.BinaryMessenger;
@@ -64,6 +66,11 @@ class DartMessenger {
     if (channel == null) {
       return;
     }
-    channel.invokeMethod(eventType.toString().toLowerCase(), args);
+    new Handler(Looper.getMainLooper()).post(new Runnable () {
+      @Override
+      public void run () {
+        channel.invokeMethod(eventType.toString().toLowerCase(), args);
+      }
+    });
   }
 }

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/DartMessenger.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/DartMessenger.java
@@ -106,12 +106,14 @@ class DartMessenger {
     if (cameraChannel == null) {
       return;
     }
-    new Handler(Looper.getMainLooper()).post(new Runnable () {
-      @Override
-      public void run () {
-        cameraChannel.invokeMethod(eventType.method, args);
-      }
-    });
+    new Handler(Looper.getMainLooper())
+        .post(
+            new Runnable() {
+              @Override
+              public void run() {
+                cameraChannel.invokeMethod(eventType.method, args);
+              }
+            });
   }
 
   void send(DeviceEventType eventType) {
@@ -122,11 +124,13 @@ class DartMessenger {
     if (deviceChannel == null) {
       return;
     }
-    new Handler(Looper.getMainLooper()).post(new Runnable () {
-      @Override
-      public void run () {
-        deviceChannel.invokeMethod(eventType.method, args);
-      }
-    });
+    new Handler(Looper.getMainLooper())
+        .post(
+            new Runnable() {
+              @Override
+              public void run() {
+                deviceChannel.invokeMethod(eventType.method, args);
+              }
+            });
   }
 }

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/DartMessenger.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/DartMessenger.java
@@ -4,6 +4,8 @@
 
 package io.flutter.plugins.camera;
 
+import android.os.Handler;
+import android.os.Looper;
 import android.text.TextUtils;
 import androidx.annotation.Nullable;
 import io.flutter.embedding.engine.systemchannels.PlatformChannel;
@@ -104,7 +106,12 @@ class DartMessenger {
     if (cameraChannel == null) {
       return;
     }
-    cameraChannel.invokeMethod(eventType.method, args);
+    new Handler(Looper.getMainLooper()).post(new Runnable () {
+      @Override
+      public void run () {
+        cameraChannel.invokeMethod(eventType.method, args);
+      }
+    });
   }
 
   void send(DeviceEventType eventType) {
@@ -115,6 +122,11 @@ class DartMessenger {
     if (deviceChannel == null) {
       return;
     }
-    deviceChannel.invokeMethod(eventType.method, args);
+    new Handler(Looper.getMainLooper()).post(new Runnable () {
+      @Override
+      public void run () {
+        deviceChannel.invokeMethod(eventType.method, args);
+      }
+    });
   }
 }

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera
 description: A Flutter plugin for getting information about and controlling the
   camera on Android and iOS. Supports previewing the camera feed, capturing images, capturing video,
   and streaming image buffers to dart.
-version: 0.7.0
+version: 0.7.0+1
 homepage: https://github.com/flutter/plugins/tree/master/packages/camera/camera
 
 dependencies:


### PR DESCRIPTION
channel.invokeMethod may only be called from the main thread. This is in the camera plugin not always the case, which causes a crash of the application. This change ensures that all calls to channel.invokeMethod are done from the main thread.

Issue fixed by this PR: [camera] [crash] Methods marked with @UiThread must be executed on the main thread #72340
https://github.com/flutter/flutter/issues/72340