### PR TITLE
[google_maps_flutter_web] update min flutter sdk version to 1.20.0

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.1.2
 
-* Add support for Custom Tiles.
+* Update min Flutter SDK to 1.20.0
 
 ## 0.1.1
 

--- a/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.1.2
 
-* Update min Flutter SDK to 1.20.0
+* Update min Flutter SDK to 1.20.0.
 
 ## 0.1.1
 

--- a/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
@@ -33,4 +33,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.3.0 <3.0.0"
-  flutter: ">=1.10.0"
+  flutter: ">=1.20.0"


### PR DESCRIPTION
Since the plugin doesn't have an iOS folder, it is required that the min sdk version is 1.20.0
Also, it looks like the last 0.1.2 version was a mistake (made in https://github.com/cyanglaz/plugins/commit/6fa2ead23e8d58de047f38c0f90ce5e218ef8ea5) and has been published, so i only updated the changelog.

