### PR TITLE
[file_selector_web] Fix typo in pubspec.

### DIFF
--- a/packages/file_selector/file_selector_web/pubspec.yaml
+++ b/packages/file_selector/file_selector_web/pubspec.yaml
@@ -22,8 +22,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: ^5.0.0-nullsafety.5
-  pedantic: ^1.10.0-nullsafety.3
+  mockito: ^4.1.1
+  pedantic: ^1.8.0
   integration_test:
     path: ../../integration_test
 


### PR DESCRIPTION
(Introduced by mistake in https://github.com/flutter/plugins/pull/3509)

A couple of dependencies were rolled forward a little bit too early. This reverts the change.

* https://github.com/flutter/plugins/pull/3509/files/52fc320a31dd6d04567686cbc8601fe1b4f3f0ce#r572360322
