### PR TITLE
[url_launcher] Update platforms to NNBD stable

### DIFF
--- a/packages/url_launcher/url_launcher_linux/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_linux/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Migrate to null safety.
 * Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.
 * Fix outdated links across a number of markdown files ([#3276](https://github.com/flutter/plugins/pull/3276))
+* Set `implementation` in pubspec.yaml
 
 ## 0.0.2+1
 

--- a/packages/url_launcher/url_launcher_linux/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_linux/CHANGELOG.md
@@ -1,18 +1,8 @@
-## 2.0.0-nullsafety
-
-* Update version for consistency with other implementations.
-
-## 0.1.0-nullsafety.3
-
-* Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.
-
-## 0.1.0-nullsafety.2
-
-* Fix outdated links across a number of markdown files ([#3276](https://github.com/flutter/plugins/pull/3276))
-
-## 0.1.0-nullsafety.1
+## 2.0.0
 
 * Migrate to null safety.
+* Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.
+* Fix outdated links across a number of markdown files ([#3276](https://github.com/flutter/plugins/pull/3276))
 
 ## 0.0.2+1
 

--- a/packages/url_launcher/url_launcher_linux/example/integration_test/url_launcher_test.dart
+++ b/packages/url_launcher/url_launcher_linux/example/integration_test/url_launcher_test.dart
@@ -2,22 +2,21 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart = 2.9
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
-import 'package:url_launcher/url_launcher.dart';
+import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets('canLaunch', (WidgetTester _) async {
-    expect(await canLaunch('randomstring'), false);
+    UrlLauncherPlatform launcher = UrlLauncherPlatform.instance;
+
+    expect(await launcher.canLaunch('randomstring'), false);
 
     // Generally all devices should have some default browser.
-    expect(await canLaunch('http://flutter.dev'), true);
-
-    // Desktop will not necessarily support sms:.
-
-    // tel: and mailto: links may not be openable on every device. iOS
-    // simulators notably can't open these link types.
+    expect(await launcher.canLaunch('http://flutter.dev'), true);
   });
 }

--- a/packages/url_launcher/url_launcher_linux/example/lib/main.dart
+++ b/packages/url_launcher/url_launcher_linux/example/lib/main.dart
@@ -6,7 +6,7 @@
 
 import 'dart:async';
 import 'package:flutter/material.dart';
-import 'package:url_launcher/url_launcher.dart';
+import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 
 void main() {
   runApp(MyApp());
@@ -26,7 +26,7 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatefulWidget {
-  MyHomePage({Key key, this.title}) : super(key: key);
+  MyHomePage({Key? key, required this.title}) : super(key: key);
   final String title;
 
   @override
@@ -34,74 +34,21 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  Future<void> _launched;
-  String _phone = '';
+  Future<void>? _launched;
 
   Future<void> _launchInBrowser(String url) async {
-    if (await canLaunch(url)) {
-      await launch(
+    if (await UrlLauncherPlatform.instance.canLaunch(url)) {
+      await UrlLauncherPlatform.instance.launch(
         url,
-        forceSafariVC: false,
-        forceWebView: false,
-        headers: <String, String>{'my_header_key': 'my_header_value'},
+        useSafariVC: false,
+        useWebView: false,
+        enableJavaScript: false,
+        enableDomStorage: false,
+        universalLinksOnly: false,
+        headers: <String, String>{},
       );
     } else {
       throw 'Could not launch $url';
-    }
-  }
-
-  Future<void> _launchInWebViewOrVC(String url) async {
-    if (await canLaunch(url)) {
-      await launch(
-        url,
-        forceSafariVC: true,
-        forceWebView: true,
-        headers: <String, String>{'my_header_key': 'my_header_value'},
-      );
-    } else {
-      throw 'Could not launch $url';
-    }
-  }
-
-  Future<void> _launchInWebViewWithJavaScript(String url) async {
-    if (await canLaunch(url)) {
-      await launch(
-        url,
-        forceSafariVC: true,
-        forceWebView: true,
-        enableJavaScript: true,
-      );
-    } else {
-      throw 'Could not launch $url';
-    }
-  }
-
-  Future<void> _launchInWebViewWithDomStorage(String url) async {
-    if (await canLaunch(url)) {
-      await launch(
-        url,
-        forceSafariVC: true,
-        forceWebView: true,
-        enableDomStorage: true,
-      );
-    } else {
-      throw 'Could not launch $url';
-    }
-  }
-
-  Future<void> _launchUniversalLinkIos(String url) async {
-    if (await canLaunch(url)) {
-      final bool nativeAppLaunchSucceeded = await launch(
-        url,
-        forceSafariVC: false,
-        universalLinksOnly: true,
-      );
-      if (!nativeAppLaunchSucceeded) {
-        await launch(
-          url,
-          forceSafariVC: true,
-        );
-      }
     }
   }
 
@@ -110,14 +57,6 @@ class _MyHomePageState extends State<MyHomePage> {
       return Text('Error: ${snapshot.error}');
     } else {
       return const Text('');
-    }
-  }
-
-  Future<void> _makePhoneCall(String url) async {
-    if (await canLaunch(url)) {
-      await launch(url);
-    } else {
-      throw 'Could not launch $url';
     }
   }
 
@@ -133,19 +72,6 @@ class _MyHomePageState extends State<MyHomePage> {
           Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[
-              Padding(
-                padding: const EdgeInsets.all(16.0),
-                child: TextField(
-                    onChanged: (String text) => _phone = text,
-                    decoration: const InputDecoration(
-                        hintText: 'Input the phone number to launch')),
-              ),
-              ElevatedButton(
-                onPressed: () => setState(() {
-                  _launched = _makePhoneCall('tel:$_phone');
-                }),
-                child: const Text('Make phone call'),
-              ),
               const Padding(
                 padding: EdgeInsets.all(16.0),
                 child: Text(toLaunch),
@@ -155,33 +81,6 @@ class _MyHomePageState extends State<MyHomePage> {
                   _launched = _launchInBrowser(toLaunch);
                 }),
                 child: const Text('Launch in browser'),
-              ),
-              const Padding(padding: EdgeInsets.all(16.0)),
-              ElevatedButton(
-                onPressed: () => setState(() {
-                  _launched = _launchInWebViewOrVC(toLaunch);
-                }),
-                child: const Text('Launch in app'),
-              ),
-              ElevatedButton(
-                onPressed: () => setState(() {
-                  _launched = _launchInWebViewWithJavaScript(toLaunch);
-                }),
-                child: const Text('Launch in app(JavaScript ON)'),
-              ),
-              ElevatedButton(
-                onPressed: () => setState(() {
-                  _launched = _launchInWebViewWithDomStorage(toLaunch);
-                }),
-                child: const Text('Launch in app(DOM storage ON)'),
-              ),
-              const Padding(padding: EdgeInsets.all(16.0)),
-              ElevatedButton(
-                onPressed: () => setState(() {
-                  _launched = _launchUniversalLinkIos(toLaunch);
-                }),
-                child: const Text(
-                    'Launch a universal link in a native app, fallback to Safari.(Youtube)'),
               ),
               const Padding(padding: EdgeInsets.all(16.0)),
               FutureBuilder<void>(future: _launched, builder: _launchStatus),

--- a/packages/url_launcher/url_launcher_linux/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_linux/example/pubspec.yaml
@@ -4,7 +4,6 @@ description: Demonstrates how to use the url_launcher plugin.
 dependencies:
   flutter:
     sdk: flutter
-  url_launcher: any
   url_launcher_linux:
     # When depending on this package from a real application you should use:
     #   url_launcher_linux: ^x.y.z
@@ -12,17 +11,18 @@ dependencies:
     # The example app is bundled with the plugin so we use a path dependency on
     # the parent directory to use the current plugin's version.
     path: ../
+  url_launcher_platform_interface: ^2.0.0
 
 dev_dependencies:
   integration_test:
     path: ../../../integration_test
   flutter_driver:
     sdk: flutter
-  pedantic: ^1.8.0
+  pedantic: ^1.10.0
 
 flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
-  flutter: ">=1.12.8"
+  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  flutter: ">=1.20.0"

--- a/packages/url_launcher/url_launcher_linux/example/test_driver/integration_test.dart
+++ b/packages/url_launcher/url_launcher_linux/example/test_driver/integration_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart = 2.9
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/packages/url_launcher/url_launcher_linux/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_linux/pubspec.yaml
@@ -5,6 +5,7 @@ homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/u
 
 flutter:
   plugin:
+    implements: url_launcher
     platforms:
       linux:
         pluginClass: UrlLauncherPlugin

--- a/packages/url_launcher/url_launcher_linux/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_linux/pubspec.yaml
@@ -1,6 +1,6 @@
 name: url_launcher_linux
 description: Linux implementation of the url_launcher plugin.
-version: 2.0.0-nullsafety
+version: 2.0.0
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher_linux
 
 flutter:
@@ -10,8 +10,8 @@ flutter:
         pluginClass: UrlLauncherPlugin
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
-  flutter: ">=1.12.8"
+  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  flutter: ">=1.20.0"
 
 dependencies:
   flutter:

--- a/packages/url_launcher/url_launcher_macos/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_macos/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Migrate to null safety.
 * Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.
+* Set `implementation` in pubspec.yaml
 
 ## 0.0.2+1
 

--- a/packages/url_launcher/url_launcher_macos/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_macos/CHANGELOG.md
@@ -1,18 +1,7 @@
-## 2.0.0-nullsafety
-
-* Update version to (semi-belatedly) meet 1.0-consistency promise.
-
-# 0.1.0-nullsafety.2
-
-* Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.
-
-# 0.1.0-nullsafety.1
-
-* Bump SDK to support null safety.
-
-# 0.1.0-nullsafety
+## 2.0.0
 
 * Migrate to null safety.
+* Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.
 
 ## 0.0.2+1
 

--- a/packages/url_launcher/url_launcher_macos/example/integration_test/url_launcher_test.dart
+++ b/packages/url_launcher/url_launcher_macos/example/integration_test/url_launcher_test.dart
@@ -2,23 +2,24 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart = 2.9
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
-import 'package:url_launcher/url_launcher.dart';
+import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets('canLaunch', (WidgetTester _) async {
-    expect(await canLaunch('randomstring'), false);
+    UrlLauncherPlatform launcher = UrlLauncherPlatform.instance;
+
+    expect(await launcher.canLaunch('randomstring'), false);
 
     // Generally all devices should have some default browser.
-    expect(await canLaunch('http://flutter.dev'), true);
+    expect(await launcher.canLaunch('http://flutter.dev'), true);
 
     // Generally all devices should have some default SMS app.
-    expect(await canLaunch('sms:5555555555'), true);
-
-    // tel: and mailto: links may not be openable on every device. iOS
-    // simulators notably can't open these link types.
+    expect(await launcher.canLaunch('sms:5555555555'), true);
   });
 }

--- a/packages/url_launcher/url_launcher_macos/example/lib/main.dart
+++ b/packages/url_launcher/url_launcher_macos/example/lib/main.dart
@@ -6,7 +6,7 @@
 
 import 'dart:async';
 import 'package:flutter/material.dart';
-import 'package:url_launcher/url_launcher.dart';
+import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 
 void main() {
   runApp(MyApp());
@@ -26,7 +26,7 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatefulWidget {
-  MyHomePage({Key key, this.title}) : super(key: key);
+  MyHomePage({Key? key, required this.title}) : super(key: key);
   final String title;
 
   @override
@@ -34,74 +34,21 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  Future<void> _launched;
-  String _phone = '';
+  Future<void>? _launched;
 
   Future<void> _launchInBrowser(String url) async {
-    if (await canLaunch(url)) {
-      await launch(
+    if (await UrlLauncherPlatform.instance.canLaunch(url)) {
+      await UrlLauncherPlatform.instance.launch(
         url,
-        forceSafariVC: false,
-        forceWebView: false,
-        headers: <String, String>{'my_header_key': 'my_header_value'},
+        useSafariVC: false,
+        useWebView: false,
+        enableJavaScript: false,
+        enableDomStorage: false,
+        universalLinksOnly: false,
+        headers: <String, String>{},
       );
     } else {
       throw 'Could not launch $url';
-    }
-  }
-
-  Future<void> _launchInWebViewOrVC(String url) async {
-    if (await canLaunch(url)) {
-      await launch(
-        url,
-        forceSafariVC: true,
-        forceWebView: true,
-        headers: <String, String>{'my_header_key': 'my_header_value'},
-      );
-    } else {
-      throw 'Could not launch $url';
-    }
-  }
-
-  Future<void> _launchInWebViewWithJavaScript(String url) async {
-    if (await canLaunch(url)) {
-      await launch(
-        url,
-        forceSafariVC: true,
-        forceWebView: true,
-        enableJavaScript: true,
-      );
-    } else {
-      throw 'Could not launch $url';
-    }
-  }
-
-  Future<void> _launchInWebViewWithDomStorage(String url) async {
-    if (await canLaunch(url)) {
-      await launch(
-        url,
-        forceSafariVC: true,
-        forceWebView: true,
-        enableDomStorage: true,
-      );
-    } else {
-      throw 'Could not launch $url';
-    }
-  }
-
-  Future<void> _launchUniversalLinkIos(String url) async {
-    if (await canLaunch(url)) {
-      final bool nativeAppLaunchSucceeded = await launch(
-        url,
-        forceSafariVC: false,
-        universalLinksOnly: true,
-      );
-      if (!nativeAppLaunchSucceeded) {
-        await launch(
-          url,
-          forceSafariVC: true,
-        );
-      }
     }
   }
 
@@ -110,14 +57,6 @@ class _MyHomePageState extends State<MyHomePage> {
       return Text('Error: ${snapshot.error}');
     } else {
       return const Text('');
-    }
-  }
-
-  Future<void> _makePhoneCall(String url) async {
-    if (await canLaunch(url)) {
-      await launch(url);
-    } else {
-      throw 'Could not launch $url';
     }
   }
 
@@ -133,19 +72,6 @@ class _MyHomePageState extends State<MyHomePage> {
           Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[
-              Padding(
-                padding: const EdgeInsets.all(16.0),
-                child: TextField(
-                    onChanged: (String text) => _phone = text,
-                    decoration: const InputDecoration(
-                        hintText: 'Input the phone number to launch')),
-              ),
-              ElevatedButton(
-                onPressed: () => setState(() {
-                  _launched = _makePhoneCall('tel:$_phone');
-                }),
-                child: const Text('Make phone call'),
-              ),
               const Padding(
                 padding: EdgeInsets.all(16.0),
                 child: Text(toLaunch),
@@ -155,33 +81,6 @@ class _MyHomePageState extends State<MyHomePage> {
                   _launched = _launchInBrowser(toLaunch);
                 }),
                 child: const Text('Launch in browser'),
-              ),
-              const Padding(padding: EdgeInsets.all(16.0)),
-              ElevatedButton(
-                onPressed: () => setState(() {
-                  _launched = _launchInWebViewOrVC(toLaunch);
-                }),
-                child: const Text('Launch in app'),
-              ),
-              ElevatedButton(
-                onPressed: () => setState(() {
-                  _launched = _launchInWebViewWithJavaScript(toLaunch);
-                }),
-                child: const Text('Launch in app(JavaScript ON)'),
-              ),
-              ElevatedButton(
-                onPressed: () => setState(() {
-                  _launched = _launchInWebViewWithDomStorage(toLaunch);
-                }),
-                child: const Text('Launch in app(DOM storage ON)'),
-              ),
-              const Padding(padding: EdgeInsets.all(16.0)),
-              ElevatedButton(
-                onPressed: () => setState(() {
-                  _launched = _launchUniversalLinkIos(toLaunch);
-                }),
-                child: const Text(
-                    'Launch a universal link in a native app, fallback to Safari.(Youtube)'),
               ),
               const Padding(padding: EdgeInsets.all(16.0)),
               FutureBuilder<void>(future: _launched, builder: _launchStatus),

--- a/packages/url_launcher/url_launcher_macos/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_macos/example/pubspec.yaml
@@ -4,7 +4,6 @@ description: Demonstrates how to use the url_launcher plugin.
 dependencies:
   flutter:
     sdk: flutter
-  url_launcher: any
   url_launcher_macos:
     # When depending on this package from a real application you should use:
     #   url_launcher_macos: ^x.y.z
@@ -12,17 +11,18 @@ dependencies:
     # The example app is bundled with the plugin so we use a path dependency on
     # the parent directory to use the current plugin's version.
     path: ../
+  url_launcher_platform_interface: ^2.0.0
 
 dev_dependencies:
   integration_test:
     path: ../../../integration_test
   flutter_driver:
     sdk: flutter
-  pedantic: ^1.8.0
+  pedantic: ^1.10.0
 
 flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
-  flutter: ">=1.12.8"
+  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  flutter: ">=1.20.0"

--- a/packages/url_launcher/url_launcher_macos/example/test_driver/integration_test.dart
+++ b/packages/url_launcher/url_launcher_macos/example/test_driver/integration_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart = 2.9
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/packages/url_launcher/url_launcher_macos/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_macos/pubspec.yaml
@@ -1,6 +1,6 @@
 name: url_launcher_macos
 description: macOS implementation of the url_launcher plugin.
-version: 2.0.0-nullsafety
+version: 2.0.0
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher_macos
 
 flutter:
@@ -11,8 +11,8 @@ flutter:
         fileName: url_launcher_macos.dart
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
-  flutter: ">=1.12.8"
+  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  flutter: ">=1.20.0"
 
 dependencies:
   flutter:

--- a/packages/url_launcher/url_launcher_macos/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_macos/pubspec.yaml
@@ -5,6 +5,7 @@ homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/u
 
 flutter:
   plugin:
+    implements: url_launcher
     platforms:
       macos:
         pluginClass: UrlLauncherPlugin

--- a/packages/url_launcher/url_launcher_web/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_web/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 2.0.0-nullsafety
+# 2.0.0
 
 - Migrate to null safety.
 

--- a/packages/url_launcher/url_launcher_web/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_web/example/pubspec.yaml
@@ -18,5 +18,5 @@ dev_dependencies:
     sdk: flutter
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.12.0-259.9.beta <3.0.0"
   flutter: ">=1.26.0-0" # For integration_test from sdk

--- a/packages/url_launcher/url_launcher_web/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: url_launcher_web
 description: Web platform implementation of url_launcher
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher_web
-version: 2.0.0-nullsafety
+version: 2.0.0
 
 flutter:
   plugin:
@@ -11,7 +11,7 @@ flutter:
         fileName: url_launcher_web.dart
 
 dependencies:
-  url_launcher_platform_interface: ^2.0.0-nullsafety
+  url_launcher_platform_interface: ^2.0.0
   meta: ^1.3.0 # null safe
   flutter:
     sdk: flutter
@@ -24,5 +24,5 @@ dev_dependencies:
     sdk: flutter
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.5"
+  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  flutter: ">=1.20.0"

--- a/packages/url_launcher/url_launcher_windows/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_windows/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Migrate to null-safety.
 * Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.
+* Set `implementation` in pubspec.yaml
 
 ## 0.0.2+1
 

--- a/packages/url_launcher/url_launcher_windows/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_windows/CHANGELOG.md
@@ -1,18 +1,7 @@
-## 2.0.0-nullsafety
-
-* Update version to (semi-belatedly) meet 1.0-consistency promise.
-
-## 0.1.0-nullsafety.2
-
-* Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.
-
-## 0.1.0-nullsafety.1
-
-* Bump Dart SDK to support null safety.
-
-## 0.1.0-nullsafety
+## 2.0.0
 
 * Migrate to null-safety.
+* Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.
 
 ## 0.0.2+1
 

--- a/packages/url_launcher/url_launcher_windows/example/integration_test/url_launcher_test.dart
+++ b/packages/url_launcher/url_launcher_windows/example/integration_test/url_launcher_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart = 2.9
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';

--- a/packages/url_launcher/url_launcher_windows/example/lib/main.dart
+++ b/packages/url_launcher/url_launcher_windows/example/lib/main.dart
@@ -26,7 +26,7 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatefulWidget {
-  MyHomePage({Key key, this.title}) : super(key: key);
+  MyHomePage({Key? key, required this.title}) : super(key: key);
   final String title;
 
   @override
@@ -34,7 +34,7 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  Future<void> _launched;
+  Future<void>? _launched;
 
   Future<void> _launchInBrowser(String url) async {
     if (await UrlLauncherPlatform.instance.canLaunch(url)) {

--- a/packages/url_launcher/url_launcher_windows/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_windows/example/pubspec.yaml
@@ -4,7 +4,7 @@ description: Demonstrates the Windows implementation of the url_launcher plugin.
 dependencies:
   flutter:
     sdk: flutter
-  url_launcher_platform_interface: any
+  url_launcher_platform_interface: ^2.0.0
   url_launcher_windows:
     # When depending on this package from a real application you should use:
     #   url_launcher_windows: ^x.y.z
@@ -18,11 +18,11 @@ dev_dependencies:
     path: ../../../integration_test
   flutter_driver:
     sdk: flutter
-  pedantic: ^1.8.0
+  pedantic: ^1.10.0
 
 flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
-  flutter: ">=1.12.8"
+  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  flutter: ">=1.20.0"

--- a/packages/url_launcher/url_launcher_windows/example/test_driver/integration_test.dart
+++ b/packages/url_launcher/url_launcher_windows/example/test_driver/integration_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart = 2.9
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/packages/url_launcher/url_launcher_windows/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_windows/pubspec.yaml
@@ -1,6 +1,6 @@
 name: url_launcher_windows
 description: Windows implementation of the url_launcher plugin.
-version: 2.0.0-nullsafety
+version: 2.0.0
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher_windows
 
 flutter:
@@ -10,8 +10,8 @@ flutter:
         pluginClass: UrlLauncherPlugin
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
-  flutter: ">=1.12.8"
+  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  flutter: ">=1.20.0"
 
 dependencies:
   flutter:

--- a/packages/url_launcher/url_launcher_windows/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_windows/pubspec.yaml
@@ -5,6 +5,7 @@ homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/u
 
 flutter:
   plugin:
+    implements: url_launcher
     platforms:
       windows:
         pluginClass: UrlLauncherPlugin


### PR DESCRIPTION
Updates all versions to stable.

Converts all desktop examples to null-safety, and migrates Linux and
macOS to use platform interface for examples rather than app-facing
package to eliminate circular dependencies (implementation copied
directly from Windows).

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
