### PR TITLE
[path_provider] Migrate path_provider_linux to null safety.

### DIFF
--- a/packages/path_provider/path_provider_linux/CHANGELOG.md
+++ b/packages/path_provider/path_provider_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0-nullsafety.0
+
+* Migrate to null safety.
+
 ## 0.1.1+3
 
 * Update Flutter SDK constraint.

--- a/packages/path_provider/path_provider_linux/example/pubspec.yaml
+++ b/packages/path_provider/path_provider_linux/example/pubspec.yaml
@@ -15,9 +15,10 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.3
 
-dependency_overrides:
-  path_provider_linux:
-    path: ../
+# Disable overrides until path_provider is migrated to null safety.
+# dependency_overrides:
+#   path_provider_linux:
+#     path: ../
 
 dev_dependencies:
   flutter_test:

--- a/packages/path_provider/path_provider_linux/lib/path_provider_linux.dart
+++ b/packages/path_provider/path_provider_linux/lib/path_provider_linux.dart
@@ -35,12 +35,12 @@ class PathProviderLinux extends PathProviderPlatform {
   }
 
   @override
-  Future<String> getApplicationDocumentsPath() {
-    return Future.value(xdg.getUserDirectory('DOCUMENTS').path);
+  Future<String?> getApplicationDocumentsPath() async {
+    return xdg.getUserDirectory('DOCUMENTS')?.path;
   }
 
   @override
-  Future<String> getDownloadsPath() {
-    return Future.value(xdg.getUserDirectory('DOWNLOAD').path);
+  Future<String?> getDownloadsPath() async {
+    return xdg.getUserDirectory('DOWNLOAD')?.path;
   }
 }

--- a/packages/path_provider/path_provider_linux/pubspec.yaml
+++ b/packages/path_provider/path_provider_linux/pubspec.yaml
@@ -1,6 +1,6 @@
 name: path_provider_linux
 description: linux implementation of the path_provider plugin
-version: 0.1.1+3
+version: 0.2.0-nullsafety.0
 homepage: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider_linux
 
 flutter:
@@ -11,17 +11,17 @@ flutter:
         pluginClass: none
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"
   flutter: ">=1.10.0"
 
 dependencies:
   path: ^1.6.4
-  xdg_directories: ^0.1.0
-  path_provider_platform_interface: ^1.0.1
+  xdg_directories: ^0.2.0-nullsafety.0
+  path_provider_platform_interface: ^2.0.0-nullsafety
   flutter:
     sdk: flutter
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.8.0
+  pedantic: ^1.10.0-nullsafety.3


### PR DESCRIPTION
Migrate path_provider_linux to null safety.

This PR migrates the library itself - the example & integration tests aren't ready to be migrated.

Issue: flutter/flutter#74996.