### PR TITLE
[local_auth] Bump version for NNBD stable

### DIFF
--- a/packages/local_auth/CHANGELOG.md
+++ b/packages/local_auth/CHANGELOG.md
@@ -1,31 +1,16 @@
-## 1.1.0-nullsafety
+## 1.1.0
 
-* Allow pin, passcode, and pattern authentication with `authenticate` method
+* Migrate to null safety.
+* Allow pin, passcode, and pattern authentication with `authenticate` method.
+* Fix incorrect error handling switch case fallthrough.
+* Update README for Android Integration.
+* Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.
+* Fix outdated links across a number of markdown files ([#3276](https://github.com/flutter/plugins/pull/3276)).
 * **Breaking change**. Parameter names refactored to use the generic `biometric` prefix in place of `fingerprint` in the `AndroidAuthMessages` class
   * `fingerprintHint` is now `biometricHint`
   * `fingerprintNotRecognized`is now `biometricNotRecognized`
   * `fingerprintSuccess`is now `biometricSuccess`
   * `fingerprintRequiredTitle` is now `biometricRequiredTitle`
-
-## 1.0.0-nullsafety.4
-
-* Fix incorrect error handling switch case fallthrough.
-
-## 1.0.0-nullsafety.3
-
-* Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.
-
-## 1.0.0-nullsafety.2
-
-* Fix outdated links across a number of markdown files ([#3276](https://github.com/flutter/plugins/pull/3276))
-
-## 1.0.0-nullsafety.1
-
-* Update README for Android Integration.
-
-## 1.0.0-nullsafety
-
-* Migrate to null safety.
 
 ## 0.6.3+5
 

--- a/packages/local_auth/example/pubspec.yaml
+++ b/packages/local_auth/example/pubspec.yaml
@@ -17,11 +17,11 @@ dev_dependencies:
     path: ../../integration_test
   flutter_driver:
     sdk: flutter
-  pedantic: ^1.8.0
+  pedantic: ^1.10.0
 
 flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.12.0-259.9.beta <3.0.0"
   flutter: ">=1.12.13+hotfix.5"

--- a/packages/local_auth/pubspec.yaml
+++ b/packages/local_auth/pubspec.yaml
@@ -2,7 +2,7 @@ name: local_auth
 description: Flutter plugin for Android and iOS devices to allow local
   authentication via fingerprint, touch ID, face ID, passcode, pin, or pattern.
 homepage: https://github.com/flutter/plugins/tree/master/packages/local_auth
-version: 1.0.0-nullsafety.4
+version: 1.1.0
 
 flutter:
   plugin:
@@ -16,10 +16,10 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.3.0-nullsafety.3
-  intl: ^0.17.0-nullsafety.2
-  platform: ^3.0.0-nullsafety.4
-  flutter_plugin_android_lifecycle: ^2.0.0-nullsafety
+  meta: ^1.3.0
+  intl: ^0.17.0
+  platform: ^3.0.0
+  flutter_plugin_android_lifecycle: ^2.0.0
 
 dev_dependencies:
   integration_test:
@@ -28,8 +28,8 @@ dev_dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
-  pedantic: ^1.10.0-nullsafety.1
+  pedantic: ^1.10.0
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.12.0-259.9.beta <3.0.0"
   flutter: ">=1.12.13+hotfix.5"


### PR DESCRIPTION
Resolves the bizarre version situation this plugin was in; https://github.com/flutter/plugins/pull/2489 set the changelog version to a 1.1.0 prerelease but not the pubspec version, and then apparently it was published with a local modification to the pubspec to correct that which was never checked in. Subsequent *later* changes added new 1.0.0-nullsafety.x releases to the changelog and updated the version accordingly, but were presumably never published.

The minor version bump of the prerelease ideally shouldn't have happened, but we shouldn't go backwards in published versions so we're stuck with 1.1.0.

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
