### PR TITLE
[cross_file] Fix base class nullability

### DIFF
--- a/packages/cross_file/CHANGELOG.md
+++ b/packages/cross_file/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.1
+
+* Fix nullability of `XFileBase`'s `path` and `name` to match the
+  implementations to avoid potential analyzer issues.
+
 ## 0.3.0
 
 * Migrated package to null-safety.

--- a/packages/cross_file/CHANGELOG.md
+++ b/packages/cross_file/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.1
+## 0.4.0
 
 * Fix nullability of `XFileBase`'s `path` and `name` to match the
   implementations to avoid potential analyzer issues.

--- a/packages/cross_file/CHANGELOG.md
+++ b/packages/cross_file/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.4.0
+## 0.3.1
 
 * Fix nullability of `XFileBase`'s `path` and `name` to match the
   implementations to avoid potential analyzer issues.

--- a/packages/cross_file/lib/src/types/base.dart
+++ b/packages/cross_file/lib/src/types/base.dart
@@ -31,14 +31,14 @@ abstract class XFileBase {
   /// Accessing the data contained in the picked file by its path
   /// is platform-dependant (and won't work on web), so use the
   /// byte getters in the CrossFile instance instead.
-  String? get path {
+  String get path {
     throw UnimplementedError('.path has not been implemented.');
   }
 
   /// The name of the file as it was selected by the user in their device.
   ///
   /// Use only for cosmetic reasons, do not try to use this as a path.
-  String? get name {
+  String get name {
     throw UnimplementedError('.name has not been implemented.');
   }
 

--- a/packages/cross_file/pubspec.yaml
+++ b/packages/cross_file/pubspec.yaml
@@ -1,7 +1,7 @@
 name: cross_file
 description: An abstraction to allow working with files across multiple platforms.
 homepage: https://github.com/flutter/plugins/tree/master/packages/cross_file
-version: 0.4.0
+version: 0.3.1
 
 dependencies:
   flutter:

--- a/packages/cross_file/pubspec.yaml
+++ b/packages/cross_file/pubspec.yaml
@@ -1,7 +1,7 @@
 name: cross_file
 description: An abstraction to allow working with files across multiple platforms.
 homepage: https://github.com/flutter/plugins/tree/master/packages/cross_file
-version: 0.3.1
+version: 0.4.0
 
 dependencies:
   flutter:

--- a/packages/cross_file/pubspec.yaml
+++ b/packages/cross_file/pubspec.yaml
@@ -1,7 +1,7 @@
 name: cross_file
 description: An abstraction to allow working with files across multiple platforms.
 homepage: https://github.com/flutter/plugins/tree/master/packages/cross_file
-version: 0.3.0
+version: 0.3.1
 
 dependencies:
   flutter:


### PR DESCRIPTION
Without this, the dummy ("interface") XFile implementation of these properties has different nullability than the others, and the analyzer doesn't match what the runtime actually sees.

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
