### PR TITLE
[google_maps_flutter_web] Implements updateTileOverlays

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/google_maps_flutter_web.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/google_maps_flutter_web.dart
@@ -86,6 +86,14 @@ class GoogleMapsPlugin extends GoogleMapsFlutterPlatform {
     _map(mapId).updateCircles(circleUpdates);
   }
 
+  @override
+  Future<void> updateTileOverlays({
+    @required Set<TileOverlay> newTileOverlays,
+    @required int mapId,
+  }) async {
+    // Empty implementation to avoid Exception
+  }
+
   /// Applies the given `cameraUpdate` to the current viewport (with animation).
   @override
   Future<void> animateCamera(


### PR DESCRIPTION
Adds implementation for updateTileOverlay in google_maps_flutter_web to prevent UnimplementedException.
This PR Fixes Issue: https://github.com/flutter/flutter/issues/76361