### PR TITLE
[connectivity] migrate unit tests to null safety

### DIFF
--- a/packages/connectivity/connectivity/CHANGELOG.md
+++ b/packages/connectivity/connectivity/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.1
+
+* Migrate tests to null safety.
+
 ## 3.0.0
 
 * Migrate to null safety.

--- a/packages/connectivity/connectivity/pubspec.yaml
+++ b/packages/connectivity/connectivity/pubspec.yaml
@@ -2,7 +2,7 @@ name: connectivity
 description: Flutter plugin for discovering the state of the network (WiFi &
   mobile/cellular) connectivity on Android and iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/connectivity/connectivity
-version: 3.0.0
+version: 3.0.1
 
 flutter:
   plugin:

--- a/packages/connectivity/connectivity/test/connectivity_test.dart
+++ b/packages/connectivity/connectivity/test/connectivity_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(cyanglaz): Remove once Mockito is migrated to null safety.
-// @dart = 2.9
 import 'package:connectivity/connectivity.dart';
 import 'package:connectivity_platform_interface/connectivity_platform_interface.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -18,8 +16,8 @@ const LocationAuthorizationStatus kGetLocationResult =
 
 void main() {
   group('Connectivity', () {
-    Connectivity connectivity;
-    MockConnectivityPlatform fakePlatform;
+    late Connectivity connectivity;
+    late MockConnectivityPlatform fakePlatform;
     setUp(() async {
       fakePlatform = MockConnectivityPlatform();
       ConnectivityPlatform.instance = fakePlatform;


### PR DESCRIPTION
Migrate unit tests to null safety. This is mistakenly left out in the 3.0.0 release.