### PR TITLE
[path_provider] Migrate path_provider_macos to null safety.

### DIFF
--- a/packages/path_provider/path_provider_macos/CHANGELOG.md
+++ b/packages/path_provider/path_provider_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0-nullsafety.0
+
+* Migrade to null safety. The example app is not migrated at this moment.
+
 ## 0.0.4+8
 
 * Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.

--- a/packages/path_provider/path_provider_macos/pubspec.yaml
+++ b/packages/path_provider/path_provider_macos/pubspec.yaml
@@ -13,7 +13,7 @@ flutter:
         pluginClass: PathProviderPlugin
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"
   flutter: ">=1.10.0"
 
 dependencies:
@@ -21,4 +21,4 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  pedantic: ^1.8.0
+  pedantic: ^1.10.0-nullsafety.3

--- a/packages/path_provider/path_provider_macos/pubspec.yaml
+++ b/packages/path_provider/path_provider_macos/pubspec.yaml
@@ -3,7 +3,7 @@ description: macOS implementation of the path_provider plugin
 # 0.0.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.0.4+8
+version: 0.1.0-nullsafety.0
 homepage: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider_macos
 
 flutter:


### PR DESCRIPTION
Because path_provider_macos has an empty Dart file, the only change is
to the pubspec config.

Issue: flutter/flutter#74996

