### PR TITLE
Migrate shared_preferences_platform_interfaces to null safety

### DIFF
--- a/packages/shared_preferences/shared_preferences_platform_interface/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-nullsafety
+
+* Migrate to null safety.
+
 ## 1.0.5
 
 * Update Flutter SDK constraint.

--- a/packages/shared_preferences/shared_preferences_platform_interface/lib/method_channel_shared_preferences.dart
+++ b/packages/shared_preferences/shared_preferences_platform_interface/lib/method_channel_shared_preferences.dart
@@ -40,7 +40,10 @@ class MethodChannelSharedPreferencesStore
 
   @override
   Future<Map<String, Object>> getAll() async {
-    return await _kChannel.invokeMapMethod<String, Object>('getAll')
-        as Map<String, Object>;
+    final Map<String, Object>? preferences =
+        await _kChannel.invokeMapMethod<String, Object>('getAll');
+
+    if (preferences == null) return <String, Object>{};
+    return preferences;
   }
 }

--- a/packages/shared_preferences/shared_preferences_platform_interface/lib/method_channel_shared_preferences.dart
+++ b/packages/shared_preferences/shared_preferences_platform_interface/lib/method_channel_shared_preferences.dart
@@ -19,23 +19,23 @@ class MethodChannelSharedPreferencesStore
     extends SharedPreferencesStorePlatform {
   @override
   Future<bool> remove(String key) async {
-    return await _kChannel.invokeMethod<bool>(
+    return (await _kChannel.invokeMethod<bool>(
       'remove',
       <String, dynamic>{'key': key},
-    ) as bool;
+    ))!;
   }
 
   @override
   Future<bool> setValue(String valueType, String key, Object value) async {
-    return await _kChannel.invokeMethod<bool>(
+    return (await _kChannel.invokeMethod<bool>(
       'set$valueType',
       <String, dynamic>{'key': key, 'value': value},
-    ) as bool;
+    ))!;
   }
 
   @override
   Future<bool> clear() async {
-    return await _kChannel.invokeMethod<bool>('clear') as bool;
+    return (await _kChannel.invokeMethod<bool>('clear'))!;
   }
 
   @override

--- a/packages/shared_preferences/shared_preferences_platform_interface/lib/method_channel_shared_preferences.dart
+++ b/packages/shared_preferences/shared_preferences_platform_interface/lib/method_channel_shared_preferences.dart
@@ -18,39 +18,29 @@ const MethodChannel _kChannel =
 class MethodChannelSharedPreferencesStore
     extends SharedPreferencesStorePlatform {
   @override
-  Future<bool> remove(String key) {
-    return _invokeBoolMethod('remove', <String, dynamic>{
-      'key': key,
-    });
+  Future<bool> remove(String key) async {
+    return await _kChannel.invokeMethod<bool>(
+      'remove',
+      <String, dynamic>{'key': key},
+    ) as bool;
   }
 
   @override
-  Future<bool> setValue(String valueType, String key, Object value) {
-    return _invokeBoolMethod('set$valueType', <String, dynamic>{
-      'key': key,
-      'value': value,
-    });
-  }
-
-  Future<bool> _invokeBoolMethod(String method, Map<String, dynamic> params) {
-    return _kChannel
-        .invokeMethod<bool>(method, params)
-        // TODO(yjbanov): I copied this from the original
-        //                shared_preferences.dart implementation, but I
-        //                actually do not know why it's necessary to pipe the
-        //                result through an identity function.
-        //
-        //                Source: https://github.com/flutter/plugins/blob/3a87296a40a2624d200917d58f036baa9fb18df8/packages/shared_preferences/lib/shared_preferences.dart#L134
-        .then<bool>((dynamic result) => result);
+  Future<bool> setValue(String valueType, String key, Object value) async {
+    return await _kChannel.invokeMethod<bool>(
+      'set$valueType',
+      <String, dynamic>{'key': key, 'value': value},
+    ) as bool;
   }
 
   @override
-  Future<bool> clear() {
-    return _kChannel.invokeMethod<bool>('clear');
+  Future<bool> clear() async {
+    return await _kChannel.invokeMethod<bool>('clear') as bool;
   }
 
   @override
-  Future<Map<String, Object>> getAll() {
-    return _kChannel.invokeMapMethod<String, Object>('getAll');
+  Future<Map<String, Object>> getAll() async {
+    return await _kChannel.invokeMapMethod<String, Object>('getAll')
+        as Map<String, Object>;
   }
 }

--- a/packages/shared_preferences/shared_preferences_platform_interface/lib/shared_preferences_platform_interface.dart
+++ b/packages/shared_preferences/shared_preferences_platform_interface/lib/shared_preferences_platform_interface.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:meta/meta.dart';
+import 'package:flutter/foundation.dart';
 
 import 'method_channel_shared_preferences.dart';
 

--- a/packages/shared_preferences/shared_preferences_platform_interface/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_platform_interface/pubspec.yaml
@@ -1,18 +1,17 @@
 name: shared_preferences_platform_interface
 description: A common platform interface for the shared_preferences plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/shared_preferences/shared_preferences_platform_interface
-version: 1.0.5
+version: 2.0.0-nullsafety
 
 dependencies:
-  meta: ^1.0.4
   flutter:
     sdk: flutter
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.8.0
+  pedantic: ^1.10.0-nullsafety
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"
   flutter: ">=1.12.8"

--- a/packages/shared_preferences/shared_preferences_platform_interface/test/method_channel_shared_preferences_test.dart
+++ b/packages/shared_preferences/shared_preferences_platform_interface/test/method_channel_shared_preferences_test.dart
@@ -15,7 +15,7 @@ void main() {
       'plugins.flutter.io/shared_preferences',
     );
 
-    const Map<String, dynamic> kTestValues = <String, dynamic>{
+    const Map<String, Object> kTestValues = <String, Object>{
       'flutter.String': 'hello world',
       'flutter.Bool': true,
       'flutter.Int': 42,
@@ -23,10 +23,10 @@ void main() {
       'flutter.StringList': <String>['foo', 'bar'],
     };
 
-    InMemorySharedPreferencesStore testData;
+    late InMemorySharedPreferencesStore testData;
 
     final List<MethodCall> log = <MethodCall>[];
-    MethodChannelSharedPreferencesStore store;
+    late MethodChannelSharedPreferencesStore store;
 
     setUp(() async {
       testData = InMemorySharedPreferencesStore.empty();
@@ -44,9 +44,9 @@ void main() {
           return await testData.clear();
         }
         final RegExp setterRegExp = RegExp(r'set(.*)');
-        final Match match = setterRegExp.matchAsPrefix(methodCall.method);
-        if (match.groupCount == 1) {
-          final String valueType = match.group(1);
+        final Match? match = setterRegExp.matchAsPrefix(methodCall.method);
+        if (match != null && match.groupCount == 1) {
+          final String valueType = match.group(1)!;
           final String key = methodCall.arguments['key'];
           final Object value = methodCall.arguments['value'];
           return await testData.setValue(valueType, key, value);
@@ -59,8 +59,6 @@ void main() {
 
     tearDown(() async {
       await testData.clear();
-      store = null;
-      testData = null;
     });
 
     test('getAll', () async {

--- a/packages/shared_preferences/shared_preferences_platform_interface/test/method_channel_shared_preferences_test.dart
+++ b/packages/shared_preferences/shared_preferences_platform_interface/test/method_channel_shared_preferences_test.dart
@@ -45,8 +45,8 @@ void main() {
         }
         final RegExp setterRegExp = RegExp(r'set(.*)');
         final Match? match = setterRegExp.matchAsPrefix(methodCall.method);
-        if (match != null && match.groupCount == 1) {
-          final String valueType = match.group(1)!;
+        if (match?.groupCount == 1) {
+          final String valueType = match!.group(1)!;
           final String key = methodCall.arguments['key'];
           final Object value = methodCall.arguments['value'];
           return await testData.setValue(valueType, key, value);

--- a/script/nnbd_plugins.sh
+++ b/script/nnbd_plugins.sh
@@ -16,6 +16,7 @@ readonly NNBD_PLUGINS_LIST=(
   "path_provider"
   "plugin_platform_interface"
   "share"
+  "shared_preferences"
   "url_launcher"
   "video_player"
   "webview_flutter"
@@ -34,7 +35,6 @@ readonly NON_NNBD_PLUGINS_LIST=(
   # "in_app_purchase"
   # "quick_actions"
   # "sensors"
-  # "shared_preferences"
   # "wifi_info_flutter"
 )
 


### PR DESCRIPTION
Migrate to null safety.

## Pre-launch Checklist

- [] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
