### PR TITLE
[camera] Fix example reference in camera's doc

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -61,3 +61,4 @@ Chris Rutkowski <chrisrutkowski89@gmail.com>
 Juan Alvarez <juan.alvarez@resideo.com>
 Aleksandr Yurkovskiy <sanekyy@gmail.com>
 Anton Borries <mail@antonborri.es>
+Alex Li <google@alexv525.com>

--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.0+2
+
+* Fix example reference in README.
+
 ## 0.7.0+1
 
 * Ensure communication from JAVA to Dart is done on the main UI thread.

--- a/packages/camera/camera/README.md
+++ b/packages/camera/camera/README.md
@@ -122,7 +122,7 @@ class _CameraAppState extends State<CameraApp> {
 }
 ```
 
-For a more elaborate usage example see [here](https://github.com/flutter/plugins/tree/master/packages/camera/example).
+For a more elaborate usage example see [here](https://github.com/flutter/plugins/tree/master/packages/camera/camera/example).
 
 *Note*: This plugin is still under development, and some APIs might not be available yet.
 [Feedback welcome](https://github.com/flutter/flutter/issues) and

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera
 description: A Flutter plugin for getting information about and controlling the
   camera on Android and iOS. Supports previewing the camera feed, capturing images, capturing video,
   and streaming image buffers to dart.
-version: 0.7.0+1
+version: 0.7.0+2
 homepage: https://github.com/flutter/plugins/tree/master/packages/camera/camera
 
 dependencies:


### PR DESCRIPTION
Example link updated
from https://github.com/flutter/plugins/tree/master/packages/camera/example
to https://github.com/flutter/plugins/tree/master/packages/camera/camera/example

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.