### PR TITLE
[shared_preferences] Bump platform versions to NNBD stable

### DIFF
--- a/packages/shared_preferences/shared_preferences_linux/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_linux/CHANGELOG.md
@@ -1,8 +1,4 @@
-## 2.0.0-nullsafety
-
-* Update version for consistency.
-
-## 0.0.4-nullsafety
+## 2.0.0
 
 * Migrate to null-safety.
 

--- a/packages/shared_preferences/shared_preferences_linux/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_linux/example/pubspec.yaml
@@ -17,11 +17,11 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     path: ../../../integration_test
-  pedantic: ^1.8.0
+  pedantic: ^1.10.0
 
 flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
-  flutter: ">=1.12.8"
+  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  flutter: ">=1.20.0"

--- a/packages/shared_preferences/shared_preferences_linux/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_linux/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shared_preferences_linux
 description: Linux implementation of the shared_preferences plugin
-version: 2.0.0-nullsafety
+version: 2.0.0
 homepage: https://github.com/flutter/plugins/tree/master/packages/shared_preferences/shared_preferences_linux
 
 flutter:
@@ -11,19 +11,19 @@ flutter:
         pluginClass: none
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
-  flutter: ">=1.12.8"
+  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  flutter: ">=1.20.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  file: ^6.0.0-nullsafety.4
-  meta: ^1.0.4
-  path: ^1.8.0-nullsafety.3
-  path_provider_linux: ^0.2.0-nullsafety
-  shared_preferences_platform_interface: ^2.0.0-nullsafety
+  file: ^6.0.0
+  meta: ^1.3.0
+  path: ^1.8.0
+  path_provider_linux: ^2.0.0
+  shared_preferences_platform_interface: ^2.0.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.8.0
+  pedantic: ^1.10.0

--- a/packages/shared_preferences/shared_preferences_macos/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_macos/CHANGELOG.md
@@ -1,10 +1,6 @@
-## 2.0.0-nullsafety
+## 2.0.0
 
-* Update version to (semi-belatedly) meet 1.0-consistency promise.
-
-## 0.0.2-nullsafety
-
-* Update Dart SDK constraint for null safety.
+* Migrate to null safety.
 
 ## 0.0.1+12
 

--- a/packages/shared_preferences/shared_preferences_macos/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_macos/example/pubspec.yaml
@@ -4,7 +4,7 @@ description: Demonstrates how to use the shared_preferences plugin.
 dependencies:
   flutter:
     sdk: flutter
-  shared_preferences_platform_interface: ^2.0.0-nullsafety
+  shared_preferences_platform_interface: ^2.0.0
   shared_preferences_macos:
     # When depending on this package from a real application you should use:
     #   shared_preferences_macos: ^x.y.z
@@ -18,11 +18,11 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     path: ../../../integration_test
-  pedantic: ^1.8.0
+  pedantic: ^1.10.0
 
 flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.12.0-259.9.beta <3.0.0"
   flutter: ">=1.12.8"

--- a/packages/shared_preferences/shared_preferences_macos/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_macos/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shared_preferences_macos
 description: macOS implementation of the shared_preferences plugin.
-version: 2.0.0-nullsafety
+version: 2.0.0
 homepage: https://github.com/flutter/plugins/tree/master/packages/shared_preferences/shared_preferences_macos
 
 flutter:
@@ -10,13 +10,13 @@ flutter:
         pluginClass: SharedPreferencesPlugin
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
-  flutter: ">=1.12.8"
+  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  flutter: ">=1.20.0"
 
 dependencies:
-  shared_preferences_platform_interface: ^2.0.0-nullsafety
+  shared_preferences_platform_interface: ^2.0.0
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  pedantic: ^1.8.0
+  pedantic: ^1.10.0

--- a/packages/shared_preferences/shared_preferences_web/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_web/CHANGELOG.md
@@ -1,8 +1,4 @@
-## 2.0.0-nullsafety
-
-* Update version to (semi-belatedly) meet 1.0-consistency promise.
-
-## 0.2.0-nullsafety
+## 2.0.0
 
 * Migrate to null-safety.
 

--- a/packages/shared_preferences/shared_preferences_web/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: shared_preferences_web
 description: Web platform implementation of shared_preferences
 homepage: https://github.com/flutter/plugins/tree/master/packages/shared_preferences/shared_preferences_web
-version: 2.0.0-nullsafety
+version: 2.0.0
 
 flutter:
   plugin:
@@ -11,18 +11,18 @@ flutter:
         fileName: shared_preferences_web.dart
 
 dependencies:
-  shared_preferences_platform_interface: ^2.0.0-nullsafety
+  shared_preferences_platform_interface: ^2.0.0
   flutter:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  meta: ^1.1.7
+  meta: ^1.3.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.8.0
+  pedantic: ^1.10.0
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.4"
+  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  flutter: ">=1.20.0"

--- a/packages/shared_preferences/shared_preferences_windows/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_windows/CHANGELOG.md
@@ -1,9 +1,4 @@
-
-## 2.0.0-nullsafety
-
-* Update version for consistency.
-
-## 0.0.3-nullsafety
+## 2.0.0
 
 * Migrate to null-safety.
 

--- a/packages/shared_preferences/shared_preferences_windows/example/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_windows/example/CHANGELOG.md
@@ -1,3 +1,0 @@
-## 0.0.1
-
-* TODO: Describe initial release.

--- a/packages/shared_preferences/shared_preferences_windows/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_windows/example/pubspec.yaml
@@ -2,13 +2,13 @@ name: shared_preferences_windows_example
 description: Demonstrates how to use the shared_preferences_windows plugin.
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
-  flutter: ">=1.12.8"
+  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  flutter: ">=1.20.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  shared_preferences_windows: ^0.0.1
+  shared_preferences_windows: ^2.0.0
 
 dependency_overrides:
   shared_preferences_windows:
@@ -24,7 +24,7 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     path: ../../../integration_test
-  pedantic: ^1.8.0
+  pedantic: ^1.10.0
 
 flutter:
   uses-material-design: true

--- a/packages/shared_preferences/shared_preferences_windows/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_windows/pubspec.yaml
@@ -1,7 +1,7 @@
 name: shared_preferences_windows
 description: Windows implementation of shared_preferences
 homepage: https://github.com/flutter/plugins/tree/master/packages/shared_preferences/shared_preferences_windows
-version: 2.0.0-nullsafety
+version: 2.0.0
 
 
 flutter:
@@ -12,20 +12,20 @@ flutter:
         pluginClass: none
 
 environment:
-  sdk: '>=2.12.0-0 <3.0.0'
-  flutter: ">=1.12.8"
+  sdk: '>=2.12.0-259.9.beta <3.0.0'
+  flutter: ">=1.20.0"
 
 dependencies:
-  shared_preferences_platform_interface: ^2.0.0-nullsafety
+  shared_preferences_platform_interface: ^2.0.0
   flutter:
     sdk: flutter
-  file: ^6.0.0-nullsafety.4
-  meta: ^1.1.7
-  path: ^1.6.4
-  path_provider_platform_interface: ^2.0.0-nullsafety
-  path_provider_windows: ^0.1.0-nullsafety.2
+  file: ^6.0.0
+  meta: ^1.3.0
+  path: ^1.8.0
+  path_provider_platform_interface: ^2.0.0
+  path_provider_windows: ^2.0.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.10.0-nullsafety.3
+  pedantic: ^1.10.0


### PR DESCRIPTION
Updates all the platform implementation packages to stable null-safety.

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
