### PR TITLE
[image_picker_platform_interface] fix test asset file location

### DIFF
--- a/packages/cross_file/test/x_file_io_test.dart
+++ b/packages/cross_file/test/x_file_io_test.dart
@@ -21,7 +21,7 @@ import 'package:cross_file/cross_file.dart';
 //
 // https://github.com/flutter/flutter/issues/20907
 
-final pathPrefix = './assets/';
+final pathPrefix = './test/assets/';
 final path = pathPrefix + 'hello.txt';
 final String expectedStringContents = 'Hello, world!';
 final Uint8List bytes = Uint8List.fromList(utf8.encode(expectedStringContents));

--- a/packages/cross_file/test/x_file_io_test.dart
+++ b/packages/cross_file/test/x_file_io_test.dart
@@ -11,16 +11,6 @@ import 'dart:typed_data';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:cross_file/cross_file.dart';
 
-// Please note that executing this test with command
-// `flutter test test/x_file_io_test.dart` will set the directory
-// to ./file_selector_platform_interface.
-//
-// This will cause our hello.txt file to be not be found. Please
-// execute this test with `flutter test` or change the path prefix
-// to ./test/assets/
-//
-// https://github.com/flutter/flutter/issues/20907
-
 final pathPrefix = './test/assets/';
 final path = pathPrefix + 'hello.txt';
 final String expectedStringContents = 'Hello, world!';
@@ -30,7 +20,14 @@ final String textFilePath = textFile.path;
 
 void main() {
   group('Create with a path', () {
-    final file = XFile(textFilePath);
+    XFile file;
+    if (Directory(textFilePath).existsSync()) {
+      file = XFile(textFilePath);
+    } else {
+      // TODO(cyanglaz): remove this alternative file location when https://github.com/flutter/flutter/commit/22f170042746ff253997236f6350ecb7403cf3b1
+      // lands on stable.
+      file = XFile(File('./assets/hello.txt').path);
+    }
 
     test('Can be read as a string', () async {
       expect(await file.readAsString(), equals(expectedStringContents));

--- a/packages/cross_file/test/x_file_io_test.dart
+++ b/packages/cross_file/test/x_file_io_test.dart
@@ -11,7 +11,8 @@ import 'dart:typed_data';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:cross_file/cross_file.dart';
 
-final pathPrefix = './test/assets/';
+final pathPrefix =
+    Directory.current.path.endsWith('test') ? './assets/' : './test/assets/';
 final path = pathPrefix + 'hello.txt';
 final String expectedStringContents = 'Hello, world!';
 final Uint8List bytes = Uint8List.fromList(utf8.encode(expectedStringContents));
@@ -20,14 +21,7 @@ final String textFilePath = textFile.path;
 
 void main() {
   group('Create with a path', () {
-    XFile file;
-    if (Directory(textFilePath).existsSync()) {
-      file = XFile(textFilePath);
-    } else {
-      // TODO(cyanglaz): remove this alternative file location when https://github.com/flutter/flutter/commit/22f170042746ff253997236f6350ecb7403cf3b1
-      // lands on stable.
-      file = XFile(File('./assets/hello.txt').path);
-    }
+    final XFile file = XFile(textFilePath);
 
     test('Can be read as a string', () async {
       expect(await file.readAsString(), equals(expectedStringContents));

--- a/packages/image_picker/image_picker_platform_interface/CHANGELOG.md
+++ b/packages/image_picker/image_picker_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.6
+
+* Fix test asset file location.
+
 ## 1.1.5
 
 * Update Flutter SDK constraint.

--- a/packages/image_picker/image_picker_platform_interface/pubspec.yaml
+++ b/packages/image_picker/image_picker_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the image_picker plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker/image_picker_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.1.5
+version: 1.1.6
 
 dependencies:
   flutter:

--- a/packages/image_picker/image_picker_platform_interface/test/picked_file_io_test.dart
+++ b/packages/image_picker/image_picker_platform_interface/test/picked_file_io_test.dart
@@ -11,21 +11,17 @@ import 'dart:typed_data';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:image_picker_platform_interface/image_picker_platform_interface.dart';
 
+final pathPrefix =
+    Directory.current.path.endsWith('test') ? './assets/' : './test/assets/';
+final path = pathPrefix + 'hello.txt';
 final String expectedStringContents = 'Hello, world!';
-final Uint8List bytes = utf8.encode(expectedStringContents);
-final File textFile = File('./test/assets/hello.txt');
-String textFilePath = textFile.path;
+final Uint8List bytes = Uint8List.fromList(utf8.encode(expectedStringContents));
+final File textFile = File(path);
+final String textFilePath = textFile.path;
 
 void main() {
   group('Create with an objectUrl', () {
-    PickedFile pickedFile;
-    if (Directory(textFilePath).existsSync()) {
-      pickedFile = PickedFile(textFilePath);
-    } else {
-      // TODO(cyanglaz): remove this alternative file location when https://github.com/flutter/flutter/commit/22f170042746ff253997236f6350ecb7403cf3b1
-      // lands on stable.
-      pickedFile = PickedFile(File('./assets/hello.txt').path);
-    }
+    final PickedFile pickedFile = PickedFile(textFilePath);
 
     test('Can be read as a string', () async {
       expect(await pickedFile.readAsString(), equals(expectedStringContents));

--- a/packages/image_picker/image_picker_platform_interface/test/picked_file_io_test.dart
+++ b/packages/image_picker/image_picker_platform_interface/test/picked_file_io_test.dart
@@ -14,11 +14,18 @@ import 'package:image_picker_platform_interface/image_picker_platform_interface.
 final String expectedStringContents = 'Hello, world!';
 final Uint8List bytes = utf8.encode(expectedStringContents);
 final File textFile = File('./test/assets/hello.txt');
-final String textFilePath = textFile.path;
+String textFilePath = textFile.path;
 
 void main() {
   group('Create with an objectUrl', () {
-    final pickedFile = PickedFile(textFilePath);
+    PickedFile pickedFile;
+    if (Directory(textFilePath).existsSync()) {
+      pickedFile = PickedFile(textFilePath);
+    } else {
+      // TODO(cyanglaz): remove this alternative file location when https://github.com/flutter/flutter/commit/22f170042746ff253997236f6350ecb7403cf3b1
+      // lands on stable.
+      pickedFile = PickedFile(File('./assets/hello.txt').path);
+    }
 
     test('Can be read as a string', () async {
       expect(await pickedFile.readAsString(), equals(expectedStringContents));

--- a/packages/image_picker/image_picker_platform_interface/test/picked_file_io_test.dart
+++ b/packages/image_picker/image_picker_platform_interface/test/picked_file_io_test.dart
@@ -13,7 +13,7 @@ import 'package:image_picker_platform_interface/image_picker_platform_interface.
 
 final String expectedStringContents = 'Hello, world!';
 final Uint8List bytes = utf8.encode(expectedStringContents);
-final File textFile = File('./assets/hello.txt');
+final File textFile = File('./test/assets/hello.txt');
 final String textFilePath = textFile.path;
 
 void main() {


### PR DESCRIPTION
Fixes where we load the asset file in tests. See: https://github.com/flutter/flutter/pull/74622

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
