### PR TITLE
[url_launcher] Fixes for Dart plugin registry

### DIFF
--- a/packages/url_launcher/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.0-nullsafety.6
+
+* Fixes for Dart plugin registry.
+
 ## 6.0.0-nullsafety.5
 
 * Document that the web plugin is not endorsed in the `nullsafety` prerelease for now.

--- a/packages/url_launcher/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher
 description: Flutter plugin for launching a URL on Android and iOS. Supports
   web, phone, SMS, and email schemes.
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher
-version: 6.0.0-nullsafety.5
+version: 6.0.0-nullsafety.6
 
 flutter:
   plugin:
@@ -16,11 +16,11 @@ flutter:
       #web:
       #  default_package: url_launcher_web
       linux:
-        default_package: url_laucher_linux
+        default_package: url_launcher_linux
       macos:
-        default_package: url_laucher_macos
+        default_package: url_launcher_macos
       windows:
-        default_package: url_laucher_windows
+        default_package: url_launcher_windows
 
 dependencies:
   flutter:

--- a/packages/url_launcher/url_launcher_linux/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0-nullsafety.4
+
+* Fixes for Dart plugin registry.
+
 ## 0.1.0-nullsafety.3
 
 * Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.

--- a/packages/url_launcher/url_launcher_linux/lib/url_launcher_linux.dart
+++ b/packages/url_launcher/url_launcher_linux/lib/url_launcher_linux.dart
@@ -5,5 +5,7 @@
 /// UrlLauncherLinux provides the registerWith() method.
 class UrlLauncherLinux {
   /// Binds the implementation to the interface.
-  static void registerWith() {}
+  static void registerWith() {
+    // todo
+  }
 }

--- a/packages/url_launcher/url_launcher_linux/lib/url_launcher_linux.dart
+++ b/packages/url_launcher/url_launcher_linux/lib/url_launcher_linux.dart
@@ -1,3 +1,9 @@
 // The url_launcher_platform_interface defaults to MethodChannelUrlLauncher
 // as its instance, which is all the Linux implementation needs. This file
 // is here to silence warnings when publishing to pub.
+
+/// UrlLauncherLinux provides the registerWith() method.
+class UrlLauncherLinux {
+  /// Binds the implementation to the interface.
+  static void registerWith() {}
+}

--- a/packages/url_launcher/url_launcher_linux/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_linux/pubspec.yaml
@@ -1,12 +1,14 @@
 name: url_launcher_linux
 description: Linux implementation of the url_launcher plugin.
-version: 0.1.0-nullsafety.3
+version: 0.1.0-nullsafety.4
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher_linux
 
 flutter:
   plugin:
+    implements: url_launcher
     platforms:
       linux:
+        dartPluginClass: UrlLauncherLinux
         pluginClass: UrlLauncherPlugin
 
 environment:

--- a/packages/url_launcher/url_launcher_macos/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0-nullsafety.3
+
+* Fixes for Dart plugin registry.
+
 # 0.1.0-nullsafety.2
 
 * Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.

--- a/packages/url_launcher/url_launcher_macos/lib/url_launcher_macos.dart
+++ b/packages/url_launcher/url_launcher_macos/lib/url_launcher_macos.dart
@@ -5,5 +5,7 @@
 /// UrlLauncherMacOS provides the registerWith() method.
 class UrlLauncherMacOS {
   /// Binds the implementation to the interface.
-  static void registerWith() {}
+  static void registerWith() {
+    // todo
+  }
 }

--- a/packages/url_launcher/url_launcher_macos/lib/url_launcher_macos.dart
+++ b/packages/url_launcher/url_launcher_macos/lib/url_launcher_macos.dart
@@ -1,3 +1,9 @@
 // The url_launcher_platform_interface defaults to MethodChannelUrlLauncher
 // as its instance, which is all the macOS implementation needs. This file
 // is here to silence warnings when publishing to pub.
+
+/// UrlLauncherMacOS provides the registerWith() method.
+class UrlLauncherMacOS {
+  /// Binds the implementation to the interface.
+  static void registerWith() {}
+}

--- a/packages/url_launcher/url_launcher_macos/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_macos/pubspec.yaml
@@ -3,13 +3,15 @@ description: macOS implementation of the url_launcher plugin.
 # 0.0.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.1.0-nullsafety.2
+version: 0.1.0-nullsafety.3
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher_macos
 
 flutter:
   plugin:
+    implements: url_launcher
     platforms:
       macos:
+        dartPluginClass: UrlLauncherMacOS
         pluginClass: UrlLauncherPlugin
         fileName: url_launcher_macos.dart
 

--- a/packages/url_launcher/url_launcher_windows/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0-nullsafety.3
+
+* Fixes for Dart plugin registry.
+
 ## 0.1.0-nullsafety.2
 
 * Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.

--- a/packages/url_launcher/url_launcher_windows/lib/url_launcher_windows.dart
+++ b/packages/url_launcher/url_launcher_windows/lib/url_launcher_windows.dart
@@ -1,3 +1,9 @@
 // The url_launcher_platform_interface defaults to MethodChannelUrlLauncher
 // as its instance, which is all the Windows implementation needs. This file
 // is here to silence warnings when publishing to pub.
+
+/// UrlLauncherWindows provides the registerWith() method.
+class UrlLauncherWindows {
+  /// Binds the implementation to the interface.
+  static void registerWith() {}
+}

--- a/packages/url_launcher/url_launcher_windows/lib/url_launcher_windows.dart
+++ b/packages/url_launcher/url_launcher_windows/lib/url_launcher_windows.dart
@@ -5,5 +5,7 @@
 /// UrlLauncherWindows provides the registerWith() method.
 class UrlLauncherWindows {
   /// Binds the implementation to the interface.
-  static void registerWith() {}
+  static void registerWith() {
+    // todo
+  }
 }

--- a/packages/url_launcher/url_launcher_windows/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_windows/pubspec.yaml
@@ -3,13 +3,15 @@ description: Windows implementation of the url_launcher plugin.
 # 0.0.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.1.0-nullsafety.2
+version: 0.1.0-nullsafety.3
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher_windows
 
 flutter:
   plugin:
+    implements: url_launcher
     platforms:
       windows:
+        dartPluginClass: UrlLauncherWindows
         pluginClass: UrlLauncherPlugin
 
 environment:


### PR DESCRIPTION
Required for https://github.com/flutter/flutter/issues/52267

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
