### PR TITLE
Webview not showing HTMLs from documents directory on ios 12.5.1

### DIFF
--- a/packages/webview_flutter/ios/Classes/FlutterWebView.m
+++ b/packages/webview_flutter/ios/Classes/FlutterWebView.m
@@ -426,7 +426,18 @@
   }
   NSMutableURLRequest* request = [NSMutableURLRequest requestWithURL:nsUrl];
   [request setAllHTTPHeaderFields:headers];
-  [_webView loadRequest:request];
+  if([url hasPrefix:@"file"]) {
+    NSString * allowingReadAccessToURL = [request.URL.path stringByDeletingLastPathComponent];
+    if (@available(iOS 9.0, *)) {
+      [_webView loadFileURL:request.URL allowingReadAccessToURL:[NSURL fileURLWithPath:allowingReadAccessToURL]];
+    }
+    else {
+      [_webView loadRequest:request];
+    }
+  }
+  else {
+    [_webView loadRequest:request];
+  }
   return true;
 }
 


### PR DESCRIPTION
WebView not showing HTMLs from documents directory on iOS 12.5.1 this has to be handled on native level allowing the access to url

Assets HTMLS files are loaded but not from the documents directory.

This does not work on iOS 12.5.1 and most of the iPad Air are upgradable upto iOS 12.5.1

This is very critical issue for our apps.