### PR TITLE
[path_provider] Update to stable NNBD

### DIFF
--- a/packages/path_provider/path_provider/CHANGELOG.md
+++ b/packages/path_provider/path_provider/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## 2.0.0
 
 * Migrate to null safety.
+* BREAKING CHANGE: Path accessors that return non-nullable results will throw
+  a `MissingPlatformDirectoryException` if the platform implementation is unable
+  to get the corresponding directory (except on platforms where the method is
+  explicitly unsupported, where they will continue to throw `UnsupportedError`).
 
 ## 1.6.28
 

--- a/packages/path_provider/path_provider/CHANGELOG.md
+++ b/packages/path_provider/path_provider/CHANGELOG.md
@@ -1,9 +1,4 @@
-## 2.0.0-nullsafety.1
-
-* Require latest path_provider_windows to avoid potential issues
-  with breaking changes in `ffi` and `win32`.
-
-## 2.0.0-nullsafety
+## 2.0.0
 
 * Migrate to null safety.
 

--- a/packages/path_provider/path_provider/example/pubspec.yaml
+++ b/packages/path_provider/path_provider/example/pubspec.yaml
@@ -17,11 +17,11 @@ dev_dependencies:
     path: ../../../integration_test
   flutter_driver:
     sdk: flutter
-  pedantic: ^1.8.0
+  pedantic: ^1.10.0
 
 flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.12.0-259.9.beta <3.0.0"
   flutter: ">=1.12.13+hotfix.5"

--- a/packages/path_provider/path_provider/lib/path_provider.dart
+++ b/packages/path_provider/path_provider/lib/path_provider.dart
@@ -20,6 +20,27 @@ set disablePathProviderPlatformOverride(bool override) {}
 
 bool _manualDartRegistrationNeeded = true;
 
