### PR TITLE
[shared_preferences] Update macOS for NNBD

### DIFF
--- a/packages/shared_preferences/shared_preferences_macos/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.2-nullsafety
+
+* Update Dart SDK constraint for null safety.
+
 ## 0.0.1+12
 
 * Update Flutter SDK constraint.

--- a/packages/shared_preferences/shared_preferences_macos/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_macos/pubspec.yaml
@@ -3,7 +3,7 @@ description: macOS implementation of the shared_preferences plugin.
 # 0.0.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.0.1+12
+version: 0.0.2-nullsafety
 homepage: https://github.com/flutter/plugins/tree/master/packages/shared_preferences/shared_preferences_macos
 
 flutter:
@@ -13,11 +13,11 @@ flutter:
         pluginClass: SharedPreferencesPlugin
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"
   flutter: ">=1.12.8"
 
 dependencies:
-  shared_preferences_platform_interface: ^1.0.0
+  shared_preferences_platform_interface: ^2.0.0-nullsafety
   flutter:
     sdk: flutter
 dev_dependencies:


### PR DESCRIPTION
macOS federated plugin implementations that contain no Dart code just
need their Dart SDK bumped in order to be considered nullsafe.

Part of https://github.com/flutter/flutter/issues/74876


## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
