### PR TITLE
Revert "[path_provider_windows] Resolve FFI stabilization changes"

### DIFF
--- a/packages/path_provider/path_provider_windows/CHANGELOG.md
+++ b/packages/path_provider/path_provider_windows/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 0.1.0-nullsafety.1
-
-* Bump win32 dependency to latest version.
-
 ## 0.1.0-nullsafety
 
 * Migrate to null safety

--- a/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_real.dart
+++ b/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_real.dart
@@ -116,7 +116,7 @@ class PathProviderWindows extends PathProviderPlatform {
   /// [WindowsKnownFolder].
   Future<String> getPath(String folderID) {
     final pathPtrPtr = allocate<Pointer<Utf16>>();
-    final Pointer<GUID> knownFolderID = calloc<GUID>()..ref.setGUID(folderID);
+    final Pointer<GUID> knownFolderID = calloc<GUID>()..setGUID(folderID);
 
     try {
       final hr = SHGetKnownFolderPath(

--- a/packages/path_provider/path_provider_windows/pubspec.yaml
+++ b/packages/path_provider/path_provider_windows/pubspec.yaml
@@ -1,7 +1,7 @@
 name: path_provider_windows
 description: Windows implementation of the path_provider plugin
 homepage: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider_windows
-version: 0.1.0-nullsafety.1
+version: 0.1.0-nullsafety
 
 flutter:
   plugin:
@@ -17,7 +17,7 @@ dependencies:
   flutter:
     sdk: flutter
   ffi: ^0.2.0-nullsafety.1
-  win32: ^2.0.0-nullsafety.9
+  win32: ^2.0.0-nullsafety.8
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Reverts flutter/plugins#3485 to fix the tree.
```dart
Running command: "pub global run tuneup check" in /b/s/w/ir/tmp/t/pluginsFHFRRF/packages/path_provider/path_provider_windows
Checking project path_provider_windows...

  error - The method 'setGUID' isn't defined for the type 'Pointer' at lib/src/path_provider_windows_real.dart:119:57 - (undefined_method)

1 issue found; analyzed 11 source files in 4.0s.
```

https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8856572090238051232/+/steps/run_test.dart_for_flutter_plugins_shard_and_subshard_analyze/0/stdout

CC @timsneath @stuartmorgan 