+/// An exception thrown when a directory that should always be available on
+/// the current platform cannot be obtained.
+class MissingPlatformDirectoryException implements Exception {
+  /// Creates a new exception
+  MissingPlatformDirectoryException(this.message, {this.details});
+
+  /// The explanation of the exception.
+  final String message;
+
+  /// Added details, if any.
+  ///
+  /// E.g., an error object from the platform implementation.
+  final Object? details;
+
+  @override
+  String toString() {
+    String detailsAddition = details == null ? '' : ': $details';
+    return 'MissingPlatformDirectoryException($message)$detailsAddition';
+  }
+}
+
 PathProviderPlatform get _platform {
   // This is to manually endorse Dart implementations until automatic
   // registration of Dart plugins is implemented. For details see
@@ -51,10 +72,11 @@ PathProviderPlatform get _platform {
 /// On iOS, this uses the `NSCachesDirectory` API.
 ///
 /// On Android, this uses the `getCacheDir` API on the context.
-Future<Directory?> getTemporaryDirectory() async {
+Future<Directory> getTemporaryDirectory() async {
   final String? path = await _platform.getTemporaryPath();
   if (path == null) {
-    return null;
+    throw MissingPlatformDirectoryException(
+        'Unable to get temporary directory');
   }
   return Directory(path);
 }
@@ -69,10 +91,11 @@ Future<Directory?> getTemporaryDirectory() async {
 /// If this directory does not exist, it is created automatically.
 ///
 /// On Android, this function uses the `getFilesDir` API on the context.
-Future<Directory?> getApplicationSupportDirectory() async {
+Future<Directory> getApplicationSupportDirectory() async {
   final String? path = await _platform.getApplicationSupportPath();
   if (path == null) {
-    return null;
+    throw MissingPlatformDirectoryException(
+        'Unable to get application support directory');
   }
 
   return Directory(path);
@@ -83,10 +106,10 @@ Future<Directory?> getApplicationSupportDirectory() async {
 ///
 /// On Android, this function throws an [UnsupportedError] as no equivalent
 /// path exists.
-Future<Directory?> getLibraryDirectory() async {
+Future<Directory> getLibraryDirectory() async {
   final String? path = await _platform.getLibraryPath();
   if (path == null) {
-    return null;
+    throw MissingPlatformDirectoryException('Unable to get library directory');
   }
   return Directory(path);
 }
@@ -100,10 +123,11 @@ Future<Directory?> getLibraryDirectory() async {
 /// On Android, this uses the `getDataDirectory` API on the context. Consider
 /// using [getExternalStorageDirectory] instead if data is intended to be visible
 /// to the user.
-Future<Directory?> getApplicationDocumentsDirectory() async {
+Future<Directory> getApplicationDocumentsDirectory() async {
   final String? path = await _platform.getApplicationDocumentsPath();
   if (path == null) {
-    return null;
+    throw MissingPlatformDirectoryException(
+        'Unable to get application documents directory');
   }
   return Directory(path);
 }

--- a/packages/path_provider/path_provider/lib/path_provider.dart
+++ b/packages/path_provider/path_provider/lib/path_provider.dart
@@ -72,6 +72,9 @@ PathProviderPlatform get _platform {
 /// On iOS, this uses the `NSCachesDirectory` API.
 ///
 /// On Android, this uses the `getCacheDir` API on the context.
+///
+/// Throws a `MissingPlatformDirectoryException` if the system is unable to
+/// provide the directory.
 Future<Directory> getTemporaryDirectory() async {
   final String? path = await _platform.getTemporaryPath();
   if (path == null) {
@@ -91,6 +94,9 @@ Future<Directory> getTemporaryDirectory() async {
 /// If this directory does not exist, it is created automatically.
 ///
 /// On Android, this function uses the `getFilesDir` API on the context.
+///
+/// Throws a `MissingPlatformDirectoryException` if the system is unable to
+/// provide the directory.
 Future<Directory> getApplicationSupportDirectory() async {
   final String? path = await _platform.getApplicationSupportPath();
   if (path == null) {
@@ -106,6 +112,9 @@ Future<Directory> getApplicationSupportDirectory() async {
 ///
 /// On Android, this function throws an [UnsupportedError] as no equivalent
 /// path exists.
+///
+/// Throws a `MissingPlatformDirectoryException` if the system is unable to
+/// provide the directory on a supported platform.
 Future<Directory> getLibraryDirectory() async {
   final String? path = await _platform.getLibraryPath();
   if (path == null) {
@@ -123,6 +132,9 @@ Future<Directory> getLibraryDirectory() async {
 /// On Android, this uses the `getDataDirectory` API on the context. Consider
 /// using [getExternalStorageDirectory] instead if data is intended to be visible
 /// to the user.
+///
+/// Throws a `MissingPlatformDirectoryException` if the system is unable to
+/// provide the directory.
 Future<Directory> getApplicationDocumentsDirectory() async {
   final String? path = await _platform.getApplicationDocumentsPath();
   if (path == null) {

--- a/packages/path_provider/path_provider/pubspec.yaml
+++ b/packages/path_provider/path_provider/pubspec.yaml
@@ -34,8 +34,8 @@ dev_dependencies:
   flutter_driver:
     sdk: flutter
   pedantic: ^1.10.0
-  mockito: ^5.0.0-nullsafety.7
   plugin_platform_interface: ">=1.0.0 <3.0.0"
+  test: ^1.16.0
 
 environment:
   sdk: ">=2.12.0-259.9.beta <3.0.0"

--- a/packages/path_provider/path_provider/pubspec.yaml
+++ b/packages/path_provider/path_provider/pubspec.yaml
@@ -1,7 +1,7 @@
 name: path_provider
 description: Flutter plugin for getting commonly used locations on host platform file systems, such as the temp and app data directories.
 homepage: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider
-version: 2.0.0-nullsafety.1
+version: 2.0.0
 
 flutter:
   plugin:
@@ -21,10 +21,10 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  path_provider_platform_interface: ^2.0.0-nullsafety
-  path_provider_macos: ^0.0.5-nullsafety
-  path_provider_linux: ^0.2.0-nullsafety
-  path_provider_windows: ^0.1.0-nullsafety.3
+  path_provider_platform_interface: ^2.0.0
+  path_provider_macos: ^2.0.0
+  path_provider_linux: ^2.0.0
+  path_provider_windows: ^2.0.0
 
 dev_dependencies:
   integration_test:
@@ -33,10 +33,10 @@ dev_dependencies:
     sdk: flutter
   flutter_driver:
     sdk: flutter
-  pedantic: ^1.10.0-nullsafety
-  mockito: ^5.0.0-nullsafety.0
-  plugin_platform_interface: ^1.1.0-nullsafety
+  pedantic: ^1.10.0
+  mockito: ^5.0.0-nullsafety.7
+  plugin_platform_interface: ">=1.0.0 <3.0.0"
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.12.0-259.9.beta <3.0.0"
   flutter: ">=1.12.13+hotfix.5"

--- a/packages/path_provider/path_provider/test/path_provider_test.dart
+++ b/packages/path_provider/path_provider/test/path_provider_test.dart
@@ -6,10 +6,10 @@ import 'dart:io' show Directory;
 import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mockito/mockito.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:test/fake.dart';
 
 const String kTemporaryPath = 'temporaryPath';
 const String kApplicationSupportPath = 'applicationSupportPath';
@@ -20,31 +20,30 @@ const String kExternalCachePath = 'externalCachePath';
 const String kExternalStoragePath = 'externalStoragePath';
 
 void main() {
-  group('PathProvider', () {
-    TestWidgetsFlutterBinding.ensureInitialized();
-
+  TestWidgetsFlutterBinding.ensureInitialized();
+  group('PathProvider full implementation', () {
     setUp(() async {
-      PathProviderPlatform.instance = MockPathProviderPlatform();
+      PathProviderPlatform.instance = FakePathProviderPlatform();
     });
 
     test('getTemporaryDirectory', () async {
-      Directory? result = await getTemporaryDirectory();
-      expect(result?.path, kTemporaryPath);
+      Directory result = await getTemporaryDirectory();
+      expect(result.path, kTemporaryPath);
     });
 
     test('getApplicationSupportDirectory', () async {
-      Directory? result = await getApplicationSupportDirectory();
-      expect(result?.path, kApplicationSupportPath);
+      Directory result = await getApplicationSupportDirectory();
+      expect(result.path, kApplicationSupportPath);
     });
 
     test('getLibraryDirectory', () async {
-      Directory? result = await getLibraryDirectory();
-      expect(result?.path, kLibraryPath);
+      Directory result = await getLibraryDirectory();
+      expect(result.path, kLibraryPath);
     });
 
     test('getApplicationDocumentsDirectory', () async {
-      Directory? result = await getApplicationDocumentsDirectory();
-      expect(result?.path, kApplicationDocumentsPath);
+      Directory result = await getApplicationDocumentsDirectory();
+      expect(result.path, kApplicationDocumentsPath);
     });
 
     test('getExternalStorageDirectory', () async {
@@ -69,42 +68,126 @@ void main() {
       expect(result?.path, kDownloadsPath);
     });
   });
+
+  group('PathProvider null implementation', () {
+    setUp(() async {
+      PathProviderPlatform.instance = AllNullFakePathProviderPlatform();
+    });
+
+    test('getTemporaryDirectory throws on null', () async {
+      expect(getTemporaryDirectory(),
+          throwsA(isA<MissingPlatformDirectoryException>()));
+    });
+
+    test('getApplicationSupportDirectory throws on null', () async {
+      expect(getApplicationSupportDirectory(),
+          throwsA(isA<MissingPlatformDirectoryException>()));
+    });
+
+    test('getLibraryDirectory throws on null', () async {
+      expect(getLibraryDirectory(),
+          throwsA(isA<MissingPlatformDirectoryException>()));
+    });
+
+    test('getApplicationDocumentsDirectory throws on null', () async {
+      expect(getApplicationDocumentsDirectory(),
+          throwsA(isA<MissingPlatformDirectoryException>()));
+    });
+
+    test('getExternalStorageDirectory passes null through', () async {
+      Directory? result = await getExternalStorageDirectory();
+      expect(result, isNull);
+    });
+
+    test('getExternalCacheDirectories passes null through', () async {
+      List<Directory>? result = await getExternalCacheDirectories();
+      expect(result, isNull);
+    });
+
+    test('getExternalStorageDirectories passes null through', () async {
+      List<Directory>? result = await getExternalStorageDirectories();
+      expect(result, isNull);
+    });
+
+    test('getDownloadsDirectory passses null through', () async {
+      Directory? result = await getDownloadsDirectory();
+      expect(result, isNull);
+    });
+  });
 }
 
-class MockPathProviderPlatform extends Mock
+class FakePathProviderPlatform extends Fake
     with MockPlatformInterfaceMixin
     implements PathProviderPlatform {
-  Future<String> getTemporaryPath() async {
+  Future<String?> getTemporaryPath() async {
     return kTemporaryPath;
   }
 
-  Future<String> getApplicationSupportPath() async {
+  Future<String?> getApplicationSupportPath() async {
     return kApplicationSupportPath;
   }
 
-  Future<String> getLibraryPath() async {
+  Future<String?> getLibraryPath() async {
     return kLibraryPath;
   }
 
-  Future<String> getApplicationDocumentsPath() async {
+  Future<String?> getApplicationDocumentsPath() async {
     return kApplicationDocumentsPath;
   }
 
-  Future<String> getExternalStoragePath() async {
+  Future<String?> getExternalStoragePath() async {
     return kExternalStoragePath;
   }
 
-  Future<List<String>> getExternalCachePaths() async {
+  Future<List<String>?> getExternalCachePaths() async {
     return <String>[kExternalCachePath];
   }
 
-  Future<List<String>> getExternalStoragePaths({
+  Future<List<String>?> getExternalStoragePaths({
     StorageDirectory? type,
   }) async {
     return <String>[kExternalStoragePath];
   }
 
-  Future<String> getDownloadsPath() async {
+  Future<String?> getDownloadsPath() async {
     return kDownloadsPath;
+  }
+}
+
+class AllNullFakePathProviderPlatform extends Fake
+    with MockPlatformInterfaceMixin
+    implements PathProviderPlatform {
+  Future<String?> getTemporaryPath() async {
+    return null;
+  }
+
+  Future<String?> getApplicationSupportPath() async {
+    return null;
+  }
+
+  Future<String?> getLibraryPath() async {
+    return null;
+  }
+
+  Future<String?> getApplicationDocumentsPath() async {
+    return null;
+  }
+
+  Future<String?> getExternalStoragePath() async {
+    return null;
+  }
+
+  Future<List<String>?> getExternalCachePaths() async {
+    return null;
+  }
+
+  Future<List<String>?> getExternalStoragePaths({
+    StorageDirectory? type,
+  }) async {
+    return null;
+  }
+
+  Future<String?> getDownloadsPath() async {
+    return null;
   }
 }


### PR DESCRIPTION
Bumps the versions in the app-facing package to make it stable NNBD.

Changes the interface of four core methods to non-nullable, and adds a new exceptions if they aren't provided by the platform implementations. The list is somewhat arbitrary, but these seem like the four that are core enough that any implementation should either provide them, or explicitly say they don't have such a concept via `UnsupportedError`, since there isn't an obvious way for a developer to fall back if they are unexpectedly missing.

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
