### PR TITLE
[url_launcher] Bump app-facing version for NNBD stable

### DIFF
--- a/packages/url_launcher/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher/CHANGELOG.md
@@ -1,35 +1,9 @@
-## 6.0.0-nullsafety.7
-
-* Re-endorse `url_launcher_web` in the `nullsafety` prerelease.
-
-## 6.0.0-nullsafety.6
-
-* Correct statement in description about which platforms url_launcher supports.
-
-## 6.0.0-nullsafety.5
-
-* Document that the web plugin is not endorsed in the `nullsafety` prerelease for now.
-
-## 6.0.0-nullsafety.4
-
-* Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.
-
-## 6.0.0-nullsafety.3
-
-* forceSafariVC should be nullable.
-
-## 6.0.0-nullsafety.2
-
-* Fix outdated links across a number of markdown files ([#3276](https://github.com/flutter/plugins/pull/3276))
-
-## 6.0.0-nullsafety.1
-
-* Bump Dart SDK to support null safety.
-
-## 6.0.0-nullsafety
+## 6.0.0
 
 * Migrate to null safety.
-* **Breaking change**: web plugins aren't endorsed in null-safe plugins yet.
+* Fix outdated links across a number of markdown files ([#3276](https://github.com/flutter/plugins/pull/3276))
+* Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.
+* Correct statement in description about which platforms url_launcher supports.
 
 ## 5.7.13
 

--- a/packages/url_launcher/url_launcher/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/example/pubspec.yaml
@@ -17,13 +17,13 @@ dev_dependencies:
     path: ../../../integration_test
   flutter_driver:
     sdk: flutter
-  pedantic: ^1.10.0-nullsafety.1
-  mockito: ^4.1.1
-  plugin_platform_interface: ^1.1.0-nullsafety.1
+  pedantic: ^1.10.0
+  mockito: ^5.0.0-nullsafety.7
+  plugin_platform_interface: ">=1.0.0 <3.0.0"
 
 flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.12.0-259.9.beta <3.0.0"
   flutter: ">=1.12.13+hotfix.5"

--- a/packages/url_launcher/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher
 description: Flutter plugin for launching a URL. Supports
   web, phone, SMS, and email schemes.
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher
-version: 6.0.0-nullsafety.7
+version: 6.0.0
 
 flutter:
   plugin:
@@ -24,25 +24,25 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  url_launcher_platform_interface: ^2.0.0-nullsafety
+  url_launcher_platform_interface: ^2.0.0
   # The design on https://flutter.dev/go/federated-plugins was to leave
   # this constraint as "any". We cannot do it right now as it fails pub publish
   # validation, so we set a ^ constraint.
   # TODO(amirh): Revisit this (either update this part in the  design or the pub tool).
   # https://github.com/flutter/flutter/issues/46264
-  url_launcher_linux: ^0.1.0-nullsafety
-  url_launcher_macos: ^0.1.0-nullsafety
-  url_launcher_windows: ^0.1.0-nullsafety
-  url_launcher_web: ^2.0.0-nullsafety
+  url_launcher_linux: ^2.0.0
+  url_launcher_macos: ^2.0.0
+  url_launcher_windows: ^2.0.0
+  url_launcher_web: ^2.0.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  test: ^1.10.0-nullsafety.1
-  mockito: ^4.1.1
-  plugin_platform_interface: ^1.1.0-nullsafety.1
-  pedantic: ^1.10.0-nullsafety.1
+  test: ^1.16.3
+  mockito: ^5.0.0-nullsafety.7
+  plugin_platform_interface: ">=1.0.0 <3.0.0"
+  pedantic: ^1.10.0
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.12.0-259.9.beta <3.0.0"
   flutter: ">=1.12.13+hotfix.5"


### PR DESCRIPTION
Completes the null-safety migration of url_launcher.

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
