### PR TITLE
Automatically add platform labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -84,3 +84,27 @@
 
 'p: wifi_info_flutter':
   - packages/wifi_info_flutter/**/*
+
+'platform-android':
+  - packages/*/*_android/**/*
+  - packages/**/android/**/*
+
+'platform-ios':
+  - packages/*/*_ios/**/*
+  - packages/**/ios/**/*
+
+'platform-linux':
+  - packages/*/*_linux/**/*
+  - packages/**/linux/**/*
+
+'platform-macos':
+  - packages/*/*_macos/**/*
+  - packages/**/macos/**/*
+
+'platform-web':
+  - packages/*/*_web/**/*
+  - packages/**/web/**/*
+
+'platform-windows':
+  - packages/*/*_windows/**/*
+  - packages/**/windows/**/*


### PR DESCRIPTION
Tags PRs with platform-* labels based on the platform(s) being edited.
This will allow filtering open PRs by OS (e.g., to allow someone
focusing on a single platform's plugin implementations to easily find
all relevant PRs).