### PR TITLE
Add plugin tools as a git submodule and depend on it directly

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,6 +14,9 @@ task:
     - flutter channel master
     - flutter upgrade
     - git fetch origin master
+  submodules_script:
+    - git submodule init
+    - git submodule update
   matrix:
     - name: publishable
       script:
@@ -121,6 +124,9 @@ task:
     - flutter channel master
     - flutter upgrade
     - git fetch origin master
+  submodules_script:
+    - git submodule init
+    - git submodule update
   matrix:
     - name: build-linux+drive-examples
       install_script:
@@ -145,6 +151,9 @@ task:
     - flutter channel master
     - flutter upgrade
     - git fetch origin master
+  submodules_script:
+    - git submodule init
+    - git submodule update
   create_simulator_script:
     - xcrun simctl list
     - xcrun simctl create Flutter-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-11 com.apple.CoreSimulator.SimRuntime.iOS-14-3 | xargs xcrun simctl boot
@@ -198,6 +207,9 @@ task:
     - flutter channel master
     - flutter upgrade
     - git fetch origin master
+  submodules_script:
+    - git submodule init
+    - git submodule update
   create_simulator_script:
     - xcrun simctl list
     - xcrun simctl create Flutter-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-X com.apple.CoreSimulator.SimRuntime.iOS-13-3 | xargs xcrun simctl boot
@@ -227,6 +239,9 @@ task:
     - flutter channel master
     - flutter upgrade
     - git fetch origin master
+  submodules_script:
+    - git submodule init
+    - git submodule update
   matrix:
     - name: build_all_plugins_app
       script:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "script/plugin_tools"]
 	path = script/plugin_tools
-	url = git@github.com:flutter/plugin_tools.git
+	url = https://github.com/flutter/plugin_tools.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "script/plugin_tools"]
+	path = script/plugin_tools
+	url = git@github.com:flutter/plugin_tools.git

--- a/script/check_publish.sh
+++ b/script/check_publish.sh
@@ -12,8 +12,7 @@ source "$SCRIPT_DIR/common.sh"
 
 function check_publish() {
   local failures=()
-  pub_command global activate flutter_plugin_tools
-  for dir in $(pub_command global run flutter_plugin_tools list --plugins="$1"); do
+  for dir in $(plugin_tools list --plugins="$1"); do
     local package_name=$(basename "$dir")
 
     echo "Checking that $package_name can be published."

--- a/script/common.sh
+++ b/script/common.sh
@@ -48,6 +48,6 @@ function check_changed_packages() {
 
 # Runs the plugin tools from the plugin_tools git submodule.
 function plugin_tools() {
-  (pushd "$REPO_DIR/script/plugin_tools" && pub get && popd) >/dev/null
+  (pushd "$REPO_DIR/script/plugin_tools" && dart pub get && popd) >/dev/null
   dart run "$REPO_DIR/script/plugin_tools/lib/src/main.dart" "$@"
 }

--- a/script/common.sh
+++ b/script/common.sh
@@ -46,18 +46,8 @@ function check_changed_packages() {
   return 0
 }
 
-# Normalizes the call to the pub command.
-function pub_command() {
-  if [ "$(expr substr $(uname -s) 1 5)" == "MINGW" ]; then
-    pub.bat "$@"
-  else
-    pub "$@"
-  fi
-}
-
-# Activates the Flutter plugin tool to ensures that the plugin tools dependencies
-# are resolved  using the current Dart SDK.
-# Finally, runs the tool with the parameters.
+# Runs the plugin tools from the plugin_tools git submodule.
 function plugin_tools() {
-  pub_command global activate flutter_plugin_tools && pub_command global run flutter_plugin_tools "$@"
+  (pushd "$REPO_DIR/script/plugin_tools" && pub get && popd) >/dev/null
+  dart run "$REPO_DIR/script/plugin_tools/lib/src/main.dart" "$@"
 }


### PR DESCRIPTION
This is the first step toward moving the plugin tools over to this repo. 

For the time being, this will allow you to change the plugin tools, and test the changes directly without the need to publish to the tool to pub.