### PR TITLE
Update plugin_platform_interface min version

### DIFF
--- a/packages/battery/battery/CHANGELOG.md
+++ b/packages/battery/battery/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+* Update platform_plugin_interface version requirement.
+
 ## 2.0.0
 
 * Migrate to null safety.

--- a/packages/battery/battery/pubspec.yaml
+++ b/packages/battery/battery/pubspec.yaml
@@ -2,7 +2,7 @@ name: battery
 description: Flutter plugin for accessing information about the battery state
   (full, charging, discharging) on Android and iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/battery/battery
-version: 2.0.0
+version: 2.0.1
 
 flutter:
   plugin:
@@ -22,7 +22,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  plugin_platform_interface: ">=1.0.0 <3.0.0"
+  plugin_platform_interface: ^2.0.0
   integration_test:
     path: ../../integration_test
   pedantic: ^1.10.0

--- a/packages/battery/battery_platform_interface/CHANGELOG.md
+++ b/packages/battery/battery_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+* Update platform_plugin_interface version requirement.
+
 ## 2.0.0
 
 * Migrate to null safety.

--- a/packages/battery/battery_platform_interface/pubspec.yaml
+++ b/packages/battery/battery_platform_interface/pubspec.yaml
@@ -3,13 +3,13 @@ description: A common platform interface for the battery plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/battery
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.0.0
+version: 2.0.1
 
 dependencies:
   flutter:
     sdk: flutter
   meta: ^1.3.0
-  plugin_platform_interface: ">=1.0.0 <3.0.0"
+  plugin_platform_interface: ^2.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/camera/camera_platform_interface/CHANGELOG.md
+++ b/packages/camera/camera_platform_interface/CHANGELOG.md
@@ -1,10 +1,14 @@
+## 2.0.1
+
+* Update platform_plugin_interface version requirement.
+
 ## 2.0.0
 
 - Stable null safety release.
 
 ## 1.6.0
 
-- Added VideoRecordedEvent to support ending a video recording in the native implementation. 
+- Added VideoRecordedEvent to support ending a video recording in the native implementation.
 
 ## 1.5.0
 

--- a/packages/camera/camera_platform_interface/pubspec.yaml
+++ b/packages/camera/camera_platform_interface/pubspec.yaml
@@ -3,13 +3,13 @@ description: A common platform interface for the camera plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/camera/camera_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.0.0
+version: 2.0.1
 
 dependencies:
   flutter:
     sdk: flutter
   meta: ^1.3.0
-  plugin_platform_interface: ">=1.0.0 <3.0.0"
+  plugin_platform_interface: ^2.0.0
   cross_file: ^0.3.1
   stream_transform: ^2.0.0
 

--- a/packages/connectivity/connectivity/CHANGELOG.md
+++ b/packages/connectivity/connectivity/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.2
+
+* Update platform_plugin_interface version requirement.
+
 ## 3.0.1
 
 * Migrate tests to null safety.

--- a/packages/connectivity/connectivity/pubspec.yaml
+++ b/packages/connectivity/connectivity/pubspec.yaml
@@ -2,7 +2,7 @@ name: connectivity
 description: Flutter plugin for discovering the state of the network (WiFi &
   mobile/cellular) connectivity on Android and iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/connectivity/connectivity
-version: 3.0.1
+version: 3.0.2
 
 flutter:
   plugin:
@@ -35,7 +35,7 @@ dev_dependencies:
   test: ^1.16.3
   integration_test:
     path: ../../integration_test
-  plugin_platform_interface: ">=1.0.0 <3.0.0"
+  plugin_platform_interface: ^2.0.0
   pedantic: ^1.10.0
 
 environment:

--- a/packages/connectivity/connectivity_platform_interface/CHANGELOG.md
+++ b/packages/connectivity/connectivity_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+* Update platform_plugin_interface version requirement.
+
 ## 2.0.0
 
 * Migrate to null safety.
@@ -12,7 +16,7 @@
 
 ## 1.0.5
 
-* Remove dart:io Platform checks from the MethodChannel implementation. This is 
+* Remove dart:io Platform checks from the MethodChannel implementation. This is
 tripping the analysis of other versions of the plugin.
 
 ## 1.0.4

--- a/packages/connectivity/connectivity_platform_interface/pubspec.yaml
+++ b/packages/connectivity/connectivity_platform_interface/pubspec.yaml
@@ -3,13 +3,13 @@ description: A common platform interface for the connectivity plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/connectivity/connectivity_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.0.0
+version: 2.0.1
 
 dependencies:
   flutter:
     sdk: flutter
   meta: ^1.3.0
-  plugin_platform_interface: ">=1.0.0 <3.0.0"
+  plugin_platform_interface: ^2.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/device_info/device_info_platform_interface/CHANGELOG.md
+++ b/packages/device_info/device_info_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+* Update platform_plugin_interface version requirement.
+
 ## 2.0.0
 
 * Migrate to null safety.

