### PR TITLE
Honor, and scrub, the 1.0 compatibility promise

### DIFF
--- a/packages/android_intent/README.md
+++ b/packages/android_intent/README.md
@@ -5,13 +5,6 @@ is Android. If the plugin is invoked on iOS, it will crash your app. In checked
 mode, we assert that the platform should be Android.
 
 
-**Please set your constraint to `android_intent: '>=0.3.y+x <2.0.0'`**
-
-## Backward compatible 1.0.0 version is coming
-The plugin has reached a stable API, we guarantee that version `1.0.0` will be backward compatible with `0.3.y+z`.
-Please use `android_intent: '>=0.3.y+x <2.0.0'` as your dependency constraint to allow a smoother ecosystem migration.
-For more details see: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-
 Use it by specifying action, category, data and extra arguments for the intent.
 It does not support returning the result of the launched activity. Sample usage:
 

--- a/packages/connectivity/connectivity_macos/CHANGELOG.md
+++ b/packages/connectivity/connectivity_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-nullsafety
+
+* Update version to (semi-belatedly) meet 1.0-consistency promise.
+
 ## 0.2.0-nullsafety.1
 
 * Remove placeholder Dart file.

--- a/packages/connectivity/connectivity_macos/README.md
+++ b/packages/connectivity/connectivity_macos/README.md
@@ -2,13 +2,6 @@
 
 The macos implementation of [`connectivity`].
 
-**Please set your constraint to `connectivity_macos: '>=0.1.y+x <2.0.0'`**
-
-## Backward compatible 1.0.0 version is coming
-The plugin has reached a stable API, we guarantee that version `1.0.0` will be backward compatible with `0.1.y+z`.
-Please use `connectivity_macos: '>=0.1.y+x <2.0.0'` as your dependency constraint to allow a smoother ecosystem migration.
-For more details see: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-
 ## Usage
 
 ### Import the package
