### PR TITLE
[android_intent] Bump version for NNBD stable

### DIFF
--- a/packages/android_intent/CHANGELOG.md
+++ b/packages/android_intent/CHANGELOG.md
@@ -1,14 +1,8 @@
-## 2.0.0-nullsafety.2
-
-* Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.
-
-## 2.0.0-nullsafety.1
-
-* Fix outdated links across a number of markdown files ([#3276](https://github.com/flutter/plugins/pull/3276))
-
-## 2.0.0-nullsafety
+## 2.0.0
 
 * Migrate to null safety.
+* Fix outdated links across a number of markdown files ([#3276](https://github.com/flutter/plugins/pull/3276))
+* Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.
 
 ## 0.3.7+8
 

--- a/packages/android_intent/example/integration_test/android_intent_test.dart
+++ b/packages/android_intent/example/integration_test/android_intent_test.dart
@@ -1,3 +1,9 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.9
+
 import 'dart:io';
 
 import 'package:android_intent/android_intent.dart';

--- a/packages/android_intent/example/pubspec.yaml
+++ b/packages/android_intent/example/pubspec.yaml
@@ -17,12 +17,12 @@ dev_dependencies:
     path: ../../integration_test
   flutter_driver:
     sdk: flutter
-  pedantic: ^1.8.0
+  pedantic: ^1.10.0
 
 # The following section is specific to Flutter.
 flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.3.0 <3.0.0"
+  sdk: ">=2.12.0-259.9.beta <3.0.0"
   flutter: ">=1.12.13+hotfix.5"

--- a/packages/android_intent/example/test_driver/integration_test.dart
+++ b/packages/android_intent/example/test_driver/integration_test.dart
@@ -1,3 +1,9 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.9
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/packages/android_intent/pubspec.yaml
+++ b/packages/android_intent/pubspec.yaml
@@ -1,7 +1,7 @@
 name: android_intent
 description: Flutter plugin for launching Android Intents. Not supported on iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/android_intent
-version: 2.0.0-nullsafety.2
+version: 2.0.0
 
 flutter:
   plugin:
@@ -13,15 +13,15 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  platform: ^3.0.0-nullsafety.4
-  meta: ^1.3.0-nullsafety.6
+  platform: ^3.0.0
+  meta: ^1.3.0
 dev_dependencies:
-  test: ^1.16.0-nullsafety.13
-  mockito: ^4.1.3
+  test: ^1.16.3
+  mockito: ^5.0.0-nullsafety.7
   flutter_test:
     sdk: flutter
-  pedantic: ^1.10.0-nullsafety.1
+  pedantic: ^1.10.0
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.12.0-259.9.beta <3.0.0"
   flutter: ">=1.12.13+hotfix.5"


### PR DESCRIPTION
Includes migrating example to null safety.

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
