### PR TITLE
[shared_preferences] Bump app-facing version for NNBD stable

### DIFF
--- a/packages/shared_preferences/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences/CHANGELOG.md
@@ -1,8 +1,4 @@
-## 2.0.0-nullsafety.1
-
-* Fix crash when list string's type is dynamic.
-
-## 2.0.0-nullsafety
+## 2.0.0
 
 * Migrate to null-safety.
 

--- a/packages/shared_preferences/shared_preferences/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences/example/pubspec.yaml
@@ -17,11 +17,11 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     path: ../../../integration_test
-  pedantic: ^1.8.0
+  pedantic: ^1.10.0
 
 flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.12.0-259.9.beta <3.0.0"
   flutter: ">=1.9.1+hotfix.2"

--- a/packages/shared_preferences/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences/pubspec.yaml
@@ -2,7 +2,7 @@ name: shared_preferences
 description: Flutter plugin for reading and writing simple key-value pairs.
   Wraps NSUserDefaults on iOS and SharedPreferences on Android.
 homepage: https://github.com/flutter/plugins/tree/master/packages/shared_preferences/shared_preferences
-version: 2.0.0-nullsafety.1
+version: 2.0.0
 
 flutter:
   plugin:
@@ -20,19 +20,19 @@ flutter:
         default_package: shared_preferences_web
 
 dependencies:
-  meta: ^1.0.4
+  meta: ^1.3.0
   flutter:
     sdk: flutter
-  shared_preferences_platform_interface: ^2.0.0-nullsafety
+  shared_preferences_platform_interface: ^2.0.0
   # The design on https://flutter.dev/go/federated-plugins was to leave
   # this constraint as "any". We cannot do it right now as it fails pub publish
   # validation, so we set a ^ constraint.
   # TODO(franciscojma): Revisit this (either update this part in the  design or the pub tool).
   # https://github.com/flutter/flutter/issues/46264
-  shared_preferences_linux: ^0.0.4-nullsafety
-  shared_preferences_macos: ^0.0.2-nullsafety
-  shared_preferences_web: ^0.2.0-nullsafety
-  shared_preferences_windows: ^0.0.3-nullsafety
+  shared_preferences_linux: ^2.0.0
+  shared_preferences_macos: ^2.0.0
+  shared_preferences_web: ^2.0.0
+  shared_preferences_windows: ^2.0.0
 
 dev_dependencies:
   flutter_test:
@@ -41,8 +41,8 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     path: ../../integration_test
-  pedantic: ^1.8.0
+  pedantic: ^1.10.0
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.12.0-259.9.beta <3.0.0"
   flutter: ">=1.12.13+hotfix.5"


### PR DESCRIPTION
Completes the shared_preferences migration to stable null safety.

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
