### PR TITLE
[image_picker] use nnbd version of deps to resolve ci failure

### DIFF
--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -27,7 +27,7 @@ dev_dependencies:
     path: ../../integration_test
   mockito: ^5.0.0-nullsafety.7
   pedantic: ^1.10.0
-  plugin_platform_interface: ^2.0.0
+  plugin_platform_interface: ">=1.0.0 <3.0.0"
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -26,8 +26,8 @@ dev_dependencies:
   integration_test:
     path: ../../integration_test
   mockito: ^5.0.0-nullsafety.7
-  pedantic: ^1.8.0
-  plugin_platform_interface: ^1.0.3
+  pedantic: ^1.10.0
+  plugin_platform_interface: ^2.0.0
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"


### PR DESCRIPTION
Landing this to fix CI.
This change will get published with https://github.com/flutter/plugins/pull/3579