### PR TITLE
[share] Migrate unit tests to null-safety.

### DIFF
--- a/packages/share/CHANGELOG.md
+++ b/packages/share/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+* Migrate unit tests to sound null safety.
+
 ## 2.0.0
 
 * Migrate to null safety.

--- a/packages/share/pubspec.yaml
+++ b/packages/share/pubspec.yaml
@@ -2,7 +2,7 @@ name: share
 description: Flutter plugin for sharing content via the platform share UI, using
   the ACTION_SEND intent on Android and UIActivityViewController on iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/share
-version: 2.0.0
+version: 2.0.1
 
 flutter:
   plugin:
@@ -20,8 +20,6 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  test: ^1.16.3
-  mockito: ^5.0.0-nullsafety.7
   flutter_test:
     sdk: flutter
   integration_test:

--- a/packages/share/test/share_test.dart
+++ b/packages/share/test/share_test.dart
@@ -2,38 +2,33 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.9
-
 import 'dart:io';
 import 'dart:ui';
 
-import 'package:flutter_test/flutter_test.dart' show TestWidgetsFlutterBinding;
-import 'package:mockito/mockito.dart';
-import 'package:share/share.dart';
-import 'package:test/test.dart';
-
 import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:share/share.dart';
 
 void main() {
-  TestWidgetsFlutterBinding.ensureInitialized();
+  TestWidgetsFlutterBinding.ensureInitialized(); // Required for MethodChannels
 
-  MockMethodChannel mockChannel;
+  late FakeMethodChannel fakeChannel;
 
   setUp(() {
-    mockChannel = MockMethodChannel();
-    // Re-pipe to mockito for easier verifies.
+    fakeChannel = FakeMethodChannel();
+    // Re-pipe to our fake to verify invocations.
     Share.channel.setMockMethodCallHandler((MethodCall call) async {
       // The explicit type can be void as the only method call has a return type of void.
-      await mockChannel.invokeMethod<void>(call.method, call.arguments);
+      await fakeChannel.invokeMethod<void>(call.method, call.arguments);
     });
   });
 
   test('sharing empty fails', () {
     expect(
       () => Share.share(''),
-      throwsA(const TypeMatcher<AssertionError>()),
+      throwsA(isA<AssertionError>()),
     );
-    verifyZeroInteractions(mockChannel);
+    expect(fakeChannel.invocation, isNull);
   });
 
   test('sharing origin sets the right params', () async {
@@ -42,22 +37,28 @@ void main() {
       subject: 'some subject to share',
       sharePositionOrigin: const Rect.fromLTWH(1.0, 2.0, 3.0, 4.0),
     );
-    verify(mockChannel.invokeMethod<void>('share', <String, dynamic>{
-      'text': 'some text to share',
-      'subject': 'some subject to share',
-      'originX': 1.0,
-      'originY': 2.0,
-      'originWidth': 3.0,
-      'originHeight': 4.0,
-    }));
+
+    expect(
+      fakeChannel.invocation,
+      equals({
+        'share': {
+          'text': 'some text to share',
+          'subject': 'some subject to share',
+          'originX': 1.0,
+          'originY': 2.0,
+          'originWidth': 3.0,
+          'originHeight': 4.0,
+        }
+      }),
+    );
   });
 
   test('sharing empty file fails', () {
     expect(
       () => Share.shareFiles(['']),
-      throwsA(const TypeMatcher<AssertionError>()),
+      throwsA(isA<AssertionError>()),
     );
-    verifyZeroInteractions(mockChannel);
+    expect(fakeChannel.invocation, isNull);
   });
 
   test('sharing file sets correct mimeType', () async {
@@ -65,11 +66,18 @@ void main() {
     final File file = File(path);
     try {
       file.createSync();
+
       await Share.shareFiles([path]);
-      verify(mockChannel.invokeMethod('shareFiles', <String, dynamic>{
-        'paths': [path],
-        'mimeTypes': ['image/png'],
-      }));
+
+      expect(
+        fakeChannel.invocation,
+        equals({
+          'shareFiles': {
+            'paths': [path],
+            'mimeTypes': ['image/png'],
+          }
+        }),
+      );
     } finally {
       file.deleteSync();
     }
@@ -80,15 +88,30 @@ void main() {
     final File file = File(path);
     try {
       file.createSync();
+
       await Share.shareFiles([path], mimeTypes: ['*/*']);
-      verify(mockChannel.invokeMethod('shareFiles', <String, dynamic>{
-        'paths': [file.path],
-        'mimeTypes': ['*/*'],
-      }));
+
+      expect(
+        fakeChannel.invocation,
+        equals({
+          'shareFiles': {
+            'paths': [file.path],
+            'mimeTypes': ['*/*'],
+          }
+        }),
+      );
     } finally {
       file.deleteSync();
     }
   });
 }
 
-class MockMethodChannel extends Mock implements MethodChannel {}
+class FakeMethodChannel extends Fake implements MethodChannel {
+  Map<String, dynamic>? invocation;
+
+  @override
+  Future<T?> invokeMethod<T>(String method, [dynamic arguments]) async {
+    this.invocation = {method: arguments};
+    return null;
+  }
+}


### PR DESCRIPTION
This PR migrates package:share unit tests to null-safety.

This removes mockito for a simpler Fake that just logs calls to the method channel.

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
