### PR TITLE
Remove cyanglaz from CODEOWNER: google_sign_in, connectivity, package_info, video_player

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,19 +8,19 @@ packages/android_alarm_manager/**              @bkonyi
 packages/android_intent/**                     @mklim @matthew-carroll
 packages/battery/**                            @matthew-carroll
 packages/camera/**                             @bparrishMines
-packages/connectivity/**                       @cyanglaz @matthew-carroll
+packages/connectivity/**                       @matthew-carroll
 packages/cross_file/**                         @ditman @mvanbeusekom
 packages/device_info/**                        @matthew-carroll
 packages/espresso/**                           @collinjackson @adazh
 packages/file_selector/**                      @ditman
 packages/google_maps_flutter/**                @cyanglaz
-packages/google_sign_in/**                     @cyanglaz @mehmetf
+packages/google_sign_in/**                     @mehmetf
 packages/image_picker/**                       @cyanglaz
 packages/integration_test/**                   @dnfield
 packages/in_app_purchase/**                    @mklim @cyanglaz @LHLL
 packages/ios_platform_images/**                @gaaclarke
-packages/package_info/**                       @cyanglaz @matthew-carroll
+packages/package_info/**                       @matthew-carroll
 packages/path_provider/**                      @matthew-carroll
 packages/shared_preferences/**                 @matthew-carroll
 packages/url_launcher/**                       @mklim
-packages/video_player/**                       @iskakaushik @cyanglaz
+packages/video_player/**                       @iskakaushik


### PR DESCRIPTION
Removing myself from some of the plugins that I won't have time to promptly check requested reviews.