### PR TITLE
Added comment about path depenendencies

### DIFF
--- a/packages/android_alarm_manager/example/pubspec.yaml
+++ b/packages/android_alarm_manager/example/pubspec.yaml
@@ -5,6 +5,11 @@ dependencies:
   flutter:
     sdk: flutter
   android_alarm_manager:
+    # When depending on this package from a real application you should use:
+    #   android_alarm_manager: ^x.y.z
+    # See https://dart.dev/tools/pub/dependencies#version-constraints
+    # The example app is bundled with the plugin so we use a path dependency on
+    # the parent directory to use the current plugin's version.
     path: ../
   shared_preferences: ^0.5.6
   integration_test:

--- a/packages/android_intent/example/pubspec.yaml
+++ b/packages/android_intent/example/pubspec.yaml
@@ -5,6 +5,11 @@ dependencies:
   flutter:
     sdk: flutter
   android_intent:
+    # When depending on this package from a real application you should use:
+    #   android_intent: ^x.y.z
+    # See https://dart.dev/tools/pub/dependencies#version-constraints
+    # The example app is bundled with the plugin so we use a path dependency on
+    # the parent directory to use the current plugin's version.
     path: ../
 
 dev_dependencies:

--- a/packages/battery/battery/example/pubspec.yaml
+++ b/packages/battery/battery/example/pubspec.yaml
@@ -5,6 +5,11 @@ dependencies:
   flutter:
     sdk: flutter
   battery:
+    # When depending on this package from a real application you should use:
+    #   battery: ^x.y.z
+    # See https://dart.dev/tools/pub/dependencies#version-constraints
+    # The example app is bundled with the plugin so we use a path dependency on
+    # the parent directory to use the current plugin's version.
     path: ../
 
 dev_dependencies:

--- a/packages/camera/camera/example/pubspec.yaml
+++ b/packages/camera/camera/example/pubspec.yaml
@@ -3,6 +3,11 @@ description: Demonstrates how to use the camera plugin.
 
 dependencies:
   camera:
+    # When depending on this package from a real application you should use:
+    #   camera: ^x.y.z
+    # See https://dart.dev/tools/pub/dependencies#version-constraints
+    # The example app is bundled with the plugin so we use a path dependency on
+    # the parent directory to use the current plugin's version.
     path: ../
   path_provider: ^0.5.0
   flutter:

--- a/packages/connectivity/connectivity/example/pubspec.yaml
+++ b/packages/connectivity/connectivity/example/pubspec.yaml
@@ -5,6 +5,11 @@ dependencies:
   flutter:
     sdk: flutter
   connectivity:
+    # When depending on this package from a real application you should use:
+    #   connectivity: ^x.y.z
+    # See https://dart.dev/tools/pub/dependencies#version-constraints
+    # The example app is bundled with the plugin so we use a path dependency on
+    # the parent directory to use the current plugin's version.
     path: ../
 
 dev_dependencies:

--- a/packages/connectivity/connectivity_macos/example/pubspec.yaml
+++ b/packages/connectivity/connectivity_macos/example/pubspec.yaml
@@ -6,6 +6,11 @@ dependencies:
     sdk: flutter
   connectivity: any
   connectivity_macos:
+    # When depending on this package from a real application you should use:
+    #   connectivity_macos: ^x.y.z
+    # See https://dart.dev/tools/pub/dependencies#version-constraints
+    # The example app is bundled with the plugin so we use a path dependency on
+    # the parent directory to use the current plugin's version.
     path: ../
 
 dev_dependencies:

--- a/packages/device_info/device_info/example/pubspec.yaml
+++ b/packages/device_info/device_info/example/pubspec.yaml
@@ -5,6 +5,11 @@ dependencies:
   flutter:
     sdk: flutter
   device_info:
+    # When depending on this package from a real application you should use:
+    #   device_info: ^x.y.z
+    # See https://dart.dev/tools/pub/dependencies#version-constraints
+    # The example app is bundled with the plugin so we use a path dependency on
+    # the parent directory to use the current plugin's version.
     path: ../
 
 dev_dependencies:

--- a/packages/espresso/example/pubspec.yaml
+++ b/packages/espresso/example/pubspec.yaml
@@ -21,6 +21,11 @@ dev_dependencies:
   pedantic: ^1.8.0
 
   espresso:
