### PR TITLE
[file_selector_platform_interface] null safety stable release

### DIFF
--- a/packages/file_selector/file_selector_platform_interface/CHANGELOG.md
+++ b/packages/file_selector/file_selector_platform_interface/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.0-nullsafety.0
+## 2.0.0
 
 * Migration to null-safety
 

--- a/packages/file_selector/file_selector_platform_interface/pubspec.yaml
+++ b/packages/file_selector/file_selector_platform_interface/pubspec.yaml
@@ -3,23 +3,22 @@ description: A common platform interface for the file_selector plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/file_selector/file_selector_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.0.0-nullsafety.0
+version: 2.0.0
 
 dependencies:
   flutter:
     sdk: flutter
   meta: ^1.0.5
-  http: ^0.13.0-nullsafety.0
-  plugin_platform_interface: ^1.1.0-nullsafety.2
-  cross_file: ^0.3.0-nullsafety
+  http: ^0.13.0
+  plugin_platform_interface: ">=1.0.0 <3.0.0"
+  cross_file: ^0.3.0
 
 dev_dependencies:
   test: ^1.15.0
   flutter_test:
     sdk: flutter
-  mockito: ^5.0.0-nullsafety.5
   pedantic: ^1.8.0
 
 environment:
-  sdk: '>=2.12.0-0 <3.0.0'
-  flutter: ">=1.9.1+hotfix.4"
+  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  flutter: ">=1.20.0"

--- a/packages/file_selector/file_selector_platform_interface/pubspec.yaml
+++ b/packages/file_selector/file_selector_platform_interface/pubspec.yaml
@@ -8,16 +8,16 @@ version: 2.0.0
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.0.5
+  meta: ^1.3.0
   http: ^0.13.0
   plugin_platform_interface: ">=1.0.0 <3.0.0"
   cross_file: ^0.3.0
 
 dev_dependencies:
-  test: ^1.15.0
+  test: ^1.16.3
   flutter_test:
     sdk: flutter
-  pedantic: ^1.8.0
+  pedantic: ^1.10.0
 
 environment:
   sdk: ">=2.12.0-259.9.beta <3.0.0"

--- a/packages/file_selector/file_selector_platform_interface/test/file_selector_platform_interface_test.dart
+++ b/packages/file_selector/file_selector_platform_interface/test/file_selector_platform_interface_test.dart
@@ -2,9 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:mockito/mockito.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
 import 'package:file_selector_platform_interface/src/method_channel/method_channel_file_selector.dart';
@@ -16,28 +14,10 @@ void main() {
           isInstanceOf<MethodChannelFileSelector>());
     });
 
-    test('Cannot be implemented with `implements`', () {
-      expect(() {
-        FileSelectorPlatform.instance = ImplementsFileSelectorPlatform();
-      }, throwsA(isInstanceOf<AssertionError>()));
-    });
-
-    test('Can be mocked with `implements`', () {
-      final FileSelectorPlatformMock mock = FileSelectorPlatformMock();
-      FileSelectorPlatform.instance = mock;
-    });
-
     test('Can be extended', () {
       FileSelectorPlatform.instance = ExtendsFileSelectorPlatform();
     });
   });
 }
-
-class FileSelectorPlatformMock extends Mock
-    with MockPlatformInterfaceMixin
-    implements FileSelectorPlatform {}
-
-class ImplementsFileSelectorPlatform extends Mock
-    implements FileSelectorPlatform {}
 
 class ExtendsFileSelectorPlatform extends FileSelectorPlatform {}


### PR DESCRIPTION
Required for the migration to stable null safety of file_selector.

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