@@ -29,4 +22,3 @@ dependencies:
 ```
 
 Refer to the `connectivity` [documentation](https://github.com/flutter/plugins/tree/master/packages/connectivity/connectivity) for more details.
-

--- a/packages/connectivity/connectivity_macos/pubspec.yaml
+++ b/packages/connectivity/connectivity_macos/pubspec.yaml
@@ -1,9 +1,6 @@
 name: connectivity_macos
 description: macOS implementation of the connectivity plugin.
-# 0.1.y+z is compatible with 1.0.0, if you land a breaking change bump
-# the version to 2.0.0.
-# See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.2.0-nullsafety.1
+version: 2.0.0-nullsafety
 homepage: https://github.com/flutter/plugins/tree/master/packages/connectivity/connectivity_macos
 
 flutter:

--- a/packages/device_info/device_info/pubspec.yaml
+++ b/packages/device_info/device_info/pubspec.yaml
@@ -2,9 +2,6 @@ name: device_info
 description: Flutter plugin providing detailed information about the device
   (make, model, etc.), and Android or iOS version the app is running on.
 homepage: https://github.com/flutter/plugins/tree/master/packages/device_info
-# 0.4.y+z is compatible with 1.0.0, if you land a breaking change bump
-# the version to 2.0.0.
-# See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
 version: 2.0.0-nullsafety.2
 
 flutter:

--- a/packages/google_maps_flutter/google_maps_flutter/example/ios/Flutter/Debug.xcconfig
+++ b/packages/google_maps_flutter/google_maps_flutter/example/ios/Flutter/Debug.xcconfig
@@ -1,2 +1,3 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/packages/google_maps_flutter/google_maps_flutter/example/ios/Flutter/Debug.xcconfig
+++ b/packages/google_maps_flutter/google_maps_flutter/example/ios/Flutter/Debug.xcconfig
@@ -1,3 +1,2 @@
-#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/packages/google_maps_flutter/google_maps_flutter/example/ios/Flutter/Release.xcconfig
+++ b/packages/google_maps_flutter/google_maps_flutter/example/ios/Flutter/Release.xcconfig
@@ -1,2 +1,3 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/packages/google_maps_flutter/google_maps_flutter/example/ios/Flutter/Release.xcconfig
+++ b/packages/google_maps_flutter/google_maps_flutter/example/ios/Flutter/Release.xcconfig
@@ -1,3 +1,2 @@
-#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/packages/package_info/CHANGELOG.md
+++ b/packages/package_info/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-nullsafety
+
+* Update version to (semi-belatedly) meet 1.0-consistency promise.
+
 ## 0.5.0-nullsafety
 
 * Migrate to null safety.

--- a/packages/package_info/README.md
+++ b/packages/package_info/README.md
@@ -3,13 +3,6 @@
 This Flutter plugin provides an API for querying information about an
 application package.
 
-**Please set your constraint to `package_info: '>=0.4.y+x <2.0.0'`**
-
-## Backward compatible 1.0.0 version is coming
-The package_info plugin has reached a stable API, we guarantee that version `1.0.0` will be backward compatible with `0.4.y+z`.
-Please use `package_info: '>=0.4.y+x <2.0.0'` as your dependency constraint to allow a smoother ecosystem migration.
-For more details see: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-
 # Usage
 
 You can use the PackageInfo to query information about the
@@ -39,10 +32,10 @@ PackageInfo.fromPlatform().then((PackageInfo packageInfo) {
 
 ## Known Issue
 
-As noted on [issue 20761](https://github.com/flutter/flutter/issues/20761#issuecomment-493434578), package_info on iOS 
-requires the Xcode build folder to be rebuilt after changes to the version string in `pubspec.yaml`. 
-Clean the Xcode build folder with: 
-`XCode Menu -> Product -> (Holding Option Key) Clean build folder`. 
+As noted on [issue 20761](https://github.com/flutter/flutter/issues/20761#issuecomment-493434578), package_info on iOS
+requires the Xcode build folder to be rebuilt after changes to the version string in `pubspec.yaml`.
+Clean the Xcode build folder with:
+`XCode Menu -> Product -> (Holding Option Key) Clean build folder`.
 
 ## Issues and feedback
 

--- a/packages/package_info/pubspec.yaml
+++ b/packages/package_info/pubspec.yaml
@@ -2,10 +2,7 @@ name: package_info
 description: Flutter plugin for querying information about the application
   package, such as CFBundleVersion on iOS or versionCode on Android.
 homepage: https://github.com/flutter/plugins/tree/master/packages/package_info
-# 0.4.y+z is compatible with 1.0.0, if you land a breaking change bump
-# the version to 2.0.0.
-# See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.5.0-nullsafety
+version: 2.0.0-nullsafety
 
 flutter:
   plugin:

--- a/packages/path_provider/path_provider_linux/CHANGELOG.md
+++ b/packages/path_provider/path_provider_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-nullsafety
+
+* Update version to (semi-belatedly) meet 1.0-consistency promise.
+
 ## 0.2.0-nullsafety
 
 * Migrate to null safety.

--- a/packages/path_provider/path_provider_linux/README.md
+++ b/packages/path_provider/path_provider_linux/README.md
@@ -2,13 +2,6 @@
 
 The linux implementation of [`path_provider`].
 
-**Please set your constraint to `path_provider: '>=0.0.y+x <2.0.0'`**
-
-## Backward compatible 1.0.0 version is coming
-The `path_provider` plugin has reached a stable API, we guarantee that version `1.0.0` will be backward compatible with `0.0.y+z`.
-Please use `path_provider: '>=0.0.y+x <2.0.0'` as your dependency constraint to allow a smoother ecosystem migration.
-For more details see: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-
 ## Usage
 
 This package is already included as part of the `path_provider` package dependency, and will

--- a/packages/path_provider/path_provider_linux/pubspec.yaml
+++ b/packages/path_provider/path_provider_linux/pubspec.yaml
@@ -1,6 +1,6 @@
 name: path_provider_linux
 description: linux implementation of the path_provider plugin
-version: 0.2.0-nullsafety
+version: 2.0.0-nullsafety
 homepage: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider_linux
 
 flutter:

--- a/packages/path_provider/path_provider_macos/CHANGELOG.md
+++ b/packages/path_provider/path_provider_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-nullsafety
+
+* Update version to (semi-belatedly) meet 1.0-consistency promise.
+
 ## 0.0.5-nullsafety
 
 * Update Dart SDK constraint for null safety.

--- a/packages/path_provider/path_provider_macos/README.md
+++ b/packages/path_provider/path_provider_macos/README.md
@@ -2,13 +2,6 @@
 
 The macos implementation of [`path_provider`].
 
-**Please set your constraint to `path_provider_macos: '>=0.0.y+x <2.0.0'`**
-
-## Backward compatible 1.0.0 version is coming
-The plugin has reached a stable API, we guarantee that version `1.0.0` will be backward compatible with `0.0.y+z`.
-Please use `path_provider_macos: '>=0.0.y+x <2.0.0'` as your dependency constraint to allow a smoother ecosystem migration.
-For more details see: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-
 ## Usage
 
 ### Import the package

--- a/packages/path_provider/path_provider_macos/pubspec.yaml
+++ b/packages/path_provider/path_provider_macos/pubspec.yaml
@@ -1,6 +1,6 @@
 name: path_provider_macos
 description: macOS implementation of the path_provider plugin
-version: 1.0.0-nullsafety
+version: 2.0.0-nullsafety
 homepage: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider_macos
 
 flutter:

--- a/packages/path_provider/path_provider_macos/pubspec.yaml
+++ b/packages/path_provider/path_provider_macos/pubspec.yaml
@@ -1,9 +1,6 @@
 name: path_provider_macos
 description: macOS implementation of the path_provider plugin
-# 0.0.y+z is compatible with 1.0.0, if you land a breaking change bump
-# the version to 2.0.0.
-# See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.0.5-nullsafety
+version: 1.0.0-nullsafety
 homepage: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider_macos
 
 flutter:

--- a/packages/path_provider/path_provider_windows/CHANGELOG.md
+++ b/packages/path_provider/path_provider_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-nullsafety
+
+* Update version to (semi-belatedly) meet 1.0-consistency promise.
+
 ## 0.1.0-nullsafety.3
 
 * Bump ffi dependency to 1.0.0

--- a/packages/path_provider/path_provider_windows/README.md
+++ b/packages/path_provider/path_provider_windows/README.md
@@ -2,14 +2,6 @@
 
 The Windows implementation of [`path_provider`][1].
 
-**Please set your constraint to `path_provider_windows: '>=0.0.y+x <2.0.0'`**
-
-## Backward compatible 1.0.0 version is coming
-
-The plugin has reached a stable API, we guarantee that version `1.0.0` will be backward compatible with `0.0.y+z`.
-Please use `path_provider_windows: '>=0.0.y+x <2.0.0'` as your dependency constraint to allow a smoother ecosystem migration.
-For more details see: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-
 ## Usage
 
 ### Import the package

--- a/packages/path_provider/path_provider_windows/pubspec.yaml
+++ b/packages/path_provider/path_provider_windows/pubspec.yaml
@@ -1,7 +1,7 @@
 name: path_provider_windows
 description: Windows implementation of the path_provider plugin
 homepage: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider_windows
-version: 0.1.0-nullsafety.3
+version: 2.0.0-nullsafety
 
 flutter:
   plugin:
@@ -27,4 +27,3 @@ dev_dependencies:
 environment:
   sdk: '>=2.12.0-259.8.beta <3.0.0'
   flutter: ">=1.12.13+hotfix.4"
-

--- a/packages/sensors/CHANGELOG.md
+++ b/packages/sensors/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-nullsafety
+
+* * Update version to (semi-belatedly) meet 1.0-consistency promise.
+
 ## 0.5.0-nullsafety
 
 * Migrate to null safety.

--- a/packages/sensors/README.md
+++ b/packages/sensors/README.md
@@ -1,12 +1,5 @@
 # sensors
 
-**Please set your constraint to `sensors: '>=0.4.y+x <2.0.0'`**
-
-## Backward compatible 1.0.0 version is coming
-The sensors plugin has reached a stable API, we guarantee that version `1.0.0` will be backward compatible with `0.4.y+z`.
-Please use `sensors: '>=0.4.y+x <2.0.0'` as your dependency constraint to allow a smoother ecosystem migration.
-For more details see: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-
 A Flutter plugin to access the accelerometer and gyroscope sensors.
 
 

--- a/packages/sensors/pubspec.yaml
+++ b/packages/sensors/pubspec.yaml
@@ -2,10 +2,7 @@ name: sensors
 description: Flutter plugin for accessing the Android and iOS accelerometer and
   gyroscope sensors.
 homepage: https://github.com/flutter/plugins/tree/master/packages/sensors
-# 0.4.y+z is compatible with 1.0.0, if you land a breaking change bump
-# the version to 2.0.0.
-# See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.5.0-nullsafety
+version: 2.0.0-nullsafety
 
 flutter:
   plugin:

--- a/packages/share/README.md
+++ b/packages/share/README.md
@@ -8,13 +8,6 @@ share dialog.
 Wraps the ACTION_SEND Intent on Android and UIActivityViewController
 on iOS.
 
-**Please set your constraint to `share: '>=0.6.y+x <2.0.0'`**
-
-## Backward compatible 1.0.0 version is coming
-The plugin has reached a stable API, we guarantee that version `1.0.0` will be backward compatible with `0.6.y+z`.
-Please use `share: '>=0.6.y+x <2.0.0'` as your dependency constraint to allow a smoother ecosystem migration.
-For more details see: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-
 ## Usage
 
 To use this plugin, add `share` as a [dependency in your pubspec.yaml file](https://flutter.dev/docs/development/packages-and-plugins/using-packages/).

--- a/packages/shared_preferences/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences/pubspec.yaml
@@ -2,9 +2,6 @@ name: shared_preferences
 description: Flutter plugin for reading and writing simple key-value pairs.
   Wraps NSUserDefaults on iOS and SharedPreferences on Android.
 homepage: https://github.com/flutter/plugins/tree/master/packages/shared_preferences/shared_preferences
-# 0.5.y+z is compatible with 1.0.0, if you land a breaking change bump
-# the version to 2.0.0.
-# See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
 version: 2.0.0-nullsafety
 
 flutter:

--- a/packages/shared_preferences/shared_preferences_linux/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-nullsafety
+
+* Update version for consistency.
+
 ## 0.0.4-nullsafety
 
 * Migrate to null-safety.

--- a/packages/shared_preferences/shared_preferences_linux/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_linux/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shared_preferences_linux
 description: Linux implementation of the shared_preferences plugin
-version: 0.0.4-nullsafety
+version: 2.0.0-nullsafety
 homepage: https://github.com/flutter/plugins/tree/master/packages/shared_preferences/shared_preferences_linux
 
 flutter:

--- a/packages/shared_preferences/shared_preferences_macos/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-nullsafety
+
+* Update version to (semi-belatedly) meet 1.0-consistency promise.
+
 ## 0.0.2-nullsafety
 
 * Update Dart SDK constraint for null safety.

--- a/packages/shared_preferences/shared_preferences_macos/README.md
+++ b/packages/shared_preferences/shared_preferences_macos/README.md
@@ -2,13 +2,6 @@
 
 The macos implementation of [`shared_preferences`][1].
 
-**Please set your constraint to `shared_preferences_macos: '>=0.0.y+x <2.0.0'`**
-
-## Backward compatible 1.0.0 version is coming
-The plugin has reached a stable API, we guarantee that version `1.0.0` will be backward compatible with `0.0.y+z`.
-Please use `shared_preferences_macos: '>=0.0.y+x <2.0.0'` as your dependency constraint to allow a smoother ecosystem migration.
-For more details see: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-
 ## Usage
 
 ### Import the package

--- a/packages/shared_preferences/shared_preferences_macos/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_macos/pubspec.yaml
@@ -1,9 +1,6 @@
 name: shared_preferences_macos
 description: macOS implementation of the shared_preferences plugin.
-# 0.0.y+z is compatible with 1.0.0, if you land a breaking change bump
-# the version to 2.0.0.
-# See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.0.2-nullsafety
+version: 2.0.0-nullsafety
 homepage: https://github.com/flutter/plugins/tree/master/packages/shared_preferences/shared_preferences_macos
 
 flutter:

--- a/packages/shared_preferences/shared_preferences_web/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-nullsafety
+
+* Update version to (semi-belatedly) meet 1.0-consistency promise.
+
 ## 0.2.0-nullsafety
 
 * Migrate to null-safety.

--- a/packages/shared_preferences/shared_preferences_web/README.md
+++ b/packages/shared_preferences/shared_preferences_web/README.md
@@ -2,13 +2,6 @@
 
 The web implementation of [`shared_preferences`][1].
 
-**Please set your constraint to `shared_preferences_web: '>=0.1.y+x <2.0.0'`**
-
-## Backward compatible 1.0.0 version is coming
-The plugin has reached a stable API, we guarantee that version `1.0.0` will be backward compatible with `0.1.y+z`.
-Please use `shared_preferences_web: '>=0.1.y+x <2.0.0'` as your dependency constraint to allow a smoother ecosystem migration.
-For more details see: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-
 ## Usage
 
 ### Import the package

--- a/packages/shared_preferences/shared_preferences_web/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_web/pubspec.yaml
@@ -1,10 +1,7 @@
 name: shared_preferences_web
 description: Web platform implementation of shared_preferences
 homepage: https://github.com/flutter/plugins/tree/master/packages/shared_preferences/shared_preferences_web
-# 0.1.y+z is compatible with 1.0.0, if you land a breaking change bump
-# the version to 2.0.0.
-# See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.2.0-nullsafety
+version: 2.0.0-nullsafety
 
 flutter:
   plugin:

--- a/packages/shared_preferences/shared_preferences_windows/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_windows/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+## 2.0.0-nullsafety
+
+* Update version for consistency.
+
 ## 0.0.3-nullsafety
 
 * Migrate to null-safety.

--- a/packages/shared_preferences/shared_preferences_windows/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_windows/pubspec.yaml
@@ -1,7 +1,7 @@
 name: shared_preferences_windows
 description: Windows implementation of shared_preferences
 homepage: https://github.com/flutter/plugins/tree/master/packages/shared_preferences/shared_preferences_windows
-version: 0.0.3-nullsafety
+version: 2.0.0-nullsafety
 
 
 flutter:

--- a/packages/url_launcher/url_launcher_linux/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-nullsafety
+
+* Update version for consistency with other implementations.
+
 ## 0.1.0-nullsafety.3
 
 * Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.

--- a/packages/url_launcher/url_launcher_linux/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_linux/pubspec.yaml
@@ -1,6 +1,6 @@
 name: url_launcher_linux
 description: Linux implementation of the url_launcher plugin.
-version: 0.1.0-nullsafety.3
+version: 2.0.0-nullsafety
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher_linux
 
 flutter:

--- a/packages/url_launcher/url_launcher_macos/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-nullsafety
+
+* Update version to (semi-belatedly) meet 1.0-consistency promise.
+
 # 0.1.0-nullsafety.2
 
 * Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.
@@ -58,4 +62,3 @@
 # 0.0.1
 
 * Initial open source release.
-

--- a/packages/url_launcher/url_launcher_macos/README.md
+++ b/packages/url_launcher/url_launcher_macos/README.md
@@ -2,13 +2,6 @@
 
 The macos implementation of [`url_launcher`][1].
 
-**Please set your constraint to `url_launcher_macos: '>=0.0.y+x <2.0.0'`**
-
-## Backward compatible 1.0.0 version is coming
-The plugin has reached a stable API, we guarantee that version `1.0.0` will be backward compatible with `0.0.y+z`.
-Please use `url_launcher_macos: '>=0.0.y+x <2.0.0'` as your dependency constraint to allow a smoother ecosystem migration.
-For more details see: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-
 ## Usage
 
 ### Import the package

--- a/packages/url_launcher/url_launcher_macos/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_macos/pubspec.yaml
@@ -1,9 +1,6 @@
 name: url_launcher_macos
 description: macOS implementation of the url_launcher plugin.
-# 0.0.y+z is compatible with 1.0.0, if you land a breaking change bump
-# the version to 2.0.0.
-# See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.1.0-nullsafety.2
+version: 2.0.0-nullsafety
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher_macos
 
 flutter:

--- a/packages/url_launcher/url_launcher_windows/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-nullsafety
+
+* Update version to (semi-belatedly) meet 1.0-consistency promise.
+
 ## 0.1.0-nullsafety.2
 
 * Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.

--- a/packages/url_launcher/url_launcher_windows/README.md
+++ b/packages/url_launcher/url_launcher_windows/README.md
@@ -2,13 +2,6 @@
 
 The Windows implementation of [`url_launcher`][1].
 
-## Backward compatible 1.0.0 version is coming
-The plugin has reached a stable API, we guarantee that version `1.0.0` will be backward compatible with `0.0.y+z`. If you use
-url_launcher_windows directly, rather than as an implementation detail
-of `url_launcher`, please use `url_launcher_windows: '>=0.0.y+x <2.0.0'`
-as your dependency constraint to allow a smoother ecosystem migration.
-For more details see: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-
 ## Usage
 
 ### Import the package

--- a/packages/url_launcher/url_launcher_windows/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_windows/pubspec.yaml
@@ -1,9 +1,6 @@
 name: url_launcher_windows
 description: Windows implementation of the url_launcher plugin.
-# 0.0.y+z is compatible with 1.0.0, if you land a breaking change bump
-# the version to 2.0.0.
-# See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.1.0-nullsafety.2
+version: 2.0.0-nullsafety
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher_windows
 
 flutter:

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -1,9 +1,6 @@
 name: video_player
 description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android, iOS, and web.
-# 0.10.y+z is compatible with 1.0.0, if you land a breaking change bump
-# the version to 2.0.0.
-# See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
 version: 2.0.0-nullsafety.9
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player
 

--- a/packages/video_player/video_player_web/README.md
+++ b/packages/video_player/video_player_web/README.md
@@ -3,13 +3,6 @@
 The web implementation of [`video_player`][1].
 
 
-**Please set your constraint to `video_player_web: '>=0.1.y+x <2.0.0'`**
-
-## Backward compatible 1.0.0 version is coming
-The plugin has reached a stable API, we guarantee that version `1.0.0` will be backward compatible with `0.1.y+z`.
-Please use `video_player_web: '>=0.1.y+x <2.0.0'` as your dependency constraint to allow a smoother ecosystem migration.
-For more details see: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-
 ## Usage
 
 This package is the endorsed implementation of `video_player` for the web platform since version `0.10.5`, so it gets automatically added to your application by depending on `video_player: ^0.10.5`.

--- a/packages/video_player/video_player_web/pubspec.yaml
+++ b/packages/video_player/video_player_web/pubspec.yaml
@@ -1,9 +1,6 @@
 name: video_player_web
 description: Web platform implementation of video_player.
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player_web
-# 0.1.y+z is compatible with 1.0.0, if you land a breaking change bump
-# the version to 2.0.0.
-# See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
 version: 2.0.0-nullsafety.2
 
 flutter:


### PR DESCRIPTION
For all plugins that have been migrated to null safety and had the
comments about guaranteed compatibility up to 1.0.0:
- Ensure that they have the correct version bumps. In some cases this is
  slightly too late, but since only pre-release versions were published
  the damage should be minimal, and we can still prevent wider issues
  when the stable null-safe versions are published.
- Remove the now-obsolete README comment and pubspec.yaml comment about
  the forward compatibility guarantee.
