### PR TITLE
Disable in_app_purchase for master

### DIFF
--- a/script/nnbd_plugins.sh
+++ b/script/nnbd_plugins.sh
@@ -40,6 +40,7 @@ readonly NNBD_PLUGINS_LIST=(
 
 readonly NON_NNBD_PLUGINS_LIST=(
   "extension_google_sign_in_as_googleapis_auth"
+  "in_app_purchase" # dev dependency on old shared_preferences
   "google_maps_flutter" # partially migrated
 )
 


### PR DESCRIPTION
It depends on the old version shared_preferences, which ultimately means
an indirect dependency on old win32, which no longer works on master.

This will be resolved when in_app_purchase is migrated to NNBD.