### PR TITLE
Add a note about Plus plugins to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,10 +19,10 @@ for any of the following plugins, we encourage you to submit it
 - `battery`
 - `connectivity`
 - `device_info`
-- `wifi_info_flutter` (corresponds to `network_info_plus`)
 - `package_info`
 - `sensors`
 - `share`
+- `wifi_info_flutter` (corresponds to `network_info_plus`)
 
 ## Things you will need
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ _See also: [Flutter's code of conduct](https://github.com/flutter/flutter/blob/m
 
 As of January 2021, we are no longer accepting non-critical PRs for plugins
 for which there is a corresponding [Flutter Community Plus
-Plugin](https://plus.fluttercommunity.dev/), as we hope that in time we're able
+Plugin](https://plus.fluttercommunity.dev/), as we hope in time to be able
 to transition users to those versions of the plugins. If you have a PR for
 something other than a critical issue (crashes, build failures, null safety, etc.)
 for any of the following plugins, we encourage you to submit it

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,25 @@
 
 _See also: [Flutter's code of conduct](https://github.com/flutter/flutter/blob/master/CODE_OF_CONDUCT.md)_
 
+## Important note
+
+As of January 2021, we are no longer accepting non-critical PRs for plugins
+for which there is a corresponding [Flutter Community Plus
+Plugin](https://plus.fluttercommunity.dev/), as we hope that in time we're able
+to transition users to those versions of the plugins. If you have a feature
+addition or other non-critical PR for any of the following plugins, we
+encourage you to submit it
+[there](https://github.com/fluttercommunity/plus_plugins/pulls) instead:
+- `android_alarm_manager`
+- `android_intent`
+- `battery`
+- `connectivity`
+- `device_info`
+- `wifi_info_flutter` (corresponds to `network_info_plus`)
+- `package_info`
+- `sensors`
+- `share`
+
 ## Things you will need
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,9 +10,9 @@ _See also: [Flutter's code of conduct](https://github.com/flutter/flutter/blob/m
 As of January 2021, we are no longer accepting non-critical PRs for plugins
 for which there is a corresponding [Flutter Community Plus
 Plugin](https://plus.fluttercommunity.dev/), as we hope that in time we're able
-to transition users to those versions of the plugins. If you have a feature
-addition or other non-critical PR for any of the following plugins, we
-encourage you to submit it
+to transition users to those versions of the plugins. If you have a PR for
+something other than a critical issue (crashes, build failures, null safety, etc.)
+for any of the following plugins, we encourage you to submit it
 [there](https://github.com/fluttercommunity/plus_plugins/pulls) instead:
 - `android_alarm_manager`
 - `android_intent`


### PR DESCRIPTION
Adds a prominent note to CONTRIBUTING.md about the new policy regarding PRs for plugins for which there is a Flutter Community Plus Plugins equivalent.