### PR TITLE
[flutter_plugin_android_lifecycle-sdk] Update Flutter SDK constraint

### DIFF
--- a/packages/flutter_plugin_android_lifecycle/pubspec.yaml
+++ b/packages/flutter_plugin_android_lifecycle/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/flutter/plugins/tree/master/packages/flutter_plugin
 
 environment:
   sdk: ">=2.12.0-259.9.beta <3.0.0"
-  flutter: ">=1.12.13"
+  flutter: ">=1.20.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Pub requires 1.20 or greater for plugins without ios/ folders.