### PR TITLE
[integration_test] Fix tests from changes to `flutter test` machine output

### DIFF
--- a/packages/integration_test/CHANGELOG.md
+++ b/packages/integration_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2+2
+
+* Fix tests from changes to `flutter test` machine output.
+
 ## 1.0.2+1
 
 * Update vm_service constraint

--- a/packages/integration_test/pubspec.yaml
+++ b/packages/integration_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: integration_test
 description: Runs tests that use the flutter_test API as integration tests.
-version: 1.0.2+1
+version: 1.0.2+2
 homepage: https://github.com/flutter/plugins/tree/master/packages/integration_test
 
 environment:

--- a/packages/integration_test/test/binding_fail_test.dart
+++ b/packages/integration_test/test/binding_fail_test.dart
@@ -61,12 +61,17 @@ Future<Map<String, dynamic>> _runTest(String scriptPath) async {
   final String testResults = (await process.stdout
           .transform(utf8.decoder)
           .expand((String text) => text.split('\n'))
-          .map((String line) {
+          .map<dynamic>((String line) {
             try {
               return jsonDecode(line);
             } on FormatException {
               // Only interested in test events which are JSON.
             }
+          })
+          .expand<Map<String, dynamic>>((dynamic json) {
+            return json is List<dynamic>
+                ? json.cast()
+                : <Map<String, dynamic>>[json as Map<String, dynamic>];
           })
           .where((dynamic testEvent) =>
               testEvent != null && testEvent['type'] == 'print')


### PR DESCRIPTION
There was a change in `flutter master` on how machine readable output is reported (https://github.com/flutter/flutter/pull/74176). It required a change to integration_test in the SDK, but that wasn't patched to the plugins repo. This PR does that.
