### PR TITLE
[camera] Added timeout to Android pre-capture sequence

### DIFF
--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.0-nullsafety.1
+
+* Added a timeout to the pre-capture sequence on Android to prevent crashes when the camera cannot get a focus.
+
 ## 0.8.0-nullsafety
 
 * Migrated to null safety.

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
@@ -74,9 +74,7 @@ interface ErrorCallback {
 public class Camera {
   private static final String TAG = "Camera";
 
-  /**
-   * Timeout for the pre-capture sequence.
-   */
+  /** Timeout for the pre-capture sequence. */
   private static final long PRECAPTURE_TIMEOUT_MS = 1000;
 
   private final SurfaceTextureEntry flutterTexture;
@@ -1154,9 +1152,7 @@ public class Camera {
     startPreview();
   }
 
-  /**
-   * Sets the time the pre-capture sequence started.
-   */
+  /** Sets the time the pre-capture sequence started. */
   private void setPreCaptureStartTime() {
     preCaptureStartTime = SystemClock.elapsedRealtime();
   }

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
@@ -36,6 +36,7 @@ import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.os.Handler;
 import android.os.Looper;
+import android.os.SystemClock;
 import android.util.Log;
 import android.util.Range;
 import android.util.Rational;
@@ -73,6 +74,11 @@ interface ErrorCallback {
 public class Camera {
   private static final String TAG = "Camera";
 
+  /**
+   * Timeout for the pre-capture sequence.
+   */
+  private static final long PRECAPTURE_TIMEOUT_MS = 1000;
+
   private final SurfaceTextureEntry flutterTexture;
   private final CameraManager cameraManager;
   private final DeviceOrientationManager deviceOrientationListener;
@@ -105,6 +111,7 @@ public class Camera {
   private boolean useAutoFocus = true;
   private Range<Integer> fpsRange;
   private PlatformChannel.DeviceOrientation lockedCaptureOrientation;
+  private long preCaptureStartTime;
 
   private static final HashMap<String, Integer> supportedImageFormats;
   // Current supported outputs
@@ -503,11 +510,16 @@ public class Camera {
                   || aeState == CaptureRequest.CONTROL_AE_STATE_FLASH_REQUIRED
                   || aeState == CaptureRequest.CONTROL_AE_STATE_CONVERGED) {
                 pictureCaptureRequest.setState(State.waitingPreCaptureReady);
+                setPreCaptureStartTime();
               }
               break;
             case waitingPreCaptureReady:
               if (aeState == null || aeState != CaptureRequest.CONTROL_AE_STATE_PRECAPTURE) {
                 runPictureCapture();
+              } else {
+                if (hitPreCaptureTimeout()) {
+                  unlockAutoFocus();
+                }
               }
           }
         }
@@ -1140,6 +1152,22 @@ public class Camera {
       imageStreamReader.setOnImageAvailableListener(null, null);
     }
     startPreview();
+  }
+
+  /**
+   * Sets the time the pre-capture sequence started.
+   */
+  private void setPreCaptureStartTime() {
+    preCaptureStartTime = SystemClock.elapsedRealtime();
+  }
+
+  /**
+   * Check if the timeout for the pre-capture sequence has been reached.
+   *
+   * @return true if the timeout is reached; otherwise false is returned.
+   */
+  private boolean hitPreCaptureTimeout() {
+    return (SystemClock.elapsedRealtime() - preCaptureStartTime) > PRECAPTURE_TIMEOUT_MS;
   }
 
   private void closeCaptureSession() {

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera
 description: A Flutter plugin for getting information about and controlling the
   camera on Android and iOS. Supports previewing the camera feed, capturing images, capturing video,
   and streaming image buffers to dart.
-version: 0.8.0-nullsafety
+version: 0.8.0-nullsafety.1
 homepage: https://github.com/flutter/plugins/tree/master/packages/camera/camera
 
 dependencies:

--- a/packages/camera/camera/test/camera_test.dart
+++ b/packages/camera/camera/test/camera_test.dart
@@ -1268,7 +1268,7 @@ class MockCameraPlatform extends Mock
   Future<int> createCamera(
     CameraDescription description,
     ResolutionPreset? resolutionPreset, {
-    bool enableAudio = true,
+    bool enableAudio = false,
   }) =>
       mockPlatformException
           ? throw PlatformException(code: 'foo', message: 'bar')


### PR DESCRIPTION
Added a timeout to the Android pre-capture sequence to prevent hard crashes when the camera is unable to acquire a focus lock. The solution is inspired by the [Android Camera2 Raw](https://github.com/googlearchive/android-Camera2Raw/blob/8ef76bbc26ff44e5dd7584efbc763d58803bf45c/Application/src/main/java/com/example/android/camera2raw/Camera2RawFragment.java#L473) example App which uses a similar solution. 

- Fixes flutter/flutter#74645

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
