### PR TITLE
[video_player_web] Bump version for NNBD stable

### DIFF
--- a/packages/video_player/video_player_web/CHANGELOG.md
+++ b/packages/video_player/video_player_web/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## 2.0.0
 
-* **Breaking changes**:
-  * Migrate to null safety.
+* Migrate to null safety.
 * Calling `setMixWithOthers()` now is silently ignored instead of throwing an exception.
 * Fixed an issue where `isBuffering` was not updating on Web.
 

--- a/packages/video_player/video_player_web/CHANGELOG.md
+++ b/packages/video_player/video_player_web/CHANGELOG.md
@@ -1,22 +1,9 @@
-## 2.0.0-nullsafety.4
+## 2.0.0
 
+* **Breaking changes**:
+  * Migrate to null safety.
 * Calling `setMixWithOthers()` now is silently ignored instead of throwing an exception.
-
-## 2.0.0-nullsafety.3
-
-* Updated to video_player_platform_interface 4.0.
-
-## 2.0.0-nullsafety.2
-
 * Fixed an issue where `isBuffering` was not updating on Web.
-
-## 2.0.0-nullsafety.1
-
-* Bump Dart SDK to support null safety.
-
-## 2.0.0-nullsafety
-
-* Migrate to null safety.
 
 ## 0.1.4+2
 

--- a/packages/video_player/video_player_web/pubspec.yaml
+++ b/packages/video_player/video_player_web/pubspec.yaml
@@ -25,4 +25,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"
-  flutter: ">=1.12.8"
+  flutter: ">=1.20.0"

--- a/packages/video_player/video_player_web/pubspec.yaml
+++ b/packages/video_player/video_player_web/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   meta: ^1.3.0
-  video_player_platform_interface: ^4.0.0-0
+  video_player_platform_interface: ^4.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/video_player/video_player_web/pubspec.yaml
+++ b/packages/video_player/video_player_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: video_player_web
 description: Web platform implementation of video_player.
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player_web
-version: 2.0.0-nullsafety.4
+version: 2.0.0
 
 flutter:
   plugin:
@@ -15,14 +15,14 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  meta: ^1.3.0-nullsafety.3
-  video_player_platform_interface: ^4.0.0-nullsafety.0
+  meta: ^1.3.0
+  video_player_platform_interface: ^4.0.0-0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.10.0-nullsafety.1
+  pedantic: ^1.10.0
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.12.0-259.9.beta <3.0.0"
   flutter: ">=1.20.0"

--- a/packages/video_player/video_player_web/test/video_player_web_test.dart
+++ b/packages/video_player/video_player_web/test/video_player_web_test.dart
@@ -98,7 +98,9 @@ void main() {
       await VideoPlayerPlatform.instance.setVolume(videoPlayerId, 0);
       await VideoPlayerPlatform.instance.play(videoPlayerId);
 
-      expect(() async { await eventStream.last; }, throwsA(isA<PlatformException>()));
+      expect(() async {
+        await eventStream.last;
+      }, throwsA(isA<PlatformException>()));
     });
 
     test('can pause', () {

--- a/packages/video_player/video_player_web/test/video_player_web_test.dart
+++ b/packages/video_player/video_player_web/test/video_player_web_test.dart
@@ -98,7 +98,7 @@ void main() {
       await VideoPlayerPlatform.instance.setVolume(videoPlayerId, 0);
       await VideoPlayerPlatform.instance.play(videoPlayerId);
 
-      expect(eventStream, emitsError(isA<PlatformException>()));
+      expect(() async { await eventStream.last; }, throwsA(isA<PlatformException>()));
     });
 
     test('can pause', () {


### PR DESCRIPTION
This PR will re-version the video_player_web as a 'preview version' with null safety enabled by default.

~(video_player_platform_interface needs to land first: https://github.com/flutter/plugins/pull/3578)~

Fixes https://github.com/flutter/flutter/issues/75493

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
