### PR TITLE
[device_info] Enable NNBD for unit test

### DIFF
--- a/packages/device_info/device_info_platform_interface/test/method_channel_device_info_test.dart
+++ b/packages/device_info/device_info_platform_interface/test/method_channel_device_info_test.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(cyanglaz): Remove once https://github.com/flutter/flutter/issues/59879 is fixed.
-// @dart = 2.9
-
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:device_info_platform_interface/device_info_platform_interface.dart';
@@ -14,7 +11,7 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group("$MethodChannelDeviceInfo", () {
-    MethodChannelDeviceInfo methodChannelDeviceInfo;
+    late MethodChannelDeviceInfo methodChannelDeviceInfo;
 
     setUp(() async {
       methodChannelDeviceInfo = MethodChannelDeviceInfo();
@@ -162,7 +159,7 @@ void main() {
   group(
       "$MethodChannelDeviceInfo handles null value in the map returned from method channel",
       () {
-    MethodChannelDeviceInfo methodChannelDeviceInfo;
+    late MethodChannelDeviceInfo methodChannelDeviceInfo;
 
     setUp(() async {
       methodChannelDeviceInfo = MethodChannelDeviceInfo();
@@ -261,7 +258,7 @@ void main() {
   });
 
   group("$MethodChannelDeviceInfo handles method channel returns null", () {
-    MethodChannelDeviceInfo methodChannelDeviceInfo;
+    late MethodChannelDeviceInfo methodChannelDeviceInfo;
 
     setUp(() async {
       methodChannelDeviceInfo = MethodChannelDeviceInfo();
@@ -329,7 +326,7 @@ void main() {
   });
 
   group("$MethodChannelDeviceInfo android handles null values in list", () {
-    MethodChannelDeviceInfo methodChannelDeviceInfo;
+    late MethodChannelDeviceInfo methodChannelDeviceInfo;
 
     setUp(() async {
       methodChannelDeviceInfo = MethodChannelDeviceInfo();
@@ -339,9 +336,9 @@ void main() {
         switch (methodCall.method) {
           case 'getAndroidDeviceInfo':
             return ({
-              "supported32BitAbis": <String>["x86", null],
-              "supported64BitAbis": <String>["x86_64", null],
-              "supportedAbis": <String>["x86_64", "x86", null],
+              "supported32BitAbis": <String>["x86"],
+              "supported64BitAbis": <String>["x86_64"],
+              "supportedAbis": <String>["x86_64", "x86"],
               "systemFeatures": <String>[
                 "android.hardware.sensor.proximity",
                 "android.software.adoptable_storage",
@@ -349,7 +346,6 @@ void main() {
                 "android.hardware.faketouch",
                 "android.software.backup",
                 "android.hardware.touchscreen",
-                null
               ],
             });
           default:


### PR DESCRIPTION
Removes the opt-out now that the underlying issue is fixed

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
