### PR TITLE
Migrate path_provider_macos to null safety

### DIFF
--- a/packages/path_provider/path_provider_macos/CHANGELOG.md
+++ b/packages/path_provider/path_provider_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.5-nullsafety
+
+* Migrate to null safety.
+
 ## 0.0.4+8
 
 * Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.

--- a/packages/path_provider/path_provider_macos/example/integration_test/path_provider_test.dart
+++ b/packages/path_provider/path_provider_macos/example/integration_test/path_provider_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path_provider/path_provider.dart';

--- a/packages/path_provider/path_provider_macos/example/lib/main.dart
+++ b/packages/path_provider/path_provider_macos/example/lib/main.dart
@@ -4,6 +4,9 @@
 
 // ignore_for_file: public_member_api_docs
 
+// TODO(bmparr) Remove once path_provider releases a null safe version.
+// @dart=2.9
+
 import 'dart:async';
 import 'dart:io' show Directory;
 

--- a/packages/path_provider/path_provider_macos/example/pubspec.yaml
+++ b/packages/path_provider/path_provider_macos/example/pubspec.yaml
@@ -17,11 +17,11 @@ dev_dependencies:
     path: ../../../integration_test
   flutter_driver:
     sdk: flutter
-  pedantic: ^1.8.0
+  pedantic: ^1.10.0-nullsafety
 
 flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"
   flutter: ">=1.10.0 <2.0.0"

--- a/packages/path_provider/path_provider_macos/example/pubspec.yaml
+++ b/packages/path_provider/path_provider_macos/example/pubspec.yaml
@@ -17,11 +17,11 @@ dev_dependencies:
     path: ../../../integration_test
   flutter_driver:
     sdk: flutter
-  pedantic: ^1.10.0-nullsafety
+  pedantic: ^1.8.0
 
 flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.1.0 <3.0.0"
   flutter: ">=1.10.0 <2.0.0"

--- a/packages/path_provider/path_provider_macos/example/test_driver/integration_test.dart
+++ b/packages/path_provider/path_provider_macos/example/test_driver/integration_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/packages/path_provider/path_provider_macos/pubspec.yaml
+++ b/packages/path_provider/path_provider_macos/pubspec.yaml
@@ -3,7 +3,7 @@ description: macOS implementation of the path_provider plugin
 # 0.0.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.0.4+8
+version: 0.0.5-nullsafety
 homepage: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider_macos
 
 flutter:
@@ -13,7 +13,7 @@ flutter:
         pluginClass: PathProviderPlugin
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"
   flutter: ">=1.10.0"
 
 dependencies:
@@ -21,4 +21,4 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  pedantic: ^1.8.0
+  pedantic: ^1.10.0-nullsafety

--- a/packages/path_provider/path_provider_macos/pubspec.yaml
+++ b/packages/path_provider/path_provider_macos/pubspec.yaml
@@ -13,7 +13,7 @@ flutter:
         pluginClass: PathProviderPlugin
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"
   flutter: ">=1.10.0"
 
 dependencies:
@@ -21,4 +21,4 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  pedantic: ^1.8.0
+  pedantic: ^1.10.0-nullsafety

--- a/packages/path_provider/path_provider_macos/pubspec.yaml
+++ b/packages/path_provider/path_provider_macos/pubspec.yaml
@@ -13,7 +13,7 @@ flutter:
         pluginClass: PathProviderPlugin
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.1.0 <3.0.0"
   flutter: ">=1.10.0"
 
 dependencies:
@@ -21,4 +21,4 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  pedantic: ^1.10.0-nullsafety
+  pedantic: ^1.8.0


### PR DESCRIPTION
Migrate to null safety.

The example app also depends on `path_provider`, so I set the dart version for `main.dart` to 2.9 until `path_provider` is migrated.

## Pre-launch Checklist

- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
