### PR TITLE
[webview_flutter] webview not showing html on ios 12.5.1 

### DIFF
--- a/packages/webview_flutter/ios/Classes/FlutterWebView.m
+++ b/packages/webview_flutter/ios/Classes/FlutterWebView.m
@@ -426,7 +426,18 @@
   }
   NSMutableURLRequest* request = [NSMutableURLRequest requestWithURL:nsUrl];
   [request setAllHTTPHeaderFields:headers];
-  [_webView loadRequest:request];
+  if([url hasPrefix:@"file"]) {
+    NSString * allowingReadAccessToURL = [request.URL.path stringByDeletingLastPathComponent];
+    if (@available(iOS 9.0, *)) {
+      [_webView loadFileURL:request.URL allowingReadAccessToURL:[NSURL fileURLWithPath:allowingReadAccessToURL]];
+    }
+    else {
+      [_webView loadRequest:request];
+    }
+  }
+  else {
+    [_webView loadRequest:request];
+  }
   return true;
 }
 


### PR DESCRIPTION
WebView not showing HTMLs from Documents Directory on iOS 12.5.1  this has to be handled on native level allowing the access to url

All assets HTMLs are showing but not from Documents Directory

This issue is only in 12.5.1 and the iPad Air is only upgradable to iOS 12.5.1

This is a critical issue as most of our users are using iPad and also has reported the content blank issue