--- a/packages/device_info/device_info_platform_interface/pubspec.yaml
+++ b/packages/device_info/device_info_platform_interface/pubspec.yaml
@@ -3,13 +3,13 @@ description: A common platform interface for the device_info plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/device_info
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.0.0
+version: 2.0.1
 
 dependencies:
   flutter:
     sdk: flutter
   meta: ^1.3.0
-  plugin_platform_interface: ">=1.0.0 <3.0.0"
+  plugin_platform_interface: ^2.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/file_selector/file_selector/CHANGELOG.md
+++ b/packages/file_selector/file_selector/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.2
+
+* Update platform_plugin_interface version requirement.
+
 ## 0.8.1
 
 Endorse the web implementation.

--- a/packages/file_selector/file_selector/pubspec.yaml
+++ b/packages/file_selector/file_selector/pubspec.yaml
@@ -1,7 +1,7 @@
 name: file_selector
 description: Flutter plugin for opening and saving files.
 homepage: https://github.com/flutter/plugins/tree/master/packages/file_selector/file_selector
-version: 0.8.1
+version: 0.8.2
 
 flutter:
   plugin:
@@ -19,7 +19,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   test: ^1.16.3
-  plugin_platform_interface: ">=1.0.0 <3.0.0"
+  plugin_platform_interface: ^2.0.0
   pedantic: ^1.10.0
 
 environment:

--- a/packages/file_selector/file_selector_platform_interface/CHANGELOG.md
+++ b/packages/file_selector/file_selector_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.2
+
+* Update platform_plugin_interface version requirement.
+
 ## 2.0.1
 
 * Replace extensions with leading dots.

--- a/packages/file_selector/file_selector_platform_interface/pubspec.yaml
+++ b/packages/file_selector/file_selector_platform_interface/pubspec.yaml
@@ -3,14 +3,14 @@ description: A common platform interface for the file_selector plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/file_selector/file_selector_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.0.1
+version: 2.0.2
 
 dependencies:
   flutter:
     sdk: flutter
   meta: ^1.3.0
   http: ^0.13.0
-  plugin_platform_interface: ">=1.0.0 <3.0.0"
+  plugin_platform_interface: ^2.0.0
   cross_file: ^0.3.0
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+* Update platform_plugin_interface version requirement.
+
 ## 2.0.0
 
 * Migrate to null-safety

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter/google_maps_flutter
-version: 2.0.0
+version: 2.0.1
 
 dependencies:
   flutter:
@@ -19,7 +19,7 @@ dev_dependencies:
     sdk: flutter
   test: ^1.16.0
   pedantic: ^1.10.0
-  plugin_platform_interface: ">=1.0.0 <3.0.0"
+  plugin_platform_interface: ^2.0.0
   stream_transform: ^2.0.0
 
 flutter:

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+* Update platform_plugin_interface version requirement.
+
 ## 2.0.0
 
 * Migrated to null-safety.

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
@@ -3,13 +3,13 @@ description: A common platform interface for the google_maps_flutter plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter/google_maps_flutter_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.0.0
+version: 2.0.1
 
 dependencies:
   flutter:
     sdk: flutter
   meta: ^1.3.0
-  plugin_platform_interface: ">=1.0.0 <3.0.0"
+  plugin_platform_interface: ^2.0.0
   stream_transform: ^2.0.0
   collection: ^1.15.0
 

--- a/packages/image_picker/image_picker/CHANGELOG.md
+++ b/packages/image_picker/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.1
+
+* Update platform_plugin_interface version requirement.
+
 ## 0.7.0
 
 * Migrate to nullsafety

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker
 description: Flutter plugin for selecting images from the Android and iOS image
   library, and taking new pictures with the camera.
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker/image_picker
-version: 0.7.0
+version: 0.7.1
 
 flutter:
   plugin:
@@ -26,7 +26,7 @@ dev_dependencies:
     path: ../../integration_test
   mockito: ^5.0.0-nullsafety.7
   pedantic: ^1.10.0
-  plugin_platform_interface: ">=1.0.0 <3.0.0"
+  plugin_platform_interface: ^2.0.0
 
 environment:
   sdk: ">=2.12.0-259.9.beta <3.0.0"

--- a/packages/image_picker/image_picker_platform_interface/CHANGELOG.md
+++ b/packages/image_picker/image_picker_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+* Update platform_plugin_interface version requirement.
+
 ## 2.0.0
 
 * Migrate to null safety.

--- a/packages/image_picker/image_picker_platform_interface/pubspec.yaml
+++ b/packages/image_picker/image_picker_platform_interface/pubspec.yaml
@@ -3,14 +3,14 @@ description: A common platform interface for the image_picker plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker/image_picker_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.0.0
+version: 2.0.1
 
 dependencies:
   flutter:
     sdk: flutter
   meta: ^1.3.0
   http: ^0.13.0
