### PR TITLE
[video_player] Ignore setting mixWithOthers in web

### DIFF
--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-nullsafety.11
+
+* Setting the `mixWithOthers` `VideoPlayerOptions` in web now is silently ignored instead of throwing an exception.
+
 ## 2.0.0-nullsafety.10
 
 * Updated to video_player_platform_interface 4.0.

--- a/packages/video_player/video_player/README.md
+++ b/packages/video_player/video_player/README.md
@@ -48,6 +48,8 @@ This plugin compiles for the web platform since version `0.10.5`, in recent enou
 
 Different web browsers may have different video-playback capabilities (supported formats, autoplay...). Check [package:video_player_web](https://pub.dev/packages/video_player_web) for more web-specific information.
 
+The `VideoPlayerOptions.mixWithOthers` option can't be implemented in web, at least at the moment. If you use this option in web it will be silently ignored.
+
 ## Supported Formats
 
 - On iOS, the backing player is [AVPlayer](https://developer.apple.com/documentation/avfoundation/avplayer).

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -1,7 +1,7 @@
 name: video_player
 description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android, iOS, and web.
-version: 2.0.0-nullsafety.10
+version: 2.0.0-nullsafety.11
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player
 
 flutter:
@@ -25,7 +25,7 @@ dependencies:
   # the constraints on the interface pins it.
   # TODO(amirh): Revisit this (either update this part in the design or the pub tool).
   # https://github.com/flutter/flutter/issues/46264
-  video_player_web: ^2.0.0-nullsafety.1
+  video_player_web: ^2.0.0-nullsafety.4
 
   flutter:
     sdk: flutter

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   # the constraints on the interface pins it.
   # TODO(amirh): Revisit this (either update this part in the design or the pub tool).
   # https://github.com/flutter/flutter/issues/46264
-  video_player_web: ^2.0.0-nullsafety.4
+  video_player_web: ^2.0.0-nullsafety.1
 
   flutter:
     sdk: flutter

--- a/packages/video_player/video_player_platform_interface/CHANGELOG.md
+++ b/packages/video_player/video_player_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.0-nullsafety.1
+
+* Add note about the `mixWithOthers` option being ignored on the web.
+
 ## 4.0.0-nullsafety.0
 
 * Update to latest Pigeon.

--- a/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
+++ b/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
@@ -346,6 +346,9 @@ class DurationRange {
 class VideoPlayerOptions {
   /// Set this to true to mix the video players audio with other audio sources.
   /// The default value is false
+  ///
+  /// Note: This option will be silently ignored in the web platform (there is
+  /// currently no way to implement this feature in this platform).
   final bool mixWithOthers;
 
   /// set additional optional player settings

--- a/packages/video_player/video_player_platform_interface/pubspec.yaml
+++ b/packages/video_player/video_player_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the video_player plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 4.0.0-nullsafety.0
+version: 4.0.0-nullsafety.1
 
 dependencies:
   flutter:

--- a/packages/video_player/video_player_web/CHANGELOG.md
+++ b/packages/video_player/video_player_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-nullsafety.4
+
+* Calling `setMixWithOthers()` now is silently ignored instead of throwing an exception.
+
 ## 2.0.0-nullsafety.3
 
 * Updated to video_player_platform_interface 4.0.

--- a/packages/video_player/video_player_web/README.md
+++ b/packages/video_player/video_player_web/README.md
@@ -28,6 +28,10 @@ The Web platform does **not** suppport `dart:io`, so attempts to create a `Video
 Playing videos without prior interaction with the site might be prohibited
 by the browser and lead to runtime errors. See also: https://goo.gl/xX8pDD.
 
+## Mixing audio with other audio sources
+
+The `VideoPlayerOptions.mixWithOthers` option can't be implemented in web, at least at the moment. If you use this option it will be silently ignored.
+
 ## Supported Formats
 
 **Different web browsers support different sets of video codecs.**

--- a/packages/video_player/video_player_web/lib/video_player_web.dart
+++ b/packages/video_player/video_player_web/lib/video_player_web.dart
@@ -144,6 +144,10 @@ class VideoPlayerPlugin extends VideoPlayerPlatform {
   Widget buildView(int textureId) {
     return HtmlElementView(viewType: 'videoPlayer-$textureId');
   }
+
+  /// Sets the audio mode to mix with other sources (ignored)
+  @override
+  Future<void> setMixWithOthers(bool mixWithOthers) => Future<void>.value();
 }
 
 class _VideoPlayer {

--- a/packages/video_player/video_player_web/pubspec.yaml
+++ b/packages/video_player/video_player_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: video_player_web
 description: Web platform implementation of video_player.
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player_web
-version: 2.0.0-nullsafety.3
+version: 2.0.0-nullsafety.4
 
 flutter:
   plugin:

--- a/packages/video_player/video_player_web/test/video_player_web_test.dart
+++ b/packages/video_player/video_player_web/test/video_player_web_test.dart
@@ -136,5 +136,10 @@ void main() {
       expect(VideoPlayerPlatform.instance.buildView(textureId),
           isInstanceOf<Widget>());
     });
+
+    test('ignores setting mixWithOthers', () {
+      expect(VideoPlayerPlatform.instance.setMixWithOthers(true), completes);
+      expect(VideoPlayerPlatform.instance.setMixWithOthers(false), completes);
+    });
   });
 }


### PR DESCRIPTION
This option can't be implemented in the web platform, so it is better to just ignore it as there is no other alternative when running in web.

The documentation is updated to note this option will be silently ignored in web.

Fixes https://github.com/flutter/flutter/issues/75493.

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy]. **(technically this might be a breaking change, so I guess the major version should be bumped, at least in the _web package, but then 2.0.0 is still a prerelease, so I guess we can make breaking changes there)**
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing. **(some existing unrelated tests are failing but I think it is because I don't know how to run them properly)**