### PR TITLE
[camera_platform_interface] Added VideoRecordedEvent

### DIFF
--- a/packages/camera/camera_platform_interface/CHANGELOG.md
+++ b/packages/camera/camera_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.1
+
+- Added VideoRecordedEvent to support ending a video recording in the native implementation. 
+
 ## 1.5.0
 
 - Introduces interface methods for locking and unlocking the capture orientation.

--- a/packages/camera/camera_platform_interface/lib/src/events/camera_event.dart
+++ b/packages/camera/camera_platform_interface/lib/src/events/camera_event.dart
@@ -235,3 +235,48 @@ class CameraErrorEvent extends CameraEvent {
   @override
   int get hashCode => super.hashCode ^ description.hashCode;
 }
+
+/// An event fired when a video has finished recording.
+class VideoRecordedEvent extends CameraEvent {
+  /// XFile of the recorded video.
+  final XFile file;
+  /// Maximum duration of the recorded video.
+  final Duration maxVideoDuration;
+
+  /// Build a VideoRecordedEvent triggered from the camera with the `cameraId`.
+  ///
+  /// The `file` represents the file of the video.
+  /// The `maxVideoDuration` shows if a maxVideoDuration shows if a maximum
+  /// video duration was set.
+  VideoRecordedEvent(int cameraId, this.file, this.maxVideoDuration)
+      : super(cameraId);
+
+  /// Converts the supplied [Map] to an instance of the [VideoRecordedEvent]
+  /// class.
+  VideoRecordedEvent.fromJson(Map<String, dynamic> json)
+      : file = XFile(json['path']),
+        maxVideoDuration = json['maxVideoDuration'] != null
+            ? Duration(milliseconds: json['maxVideoDuration'] as int)
+            : null,
+        super(json['cameraId']);
+
+  /// Converts the [VideoRecordedEvent] instance into a [Map] instance that can be
+  /// serialized to JSON.
+  Map<String, dynamic> toJson() => {
+        'cameraId': cameraId,
+        'path': file.path,
+        'maxVideoDuration': maxVideoDuration?.inMilliseconds
+      };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      super == other &&
+          other is VideoRecordedEvent &&
+          runtimeType == other.runtimeType &&
+          maxVideoDuration == other.maxVideoDuration;
+
+  @override
+  int get hashCode =>
+      super.hashCode ^ file.hashCode ^ maxVideoDuration.hashCode;
+}

--- a/packages/camera/camera_platform_interface/lib/src/method_channel/method_channel_camera.dart
+++ b/packages/camera/camera_platform_interface/lib/src/method_channel/method_channel_camera.dart
@@ -14,6 +14,7 @@ import 'package:cross_file/cross_file.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
+import 'package:pedantic/pedantic.dart';
 import 'package:stream_transform/stream_transform.dart';
 
 const MethodChannel _channel = MethodChannel('plugins.flutter.io/camera');
@@ -157,6 +158,11 @@ class MethodChannelCamera extends CameraPlatform {
   }
 
   @override
+  Stream<VideoRecordedEvent> onVideoRecordedEvent(int cameraId) {
+    return _cameraEvents(cameraId).whereType<VideoRecordedEvent>();
+  }
+
+  @override
   Stream<DeviceOrientationChangedEvent> onDeviceOrientationChanged() {
     return deviceEventStreamController.stream
         .whereType<DeviceOrientationChangedEvent>();
@@ -209,11 +215,15 @@ class MethodChannelCamera extends CameraPlatform {
 
   @override
   Future<XFile> stopVideoRecording(int cameraId) async {
-    String path = await _channel.invokeMethod<String>(
+    Completer<XFile> completer = Completer();
+    unawaited(onVideoRecordedEvent(cameraId)
+        .first
+        .then((event) => completer.complete(event.file)));
+    unawaited(_channel.invokeMethod<void>(
       'stopVideoRecording',
       <String, dynamic>{'cameraId': cameraId},
-    );
-    return XFile(path);
+    ));
+    return completer.future;
   }
 
   @override
@@ -419,6 +429,15 @@ class MethodChannelCamera extends CameraPlatform {
           call.arguments['exposurePointSupported'],
           deserializeFocusMode(call.arguments['focusMode']),
           call.arguments['focusPointSupported'],
+        ));
+        break;
+      case 'video_recorded':
+        cameraEventStreamController.add(VideoRecordedEvent(
+          cameraId,
+          XFile(call.arguments['path']),
+          call.arguments['maxVideoDuration'] != null
+              ? Duration(milliseconds: call.arguments['maxVideoDuration'])
+              : null,
         ));
         break;
       case 'resolution_changed':

--- a/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
+++ b/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
@@ -87,6 +87,11 @@ abstract class CameraPlatform extends PlatformInterface {
     throw UnimplementedError('onCameraError() is not implemented.');
   }
 
+  /// The camera finished recording a video
+  Stream<VideoRecordedEvent> onVideoRecordedEvent(int cameraId) {
+    throw UnimplementedError('onCameraTimeLimitReached() is not implemented.');
+  }
+
   /// The device orientation changed.
   ///
   /// Implementations for this:

--- a/packages/camera/camera_platform_interface/pubspec.yaml
+++ b/packages/camera/camera_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the camera plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/camera/camera_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.5.0
+version: 1.5.1
 
 dependencies:
   flutter:


### PR DESCRIPTION
Added a VideoRecordedEvent to make it possible to return a recorded video on the native side without calling stopVideoRecording. 

This PR is an addition to #3365.
This PR is needed for the implementation of #3403.
This is needed to solve [#23414](https://github.com/flutter/flutter/issues/23414).

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
