### PR TITLE
[url_launcher_web] Fix Link misalignment issue

### DIFF
--- a/packages/url_launcher/url_launcher_web/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.5+3
+
+- Fix Link misalignment [issue](https://github.com/flutter/flutter/issues/70053).
+
 # 0.1.5+2
 
 - Update Flutter SDK constraint.

--- a/packages/url_launcher/url_launcher_web/lib/src/link.dart
+++ b/packages/url_launcher/url_launcher_web/lib/src/link.dart
@@ -66,6 +66,7 @@ class WebLinkDelegateState extends State<WebLinkDelegate> {
   @override
   Widget build(BuildContext context) {
     return Stack(
+      fit: StackFit.passthrough,
       children: <Widget>[
         widget.link.builder(
           context,

--- a/packages/url_launcher/url_launcher_web/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_web/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/u
 # 0.1.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.1.5+2
+version: 0.1.5+3
 
 flutter:
   plugin:

--- a/packages/url_launcher/url_launcher_web/test/lib/main.dart
+++ b/packages/url_launcher/url_launcher_web/test/lib/main.dart
@@ -17,6 +17,9 @@ class MyApp extends StatefulWidget {
 class _MyAppState extends State<MyApp> {
   @override
   Widget build(BuildContext context) {
-    return Text('Testing... Look at the console output for results!');
+    return Directionality(
+      textDirection: TextDirection.ltr,
+      child: Text('Testing... Look at the console output for results!'),
+    );
   }
 }

--- a/packages/url_launcher/url_launcher_web/test/test_driver/url_launcher_web_integration.dart
+++ b/packages/url_launcher/url_launcher_web/test/test_driver/url_launcher_web_integration.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.9
 import 'dart:html' as html;
 import 'dart:js_util';
 import 'package:flutter/widgets.dart';
@@ -270,6 +271,38 @@ void main() {
       // Check that the same anchor has been updated.
       expect(anchor.getAttribute('href'), uri2.toString());
       expect(anchor.getAttribute('target'), '_self');
+    });
+
+    testWidgets('sizes itself correctly', (WidgetTester tester) async {
+      final Key containerKey = GlobalKey();
+      final Uri uri = Uri.parse('http://foobar');
+      await tester.pumpWidget(Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: ConstrainedBox(
+            constraints: BoxConstraints.tight(Size(100.0, 100.0)),
+            child: WebLinkDelegate(TestLinkInfo(
+              uri: uri,
+              target: LinkTarget.blank,
+              builder: (BuildContext context, FollowLink followLink) {
+                return Container(
+                  key: containerKey,
+                  child: SizedBox(width: 50.0, height: 50.0),
+                );
+              },
+            )),
+          ),
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      final Size containerSize = tester.getSize(find.byKey(containerKey));
+      // The Stack widget inserted by the `WebLinkDelegate` shouldn't loosen the
+      // constraints before passing them to the inner container. So the inner
+      // container should respect the tight constraints given by the ancestor
+      // `ConstrainedBox` widget.
+      expect(containerSize.width, 100.0);
+      expect(containerSize.height, 100.0);
     });
   });
 }

--- a/packages/url_launcher/url_launcher_web/test/test_driver/url_launcher_web_integration_test.dart
+++ b/packages/url_launcher/url_launcher_web/test/test_driver/url_launcher_web_integration_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.9
 import 'package:integration_test/integration_test_driver.dart';
 
 Future<void> main() async => integrationDriver();


### PR DESCRIPTION
The Link widget builds a Stack on the web. The Stack by default [loosens](https://master-api.flutter.dev/flutter/widgets/Stack/fit.html) the constraints passed by the parent. This is what was causing the misalignment.

In order to fix it, we just need to pass `fit: StackFit.passthrough` to the Stack.

Fixes https://github.com/flutter/flutter/issues/70053