### PR TITLE
[camera] Solves delay when using the zoom feature on iOS.

### DIFF
--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.0-nullsafety.2
+
+* Solved delay when using the zoom feature on iOS.
+
 ## 0.8.0-nullsafety.1
 
 * Added a timeout to the pre-capture sequence on Android to prevent crashes when the camera cannot get a focus.

--- a/packages/camera/camera/example/lib/main.dart
+++ b/packages/camera/camera/example/lib/main.dart
@@ -56,9 +56,6 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
   double _currentScale = 1.0;
   double _baseScale = 1.0;
 
-  // Counting pointers (number of user fingers on screen)
-  int _pointers = 0;
-
   @override
   void initState() {
     super.initState();
@@ -171,21 +168,17 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
         ),
       );
     } else {
-      return Listener(
-        onPointerDown: (_) => _pointers++,
-        onPointerUp: (_) => _pointers--,
-        child: CameraPreview(
-          controller,
-          child: LayoutBuilder(
-              builder: (BuildContext context, BoxConstraints constraints) {
-            return GestureDetector(
-              behavior: HitTestBehavior.opaque,
-              onScaleStart: _handleScaleStart,
-              onScaleUpdate: _handleScaleUpdate,
-              onTapDown: (details) => onViewFinderTap(details, constraints),
-            );
-          }),
-        ),
+      return CameraPreview(
+        controller,
+        child: LayoutBuilder(
+            builder: (BuildContext context, BoxConstraints constraints) {
+          return GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onScaleStart: _handleScaleStart,
+            onScaleUpdate: _handleScaleUpdate,
+            onTapDown: (details) => onViewFinderTap(details, constraints),
+          );
+        }),
       );
     }
   }
@@ -196,7 +189,7 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
 
   Future<void> _handleScaleUpdate(ScaleUpdateDetails details) async {
     // When there are not exactly two fingers on screen don't scale
-    if (_pointers != 2) {
+    if (details.pointerCount != 2) {
       return;
     }
 

--- a/packages/camera/camera/example/lib/main.dart
+++ b/packages/camera/camera/example/lib/main.dart
@@ -56,6 +56,9 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
   double _currentScale = 1.0;
   double _baseScale = 1.0;
 
+  // Counting pointers (number of user fingers on screen)
+  int _pointers = 0;
+
   @override
   void initState() {
     super.initState();
@@ -168,17 +171,21 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
         ),
       );
     } else {
-      return CameraPreview(
-        controller,
-        child: LayoutBuilder(
-            builder: (BuildContext context, BoxConstraints constraints) {
-          return GestureDetector(
-            behavior: HitTestBehavior.opaque,
-            onScaleStart: _handleScaleStart,
-            onScaleUpdate: _handleScaleUpdate,
-            onTapDown: (details) => onViewFinderTap(details, constraints),
-          );
-        }),
+      return Listener(
+        onPointerDown: (_) => _pointers++,
+        onPointerUp: (_) => _pointers--,
+        child: CameraPreview(
+          controller,
+          child: LayoutBuilder(
+              builder: (BuildContext context, BoxConstraints constraints) {
+            return GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onScaleStart: _handleScaleStart,
+              onScaleUpdate: _handleScaleUpdate,
+              onTapDown: (details) => onViewFinderTap(details, constraints),
+            );
+          }),
+        ),
       );
     }
   }
@@ -189,7 +196,7 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
 
   Future<void> _handleScaleUpdate(ScaleUpdateDetails details) async {
     // When there are not exactly two fingers on screen don't scale
-    if (details.pointerCount != 2) {
+    if (_pointers != 2) {
       return;
     }
 

--- a/packages/camera/camera/ios/Classes/CameraPlugin.m
+++ b/packages/camera/camera/ios/Classes/CameraPlugin.m
@@ -1068,7 +1068,7 @@ NSString *const errorMethod = @"error";
     result(getFlutterError(error));
     return;
   }
-  [_captureDevice rampToVideoZoomFactor:zoom withRate:1];
+  _captureDevice.videoZoomFactor = zoom;
   [_captureDevice unlockForConfiguration];
 
   result(nil);

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera
 description: A Flutter plugin for getting information about and controlling the
   camera on Android and iOS. Supports previewing the camera feed, capturing images, capturing video,
   and streaming image buffers to dart.
-version: 0.8.0-nullsafety.1
+version: 0.8.0-nullsafety.2
 homepage: https://github.com/flutter/plugins/tree/master/packages/camera/camera
 
 dependencies:


### PR DESCRIPTION
Initial version of the zoom feature used the `rampToVideoZoomFactor:withRate` method on iOS to update the zoom scale. This method introduces smooth transition at the specified rate, which is ideal when jumping in large zoom increments (e.g. directly zooming from factor 1 to factor 5). 

However in most use cases you would zoom in very small increments (using pinch to zoom or a slider). Using the `rampToVideoZoomFactor:withRate` method would cause an annoying delay in zoom functionality. Especially since the `rate` parameter is hardcoded since it is not cross platform compatible. Therefore this PR updates the iOS implementation to use the `videoZoomFactor` property instead which jumps directly to the desired zoom level. 

Added benefit is that this now behaves the same way on Android and iOS. It should also be relative easy to implement a smooth transition in cases which require jumping in large zoom increments by breaking the jump down in small increments and send them one by one over a certain period of time.

- Fixes flutter/flutter#74350

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
