### PR TITLE
[path_provider_linux] Migrate to nnbd

### DIFF
--- a/packages/path_provider/path_provider_linux/CHANGELOG.md
+++ b/packages/path_provider/path_provider_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0-nullsafety.0
+
+* Migrate to null-safety
+
 ## 0.1.1+3
 
 * Update Flutter SDK constraint.

--- a/packages/path_provider/path_provider_linux/example/pubspec.yaml
+++ b/packages/path_provider/path_provider_linux/example/pubspec.yaml
@@ -9,15 +9,12 @@ dependencies:
   flutter:
     sdk: flutter
 
-  path_provider: ^1.6.10
+  path_provider:
+    path: ../../path_provider
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.3
-
-dependency_overrides:
-  path_provider_linux:
-    path: ../
 
 dev_dependencies:
   flutter_test:

--- a/packages/path_provider/path_provider_linux/lib/path_provider_linux.dart
+++ b/packages/path_provider/path_provider_linux/lib/path_provider_linux.dart
@@ -36,11 +36,11 @@ class PathProviderLinux extends PathProviderPlatform {
 
   @override
   Future<String> getApplicationDocumentsPath() {
-    return Future.value(xdg.getUserDirectory('DOCUMENTS').path);
+    return Future.value(xdg.getUserDirectory('DOCUMENTS')!.path);
   }
 
   @override
   Future<String> getDownloadsPath() {
-    return Future.value(xdg.getUserDirectory('DOWNLOAD').path);
+    return Future.value(xdg.getUserDirectory('DOWNLOAD')!.path);
   }
 }

--- a/packages/path_provider/path_provider_linux/pubspec.yaml
+++ b/packages/path_provider/path_provider_linux/pubspec.yaml
@@ -1,6 +1,6 @@
 name: path_provider_linux
 description: linux implementation of the path_provider plugin
-version: 0.1.1+3
+version: 0.2.0-nullsafety.0
 homepage: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider_linux
 
 flutter:
@@ -11,13 +11,13 @@ flutter:
         pluginClass: none
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: '>=2.12.0-0 <3.0.0'
   flutter: ">=1.10.0"
 
 dependencies:
   path: ^1.6.4
-  xdg_directories: ^0.1.0
-  path_provider_platform_interface: ^1.0.1
+  xdg_directories: ^0.2.0-nullsafety.0
+  path_provider_platform_interface: ^2.0.0-nullsafety
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
Migrating `path_provider_linux` to null-safety. Needed to migrate `shared_preferences`.

It contributes to fixing https://github.com/flutter/flutter/issues/74876.

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
