### PR TITLE
[url_launcher] Fix SDK copypasta in platform interface

### DIFF
--- a/packages/url_launcher/url_launcher_platform_interface/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+* Fix SDK range.
+
 ## 2.0.0
 
 * Migrate to null safety.

--- a/packages/url_launcher/url_launcher_platform_interface/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the url_launcher plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.0.0
+version: 2.0.1
 
 dependencies:
   flutter:
@@ -17,5 +17,5 @@ dev_dependencies:
   pedantic: ^1.10.0
 
 environment:
-  sdk: ">=2.12.0-2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0-259.9.beta <3.0.0"
   flutter: ">=1.22.0"


### PR DESCRIPTION
The lower end of the SDK range was wrong due to a bad copy/paste.