### PR TITLE
Use Cirrus compute credits on PRs for collaborators

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,8 @@
+use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
+
 task:
   # don't run on release tags since it creates O(n^2) tasks where n is the number of plugins
   only_if: $CIRRUS_TAG == ''
-  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   container:
     dockerfile: .ci/Dockerfile
     cpu: 8
@@ -119,7 +120,6 @@ task:
 task:
   # don't run on release tags since it creates O(n^2) tasks where n is the number of plugins
   only_if: $CIRRUS_TAG == ''
-  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   container:
     dockerfile: .ci/Dockerfile-LinuxDesktop
     cpu: 8
@@ -148,7 +148,6 @@ task:
   # Xcode 12 task
   # don't run on release tags since it creates O(n^2) tasks where n is the number of plugins
   only_if: $CIRRUS_TAG == ''
-  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   osx_instance:
     image: big-sur-xcode-12.3
   upgrade_script:
@@ -208,7 +207,6 @@ task:
   # TODO(cyanglaz): merge Xcode 11 task to Xcode 12 task when all the matrix can be run in Xcode 12.
   # don't run on release tags since it creates O(n^2) tasks where n is the number of plugins
   only_if: $CIRRUS_TAG == ''
-  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   osx_instance:
     image: catalina-xcode-11.3.1-flutter
   upgrade_script:
@@ -237,7 +235,6 @@ task:
 task:
   # don't run on release tags since it creates O(n^2) tasks where n is the number of plugins
   only_if: $CIRRUS_TAG == ''
-  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   osx_instance:
     image: big-sur-xcode-12.3
   setup_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 task:
   # don't run on release tags since it creates O(n^2) tasks where n is the number of plugins
   only_if: $CIRRUS_TAG == ''
-  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
+  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   container:
     dockerfile: .ci/Dockerfile
     cpu: 8
@@ -119,7 +119,7 @@ task:
 task:
   # don't run on release tags since it creates O(n^2) tasks where n is the number of plugins
   only_if: $CIRRUS_TAG == ''
-  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
+  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   container:
     dockerfile: .ci/Dockerfile-LinuxDesktop
     cpu: 8


### PR DESCRIPTION
Always use Cirrus compute credits on PRs for members of flutter-hackers.  Avoids `Scheduling was delayed due to a concurrency limit on community tasks` preemption.

<img width="1166" alt="Screen Shot 2021-03-02 at 6 48 50 PM" src="https://user-images.githubusercontent.com/682784/109744999-18fdff80-7b88-11eb-9389-46cc219088e5.png">


This was already set for half the tasks:
https://github.com/flutter/plugins/blob/2eba00a05cc147cd89f48657d881edf21cd406db/.cirrus.yml#L151
https://github.com/flutter/plugins/blob/2eba00a05cc147cd89f48657d881edf21cd406db/.cirrus.yml#L240

For example, I've been waiting on https://cirrus-ci.com/build/5267162739769344 to schedule for more than an hour, all pre-empted due to concurrency limit on non-compute credit tasks.
<img width="538" alt="Screen Shot 2021-03-02 at 6 48 42 PM" src="https://user-images.githubusercontent.com/682784/109745380-a04b7300-7b88-11eb-88a1-d256ce652f87.png">
