### PR TITLE
[package_info] Make PackageInfo testable

### DIFF
--- a/packages/package_info/lib/package_info.dart
+++ b/packages/package_info/lib/package_info.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:flutter/services.dart';
+import 'package:meta/meta.dart';
 
 const MethodChannel _kChannel =
     MethodChannel('plugins.flutter.io/package_info');
@@ -62,4 +63,21 @@ class PackageInfo {
 
   /// The build number. `CFBundleVersion` on iOS, `versionCode` on Android.
   final String buildNumber;
+
+  /// Initializes the application metadata with mock values for testing.
+  ///
+  /// If the singleton instance has been initialized already, it is overwritten.
+  @visibleForTesting
+  static void setMockInitialValues({
+    required String appName,
+    required String packageName,
+    required String version,
+    required String buildNumber,
+  }) {
+    _fromPlatform = PackageInfo(
+        appName: appName,
+        packageName: packageName,
+        version: version,
+        buildNumber: buildNumber);
+  }
 }

--- a/packages/package_info/pubspec.yaml
+++ b/packages/package_info/pubspec.yaml
@@ -16,6 +16,7 @@ flutter:
         pluginClass: FLTPackageInfoPlugin
 
 dependencies:
+  meta: ^1.3.0
   flutter:
     sdk: flutter
 

--- a/packages/package_info/test/package_info_test.dart
+++ b/packages/package_info/test/package_info_test.dart
@@ -46,4 +46,18 @@ void main() {
       ],
     );
   });
+
+  test('Mock initial values', () async {
+    PackageInfo.setMockInitialValues(
+      appName: 'mock_package_info_example',
+      packageName: 'io.flutter.plugins.mockpackageinfoexample',
+      version: '1.1',
+      buildNumber: '2',
+    );
+    final PackageInfo info = await PackageInfo.fromPlatform();
+    expect(info.appName, 'mock_package_info_example');
+    expect(info.buildNumber, '2');
+    expect(info.packageName, 'io.flutter.plugins.mockpackageinfoexample');
+    expect(info.version, '1.1');
+  });
 }


### PR DESCRIPTION
Added a similar method as already given in the shared_preference plugin (https://github.com/flutter/plugins/blob/master/packages/shared_preferences/shared_preferences/lib/shared_preferences.dart#L196), to allow the easy usage of the package_info plugin during tests. The method allows the setup of mock data and also enables the developer to change the data during tests.

Fixes https://github.com/flutter/flutter/issues/76076

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.