### PR TITLE
[url_launcher] Re-endorse null-safe web implementation.

### DIFF
--- a/packages/url_launcher/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.0-nullsafety.7
+
+* Re-endorse `url_launcher_web` in the `nullsafety` prerelease.
+
 ## 6.0.0-nullsafety.6
 
 * Correct statement in description about which platforms url_launcher supports.

--- a/packages/url_launcher/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher
 description: Flutter plugin for launching a URL. Supports
   web, phone, SMS, and email schemes.
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher
-version: 6.0.0-nullsafety.6
+version: 6.0.0-nullsafety.7
 
 flutter:
   plugin:
@@ -12,9 +12,8 @@ flutter:
         pluginClass: UrlLauncherPlugin
       ios:
         pluginClass: FLTURLLauncherPlugin
-      # TODO(mvanbeusekom): Temporary disabled until web is migrated to nnbd (advised by @blasten).
-      #web:
-      #  default_package: url_launcher_web
+      web:
+        default_package: url_launcher_web
       linux:
         default_package: url_laucher_linux
       macos:
@@ -34,8 +33,7 @@ dependencies:
   url_launcher_linux: ^0.1.0-nullsafety
   url_launcher_macos: ^0.1.0-nullsafety
   url_launcher_windows: ^0.1.0-nullsafety
-  # TODO(mvanbeusekom): Temporary disabled until web is migrated to nnbd (advised by @blasten).
-  #url_launcher_web: ^0.1.3
+  url_launcher_web: ^2.0.0-nullsafety
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Now that the `url_launcher_web` plugin has been migrated to null-safety, re-endorse it.

Fixes https://github.com/flutter/flutter/issues/72239
Fixes https://github.com/flutter/flutter/issues/73679
Fixes https://github.com/flutter/flutter/issues/75244

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
