### PR TITLE
[image_picker] Migrate image_picker_web to null-safety

### DIFF
--- a/packages/image_picker/image_picker_for_web/CHANGELOG.md
+++ b/packages/image_picker/image_picker_for_web/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.0.0-nullsafety
+# 2.0.0-nullsafety
 
 * Migrate to null safety.
 

--- a/packages/image_picker/image_picker_for_web/CHANGELOG.md
+++ b/packages/image_picker/image_picker_for_web/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.0.0-nullsafety
 
 * Migrate to null safety.
+
 # 0.1.0+3
 
 * Update Flutter SDK constraint.

--- a/packages/image_picker/image_picker_for_web/CHANGELOG.md
+++ b/packages/image_picker/image_picker_for_web/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.0.0-nullsafety
+
+* Migrate to null safety.
 # 0.1.0+3
 
 * Update Flutter SDK constraint.

--- a/packages/image_picker/image_picker_for_web/lib/image_picker_for_web.dart
+++ b/packages/image_picker/image_picker_for_web/lib/image_picker_for_web.dart
@@ -62,7 +62,8 @@ class ImagePickerPlugin extends ImagePickerPlatform {
     String? accept,
     String? capture,
   }) {
-    html.FileUploadInputElement input = createInputElement(accept, capture) as html.FileUploadInputElement;
+    html.FileUploadInputElement input =
+        createInputElement(accept, capture) as html.FileUploadInputElement;
     _injectAndActivate(input);
     return _getSelectedFile(input);
   }
