### PR TITLE
[path_provider_windows] Resolve FFI stabilization changes

### DIFF
--- a/packages/path_provider/path_provider_windows/CHANGELOG.md
+++ b/packages/path_provider/path_provider_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0-nullsafety.1
+
+* Bump win32 dependency to latest version.
+
 ## 0.1.0-nullsafety
 
 * Migrate to null safety

--- a/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_real.dart
+++ b/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_real.dart
@@ -116,7 +116,7 @@ class PathProviderWindows extends PathProviderPlatform {
   /// [WindowsKnownFolder].
   Future<String> getPath(String folderID) {
     final pathPtrPtr = allocate<Pointer<Utf16>>();
-    final Pointer<GUID> knownFolderID = calloc<GUID>()..setGUID(folderID);
+    final Pointer<GUID> knownFolderID = calloc<GUID>()..ref.setGUID(folderID);
 
     try {
       final hr = SHGetKnownFolderPath(

--- a/packages/path_provider/path_provider_windows/pubspec.yaml
+++ b/packages/path_provider/path_provider_windows/pubspec.yaml
@@ -1,7 +1,7 @@
 name: path_provider_windows
 description: Windows implementation of the path_provider plugin
 homepage: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider_windows
-version: 0.1.0-nullsafety
+version: 0.1.0-nullsafety.1
 
 flutter:
   plugin:

--- a/packages/path_provider/path_provider_windows/pubspec.yaml
+++ b/packages/path_provider/path_provider_windows/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   flutter:
     sdk: flutter
   ffi: ^0.2.0-nullsafety.1
-  win32: ^2.0.0-nullsafety.8
+  win32: ^2.0.0-nullsafety.9
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Fixes flutter/flutter#75050. When ffi 0.2.0-nullsafety.2 lands, the `calloc` method will be provided by ffi itself, which might trigger another set of changes, but this change will ensure that path_provider_windows works on current null safety builds. 

## Pre-launch Checklist

- [X] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
