### PR TITLE
[shared_preferences] Don't create additional Handler when method channel is called.

### DIFF
--- a/packages/shared_preferences/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.3
+
+* Don't create additional handler when method channel is called.
+
 ## 2.0.2
 
 * Don't create additional thread pools when method channel is called.

--- a/packages/shared_preferences/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.0.3
 
-* Don't create additional handler when method channel is called.
+* Android: don't create additional Handler when method channel is called.
 
 ## 2.0.2
 

--- a/packages/shared_preferences/shared_preferences/android/src/main/java/io/flutter/plugins/sharedpreferences/MethodCallHandlerImpl.java
+++ b/packages/shared_preferences/shared_preferences/android/src/main/java/io/flutter/plugins/sharedpreferences/MethodCallHandlerImpl.java
@@ -44,6 +44,7 @@ class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
   private final android.content.SharedPreferences preferences;
 
   private final ExecutorService executor;
+  private final Handler handler;
 
   /**
    * Constructs a {@link MethodCallHandlerImpl} instance. Creates a {@link
@@ -53,6 +54,7 @@ class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
     preferences = context.getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE);
     executor =
         new ThreadPoolExecutor(0, 1, 30L, TimeUnit.SECONDS, new SynchronousQueue<Runnable>());
+    handler = new Handler(Looper.getMainLooper());
   }
 
   @Override
@@ -125,10 +127,13 @@ class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
     }
   }
 
+  public void teardown() {
+    handler.removeCallbacksAndMessages(null);
+    executor.shutdown();
+  }
+
   private void commitAsync(
       final SharedPreferences.Editor editor, final MethodChannel.Result result) {
-    final Handler handler = new Handler(Looper.getMainLooper());
-
     executor.execute(
         new Runnable() {
           @Override

--- a/packages/shared_preferences/shared_preferences/android/src/main/java/io/flutter/plugins/sharedpreferences/SharedPreferencesPlugin.java
+++ b/packages/shared_preferences/shared_preferences/android/src/main/java/io/flutter/plugins/sharedpreferences/SharedPreferencesPlugin.java
@@ -13,6 +13,7 @@ import io.flutter.plugin.common.MethodChannel;
 public class SharedPreferencesPlugin implements FlutterPlugin {
   private static final String CHANNEL_NAME = "plugins.flutter.io/shared_preferences";
   private MethodChannel channel;
+  private MethodCallHandlerImpl handler;
 
   @SuppressWarnings("deprecation")
   public static void registerWith(io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
@@ -32,11 +33,13 @@ public class SharedPreferencesPlugin implements FlutterPlugin {
 
   private void setupChannel(BinaryMessenger messenger, Context context) {
     channel = new MethodChannel(messenger, CHANNEL_NAME);
-    MethodCallHandlerImpl handler = new MethodCallHandlerImpl(context);
+    handler = new MethodCallHandlerImpl(context);
     channel.setMethodCallHandler(handler);
   }
 
   private void teardownChannel() {
+    handler.teardown();
+    handler = null;
     channel.setMethodCallHandler(null);
     channel = null;
   }

--- a/packages/shared_preferences/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences/pubspec.yaml
@@ -2,7 +2,7 @@ name: shared_preferences
 description: Flutter plugin for reading and writing simple key-value pairs.
   Wraps NSUserDefaults on iOS and SharedPreferences on Android.
 homepage: https://github.com/flutter/plugins/tree/master/packages/shared_preferences/shared_preferences
-version: 2.0.2
+version: 2.0.3
 
 flutter:
   plugin:


### PR DESCRIPTION
## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