@@ -90,7 +91,8 @@ class ImagePickerPlugin extends ImagePickerPlatform {
   /// Handles the OnChange event from a FileUploadInputElement object
   /// Returns the objectURL of the selected file.
   String? _handleOnChangeEvent(html.Event event) {
-    final html.FileUploadInputElement? input = event.target as html.FileUploadInputElement;
+    final html.FileUploadInputElement? input =
+        event.target as html.FileUploadInputElement;
     final html.File? file = _getFileFromInput(input);
 
     if (file != null) {

--- a/packages/image_picker/image_picker_for_web/lib/image_picker_for_web.dart
+++ b/packages/image_picker/image_picker_for_web/lib/image_picker_for_web.dart
@@ -81,17 +81,17 @@ class ImagePickerPlugin extends ImagePickerPlatform {
     return null;
   }
 
-  html.File? _getFileFromInput(html.FileUploadInputElement? input) {
+  html.File? _getFileFromInput(html.FileUploadInputElement input) {
     if (_hasOverrides) {
       return _overrides!.getFileFromInput(input);
     }
-    return input?.files?.first;
+    return input.files?.first;
   }
 
   /// Handles the OnChange event from a FileUploadInputElement object
   /// Returns the objectURL of the selected file.
   String? _handleOnChangeEvent(html.Event event) {
-    final html.FileUploadInputElement? input =
+    final html.FileUploadInputElement input =
         event.target as html.FileUploadInputElement;
     final html.File? file = _getFileFromInput(input);
 
@@ -107,8 +107,8 @@ class ImagePickerPlugin extends ImagePickerPlatform {
     // Observe the input until we can return something
     input.onChange.first.then((event) {
       final objectUrl = _handleOnChangeEvent(event);
-      if (!_completer.isCompleted) {
-        _completer.complete(PickedFile(objectUrl!));
+      if (!_completer.isCompleted && objectUrl != null) {
+        _completer.complete(PickedFile(objectUrl));
       }
     });
     input.onError.first.then((event) {

--- a/packages/image_picker/image_picker_for_web/lib/image_picker_for_web.dart
+++ b/packages/image_picker/image_picker_for_web/lib/image_picker_for_web.dart
@@ -13,14 +13,14 @@ final String _kAcceptVideoMimeType = 'video/3gpp,video/x-m4v,video/mp4,video/*';
 ///
 /// This class implements the `package:image_picker` functionality for the web.
 class ImagePickerPlugin extends ImagePickerPlatform {
-  final ImagePickerPluginTestOverrides _overrides;
+  final ImagePickerPluginTestOverrides? _overrides;
   bool get _hasOverrides => _overrides != null;
 
-  html.Element _target;
+  late html.Element _target;
 
   /// A constructor that allows tests to override the function that creates file inputs.
   ImagePickerPlugin({
-    @visibleForTesting ImagePickerPluginTestOverrides overrides,
+    @visibleForTesting ImagePickerPluginTestOverrides? overrides,
   }) : _overrides = overrides {
     _target = _ensureInitialized(_kImagePickerInputsDomId);
   }
@@ -32,23 +32,23 @@ class ImagePickerPlugin extends ImagePickerPlatform {
 
   @override
   Future<PickedFile> pickImage({
-    @required ImageSource source,
-    double maxWidth,
-    double maxHeight,
-    int imageQuality,
+    required ImageSource source,
+    double? maxWidth,
+    double? maxHeight,
+    int? imageQuality,
     CameraDevice preferredCameraDevice = CameraDevice.rear,
   }) {
-    String capture = computeCaptureAttribute(source, preferredCameraDevice);
+    String? capture = computeCaptureAttribute(source, preferredCameraDevice);
     return pickFile(accept: _kAcceptImageMimeType, capture: capture);
   }
 
   @override
   Future<PickedFile> pickVideo({
-    @required ImageSource source,
+    required ImageSource source,
     CameraDevice preferredCameraDevice = CameraDevice.rear,
-    Duration maxDuration,
+    Duration? maxDuration,
   }) {
-    String capture = computeCaptureAttribute(source, preferredCameraDevice);
+    String? capture = computeCaptureAttribute(source, preferredCameraDevice);
     return pickFile(accept: _kAcceptVideoMimeType, capture: capture);
   }
 
@@ -59,10 +59,10 @@ class ImagePickerPlugin extends ImagePickerPlatform {
   /// See https://caniuse.com/#feat=html-media-capture
   @visibleForTesting
   Future<PickedFile> pickFile({
-    String accept,
-    String capture,
+    String? accept,
+    String? capture,
   }) {
-    html.FileUploadInputElement input = createInputElement(accept, capture);
+    html.FileUploadInputElement input = createInputElement(accept, capture) as html.FileUploadInputElement;
     _injectAndActivate(input);
     return _getSelectedFile(input);
   }
@@ -73,25 +73,25 @@ class ImagePickerPlugin extends ImagePickerPlatform {
   ///
   /// See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#capture
   @visibleForTesting
-  String computeCaptureAttribute(ImageSource source, CameraDevice device) {
+  String? computeCaptureAttribute(ImageSource source, CameraDevice device) {
     if (source == ImageSource.camera) {
       return (device == CameraDevice.front) ? 'user' : 'environment';
     }
     return null;
   }
 
-  html.File _getFileFromInput(html.FileUploadInputElement input) {
+  html.File? _getFileFromInput(html.FileUploadInputElement? input) {
     if (_hasOverrides) {
-      return _overrides.getFileFromInput(input);
+      return _overrides!.getFileFromInput(input);
     }
     return input?.files?.first;
   }
 
   /// Handles the OnChange event from a FileUploadInputElement object
   /// Returns the objectURL of the selected file.
-  String _handleOnChangeEvent(html.Event event) {
-    final html.FileUploadInputElement input = event?.target;
-    final html.File file = _getFileFromInput(input);
+  String? _handleOnChangeEvent(html.Event event) {
+    final html.FileUploadInputElement? input = event.target as html.FileUploadInputElement;
+    final html.File? file = _getFileFromInput(input);
 
     if (file != null) {
       return html.Url.createObjectUrl(file);
@@ -106,7 +106,7 @@ class ImagePickerPlugin extends ImagePickerPlatform {
     input.onChange.first.then((event) {
       final objectUrl = _handleOnChangeEvent(event);
       if (!_completer.isCompleted) {
-        _completer.complete(PickedFile(objectUrl));
+        _completer.complete(PickedFile(objectUrl!));
       }
     });
     input.onError.first.then((event) {
@@ -127,7 +127,7 @@ class ImagePickerPlugin extends ImagePickerPlatform {
       final html.Element targetElement =
           html.Element.tag('flt-image-picker-inputs')..id = id;
 
-      html.querySelector('body').children.add(targetElement);
+      html.querySelector('body')!.children.add(targetElement);
       target = targetElement;
     }
     return target;
@@ -136,9 +136,9 @@ class ImagePickerPlugin extends ImagePickerPlatform {
   /// Creates an input element that accepts certain file types, and
   /// allows to `capture` from the device's cameras (where supported)
   @visibleForTesting
-  html.Element createInputElement(String accept, String capture) {
+  html.Element createInputElement(String? accept, String? capture) {
     if (_hasOverrides) {
-      return _overrides.createInputElement(accept, capture);
+      return _overrides!.createInputElement(accept, capture);
     }
 
     html.Element element = html.FileUploadInputElement()..accept = accept;
@@ -162,22 +162,22 @@ class ImagePickerPlugin extends ImagePickerPlatform {
 /// A function that creates a file input with the passed in `accept` and `capture` attributes.
 @visibleForTesting
 typedef OverrideCreateInputFunction = html.Element Function(
-  String accept,
-  String capture,
+  String? accept,
+  String? capture,
 );
 
 /// A function that extracts a [html.File] from the file `input` passed in.
 @visibleForTesting
 typedef OverrideExtractFilesFromInputFunction = html.File Function(
-  html.Element input,
+  html.Element? input,
 );
 
 /// Overrides for some of the functionality above.
 @visibleForTesting
 class ImagePickerPluginTestOverrides {
   /// Override the creation of the input element.
-  OverrideCreateInputFunction createInputElement;
+  late OverrideCreateInputFunction createInputElement;
 
   /// Override the extraction of the selected file from an input element.
-  OverrideExtractFilesFromInputFunction getFileFromInput;
+  late OverrideExtractFilesFromInputFunction getFileFromInput;
 }

--- a/packages/image_picker/image_picker_for_web/pubspec.yaml
+++ b/packages/image_picker/image_picker_for_web/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker/i
 # 0.1.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.1.0+3
+version: 1.0.0-nullsafety
 
 flutter:
   plugin:
@@ -14,19 +14,19 @@ flutter:
         fileName: image_picker_for_web.dart
 
 dependencies:
-  image_picker_platform_interface: ^1.1.0
+  image_picker_platform_interface: ^2.0.0-nullsafety
   flutter:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  meta: ^1.1.7
-  js: ^0.6.0
+  meta: ^1.3.0-nullsafety.6
+  js: ^0.6.3-nullsafety.3
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.8.0
+  pedantic: ^1.10.0
 
 environment:
-  sdk: ">=2.5.0 <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"
   flutter: ">=1.10.0"

--- a/packages/image_picker/image_picker_for_web/pubspec.yaml
+++ b/packages/image_picker/image_picker_for_web/pubspec.yaml
@@ -1,10 +1,8 @@
 name: image_picker_for_web
 description: Web platform implementation of image_picker
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker/image_picker_for_web
-# 0.1.y+z is compatible with 1.0.0, if you land a breaking change bump
-# the version to 2.0.0.
-# See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 1.0.0-nullsafety
+
+version: 2.0.0-nullsafety
 
 flutter:
   plugin:

--- a/packages/image_picker/image_picker_for_web/test/image_picker_for_web_test.dart
+++ b/packages/image_picker/image_picker_for_web/test/image_picker_for_web_test.dart
@@ -13,12 +13,12 @@ import 'package:image_picker_for_web/image_picker_for_web.dart';
 import 'package:image_picker_platform_interface/image_picker_platform_interface.dart';
 
 final String expectedStringContents = "Hello, world!";
-final Uint8List bytes = utf8.encode(expectedStringContents);
+final Uint8List bytes = utf8.encode(expectedStringContents) as Uint8List;
 final html.File textFile = html.File([bytes], "hello.txt");
 
 void main() {
   // Under test...
-  ImagePickerPlugin plugin;
+  late ImagePickerPlugin plugin;
 
   setUp(() {
     plugin = ImagePickerPlugin();


### PR DESCRIPTION
Migrate` image_picker_web to null-safety`

closes flutter/flutter#75162

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
