### PR TITLE
[google_maps_flutter] embedded_views_preview not required since v1.0.0

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/example/ios/Runner/Info.plist
+++ b/packages/google_maps_flutter/google_maps_flutter/example/ios/Runner/Info.plist
@@ -47,7 +47,5 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-	<key>io.flutter.embedded_views_preview</key>
-	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
The [release notes](https://github.com/flutter/plugins/blob/master/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md#100---out-of-developer-preview--) state that `io.flutter.embedded_views_preview` is not required since version `1.0.0`.

Thus removed this from the example, to keep things clean and tidy ✨
