### PR TITLE
[image_picker_for_web] Bump version for NNBD stable

### DIFF
--- a/packages/image_picker/image_picker_for_web/CHANGELOG.md
+++ b/packages/image_picker/image_picker_for_web/CHANGELOG.md
@@ -1,10 +1,7 @@
-# 2.0.0-nullsafety.1
-
-* Add doc comments to point out that some arguments aren't supported on the web.
-
-# 2.0.0-nullsafety
+# 2.0.0
 
 * Migrate to null safety.
+* Add doc comments to point out that some arguments aren't supported on the web.
 
 # 0.1.0+3
 

--- a/packages/image_picker/image_picker_for_web/pubspec.yaml
+++ b/packages/image_picker/image_picker_for_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker_for_web
 description: Web platform implementation of image_picker
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker/image_picker_for_web
 
-version: 2.0.0-nullsafety.1
+version: 2.0.0
 
 flutter:
   plugin:
@@ -12,19 +12,18 @@ flutter:
         fileName: image_picker_for_web.dart
 
 dependencies:
-  image_picker_platform_interface: ^2.0.0-nullsafety
+  image_picker_platform_interface: ^2.0.0
+  meta: ^1.3.0
   flutter:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  meta: ^1.3.0-nullsafety.6
-  js: ^0.6.3-nullsafety.3
 
 dev_dependencies:
+  pedantic: ^1.10.0
   flutter_test:
     sdk: flutter
-  pedantic: ^1.10.0
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
-  flutter: ">=1.10.0"
+  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  flutter: ">=1.20.0"


### PR DESCRIPTION
This PR will re-version the image_picker_for_web as a 'preview version' with null safety enabled by default.

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
