### PR TITLE
[shared_preferences] fix crash when list type is dynaimc

### DIFF
--- a/packages/in_app_purchase/example/pubspec.yaml
+++ b/packages/in_app_purchase/example/pubspec.yaml
@@ -5,13 +5,8 @@ author: Flutter Team <flutter-dev@googlegroups.com>
 dependencies:
   flutter:
     sdk: flutter
-<<<<<<< Updated upstream
   cupertino_icons: ^0.1.2
   shared_preferences: ^0.5.2
-=======
-  shared_preferences:
-    path: ../../shared_preferences/shared_preferences
->>>>>>> Stashed changes
 
 dev_dependencies:
   test: ^1.5.2

--- a/packages/in_app_purchase/example/pubspec.yaml
+++ b/packages/in_app_purchase/example/pubspec.yaml
@@ -5,8 +5,13 @@ author: Flutter Team <flutter-dev@googlegroups.com>
 dependencies:
   flutter:
     sdk: flutter
+<<<<<<< Updated upstream
   cupertino_icons: ^0.1.2
   shared_preferences: ^0.5.2
+=======
+  shared_preferences:
+    path: ../../shared_preferences/shared_preferences
+>>>>>>> Stashed changes
 
 dev_dependencies:
   test: ^1.5.2

--- a/packages/shared_preferences/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-nullsafety.1
+
+* Fix crash when list string's type is dynamic.
+
 ## 2.0.0-nullsafety
 
 * Migrate to null-safety.

--- a/packages/shared_preferences/shared_preferences/lib/shared_preferences.dart
+++ b/packages/shared_preferences/shared_preferences/lib/shared_preferences.dart
@@ -107,13 +107,17 @@ class SharedPreferences {
   /// Reads a set of string values from persistent storage, throwing an
   /// exception if it's not a string set.
   List<String>? getStringList(String key) {
-    List<Object>? list = _preferenceCache[key] as List<Object>?;
+    final Object? rawValue = _preferenceCache[key];
+    if (rawValue == null) {
+      return null;
+    }
+    List<Object>? list = List.castFrom<dynamic, String>(rawValue as List<dynamic>);
     if (list != null && list is! List<String>) {
       list = list.cast<String>().toList();
       _preferenceCache[key] = list;
     }
     // Make a copy of the list so that later mutations won't propagate
-    return list?.toList() as List<String>?;
+    return list.toList() as List<String>?;
   }
 
   /// Saves a boolean [value] to persistent storage in the background.

--- a/packages/shared_preferences/shared_preferences/lib/shared_preferences.dart
+++ b/packages/shared_preferences/shared_preferences/lib/shared_preferences.dart
@@ -107,18 +107,13 @@ class SharedPreferences {
   /// Reads a set of string values from persistent storage, throwing an
   /// exception if it's not a string set.
   List<String>? getStringList(String key) {
-    final Object? rawValue = _preferenceCache[key];
-    if (rawValue == null) {
-      return null;
-    }
-    List<Object>? list =
-        List.castFrom<dynamic, String>(rawValue as List<dynamic>);
+    List<dynamic>? list = _preferenceCache[key] as List<dynamic>?;
     if (list != null && list is! List<String>) {
       list = list.cast<String>().toList();
       _preferenceCache[key] = list;
     }
     // Make a copy of the list so that later mutations won't propagate
-    return list.toList() as List<String>?;
+    return list?.toList() as List<String>?;
   }
 
   /// Saves a boolean [value] to persistent storage in the background.

--- a/packages/shared_preferences/shared_preferences/lib/shared_preferences.dart
+++ b/packages/shared_preferences/shared_preferences/lib/shared_preferences.dart
@@ -111,7 +111,8 @@ class SharedPreferences {
     if (rawValue == null) {
       return null;
     }
-    List<Object>? list = List.castFrom<dynamic, String>(rawValue as List<dynamic>);
+    List<Object>? list =
+        List.castFrom<dynamic, String>(rawValue as List<dynamic>);
     if (list != null && list is! List<String>) {
       list = list.cast<String>().toList();
       _preferenceCache[key] = list;

--- a/packages/shared_preferences/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences/pubspec.yaml
@@ -2,7 +2,7 @@ name: shared_preferences
 description: Flutter plugin for reading and writing simple key-value pairs.
   Wraps NSUserDefaults on iOS and SharedPreferences on Android.
 homepage: https://github.com/flutter/plugins/tree/master/packages/shared_preferences/shared_preferences
-version: 2.0.0-nullsafety
+version: 2.0.0-nullsafety.1
 
 flutter:
   plugin:

--- a/packages/shared_preferences/shared_preferences/test/shared_preferences_test.dart
+++ b/packages/shared_preferences/shared_preferences/test/shared_preferences_test.dart
@@ -158,8 +158,9 @@ void main() {
     });
 
     test('string list type is dynamic (usually from method channel)', () async {
-      SharedPreferences.setMockInitialValues(
-          <String, Object>{'dynamic_list': <dynamic>['1', '2']});
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'dynamic_list': <dynamic>['1', '2']
+      });
       final SharedPreferences prefs = await SharedPreferences.getInstance();
       final List<String>? value = prefs.getStringList('dynamic_list');
       expect(value, <String>['1', '2']);

--- a/packages/shared_preferences/shared_preferences/test/shared_preferences_test.dart
+++ b/packages/shared_preferences/shared_preferences/test/shared_preferences_test.dart
@@ -39,6 +39,7 @@ void main() {
 
     tearDown(() async {
       await preferences.clear();
+      await store.clear();
     });
 
     test('reading', () async {
@@ -154,6 +155,14 @@ void main() {
       final Future<SharedPreferences> first = SharedPreferences.getInstance();
       final Future<SharedPreferences> second = SharedPreferences.getInstance();
       expect(await first, await second);
+    });
+
+    test('string list type is dynamic (usually from method channel)', () async {
+      SharedPreferences.setMockInitialValues(
+          <String, Object>{'dynamic_list': <dynamic>['1', '2']});
+      final SharedPreferences prefs = await SharedPreferences.getInstance();
+      final List<String>? value = prefs.getStringList('dynamic_list');
+      expect(value, <String>['1', '2']);
     });
 
     group('mocking', () {


### PR DESCRIPTION
The type of List could be converted to `dynamic` when coming from method channel. We needs to initially treat it as dynamic then convert back to `Object`

See: https://github.com/flutter/plugins/pull/3555#issuecomment-781616325

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
