### PR TITLE
[camera_platform_interface] Migrate to null safety

### DIFF
--- a/packages/camera/camera_platform_interface/CHANGELOG.md
+++ b/packages/camera/camera_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-nullsafety.0
+
+- Migrate to null safety.
+
 ## 1.6.0
 
 - Added VideoRecordedEvent to support ending a video recording in the native implementation. 

--- a/packages/camera/camera_platform_interface/CHANGELOG.md
+++ b/packages/camera/camera_platform_interface/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.0-nullsafety.0
+## 2.0.0-nullsafety
 
 - Migrate to null safety.
 

--- a/packages/camera/camera_platform_interface/lib/src/events/camera_event.dart
+++ b/packages/camera/camera_platform_interface/lib/src/events/camera_event.dart
@@ -71,9 +71,9 @@ class CameraInitializedEvent extends CameraEvent {
     int cameraId,
     this.previewWidth,
     this.previewHeight, [
-    this.exposureMode,
+    this.exposureMode = ExposureMode.auto,
     this.exposurePointSupported = false,
-    this.focusMode,
+    this.focusMode = FocusMode.auto,
     this.focusPointSupported = false,
   ]) : super(cameraId);
 

--- a/packages/camera/camera_platform_interface/lib/src/events/camera_event.dart
+++ b/packages/camera/camera_platform_interface/lib/src/events/camera_event.dart
@@ -242,7 +242,7 @@ class VideoRecordedEvent extends CameraEvent {
   final XFile file;
 
   /// Maximum duration of the recorded video.
-  final Duration maxVideoDuration;
+  final Duration? maxVideoDuration;
 
   /// Build a VideoRecordedEvent triggered from the camera with the `cameraId`.
   ///

--- a/packages/camera/camera_platform_interface/lib/src/events/camera_event.dart
+++ b/packages/camera/camera_platform_interface/lib/src/events/camera_event.dart
@@ -70,12 +70,12 @@ class CameraInitializedEvent extends CameraEvent {
   CameraInitializedEvent(
     int cameraId,
     this.previewWidth,
-    this.previewHeight, [
-    this.exposureMode = ExposureMode.auto,
-    this.exposurePointSupported = false,
-    this.focusMode = FocusMode.auto,
-    this.focusPointSupported = false,
-  ]) : super(cameraId);
+    this.previewHeight,
+    this.exposureMode,
+    this.exposurePointSupported,
+    this.focusMode,
+    this.focusPointSupported,
+  ) : super(cameraId);
 
   /// Converts the supplied [Map] to an instance of the [CameraInitializedEvent]
   /// class.

--- a/packages/camera/camera_platform_interface/lib/src/method_channel/method_channel_camera.dart
+++ b/packages/camera/camera_platform_interface/lib/src/method_channel/method_channel_camera.dart
@@ -131,15 +131,16 @@ class MethodChannelCamera extends CameraPlatform {
 
   @override
   Future<void> dispose(int cameraId) async {
+    if (_channels.containsKey(cameraId)) {
+      final cameraChannel = _channels[cameraId];
+      cameraChannel?.setMethodCallHandler(null);
+      _channels.remove(cameraId);
+    }
+
     await _channel.invokeMethod<void>(
       'dispose',
       <String, dynamic>{'cameraId': cameraId},
     );
-
-    if (_channels.containsKey(cameraId)) {
-      _channels[cameraId]!.setMethodCallHandler(null);
-      _channels.remove(cameraId);
-    }
   }
 
   @override

--- a/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
+++ b/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
@@ -51,8 +51,8 @@ abstract class CameraPlatform extends PlatformInterface {
   /// Creates an uninitialized camera instance and returns the cameraId.
   Future<int> createCamera(
     CameraDescription cameraDescription,
-    ResolutionPreset resolutionPreset, {
-    bool enableAudio,
+    ResolutionPreset? resolutionPreset, {
+    bool enableAudio = true,
   }) {
     throw UnimplementedError('createCamera() is not implemented.');
   }
@@ -62,8 +62,10 @@ abstract class CameraPlatform extends PlatformInterface {
   /// [imageFormatGroup] is used to specify the image formatting used.
   /// On Android this defaults to ImageFormat.YUV_420_888 and applies only to the imageStream.
   /// On iOS this defaults to kCVPixelFormatType_32BGRA.
-  Future<void> initializeCamera(int cameraId,
-      {ImageFormatGroup imageFormatGroup}) {
+  Future<void> initializeCamera(
+    int cameraId, {
+    ImageFormatGroup imageFormatGroup = ImageFormatGroup.unknown,
+  }) {
     throw UnimplementedError('initializeCamera() is not implemented.');
   }
 
@@ -130,7 +132,7 @@ abstract class CameraPlatform extends PlatformInterface {
   /// meaning the recording will continue until manually stopped.
   /// With [maxVideoDuration] set the video is returned in a [VideoRecordedEvent]
   /// through the [onVideoRecordedEvent] stream when the set duration is reached.
-  Future<void> startVideoRecording(int cameraId, {Duration maxVideoDuration}) {
+  Future<void> startVideoRecording(int cameraId, {Duration? maxVideoDuration}) {
     throw UnimplementedError('startVideoRecording() is not implemented.');
   }
 
@@ -160,7 +162,10 @@ abstract class CameraPlatform extends PlatformInterface {
   }
 
   /// Sets the exposure point for automatically determining the exposure values.
-  Future<void> setExposurePoint(int cameraId, Point<double> point) {
+  ///
+  /// Supplying `null` for the [point] argument will result in resetting to the
+  /// original exposure point value.
+  Future<void> setExposurePoint(int cameraId, Point<double>? point) {
     throw UnimplementedError('setExposurePoint() is not implemented.');
   }
 
@@ -202,7 +207,10 @@ abstract class CameraPlatform extends PlatformInterface {
   }
 
   /// Sets the focus point for automatically determining the focus values.
-  Future<void> setFocusPoint(int cameraId, Point<double> point) {
+  ///
+  /// Supplying `null` for the [point] argument will result in resetting to the
+  /// original focus point value.
+  Future<void> setFocusPoint(int cameraId, Point<double>? point) {
     throw UnimplementedError('setFocusPoint() is not implemented.');
   }
 

--- a/packages/camera/camera_platform_interface/lib/src/types/camera_description.dart
+++ b/packages/camera/camera_platform_interface/lib/src/types/camera_description.dart
@@ -17,7 +17,11 @@ enum CameraLensDirection {
 /// Properties of a camera device.
 class CameraDescription {
   /// Creates a new camera description with the given properties.
-  CameraDescription({this.name, this.lensDirection, this.sensorOrientation});
+  CameraDescription({
+    required this.name,
+    required this.lensDirection,
+    required this.sensorOrientation,
+  });
 
   /// The name of the camera device.
   final String name;

--- a/packages/camera/camera_platform_interface/lib/src/types/camera_exception.dart
+++ b/packages/camera/camera_platform_interface/lib/src/types/camera_exception.dart
@@ -13,7 +13,7 @@ class CameraException implements Exception {
   String code;
 
   /// Textual description of the error.
-  String description;
+  String? description;
 
   @override
   String toString() => 'CameraException($code, $description)';

--- a/packages/camera/camera_platform_interface/lib/src/types/exposure_mode.dart
+++ b/packages/camera/camera_platform_interface/lib/src/types/exposure_mode.dart
@@ -13,7 +13,6 @@ enum ExposureMode {
 
 /// Returns the exposure mode as a String.
 String serializeExposureMode(ExposureMode exposureMode) {
-  if (exposureMode == null) return null;
   switch (exposureMode) {
     case ExposureMode.locked:
       return 'locked';
@@ -26,7 +25,6 @@ String serializeExposureMode(ExposureMode exposureMode) {
 
 /// Returns the exposure mode for a given String.
 ExposureMode deserializeExposureMode(String str) {
-  if (str == null) return null;
   switch (str) {
     case "locked":
       return ExposureMode.locked;

--- a/packages/camera/camera_platform_interface/lib/src/types/focus_mode.dart
+++ b/packages/camera/camera_platform_interface/lib/src/types/focus_mode.dart
@@ -13,7 +13,6 @@ enum FocusMode {
 
 /// Returns the focus mode as a String.
 String serializeFocusMode(FocusMode focusMode) {
-  if (focusMode == null) return null;
   switch (focusMode) {
     case FocusMode.locked:
       return 'locked';
@@ -26,7 +25,6 @@ String serializeFocusMode(FocusMode focusMode) {
 
 /// Returns the focus mode for a given String.
 FocusMode deserializeFocusMode(String str) {
-  if (str == null) return null;
   switch (str) {
     case "locked":
       return FocusMode.locked;

--- a/packages/camera/camera_platform_interface/pubspec.yaml
+++ b/packages/camera/camera_platform_interface/pubspec.yaml
@@ -21,5 +21,5 @@ dev_dependencies:
   pedantic: ^1.10.0-nullsafety.3
 
 environment:
-  sdk: '>=2.12.0-133.7.beta <3.0.0'
+  sdk: '>=2.12.0-0 <3.0.0'
   flutter: ">=1.22.0"

--- a/packages/camera/camera_platform_interface/pubspec.yaml
+++ b/packages/camera/camera_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the camera plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/camera/camera_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.0.0-nullsafety.0
+version: 2.0.0-nullsafety
 
 dependencies:
   flutter:

--- a/packages/camera/camera_platform_interface/pubspec.yaml
+++ b/packages/camera/camera_platform_interface/pubspec.yaml
@@ -3,23 +3,23 @@ description: A common platform interface for the camera plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/camera/camera_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.6.0
+version: 2.0.0-nullsafety.0
 
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.0.5
-  plugin_platform_interface: ^1.0.1
-  cross_file: ^0.1.0
-  stream_transform: ^1.2.0
+  meta: ^1.3.0-nullsafety.6
+  plugin_platform_interface: ^1.1.0-nullsafety.2
+  cross_file: ^0.3.0-nullsafety
+  stream_transform: ^2.0.0-nullsafety.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  async: ^2.4.2
-  mockito: ^4.1.1
-  pedantic: ^1.8.0
+  async: ^2.5.0-nullsafety.3
+  mockito: ^5.0.0-nullsafety.5
+  pedantic: ^1.10.0-nullsafety.3
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: '>=2.12.0-133.7.beta <3.0.0'
   flutter: ">=1.22.0"

--- a/packages/camera/camera_platform_interface/test/camera_platform_interface_test.dart
+++ b/packages/camera/camera_platform_interface/test/camera_platform_interface_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:camera_platform_interface/camera_platform_interface.dart';
 import 'package:camera_platform_interface/src/method_channel/method_channel_camera.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
@@ -117,7 +118,8 @@ void main() {
 
       // Act & Assert
       expect(
-        () => cameraPlatform.lockCaptureOrientation(1, null),
+        () => cameraPlatform.lockCaptureOrientation(
+            1, DeviceOrientation.portraitUp),
         throwsUnimplementedError,
       );
     });
@@ -155,7 +157,14 @@ void main() {
 
       // Act & Assert
       expect(
-        () => cameraPlatform.createCamera(null, null),
+        () => cameraPlatform.createCamera(
+          CameraDescription(
+            name: 'back',
+            lensDirection: CameraLensDirection.back,
+            sensorOrientation: 0,
+          ),
+          ResolutionPreset.high,
+        ),
         throwsUnimplementedError,
       );
     });
@@ -168,7 +177,7 @@ void main() {
 
       // Act & Assert
       expect(
-        () => cameraPlatform.initializeCamera(null),
+        () => cameraPlatform.initializeCamera(1),
         throwsUnimplementedError,
       );
     });
@@ -220,7 +229,7 @@ void main() {
 
       // Act & Assert
       expect(
-        () => cameraPlatform.setFlashMode(1, null),
+        () => cameraPlatform.setFlashMode(1, FlashMode.auto),
         throwsUnimplementedError,
       );
     });
@@ -233,7 +242,7 @@ void main() {
 
       // Act & Assert
       expect(
-        () => cameraPlatform.setExposureMode(1, null),
+        () => cameraPlatform.setExposureMode(1, ExposureMode.auto),
         throwsUnimplementedError,
       );
     });
@@ -298,7 +307,7 @@ void main() {
 
       // Act & Assert
       expect(
-        () => cameraPlatform.setExposureOffset(1, null),
+        () => cameraPlatform.setExposureOffset(1, 2.0),
         throwsUnimplementedError,
       );
     });
@@ -311,7 +320,7 @@ void main() {
 
       // Act & Assert
       expect(
-        () => cameraPlatform.setFocusMode(1, null),
+        () => cameraPlatform.setFocusMode(1, FocusMode.auto),
         throwsUnimplementedError,
       );
     });

--- a/packages/camera/camera_platform_interface/test/method_channel/method_channel_camera_test.dart
+++ b/packages/camera/camera_platform_interface/test/method_channel/method_channel_camera_test.dart
@@ -376,7 +376,8 @@ void main() {
 
     group('Function Tests', () {
       late MethodChannelCamera camera;
-      int? cameraId;
+      late int cameraId;
+
       setUp(() async {
         MethodChannelMock(
           channelName: 'plugins.flutter.io/camera',
@@ -394,10 +395,10 @@ void main() {
           ),
           ResolutionPreset.high,
         );
-        Future<void> initializeFuture = camera.initializeCamera(cameraId!);
+        Future<void> initializeFuture = camera.initializeCamera(cameraId);
         camera.cameraEventStreamController.add(
           CameraInitializedEvent(
-            cameraId!,
+            cameraId,
             1920,
             1080,
             ExposureMode.auto,
@@ -470,7 +471,7 @@ void main() {
             methods: {'takePicture': '/test/path.jpg'});
 
         // Act
-        XFile file = await camera.takePicture(cameraId!);
+        XFile file = await camera.takePicture(cameraId);
 
         // Assert
         expect(channel.log, <Matcher>[
@@ -505,7 +506,7 @@ void main() {
         );
 
         // Act
-        await camera.startVideoRecording(cameraId!);
+        await camera.startVideoRecording(cameraId);
 
         // Assert
         expect(channel.log, <Matcher>[
@@ -526,7 +527,7 @@ void main() {
 
         // Act
         await camera.startVideoRecording(
-          cameraId!,
+          cameraId,
           maxVideoDuration: Duration(seconds: 10),
         );
 
@@ -545,7 +546,7 @@ void main() {
         );
 
         // Act
-        XFile file = await camera.stopVideoRecording(cameraId!);
+        XFile file = await camera.stopVideoRecording(cameraId);
 
         // Assert
         expect(channel.log, <Matcher>[
@@ -564,7 +565,7 @@ void main() {
         );
 
         // Act
-        await camera.pauseVideoRecording(cameraId!);
+        await camera.pauseVideoRecording(cameraId);
 
         // Assert
         expect(channel.log, <Matcher>[
@@ -582,7 +583,7 @@ void main() {
         );
 
         // Act
-        await camera.resumeVideoRecording(cameraId!);
+        await camera.resumeVideoRecording(cameraId);
 
         // Assert
         expect(channel.log, <Matcher>[
@@ -600,10 +601,10 @@ void main() {
         );
 
         // Act
-        await camera.setFlashMode(cameraId!, FlashMode.torch);
-        await camera.setFlashMode(cameraId!, FlashMode.always);
-        await camera.setFlashMode(cameraId!, FlashMode.auto);
-        await camera.setFlashMode(cameraId!, FlashMode.off);
+        await camera.setFlashMode(cameraId, FlashMode.torch);
+        await camera.setFlashMode(cameraId, FlashMode.always);
+        await camera.setFlashMode(cameraId, FlashMode.auto);
+        await camera.setFlashMode(cameraId, FlashMode.off);
 
         // Assert
         expect(channel.log, <Matcher>[
@@ -626,8 +627,8 @@ void main() {
         );
 
         // Act
-        await camera.setExposureMode(cameraId!, ExposureMode.auto);
-        await camera.setExposureMode(cameraId!, ExposureMode.locked);
+        await camera.setExposureMode(cameraId, ExposureMode.auto);
+        await camera.setExposureMode(cameraId, ExposureMode.locked);
 
         // Assert
         expect(channel.log, <Matcher>[
@@ -646,8 +647,8 @@ void main() {
         );
 
         // Act
-        await camera.setExposurePoint(cameraId!, Point<double>(0.5, 0.5));
-        await camera.setExposurePoint(cameraId!, null);
+        await camera.setExposurePoint(cameraId, Point<double>(0.5, 0.5));
+        await camera.setExposurePoint(cameraId, null);
 
         // Assert
         expect(channel.log, <Matcher>[
@@ -674,7 +675,7 @@ void main() {
         );
 
         // Act
-        final minExposureOffset = await camera.getMinExposureOffset(cameraId!);
+        final minExposureOffset = await camera.getMinExposureOffset(cameraId);
 
         // Assert
         expect(minExposureOffset, 2.0);
@@ -693,7 +694,7 @@ void main() {
         );
 
         // Act
-        final maxExposureOffset = await camera.getMaxExposureOffset(cameraId!);
+        final maxExposureOffset = await camera.getMaxExposureOffset(cameraId);
 
         // Assert
         expect(maxExposureOffset, 2.0);
@@ -712,7 +713,7 @@ void main() {
         );
 
         // Act
-        final stepSize = await camera.getExposureOffsetStepSize(cameraId!);
+        final stepSize = await camera.getExposureOffsetStepSize(cameraId);
 
         // Assert
         expect(stepSize, 0.25);
@@ -731,7 +732,7 @@ void main() {
         );
 
         // Act
-        final actualOffset = await camera.setExposureOffset(cameraId!, 0.5);
+        final actualOffset = await camera.setExposureOffset(cameraId, 0.5);
 
         // Assert
         expect(actualOffset, 0.6);
@@ -751,8 +752,8 @@ void main() {
         );
 
         // Act
-        await camera.setFocusMode(cameraId!, FocusMode.auto);
-        await camera.setFocusMode(cameraId!, FocusMode.locked);
+        await camera.setFocusMode(cameraId, FocusMode.auto);
+        await camera.setFocusMode(cameraId, FocusMode.locked);
 
         // Assert
         expect(channel.log, <Matcher>[
@@ -771,8 +772,8 @@ void main() {
         );
 
         // Act
-        await camera.setFocusPoint(cameraId!, Point<double>(0.5, 0.5));
-        await camera.setFocusPoint(cameraId!, null);
+        await camera.setFocusPoint(cameraId, Point<double>(0.5, 0.5));
+        await camera.setFocusPoint(cameraId, null);
 
         // Assert
         expect(channel.log, <Matcher>[
@@ -793,7 +794,7 @@ void main() {
 
       test('Should build a texture widget as preview widget', () async {
         // Act
-        Widget widget = camera.buildPreview(cameraId!);
+        Widget widget = camera.buildPreview(cameraId);
 
         // Act
         expect(widget is Texture, isTrue);
@@ -818,7 +819,7 @@ void main() {
         );
 
         // Act
-        final maxZoomLevel = await camera.getMaxZoomLevel(cameraId!);
+        final maxZoomLevel = await camera.getMaxZoomLevel(cameraId);
 
         // Assert
         expect(maxZoomLevel, 10.0);
@@ -837,7 +838,7 @@ void main() {
         );
 
         // Act
-        final maxZoomLevel = await camera.getMinZoomLevel(cameraId!);
+        final maxZoomLevel = await camera.getMinZoomLevel(cameraId);
 
         // Assert
         expect(maxZoomLevel, 1.0);
@@ -856,7 +857,7 @@ void main() {
         );
 
         // Act
-        await camera.setZoomLevel(cameraId!, 2.0);
+        await camera.setZoomLevel(cameraId, 2.0);
 
         // Assert
         expect(channel.log, <Matcher>[
@@ -881,7 +882,7 @@ void main() {
 
         // Act & assert
         expect(
-            () => camera.setZoomLevel(cameraId!, -1.0),
+            () => camera.setZoomLevel(cameraId, -1.0),
             throwsA(isA<CameraException>()
                 .having((e) => e.code, 'code', 'ZOOM_ERROR')
                 .having((e) => e.description, 'description',
@@ -897,7 +898,7 @@ void main() {
 
         // Act
         await camera.lockCaptureOrientation(
-            cameraId!, DeviceOrientation.portraitUp);
+            cameraId, DeviceOrientation.portraitUp);
 
         // Assert
         expect(channel.log, <Matcher>[
@@ -914,7 +915,7 @@ void main() {
         );
 
         // Act
-        await camera.unlockCaptureOrientation(cameraId!);
+        await camera.unlockCaptureOrientation(cameraId);
 
         // Assert
         expect(channel.log, <Matcher>[

--- a/packages/camera/camera_platform_interface/test/method_channel/method_channel_camera_test.dart
+++ b/packages/camera/camera_platform_interface/test/method_channel/method_channel_camera_test.dart
@@ -37,7 +37,10 @@ void main() {
 
         // Act
         final cameraId = await camera.createCamera(
-          CameraDescription(name: 'Test'),
+          CameraDescription(
+              name: 'Test',
+              lensDirection: CameraLensDirection.back,
+              sensorOrientation: 0),
           ResolutionPreset.high,
         );
 
@@ -48,7 +51,7 @@ void main() {
             arguments: {
               'cameraName': 'Test',
               'resolutionPreset': 'high',
-              'enableAudio': null
+              'enableAudio': true
             },
           ),
         ]);
@@ -70,7 +73,11 @@ void main() {
         // Act
         expect(
           () => camera.createCamera(
-            CameraDescription(name: 'Test'),
+            CameraDescription(
+              name: 'Test',
+              lensDirection: CameraLensDirection.back,
+              sensorOrientation: 0,
+            ),
             ResolutionPreset.high,
           ),
           throwsA(
@@ -97,7 +104,11 @@ void main() {
         // Act
         expect(
           () => camera.createCamera(
-            CameraDescription(name: 'Test'),
+            CameraDescription(
+              name: 'Test',
+              lensDirection: CameraLensDirection.back,
+              sensorOrientation: 0,
+            ),
             ResolutionPreset.high,
           ),
           throwsA(
@@ -122,7 +133,11 @@ void main() {
             });
         final camera = MethodChannelCamera();
         final cameraId = await camera.createCamera(
-          CameraDescription(name: 'Test'),
+          CameraDescription(
+            name: 'Test',
+            lensDirection: CameraLensDirection.back,
+            sensorOrientation: 0,
+          ),
           ResolutionPreset.high,
         );
 
@@ -165,7 +180,11 @@ void main() {
 
         final camera = MethodChannelCamera();
         final cameraId = await camera.createCamera(
-          CameraDescription(name: 'Test'),
+          CameraDescription(
+            name: 'Test',
+            lensDirection: CameraLensDirection.back,
+            sensorOrientation: 0,
+          ),
           ResolutionPreset.high,
         );
         Future<void> initializeFuture = camera.initializeCamera(cameraId);
@@ -197,8 +216,8 @@ void main() {
     });
 
     group('Event Tests', () {
-      MethodChannelCamera camera;
-      int cameraId;
+      late MethodChannelCamera camera;
+      late int cameraId;
       setUp(() async {
         MethodChannelMock(
           channelName: 'plugins.flutter.io/camera',
@@ -209,7 +228,11 @@ void main() {
         );
         camera = MethodChannelCamera();
         cameraId = await camera.createCamera(
-          CameraDescription(name: 'Test'),
+          CameraDescription(
+            name: 'Test',
+            lensDirection: CameraLensDirection.back,
+            sensorOrientation: 0,
+          ),
           ResolutionPreset.high,
         );
         Future<void> initializeFuture = camera.initializeCamera(cameraId);
@@ -352,8 +375,8 @@ void main() {
     });
 
     group('Function Tests', () {
-      MethodChannelCamera camera;
-      int cameraId;
+      late MethodChannelCamera camera;
+      int? cameraId;
       setUp(() async {
         MethodChannelMock(
           channelName: 'plugins.flutter.io/camera',
@@ -364,13 +387,17 @@ void main() {
         );
         camera = MethodChannelCamera();
         cameraId = await camera.createCamera(
-          CameraDescription(name: 'Test'),
+          CameraDescription(
+            name: 'Test',
+            lensDirection: CameraLensDirection.back,
+            sensorOrientation: 0,
+          ),
           ResolutionPreset.high,
         );
-        Future<void> initializeFuture = camera.initializeCamera(cameraId);
+        Future<void> initializeFuture = camera.initializeCamera(cameraId!);
         camera.cameraEventStreamController.add(
           CameraInitializedEvent(
-            cameraId,
+            cameraId!,
             1920,
             1080,
             ExposureMode.auto,
@@ -443,7 +470,7 @@ void main() {
             methods: {'takePicture': '/test/path.jpg'});
 
         // Act
-        XFile file = await camera.takePicture(cameraId);
+        XFile file = await camera.takePicture(cameraId!);
 
         // Assert
         expect(channel.log, <Matcher>[
@@ -478,7 +505,7 @@ void main() {
         );
 
         // Act
-        await camera.startVideoRecording(cameraId);
+        await camera.startVideoRecording(cameraId!);
 
         // Assert
         expect(channel.log, <Matcher>[
@@ -499,7 +526,7 @@ void main() {
 
         // Act
         await camera.startVideoRecording(
-          cameraId,
+          cameraId!,
           maxVideoDuration: Duration(seconds: 10),
         );
 
@@ -518,7 +545,7 @@ void main() {
         );
 
         // Act
-        XFile file = await camera.stopVideoRecording(cameraId);
+        XFile file = await camera.stopVideoRecording(cameraId!);
 
         // Assert
         expect(channel.log, <Matcher>[
@@ -537,7 +564,7 @@ void main() {
         );
 
         // Act
-        await camera.pauseVideoRecording(cameraId);
+        await camera.pauseVideoRecording(cameraId!);
 
         // Assert
         expect(channel.log, <Matcher>[
@@ -555,7 +582,7 @@ void main() {
         );
 
         // Act
-        await camera.resumeVideoRecording(cameraId);
+        await camera.resumeVideoRecording(cameraId!);
 
         // Assert
         expect(channel.log, <Matcher>[
@@ -573,10 +600,10 @@ void main() {
         );
 
         // Act
-        await camera.setFlashMode(cameraId, FlashMode.torch);
-        await camera.setFlashMode(cameraId, FlashMode.always);
-        await camera.setFlashMode(cameraId, FlashMode.auto);
-        await camera.setFlashMode(cameraId, FlashMode.off);
+        await camera.setFlashMode(cameraId!, FlashMode.torch);
+        await camera.setFlashMode(cameraId!, FlashMode.always);
+        await camera.setFlashMode(cameraId!, FlashMode.auto);
+        await camera.setFlashMode(cameraId!, FlashMode.off);
 
         // Assert
         expect(channel.log, <Matcher>[
@@ -599,8 +626,8 @@ void main() {
         );
 
         // Act
-        await camera.setExposureMode(cameraId, ExposureMode.auto);
-        await camera.setExposureMode(cameraId, ExposureMode.locked);
+        await camera.setExposureMode(cameraId!, ExposureMode.auto);
+        await camera.setExposureMode(cameraId!, ExposureMode.locked);
 
         // Assert
         expect(channel.log, <Matcher>[
@@ -619,8 +646,8 @@ void main() {
         );
 
         // Act
-        await camera.setExposurePoint(cameraId, Point<double>(0.5, 0.5));
-        await camera.setExposurePoint(cameraId, null);
+        await camera.setExposurePoint(cameraId!, Point<double>(0.5, 0.5));
+        await camera.setExposurePoint(cameraId!, null);
 
         // Assert
         expect(channel.log, <Matcher>[
@@ -647,7 +674,7 @@ void main() {
         );
 
         // Act
-        final minExposureOffset = await camera.getMinExposureOffset(cameraId);
+        final minExposureOffset = await camera.getMinExposureOffset(cameraId!);
 
         // Assert
         expect(minExposureOffset, 2.0);
@@ -666,7 +693,7 @@ void main() {
         );
 
         // Act
-        final maxExposureOffset = await camera.getMaxExposureOffset(cameraId);
+        final maxExposureOffset = await camera.getMaxExposureOffset(cameraId!);
 
         // Assert
         expect(maxExposureOffset, 2.0);
@@ -685,7 +712,7 @@ void main() {
         );
 
         // Act
-        final stepSize = await camera.getExposureOffsetStepSize(cameraId);
+        final stepSize = await camera.getExposureOffsetStepSize(cameraId!);
 
         // Assert
         expect(stepSize, 0.25);
@@ -704,7 +731,7 @@ void main() {
         );
 
         // Act
-        final actualOffset = await camera.setExposureOffset(cameraId, 0.5);
+        final actualOffset = await camera.setExposureOffset(cameraId!, 0.5);
 
         // Assert
         expect(actualOffset, 0.6);
@@ -724,8 +751,8 @@ void main() {
         );
 
         // Act
-        await camera.setFocusMode(cameraId, FocusMode.auto);
-        await camera.setFocusMode(cameraId, FocusMode.locked);
+        await camera.setFocusMode(cameraId!, FocusMode.auto);
+        await camera.setFocusMode(cameraId!, FocusMode.locked);
 
         // Assert
         expect(channel.log, <Matcher>[
@@ -744,8 +771,8 @@ void main() {
         );
 
         // Act
-        await camera.setFocusPoint(cameraId, Point<double>(0.5, 0.5));
-        await camera.setFocusPoint(cameraId, null);
+        await camera.setFocusPoint(cameraId!, Point<double>(0.5, 0.5));
+        await camera.setFocusPoint(cameraId!, null);
 
         // Assert
         expect(channel.log, <Matcher>[
@@ -766,7 +793,7 @@ void main() {
 
       test('Should build a texture widget as preview widget', () async {
         // Act
-        Widget widget = camera.buildPreview(cameraId);
+        Widget widget = camera.buildPreview(cameraId!);
 
         // Act
         expect(widget is Texture, isTrue);
@@ -791,7 +818,7 @@ void main() {
         );
 
         // Act
-        final maxZoomLevel = await camera.getMaxZoomLevel(cameraId);
+        final maxZoomLevel = await camera.getMaxZoomLevel(cameraId!);
 
         // Assert
         expect(maxZoomLevel, 10.0);
@@ -810,7 +837,7 @@ void main() {
         );
 
         // Act
-        final maxZoomLevel = await camera.getMinZoomLevel(cameraId);
+        final maxZoomLevel = await camera.getMinZoomLevel(cameraId!);
 
         // Assert
         expect(maxZoomLevel, 1.0);
@@ -829,7 +856,7 @@ void main() {
         );
 
         // Act
-        await camera.setZoomLevel(cameraId, 2.0);
+        await camera.setZoomLevel(cameraId!, 2.0);
 
         // Assert
         expect(channel.log, <Matcher>[
@@ -854,7 +881,7 @@ void main() {
 
         // Act & assert
         expect(
-            () => camera.setZoomLevel(cameraId, -1.0),
+            () => camera.setZoomLevel(cameraId!, -1.0),
             throwsA(isA<CameraException>()
                 .having((e) => e.code, 'code', 'ZOOM_ERROR')
                 .having((e) => e.description, 'description',
@@ -870,7 +897,7 @@ void main() {
 
         // Act
         await camera.lockCaptureOrientation(
-            cameraId, DeviceOrientation.portraitUp);
+            cameraId!, DeviceOrientation.portraitUp);
 
         // Assert
         expect(channel.log, <Matcher>[
@@ -887,7 +914,7 @@ void main() {
         );
 
         // Act
-        await camera.unlockCaptureOrientation(cameraId);
+        await camera.unlockCaptureOrientation(cameraId!);
 
         // Assert
         expect(channel.log, <Matcher>[

--- a/packages/camera/camera_platform_interface/test/utils/method_channel_mock.dart
+++ b/packages/camera/camera_platform_interface/test/utils/method_channel_mock.dart
@@ -5,15 +5,15 @@
 import 'package:flutter/services.dart';
 
 class MethodChannelMock {
-  final Duration delay;
+  final Duration? delay;
   final MethodChannel methodChannel;
   final Map<String, dynamic> methods;
   final log = <MethodCall>[];
 
   MethodChannelMock({
-    String channelName,
+    required String channelName,
     this.delay,
-    this.methods,
+    required this.methods,
   }) : methodChannel = MethodChannel(channelName) {
     methodChannel.setMockMethodCallHandler(_handler);
   }

--- a/script/build_all_plugins_app.sh
+++ b/script/build_all_plugins_app.sh
@@ -19,12 +19,7 @@ source "$SCRIPT_DIR/nnbd_plugins.sh"
 check_changed_packages > /dev/null
 
 readonly EXCLUDED_PLUGINS_LIST=(
-<<<<<<< HEAD
   "camera_platform_interface"
-||||||| constructed merge base
-=======
-  "camera_platform_interface",
->>>>>>> Attempt to fix dependency problem building all plugins
   "connectivity_macos"
   "connectivity_platform_interface"
   "connectivity_web"

--- a/script/build_all_plugins_app.sh
+++ b/script/build_all_plugins_app.sh
@@ -19,7 +19,6 @@ source "$SCRIPT_DIR/nnbd_plugins.sh"
 check_changed_packages > /dev/null
 
 readonly EXCLUDED_PLUGINS_LIST=(
-  "camera_platform_interface"
   "connectivity_macos"
   "connectivity_platform_interface"
   "connectivity_web"

--- a/script/build_all_plugins_app.sh
+++ b/script/build_all_plugins_app.sh
@@ -19,7 +19,12 @@ source "$SCRIPT_DIR/nnbd_plugins.sh"
 check_changed_packages > /dev/null
 
 readonly EXCLUDED_PLUGINS_LIST=(
+<<<<<<< HEAD
   "camera_platform_interface"
+||||||| constructed merge base
+=======
+  "camera_platform_interface",
+>>>>>>> Attempt to fix dependency problem building all plugins
   "connectivity_macos"
   "connectivity_platform_interface"
   "connectivity_web"

--- a/script/build_all_plugins_app.sh
+++ b/script/build_all_plugins_app.sh
@@ -19,6 +19,7 @@ source "$SCRIPT_DIR/nnbd_plugins.sh"
 check_changed_packages > /dev/null
 
 readonly EXCLUDED_PLUGINS_LIST=(
+  "camera_platform_interface"
   "connectivity_macos"
   "connectivity_platform_interface"
   "connectivity_web"

--- a/script/nnbd_plugins.sh
+++ b/script/nnbd_plugins.sh
@@ -7,7 +7,7 @@
 readonly NNBD_PLUGINS_LIST=(
   "android_intent"
   "battery"
-  "camera_platform_interface"
+  "camera"
   "connectivity"
   "cross_file"
   "device_info"

--- a/script/nnbd_plugins.sh
+++ b/script/nnbd_plugins.sh
@@ -7,6 +7,7 @@
 readonly NNBD_PLUGINS_LIST=(
   "android_intent"
   "battery"
+  "camera_platform_interface"
   "connectivity"
   "cross_file"
   "device_info"

--- a/script/nnbd_plugins.sh
+++ b/script/nnbd_plugins.sh
@@ -7,7 +7,7 @@
 readonly NNBD_PLUGINS_LIST=(
   "android_intent"
   "battery"
-  "camera"
+  "camera_platform_interface"
   "connectivity"
   "cross_file"
   "device_info"

--- a/script/nnbd_plugins.sh
+++ b/script/nnbd_plugins.sh
@@ -34,7 +34,7 @@ readonly NNBD_PLUGINS_LIST=(
 readonly NON_NNBD_PLUGINS_LIST=(
   # "android_alarm_manager"
   "camera"
-  # "google_maps_flutter"
+  "google_maps_flutter"
   # "image_picker"
   # "in_app_purchase"
   # "quick_actions"

--- a/script/nnbd_plugins.sh
+++ b/script/nnbd_plugins.sh
@@ -7,7 +7,6 @@
 readonly NNBD_PLUGINS_LIST=(
   "android_intent"
   "battery"
-  "camera_platform_interface"
   "connectivity"
   "cross_file"
   "device_info"
@@ -34,7 +33,7 @@ readonly NNBD_PLUGINS_LIST=(
 readonly NON_NNBD_PLUGINS_LIST=(
   # "android_alarm_manager"
   "camera"
-  "google_maps_flutter"
+  # "google_maps_flutter"
   # "image_picker"
   # "in_app_purchase"
   # "quick_actions"

--- a/script/nnbd_plugins.sh
+++ b/script/nnbd_plugins.sh
@@ -7,6 +7,7 @@
 readonly NNBD_PLUGINS_LIST=(
   "android_intent"
   "battery"
+  "camera"
   "connectivity"
   "cross_file"
   "device_info"


### PR DESCRIPTION
This PR migrates the `camera_platform_interface` package to null safety.

flutter/flutter#75228
flutter/flutter#75247

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
