### PR TITLE
[google_maps_flutter] Fix CameraPosition regression

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-nullsafety.1
+
+* Fix overly-restrictive type check.
+
 ## 2.0.0-nullsafety
 
 * Migrated to null-safety.

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/camera.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/camera.dart
@@ -72,7 +72,7 @@ class CameraPosition {
   ///
   /// Mainly for internal use.
   static CameraPosition? fromMap(Object? json) {
-    if (json == null || !(json is Map<String, dynamic>)) {
+    if (json == null || !(json is Map<dynamic, dynamic>)) {
       return null;
     }
     final LatLng? target = LatLng.fromJson(json['target']);

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the google_maps_flutter plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter/google_maps_flutter_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.0.0-nullsafety
+version: 2.0.0-nullsafety.1
 
 dependencies:
   flutter:

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/camera_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/camera_test.dart
@@ -1,0 +1,23 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:google_maps_flutter_platform_interface/google_maps_flutter_platform_interface.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('toMap / fromMap', () {
+    final cameraPosition = CameraPosition(
+        target: LatLng(10.0, 15.0), bearing: 0.5, tilt: 30.0, zoom: 1.5);
+    // Cast to <dynamic, dynamic> to ensure that recreating from JSON, where
+    // type information will have likely been lost, still works.
+    final json = (cameraPosition.toMap() as Map<String, dynamic>)
+        .cast<dynamic, dynamic>();
+    final cameraPositionFromJson = CameraPosition.fromMap(json);
+
+    expect(cameraPosition, cameraPositionFromJson);
+  });
+}


### PR DESCRIPTION
The nullability conversion added a type check when recreating a
CameraPosition from JSON that was too restrictive, and regressed the
app-facing package. This relaxes that assertion, and adds a test to
catch the issue.

Part of flutter/flutter#75236

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
