### PR TITLE
Support breaking http change

### DIFF
--- a/packages/cross_file/CHANGELOG.md
+++ b/packages/cross_file/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1
+
+* Prepare for breaking `package:http` change. 
+
 ## 0.2.0
 
 * **breaking change** Make sure the `saveTo` method returns a `Future` so it can be awaited and users are sure the file has been written to disk.

--- a/packages/cross_file/lib/src/types/html.dart
+++ b/packages/cross_file/lib/src/types/html.dart
@@ -3,14 +3,14 @@
 // found in the LICENSE file.
 
 import 'dart:convert';
+import 'dart:html';
 import 'dart:typed_data';
 
 import 'package:http/http.dart' as http show readBytes;
 import 'package:meta/meta.dart';
-import 'dart:html';
 
-import '../web_helpers/web_helpers.dart';
 import './base.dart';
+import '../web_helpers/web_helpers.dart';
 
 /// A CrossFile that works on web.
 ///
@@ -82,7 +82,7 @@ class XFile extends XFileBase {
     if (_data != null) {
       return Future.value(UnmodifiableUint8ListView(_data));
     }
-    return http.readBytes(path);
+    return http.readBytes(Uri.parse(path));
   }
 
   @override

--- a/packages/cross_file/pubspec.yaml
+++ b/packages/cross_file/pubspec.yaml
@@ -1,7 +1,7 @@
 name: cross_file
 description: An abstraction to allow working with files across multiple platforms.
 homepage: https://github.com/flutter/plugins/tree/master/packages/cross_file
-version: 0.2.0
+version: 0.2.1
 
 dependencies:
   flutter:


### PR DESCRIPTION
The next version of `package:http` expects `URI`s. See https://github.com/dart-lang/http/pull/507