+    # When depending on this package from a real application you should use:
+    #   espresso: ^x.y.z
+    # See https://dart.dev/tools/pub/dependencies#version-constraints
+    # The example app is bundled with the plugin so we use a path dependency on
+    # the parent directory to use the current plugin's version.
     path: ../
 
 # For information on the generic Dart part of this file, see the

--- a/packages/file_selector/file_selector/example/pubspec.yaml
+++ b/packages/file_selector/file_selector/example/pubspec.yaml
@@ -25,6 +25,11 @@ dependencies:
     sdk: flutter
 
   file_selector:
+    # When depending on this package from a real application you should use:
+    #   file_selector: ^x.y.z
+    # See https://dart.dev/tools/pub/dependencies#version-constraints
+    # The example app is bundled with the plugin so we use a path dependency on
+    # the parent directory to use the current plugin's version.
     path: ../
 
   # The following adds the Cupertino Icons font to your application.

--- a/packages/flutter_plugin_android_lifecycle/example/pubspec.yaml
+++ b/packages/flutter_plugin_android_lifecycle/example/pubspec.yaml
@@ -5,6 +5,11 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_plugin_android_lifecycle:
+    # When depending on this package from a real application you should use:
+    #   flutter_plugin_android_lifecycle: ^x.y.z
+    # See https://dart.dev/tools/pub/dependencies#version-constraints
+    # The example app is bundled with the plugin so we use a path dependency on
+    # the parent directory to use the current plugin's version.
     path: ../
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/example/pubspec.yaml
@@ -13,6 +13,11 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.0
   google_maps_flutter:
+    # When depending on this package from a real application you should use:
+    #   google_maps_flutter: ^x.y.z
+    # See https://dart.dev/tools/pub/dependencies#version-constraints
+    # The example app is bundled with the plugin so we use a path dependency on
+    # the parent directory to use the current plugin's version.
     path: ../
   flutter_plugin_android_lifecycle: ^1.0.0
 

--- a/packages/google_sign_in/extension_google_sign_in_as_googleapis_auth/example/pubspec.yaml
+++ b/packages/google_sign_in/extension_google_sign_in_as_googleapis_auth/example/pubspec.yaml
@@ -6,6 +6,11 @@ dependencies:
     sdk: flutter
   google_sign_in: ^4.4.1
   extension_google_sign_in_as_googleapis_auth:
+    # When depending on this package from a real application you should use:
+    #   extension_google_sign_in_as_googleapis_auth: ^x.y.z
+    # See https://dart.dev/tools/pub/dependencies#version-constraints
+    # The example app is bundled with the plugin so we use a path dependency on
+    # the parent directory to use the current plugin's version.
     path: ../
   googleapis: ^0.55.0
 

--- a/packages/google_sign_in/google_sign_in/example/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in/example/pubspec.yaml
@@ -5,6 +5,11 @@ dependencies:
   flutter:
     sdk: flutter
   google_sign_in:
+    # When depending on this package from a real application you should use:
+    #   google_sign_in: ^x.y.z
+    # See https://dart.dev/tools/pub/dependencies#version-constraints
+    # The example app is bundled with the plugin so we use a path dependency on
+    # the parent directory to use the current plugin's version.
     path: ../
   http: ^0.12.0
 

--- a/packages/image_picker/image_picker/example/pubspec.yaml
+++ b/packages/image_picker/image_picker/example/pubspec.yaml
@@ -8,6 +8,11 @@ dependencies:
     sdk: flutter
   flutter_plugin_android_lifecycle: ^2.0.0-nullsafety.2
   image_picker:
+    # When depending on this package from a real application you should use:
+    #   image_picker: ^x.y.z
+    # See https://dart.dev/tools/pub/dependencies#version-constraints
+    # The example app is bundled with the plugin so we use a path dependency on
+    # the parent directory to use the current plugin's version.
     path: ../
 
 dev_dependencies:

--- a/packages/in_app_purchase/example/pubspec.yaml
+++ b/packages/in_app_purchase/example/pubspec.yaml
@@ -13,6 +13,11 @@ dev_dependencies:
   flutter_driver:
     sdk: flutter
   in_app_purchase:
+    # When depending on this package from a real application you should use:
+    #   in_app_purchase: ^x.y.z
+    # See https://dart.dev/tools/pub/dependencies#version-constraints
+    # The example app is bundled with the plugin so we use a path dependency on
+    # the parent directory to use the current plugin's version.
     path: ../
   integration_test:
     path: ../../integration_test

