### PR TITLE
Adopt Xcode 12 for podspec lints

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -202,26 +202,6 @@ task:
         # This UI change sometimes affects `xctest`.
         # So we run `drive-examples` after `xctest`, changing the order will result ci failure.
         - ./script/incremental_build.sh drive-examples --ios
-
-task:
-  # Xcode 11 task
-  # TODO(cyanglaz): merge Xcode 11 task to Xcode 12 task when all the matrix can be run in Xcode 12.
-  # don't run on release tags since it creates O(n^2) tasks where n is the number of plugins
-  only_if: $CIRRUS_TAG == ''
-  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
-  osx_instance:
-    image: catalina-xcode-11.3.1-flutter
-  upgrade_script:
-    - sudo gem install cocoapods
-    - flutter channel stable
-    - flutter upgrade
-    - flutter channel master
-    - flutter upgrade
-    - git fetch origin master
-  create_simulator_script:
-    - xcrun simctl list
-    - xcrun simctl create Flutter-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-X com.apple.CoreSimulator.SimRuntime.iOS-13-3 | xargs xcrun simctl boot
-  matrix:
     - name: lint_darwin_plugins
       env:
         matrix:

--- a/script/tool/lib/src/lint_podspecs_command.dart
+++ b/script/tool/lib/src/lint_podspecs_command.dart
@@ -122,6 +122,7 @@ class LintPodspecsCommand extends PluginCommand {
       'lib',
       'lint',
       podspecPath,
+      '--configuration=Debug', // Release targets unsupported arm64 simulators. Use Debug to only build against targeted x86_64 simulator devices.
       if (allowWarnings) '--allow-warnings',
       if (libraryLint) '--use-libraries'
     ];

--- a/script/tool/test/lint_podspecs_command_test.dart
+++ b/script/tool/test/lint_podspecs_command_test.dart
@@ -81,6 +81,7 @@ void main() {
                 'lib',
                 'lint',
                 p.join(plugin1Dir.path, 'ios', 'plugin1.podspec'),
+                '--configuration=Debug',
                 '--use-libraries'
               ],
               mockPackagesDir.path),
@@ -90,6 +91,7 @@ void main() {
                 'lib',
                 'lint',
                 p.join(plugin1Dir.path, 'ios', 'plugin1.podspec'),
+                '--configuration=Debug',
               ],
               mockPackagesDir.path),
         ]),
@@ -138,6 +140,7 @@ void main() {
                 'lib',
                 'lint',
                 p.join(plugin1Dir.path, 'plugin1.podspec'),
+                '--configuration=Debug',
                 '--allow-warnings',
                 '--use-libraries'
               ],
@@ -148,6 +151,7 @@ void main() {
                 'lib',
                 'lint',
                 p.join(plugin1Dir.path, 'plugin1.podspec'),
+                '--configuration=Debug',
                 '--allow-warnings',
               ],
               mockPackagesDir.path),


### PR DESCRIPTION
Adopt Xcode 12 for all Cirrus tasks.
Add `--configuration=Debug` option ([available as of CocoaPods 1.10](https://github.com/CocoaPods/CocoaPods/pull/9760)) to `pod lib lint` CI script so the build only targets the supported x86_64 simulator, not the unsupported (by Flutter) arm64 simulator.

See also https://github.com/flutter/plugins/pull/3304.