-  plugin_platform_interface: ">=1.0.0 <3.0.0"
+  plugin_platform_interface: ^2.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/path_provider/path_provider/CHANGELOG.md
+++ b/packages/path_provider/path_provider/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+* Update platform_plugin_interface version requirement.
+
 ## 2.0.0
 
 * Migrate to null safety.

--- a/packages/path_provider/path_provider/pubspec.yaml
+++ b/packages/path_provider/path_provider/pubspec.yaml
@@ -1,7 +1,7 @@
 name: path_provider
 description: Flutter plugin for getting commonly used locations on host platform file systems, such as the temp and app data directories.
 homepage: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider
-version: 2.0.0
+version: 2.0.1
 
 flutter:
   plugin:
@@ -34,7 +34,7 @@ dev_dependencies:
   flutter_driver:
     sdk: flutter
   pedantic: ^1.10.0
-  plugin_platform_interface: ">=1.0.0 <3.0.0"
+  plugin_platform_interface: ^2.0.0
   test: ^1.16.0
 
 environment:

--- a/packages/path_provider/path_provider_platform_interface/CHANGELOG.md
+++ b/packages/path_provider/path_provider_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+* Update platform_plugin_interface version requirement.
+
 ## 2.0.0
 
 * Migrate to null safety.

--- a/packages/path_provider/path_provider_platform_interface/pubspec.yaml
+++ b/packages/path_provider/path_provider_platform_interface/pubspec.yaml
@@ -3,14 +3,14 @@ description: A common platform interface for the path_provider plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.0.0
+version: 2.0.1
 
 dependencies:
   flutter:
     sdk: flutter
   meta: ^1.3.0
   platform: ^3.0.0
-  plugin_platform_interface: ">=1.0.0 <3.0.0"
+  plugin_platform_interface: ^2.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/url_launcher/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.2
+
+* Update platform_plugin_interface version requirement.
+
 ## 6.0.1
 
 * Update result to `True` on iOS when the url was loaded successfully.

--- a/packages/url_launcher/url_launcher/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/example/pubspec.yaml
@@ -19,7 +19,7 @@ dev_dependencies:
     sdk: flutter
   pedantic: ^1.10.0
   mockito: ^5.0.0-nullsafety.7
-  plugin_platform_interface: ">=1.0.0 <3.0.0"
+  plugin_platform_interface: ^2.0.0
 
 flutter:
   uses-material-design: true

--- a/packages/url_launcher/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher
 description: Flutter plugin for launching a URL. Supports
   web, phone, SMS, and email schemes.
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher
-version: 6.0.1
+version: 6.0.2
 
 flutter:
   plugin:
@@ -40,7 +40,7 @@ dev_dependencies:
     sdk: flutter
   test: ^1.16.3
   mockito: ^5.0.0-nullsafety.7
-  plugin_platform_interface: ">=1.0.0 <3.0.0"
+  plugin_platform_interface: ^2.0.0
   pedantic: ^1.10.0
 
 environment:

--- a/packages/url_launcher/url_launcher_platform_interface/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.2
+
+* Update platform_plugin_interface version requirement.
+
 ## 2.0.1
 
 * Fix SDK range.

--- a/packages/url_launcher/url_launcher_platform_interface/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_platform_interface/pubspec.yaml
@@ -3,12 +3,12 @@ description: A common platform interface for the url_launcher plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.0.1
+version: 2.0.2
 
 dependencies:
   flutter:
     sdk: flutter
-  plugin_platform_interface: ">=1.0.0 <3.0.0"
+  plugin_platform_interface: ^2.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/wifi_info_flutter/wifi_info_flutter_platform_interface/CHANGELOG.md
+++ b/packages/wifi_info_flutter/wifi_info_flutter_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+* Update platform_plugin_interface version requirement.
+
 ## 2.0.0
 
 * Migrate to null safety.

--- a/packages/wifi_info_flutter/wifi_info_flutter_platform_interface/pubspec.yaml
+++ b/packages/wifi_info_flutter/wifi_info_flutter_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: wifi_info_flutter_platform_interface
 description: A common platform interface for the wifi_info_flutter plugin.
-version: 2.0.0
+version: 2.0.1
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
 homepage: https://github.com/flutter/plugins/tree/master/packages/wifi_info_flutter/wifi_info_flutter_platform_interface
@@ -10,7 +10,7 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
-  plugin_platform_interface: ">=1.0.0 <3.0.0"
+  plugin_platform_interface: ^2.0.0
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
To avoid intra-repo plugin conflicts during the NNBD stable migration,
`plugin_platform_interface` allowed either 1.x or 2.0. However, 1.0.x
isn't null-safe so this can cause apps that don't have all their
packages fully updated can fail to run in strong mode (due to having an
old local `plugin_platform_interface`).

Now that everything has been updated, we can bump all the minimums so
that people updating their plugins will get new versions of the
dependency.