### PR TITLE
[local_auth] Fix incorrect switch fallthrough

### DIFF
--- a/packages/local_auth/CHANGELOG.md
+++ b/packages/local_auth/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 * Allow pin, passcode, and pattern authentication with `authenticate` method
 * **Breaking change**. Parameter names refactored to use the generic `biometric` prefix in place of `fingerprint` in the `AndroidAuthMessages` class
-  * `fingerprintHint` is now `biometricHint`  
-  * `fingerprintNotRecognized`is now `biometricNotRecognized`  
-  * `fingerprintSuccess`is now `biometricSuccess`  
-  * `fingerprintRequiredTitle` is now `biometricRequiredTitle` 
+  * `fingerprintHint` is now `biometricHint`
+  * `fingerprintNotRecognized`is now `biometricNotRecognized`
+  * `fingerprintSuccess`is now `biometricSuccess`
+  * `fingerprintRequiredTitle` is now `biometricRequiredTitle`
+
+## 1.0.0-nullsafety.4
+
+* Fix incorrect error handling switch case fallthrough.
 
 ## 1.0.0-nullsafety.3
 

--- a/packages/local_auth/android/src/main/java/io/flutter/plugins/localauth/AuthenticationHelper.java
+++ b/packages/local_auth/android/src/main/java/io/flutter/plugins/localauth/AuthenticationHelper.java
@@ -138,6 +138,7 @@ class AuthenticationHelper extends BiometricPrompt.AuthenticationCallback
           return;
         }
         completionHandler.onError("NotAvailable", "Security credentials not available.");
+        break;
       case BiometricPrompt.ERROR_NO_SPACE:
       case BiometricPrompt.ERROR_NO_BIOMETRICS:
         if (promptInfo.isDeviceCredentialAllowed()) return;

--- a/packages/local_auth/pubspec.yaml
+++ b/packages/local_auth/pubspec.yaml
@@ -1,8 +1,8 @@
 name: local_auth
-description: Flutter plugin for Android and iOS devices to allow local 
+description: Flutter plugin for Android and iOS devices to allow local
   authentication via fingerprint, touch ID, face ID, passcode, pin, or pattern.
 homepage: https://github.com/flutter/plugins/tree/master/packages/local_auth
-version: 1.0.0-nullsafety.3
+version: 1.0.0-nullsafety.4
 
 flutter:
   plugin:


### PR DESCRIPTION
This breaks internal lints when imported, because the switch case continues to the next case. I'm not familiar with the code, but I assume that since the error is handled in `completionHandler.onError` this `case` is complete and we should `break`,