### PR TITLE
[shared_preferences] Migrate examples to NNBD

### DIFF
--- a/packages/shared_preferences/shared_preferences/example/integration_test/shared_preferences_test.dart
+++ b/packages/shared_preferences/shared_preferences/example/integration_test/shared_preferences_test.dart
@@ -1,3 +1,9 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart=2.9
+
 import 'dart:async';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';

--- a/packages/shared_preferences/shared_preferences/example/lib/main.dart
+++ b/packages/shared_preferences/shared_preferences/example/lib/main.dart
@@ -32,7 +32,7 @@ class SharedPreferencesDemo extends StatefulWidget {
 
 class SharedPreferencesDemoState extends State<SharedPreferencesDemo> {
   Future<SharedPreferences> _prefs = SharedPreferences.getInstance();
-  Future<int>? _counter;
+  late Future<int> _counter;
 
   Future<void> _incrementCounter() async {
     final SharedPreferences prefs = await _prefs;

--- a/packages/shared_preferences/shared_preferences/example/lib/main.dart
+++ b/packages/shared_preferences/shared_preferences/example/lib/main.dart
@@ -24,7 +24,7 @@ class MyApp extends StatelessWidget {
 }
 
 class SharedPreferencesDemo extends StatefulWidget {
-  SharedPreferencesDemo({Key key}) : super(key: key);
+  SharedPreferencesDemo({Key? key}) : super(key: key);
 
   @override
   SharedPreferencesDemoState createState() => SharedPreferencesDemoState();
@@ -32,7 +32,7 @@ class SharedPreferencesDemo extends StatefulWidget {
 
 class SharedPreferencesDemoState extends State<SharedPreferencesDemo> {
   Future<SharedPreferences> _prefs = SharedPreferences.getInstance();
-  Future<int> _counter;
+  Future<int>? _counter;
 
   Future<void> _incrementCounter() async {
     final SharedPreferences prefs = await _prefs;

--- a/packages/shared_preferences/shared_preferences/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences/example/pubspec.yaml
@@ -23,6 +23,5 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.0.0-dev.28.0 <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"
   flutter: ">=1.9.1+hotfix.2"
-

--- a/packages/shared_preferences/shared_preferences/example/test_driver/integration_test.dart
+++ b/packages/shared_preferences/shared_preferences/example/test_driver/integration_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/packages/shared_preferences/shared_preferences_linux/example/integration_test/shared_preferences_test.dart
+++ b/packages/shared_preferences/shared_preferences_linux/example/integration_test/shared_preferences_test.dart
@@ -1,3 +1,9 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart=2.9
+
 import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/shared_preferences/shared_preferences_linux/example/lib/main.dart
+++ b/packages/shared_preferences/shared_preferences_linux/example/lib/main.dart
@@ -24,7 +24,7 @@ class MyApp extends StatelessWidget {
 }
 
 class SharedPreferencesDemo extends StatefulWidget {
-  SharedPreferencesDemo({Key key}) : super(key: key);
+  SharedPreferencesDemo({Key? key}) : super(key: key);
 
   @override
   SharedPreferencesDemoState createState() => SharedPreferencesDemoState();
@@ -32,14 +32,14 @@ class SharedPreferencesDemo extends StatefulWidget {
 
 class SharedPreferencesDemoState extends State<SharedPreferencesDemo> {
   final prefs = SharedPreferencesLinux.instance;
-  Future<int> _counter;
+  Future<int>? _counter;
 
   Future<void> _incrementCounter() async {
     final values = await prefs.getAll();
-    final int counter = (values['counter'] as int ?? 0) + 1;
+    final int counter = (values['counter'] as int? ?? 0) + 1;
 
     setState(() {
-      _counter = prefs.setValue(null, "counter", counter).then((bool success) {
+      _counter = prefs.setValue('Int', 'counter', counter).then((bool success) {
         return counter;
       });
     });
@@ -49,7 +49,7 @@ class SharedPreferencesDemoState extends State<SharedPreferencesDemo> {
   void initState() {
     super.initState();
     _counter = prefs.getAll().then((Map<String, Object> values) {
-      return (values['counter'] ?? 0);
+      return (values['counter'] as int? ?? 0);
     });
   }
 

--- a/packages/shared_preferences/shared_preferences_linux/example/lib/main.dart
+++ b/packages/shared_preferences/shared_preferences_linux/example/lib/main.dart
@@ -32,7 +32,7 @@ class SharedPreferencesDemo extends StatefulWidget {
 
 class SharedPreferencesDemoState extends State<SharedPreferencesDemo> {
   final prefs = SharedPreferencesLinux.instance;
-  Future<int>? _counter;
+  late Future<int> _counter;
 
   Future<void> _incrementCounter() async {
     final values = await prefs.getAll();

--- a/packages/shared_preferences/shared_preferences_linux/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_linux/example/pubspec.yaml
@@ -23,5 +23,5 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"
   flutter: ">=1.12.8"

--- a/packages/shared_preferences/shared_preferences_linux/example/test_driver/integration_test.dart
+++ b/packages/shared_preferences/shared_preferences_linux/example/test_driver/integration_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/packages/shared_preferences/shared_preferences_macos/example/integration_test/shared_preferences_test.dart
+++ b/packages/shared_preferences/shared_preferences_macos/example/integration_test/shared_preferences_test.dart
@@ -1,12 +1,18 @@
+// Copyright 2017, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// @dart=2.9
+
 import 'dart:async';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
 import 'package:integration_test/integration_test.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  group('$SharedPreferences', () {
+  group('SharedPreferencesMacOS', () {
     const Map<String, dynamic> kTestValues = <String, dynamic>{
       'flutter.String': 'hello world',
       'flutter.bool': true,
@@ -23,67 +29,81 @@ void main() {
       'flutter.List': <String>['baz', 'quox'],
     };
 
-    SharedPreferences preferences;
+    SharedPreferencesStorePlatform preferences;
 
     setUp(() async {
-      preferences = await SharedPreferences.getInstance();
+      preferences = SharedPreferencesStorePlatform.instance;
     });
 
     tearDown(() {
       preferences.clear();
     });
 
-    test('reading', () async {
-      expect(preferences.get('String'), isNull);
-      expect(preferences.get('bool'), isNull);
-      expect(preferences.get('int'), isNull);
-      expect(preferences.get('double'), isNull);
-      expect(preferences.get('List'), isNull);
-      expect(preferences.getString('String'), isNull);
-      expect(preferences.getBool('bool'), isNull);
-      expect(preferences.getInt('int'), isNull);
-      expect(preferences.getDouble('double'), isNull);
-      expect(preferences.getStringList('List'), isNull);
+    // Normally the app-facing package adds the prefix, but since this test
+    // bypasses the app-facing package it needs to be manually added.
+    String _prefixedKey(String key) {
+      return 'flutter.$key';
+    }
+
+    testWidgets('reading', (WidgetTester _) async {
+      final Map<String, Object> values = await preferences.getAll();
+      expect(values[_prefixedKey('String')], isNull);
+      expect(values[_prefixedKey('bool')], isNull);
+      expect(values[_prefixedKey('int')], isNull);
+      expect(values[_prefixedKey('double')], isNull);
+      expect(values[_prefixedKey('List')], isNull);
     });
 
-    test('writing', () async {
+    testWidgets('writing', (WidgetTester _) async {
       await Future.wait(<Future<bool>>[
-        preferences.setString('String', kTestValues2['flutter.String']),
-        preferences.setBool('bool', kTestValues2['flutter.bool']),
-        preferences.setInt('int', kTestValues2['flutter.int']),
-        preferences.setDouble('double', kTestValues2['flutter.double']),
-        preferences.setStringList('List', kTestValues2['flutter.List'])
+        preferences.setValue(
+            'String', _prefixedKey('String'), kTestValues2['flutter.String']),
+        preferences.setValue(
+            'Bool', _prefixedKey('bool'), kTestValues2['flutter.bool']),
+        preferences.setValue(
+            'Int', _prefixedKey('int'), kTestValues2['flutter.int']),
+        preferences.setValue(
+            'Double', _prefixedKey('double'), kTestValues2['flutter.double']),
+        preferences.setValue(
+            'StringList', _prefixedKey('List'), kTestValues2['flutter.List'])
       ]);
-      expect(preferences.getString('String'), kTestValues2['flutter.String']);
-      expect(preferences.getBool('bool'), kTestValues2['flutter.bool']);
-      expect(preferences.getInt('int'), kTestValues2['flutter.int']);
-      expect(preferences.getDouble('double'), kTestValues2['flutter.double']);
-      expect(preferences.getStringList('List'), kTestValues2['flutter.List']);
+      final Map<String, Object> values = await preferences.getAll();
+      expect(values[_prefixedKey('String')], kTestValues2['flutter.String']);
+      expect(values[_prefixedKey('bool')], kTestValues2['flutter.bool']);
+      expect(values[_prefixedKey('int')], kTestValues2['flutter.int']);
+      expect(values[_prefixedKey('double')], kTestValues2['flutter.double']);
+      expect(values[_prefixedKey('List')], kTestValues2['flutter.List']);
     });
 
-    test('removing', () async {
-      const String key = 'testKey';
-      await preferences.setString(key, kTestValues['flutter.String']);
-      await preferences.setBool(key, kTestValues['flutter.bool']);
-      await preferences.setInt(key, kTestValues['flutter.int']);
-      await preferences.setDouble(key, kTestValues['flutter.double']);
-      await preferences.setStringList(key, kTestValues['flutter.List']);
+    testWidgets('removing', (WidgetTester _) async {
+      final String key = _prefixedKey('testKey');
+      await preferences.setValue('String', key, kTestValues['flutter.String']);
+      await preferences.setValue('Bool', key, kTestValues['flutter.bool']);
+      await preferences.setValue('Int', key, kTestValues['flutter.int']);
+      await preferences.setValue('Double', key, kTestValues['flutter.double']);
+      await preferences.setValue(
+          'StringList', key, kTestValues['flutter.List']);
       await preferences.remove(key);
-      expect(preferences.get('testKey'), isNull);
+      final Map<String, Object> values = await preferences.getAll();
+      expect(values[key], isNull);
     });
 
-    test('clearing', () async {
-      await preferences.setString('String', kTestValues['flutter.String']);
-      await preferences.setBool('bool', kTestValues['flutter.bool']);
-      await preferences.setInt('int', kTestValues['flutter.int']);
-      await preferences.setDouble('double', kTestValues['flutter.double']);
-      await preferences.setStringList('List', kTestValues['flutter.List']);
+    testWidgets('clearing', (WidgetTester _) async {
+      await preferences.setValue(
+          'String', 'String', kTestValues['flutter.String']);
+      await preferences.setValue('Bool', 'bool', kTestValues['flutter.bool']);
+      await preferences.setValue('Int', 'int', kTestValues['flutter.int']);
+      await preferences.setValue(
+          'Double', 'double', kTestValues['flutter.double']);
+      await preferences.setValue(
+          'StringList', 'List', kTestValues['flutter.List']);
       await preferences.clear();
-      expect(preferences.getString('String'), null);
-      expect(preferences.getBool('bool'), null);
-      expect(preferences.getInt('int'), null);
-      expect(preferences.getDouble('double'), null);
-      expect(preferences.getStringList('List'), null);
+      final Map<String, Object> values = await preferences.getAll();
+      expect(values['String'], null);
+      expect(values['bool'], null);
+      expect(values['int'], null);
+      expect(values['double'], null);
+      expect(values['List'], null);
     });
   });
 }

--- a/packages/shared_preferences/shared_preferences_macos/example/lib/main.dart
+++ b/packages/shared_preferences/shared_preferences_macos/example/lib/main.dart
@@ -7,7 +7,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
 
 void main() {
   runApp(MyApp());
@@ -24,22 +24,28 @@ class MyApp extends StatelessWidget {
 }
 
 class SharedPreferencesDemo extends StatefulWidget {
-  SharedPreferencesDemo({Key key}) : super(key: key);
+  SharedPreferencesDemo({Key? key}) : super(key: key);
 
   @override
   SharedPreferencesDemoState createState() => SharedPreferencesDemoState();
 }
 
 class SharedPreferencesDemoState extends State<SharedPreferencesDemo> {
-  Future<SharedPreferences> _prefs = SharedPreferences.getInstance();
-  Future<int> _counter;
+  SharedPreferencesStorePlatform _prefs =
+      SharedPreferencesStorePlatform.instance;
+  late Future<int> _counter;
+
+  // Includes the prefix because this is using the platform interface directly,
+  // but the prefix (which the native code assumes is present) is added by the
+  // app-facing package.
+  static const String _prefKey = 'flutter.counter';
 
   Future<void> _incrementCounter() async {
-    final SharedPreferences prefs = await _prefs;
-    final int counter = (prefs.getInt('counter') ?? 0) + 1;
+    final Map<String, Object> values = await _prefs.getAll();
+    final int counter = ((values[_prefKey] as int?) ?? 0) + 1;
 
     setState(() {
-      _counter = prefs.setInt("counter", counter).then((bool success) {
+      _counter = _prefs.setValue('Int', _prefKey, counter).then((bool success) {
         return counter;
       });
     });
@@ -48,8 +54,8 @@ class SharedPreferencesDemoState extends State<SharedPreferencesDemo> {
   @override
   void initState() {
     super.initState();
-    _counter = _prefs.then((SharedPreferences prefs) {
-      return (prefs.getInt('counter') ?? 0);
+    _counter = _prefs.getAll().then((Map<String, Object> values) {
+      return (values[_prefKey] as int?) ?? 0;
     });
   }
 

--- a/packages/shared_preferences/shared_preferences_macos/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/packages/shared_preferences/shared_preferences_macos/example/macos/Runner.xcodeproj/project.pbxproj
@@ -26,10 +26,6 @@
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
-		33D1A10422148B71006C7A3E /* FlutterMacOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 33D1A10322148B71006C7A3E /* FlutterMacOS.framework */; };
-		33D1A10522148B93006C7A3E /* FlutterMacOS.framework in Bundle Framework */ = {isa = PBXBuildFile; fileRef = 33D1A10322148B71006C7A3E /* FlutterMacOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		D73912F022F37F9E000D13A0 /* App.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D73912EF22F37F9E000D13A0 /* App.framework */; };
-		D73912F222F3801D000D13A0 /* App.framework in Bundle Framework */ = {isa = PBXBuildFile; fileRef = D73912EF22F37F9E000D13A0 /* App.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DD4A1B9DEDBB72C87CD7AE27 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5067D74CB28D28AE3B3DD05B /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
@@ -50,8 +46,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				D73912F222F3801D000D13A0 /* App.framework in Bundle Framework */,
-				33D1A10522148B93006C7A3E /* FlutterMacOS.framework in Bundle Framework */,
 			);
 			name = "Bundle Framework";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -70,7 +64,6 @@
 		33CEB47222A05771004F2AC0 /* Flutter-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Flutter-Debug.xcconfig"; sourceTree = "<group>"; };
 		33CEB47422A05771004F2AC0 /* Flutter-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Flutter-Release.xcconfig"; sourceTree = "<group>"; };
 		33CEB47722A0578A004F2AC0 /* Flutter-Generated.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "Flutter-Generated.xcconfig"; path = "ephemeral/Flutter-Generated.xcconfig"; sourceTree = "<group>"; };
-		33D1A10322148B71006C7A3E /* FlutterMacOS.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FlutterMacOS.framework; path = Flutter/ephemeral/FlutterMacOS.framework; sourceTree = SOURCE_ROOT; };
 		33E51913231747F40026EE4D /* DebugProfile.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = DebugProfile.entitlements; sourceTree = "<group>"; };
 		33E51914231749380026EE4D /* Release.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = Release.entitlements; sourceTree = "<group>"; };
 		33E5194F232828860026EE4D /* AppInfo.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = AppInfo.xcconfig; sourceTree = "<group>"; };
@@ -80,7 +73,6 @@
 		899489AD6AA35AECA4E2BEA6 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		B36FDC1D769C9045B8821207 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
-		D73912EF22F37F9E000D13A0 /* App.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = App.framework; path = Flutter/ephemeral/App.framework; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -88,8 +80,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D73912F022F37F9E000D13A0 /* App.framework in Frameworks */,
-				33D1A10422148B71006C7A3E /* FlutterMacOS.framework in Frameworks */,
 				DD4A1B9DEDBB72C87CD7AE27 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -145,8 +135,6 @@
 				33CEB47222A05771004F2AC0 /* Flutter-Debug.xcconfig */,
 				33CEB47422A05771004F2AC0 /* Flutter-Release.xcconfig */,
 				33CEB47722A0578A004F2AC0 /* Flutter-Generated.xcconfig */,
-				D73912EF22F37F9E000D13A0 /* App.framework */,
-				33D1A10322148B71006C7A3E /* FlutterMacOS.framework */,
 			);
 			path = Flutter;
 			sourceTree = "<group>";
@@ -281,7 +269,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "echo \"$PRODUCT_NAME.app\" > \"$PROJECT_DIR\"/Flutter/ephemeral/.app_filename\n";
+			shellScript = "echo \"$PRODUCT_NAME.app\" > \"$PROJECT_DIR\"/Flutter/ephemeral/.app_filename && \"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh embed\n";
 		};
 		33CC111E2044C6BF0003C045 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -308,10 +296,13 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputFileListPaths = (
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/shared_preferences_macos/shared_preferences_macos.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/shared_preferences_macos.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/packages/shared_preferences/shared_preferences_macos/example/macos/Runner.xcworkspace/contents.xcworkspacedata
+++ b/packages/shared_preferences/shared_preferences_macos/example/macos/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/packages/shared_preferences/shared_preferences_macos/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_macos/example/pubspec.yaml
@@ -4,7 +4,7 @@ description: Demonstrates how to use the shared_preferences plugin.
 dependencies:
   flutter:
     sdk: flutter
-  shared_preferences: any
+  shared_preferences_platform_interface: ^2.0.0-nullsafety
   shared_preferences_macos:
     # When depending on this package from a real application you should use:
     #   shared_preferences_macos: ^x.y.z
@@ -24,5 +24,5 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"
   flutter: ">=1.12.8"

--- a/packages/shared_preferences/shared_preferences_macos/example/test_driver/integration_test.dart
+++ b/packages/shared_preferences/shared_preferences_macos/example/test_driver/integration_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/packages/shared_preferences/shared_preferences_macos/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_macos/pubspec.yaml
@@ -17,5 +17,6 @@ dependencies:
   shared_preferences_platform_interface: ^2.0.0-nullsafety
   flutter:
     sdk: flutter
+
 dev_dependencies:
   pedantic: ^1.8.0

--- a/packages/shared_preferences/shared_preferences_windows/example/integration_test/shared_preferences_test.dart
+++ b/packages/shared_preferences/shared_preferences_windows/example/integration_test/shared_preferences_test.dart
@@ -2,13 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'dart:async';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences_windows/shared_preferences_windows.dart';
-import 'package:e2e/e2e.dart';
+import 'package:integration_test/integration_test.dart';
 
 void main() {
-  E2EWidgetsFlutterBinding.ensureInitialized();
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   group('SharedPreferencesWindows', () {
     const Map<String, dynamic> kTestValues = <String, dynamic>{

--- a/packages/shared_preferences/shared_preferences_windows/example/lib/main.dart
+++ b/packages/shared_preferences/shared_preferences_windows/example/lib/main.dart
@@ -24,7 +24,7 @@ class MyApp extends StatelessWidget {
 }
 
 class SharedPreferencesDemo extends StatefulWidget {
-  SharedPreferencesDemo({Key key}) : super(key: key);
+  SharedPreferencesDemo({Key? key}) : super(key: key);
 
   @override
   SharedPreferencesDemoState createState() => SharedPreferencesDemoState();
@@ -32,14 +32,14 @@ class SharedPreferencesDemo extends StatefulWidget {
 
 class SharedPreferencesDemoState extends State<SharedPreferencesDemo> {
   final prefs = SharedPreferencesWindows.instance;
-  Future<int> _counter;
+  Future<int>? _counter;
 
   Future<void> _incrementCounter() async {
     final values = await prefs.getAll();
-    final int counter = (values['counter'] as int ?? 0) + 1;
+    final int counter = (values['counter'] as int? ?? 0) + 1;
 
     setState(() {
-      _counter = prefs.setValue(null, "counter", counter).then((bool success) {
+      _counter = prefs.setValue('Int', 'counter', counter).then((bool success) {
         return counter;
       });
     });
@@ -49,7 +49,7 @@ class SharedPreferencesDemoState extends State<SharedPreferencesDemo> {
   void initState() {
     super.initState();
     _counter = prefs.getAll().then((Map<String, Object> values) {
-      return (values['counter'] ?? 0);
+      return (values['counter'] as int? ?? 0);
     });
   }
 

--- a/packages/shared_preferences/shared_preferences_windows/example/lib/main.dart
+++ b/packages/shared_preferences/shared_preferences_windows/example/lib/main.dart
@@ -32,7 +32,7 @@ class SharedPreferencesDemo extends StatefulWidget {
 
 class SharedPreferencesDemoState extends State<SharedPreferencesDemo> {
   final prefs = SharedPreferencesWindows.instance;
-  Future<int>? _counter;
+  late Future<int> _counter;
 
   Future<void> _incrementCounter() async {
     final values = await prefs.getAll();

--- a/packages/shared_preferences/shared_preferences_windows/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_windows/example/pubspec.yaml
@@ -2,7 +2,8 @@ name: shared_preferences_windows_example
 description: Demonstrates how to use the shared_preferences_windows plugin.
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"
+  flutter: ">=1.12.8"
 
 dependencies:
   flutter:
@@ -21,7 +22,8 @@ dependency_overrides:
 dev_dependencies:
   flutter_driver:
     sdk: flutter
-  e2e: ^0.2.0
+  integration_test:
+    path: ../../../integration_test
   pedantic: ^1.8.0
 
 flutter:

--- a/packages/shared_preferences/shared_preferences_windows/example/test_driver/integration_test.dart
+++ b/packages/shared_preferences/shared_preferences_windows/example/test_driver/integration_test.dart
@@ -3,13 +3,15 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 import 'package:flutter_driver/flutter_driver.dart';
 
 Future<void> main() async {
   final FlutterDriver driver = await FlutterDriver.connect();
-  final String result =
+  final String data =
       await driver.requestData(null, timeout: const Duration(minutes: 1));
   await driver.close();
-  exit(result == 'pass' ? 0 : 1);
+  final Map<String, dynamic> result = jsonDecode(data);
+  exit(result['result'] == 'true' ? 0 : 1);
 }

--- a/packages/shared_preferences/shared_preferences_windows/example/test_driver/integration_test.dart
+++ b/packages/shared_preferences/shared_preferences_windows/example/test_driver/integration_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.9
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';


### PR DESCRIPTION
Migrate all examples to NNBD so that the example apps will run in strong mode.

Converts macOS example to use the platform interface to remove circular dependencies (code is based on the Linux and Windows versions which already use essentially that approach).

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
