### PR TITLE
[quick_action] null safety stable release

### DIFF
--- a/packages/quick_actions/CHANGELOG.md
+++ b/packages/quick_actions/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.5.0-nullsafety
+## 0.5.0
 
 * Migrate to null safety.
 

--- a/packages/quick_actions/example/integration_test/quick_actions_test.dart
+++ b/packages/quick_actions/example/integration_test/quick_actions_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart = 2.9
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:quick_actions/quick_actions.dart';

--- a/packages/quick_actions/example/lib/main.dart
+++ b/packages/quick_actions/example/lib/main.dart
@@ -25,7 +25,7 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatefulWidget {
-  MyHomePage({Key key}) : super(key: key);
+  MyHomePage({Key? key}) : super(key: key);
 
   @override
   _MyHomePageState createState() => _MyHomePageState();

--- a/packages/quick_actions/example/pubspec.yaml
+++ b/packages/quick_actions/example/pubspec.yaml
@@ -17,11 +17,11 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     path: ../../integration_test
-  pedantic: ^1.8.0
+  pedantic: ^1.10.0
 
 flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.0.0-dev.28.0 <3.0.0"
+  sdk: ">=2.12.0-259.9.beta <3.0.0"
   flutter: ">=1.9.1+hotfix.2"

--- a/packages/quick_actions/example/test_driver/integration_test.dart
+++ b/packages/quick_actions/example/test_driver/integration_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart = 2.9
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/packages/quick_actions/pubspec.yaml
+++ b/packages/quick_actions/pubspec.yaml
@@ -2,7 +2,7 @@ name: quick_actions
 description: Flutter plugin for creating shortcuts on home screen, also known as
   Quick Actions on iOS and App Shortcuts on Android.
 homepage: https://github.com/flutter/plugins/tree/master/packages/quick_actions
-version: 0.5.0-nullsafety
+version: 0.5.0
 
 flutter:
   plugin:
@@ -16,17 +16,16 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.3.0-nullsafety
+  meta: ^1.3.0
 
 dev_dependencies:
-  test: ^1.16.0-nullsafety
-  mockito: ^5.0.0-nullsafety.0
+  test: ^1.16.3
   flutter_test:
     sdk: flutter
   integration_test:
     path: ../integration_test
-  pedantic: ^1.10.0-nullsafety
+  pedantic: ^1.10.0
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.12.0-259.9.beta <3.0.0"
   flutter: ">=1.12.13+hotfix.5"


### PR DESCRIPTION
Release the null safety version as stable and move the example app to null safety.