### PR TITLE
[video_player] Update video_player readme to change sample video to https

### DIFF
--- a/packages/video_player/video_player/README.md
+++ b/packages/video_player/video_player/README.md
@@ -77,7 +77,7 @@ class _VideoAppState extends State<VideoApp> {
   void initState() {
     super.initState();
     _controller = VideoPlayerController.network(
-        'http://www.sample-videos.com/video123/mp4/720/big_buck_bunny_720p_20mb.mp4')
+        'https://www.sample-videos.com/video123/mp4/720/big_buck_bunny_720p_20mb.mp4')
       ..initialize().then((_) {
         // Ensure the first frame is shown after the video is initialized, even before the play button has been pressed.
         setState(() {});


### PR DESCRIPTION
The android simulator is throwing an error on http calls now. Changing to https fixes the error and is better for several other reasons.

```
I/ExoPlayerImpl( 3419): Init 896a4d7 [ExoPlayerLib/2.12.1] [generic_x86_arm, AOSP on IA Emulator, Google, 28]
E/ExoPlayerImplInternal( 3419): Playback error
E/ExoPlayerImplInternal( 3419):   com.google.android.exoplayer2.ExoPlaybackException: Source error
E/ExoPlayerImplInternal( 3419):       at com.google.android.exoplayer2.ExoPlayerImplInternal.handleMessage(ExoPlayerImplInternal.java:554)
E/ExoPlayerImplInternal( 3419):       at android.os.Handler.dispatchMessage(Handler.java:102)
E/ExoPlayerImplInternal( 3419):       at android.os.Looper.loop(Looper.java:193)
E/ExoPlayerImplInternal( 3419):       at android.os.HandlerThread.run(HandlerThread.java:65)
E/ExoPlayerImplInternal( 3419):   Caused by: com.google.android.exoplayer2.upstream.HttpDataSource$HttpDataSourceException: Unable to connect
E/ExoPlayerImplInternal( 3419):       at com.google.android.exoplayer2.upstream.DefaultHttpDataSource.open(DefaultHttpDataSource.java:309)
E/ExoPlayerImplInternal( 3419):       at com.google.android.exoplayer2.upstream.StatsDataSource.open(StatsDataSource.java:84)
E/ExoPlayerImplInternal( 3419):       at com.google.android.exoplayer2.source.ProgressiveMediaPeriod$ExtractingLoadable.load(ProgressiveMediaPeriod.java:1013)
E/ExoPlayerImplInternal( 3419):       at com.google.android.exoplayer2.upstream.Loader$LoadTask.run(Loader.java:415)
E/ExoPlayerImplInternal( 3419):       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
E/ExoPlayerImplInternal( 3419):       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
E/ExoPlayerImplInternal( 3419):       at java.lang.Thread.run(Thread.java:764)
E/ExoPlayerImplInternal( 3419):   Caused by: java.io.IOException: Cleartext HTTP traffic to www.sample-videos.com not permitted
E/ExoPlayerImplInternal( 3419):       at com.android.okhttp.HttpHandler$CleartextURLFilter.checkURLPermitted(HttpHandler.java:115)
E/ExoPlayerImplInternal( 3419):       at com.android.okhttp.internal.huc.HttpURLConnectionImpl.execute(HttpURLConnectionImpl.java:458)
E/ExoPlayerImplInternal( 3419):       at com.android.okhttp.internal.huc.HttpURLConnectionImpl.connect(HttpURLConnectionImpl.java:127)
E/ExoPlayerImplInternal( 3419):       at com.google.android.exoplayer2.upstream.DefaultHttpDataSource.makeConnection(DefaultHttpDataSource.java:589)
E/ExoPlayerImplInternal( 3419):       at com.google.android.exoplayer2.upstream.DefaultHttpDataSource.makeConnection(DefaultHttpDataSource.java:493)
E/ExoPlayerImplInternal( 3419):       at com.google.android.exoplayer2.upstream.DefaultHttpDataSource.open(DefaultHttpDataSource.java:307)
E/ExoPlayerImplInternal( 3419):       ... 6 more
E/flutter ( 3419): [ERROR:flutter/lib/ui/ui_dart_state.cc(186)] Unhandled Exception: PlatformException(VideoError, Video player had error com.google.android.exoplayer2.ExoPlaybackException: Source error, null, null)
```
Before Change:
<img width="1559" alt="Screen Shot 2021-02-14 at 7 01 29 PM" src="https://user-images.githubusercontent.com/17206638/107893081-1c8e5700-6ef7-11eb-820f-ce23679de441.png">


After change:
<img width="1561" alt="Screen Shot 2021-02-14 at 7 02 54 PM" src="https://user-images.githubusercontent.com/17206638/107893102-48114180-6ef7-11eb-94af-abc1e176b8a4.png">



*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ X] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [ X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ X] I updated CHANGELOG.md to add a description of the change.
- [X ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [X ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
