### PR TITLE
Remove Dart stubs from macOS plugins

### DIFF
--- a/packages/connectivity/connectivity_macos/CHANGELOG.md
+++ b/packages/connectivity/connectivity_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0-nullsafety.1
+
+* Remove placeholder Dart file.
+
 ## 0.2.0-nullsafety
 
 * Update Dart SDK constraint.

--- a/packages/connectivity/connectivity_macos/lib/connectivity_macos.dart
+++ b/packages/connectivity/connectivity_macos/lib/connectivity_macos.dart
@@ -1,3 +1,0 @@
-// Analyze will fail if there is no main.dart file. This file should
-// be removed once an example app has been added to connectivity_macos.
-// https://github.com/flutter/flutter/issues/51007

--- a/packages/connectivity/connectivity_macos/pubspec.yaml
+++ b/packages/connectivity/connectivity_macos/pubspec.yaml
@@ -3,7 +3,7 @@ description: macOS implementation of the connectivity plugin.
 # 0.1.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.2.0-nullsafety
+version: 0.2.0-nullsafety.1
 homepage: https://github.com/flutter/plugins/tree/master/packages/connectivity/connectivity_macos
 
 flutter:

--- a/packages/path_provider/path_provider_macos/CHANGELOG.md
+++ b/packages/path_provider/path_provider_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.4+9
+
+* Remove placeholder Dart file.
+
 ## 0.0.4+8
 
 * Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.

--- a/packages/path_provider/path_provider_macos/lib/path_provider_macos.dart
+++ b/packages/path_provider/path_provider_macos/lib/path_provider_macos.dart
@@ -1,3 +1,0 @@
-// Analyze will fail if there is no main.dart file. This file should
-// be removed once an example app has been added to path_provider_macos.
-// https://github.com/flutter/flutter/issues/51007

--- a/packages/path_provider/path_provider_macos/pubspec.yaml
+++ b/packages/path_provider/path_provider_macos/pubspec.yaml
@@ -3,7 +3,7 @@ description: macOS implementation of the path_provider plugin
 # 0.0.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.0.4+8
+version: 0.0.4+9
 homepage: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider_macos
 
 flutter:


### PR DESCRIPTION
When these federated plugins were created, plugins had to have at least
one Dart file to avoid issues with the analyzer, so were created with a
stub file since all the code is native. The analyzer no longer has this
limitation, so the stub is no longer necesssary.