--- a/packages/integration_test/example/pubspec.yaml
+++ b/packages/integration_test/example/pubspec.yaml
@@ -18,6 +18,11 @@ dev_dependencies:
   flutter_driver:
     sdk: flutter
   integration_test:
+    # When depending on this package from a real application you should use:
+    #   integration_test: ^x.y.z
+    # See https://dart.dev/tools/pub/dependencies#version-constraints
+    # The example app is bundled with the plugin so we use a path dependency on
+    # the parent directory to use the current plugin's version.
     path: ../
   integration_test_macos:
     path: ../integration_test_macos

--- a/packages/ios_platform_images/example/pubspec.yaml
+++ b/packages/ios_platform_images/example/pubspec.yaml
@@ -18,6 +18,11 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   ios_platform_images:
+    # When depending on this package from a real application you should use:
+    #   ios_platform_images: ^x.y.z
+    # See https://dart.dev/tools/pub/dependencies#version-constraints
+    # The example app is bundled with the plugin so we use a path dependency on
+    # the parent directory to use the current plugin's version.
     path: ../
   pedantic: ^1.8.0
 

--- a/packages/local_auth/example/pubspec.yaml
+++ b/packages/local_auth/example/pubspec.yaml
@@ -5,6 +5,11 @@ dependencies:
   flutter:
     sdk: flutter
   local_auth:
+    # When depending on this package from a real application you should use:
+    #   local_auth: ^x.y.z
+    # See https://dart.dev/tools/pub/dependencies#version-constraints
+    # The example app is bundled with the plugin so we use a path dependency on
+    # the parent directory to use the current plugin's version.
     path: ../
 
 dev_dependencies:

--- a/packages/package_info/example/pubspec.yaml
+++ b/packages/package_info/example/pubspec.yaml
@@ -5,6 +5,11 @@ dependencies:
   flutter:
     sdk: flutter
   package_info:
+    # When depending on this package from a real application you should use:
+    #   package_info: ^x.y.z
+    # See https://dart.dev/tools/pub/dependencies#version-constraints
+    # The example app is bundled with the plugin so we use a path dependency on
+    # the parent directory to use the current plugin's version.
     path: ../
   integration_test:
     path: ../../integration_test

--- a/packages/path_provider/path_provider/example/pubspec.yaml
+++ b/packages/path_provider/path_provider/example/pubspec.yaml
@@ -5,6 +5,11 @@ dependencies:
   flutter:
     sdk: flutter
   path_provider:
+    # When depending on this package from a real application you should use:
+    #   path_provider: ^x.y.z
+    # See https://dart.dev/tools/pub/dependencies#version-constraints
+    # The example app is bundled with the plugin so we use a path dependency on
+    # the parent directory to use the current plugin's version.
     path: ../
 
 dev_dependencies:

--- a/packages/path_provider/path_provider_linux/example/pubspec.yaml
+++ b/packages/path_provider/path_provider_linux/example/pubspec.yaml
@@ -17,6 +17,11 @@ dependencies:
 
 dependency_overrides:
   path_provider_linux:
+    # When depending on this package from a real application you should use:
+    #   path_provider_linux: ^x.y.z
+    # See https://dart.dev/tools/pub/dependencies#version-constraints
+    # The example app is bundled with the plugin so we use a path dependency on
+    # the parent directory to use the current plugin's version.
     path: ../
 
 dev_dependencies:

--- a/packages/path_provider/path_provider_macos/example/pubspec.yaml
+++ b/packages/path_provider/path_provider_macos/example/pubspec.yaml
@@ -10,6 +10,11 @@ dependencies:
 # to depend on it from path:
 dependency_overrides:
   path_provider_macos:
+    # When depending on this package from a real application you should use:
+    #   path_provider_macos: ^x.y.z
+    # See https://dart.dev/tools/pub/dependencies#version-constraints
+    # The example app is bundled with the plugin so we use a path dependency on
+    # the parent directory to use the current plugin's version.
     path: ../
 
 dev_dependencies:

--- a/packages/path_provider/path_provider_windows/example/pubspec.yaml
+++ b/packages/path_provider/path_provider_windows/example/pubspec.yaml
@@ -8,6 +8,11 @@ dependencies:
 
 dependency_overrides:
   path_provider_windows:
