### PR TITLE
[camera_platform_interface] Add support for NV21 image format

### DIFF
--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
@@ -65,7 +65,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.Executors;
-import java.util.stream.IntStream;
 
 @FunctionalInterface
 interface ErrorCallback {
@@ -121,13 +120,13 @@ public class Camera {
   }
 
   public Camera(
-      final Activity activity,
-      final SurfaceTextureEntry flutterTexture,
-      final DartMessenger dartMessenger,
-      final String cameraName,
-      final String resolutionPreset,
-      final boolean enableAudio)
-      throws CameraAccessException {
+          final Activity activity,
+          final SurfaceTextureEntry flutterTexture,
+          final DartMessenger dartMessenger,
+          final String cameraName,
+          final String resolutionPreset,
+          final boolean enableAudio)
+          throws CameraAccessException {
     if (activity == null) {
       throw new IllegalStateException("No activity available!");
     }
@@ -137,7 +136,7 @@ public class Camera {
     this.dartMessenger = dartMessenger;
     this.cameraManager = (CameraManager) activity.getSystemService(Context.CAMERA_SERVICE);
     this.applicationContext = activity.getApplicationContext();
-    this.flashMode = FlashMode.off;
+    this.flashMode = FlashMode.auto;
     this.exposureMode = ExposureMode.auto;
     this.focusMode = FocusMode.auto;
     this.exposureOffset = 0;
@@ -146,27 +145,27 @@ public class Camera {
     initFps(cameraCharacteristics);
     sensorOrientation = cameraCharacteristics.get(CameraCharacteristics.SENSOR_ORIENTATION);
     isFrontFacing =
-        cameraCharacteristics.get(CameraCharacteristics.LENS_FACING)
-            == CameraMetadata.LENS_FACING_FRONT;
+            cameraCharacteristics.get(CameraCharacteristics.LENS_FACING)
+                    == CameraMetadata.LENS_FACING_FRONT;
     ResolutionPreset preset = ResolutionPreset.valueOf(resolutionPreset);
     recordingProfile =
-        CameraUtils.getBestAvailableCamcorderProfileForResolutionPreset(cameraName, preset);
+            CameraUtils.getBestAvailableCamcorderProfileForResolutionPreset(cameraName, preset);
     captureSize = new Size(recordingProfile.videoFrameWidth, recordingProfile.videoFrameHeight);
     previewSize = computeBestPreviewSize(cameraName, preset);
     cameraZoom =
-        new CameraZoom(
-            cameraCharacteristics.get(CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE),
-            cameraCharacteristics.get(CameraCharacteristics.SCALER_AVAILABLE_MAX_DIGITAL_ZOOM));
+            new CameraZoom(
+                    cameraCharacteristics.get(CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE),
+                    cameraCharacteristics.get(CameraCharacteristics.SCALER_AVAILABLE_MAX_DIGITAL_ZOOM));
 
     deviceOrientationListener =
-        new DeviceOrientationManager(activity, dartMessenger, isFrontFacing, sensorOrientation);
+            new DeviceOrientationManager(activity, dartMessenger, isFrontFacing, sensorOrientation);
     deviceOrientationListener.start();
   }
 
   private void initFps(CameraCharacteristics cameraCharacteristics) {
     try {
       Range<Integer>[] ranges =
-          cameraCharacteristics.get(CameraCharacteristics.CONTROL_AE_AVAILABLE_TARGET_FPS_RANGES);
+              cameraCharacteristics.get(CameraCharacteristics.CONTROL_AE_AVAILABLE_TARGET_FPS_RANGES);
       if (ranges != null) {
         for (Range<Integer> range : ranges) {
           int upper = range.getUpper();
@@ -190,20 +189,20 @@ public class Camera {
     }
 
     mediaRecorder =
-        new MediaRecorderBuilder(recordingProfile, outputFilePath)
-            .setEnableAudio(enableAudio)
-            .setMediaOrientation(
-                lockedCaptureOrientation == null
-                    ? deviceOrientationListener.getMediaOrientation()
-                    : deviceOrientationListener.getMediaOrientation(lockedCaptureOrientation))
-            .build();
+            new MediaRecorderBuilder(recordingProfile, outputFilePath)
+                    .setEnableAudio(enableAudio)
+                    .setMediaOrientation(
+                            lockedCaptureOrientation == null
+                                    ? deviceOrientationListener.getMediaOrientation()
+                                    : deviceOrientationListener.getMediaOrientation(lockedCaptureOrientation))
+                    .build();
   }
 
   @SuppressLint("MissingPermission")
   public void open(String imageFormatGroup) throws CameraAccessException {
     pictureImageReader =
-        ImageReader.newInstance(
-            captureSize.getWidth(), captureSize.getHeight(), ImageFormat.JPEG, 2);
+            ImageReader.newInstance(
+                    captureSize.getWidth(), captureSize.getHeight(), ImageFormat.JPEG, 2);
 
     Integer imageFormat = supportedImageFormats.get(imageFormatGroup);
     if (imageFormat == null) {
@@ -213,78 +212,78 @@ public class Camera {
 
     // Used to steam image byte data to dart side.
     imageStreamReader =
-        ImageReader.newInstance(previewSize.getWidth(), previewSize.getHeight(), imageFormat, 2);
+            ImageReader.newInstance(previewSize.getWidth(), previewSize.getHeight(), imageFormat, 2);
 
     cameraManager.openCamera(
-        cameraName,
-        new CameraDevice.StateCallback() {
-          @Override
-          public void onOpened(@NonNull CameraDevice device) {
-            cameraDevice = device;
-            try {
-              startPreview();
-              dartMessenger.sendCameraInitializedEvent(
-                  previewSize.getWidth(),
-                  previewSize.getHeight(),
-                  exposureMode,
-                  focusMode,
-                  isExposurePointSupported(),
-                  isFocusPointSupported());
-            } catch (CameraAccessException e) {
-              dartMessenger.sendCameraErrorEvent(e.getMessage());
-              close();
-            }
-          }
+            cameraName,
+            new CameraDevice.StateCallback() {
+              @Override
+              public void onOpened(@NonNull CameraDevice device) {
+                cameraDevice = device;
+                try {
+                  startPreview();
+                  dartMessenger.sendCameraInitializedEvent(
+                          previewSize.getWidth(),
+                          previewSize.getHeight(),
+                          exposureMode,
+                          focusMode,
+                          isExposurePointSupported(),
+                          isFocusPointSupported());
+                } catch (CameraAccessException e) {
+                  dartMessenger.sendCameraErrorEvent(e.getMessage());
+                  close();
+                }
+              }
 
-          @Override
-          public void onClosed(@NonNull CameraDevice camera) {
-            dartMessenger.sendCameraClosingEvent();
-            super.onClosed(camera);
-          }
+              @Override
+              public void onClosed(@NonNull CameraDevice camera) {
+                dartMessenger.sendCameraClosingEvent();
+                super.onClosed(camera);
+              }
 
-          @Override
-          public void onDisconnected(@NonNull CameraDevice cameraDevice) {
-            close();
-            dartMessenger.sendCameraErrorEvent("The camera was disconnected.");
-          }
+              @Override
+              public void onDisconnected(@NonNull CameraDevice cameraDevice) {
+                close();
+                dartMessenger.sendCameraErrorEvent("The camera was disconnected.");
+              }
 
-          @Override
-          public void onError(@NonNull CameraDevice cameraDevice, int errorCode) {
-            close();
-            String errorDescription;
-            switch (errorCode) {
-              case ERROR_CAMERA_IN_USE:
-                errorDescription = "The camera device is in use already.";
-                break;
-              case ERROR_MAX_CAMERAS_IN_USE:
-                errorDescription = "Max cameras in use";
-                break;
-              case ERROR_CAMERA_DISABLED:
-                errorDescription = "The camera device could not be opened due to a device policy.";
-                break;
-              case ERROR_CAMERA_DEVICE:
-                errorDescription = "The camera device has encountered a fatal error";
-                break;
-              case ERROR_CAMERA_SERVICE:
-                errorDescription = "The camera service has encountered a fatal error.";
-                break;
-              default:
-                errorDescription = "Unknown camera error";
-            }
-            dartMessenger.sendCameraErrorEvent(errorDescription);
-          }
-        },
-        null);
+              @Override
+              public void onError(@NonNull CameraDevice cameraDevice, int errorCode) {
+                close();
+                String errorDescription;
+                switch (errorCode) {
+                  case ERROR_CAMERA_IN_USE:
+                    errorDescription = "The camera device is in use already.";
+                    break;
+                  case ERROR_MAX_CAMERAS_IN_USE:
+                    errorDescription = "Max cameras in use";
+                    break;
+                  case ERROR_CAMERA_DISABLED:
+                    errorDescription = "The camera device could not be opened due to a device policy.";
+                    break;
+                  case ERROR_CAMERA_DEVICE:
+                    errorDescription = "The camera device has encountered a fatal error";
+                    break;
+                  case ERROR_CAMERA_SERVICE:
+                    errorDescription = "The camera service has encountered a fatal error.";
+                    break;
+                  default:
+                    errorDescription = "Unknown camera error";
+                }
+                dartMessenger.sendCameraErrorEvent(errorDescription);
+              }
+            },
+            null);
   }
 
   private void createCaptureSession(int templateType, Surface... surfaces)
-      throws CameraAccessException {
+          throws CameraAccessException {
     createCaptureSession(templateType, null, surfaces);
   }
 
   private void createCaptureSession(
-      int templateType, Runnable onSuccessCallback, Surface... surfaces)
-      throws CameraAccessException {
+          int templateType, Runnable onSuccessCallback, Surface... surfaces)
+          throws CameraAccessException {
     // Close any existing capture session.
     closeCaptureSession();
 
@@ -309,29 +308,29 @@ public class Camera {
 
     // Prepare the callback
     CameraCaptureSession.StateCallback callback =
-        new CameraCaptureSession.StateCallback() {
-          @Override
-          public void onConfigured(@NonNull CameraCaptureSession session) {
-            if (cameraDevice == null) {
-              dartMessenger.sendCameraErrorEvent("The camera was closed during configuration.");
-              return;
-            }
-            cameraCaptureSession = session;
+            new CameraCaptureSession.StateCallback() {
+              @Override
+              public void onConfigured(@NonNull CameraCaptureSession session) {
+                if (cameraDevice == null) {
+                  dartMessenger.sendCameraErrorEvent("The camera was closed during configuration.");
+                  return;
+                }
+                cameraCaptureSession = session;
 
-            updateFpsRange();
-            updateFocus(focusMode);
-            updateFlash(flashMode);
-            updateExposure(exposureMode);
+                updateFpsRange();
+                updateFocus(focusMode);
+                updateFlash(flashMode);
+                updateExposure(exposureMode);
 
-            refreshPreviewCaptureSession(
-                onSuccessCallback, (code, message) -> dartMessenger.sendCameraErrorEvent(message));
-          }
+                refreshPreviewCaptureSession(
+                        onSuccessCallback, (code, message) -> dartMessenger.sendCameraErrorEvent(message));
+              }
 
-          @Override
-          public void onConfigureFailed(@NonNull CameraCaptureSession cameraCaptureSession) {
-            dartMessenger.sendCameraErrorEvent("Failed to configure camera session.");
-          }
-        };
+              @Override
+              public void onConfigureFailed(@NonNull CameraCaptureSession cameraCaptureSession) {
+                dartMessenger.sendCameraErrorEvent("Failed to configure camera session.");
+              }
+            };
 
     // Start the session
     if (VERSION.SDK_INT >= VERSION_CODES.P) {
@@ -353,35 +352,35 @@ public class Camera {
 
   @TargetApi(VERSION_CODES.P)
   private void createCaptureSessionWithSessionConfig(
-      List<OutputConfiguration> outputConfigs, CameraCaptureSession.StateCallback callback)
-      throws CameraAccessException {
+          List<OutputConfiguration> outputConfigs, CameraCaptureSession.StateCallback callback)
+          throws CameraAccessException {
     cameraDevice.createCaptureSession(
-        new SessionConfiguration(
-            SessionConfiguration.SESSION_REGULAR,
-            outputConfigs,
-            Executors.newSingleThreadExecutor(),
-            callback));
+            new SessionConfiguration(
+                    SessionConfiguration.SESSION_REGULAR,
+                    outputConfigs,
+                    Executors.newSingleThreadExecutor(),
+                    callback));
   }
 
   @TargetApi(VERSION_CODES.LOLLIPOP)
   @SuppressWarnings("deprecation")
   private void createCaptureSession(
-      List<Surface> surfaces, CameraCaptureSession.StateCallback callback)
-      throws CameraAccessException {
+          List<Surface> surfaces, CameraCaptureSession.StateCallback callback)
+          throws CameraAccessException {
     cameraDevice.createCaptureSession(surfaces, callback, null);
   }
 
   private void refreshPreviewCaptureSession(
-      @Nullable Runnable onSuccessCallback, @NonNull ErrorCallback onErrorCallback) {
+          @Nullable Runnable onSuccessCallback, @NonNull ErrorCallback onErrorCallback) {
     if (cameraCaptureSession == null) {
       return;
     }
 
     try {
       cameraCaptureSession.setRepeatingRequest(
-          captureRequestBuilder.build(),
-          pictureCaptureCallback,
-          new Handler(Looper.getMainLooper()));
+              captureRequestBuilder.build(),
+              pictureCaptureCallback,
+              new Handler(Looper.getMainLooper()));
 
       if (onSuccessCallback != null) {
         onSuccessCallback.run();
@@ -420,248 +419,140 @@ public class Camera {
 
     // Listen for picture being taken
     pictureImageReader.setOnImageAvailableListener(
-        reader -> {
-          try (Image image = reader.acquireLatestImage()) {
-            ByteBuffer buffer = image.getPlanes()[0].getBuffer();
-            writeToFile(buffer, file);
-            pictureCaptureRequest.finish(file.getAbsolutePath());
-          } catch (IOException e) {
-            pictureCaptureRequest.error("IOError", "Failed saving image", null);
-          }
-        },
-        null);
+            reader -> {
+              try (Image image = reader.acquireLatestImage()) {
+                ByteBuffer buffer = image.getPlanes()[0].getBuffer();
+                writeToFile(buffer, file);
+                pictureCaptureRequest.finish(file.getAbsolutePath());
+              } catch (IOException e) {
+                pictureCaptureRequest.error("IOError", "Failed saving image", null);
+              }
+            },
+            null);
 
     if (useAutoFocus) {
-      lockFocus();
+      runPictureAutoFocus();
     } else {
-      runPictureCapture();
+      runPicturePreCapture();
     }
-  }
-
-  private ArrayList<Integer> getAvailableAeModes() {
-    ArrayList<Integer> vals = new ArrayList<Integer>();
-    try {
-      int[] result = cameraManager
-              .getCameraCharacteristics(cameraDevice.getId()).get(CameraCharacteristics.CONTROL_AE_AVAILABLE_MODES);
-      for (int val : result) {
-        vals.add(val);
-      }
-    } catch (CameraAccessException e) {
-      //
-    }
-    return vals;
   }
 
   private final CameraCaptureSession.CaptureCallback pictureCaptureCallback =
-      new CameraCaptureSession.CaptureCallback() {
-        @Override
-        public void onCaptureCompleted(
-            @NonNull CameraCaptureSession session,
-            @NonNull CaptureRequest request,
-            @NonNull TotalCaptureResult result) {
-          processCapture(result);
-        }
+          new CameraCaptureSession.CaptureCallback() {
+            @Override
+            public void onCaptureCompleted(
+                    @NonNull CameraCaptureSession session,
+                    @NonNull CaptureRequest request,
+                    @NonNull TotalCaptureResult result) {
+              processCapture(result);
+            }
 
-        @Override
-        public void onCaptureProgressed(
-            @NonNull CameraCaptureSession session,
-            @NonNull CaptureRequest request,
-            @NonNull CaptureResult partialResult) {
-//          Log.d("flutter", "onCaptureProgressed");
-          processCapture(partialResult);
-        }
+            @Override
+            public void onCaptureProgressed(
+                    @NonNull CameraCaptureSession session,
+                    @NonNull CaptureRequest request,
+                    @NonNull CaptureResult partialResult) {
+              processCapture(partialResult);
+            }
 
-        @Override
-        public void onCaptureFailed(
-            @NonNull CameraCaptureSession session,
-            @NonNull CaptureRequest request,
-            @NonNull CaptureFailure failure) {
-//          Log.d("flutter", "onCaptureFailed");
+            @Override
+            public void onCaptureFailed(
+                    @NonNull CameraCaptureSession session,
+                    @NonNull CaptureRequest request,
+                    @NonNull CaptureFailure failure) {
+              if (pictureCaptureRequest == null || pictureCaptureRequest.isFinished()) {
+                return;
+              }
+              String reason;
+              boolean fatalFailure = false;
+              switch (failure.getReason()) {
+                case CaptureFailure.REASON_ERROR:
+                  reason = "An error happened in the framework";
+                  break;
+                case CaptureFailure.REASON_FLUSHED:
+                  reason = "The capture has failed due to an abortCaptures() call";
+                  fatalFailure = true;
+                  break;
+                default:
+                  reason = "Unknown reason";
+              }
+              Log.w("Camera", "pictureCaptureCallback.onCaptureFailed(): " + reason);
+              if (fatalFailure) pictureCaptureRequest.error("captureFailure", reason, null);
+            }
 
-          if (pictureCaptureRequest == null || pictureCaptureRequest.isFinished()) {
-            return;
-          }
-          String reason;
-          boolean fatalFailure = false;
-          switch (failure.getReason()) {
-            case CaptureFailure.REASON_ERROR:
-              reason = "An error happened in the framework";
-              break;
-            case CaptureFailure.REASON_FLUSHED:
-              reason = "The capture has failed due to an abortCaptures() call";
-              fatalFailure = true;
-              break;
-            default:
-              reason = "Unknown reason";
-          }
-          Log.w("Camera", "pictureCaptureCallback.onCaptureFailed(): " + reason);
-          if (fatalFailure) pictureCaptureRequest.error("captureFailure", reason, null);
-        }
-
-
-
-        private void processCapture(CaptureResult result) {
-          if (pictureCaptureRequest == null) {
-            return;
-          }
-
-
-
-          Integer aeState = result.get(CaptureResult.CONTROL_AE_STATE);
-          Integer afState = result.get(CaptureResult.CONTROL_AF_STATE);
-          if (pictureCaptureRequest.getState() != State.finished) {
-//            Log.i("flutter", "state: " + pictureCaptureRequest.getState() + " | afState: " + afState + " | aeState: " + aeState);
-          }
-
-          switch (pictureCaptureRequest.getState()) {
-
-
-            case focusing:
-              if(afState == null) {
+            private void processCapture(CaptureResult result) {
+              if (pictureCaptureRequest == null) {
                 return;
               }
 
-              /// Time to start the capture
-              if (
-                // We have passive focus lock (some devices use passive)
-                      afState == CaptureResult.CONTROL_AF_STATE_PASSIVE_FOCUSED ||
-
-                              // We have active focus lock
-                              afState == CaptureResult.CONTROL_AF_STATE_FOCUSED_LOCKED ||
-
-//                              // Passive focus is inactive but AE says we are ready to capture
-//                              (afState == CaptureResult.CONTROL_AF_STATE_INACTIVE && aeState == CaptureResult.CONTROL_AE_STATE_CONVERGED) ||
-
-                              // Focus failed, take the picture anyways
-                              afState == CaptureResult.CONTROL_AF_STATE_NOT_FOCUSED_LOCKED) {
-
-                // CONTROL_AE_STATE can be null on some devices
-                if (aeState == null || aeState == CaptureResult.CONTROL_AE_STATE_CONVERGED) {
-//                  Log.i("flutter", "AE state is converged, taking piture");
-                  runPictureCapture();
-                } else {
-//                  Log.i("flutter", "Moving to precapture state");
-                  pictureCaptureRequest.setState(State.preCapture);
-                }
+              Integer aeState = result.get(CaptureResult.CONTROL_AE_STATE);
+              Integer afState = result.get(CaptureResult.CONTROL_AF_STATE);
+              switch (pictureCaptureRequest.getState()) {
+                case focusing:
+                  if (afState == null) {
+                    return;
+                  } else if (afState == CaptureResult.CONTROL_AF_STATE_FOCUSED_LOCKED
+                          || afState == CaptureResult.CONTROL_AF_STATE_NOT_FOCUSED_LOCKED) {
+                    // Some devices might return null here, in which case we will also continue.
+                    if (aeState == null || aeState == CaptureResult.CONTROL_AE_STATE_CONVERGED) {
+                      runPictureCapture();
+                    } else {
+                      runPicturePreCapture();
+                    }
+                  }
+                  break;
+                case preCapture:
+                  // Some devices might return null here, in which case we will also continue.
+                  if (aeState == null
+                          || aeState == CaptureRequest.CONTROL_AE_STATE_PRECAPTURE
+                          || aeState == CaptureRequest.CONTROL_AE_STATE_FLASH_REQUIRED
+                          || aeState == CaptureRequest.CONTROL_AE_STATE_CONVERGED) {
+                    pictureCaptureRequest.setState(State.waitingPreCaptureReady);
+                    setPreCaptureStartTime();
+                  }
+                  break;
+                case waitingPreCaptureReady:
+                  if (aeState == null || aeState != CaptureRequest.CONTROL_AE_STATE_PRECAPTURE) {
+                    runPictureCapture();
+                  } else {
+                    if (hitPreCaptureTimeout()) {
+                      unlockAutoFocus();
+                    }
+                  }
               }
+            }
+          };
 
-              break;
-            case preCapture:
-              // Some devices might return null here, in which case we will also continue.
-              if (aeState == null
-                  || aeState == CaptureRequest.CONTROL_AE_STATE_PRECAPTURE
-                  || aeState == CaptureRequest.CONTROL_AE_STATE_FLASH_REQUIRED
-                  || aeState == CaptureRequest.CONTROL_AE_STATE_CONVERGED) {
+  private void runPictureAutoFocus() {
+    assert (pictureCaptureRequest != null);
 
-                pictureCaptureRequest.setState(State.waitingPreCaptureReady);
-                setPreCaptureStartTime();
-              }
-              break;
-            case waitingPreCaptureReady:
-              if (aeState == null || aeState != CaptureRequest.CONTROL_AE_STATE_PRECAPTURE) {
-                runPictureCapture();
-              } else {
-                if (hitPreCaptureTimeout()) {
-                  unlockAutoFocus();
-                }
-              }
-          }
-        }
-      };
-
-  private void initPreviewRequest() {
-    if(captureRequestBuilder == null) {
-      return;
-    }
-    captureRequestBuilder.set(CaptureRequest.JPEG_ORIENTATION, lockedCaptureOrientation == null
-            ? deviceOrientationListener.getMediaOrientation()
-            : deviceOrientationListener.getMediaOrientation(lockedCaptureOrientation));
-    switch (flashMode) {
-      case auto:
-        captureRequestBuilder.set(CaptureRequest.CONTROL_AE_MODE, getAvailableAeModes().contains(CaptureRequest.CONTROL_AE_MODE_ON_AUTO_FLASH) ? CaptureRequest.CONTROL_AE_MODE_ON_AUTO_FLASH : CaptureRequest.CONTROL_AE_MODE_ON);
-        captureRequestBuilder.set(CaptureRequest.FLASH_MODE, CaptureRequest.FLASH_MODE_OFF);
-        break;
-      case torch:
-        captureRequestBuilder.set(CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_ON);
-        captureRequestBuilder.set(CaptureRequest.FLASH_MODE, CaptureRequest.FLASH_MODE_TORCH);
-        break;
-      case off:
-        captureRequestBuilder.set(CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_ON);
-        captureRequestBuilder.set(CaptureRequest.FLASH_MODE, CaptureRequest.FLASH_MODE_OFF);
-        break;
-      case always:
-      default:
-        captureRequestBuilder.set(CaptureRequest.CONTROL_AE_MODE, getAvailableAeModes().contains(CaptureRequest.CONTROL_AE_MODE_ON_ALWAYS_FLASH) ? CaptureRequest.CONTROL_AE_MODE_ON_ALWAYS_FLASH : CaptureRequest.CONTROL_AE_MODE_ON);
-        captureRequestBuilder.set(CaptureRequest.FLASH_MODE, CaptureRequest.FLASH_MODE_OFF);
-        break;
-    }
-    captureRequestBuilder.set(CaptureRequest.CONTROL_MODE, CaptureRequest.CONTROL_MODE_AUTO);
-    captureRequestBuilder.set(CaptureRequest.CONTROL_AF_MODE, useAutoFocus ? CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_PICTURE : CaptureRequest.CONTROL_AF_MODE_OFF);
+    pictureCaptureRequest.setState(PictureCaptureRequest.State.focusing);
+    lockAutoFocus(pictureCaptureCallback);
   }
 
-  public void lockFocus() {
-    pictureCaptureRequest.setState(State.focusing);
-    captureRequestBuilder.set(CaptureRequest.CONTROL_AF_TRIGGER, CameraMetadata.CONTROL_AF_TRIGGER_START);
-    refreshConfiguration();
-  }
+  private void runPicturePreCapture() {
+    assert (pictureCaptureRequest != null);
+    pictureCaptureRequest.setState(PictureCaptureRequest.State.preCapture);
 
-  public void unlockFocus() {
-    captureRequestBuilder.set(CaptureRequest.CONTROL_AF_TRIGGER, CameraMetadata.CONTROL_AF_TRIGGER_CANCEL);
-    pictureCaptureRequest.setState(null);
-    initPreviewRequest();
-    try {
-      cameraCaptureSession.capture(captureRequestBuilder.build(), pictureCaptureCallback , null);
-    } catch (CameraAccessException ignored) { }
-    captureRequestBuilder.set(CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_IDLE);
-    refreshConfiguration();
-  }
+    captureRequestBuilder.set(
+            CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER,
+            CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER_START);
 
-  private void refreshConfiguration() {
-//    if(cameraCaptureSession == null) {
-//      return;
-//    }
-//    try {
-//      cameraCaptureSession.setRepeatingRequest(captureRequestBuilder.build(), mCaptureFocusedCallback, null);
-//    } catch (CameraAccessException | IllegalStateException | IllegalArgumentException e) {
-//      Log.e(TAG, "refreshConfiguration", e);
-//    }
-    if(cameraCaptureSession == null) {
-      return;
-    }
     refreshPreviewCaptureSession(
-            null, (code, message) -> pictureCaptureRequest.error(code, message, null));
+            () ->
+                    captureRequestBuilder.set(
+                            CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER,
+                            CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER_IDLE),
+            (code, message) -> pictureCaptureRequest.error(code, message, null));
   }
 
   private void runPictureCapture() {
-//    Log.i("flutter", "runPictureCapture");
-
     assert (pictureCaptureRequest != null);
     pictureCaptureRequest.setState(PictureCaptureRequest.State.capturing);
     try {
       final CaptureRequest.Builder captureBuilder =
-          cameraDevice.createCaptureRequest(CameraDevice.TEMPLATE_STILL_CAPTURE);
+              cameraDevice.createCaptureRequest(CameraDevice.TEMPLATE_STILL_CAPTURE);
       captureBuilder.addTarget(pictureImageReader.getSurface());
-
-
-      switch (flashMode) {
-        case auto:
-          captureRequestBuilder.set(CaptureRequest.CONTROL_AE_MODE, getAvailableAeModes().contains(CaptureRequest.CONTROL_AE_MODE_ON_AUTO_FLASH) ? CaptureRequest.CONTROL_AE_MODE_ON_AUTO_FLASH : CaptureRequest.CONTROL_AE_MODE_ON);
-          captureRequestBuilder.set(CaptureRequest.FLASH_MODE, CaptureRequest.FLASH_MODE_OFF);
-          break;
-        case torch:
-          captureRequestBuilder.set(CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_ON);
-          captureRequestBuilder.set(CaptureRequest.FLASH_MODE, CaptureRequest.FLASH_MODE_TORCH);
-          break;
-        case off:
-          captureRequestBuilder.set(CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_ON);
-          captureRequestBuilder.set(CaptureRequest.FLASH_MODE, CaptureRequest.FLASH_MODE_OFF);
-          break;
-        case always:
-        default:
-          captureRequestBuilder.set(CaptureRequest.CONTROL_AE_MODE, getAvailableAeModes().contains(CaptureRequest.CONTROL_AE_MODE_ON_ALWAYS_FLASH) ? CaptureRequest.CONTROL_AE_MODE_ON_ALWAYS_FLASH : CaptureRequest.CONTROL_AE_MODE_ON);
-          captureRequestBuilder.set(CaptureRequest.FLASH_MODE, CaptureRequest.FLASH_MODE_OFF);
-          break;
-      }
       captureBuilder.set(
               CaptureRequest.SCALER_CROP_REGION,
               captureRequestBuilder.get(CaptureRequest.SCALER_CROP_REGION));
@@ -671,46 +562,61 @@ public class Camera {
                       ? deviceOrientationListener.getMediaOrientation()
                       : deviceOrientationListener.getMediaOrientation(lockedCaptureOrientation));
 
+      switch (flashMode) {
+        case off:
+          captureBuilder.set(CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_ON);
+          captureBuilder.set(CaptureRequest.FLASH_MODE, CaptureRequest.FLASH_MODE_OFF);
+          break;
+        case auto:
+          captureBuilder.set(
+                  CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_ON_AUTO_FLASH);
+          break;
+        case always:
+        default:
+          captureBuilder.set(
+                  CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_ON_ALWAYS_FLASH);
+          break;
+      }
       cameraCaptureSession.stopRepeating();
-      cameraCaptureSession.capture(captureBuilder.build(), mCaptureCallback, null);
+      cameraCaptureSession.capture(
+              captureBuilder.build(),
+              new CameraCaptureSession.CaptureCallback() {
+                @Override
+                public void onCaptureCompleted(
+                        @NonNull CameraCaptureSession session,
+                        @NonNull CaptureRequest request,
+                        @NonNull TotalCaptureResult result) {
+                  unlockAutoFocus();
+                }
+              },
+              null);
     } catch (CameraAccessException e) {
       pictureCaptureRequest.error("cameraAccess", e.getMessage(), null);
     }
   }
 
-  private CameraCaptureSession.CaptureCallback mCaptureCallback = new CameraCaptureSession.CaptureCallback() {
-    @Override
-    public void onCaptureCompleted(CameraCaptureSession session, CaptureRequest request, TotalCaptureResult result) {
-      if(pictureCaptureRequest.getState() != null && pictureCaptureRequest.getState().equals(State.focusing)) {
-        unlockFocus();
-      } else {
-        refreshConfiguration();
-      }
-    }
-  };
-
   private void lockAutoFocus(CaptureCallback callback) {
     captureRequestBuilder.set(
-        CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_START);
+            CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_START);
 
     refreshPreviewCaptureSession(
-        null, (code, message) -> pictureCaptureRequest.error(code, message, null));
+            null, (code, message) -> pictureCaptureRequest.error(code, message, null));
   }
 
   private void unlockAutoFocus() {
     captureRequestBuilder.set(
-        CaptureRequest.CONTROL_AF_TRIGGER, CameraMetadata.CONTROL_AF_TRIGGER_CANCEL);
+            CaptureRequest.CONTROL_AF_TRIGGER, CameraMetadata.CONTROL_AF_TRIGGER_CANCEL);
     updateFocus(focusMode);
     try {
       cameraCaptureSession.capture(captureRequestBuilder.build(), null, null);
     } catch (CameraAccessException ignored) {
     }
     captureRequestBuilder.set(
-        CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_IDLE);
+            CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_IDLE);
 
     refreshPreviewCaptureSession(
-        null,
-        (errorCode, errorMessage) -> pictureCaptureRequest.error(errorCode, errorMessage, null));
+            null,
+            (errorCode, errorMessage) -> pictureCaptureRequest.error(errorCode, errorMessage, null));
   }
 
   public void startVideoRecording(Result result) {
@@ -726,7 +632,7 @@ public class Camera {
       prepareMediaRecorder(videoRecordingFile.getAbsolutePath());
       recordingVideo = true;
       createCaptureSession(
-          CameraDevice.TEMPLATE_RECORD, () -> mediaRecorder.start(), mediaRecorder.getSurface());
+              CameraDevice.TEMPLATE_RECORD, () -> mediaRecorder.start(), mediaRecorder.getSurface());
       result.success(null);
     } catch (CameraAccessException | IOException e) {
       recordingVideo = false;
@@ -792,7 +698,7 @@ public class Camera {
         mediaRecorder.resume();
       } else {
         result.error(
-            "videoRecordingFailed", "resumeVideoRecording requires Android API +24.", null);
+                "videoRecordingFailed", "resumeVideoRecording requires Android API +24.", null);
         return;
       }
     } catch (IllegalStateException e) {
@@ -804,12 +710,12 @@ public class Camera {
   }
 
   public void setFlashMode(@NonNull final Result result, FlashMode mode)
-      throws CameraAccessException {
+          throws CameraAccessException {
     // Get the flash availability
     Boolean flashAvailable =
-        cameraManager
-            .getCameraCharacteristics(cameraDevice.getId())
-            .get(CameraCharacteristics.FLASH_INFO_AVAILABLE);
+            cameraManager
+                    .getCameraCharacteristics(cameraDevice.getId())
+                    .get(CameraCharacteristics.FLASH_INFO_AVAILABLE);
 
     // Check if flash is available.
     if (flashAvailable == null || !flashAvailable) {
@@ -822,65 +728,65 @@ public class Camera {
       updateFlash(FlashMode.off);
 
       this.cameraCaptureSession.setRepeatingRequest(
-          captureRequestBuilder.build(),
-          new CaptureCallback() {
-            private boolean isFinished = false;
+              captureRequestBuilder.build(),
+              new CaptureCallback() {
+                private boolean isFinished = false;
 
-            @Override
-            public void onCaptureCompleted(
-                @NonNull CameraCaptureSession session,
-                @NonNull CaptureRequest request,
-                @NonNull TotalCaptureResult captureResult) {
-              if (isFinished) {
-                return;
-              }
+                @Override
+                public void onCaptureCompleted(
+                        @NonNull CameraCaptureSession session,
+                        @NonNull CaptureRequest request,
+                        @NonNull TotalCaptureResult captureResult) {
+                  if (isFinished) {
+                    return;
+                  }
 
-              updateFlash(mode);
-              refreshPreviewCaptureSession(
-                  () -> {
-                    result.success(null);
-                    isFinished = true;
-                  },
-                  (code, message) ->
-                      result.error("setFlashModeFailed", "Could not set flash mode.", null));
-            }
+                  updateFlash(mode);
+                  refreshPreviewCaptureSession(
+                          () -> {
+                            result.success(null);
+                            isFinished = true;
+                          },
+                          (code, message) ->
+                                  result.error("setFlashModeFailed", "Could not set flash mode.", null));
+                }
 
-            @Override
-            public void onCaptureFailed(
-                @NonNull CameraCaptureSession session,
-                @NonNull CaptureRequest request,
-                @NonNull CaptureFailure failure) {
-              if (isFinished) {
-                return;
-              }
+                @Override
+                public void onCaptureFailed(
+                        @NonNull CameraCaptureSession session,
+                        @NonNull CaptureRequest request,
+                        @NonNull CaptureFailure failure) {
+                  if (isFinished) {
+                    return;
+                  }
 
-              result.error("setFlashModeFailed", "Could not set flash mode.", null);
-              isFinished = true;
-            }
-          },
-          null);
+                  result.error("setFlashModeFailed", "Could not set flash mode.", null);
+                  isFinished = true;
+                }
+              },
+              null);
     } else {
       updateFlash(mode);
 
       refreshPreviewCaptureSession(
-          () -> result.success(null),
-          (code, message) -> result.error("setFlashModeFailed", "Could not set flash mode.", null));
+              () -> result.success(null),
+              (code, message) -> result.error("setFlashModeFailed", "Could not set flash mode.", null));
     }
   }
 
   public void setExposureMode(@NonNull final Result result, ExposureMode mode)
-      throws CameraAccessException {
+          throws CameraAccessException {
     updateExposure(mode);
     cameraCaptureSession.setRepeatingRequest(captureRequestBuilder.build(), null, null);
     result.success(null);
   }
 
   public void setExposurePoint(@NonNull final Result result, Double x, Double y)
-      throws CameraAccessException {
+          throws CameraAccessException {
     // Check if exposure point functionality is available.
     if (!isExposurePointSupported()) {
       result.error(
-          "setExposurePointFailed", "Device does not have exposure point capabilities", null);
+              "setExposurePointFailed", "Device does not have exposure point capabilities", null);
       return;
     }
     // Check if the current region boundaries are known
@@ -894,11 +800,11 @@ public class Camera {
     // Apply it
     updateExposure(exposureMode);
     refreshPreviewCaptureSession(
-        () -> result.success(null), (code, message) -> result.error("CameraAccess", message, null));
+            () -> result.success(null), (code, message) -> result.error("CameraAccess", message, null));
   }
 
   public void setFocusMode(@NonNull final Result result, FocusMode mode)
-      throws CameraAccessException {
+          throws CameraAccessException {
     this.focusMode = mode;
 
     updateFocus(mode);
@@ -906,26 +812,26 @@ public class Camera {
     switch (mode) {
       case auto:
         refreshPreviewCaptureSession(
-            null, (code, message) -> result.error("setFocusMode", message, null));
+                null, (code, message) -> result.error("setFocusMode", message, null));
         break;
       case locked:
         lockAutoFocus(
-            new CaptureCallback() {
-              @Override
-              public void onCaptureCompleted(
-                  @NonNull CameraCaptureSession session,
-                  @NonNull CaptureRequest request,
-                  @NonNull TotalCaptureResult result) {
-                unlockAutoFocus();
-              }
-            });
+                new CaptureCallback() {
+                  @Override
+                  public void onCaptureCompleted(
+                          @NonNull CameraCaptureSession session,
+                          @NonNull CaptureRequest request,
+                          @NonNull TotalCaptureResult result) {
+                    unlockAutoFocus();
+                  }
+                });
         break;
     }
     result.success(null);
   }
 
   public void setFocusPoint(@NonNull final Result result, Double x, Double y)
-      throws CameraAccessException {
+          throws CameraAccessException {
     // Check if focus point functionality is available.
     if (!isFocusPointSupported()) {
       result.error("setFocusPointFailed", "Device does not have focus point capabilities", null);
@@ -952,14 +858,14 @@ public class Camera {
   @TargetApi(VERSION_CODES.P)
   private boolean supportsDistortionCorrection() throws CameraAccessException {
     int[] availableDistortionCorrectionModes =
-        cameraManager
-            .getCameraCharacteristics(cameraDevice.getId())
-            .get(CameraCharacteristics.DISTORTION_CORRECTION_AVAILABLE_MODES);
+            cameraManager
+                    .getCameraCharacteristics(cameraDevice.getId())
+                    .get(CameraCharacteristics.DISTORTION_CORRECTION_AVAILABLE_MODES);
     if (availableDistortionCorrectionModes == null) availableDistortionCorrectionModes = new int[0];
     long nonOffModesSupported =
-        Arrays.stream(availableDistortionCorrectionModes)
-            .filter((value) -> value != CaptureRequest.DISTORTION_CORRECTION_MODE_OFF)
-            .count();
+            Arrays.stream(availableDistortionCorrectionModes)
+                    .filter((value) -> value != CaptureRequest.DISTORTION_CORRECTION_MODE_OFF)
+                    .count();
     return nonOffModesSupported > 0;
   }
 
@@ -967,50 +873,50 @@ public class Camera {
     // No distortion correction support
     if (android.os.Build.VERSION.SDK_INT < VERSION_CODES.P || !supportsDistortionCorrection()) {
       return cameraManager
-          .getCameraCharacteristics(cameraDevice.getId())
-          .get(CameraCharacteristics.SENSOR_INFO_PIXEL_ARRAY_SIZE);
+              .getCameraCharacteristics(cameraDevice.getId())
+              .get(CameraCharacteristics.SENSOR_INFO_PIXEL_ARRAY_SIZE);
     }
     // Get the current distortion correction mode
     Integer distortionCorrectionMode =
-        captureRequestBuilder.get(CaptureRequest.DISTORTION_CORRECTION_MODE);
+            captureRequestBuilder.get(CaptureRequest.DISTORTION_CORRECTION_MODE);
     // Return the correct boundaries depending on the mode
     android.graphics.Rect rect;
     if (distortionCorrectionMode == null
-        || distortionCorrectionMode == CaptureRequest.DISTORTION_CORRECTION_MODE_OFF) {
+            || distortionCorrectionMode == CaptureRequest.DISTORTION_CORRECTION_MODE_OFF) {
       rect =
-          cameraManager
-              .getCameraCharacteristics(cameraDevice.getId())
-              .get(CameraCharacteristics.SENSOR_INFO_PRE_CORRECTION_ACTIVE_ARRAY_SIZE);
+              cameraManager
+                      .getCameraCharacteristics(cameraDevice.getId())
+                      .get(CameraCharacteristics.SENSOR_INFO_PRE_CORRECTION_ACTIVE_ARRAY_SIZE);
     } else {
       rect =
-          cameraManager
-              .getCameraCharacteristics(cameraDevice.getId())
-              .get(CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE);
+              cameraManager
+                      .getCameraCharacteristics(cameraDevice.getId())
+                      .get(CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE);
     }
     return rect == null ? null : new Size(rect.width(), rect.height());
   }
 
   private boolean isExposurePointSupported() throws CameraAccessException {
     Integer supportedRegions =
-        cameraManager
-            .getCameraCharacteristics(cameraDevice.getId())
-            .get(CameraCharacteristics.CONTROL_MAX_REGIONS_AE);
+            cameraManager
+                    .getCameraCharacteristics(cameraDevice.getId())
+                    .get(CameraCharacteristics.CONTROL_MAX_REGIONS_AE);
     return supportedRegions != null && supportedRegions > 0;
   }
 
   private boolean isFocusPointSupported() throws CameraAccessException {
     Integer supportedRegions =
-        cameraManager
-            .getCameraCharacteristics(cameraDevice.getId())
-            .get(CameraCharacteristics.CONTROL_MAX_REGIONS_AF);
+            cameraManager
+                    .getCameraCharacteristics(cameraDevice.getId())
+                    .get(CameraCharacteristics.CONTROL_MAX_REGIONS_AF);
     return supportedRegions != null && supportedRegions > 0;
   }
 
   public double getMinExposureOffset() throws CameraAccessException {
     Range<Integer> range =
-        cameraManager
-            .getCameraCharacteristics(cameraDevice.getId())
-            .get(CameraCharacteristics.CONTROL_AE_COMPENSATION_RANGE);
+            cameraManager
+                    .getCameraCharacteristics(cameraDevice.getId())
+                    .get(CameraCharacteristics.CONTROL_AE_COMPENSATION_RANGE);
     double minStepped = range == null ? 0 : range.getLower();
     double stepSize = getExposureOffsetStepSize();
     return minStepped * stepSize;
@@ -1018,9 +924,9 @@ public class Camera {
 
   public double getMaxExposureOffset() throws CameraAccessException {
     Range<Integer> range =
-        cameraManager
-            .getCameraCharacteristics(cameraDevice.getId())
-            .get(CameraCharacteristics.CONTROL_AE_COMPENSATION_RANGE);
+            cameraManager
+                    .getCameraCharacteristics(cameraDevice.getId())
+                    .get(CameraCharacteristics.CONTROL_AE_COMPENSATION_RANGE);
     double maxStepped = range == null ? 0 : range.getUpper();
     double stepSize = getExposureOffsetStepSize();
     return maxStepped * stepSize;
@@ -1028,14 +934,14 @@ public class Camera {
 
   public double getExposureOffsetStepSize() throws CameraAccessException {
     Rational stepSize =
-        cameraManager
-            .getCameraCharacteristics(cameraDevice.getId())
-            .get(CameraCharacteristics.CONTROL_AE_COMPENSATION_STEP);
+            cameraManager
+                    .getCameraCharacteristics(cameraDevice.getId())
+                    .get(CameraCharacteristics.CONTROL_AE_COMPENSATION_STEP);
     return stepSize == null ? 0.0 : stepSize.doubleValue();
   }
 
   public void setExposureOffset(@NonNull final Result result, double offset)
-      throws CameraAccessException {
+          throws CameraAccessException {
     // Set the exposure offset
     double stepSize = getExposureOffsetStepSize();
     exposureOffset = (int) (offset / stepSize);
@@ -1059,11 +965,11 @@ public class Camera {
 
     if (zoom > maxZoom || zoom < minZoom) {
       String errorMessage =
-          String.format(
-              Locale.ENGLISH,
-              "Zoom level out of bounds (zoom level should be between %f and %f).",
-              minZoom,
-              maxZoom);
+              String.format(
+                      Locale.ENGLISH,
+                      "Zoom level out of bounds (zoom level should be between %f and %f).",
+                      minZoom,
+                      maxZoom);
       result.error("ZOOM_ERROR", errorMessage, null);
       return;
     }
@@ -1099,31 +1005,31 @@ public class Camera {
       int[] modes = cameraCharacteristics.get(CameraCharacteristics.CONTROL_AF_AVAILABLE_MODES);
       // Auto focus is not supported
       if (modes == null
-          || modes.length == 0
-          || (modes.length == 1 && modes[0] == CameraCharacteristics.CONTROL_AF_MODE_OFF)) {
+              || modes.length == 0
+              || (modes.length == 1 && modes[0] == CameraCharacteristics.CONTROL_AF_MODE_OFF)) {
         useAutoFocus = false;
         captureRequestBuilder.set(
-            CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_OFF);
+                CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_OFF);
       } else {
         // Applying auto focus
         switch (mode) {
           case locked:
             captureRequestBuilder.set(
-                CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_AUTO);
+                    CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_AUTO);
             break;
           case auto:
             captureRequestBuilder.set(
-                CaptureRequest.CONTROL_AF_MODE,
-                recordingVideo
-                    ? CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_VIDEO
-                    : CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_PICTURE);
+                    CaptureRequest.CONTROL_AF_MODE,
+                    recordingVideo
+                            ? CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_VIDEO
+                            : CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_PICTURE);
           default:
             break;
         }
         MeteringRectangle afRect = cameraRegions.getAFMeteringRectangle();
         captureRequestBuilder.set(
-            CaptureRequest.CONTROL_AF_REGIONS,
-            afRect == null ? null : new MeteringRectangle[] {afRect});
+                CaptureRequest.CONTROL_AF_REGIONS,
+                afRect == null ? null : new MeteringRectangle[] {afRect});
       }
     } else {
       captureRequestBuilder.set(CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_OFF);
@@ -1136,8 +1042,8 @@ public class Camera {
     // Applying auto exposure
     MeteringRectangle aeRect = cameraRegions.getAEMeteringRectangle();
     captureRequestBuilder.set(
-        CaptureRequest.CONTROL_AE_REGIONS,
-        aeRect == null ? null : new MeteringRectangle[] {cameraRegions.getAEMeteringRectangle()});
+            CaptureRequest.CONTROL_AE_REGIONS,
+            aeRect == null ? null : new MeteringRectangle[] {cameraRegions.getAEMeteringRectangle()});
 
     switch (mode) {
       case locked:
@@ -1158,22 +1064,26 @@ public class Camera {
 
     // Applying flash modes
     switch (flashMode) {
-      case auto:
-        captureRequestBuilder.set(CaptureRequest.CONTROL_AE_MODE, getAvailableAeModes().contains(CaptureRequest.CONTROL_AE_MODE_ON_AUTO_FLASH) ? CaptureRequest.CONTROL_AE_MODE_ON_AUTO_FLASH : CaptureRequest.CONTROL_AE_MODE_ON);
+      case off:
+        captureRequestBuilder.set(
+                CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_ON);
         captureRequestBuilder.set(CaptureRequest.FLASH_MODE, CaptureRequest.FLASH_MODE_OFF);
         break;
-      case torch:
-        captureRequestBuilder.set(CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_ON);
-        captureRequestBuilder.set(CaptureRequest.FLASH_MODE, CaptureRequest.FLASH_MODE_TORCH);
-        break;
-      case off:
-        captureRequestBuilder.set(CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_ON);
+      case auto:
+        captureRequestBuilder.set(
+                CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_ON_AUTO_FLASH);
         captureRequestBuilder.set(CaptureRequest.FLASH_MODE, CaptureRequest.FLASH_MODE_OFF);
         break;
       case always:
-      default:
-        captureRequestBuilder.set(CaptureRequest.CONTROL_AE_MODE, getAvailableAeModes().contains(CaptureRequest.CONTROL_AE_MODE_ON_ALWAYS_FLASH) ? CaptureRequest.CONTROL_AE_MODE_ON_ALWAYS_FLASH : CaptureRequest.CONTROL_AE_MODE_ON);
+        captureRequestBuilder.set(
+                CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_ON_ALWAYS_FLASH);
         captureRequestBuilder.set(CaptureRequest.FLASH_MODE, CaptureRequest.FLASH_MODE_OFF);
+        break;
+      case torch:
+      default:
+        captureRequestBuilder.set(
+                CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_ON);
+        captureRequestBuilder.set(CaptureRequest.FLASH_MODE, CaptureRequest.FLASH_MODE_TORCH);
         break;
     }
   }
@@ -1185,54 +1095,54 @@ public class Camera {
   }
 
   public void startPreviewWithImageStream(EventChannel imageStreamChannel)
-      throws CameraAccessException {
+          throws CameraAccessException {
     createCaptureSession(CameraDevice.TEMPLATE_RECORD, imageStreamReader.getSurface());
 
     imageStreamChannel.setStreamHandler(
-        new EventChannel.StreamHandler() {
-          @Override
-          public void onListen(Object o, EventChannel.EventSink imageStreamSink) {
-            setImageStreamImageAvailableListener(imageStreamSink);
-          }
+            new EventChannel.StreamHandler() {
+              @Override
+              public void onListen(Object o, EventChannel.EventSink imageStreamSink) {
+                setImageStreamImageAvailableListener(imageStreamSink);
+              }
 
-          @Override
-          public void onCancel(Object o) {
-            imageStreamReader.setOnImageAvailableListener(null, null);
-          }
-        });
+              @Override
+              public void onCancel(Object o) {
+                imageStreamReader.setOnImageAvailableListener(null, null);
+              }
+            });
   }
 
   private void setImageStreamImageAvailableListener(final EventChannel.EventSink imageStreamSink) {
     imageStreamReader.setOnImageAvailableListener(
-        reader -> {
-          Image img = reader.acquireLatestImage();
-          if (img == null) return;
+            reader -> {
+              Image img = reader.acquireLatestImage();
+              if (img == null) return;
 
-          List<Map<String, Object>> planes = new ArrayList<>();
-          for (Image.Plane plane : img.getPlanes()) {
-            ByteBuffer buffer = plane.getBuffer();
+              List<Map<String, Object>> planes = new ArrayList<>();
+              for (Image.Plane plane : img.getPlanes()) {
+                ByteBuffer buffer = plane.getBuffer();
 
-            byte[] bytes = new byte[buffer.remaining()];
-            buffer.get(bytes, 0, bytes.length);
+                byte[] bytes = new byte[buffer.remaining()];
+                buffer.get(bytes, 0, bytes.length);
 
-            Map<String, Object> planeBuffer = new HashMap<>();
-            planeBuffer.put("bytesPerRow", plane.getRowStride());
-            planeBuffer.put("bytesPerPixel", plane.getPixelStride());
-            planeBuffer.put("bytes", bytes);
+                Map<String, Object> planeBuffer = new HashMap<>();
+                planeBuffer.put("bytesPerRow", plane.getRowStride());
+                planeBuffer.put("bytesPerPixel", plane.getPixelStride());
+                planeBuffer.put("bytes", bytes);
 
-            planes.add(planeBuffer);
-          }
+                planes.add(planeBuffer);
+              }
 
-          Map<String, Object> imageBuffer = new HashMap<>();
-          imageBuffer.put("width", img.getWidth());
-          imageBuffer.put("height", img.getHeight());
-          imageBuffer.put("format", img.getFormat());
-          imageBuffer.put("planes", planes);
+              Map<String, Object> imageBuffer = new HashMap<>();
+              imageBuffer.put("width", img.getWidth());
+              imageBuffer.put("height", img.getHeight());
+              imageBuffer.put("format", img.getFormat());
+              imageBuffer.put("planes", planes);
 
-          imageStreamSink.success(imageBuffer);
-          img.close();
-        },
-        null);
+              imageStreamSink.success(imageBuffer);
+              img.close();
+            },
+            null);
   }
 
   public void stopImageStream() throws CameraAccessException {

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
@@ -120,13 +120,13 @@ public class Camera {
   }
 
   public Camera(
-          final Activity activity,
-          final SurfaceTextureEntry flutterTexture,
-          final DartMessenger dartMessenger,
-          final String cameraName,
-          final String resolutionPreset,
-          final boolean enableAudio)
-          throws CameraAccessException {
+      final Activity activity,
+      final SurfaceTextureEntry flutterTexture,
+      final DartMessenger dartMessenger,
+      final String cameraName,
+      final String resolutionPreset,
+      final boolean enableAudio)
+      throws CameraAccessException {
     if (activity == null) {
       throw new IllegalStateException("No activity available!");
     }
@@ -145,27 +145,27 @@ public class Camera {
     initFps(cameraCharacteristics);
     sensorOrientation = cameraCharacteristics.get(CameraCharacteristics.SENSOR_ORIENTATION);
     isFrontFacing =
-            cameraCharacteristics.get(CameraCharacteristics.LENS_FACING)
-                    == CameraMetadata.LENS_FACING_FRONT;
+        cameraCharacteristics.get(CameraCharacteristics.LENS_FACING)
+            == CameraMetadata.LENS_FACING_FRONT;
     ResolutionPreset preset = ResolutionPreset.valueOf(resolutionPreset);
     recordingProfile =
-            CameraUtils.getBestAvailableCamcorderProfileForResolutionPreset(cameraName, preset);
+        CameraUtils.getBestAvailableCamcorderProfileForResolutionPreset(cameraName, preset);
     captureSize = new Size(recordingProfile.videoFrameWidth, recordingProfile.videoFrameHeight);
     previewSize = computeBestPreviewSize(cameraName, preset);
     cameraZoom =
-            new CameraZoom(
-                    cameraCharacteristics.get(CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE),
-                    cameraCharacteristics.get(CameraCharacteristics.SCALER_AVAILABLE_MAX_DIGITAL_ZOOM));
+        new CameraZoom(
+            cameraCharacteristics.get(CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE),
+            cameraCharacteristics.get(CameraCharacteristics.SCALER_AVAILABLE_MAX_DIGITAL_ZOOM));
 
     deviceOrientationListener =
-            new DeviceOrientationManager(activity, dartMessenger, isFrontFacing, sensorOrientation);
+        new DeviceOrientationManager(activity, dartMessenger, isFrontFacing, sensorOrientation);
     deviceOrientationListener.start();
   }
 
   private void initFps(CameraCharacteristics cameraCharacteristics) {
     try {
       Range<Integer>[] ranges =
-              cameraCharacteristics.get(CameraCharacteristics.CONTROL_AE_AVAILABLE_TARGET_FPS_RANGES);
+          cameraCharacteristics.get(CameraCharacteristics.CONTROL_AE_AVAILABLE_TARGET_FPS_RANGES);
       if (ranges != null) {
         for (Range<Integer> range : ranges) {
           int upper = range.getUpper();
@@ -189,20 +189,20 @@ public class Camera {
     }
 
     mediaRecorder =
-            new MediaRecorderBuilder(recordingProfile, outputFilePath)
-                    .setEnableAudio(enableAudio)
-                    .setMediaOrientation(
-                            lockedCaptureOrientation == null
-                                    ? deviceOrientationListener.getMediaOrientation()
-                                    : deviceOrientationListener.getMediaOrientation(lockedCaptureOrientation))
-                    .build();
+        new MediaRecorderBuilder(recordingProfile, outputFilePath)
+            .setEnableAudio(enableAudio)
+            .setMediaOrientation(
+                lockedCaptureOrientation == null
+                    ? deviceOrientationListener.getMediaOrientation()
+                    : deviceOrientationListener.getMediaOrientation(lockedCaptureOrientation))
+            .build();
   }
 
   @SuppressLint("MissingPermission")
   public void open(String imageFormatGroup) throws CameraAccessException {
     pictureImageReader =
-            ImageReader.newInstance(
-                    captureSize.getWidth(), captureSize.getHeight(), ImageFormat.JPEG, 2);
+        ImageReader.newInstance(
+            captureSize.getWidth(), captureSize.getHeight(), ImageFormat.JPEG, 2);
 
     Integer imageFormat = supportedImageFormats.get(imageFormatGroup);
     if (imageFormat == null) {
@@ -212,78 +212,78 @@ public class Camera {
 
     // Used to steam image byte data to dart side.
     imageStreamReader =
-            ImageReader.newInstance(previewSize.getWidth(), previewSize.getHeight(), imageFormat, 2);
+        ImageReader.newInstance(previewSize.getWidth(), previewSize.getHeight(), imageFormat, 2);
 
     cameraManager.openCamera(
-            cameraName,
-            new CameraDevice.StateCallback() {
-              @Override
-              public void onOpened(@NonNull CameraDevice device) {
-                cameraDevice = device;
-                try {
-                  startPreview();
-                  dartMessenger.sendCameraInitializedEvent(
-                          previewSize.getWidth(),
-                          previewSize.getHeight(),
-                          exposureMode,
-                          focusMode,
-                          isExposurePointSupported(),
-                          isFocusPointSupported());
-                } catch (CameraAccessException e) {
-                  dartMessenger.sendCameraErrorEvent(e.getMessage());
-                  close();
-                }
-              }
+        cameraName,
+        new CameraDevice.StateCallback() {
+          @Override
+          public void onOpened(@NonNull CameraDevice device) {
+            cameraDevice = device;
+            try {
+              startPreview();
+              dartMessenger.sendCameraInitializedEvent(
+                  previewSize.getWidth(),
+                  previewSize.getHeight(),
+                  exposureMode,
+                  focusMode,
+                  isExposurePointSupported(),
+                  isFocusPointSupported());
+            } catch (CameraAccessException e) {
+              dartMessenger.sendCameraErrorEvent(e.getMessage());
+              close();
+            }
+          }
 
-              @Override
-              public void onClosed(@NonNull CameraDevice camera) {
-                dartMessenger.sendCameraClosingEvent();
-                super.onClosed(camera);
-              }
+          @Override
+          public void onClosed(@NonNull CameraDevice camera) {
+            dartMessenger.sendCameraClosingEvent();
+            super.onClosed(camera);
+          }
 
-              @Override
-              public void onDisconnected(@NonNull CameraDevice cameraDevice) {
-                close();
-                dartMessenger.sendCameraErrorEvent("The camera was disconnected.");
-              }
+          @Override
+          public void onDisconnected(@NonNull CameraDevice cameraDevice) {
+            close();
+            dartMessenger.sendCameraErrorEvent("The camera was disconnected.");
+          }
 
-              @Override
-              public void onError(@NonNull CameraDevice cameraDevice, int errorCode) {
-                close();
-                String errorDescription;
-                switch (errorCode) {
-                  case ERROR_CAMERA_IN_USE:
-                    errorDescription = "The camera device is in use already.";
-                    break;
-                  case ERROR_MAX_CAMERAS_IN_USE:
-                    errorDescription = "Max cameras in use";
-                    break;
-                  case ERROR_CAMERA_DISABLED:
-                    errorDescription = "The camera device could not be opened due to a device policy.";
-                    break;
-                  case ERROR_CAMERA_DEVICE:
-                    errorDescription = "The camera device has encountered a fatal error";
-                    break;
-                  case ERROR_CAMERA_SERVICE:
-                    errorDescription = "The camera service has encountered a fatal error.";
-                    break;
-                  default:
-                    errorDescription = "Unknown camera error";
-                }
-                dartMessenger.sendCameraErrorEvent(errorDescription);
-              }
-            },
-            null);
+          @Override
+          public void onError(@NonNull CameraDevice cameraDevice, int errorCode) {
+            close();
+            String errorDescription;
+            switch (errorCode) {
+              case ERROR_CAMERA_IN_USE:
+                errorDescription = "The camera device is in use already.";
+                break;
+              case ERROR_MAX_CAMERAS_IN_USE:
+                errorDescription = "Max cameras in use";
+                break;
+              case ERROR_CAMERA_DISABLED:
+                errorDescription = "The camera device could not be opened due to a device policy.";
+                break;
+              case ERROR_CAMERA_DEVICE:
+                errorDescription = "The camera device has encountered a fatal error";
+                break;
+              case ERROR_CAMERA_SERVICE:
+                errorDescription = "The camera service has encountered a fatal error.";
+                break;
+              default:
+                errorDescription = "Unknown camera error";
+            }
+            dartMessenger.sendCameraErrorEvent(errorDescription);
+          }
+        },
+        null);
   }
 
   private void createCaptureSession(int templateType, Surface... surfaces)
-          throws CameraAccessException {
+      throws CameraAccessException {
     createCaptureSession(templateType, null, surfaces);
   }
 
   private void createCaptureSession(
-          int templateType, Runnable onSuccessCallback, Surface... surfaces)
-          throws CameraAccessException {
+      int templateType, Runnable onSuccessCallback, Surface... surfaces)
+      throws CameraAccessException {
     // Close any existing capture session.
     closeCaptureSession();
 
@@ -308,29 +308,29 @@ public class Camera {
 
     // Prepare the callback
     CameraCaptureSession.StateCallback callback =
-            new CameraCaptureSession.StateCallback() {
-              @Override
-              public void onConfigured(@NonNull CameraCaptureSession session) {
-                if (cameraDevice == null) {
-                  dartMessenger.sendCameraErrorEvent("The camera was closed during configuration.");
-                  return;
-                }
-                cameraCaptureSession = session;
+        new CameraCaptureSession.StateCallback() {
+          @Override
+          public void onConfigured(@NonNull CameraCaptureSession session) {
+            if (cameraDevice == null) {
+              dartMessenger.sendCameraErrorEvent("The camera was closed during configuration.");
+              return;
+            }
+            cameraCaptureSession = session;
 
-                updateFpsRange();
-                updateFocus(focusMode);
-                updateFlash(flashMode);
-                updateExposure(exposureMode);
+            updateFpsRange();
+            updateFocus(focusMode);
+            updateFlash(flashMode);
+            updateExposure(exposureMode);
 
-                refreshPreviewCaptureSession(
-                        onSuccessCallback, (code, message) -> dartMessenger.sendCameraErrorEvent(message));
-              }
+            refreshPreviewCaptureSession(
+                onSuccessCallback, (code, message) -> dartMessenger.sendCameraErrorEvent(message));
+          }
 
-              @Override
-              public void onConfigureFailed(@NonNull CameraCaptureSession cameraCaptureSession) {
-                dartMessenger.sendCameraErrorEvent("Failed to configure camera session.");
-              }
-            };
+          @Override
+          public void onConfigureFailed(@NonNull CameraCaptureSession cameraCaptureSession) {
+            dartMessenger.sendCameraErrorEvent("Failed to configure camera session.");
+          }
+        };
 
     // Start the session
     if (VERSION.SDK_INT >= VERSION_CODES.P) {
@@ -352,35 +352,35 @@ public class Camera {
 
   @TargetApi(VERSION_CODES.P)
   private void createCaptureSessionWithSessionConfig(
-          List<OutputConfiguration> outputConfigs, CameraCaptureSession.StateCallback callback)
-          throws CameraAccessException {
+      List<OutputConfiguration> outputConfigs, CameraCaptureSession.StateCallback callback)
+      throws CameraAccessException {
     cameraDevice.createCaptureSession(
-            new SessionConfiguration(
-                    SessionConfiguration.SESSION_REGULAR,
-                    outputConfigs,
-                    Executors.newSingleThreadExecutor(),
-                    callback));
+        new SessionConfiguration(
+            SessionConfiguration.SESSION_REGULAR,
+            outputConfigs,
+            Executors.newSingleThreadExecutor(),
+            callback));
   }
 
   @TargetApi(VERSION_CODES.LOLLIPOP)
   @SuppressWarnings("deprecation")
   private void createCaptureSession(
-          List<Surface> surfaces, CameraCaptureSession.StateCallback callback)
-          throws CameraAccessException {
+      List<Surface> surfaces, CameraCaptureSession.StateCallback callback)
+      throws CameraAccessException {
     cameraDevice.createCaptureSession(surfaces, callback, null);
   }
 
   private void refreshPreviewCaptureSession(
-          @Nullable Runnable onSuccessCallback, @NonNull ErrorCallback onErrorCallback) {
+      @Nullable Runnable onSuccessCallback, @NonNull ErrorCallback onErrorCallback) {
     if (cameraCaptureSession == null) {
       return;
     }
 
     try {
       cameraCaptureSession.setRepeatingRequest(
-              captureRequestBuilder.build(),
-              pictureCaptureCallback,
-              new Handler(Looper.getMainLooper()));
+          captureRequestBuilder.build(),
+          pictureCaptureCallback,
+          new Handler(Looper.getMainLooper()));
 
       if (onSuccessCallback != null) {
         onSuccessCallback.run();
@@ -419,16 +419,16 @@ public class Camera {
 
     // Listen for picture being taken
     pictureImageReader.setOnImageAvailableListener(
-            reader -> {
-              try (Image image = reader.acquireLatestImage()) {
-                ByteBuffer buffer = image.getPlanes()[0].getBuffer();
-                writeToFile(buffer, file);
-                pictureCaptureRequest.finish(file.getAbsolutePath());
-              } catch (IOException e) {
-                pictureCaptureRequest.error("IOError", "Failed saving image", null);
-              }
-            },
-            null);
+        reader -> {
+          try (Image image = reader.acquireLatestImage()) {
+            ByteBuffer buffer = image.getPlanes()[0].getBuffer();
+            writeToFile(buffer, file);
+            pictureCaptureRequest.finish(file.getAbsolutePath());
+          } catch (IOException e) {
+            pictureCaptureRequest.error("IOError", "Failed saving image", null);
+          }
+        },
+        null);
 
     if (useAutoFocus) {
       runPictureAutoFocus();
@@ -438,90 +438,90 @@ public class Camera {
   }
 
   private final CameraCaptureSession.CaptureCallback pictureCaptureCallback =
-          new CameraCaptureSession.CaptureCallback() {
-            @Override
-            public void onCaptureCompleted(
-                    @NonNull CameraCaptureSession session,
-                    @NonNull CaptureRequest request,
-                    @NonNull TotalCaptureResult result) {
-              processCapture(result);
-            }
+      new CameraCaptureSession.CaptureCallback() {
+        @Override
+        public void onCaptureCompleted(
+            @NonNull CameraCaptureSession session,
+            @NonNull CaptureRequest request,
+            @NonNull TotalCaptureResult result) {
+          processCapture(result);
+        }
 
-            @Override
-            public void onCaptureProgressed(
-                    @NonNull CameraCaptureSession session,
-                    @NonNull CaptureRequest request,
-                    @NonNull CaptureResult partialResult) {
-              processCapture(partialResult);
-            }
+        @Override
+        public void onCaptureProgressed(
+            @NonNull CameraCaptureSession session,
+            @NonNull CaptureRequest request,
+            @NonNull CaptureResult partialResult) {
+          processCapture(partialResult);
+        }
 
-            @Override
-            public void onCaptureFailed(
-                    @NonNull CameraCaptureSession session,
-                    @NonNull CaptureRequest request,
-                    @NonNull CaptureFailure failure) {
-              if (pictureCaptureRequest == null || pictureCaptureRequest.isFinished()) {
+        @Override
+        public void onCaptureFailed(
+            @NonNull CameraCaptureSession session,
+            @NonNull CaptureRequest request,
+            @NonNull CaptureFailure failure) {
+          if (pictureCaptureRequest == null || pictureCaptureRequest.isFinished()) {
+            return;
+          }
+          String reason;
+          boolean fatalFailure = false;
+          switch (failure.getReason()) {
+            case CaptureFailure.REASON_ERROR:
+              reason = "An error happened in the framework";
+              break;
+            case CaptureFailure.REASON_FLUSHED:
+              reason = "The capture has failed due to an abortCaptures() call";
+              fatalFailure = true;
+              break;
+            default:
+              reason = "Unknown reason";
+          }
+          Log.w("Camera", "pictureCaptureCallback.onCaptureFailed(): " + reason);
+          if (fatalFailure) pictureCaptureRequest.error("captureFailure", reason, null);
+        }
+
+        private void processCapture(CaptureResult result) {
+          if (pictureCaptureRequest == null) {
+            return;
+          }
+
+          Integer aeState = result.get(CaptureResult.CONTROL_AE_STATE);
+          Integer afState = result.get(CaptureResult.CONTROL_AF_STATE);
+          switch (pictureCaptureRequest.getState()) {
+            case focusing:
+              if (afState == null) {
                 return;
+              } else if (afState == CaptureResult.CONTROL_AF_STATE_FOCUSED_LOCKED
+                  || afState == CaptureResult.CONTROL_AF_STATE_NOT_FOCUSED_LOCKED) {
+                // Some devices might return null here, in which case we will also continue.
+                if (aeState == null || aeState == CaptureResult.CONTROL_AE_STATE_CONVERGED) {
+                  runPictureCapture();
+                } else {
+                  runPicturePreCapture();
+                }
               }
-              String reason;
-              boolean fatalFailure = false;
-              switch (failure.getReason()) {
-                case CaptureFailure.REASON_ERROR:
-                  reason = "An error happened in the framework";
-                  break;
-                case CaptureFailure.REASON_FLUSHED:
-                  reason = "The capture has failed due to an abortCaptures() call";
-                  fatalFailure = true;
-                  break;
-                default:
-                  reason = "Unknown reason";
+              break;
+            case preCapture:
+              // Some devices might return null here, in which case we will also continue.
+              if (aeState == null
+                  || aeState == CaptureRequest.CONTROL_AE_STATE_PRECAPTURE
+                  || aeState == CaptureRequest.CONTROL_AE_STATE_FLASH_REQUIRED
+                  || aeState == CaptureRequest.CONTROL_AE_STATE_CONVERGED) {
+                pictureCaptureRequest.setState(State.waitingPreCaptureReady);
+                setPreCaptureStartTime();
               }
-              Log.w("Camera", "pictureCaptureCallback.onCaptureFailed(): " + reason);
-              if (fatalFailure) pictureCaptureRequest.error("captureFailure", reason, null);
-            }
-
-            private void processCapture(CaptureResult result) {
-              if (pictureCaptureRequest == null) {
-                return;
+              break;
+            case waitingPreCaptureReady:
+              if (aeState == null || aeState != CaptureRequest.CONTROL_AE_STATE_PRECAPTURE) {
+                runPictureCapture();
+              } else {
+                if (hitPreCaptureTimeout()) {
+                  unlockAutoFocus();
+                }
               }
-
-              Integer aeState = result.get(CaptureResult.CONTROL_AE_STATE);
-              Integer afState = result.get(CaptureResult.CONTROL_AF_STATE);
-              switch (pictureCaptureRequest.getState()) {
-                case focusing:
-                  if (afState == null) {
-                    return;
-                  } else if (afState == CaptureResult.CONTROL_AF_STATE_FOCUSED_LOCKED
-                          || afState == CaptureResult.CONTROL_AF_STATE_NOT_FOCUSED_LOCKED) {
-                    // Some devices might return null here, in which case we will also continue.
-                    if (aeState == null || aeState == CaptureResult.CONTROL_AE_STATE_CONVERGED) {
-                      runPictureCapture();
-                    } else {
-                      runPicturePreCapture();
-                    }
-                  }
-                  break;
-                case preCapture:
-                  // Some devices might return null here, in which case we will also continue.
-                  if (aeState == null
-                          || aeState == CaptureRequest.CONTROL_AE_STATE_PRECAPTURE
-                          || aeState == CaptureRequest.CONTROL_AE_STATE_FLASH_REQUIRED
-                          || aeState == CaptureRequest.CONTROL_AE_STATE_CONVERGED) {
-                    pictureCaptureRequest.setState(State.waitingPreCaptureReady);
-                    setPreCaptureStartTime();
-                  }
-                  break;
-                case waitingPreCaptureReady:
-                  if (aeState == null || aeState != CaptureRequest.CONTROL_AE_STATE_PRECAPTURE) {
-                    runPictureCapture();
-                  } else {
-                    if (hitPreCaptureTimeout()) {
-                      unlockAutoFocus();
-                    }
-                  }
-              }
-            }
-          };
+          }
+        }
+      };
 
   private void runPictureAutoFocus() {
     assert (pictureCaptureRequest != null);
@@ -535,15 +535,15 @@ public class Camera {
     pictureCaptureRequest.setState(PictureCaptureRequest.State.preCapture);
 
     captureRequestBuilder.set(
-            CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER,
-            CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER_START);
+        CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER,
+        CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER_START);
 
     refreshPreviewCaptureSession(
-            () ->
-                    captureRequestBuilder.set(
-                            CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER,
-                            CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER_IDLE),
-            (code, message) -> pictureCaptureRequest.error(code, message, null));
+        () ->
+            captureRequestBuilder.set(
+                CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER,
+                CaptureRequest.CONTROL_AE_PRECAPTURE_TRIGGER_IDLE),
+        (code, message) -> pictureCaptureRequest.error(code, message, null));
   }
 
   private void runPictureCapture() {
@@ -551,16 +551,16 @@ public class Camera {
     pictureCaptureRequest.setState(PictureCaptureRequest.State.capturing);
     try {
       final CaptureRequest.Builder captureBuilder =
-              cameraDevice.createCaptureRequest(CameraDevice.TEMPLATE_STILL_CAPTURE);
+          cameraDevice.createCaptureRequest(CameraDevice.TEMPLATE_STILL_CAPTURE);
       captureBuilder.addTarget(pictureImageReader.getSurface());
       captureBuilder.set(
-              CaptureRequest.SCALER_CROP_REGION,
-              captureRequestBuilder.get(CaptureRequest.SCALER_CROP_REGION));
+          CaptureRequest.SCALER_CROP_REGION,
+          captureRequestBuilder.get(CaptureRequest.SCALER_CROP_REGION));
       captureBuilder.set(
-              CaptureRequest.JPEG_ORIENTATION,
-              lockedCaptureOrientation == null
-                      ? deviceOrientationListener.getMediaOrientation()
-                      : deviceOrientationListener.getMediaOrientation(lockedCaptureOrientation));
+          CaptureRequest.JPEG_ORIENTATION,
+          lockedCaptureOrientation == null
+              ? deviceOrientationListener.getMediaOrientation()
+              : deviceOrientationListener.getMediaOrientation(lockedCaptureOrientation));
 
       switch (flashMode) {
         case off:
@@ -569,27 +569,27 @@ public class Camera {
           break;
         case auto:
           captureBuilder.set(
-                  CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_ON_AUTO_FLASH);
+              CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_ON_AUTO_FLASH);
           break;
         case always:
         default:
           captureBuilder.set(
-                  CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_ON_ALWAYS_FLASH);
+              CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_ON_ALWAYS_FLASH);
           break;
       }
       cameraCaptureSession.stopRepeating();
       cameraCaptureSession.capture(
-              captureBuilder.build(),
-              new CameraCaptureSession.CaptureCallback() {
-                @Override
-                public void onCaptureCompleted(
-                        @NonNull CameraCaptureSession session,
-                        @NonNull CaptureRequest request,
-                        @NonNull TotalCaptureResult result) {
-                  unlockAutoFocus();
-                }
-              },
-              null);
+          captureBuilder.build(),
+          new CameraCaptureSession.CaptureCallback() {
+            @Override
+            public void onCaptureCompleted(
+                @NonNull CameraCaptureSession session,
+                @NonNull CaptureRequest request,
+                @NonNull TotalCaptureResult result) {
+              unlockAutoFocus();
+            }
+          },
+          null);
     } catch (CameraAccessException e) {
       pictureCaptureRequest.error("cameraAccess", e.getMessage(), null);
     }
@@ -597,26 +597,26 @@ public class Camera {
 
   private void lockAutoFocus(CaptureCallback callback) {
     captureRequestBuilder.set(
-            CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_START);
+        CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_START);
 
     refreshPreviewCaptureSession(
-            null, (code, message) -> pictureCaptureRequest.error(code, message, null));
+        null, (code, message) -> pictureCaptureRequest.error(code, message, null));
   }
 
   private void unlockAutoFocus() {
     captureRequestBuilder.set(
-            CaptureRequest.CONTROL_AF_TRIGGER, CameraMetadata.CONTROL_AF_TRIGGER_CANCEL);
+        CaptureRequest.CONTROL_AF_TRIGGER, CameraMetadata.CONTROL_AF_TRIGGER_CANCEL);
     updateFocus(focusMode);
     try {
       cameraCaptureSession.capture(captureRequestBuilder.build(), null, null);
     } catch (CameraAccessException ignored) {
     }
     captureRequestBuilder.set(
-            CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_IDLE);
+        CaptureRequest.CONTROL_AF_TRIGGER, CaptureRequest.CONTROL_AF_TRIGGER_IDLE);
 
     refreshPreviewCaptureSession(
-            null,
-            (errorCode, errorMessage) -> pictureCaptureRequest.error(errorCode, errorMessage, null));
+        null,
+        (errorCode, errorMessage) -> pictureCaptureRequest.error(errorCode, errorMessage, null));
   }
 
   public void startVideoRecording(Result result) {
@@ -632,7 +632,7 @@ public class Camera {
       prepareMediaRecorder(videoRecordingFile.getAbsolutePath());
       recordingVideo = true;
       createCaptureSession(
-              CameraDevice.TEMPLATE_RECORD, () -> mediaRecorder.start(), mediaRecorder.getSurface());
+          CameraDevice.TEMPLATE_RECORD, () -> mediaRecorder.start(), mediaRecorder.getSurface());
       result.success(null);
     } catch (CameraAccessException | IOException e) {
       recordingVideo = false;
@@ -698,7 +698,7 @@ public class Camera {
         mediaRecorder.resume();
       } else {
         result.error(
-                "videoRecordingFailed", "resumeVideoRecording requires Android API +24.", null);
+            "videoRecordingFailed", "resumeVideoRecording requires Android API +24.", null);
         return;
       }
     } catch (IllegalStateException e) {
@@ -710,12 +710,12 @@ public class Camera {
   }
 
   public void setFlashMode(@NonNull final Result result, FlashMode mode)
-          throws CameraAccessException {
+      throws CameraAccessException {
     // Get the flash availability
     Boolean flashAvailable =
-            cameraManager
-                    .getCameraCharacteristics(cameraDevice.getId())
-                    .get(CameraCharacteristics.FLASH_INFO_AVAILABLE);
+        cameraManager
+            .getCameraCharacteristics(cameraDevice.getId())
+            .get(CameraCharacteristics.FLASH_INFO_AVAILABLE);
 
     // Check if flash is available.
     if (flashAvailable == null || !flashAvailable) {
@@ -728,65 +728,65 @@ public class Camera {
       updateFlash(FlashMode.off);
 
       this.cameraCaptureSession.setRepeatingRequest(
-              captureRequestBuilder.build(),
-              new CaptureCallback() {
-                private boolean isFinished = false;
+          captureRequestBuilder.build(),
+          new CaptureCallback() {
+            private boolean isFinished = false;
 
-                @Override
-                public void onCaptureCompleted(
-                        @NonNull CameraCaptureSession session,
-                        @NonNull CaptureRequest request,
-                        @NonNull TotalCaptureResult captureResult) {
-                  if (isFinished) {
-                    return;
-                  }
+            @Override
+            public void onCaptureCompleted(
+                @NonNull CameraCaptureSession session,
+                @NonNull CaptureRequest request,
+                @NonNull TotalCaptureResult captureResult) {
+              if (isFinished) {
+                return;
+              }
 
-                  updateFlash(mode);
-                  refreshPreviewCaptureSession(
-                          () -> {
-                            result.success(null);
-                            isFinished = true;
-                          },
-                          (code, message) ->
-                                  result.error("setFlashModeFailed", "Could not set flash mode.", null));
-                }
+              updateFlash(mode);
+              refreshPreviewCaptureSession(
+                  () -> {
+                    result.success(null);
+                    isFinished = true;
+                  },
+                  (code, message) ->
+                      result.error("setFlashModeFailed", "Could not set flash mode.", null));
+            }
 
-                @Override
-                public void onCaptureFailed(
-                        @NonNull CameraCaptureSession session,
-                        @NonNull CaptureRequest request,
-                        @NonNull CaptureFailure failure) {
-                  if (isFinished) {
-                    return;
-                  }
+            @Override
+            public void onCaptureFailed(
+                @NonNull CameraCaptureSession session,
+                @NonNull CaptureRequest request,
+                @NonNull CaptureFailure failure) {
+              if (isFinished) {
+                return;
+              }
 
-                  result.error("setFlashModeFailed", "Could not set flash mode.", null);
-                  isFinished = true;
-                }
-              },
-              null);
+              result.error("setFlashModeFailed", "Could not set flash mode.", null);
+              isFinished = true;
+            }
+          },
+          null);
     } else {
       updateFlash(mode);
 
       refreshPreviewCaptureSession(
-              () -> result.success(null),
-              (code, message) -> result.error("setFlashModeFailed", "Could not set flash mode.", null));
+          () -> result.success(null),
+          (code, message) -> result.error("setFlashModeFailed", "Could not set flash mode.", null));
     }
   }
 
   public void setExposureMode(@NonNull final Result result, ExposureMode mode)
-          throws CameraAccessException {
+      throws CameraAccessException {
     updateExposure(mode);
     cameraCaptureSession.setRepeatingRequest(captureRequestBuilder.build(), null, null);
     result.success(null);
   }
 
   public void setExposurePoint(@NonNull final Result result, Double x, Double y)
-          throws CameraAccessException {
+      throws CameraAccessException {
     // Check if exposure point functionality is available.
     if (!isExposurePointSupported()) {
       result.error(
-              "setExposurePointFailed", "Device does not have exposure point capabilities", null);
+          "setExposurePointFailed", "Device does not have exposure point capabilities", null);
       return;
     }
     // Check if the current region boundaries are known
@@ -800,11 +800,11 @@ public class Camera {
     // Apply it
     updateExposure(exposureMode);
     refreshPreviewCaptureSession(
-            () -> result.success(null), (code, message) -> result.error("CameraAccess", message, null));
+        () -> result.success(null), (code, message) -> result.error("CameraAccess", message, null));
   }
 
   public void setFocusMode(@NonNull final Result result, FocusMode mode)
-          throws CameraAccessException {
+      throws CameraAccessException {
     this.focusMode = mode;
 
     updateFocus(mode);
@@ -812,26 +812,26 @@ public class Camera {
     switch (mode) {
       case auto:
         refreshPreviewCaptureSession(
-                null, (code, message) -> result.error("setFocusMode", message, null));
+            null, (code, message) -> result.error("setFocusMode", message, null));
         break;
       case locked:
         lockAutoFocus(
-                new CaptureCallback() {
-                  @Override
-                  public void onCaptureCompleted(
-                          @NonNull CameraCaptureSession session,
-                          @NonNull CaptureRequest request,
-                          @NonNull TotalCaptureResult result) {
-                    unlockAutoFocus();
-                  }
-                });
+            new CaptureCallback() {
+              @Override
+              public void onCaptureCompleted(
+                  @NonNull CameraCaptureSession session,
+                  @NonNull CaptureRequest request,
+                  @NonNull TotalCaptureResult result) {
+                unlockAutoFocus();
+              }
+            });
         break;
     }
     result.success(null);
   }
 
   public void setFocusPoint(@NonNull final Result result, Double x, Double y)
-          throws CameraAccessException {
+      throws CameraAccessException {
     // Check if focus point functionality is available.
     if (!isFocusPointSupported()) {
       result.error("setFocusPointFailed", "Device does not have focus point capabilities", null);
@@ -858,14 +858,14 @@ public class Camera {
   @TargetApi(VERSION_CODES.P)
   private boolean supportsDistortionCorrection() throws CameraAccessException {
     int[] availableDistortionCorrectionModes =
-            cameraManager
-                    .getCameraCharacteristics(cameraDevice.getId())
-                    .get(CameraCharacteristics.DISTORTION_CORRECTION_AVAILABLE_MODES);
+        cameraManager
+            .getCameraCharacteristics(cameraDevice.getId())
+            .get(CameraCharacteristics.DISTORTION_CORRECTION_AVAILABLE_MODES);
     if (availableDistortionCorrectionModes == null) availableDistortionCorrectionModes = new int[0];
     long nonOffModesSupported =
-            Arrays.stream(availableDistortionCorrectionModes)
-                    .filter((value) -> value != CaptureRequest.DISTORTION_CORRECTION_MODE_OFF)
-                    .count();
+        Arrays.stream(availableDistortionCorrectionModes)
+            .filter((value) -> value != CaptureRequest.DISTORTION_CORRECTION_MODE_OFF)
+            .count();
     return nonOffModesSupported > 0;
   }
 
@@ -873,50 +873,50 @@ public class Camera {
     // No distortion correction support
     if (android.os.Build.VERSION.SDK_INT < VERSION_CODES.P || !supportsDistortionCorrection()) {
       return cameraManager
-              .getCameraCharacteristics(cameraDevice.getId())
-              .get(CameraCharacteristics.SENSOR_INFO_PIXEL_ARRAY_SIZE);
+          .getCameraCharacteristics(cameraDevice.getId())
+          .get(CameraCharacteristics.SENSOR_INFO_PIXEL_ARRAY_SIZE);
     }
     // Get the current distortion correction mode
     Integer distortionCorrectionMode =
-            captureRequestBuilder.get(CaptureRequest.DISTORTION_CORRECTION_MODE);
+        captureRequestBuilder.get(CaptureRequest.DISTORTION_CORRECTION_MODE);
     // Return the correct boundaries depending on the mode
     android.graphics.Rect rect;
     if (distortionCorrectionMode == null
-            || distortionCorrectionMode == CaptureRequest.DISTORTION_CORRECTION_MODE_OFF) {
+        || distortionCorrectionMode == CaptureRequest.DISTORTION_CORRECTION_MODE_OFF) {
       rect =
-              cameraManager
-                      .getCameraCharacteristics(cameraDevice.getId())
-                      .get(CameraCharacteristics.SENSOR_INFO_PRE_CORRECTION_ACTIVE_ARRAY_SIZE);
+          cameraManager
+              .getCameraCharacteristics(cameraDevice.getId())
+              .get(CameraCharacteristics.SENSOR_INFO_PRE_CORRECTION_ACTIVE_ARRAY_SIZE);
     } else {
       rect =
-              cameraManager
-                      .getCameraCharacteristics(cameraDevice.getId())
-                      .get(CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE);
+          cameraManager
+              .getCameraCharacteristics(cameraDevice.getId())
+              .get(CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE);
     }
     return rect == null ? null : new Size(rect.width(), rect.height());
   }
 
   private boolean isExposurePointSupported() throws CameraAccessException {
     Integer supportedRegions =
-            cameraManager
-                    .getCameraCharacteristics(cameraDevice.getId())
-                    .get(CameraCharacteristics.CONTROL_MAX_REGIONS_AE);
+        cameraManager
+            .getCameraCharacteristics(cameraDevice.getId())
+            .get(CameraCharacteristics.CONTROL_MAX_REGIONS_AE);
     return supportedRegions != null && supportedRegions > 0;
   }
 
   private boolean isFocusPointSupported() throws CameraAccessException {
     Integer supportedRegions =
-            cameraManager
-                    .getCameraCharacteristics(cameraDevice.getId())
-                    .get(CameraCharacteristics.CONTROL_MAX_REGIONS_AF);
+        cameraManager
+            .getCameraCharacteristics(cameraDevice.getId())
+            .get(CameraCharacteristics.CONTROL_MAX_REGIONS_AF);
     return supportedRegions != null && supportedRegions > 0;
   }
 
   public double getMinExposureOffset() throws CameraAccessException {
     Range<Integer> range =
-            cameraManager
-                    .getCameraCharacteristics(cameraDevice.getId())
-                    .get(CameraCharacteristics.CONTROL_AE_COMPENSATION_RANGE);
+        cameraManager
+            .getCameraCharacteristics(cameraDevice.getId())
+            .get(CameraCharacteristics.CONTROL_AE_COMPENSATION_RANGE);
     double minStepped = range == null ? 0 : range.getLower();
     double stepSize = getExposureOffsetStepSize();
     return minStepped * stepSize;
@@ -924,9 +924,9 @@ public class Camera {
 
   public double getMaxExposureOffset() throws CameraAccessException {
     Range<Integer> range =
-            cameraManager
-                    .getCameraCharacteristics(cameraDevice.getId())
-                    .get(CameraCharacteristics.CONTROL_AE_COMPENSATION_RANGE);
+        cameraManager
+            .getCameraCharacteristics(cameraDevice.getId())
+            .get(CameraCharacteristics.CONTROL_AE_COMPENSATION_RANGE);
     double maxStepped = range == null ? 0 : range.getUpper();
     double stepSize = getExposureOffsetStepSize();
     return maxStepped * stepSize;
@@ -934,14 +934,14 @@ public class Camera {
 
   public double getExposureOffsetStepSize() throws CameraAccessException {
     Rational stepSize =
-            cameraManager
-                    .getCameraCharacteristics(cameraDevice.getId())
-                    .get(CameraCharacteristics.CONTROL_AE_COMPENSATION_STEP);
+        cameraManager
+            .getCameraCharacteristics(cameraDevice.getId())
+            .get(CameraCharacteristics.CONTROL_AE_COMPENSATION_STEP);
     return stepSize == null ? 0.0 : stepSize.doubleValue();
   }
 
   public void setExposureOffset(@NonNull final Result result, double offset)
-          throws CameraAccessException {
+      throws CameraAccessException {
     // Set the exposure offset
     double stepSize = getExposureOffsetStepSize();
     exposureOffset = (int) (offset / stepSize);
@@ -965,11 +965,11 @@ public class Camera {
 
     if (zoom > maxZoom || zoom < minZoom) {
       String errorMessage =
-              String.format(
-                      Locale.ENGLISH,
-                      "Zoom level out of bounds (zoom level should be between %f and %f).",
-                      minZoom,
-                      maxZoom);
+          String.format(
+              Locale.ENGLISH,
+              "Zoom level out of bounds (zoom level should be between %f and %f).",
+              minZoom,
+              maxZoom);
       result.error("ZOOM_ERROR", errorMessage, null);
       return;
     }
@@ -1005,31 +1005,31 @@ public class Camera {
       int[] modes = cameraCharacteristics.get(CameraCharacteristics.CONTROL_AF_AVAILABLE_MODES);
       // Auto focus is not supported
       if (modes == null
-              || modes.length == 0
-              || (modes.length == 1 && modes[0] == CameraCharacteristics.CONTROL_AF_MODE_OFF)) {
+          || modes.length == 0
+          || (modes.length == 1 && modes[0] == CameraCharacteristics.CONTROL_AF_MODE_OFF)) {
         useAutoFocus = false;
         captureRequestBuilder.set(
-                CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_OFF);
+            CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_OFF);
       } else {
         // Applying auto focus
         switch (mode) {
           case locked:
             captureRequestBuilder.set(
-                    CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_AUTO);
+                CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_AUTO);
             break;
           case auto:
             captureRequestBuilder.set(
-                    CaptureRequest.CONTROL_AF_MODE,
-                    recordingVideo
-                            ? CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_VIDEO
-                            : CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_PICTURE);
+                CaptureRequest.CONTROL_AF_MODE,
+                recordingVideo
+                    ? CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_VIDEO
+                    : CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_PICTURE);
           default:
             break;
         }
         MeteringRectangle afRect = cameraRegions.getAFMeteringRectangle();
         captureRequestBuilder.set(
-                CaptureRequest.CONTROL_AF_REGIONS,
-                afRect == null ? null : new MeteringRectangle[] {afRect});
+            CaptureRequest.CONTROL_AF_REGIONS,
+            afRect == null ? null : new MeteringRectangle[] {afRect});
       }
     } else {
       captureRequestBuilder.set(CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_OFF);
@@ -1042,8 +1042,8 @@ public class Camera {
     // Applying auto exposure
     MeteringRectangle aeRect = cameraRegions.getAEMeteringRectangle();
     captureRequestBuilder.set(
-            CaptureRequest.CONTROL_AE_REGIONS,
-            aeRect == null ? null : new MeteringRectangle[] {cameraRegions.getAEMeteringRectangle()});
+        CaptureRequest.CONTROL_AE_REGIONS,
+        aeRect == null ? null : new MeteringRectangle[] {cameraRegions.getAEMeteringRectangle()});
 
     switch (mode) {
       case locked:
@@ -1066,23 +1066,23 @@ public class Camera {
     switch (flashMode) {
       case off:
         captureRequestBuilder.set(
-                CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_ON);
+            CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_ON);
         captureRequestBuilder.set(CaptureRequest.FLASH_MODE, CaptureRequest.FLASH_MODE_OFF);
         break;
       case auto:
         captureRequestBuilder.set(
-                CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_ON_AUTO_FLASH);
+            CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_ON_AUTO_FLASH);
         captureRequestBuilder.set(CaptureRequest.FLASH_MODE, CaptureRequest.FLASH_MODE_OFF);
         break;
       case always:
         captureRequestBuilder.set(
-                CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_ON_ALWAYS_FLASH);
+            CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_ON_ALWAYS_FLASH);
         captureRequestBuilder.set(CaptureRequest.FLASH_MODE, CaptureRequest.FLASH_MODE_OFF);
         break;
       case torch:
       default:
         captureRequestBuilder.set(
-                CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_ON);
+            CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_ON);
         captureRequestBuilder.set(CaptureRequest.FLASH_MODE, CaptureRequest.FLASH_MODE_TORCH);
         break;
     }
@@ -1095,54 +1095,54 @@ public class Camera {
   }
 
   public void startPreviewWithImageStream(EventChannel imageStreamChannel)
-          throws CameraAccessException {
+      throws CameraAccessException {
     createCaptureSession(CameraDevice.TEMPLATE_RECORD, imageStreamReader.getSurface());
 
     imageStreamChannel.setStreamHandler(
-            new EventChannel.StreamHandler() {
-              @Override
-              public void onListen(Object o, EventChannel.EventSink imageStreamSink) {
-                setImageStreamImageAvailableListener(imageStreamSink);
-              }
+        new EventChannel.StreamHandler() {
+          @Override
+          public void onListen(Object o, EventChannel.EventSink imageStreamSink) {
+            setImageStreamImageAvailableListener(imageStreamSink);
+          }
 
-              @Override
-              public void onCancel(Object o) {
-                imageStreamReader.setOnImageAvailableListener(null, null);
-              }
-            });
+          @Override
+          public void onCancel(Object o) {
+            imageStreamReader.setOnImageAvailableListener(null, null);
+          }
+        });
   }
 
   private void setImageStreamImageAvailableListener(final EventChannel.EventSink imageStreamSink) {
     imageStreamReader.setOnImageAvailableListener(
-            reader -> {
-              Image img = reader.acquireLatestImage();
-              if (img == null) return;
+        reader -> {
+          Image img = reader.acquireLatestImage();
+          if (img == null) return;
 
-              List<Map<String, Object>> planes = new ArrayList<>();
-              for (Image.Plane plane : img.getPlanes()) {
-                ByteBuffer buffer = plane.getBuffer();
+          List<Map<String, Object>> planes = new ArrayList<>();
+          for (Image.Plane plane : img.getPlanes()) {
+            ByteBuffer buffer = plane.getBuffer();
 
-                byte[] bytes = new byte[buffer.remaining()];
-                buffer.get(bytes, 0, bytes.length);
+            byte[] bytes = new byte[buffer.remaining()];
+            buffer.get(bytes, 0, bytes.length);
 
-                Map<String, Object> planeBuffer = new HashMap<>();
-                planeBuffer.put("bytesPerRow", plane.getRowStride());
-                planeBuffer.put("bytesPerPixel", plane.getPixelStride());
-                planeBuffer.put("bytes", bytes);
+            Map<String, Object> planeBuffer = new HashMap<>();
+            planeBuffer.put("bytesPerRow", plane.getRowStride());
+            planeBuffer.put("bytesPerPixel", plane.getPixelStride());
+            planeBuffer.put("bytes", bytes);
 
-                planes.add(planeBuffer);
-              }
+            planes.add(planeBuffer);
+          }
 
-              Map<String, Object> imageBuffer = new HashMap<>();
-              imageBuffer.put("width", img.getWidth());
-              imageBuffer.put("height", img.getHeight());
-              imageBuffer.put("format", img.getFormat());
-              imageBuffer.put("planes", planes);
+          Map<String, Object> imageBuffer = new HashMap<>();
+          imageBuffer.put("width", img.getWidth());
+          imageBuffer.put("height", img.getHeight());
+          imageBuffer.put("format", img.getFormat());
+          imageBuffer.put("planes", planes);
 
-              imageStreamSink.success(imageBuffer);
-              img.close();
-            },
-            null);
+          imageStreamSink.success(imageBuffer);
+          img.close();
+        },
+        null);
   }
 
   public void stopImageStream() throws CameraAccessException {

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
@@ -467,7 +467,7 @@ public class Camera {
             @NonNull CameraCaptureSession session,
             @NonNull CaptureRequest request,
             @NonNull CaptureResult partialResult) {
-          Log.d("flutter", "onCaptureProgressed");
+//          Log.d("flutter", "onCaptureProgressed");
           processCapture(partialResult);
         }
 
@@ -476,7 +476,7 @@ public class Camera {
             @NonNull CameraCaptureSession session,
             @NonNull CaptureRequest request,
             @NonNull CaptureFailure failure) {
-          Log.d("flutter", "onCaptureFailed");
+//          Log.d("flutter", "onCaptureFailed");
 
           if (pictureCaptureRequest == null || pictureCaptureRequest.isFinished()) {
             return;
@@ -510,7 +510,7 @@ public class Camera {
           Integer aeState = result.get(CaptureResult.CONTROL_AE_STATE);
           Integer afState = result.get(CaptureResult.CONTROL_AF_STATE);
           if (pictureCaptureRequest.getState() != State.finished) {
-            Log.i("flutter", "state: " + pictureCaptureRequest.getState() + " | afState: " + afState + " | aeState: " + aeState);
+//            Log.i("flutter", "state: " + pictureCaptureRequest.getState() + " | afState: " + afState + " | aeState: " + aeState);
           }
 
           switch (pictureCaptureRequest.getState()) {
@@ -537,10 +537,10 @@ public class Camera {
 
                 // CONTROL_AE_STATE can be null on some devices
                 if (aeState == null || aeState == CaptureResult.CONTROL_AE_STATE_CONVERGED) {
-                  Log.i("flutter", "AE state is converged, taking piture");
+//                  Log.i("flutter", "AE state is converged, taking piture");
                   runPictureCapture();
                 } else {
-                  Log.i("flutter", "Moving to precapture state");
+//                  Log.i("flutter", "Moving to precapture state");
                   pictureCaptureRequest.setState(State.preCapture);
                 }
               }
@@ -633,7 +633,7 @@ public class Camera {
   }
 
   private void runPictureCapture() {
-    Log.i("flutter", "runPictureCapture");
+//    Log.i("flutter", "runPictureCapture");
 
     assert (pictureCaptureRequest != null);
     pictureCaptureRequest.setState(PictureCaptureRequest.State.capturing);

--- a/packages/camera/camera_platform_interface/CHANGELOG.md
+++ b/packages/camera/camera_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.2
+
+- Added support for NV21 image stream format in Android.
+
 ## 2.0.1
 
 * Update platform_plugin_interface version requirement.

--- a/packages/camera/camera_platform_interface/lib/src/types/image_format_group.dart
+++ b/packages/camera/camera_platform_interface/lib/src/types/image_format_group.dart
@@ -14,7 +14,32 @@ enum ImageFormatGroup {
   ///
   /// On iOS, this is `kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange`. See
   /// https://developer.apple.com/documentation/corevideo/1563591-pixel_format_identifiers/kcvpixelformattype_420ypcbcr8biplanarvideorange?language=objc
+  ///
+  /// Note: if you are using YUV420 with Firebase ML Vision you need to concatenate the planes
+  /// using the following function:
+  /// ```dart
+  /// Uint8List concatenatePlanes(List<Plane> planes) {
+  ///   var totalBytes = 0;
+  ///   for (var i = 0; i < planes.length; ++i) {
+  ///     totalBytes += planes[i].bytes.length;
+  ///   }
+  ///
+  ///   final bytes = Uint8List(totalBytes);
+  ///
+  ///   var byteOffset = 0;
+  ///   for (var i = 0; i < planes.length; ++i) {
+  ///     final length = planes[i].bytes.length;
+  ///     bytes.setRange(byteOffset, byteOffset += length, planes[i].bytes);
+  ///   }
+  ///   return bytes;
+  /// }
+  /// ```
   yuv420,
+
+  /// NV21 is only valid in Android and should be used when feeding images to Firebase ML Vision. If you
+  /// don't use this format then you need to concatenate the planes from YUV420 which is costly both in
+  /// memory and CPU. It's most efficient to just feed it NV21.
+  nv21,
 
   /// 32-bit BGRA.
   ///

--- a/packages/camera/camera_platform_interface/lib/src/types/image_format_group.dart
+++ b/packages/camera/camera_platform_interface/lib/src/types/image_format_group.dart
@@ -65,6 +65,8 @@ extension ImageFormatGroupName on ImageFormatGroup {
         return 'bgra8888';
       case ImageFormatGroup.yuv420:
         return 'yuv420';
+      case ImageFormatGroup.nv21:
+        return 'nv21';
       case ImageFormatGroup.jpeg:
         return 'jpeg';
       case ImageFormatGroup.unknown:

--- a/packages/camera/camera_platform_interface/pubspec.yaml
+++ b/packages/camera/camera_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the camera plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/camera/camera_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.0.1
+version: 2.0.2
 
 dependencies:
   flutter:


### PR DESCRIPTION
This is a companion to https://github.com/flutter/plugins/pull/3651 and adds the option for NV21 image format, used in Android.

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
