### PR TITLE
[image_picker_for_web] Add doc comments to point out that some arguments aren't supported on the web

### DIFF
--- a/packages/image_picker/image_picker_for_web/CHANGELOG.md
+++ b/packages/image_picker/image_picker_for_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.0.0-nullsafety.1
+
+* Add doc comments to point out that some arguments are'nt supported on the web
+
 # 2.0.0-nullsafety
 
 * Migrate to null safety.

--- a/packages/image_picker/image_picker_for_web/CHANGELOG.md
+++ b/packages/image_picker/image_picker_for_web/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 2.0.0-nullsafety.1
 
-* Add doc comments to point out that some arguments aren't supported on the web
+* Add doc comments to point out that some arguments aren't supported on the web.
 
 # 2.0.0-nullsafety
 

--- a/packages/image_picker/image_picker_for_web/CHANGELOG.md
+++ b/packages/image_picker/image_picker_for_web/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 2.0.0-nullsafety.1
 
-* Add doc comments to point out that some arguments are'nt supported on the web
+* Add doc comments to point out that some arguments aren't supported on the web
 
 # 2.0.0-nullsafety
 

--- a/packages/image_picker/image_picker_for_web/README.md
+++ b/packages/image_picker/image_picker_for_web/README.md
@@ -2,7 +2,7 @@
 
 A web implementation of [`image_picker`][1].
 
-## Browser Support
+## Limitations on the web platform
 
 Since Web Browsers don't offer direct access to their users' file system,
 this plugin provides a `PickedFile` abstraction to make access access uniform
@@ -41,6 +41,12 @@ In order to "take a photo", some mobile browsers offer a [`capture` attribute](h
 
 Each browser may implement `capture` any way they please, so it may (or may not) make a
 difference in your users' experience.
+
+### pickImage()
+The arguments `maxWidth`, `maxHeight` and `imageQuality` are not supported on the web.
+
+### pickVideo()
+The argument `maxDuration` is not supported on the web.
 
 ## Usage
 

--- a/packages/image_picker/image_picker_for_web/lib/image_picker_for_web.dart
+++ b/packages/image_picker/image_picker_for_web/lib/image_picker_for_web.dart
@@ -35,7 +35,7 @@ class ImagePickerPlugin extends ImagePickerPlatform {
   /// The `source` argument controls where the image comes from. This can
   /// be either [ImageSource.camera] or [ImageSource.gallery].
   ///
-  /// Note that the `maxWidth`, `maxHeight` and `imageQuality` arguments are not supported on the web. If any of these arguments is supplied, it'll be silently ignored by the web version of the plugin. 
+  /// Note that the `maxWidth`, `maxHeight` and `imageQuality` arguments are not supported on the web. If any of these arguments is supplied, it'll be silently ignored by the web version of the plugin.
   ///
   /// Use `preferredCameraDevice` to specify the camera to use when the `source` is [ImageSource.camera].
   /// The `preferredCameraDevice` is ignored when `source` is [ImageSource.gallery]. It is also ignored if the chosen camera is not supported on the device.

--- a/packages/image_picker/image_picker_for_web/lib/image_picker_for_web.dart
+++ b/packages/image_picker/image_picker_for_web/lib/image_picker_for_web.dart
@@ -30,6 +30,18 @@ class ImagePickerPlugin extends ImagePickerPlatform {
     ImagePickerPlatform.instance = ImagePickerPlugin();
   }
 
+  /// Returns a [PickedFile] with the image that was picked.
+  ///
+  /// The `source` argument controls where the image comes from. This can
+  /// be either [ImageSource.camera] or [ImageSource.gallery].
+  ///
+  /// Note that the `maxWidth`, `maxHeight` and `imageQuality` arguments are not supported on the web.
+  ///
+  /// Use `preferredCameraDevice` to specify the camera to use when the `source` is [ImageSource.camera].
+  /// The `preferredCameraDevice` is ignored when `source` is [ImageSource.gallery]. It is also ignored if the chosen camera is not supported on the device.
+  /// Defaults to [CameraDevice.rear].
+  ///
+  /// If no images were picked, the return value is null.
   @override
   Future<PickedFile> pickImage({
     required ImageSource source,
@@ -42,6 +54,18 @@ class ImagePickerPlugin extends ImagePickerPlatform {
     return pickFile(accept: _kAcceptImageMimeType, capture: capture);
   }
 
+  /// Returns a [PickedFile] containing the video that was picked.
+  ///
+  /// The [source] argument controls where the video comes from. This can
+  /// be either [ImageSource.camera] or [ImageSource.gallery].
+  ///
+  /// Note that the `maxDuration` argument is not supported on the web.
+  ///
+  /// Use `preferredCameraDevice` to specify the camera to use when the `source` is [ImageSource.camera].
+  /// The `preferredCameraDevice` is ignored when `source` is [ImageSource.gallery]. It is also ignored if the chosen camera is not supported on the device.
+  /// Defaults to [CameraDevice.rear].
+  ///
+  /// If no images were picked, the return value is null.
   @override
   Future<PickedFile> pickVideo({
     required ImageSource source,

--- a/packages/image_picker/image_picker_for_web/lib/image_picker_for_web.dart
+++ b/packages/image_picker/image_picker_for_web/lib/image_picker_for_web.dart
@@ -35,7 +35,7 @@ class ImagePickerPlugin extends ImagePickerPlatform {
   /// The `source` argument controls where the image comes from. This can
   /// be either [ImageSource.camera] or [ImageSource.gallery].
   ///
-  /// Note that the `maxWidth`, `maxHeight` and `imageQuality` arguments are not supported on the web.
+  /// Note that the `maxWidth`, `maxHeight` and `imageQuality` arguments are not supported on the web. If any of these arguments is supplied, it'll be silently ignored by the web version of the plugin. 
   ///
   /// Use `preferredCameraDevice` to specify the camera to use when the `source` is [ImageSource.camera].
   /// The `preferredCameraDevice` is ignored when `source` is [ImageSource.gallery]. It is also ignored if the chosen camera is not supported on the device.
@@ -59,7 +59,7 @@ class ImagePickerPlugin extends ImagePickerPlatform {
   /// The [source] argument controls where the video comes from. This can
   /// be either [ImageSource.camera] or [ImageSource.gallery].
   ///
-  /// Note that the `maxDuration` argument is not supported on the web.
+  /// Note that the `maxDuration` argument is not supported on the web. If the argument is supplied, it'll be silently ignored by the web version of the plugin.
   ///
   /// Use `preferredCameraDevice` to specify the camera to use when the `source` is [ImageSource.camera].
   /// The `preferredCameraDevice` is ignored when `source` is [ImageSource.gallery]. It is also ignored if the chosen camera is not supported on the device.

--- a/packages/image_picker/image_picker_for_web/pubspec.yaml
+++ b/packages/image_picker/image_picker_for_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker_for_web
 description: Web platform implementation of image_picker
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker/image_picker_for_web
 
-version: 2.0.0-nullsafety
+version: 2.0.0-nullsafety.1
 
 flutter:
   plugin:


### PR DESCRIPTION
While attempting to update @devj3ns' PR with the latest master, I did the wrong thing and ended up locking myself out of his PR (probably for the better).

This PR relands the same code that @devj3ns was attempting to land in his PR (#3551)

---

The arguments `maxWidth`, `maxHeight` and `imageQuality` of `pickImage()` and the argument `maxDuration` of `pickVideo()` are not supported in web version of the image_picker package.

I added some doc comments to point out that specifying these argument does not change anything on the pickedFile.

### Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
