### PR TITLE
 [image_picker] Migrate Image_picker_platform interface to Null Safety

### DIFF
--- a/packages/image_picker/image_picker_platform_interface/CHANGELOG.md
+++ b/packages/image_picker/image_picker_platform_interface/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.0-nullsafety
+
+* Migrate to null safety.
 ## 1.1.6
 
 * Fix test asset file location.

--- a/packages/image_picker/image_picker_platform_interface/lib/src/method_channel/method_channel_image_picker.dart
+++ b/packages/image_picker/image_picker_platform_interface/lib/src/method_channel/method_channel_image_picker.dart
@@ -7,7 +7,7 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
-import 'package:meta/meta.dart' show required, visibleForTesting;
+import 'package:meta/meta.dart' show  visibleForTesting;
 
 import 'package:image_picker_platform_interface/image_picker_platform_interface.dart';
 
@@ -20,14 +20,14 @@ class MethodChannelImagePicker extends ImagePickerPlatform {
   MethodChannel get channel => _channel;
 
   @override
-  Future<PickedFile> pickImage({
-    @required ImageSource source,
-    double maxWidth,
-    double maxHeight,
-    int imageQuality,
+  Future<PickedFile?> pickImage({
+    required ImageSource source,
+    double? maxWidth,
+    double? maxHeight,
+    int? imageQuality,
     CameraDevice preferredCameraDevice = CameraDevice.rear,
   }) async {
-    String path = await pickImagePath(
+    String? path = await pickImagePath(
       source: source,
       maxWidth: maxWidth,
       maxHeight: maxHeight,
@@ -38,14 +38,14 @@ class MethodChannelImagePicker extends ImagePickerPlatform {
   }
 
   @override
-  Future<String> pickImagePath({
-    @required ImageSource source,
-    double maxWidth,
-    double maxHeight,
-    int imageQuality,
+  Future<String?> pickImagePath({
+    required ImageSource source,
+    double? maxWidth,
+    double? maxHeight,
+    int? imageQuality,
     CameraDevice preferredCameraDevice = CameraDevice.rear,
   }) {
-    assert(source != null);
+
     if (imageQuality != null && (imageQuality < 0 || imageQuality > 100)) {
       throw ArgumentError.value(
           imageQuality, 'imageQuality', 'must be between 0 and 100');
@@ -72,12 +72,12 @@ class MethodChannelImagePicker extends ImagePickerPlatform {
   }
 
   @override
-  Future<PickedFile> pickVideo({
-    @required ImageSource source,
+  Future<PickedFile?> pickVideo({
+    required ImageSource source,
     CameraDevice preferredCameraDevice = CameraDevice.rear,
-    Duration maxDuration,
+    Duration? maxDuration,
   }) async {
-    String path = await pickVideoPath(
+    String? path = await pickVideoPath(
       source: source,
       maxDuration: maxDuration,
       preferredCameraDevice: preferredCameraDevice,
@@ -86,12 +86,12 @@ class MethodChannelImagePicker extends ImagePickerPlatform {
   }
 
   @override
-  Future<String> pickVideoPath({
-    @required ImageSource source,
+  Future<String?> pickVideoPath({
+    required ImageSource source,
     CameraDevice preferredCameraDevice = CameraDevice.rear,
-    Duration maxDuration,
+    Duration? maxDuration,
   }) {
-    assert(source != null);
+
     return _channel.invokeMethod<String>(
       'pickVideo',
       <String, dynamic>{
@@ -104,7 +104,7 @@ class MethodChannelImagePicker extends ImagePickerPlatform {
 
   @override
   Future<LostData> retrieveLostData() async {
-    final Map<String, dynamic> result =
+    final Map<String, dynamic>? result =
         await _channel.invokeMapMethod<String, dynamic>('retrieve');
 
     if (result == null) {
@@ -113,23 +113,23 @@ class MethodChannelImagePicker extends ImagePickerPlatform {
 
     assert(result.containsKey('path') ^ result.containsKey('errorCode'));
 
-    final String type = result['type'];
+    final String? type = result['type'];
     assert(type == kTypeImage || type == kTypeVideo);
 
-    RetrieveType retrieveType;
+    RetrieveType? retrieveType;
     if (type == kTypeImage) {
       retrieveType = RetrieveType.image;
     } else if (type == kTypeVideo) {
       retrieveType = RetrieveType.video;
     }
 
-    PlatformException exception;
+    PlatformException? exception;
     if (result.containsKey('errorCode')) {
       exception = PlatformException(
           code: result['errorCode'], message: result['errorMessage']);
     }
 
-    final String path = result['path'];
+    final String? path = result['path'];
 
     return LostData(
       file: path != null ? PickedFile(path) : null,
@@ -141,7 +141,7 @@ class MethodChannelImagePicker extends ImagePickerPlatform {
   @override
   // ignore: deprecated_member_use_from_same_package
   Future<LostDataResponse> retrieveLostDataAsDartIoFile() async {
-    final Map<String, dynamic> result =
+    final Map<String, dynamic>? result =
         await _channel.invokeMapMethod<String, dynamic>('retrieve');
     if (result == null) {
       // ignore: deprecated_member_use_from_same_package
@@ -149,23 +149,23 @@ class MethodChannelImagePicker extends ImagePickerPlatform {
     }
     assert(result.containsKey('path') ^ result.containsKey('errorCode'));
 
-    final String type = result['type'];
+    final String? type = result['type'];
     assert(type == kTypeImage || type == kTypeVideo);
 
-    RetrieveType retrieveType;
+    RetrieveType? retrieveType;
     if (type == kTypeImage) {
       retrieveType = RetrieveType.image;
     } else if (type == kTypeVideo) {
       retrieveType = RetrieveType.video;
     }
 
-    PlatformException exception;
+    PlatformException? exception;
     if (result.containsKey('errorCode')) {
       exception = PlatformException(
           code: result['errorCode'], message: result['errorMessage']);
     }
 
-    final String path = result['path'];
+    final String? path = result['path'];
 
     // ignore: deprecated_member_use_from_same_package
     return LostDataResponse(

--- a/packages/image_picker/image_picker_platform_interface/lib/src/method_channel/method_channel_image_picker.dart
+++ b/packages/image_picker/image_picker_platform_interface/lib/src/method_channel/method_channel_image_picker.dart
@@ -7,7 +7,7 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
-import 'package:meta/meta.dart' show  visibleForTesting;
+import 'package:meta/meta.dart' show visibleForTesting;
 
 import 'package:image_picker_platform_interface/image_picker_platform_interface.dart';
 
@@ -45,7 +45,6 @@ class MethodChannelImagePicker extends ImagePickerPlatform {
     int? imageQuality,
     CameraDevice preferredCameraDevice = CameraDevice.rear,
   }) {
-
     if (imageQuality != null && (imageQuality < 0 || imageQuality > 100)) {
       throw ArgumentError.value(
           imageQuality, 'imageQuality', 'must be between 0 and 100');
@@ -91,7 +90,6 @@ class MethodChannelImagePicker extends ImagePickerPlatform {
     CameraDevice preferredCameraDevice = CameraDevice.rear,
     Duration? maxDuration,
   }) {
-
     return _channel.invokeMethod<String>(
       'pickVideo',
       <String, dynamic>{

--- a/packages/image_picker/image_picker_platform_interface/lib/src/platform_interface/image_picker_platform.dart
+++ b/packages/image_picker/image_picker_platform_interface/lib/src/platform_interface/image_picker_platform.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 
-
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 import 'package:image_picker_platform_interface/src/method_channel/method_channel_image_picker.dart';

--- a/packages/image_picker/image_picker_platform_interface/lib/src/platform_interface/image_picker_platform.dart
+++ b/packages/image_picker/image_picker_platform_interface/lib/src/platform_interface/image_picker_platform.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:meta/meta.dart' show required;
+
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 import 'package:image_picker_platform_interface/src/method_channel/method_channel_image_picker.dart';
@@ -61,11 +61,11 @@ abstract class ImagePickerPlatform extends PlatformInterface {
   /// In Android, the MainActivity can be destroyed for various reasons. If that happens, the result will be lost
   /// in this call. You can then call [retrieveLostDataAsDartIoFile] when your app relaunches to retrieve the lost data.
   @Deprecated('Use pickImage instead.')
-  Future<String> pickImagePath({
-    @required ImageSource source,
-    double maxWidth,
-    double maxHeight,
-    int imageQuality,
+  Future<String?> pickImagePath({
+    required ImageSource source,
+    double? maxWidth,
+    double? maxHeight,
+    int? imageQuality,
     CameraDevice preferredCameraDevice = CameraDevice.rear,
   }) {
     throw UnimplementedError('legacyPickImage() has not been implemented.');
@@ -86,10 +86,10 @@ abstract class ImagePickerPlatform extends PlatformInterface {
   /// In Android, the MainActivity can be destroyed for various fo reasons. If that happens, the result will be lost
   /// in this call. You can then call [retrieveLostDataAsDartIoFile] when your app relaunches to retrieve the lost data.
   @Deprecated('Use pickVideo instead.')
-  Future<String> pickVideoPath({
-    @required ImageSource source,
+  Future<String?> pickVideoPath({
+    required ImageSource source,
     CameraDevice preferredCameraDevice = CameraDevice.rear,
-    Duration maxDuration,
+    Duration? maxDuration,
   }) {
     throw UnimplementedError('pickVideoPath() has not been implemented.');
   }
@@ -141,11 +141,11 @@ abstract class ImagePickerPlatform extends PlatformInterface {
   ///
   /// In Android, the MainActivity can be destroyed for various reasons. If that happens, the result will be lost
   /// in this call. You can then call [retrieveLostData] when your app relaunches to retrieve the lost data.
-  Future<PickedFile> pickImage({
-    @required ImageSource source,
-    double maxWidth,
-    double maxHeight,
-    int imageQuality,
+  Future<PickedFile?> pickImage({
+    required ImageSource source,
+    double? maxWidth,
+    double? maxHeight,
+    int? imageQuality,
     CameraDevice preferredCameraDevice = CameraDevice.rear,
   }) {
     throw UnimplementedError('pickImage() has not been implemented.');
@@ -165,10 +165,10 @@ abstract class ImagePickerPlatform extends PlatformInterface {
   ///
   /// In Android, the MainActivity can be destroyed for various fo reasons. If that happens, the result will be lost
   /// in this call. You can then call [retrieveLostData] when your app relaunches to retrieve the lost data.
-  Future<PickedFile> pickVideo({
-    @required ImageSource source,
+  Future<PickedFile?> pickVideo({
+    required ImageSource source,
     CameraDevice preferredCameraDevice = CameraDevice.rear,
-    Duration maxDuration,
+    Duration? maxDuration,
   }) {
     throw UnimplementedError('pickVideo() has not been implemented.');
   }

--- a/packages/image_picker/image_picker_platform_interface/lib/src/types/lost_data_response.dart
+++ b/packages/image_picker/image_picker_platform_interface/lib/src/types/lost_data_response.dart
@@ -34,7 +34,7 @@ class LostDataResponse {
   /// The file that was lost in a previous [pickImage] or [pickVideo] call due to MainActivity being destroyed.
   ///
   /// Can be null if [exception] exists.
-  final File file;
+  final File? file;
 
   /// The exception of the last [pickImage] or [pickVideo].
   ///
@@ -43,10 +43,10 @@ class LostDataResponse {
   /// You should handle this exception as if the [pickImage] or [pickVideo] got an exception when the MainActivity was not destroyed.
   ///
   /// Note that it is not the exception that caused the destruction of the MainActivity.
-  final PlatformException exception;
+  final PlatformException? exception;
 
   /// Can either be [RetrieveType.image] or [RetrieveType.video];
-  final RetrieveType type;
+  final RetrieveType? type;
 
   bool _empty = false;
 }

--- a/packages/image_picker/image_picker_platform_interface/lib/src/types/picked_file/base.dart
+++ b/packages/image_picker/image_picker_platform_interface/lib/src/types/picked_file/base.dart
@@ -52,7 +52,7 @@ abstract class PickedFileBase {
   /// If `end` is present, only up to byte-index `end` will be read. Otherwise, until end of file.
   ///
   /// In order to make sure that system resources are freed, the stream must be read to completion or the subscription on the stream must be cancelled.
-  Stream<Uint8List> openRead([int start, int end]) {
+  Stream<Uint8List> openRead([int? start, int? end]) {
     throw UnimplementedError('openRead() has not been implemented.');
   }
 }

--- a/packages/image_picker/image_picker_platform_interface/lib/src/types/picked_file/html.dart
+++ b/packages/image_picker/image_picker_platform_interface/lib/src/types/picked_file/html.dart
@@ -10,19 +10,19 @@ import './base.dart';
 /// It wraps the bytes of a selected file.
 class PickedFile extends PickedFileBase {
   final String path;
-  final Uint8List _initBytes;
+  final Uint8List? _initBytes;
 
   /// Construct a PickedFile object from its ObjectUrl.
   ///
   /// Optionally, this can be initialized with `bytes`
   /// so no http requests are performed to retrieve files later.
-  PickedFile(this.path, {Uint8List bytes})
+  PickedFile(this.path, {Uint8List? bytes})
       : _initBytes = bytes,
         super(path);
 
   Future<Uint8List> get _bytes async {
     if (_initBytes != null) {
-      return Future.value(UnmodifiableUint8ListView(_initBytes));
+      return Future.value(UnmodifiableUint8ListView(_initBytes!));
     }
     return http.readBytes(Uri.parse(path));
   }
@@ -38,7 +38,7 @@ class PickedFile extends PickedFileBase {
   }
 
   @override
-  Stream<Uint8List> openRead([int start, int end]) async* {
+  Stream<Uint8List> openRead([int? start, int? end]) async* {
     final bytes = await _bytes;
     yield bytes.sublist(start ?? 0, end ?? bytes.length);
   }

--- a/packages/image_picker/image_picker_platform_interface/lib/src/types/picked_file/io.dart
+++ b/packages/image_picker/image_picker_platform_interface/lib/src/types/picked_file/io.dart
@@ -29,7 +29,7 @@ class PickedFile extends PickedFileBase {
   }
 
   @override
-  Stream<Uint8List> openRead([int start, int end]) {
+  Stream<Uint8List> openRead([int? start, int? end]) {
     return _file
         .openRead(start ?? 0, end)
         .map((chunk) => Uint8List.fromList(chunk));

--- a/packages/image_picker/image_picker_platform_interface/lib/src/types/picked_file/lost_data.dart
+++ b/packages/image_picker/image_picker_platform_interface/lib/src/types/picked_file/lost_data.dart
@@ -31,7 +31,7 @@ class LostData {
   /// The file that was lost in a previous [pickImage] or [pickVideo] call due to MainActivity being destroyed.
   ///
   /// Can be null if [exception] exists.
-  final PickedFile file;
+  final PickedFile? file;
 
   /// The exception of the last [pickImage] or [pickVideo].
   ///
@@ -40,10 +40,10 @@ class LostData {
   /// You should handle this exception as if the [pickImage] or [pickVideo] got an exception when the MainActivity was not destroyed.
   ///
   /// Note that it is not the exception that caused the destruction of the MainActivity.
-  final PlatformException exception;
+  final PlatformException? exception;
 
   /// Can either be [RetrieveType.image] or [RetrieveType.video];
-  final RetrieveType type;
+  final RetrieveType? type;
 
   bool _empty = false;
 }

--- a/packages/image_picker/image_picker_platform_interface/pubspec.yaml
+++ b/packages/image_picker/image_picker_platform_interface/pubspec.yaml
@@ -9,15 +9,15 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.1.8
-  http: ^0.12.1
-  plugin_platform_interface: ^1.0.2
+  http: ^0.13.0-nullsafety.0
+  plugin_platform_interface: ^1.1.0-nullsafety.2
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: ^4.1.1
-  pedantic: ^1.8.0+1
+  mockito: ^5.0.0-nullsafety.6
+  pedantic: ^1.10.0-nullsafety.3
 
 environment:
-  sdk: ">=2.5.0 <3.0.0"
+  sdk: '>=2.12.0-133.7.beta <3.0.0'
   flutter: ">=1.10.0"

--- a/packages/image_picker/image_picker_platform_interface/pubspec.yaml
+++ b/packages/image_picker/image_picker_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the image_picker plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker/image_picker_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.1.6
+version: 0.2.0-nullsafety
 
 dependencies:
   flutter:

--- a/packages/image_picker/image_picker_platform_interface/test/method_channel_image_picker_test.dart
+++ b/packages/image_picker/image_picker_platform_interface/test/method_channel_image_picker_test.dart
@@ -303,7 +303,7 @@ void main() {
         final LostDataResponse response =
             await picker.retrieveLostDataAsDartIoFile();
         expect(response.type, RetrieveType.image);
-        expect(response.file.path, '/example/path');
+        expect(response.file!.path, '/example/path');
       });
 
       test('retrieveLostData get error response', () async {
@@ -318,8 +318,8 @@ void main() {
         final LostDataResponse response =
             await picker.retrieveLostDataAsDartIoFile();
         expect(response.type, RetrieveType.video);
-        expect(response.exception.code, 'test_error_code');
-        expect(response.exception.message, 'test_error_message');
+        expect(response.exception!.code, 'test_error_code');
+        expect(response.exception!.message, 'test_error_message');
       });
 
       test('retrieveLostData get null response', () async {

--- a/packages/image_picker/image_picker_platform_interface/test/new_method_channel_image_picker_test.dart
+++ b/packages/image_picker/image_picker_platform_interface/test/new_method_channel_image_picker_test.dart
@@ -312,7 +312,7 @@ void main() {
         // ignore: deprecated_member_use_from_same_package
         final LostData response = await picker.retrieveLostData();
         expect(response.type, RetrieveType.image);
-        expect(response.file.path, '/example/path');
+        expect(response.file!.path, '/example/path');
       });
 
       test('retrieveLostData get error response', () async {
@@ -326,8 +326,8 @@ void main() {
         // ignore: deprecated_member_use_from_same_package
         final LostData response = await picker.retrieveLostData();
         expect(response.type, RetrieveType.video);
-        expect(response.exception.code, 'test_error_code');
-        expect(response.exception.message, 'test_error_message');
+        expect(response.exception!.code, 'test_error_code');
+        expect(response.exception!.message, 'test_error_message');
       });
 
       test('retrieveLostData get null response', () async {

--- a/packages/image_picker/image_picker_platform_interface/test/picked_file_html_test.dart
+++ b/packages/image_picker/image_picker_platform_interface/test/picked_file_html_test.dart
@@ -12,7 +12,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:image_picker_platform_interface/image_picker_platform_interface.dart';
 
 final String expectedStringContents = 'Hello, world!';
-final Uint8List bytes = utf8.encode(expectedStringContents);
+final Uint8List bytes = utf8.encode(expectedStringContents) as Uint8List;
 final html.File textFile = html.File([bytes], 'hello.txt');
 final String textFileUrl = html.Url.createObjectUrl(textFile);
 


### PR DESCRIPTION


Migrate Image_picker_platform interface to Null Safety 

Related to #75162

All existing tests are passing 


## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