+    # When depending on this package from a real application you should use:
+    #   path_provider_windows: ^x.y.z
+    # See https://dart.dev/tools/pub/dependencies#version-constraints
+    # The example app is bundled with the plugin so we use a path dependency on
+    # the parent directory to use the current plugin's version.
     path: ../
 
 dev_dependencies:

--- a/packages/quick_actions/example/pubspec.yaml
+++ b/packages/quick_actions/example/pubspec.yaml
@@ -5,6 +5,11 @@ dependencies:
   flutter:
     sdk: flutter
   quick_actions:
+    # When depending on this package from a real application you should use:
+    #   quick_actions: ^x.y.z
+    # See https://dart.dev/tools/pub/dependencies#version-constraints
+    # The example app is bundled with the plugin so we use a path dependency on
+    # the parent directory to use the current plugin's version.
     path: ../
 
 dev_dependencies:

--- a/packages/sensors/example/pubspec.yaml
+++ b/packages/sensors/example/pubspec.yaml
@@ -5,6 +5,11 @@ dependencies:
   flutter:
     sdk: flutter
   sensors:
+    # When depending on this package from a real application you should use:
+    #   sensors: ^x.y.z
+    # See https://dart.dev/tools/pub/dependencies#version-constraints
+    # The example app is bundled with the plugin so we use a path dependency on
+    # the parent directory to use the current plugin's version.
     path: ../
 
 dev_dependencies:

--- a/packages/share/example/pubspec.yaml
+++ b/packages/share/example/pubspec.yaml
@@ -5,6 +5,11 @@ dependencies:
   flutter:
     sdk: flutter
   share:
+    # When depending on this package from a real application you should use:
+    #   share: ^x.y.z
+    # See https://dart.dev/tools/pub/dependencies#version-constraints
+    # The example app is bundled with the plugin so we use a path dependency on
+    # the parent directory to use the current plugin's version.
     path: ../
   image_picker: ^0.6.7+4
 

--- a/packages/shared_preferences/shared_preferences/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences/example/pubspec.yaml
@@ -5,6 +5,11 @@ dependencies:
   flutter:
     sdk: flutter
   shared_preferences:
+    # When depending on this package from a real application you should use:
+    #   shared_preferences: ^x.y.z
+    # See https://dart.dev/tools/pub/dependencies#version-constraints
+    # The example app is bundled with the plugin so we use a path dependency on
+    # the parent directory to use the current plugin's version.
     path: ../
 
 dev_dependencies:

--- a/packages/shared_preferences/shared_preferences_linux/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_linux/example/pubspec.yaml
@@ -5,6 +5,11 @@ dependencies:
   flutter:
     sdk: flutter
   shared_preferences_linux:
+    # When depending on this package from a real application you should use:
+    #   shared_preferences_linux: ^x.y.z
+    # See https://dart.dev/tools/pub/dependencies#version-constraints
+    # The example app is bundled with the plugin so we use a path dependency on
+    # the parent directory to use the current plugin's version.
     path: ../
 
 dev_dependencies:

--- a/packages/shared_preferences/shared_preferences_macos/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_macos/example/pubspec.yaml
@@ -6,6 +6,11 @@ dependencies:
     sdk: flutter
   shared_preferences: any
   shared_preferences_macos:
+    # When depending on this package from a real application you should use:
+    #   shared_preferences_macos: ^x.y.z
+    # See https://dart.dev/tools/pub/dependencies#version-constraints
+    # The example app is bundled with the plugin so we use a path dependency on
+    # the parent directory to use the current plugin's version.
     path: ../
 
 dev_dependencies:

--- a/packages/shared_preferences/shared_preferences_windows/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_windows/example/pubspec.yaml
@@ -11,6 +11,11 @@ dependencies:
 
 dependency_overrides:
   shared_preferences_windows:
+    # When depending on this package from a real application you should use:
+    #   shared_preferences_windows: ^x.y.z
+    # See https://dart.dev/tools/pub/dependencies#version-constraints
+    # The example app is bundled with the plugin so we use a path dependency on
+    # the parent directory to use the current plugin's version.
     path: ../
 
 dev_dependencies:

