### PR TITLE
[camera] Fixes crash on takePicture()

### DIFF
--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.0+4
+
+* Fix crash when taking picture with orientation lock
+
 ## 0.7.0+3
 
 * Clockwise rotation of focus point in android 

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/DeviceOrientationManager.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/DeviceOrientationManager.java
@@ -57,7 +57,7 @@ class DeviceOrientationManager {
     int angle = 0;
 
     // Fallback to device orientation when the orientation value is null
-    if(orientation==null){
+    if (orientation == null) {
       orientation = getUIOrientation();
     }
 

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/DeviceOrientationManager.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/DeviceOrientationManager.java
@@ -55,6 +55,12 @@ class DeviceOrientationManager {
 
   public int getMediaOrientation(PlatformChannel.DeviceOrientation orientation) {
     int angle = 0;
+
+    // Fallback to device orientation when the orientation value is null
+    if(orientation==null){
+      orientation = getUIOrientation();
+    }
+
     switch (orientation) {
       case PORTRAIT_UP:
         angle = 0;

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera
 description: A Flutter plugin for getting information about and controlling the
   camera on Android and iOS. Supports previewing the camera feed, capturing images, capturing video,
   and streaming image buffers to dart.
-version: 0.7.0+3
+version: 0.7.0+4
 homepage: https://github.com/flutter/plugins/tree/master/packages/camera/camera
 
 dependencies:


### PR DESCRIPTION
* Added a fallback to UI Orientation when the orientation value is not available. 

* Fixes issue [#75133](https://github.com/flutter/flutter/issues/75133)

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
