### PR TITLE
[google_maps_flutter] fixed a small bug in example app.

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1-nullsafety
+
+* Fix in example app to properly change marker icon.
+
 ## 2.0.0-nullsafety
 
 * Migrate to null-safety

--- a/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.1-nullsafety
+## 2.0.0-nullsafety.1
 
 * Fix in example app to properly change marker icon.
 

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/place_marker.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/place_marker.dart
@@ -57,7 +57,7 @@ class PlaceMarkerBodyState extends State<PlaceMarkerBody> {
         if (previousMarkerId != null && markers.containsKey(previousMarkerId)) {
           final Marker resetOld = markers[previousMarkerId]!
               .copyWith(iconParam: BitmapDescriptor.defaultMarker);
-          markers[previousMarkerId!] = resetOld;
+          markers[previousMarkerId] = resetOld;
         }
         selectedMarker = markerId;
         final Marker newMarker = tappedMarker.copyWith(

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/place_marker.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/place_marker.dart
@@ -53,10 +53,10 @@ class PlaceMarkerBodyState extends State<PlaceMarkerBody> {
     final Marker? tappedMarker = markers[markerId];
     if (tappedMarker != null) {
       setState(() {
-        if (markers.containsKey(markerId)) {
-          final Marker resetOld = markers[markerId]!
+        if (markers.containsKey(selectedMarker)) {
+          final Marker resetOld = markers[selectedMarker]!
               .copyWith(iconParam: BitmapDescriptor.defaultMarker);
-          markers[markerId] = resetOld;
+          markers[selectedMarker] = resetOld;
         }
         selectedMarker = markerId;
         final Marker newMarker = tappedMarker.copyWith(

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/place_marker.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/place_marker.dart
@@ -56,7 +56,7 @@ class PlaceMarkerBodyState extends State<PlaceMarkerBody> {
         if (markers.containsKey(selectedMarker)) {
           final Marker resetOld = markers[selectedMarker]!
               .copyWith(iconParam: BitmapDescriptor.defaultMarker);
-          markers[selectedMarker] = resetOld;
+          markers[selectedMarker!] = resetOld;
         }
         selectedMarker = markerId;
         final Marker newMarker = tappedMarker.copyWith(

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/place_marker.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/place_marker.dart
@@ -53,10 +53,11 @@ class PlaceMarkerBodyState extends State<PlaceMarkerBody> {
     final Marker? tappedMarker = markers[markerId];
     if (tappedMarker != null) {
       setState(() {
-        if (markers.containsKey(selectedMarker)) {
-          final Marker resetOld = markers[selectedMarker]!
+        final MarkerId? previousMarkerId = selectedMarker;
+        if (previousMarkerId != null && markers.containsKey(previousMarkerId)) {
+          final Marker resetOld = markers[previousMarkerId]!
               .copyWith(iconParam: BitmapDescriptor.defaultMarker);
-          markers[selectedMarker!] = resetOld;
+          markers[previousMarkerId!] = resetOld;
         }
         selectedMarker = markerId;
         final Marker newMarker = tappedMarker.copyWith(

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter/google_maps_flutter
-version: 2.0.0-nullsafety
+version: 2.0.1-nullsafety
 
 dependencies:
   flutter:

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter/google_maps_flutter
-version: 2.0.1-nullsafety
+version: 2.0.0-nullsafety.1
 
 dependencies:
   flutter:


### PR DESCRIPTION
In _onMarkerTapped function we were changing markers[markerId] to defaultMarker and than again markers[markerId] to hueGreen marker, while instead we should have changed markers[selectedMarker] to defaultMarker first instead of markers[markerId]

This PR fixes issue [#76492](https://github.com/flutter/flutter/issues/76492)

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