--- a/packages/url_launcher/url_launcher/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/example/pubspec.yaml
@@ -5,6 +5,11 @@ dependencies:
   flutter:
     sdk: flutter
   url_launcher:
+    # When depending on this package from a real application you should use:
+    #   url_launcher: ^x.y.z
+    # See https://dart.dev/tools/pub/dependencies#version-constraints
+    # The example app is bundled with the plugin so we use a path dependency on
+    # the parent directory to use the current plugin's version.
     path: ../
 
 dev_dependencies:

--- a/packages/url_launcher/url_launcher_linux/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_linux/example/pubspec.yaml
@@ -6,6 +6,11 @@ dependencies:
     sdk: flutter
   url_launcher: any
   url_launcher_linux:
+    # When depending on this package from a real application you should use:
+    #   url_launcher_linux: ^x.y.z
+    # See https://dart.dev/tools/pub/dependencies#version-constraints
+    # The example app is bundled with the plugin so we use a path dependency on
+    # the parent directory to use the current plugin's version.
     path: ../
 
 dev_dependencies:

--- a/packages/url_launcher/url_launcher_macos/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_macos/example/pubspec.yaml
@@ -6,6 +6,11 @@ dependencies:
     sdk: flutter
   url_launcher: any
   url_launcher_macos:
+    # When depending on this package from a real application you should use:
+    #   url_launcher_macos: ^x.y.z
+    # See https://dart.dev/tools/pub/dependencies#version-constraints
+    # The example app is bundled with the plugin so we use a path dependency on
+    # the parent directory to use the current plugin's version.
     path: ../
 
 dev_dependencies:

--- a/packages/url_launcher/url_launcher_windows/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_windows/example/pubspec.yaml
@@ -6,6 +6,11 @@ dependencies:
     sdk: flutter
   url_launcher_platform_interface: any
   url_launcher_windows:
+    # When depending on this package from a real application you should use:
+    #   url_launcher_windows: ^x.y.z
+    # See https://dart.dev/tools/pub/dependencies#version-constraints
+    # The example app is bundled with the plugin so we use a path dependency on
+    # the parent directory to use the current plugin's version.
     path: ../
 
 dev_dependencies:

--- a/packages/video_player/video_player/example/pubspec.yaml
+++ b/packages/video_player/video_player/example/pubspec.yaml
@@ -7,6 +7,11 @@ dependencies:
   flutter:
     sdk: flutter
   video_player:
+    # When depending on this package from a real application you should use:
+    #   video_player: ^x.y.z
+    # See https://dart.dev/tools/pub/dependencies#version-constraints
+    # The example app is bundled with the plugin so we use a path dependency on
+    # the parent directory to use the current plugin's version.
     path: ../
 
 dev_dependencies:

--- a/packages/webview_flutter/example/pubspec.yaml
+++ b/packages/webview_flutter/example/pubspec.yaml
@@ -8,6 +8,11 @@ dependencies:
   flutter:
     sdk: flutter
   webview_flutter:
+    # When depending on this package from a real application you should use:
+    #   webview_flutter: ^x.y.z
+    # See https://dart.dev/tools/pub/dependencies#version-constraints
+    # The example app is bundled with the plugin so we use a path dependency on
+    # the parent directory to use the current plugin's version.
     path: ../
 
 dev_dependencies:

--- a/packages/wifi_info_flutter/wifi_info_flutter/example/pubspec.yaml
+++ b/packages/wifi_info_flutter/wifi_info_flutter/example/pubspec.yaml
@@ -10,6 +10,11 @@ dependencies:
   flutter:
     sdk: flutter
   wifi_info_flutter:
+    # When depending on this package from a real application you should use:
+    #   wifi_info_flutter: ^x.y.z
+    # See https://dart.dev/tools/pub/dependencies#version-constraints
+    # The example app is bundled with the plugin so we use a path dependency on
+    # the parent directory to use the current plugin's version.
     path: ../
   cupertino_icons: ^1.0.0
 


### PR DESCRIPTION
Adds a comment `# ^x.y.z in your application` where examples have path dependencies.

This was motivated by https://github.com/dart-lang/pub/issues/1850#issuecomment-581117550 where a user is running into problems by copying the dependency from an `example/pubspec.yaml`.

Maybe we shouldn't make it all one-line... and maybe we could phrase the comment better.
Or maybe we shouldn't even do this -- feel free to close this if you think this is too obvious :)