### PR TITLE
Fix the build-all exclusion list

### DIFF
--- a/script/build_all_plugins_app.sh
+++ b/script/build_all_plugins_app.sh
@@ -18,37 +18,19 @@ source "$SCRIPT_DIR/nnbd_plugins.sh"
 
 check_changed_packages > /dev/null
 
+# This list should be kept as short as possible, and things should remain here
+# only as long as necessary, since in general the goal is for all of the latest
+# versions of plugins to be mutually compatible.
+#
+# An example use case for this list would be to temporarily add plugins while
+# updating multiple plugins for a breaking change in a common dependency in
+# cases where using a relaxed version constraint isn't possible.
 readonly EXCLUDED_PLUGINS_LIST=(
-  "connectivity_macos"
-  "connectivity_platform_interface"
-  "connectivity_web"
-  "extension_google_sign_in_as_googleapis_auth"
   "file_selector" # currently out of sync with camera
   "flutter_plugin_android_lifecycle"
-  "google_maps_flutter_platform_interface"
-  "google_maps_flutter_web"
-  "google_sign_in_platform_interface"
-  "google_sign_in_web"
-  "image_picker_platform_interface"
   "image_picker"
-  "instrumentation_adapter"
   "local_auth" # flutter_plugin_android_lifecycle conflict
-  "path_provider_linux"
-  "path_provider_macos"
-  "path_provider_platform_interface"
-  "path_provider_web"
-  "plugin_platform_interface"
-  "shared_preferences_linux"
-  "shared_preferences_macos"
-  "shared_preferences_platform_interface"
-  "shared_preferences_web"
-  "shared_preferences_windows"
-  "url_launcher_linux"
-  "url_launcher_macos"
-  "url_launcher_platform_interface"
-  "url_launcher_web"
-  "video_player_platform_interface"
-  "video_player_web"
+  "plugin_platform_interface" # This should never be a direct app dependency.
 )
 # Comma-separated string of the list above
 readonly EXCLUDED=$(IFS=, ; echo "${EXCLUDED_PLUGINS_LIST[*]}")

--- a/script/build_all_plugins_app.sh
+++ b/script/build_all_plugins_app.sh
@@ -26,10 +26,10 @@ check_changed_packages > /dev/null
 # updating multiple plugins for a breaking change in a common dependency in
 # cases where using a relaxed version constraint isn't possible.
 readonly EXCLUDED_PLUGINS_LIST=(
-  "file_selector" # currently out of sync with camera
-  "flutter_plugin_android_lifecycle"
-  "image_picker"
-  "local_auth" # flutter_plugin_android_lifecycle conflict
+  # "file_selector" # currently out of sync with camera
+  # "flutter_plugin_android_lifecycle"
+  # "image_picker"
+  # "local_auth" # flutter_plugin_android_lifecycle conflict
   "plugin_platform_interface" # This should never be a direct app dependency.
 )
 # Comma-separated string of the list above

--- a/script/nnbd_plugins.sh
+++ b/script/nnbd_plugins.sh
@@ -38,13 +38,9 @@ readonly NNBD_PLUGINS_LIST=(
 # building the all plugins app. This list should be kept empty.
 
 readonly NON_NNBD_PLUGINS_LIST=(
-  "camera"
-  "google_maps_flutter" # half migrated
-  # "image_picker"
-  # "in_app_purchase"
-  # "quick_actions"
-  # "sensors"
-  # "wifi_info_flutter"
+  "camera" # partially migrated
+  "extension_google_sign_in_as_googleapis_auth"
+  "google_maps_flutter" # partially migrated
 )
 
 export EXCLUDED_PLUGINS_FROM_STABLE=$(IFS=, ; echo "${NNBD_PLUGINS_LIST[*]}")

--- a/script/tool/lib/src/common.dart
+++ b/script/tool/lib/src/common.dart
@@ -294,8 +294,10 @@ abstract class PluginCommand extends Command<Null> {
             // passed.
             final String relativePath =
                 p.relative(subdir.path, from: packagesDir.path);
+            final String packageName = p.basename(subdir.path);
             final String basenamePath = p.basename(entity.path);
             if (!excludedPlugins.contains(basenamePath) &&
+                !excludedPlugins.contains(packageName) &&
                 !excludedPlugins.contains(relativePath) &&
                 (plugins.isEmpty ||
                     plugins.contains(relativePath) ||


### PR DESCRIPTION
build_all_plugins_app.sh contains an exclusion list, which currently contains almost all of the non-app-facing plugins. However, the script those exclusions are passed to expects federated plugin exclusions to be of the form `plugin_name/plugin_name_subplugin_name`, not just `plugin_name_subplugin_name`, so in practice almost nothing on that list has actually been doing anything.

This fixes the script to allow either mode of exclusion (since clearly people expect using just the name to work), and scrubs everything from the list that clearly wasn't actually needed.