### PR TITLE
[camera] Clockwise rotation of focus point in android

### DIFF
--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.0+3
+
+* Clockwise rotation of focus point in android 
+
 ## 0.7.0+2
 
 * Fix example reference in README.

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
@@ -786,7 +786,7 @@ public class Camera {
     }
     // Set the metering rectangle
     if (x == null || y == null) cameraRegions.resetAutoExposureMeteringRectangle();
-    else cameraRegions.setAutoExposureMeteringRectangleFromPoint(x, y);
+    else cameraRegions.setAutoExposureMeteringRectangleFromPoint(y, 1 - x);
     // Apply it
     updateExposure(exposureMode);
     refreshPreviewCaptureSession(
@@ -838,7 +838,7 @@ public class Camera {
     if (x == null || y == null) {
       cameraRegions.resetAutoFocusMeteringRectangle();
     } else {
-      cameraRegions.setAutoFocusMeteringRectangleFromPoint(x, y);
+      cameraRegions.setAutoFocusMeteringRectangleFromPoint(y, 1 - x);
     }
 
     // Apply the new metering rectangle

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera
 description: A Flutter plugin for getting information about and controlling the
   camera on Android and iOS. Supports previewing the camera feed, capturing images, capturing video,
   and streaming image buffers to dart.
-version: 0.7.0+2
+version: 0.7.0+3
 homepage: https://github.com/flutter/plugins/tree/master/packages/camera/camera
 
 dependencies:


### PR DESCRIPTION
use same behavior for setting point of focus in android and iOS. 

In iOS, the landscape mode is used to calculate the point, but in android it doesn't.

https://github.com/flutter/plugins/blob/712dcc184380188522ca80b56e9b5b11651541ce/packages/camera/camera/ios/Classes/CameraPlugin.m#L985
https://github.com/flutter/plugins/blob/712dcc184380188522ca80b56e9b5b11651541ce/packages/camera/camera/ios/Classes/CameraPlugin.m#L1000
