### PR TITLE
[video_player] Bump app-facing version for NNBD stable

### DIFF
--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,50 +1,13 @@
-## 2.0.0-nullsafety.11
+## 2.0.0
 
-* Setting the `mixWithOthers` `VideoPlayerOptions` in web now is silently ignored instead of throwing an exception.
-
-## 2.0.0-nullsafety.10
-
-* Updated to video_player_platform_interface 4.0.
-
-## 2.0.0-nullsafety.9
-
-* Fixed an issue where a crash can occur after a closing a video player view on iOS.
-
-## 2.0.0-nullsafety.8
-
-* Migrated from deprecated `defaultBinaryMessenger`.
-
-## 2.0.0-nullsafety.7
-
-* Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.
-
-## 2.0.0-nullsafety.6
-
-* Fix `VideoPlayerValue toString()` test.
-
-## 2.0.0-nullsafety.5
-
+* Migrate to null safety.
+* Fix an issue where `isBuffering` was not updating on Android.
 * Fix outdated links across a number of markdown files ([#3276](https://github.com/flutter/plugins/pull/3276))
-
-## 2.0.0-nullsafety.4
-
-* Fixed an issue where `isBuffering` was not updating on Android.
-
-## 2.0.0-nullsafety.3
-
-* Dart null safety requires `2.12`.
-
-## 2.0.0-nullsafety.2
-
-* Bump SDK version.
-
-## 2.0.0-nullsafety.1
-
-* Merge master.
-
-## 2.0.0-nullsafety
-
-* Migration to null safety.
+* Fix `VideoPlayerValue toString()` test.
+* Update the example app: remove the deprecated `RaisedButton` and `FlatButton` widgets.
+* Migrate from deprecated `defaultBinaryMessenger`.
+* Fix an issue where a crash can occur after a closing a video player view on iOS.
+* Setting the `mixWithOthers` `VideoPlayerOptions` in web now is silently ignored instead of throwing an exception.
 
 ## 1.0.2
 

--- a/packages/video_player/video_player/example/pubspec.yaml
+++ b/packages/video_player/video_player/example/pubspec.yaml
@@ -22,7 +22,7 @@ dev_dependencies:
   integration_test:
     path: ../../../integration_test
   test: any
-  pedantic: ^1.10.0-nullsafety.1
+  pedantic: ^1.10.0
 
 flutter:
   uses-material-design: true
@@ -32,5 +32,5 @@ flutter:
    - assets/bumble_bee_captions.srt
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.12.0-259.9.beta <3.0.0"
   flutter: ">=1.12.13+hotfix.5"

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -1,7 +1,7 @@
 name: video_player
 description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android, iOS, and web.
-version: 2.0.0-nullsafety.11
+version: 2.0.0
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player
 
 flutter:
@@ -16,8 +16,8 @@ flutter:
         default_package: video_player_web
 
 dependencies:
-  meta: ^1.3.0-nullsafety.3
-  video_player_platform_interface: ^4.0.0-nullsafety.0
+  meta: ^1.3.0
+  video_player_platform_interface: ^4.0.0
 
   # The design on https://flutter.dev/go/federated-plugins was to leave
   # this constraint as "any". We cannot do it right now as it fails pub publish
@@ -25,7 +25,7 @@ dependencies:
   # the constraints on the interface pins it.
   # TODO(amirh): Revisit this (either update this part in the design or the pub tool).
   # https://github.com/flutter/flutter/issues/46264
-  video_player_web: ^2.0.0-nullsafety.1
+  video_player_web: ^2.0.0
 
   flutter:
     sdk: flutter
@@ -33,9 +33,9 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  pedantic: ^1.10.0-nullsafety.1
-  pigeon: ^0.1.19
+  pedantic: ^1.10.0
+  pigeon: ^0.1.21
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.12.0-259.9.beta <3.0.0"
   flutter: ">=1.12.13+hotfix.5"


### PR DESCRIPTION
## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
