### PR TITLE
[file_selector] Return a non-null value from getSavePath on web

### DIFF
--- a/packages/file_selector/file_selector_web/CHANGELOG.md
+++ b/packages/file_selector/file_selector_web/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 0.8.1
 
 - Return a non-null value from `getSavePath` for consistency with
-  API expectations that null indications canceling.
+  API expectations that null indicates canceling.
 
 # 0.8.0
 

--- a/packages/file_selector/file_selector_web/CHANGELOG.md
+++ b/packages/file_selector/file_selector_web/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.8.1
+
+- Return a non-null value from `getSavePath` for consistency with
+  API expectations that null indications canceling.
+
 # 0.8.0
 
 - Migrated to null-safety

--- a/packages/file_selector/file_selector_web/example/integration_test/file_selector_web_test.dart
+++ b/packages/file_selector/file_selector_web/example/integration_test/file_selector_web_test.dart
@@ -73,6 +73,14 @@ void main() {
         expect(await files[1].lastModified(), isNotNull);
       });
     });
+
+    group('getSavePath', () {
+      testWidgets('returns non-null', (WidgetTester _) async {
+        final plugin = FileSelectorWeb();
+        final savePath = plugin.getSavePath();
+        expect(await savePath, isNotNull);
+      });
+    });
   });
 }
 

--- a/packages/file_selector/file_selector_web/lib/file_selector_web.dart
+++ b/packages/file_selector/file_selector_web/lib/file_selector_web.dart
@@ -45,6 +45,9 @@ class FileSelectorWeb extends FileSelectorPlatform {
     return _openFiles(acceptedTypeGroups: acceptedTypeGroups, multiple: true);
   }
 
+  // This is intended to be passed to XFile, which ignores the path, but 'null'
+  // indicates a canceled save on other platforms, so provide a non-null dummy
+  // value.
   @override
   Future<String?> getSavePath({
     List<XTypeGroup>? acceptedTypeGroups,
@@ -52,7 +55,7 @@ class FileSelectorWeb extends FileSelectorPlatform {
     String? suggestedName,
     String? confirmButtonText,
   }) async =>
-      null;
+      '';
 
   @override
   Future<String?> getDirectoryPath({

--- a/packages/file_selector/file_selector_web/pubspec.yaml
+++ b/packages/file_selector/file_selector_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: file_selector_web
 description: Web platform implementation of file_selector
 homepage: https://github.com/flutter/plugins/tree/master/packages/file_selector/file_selector_web
-version: 0.8.0
+version: 0.8.1
 
 flutter:
   plugin:


### PR DESCRIPTION
Null indicates cancelation on other platforms, so returning null here makes using this in a cross-platform way very awkward.

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
