### PR TITLE
[path_provider] Make a 0.0.5 for Dart 2.12 compat

### DIFF
--- a/packages/path_provider/path_provider_windows/CHANGELOG.md
+++ b/packages/path_provider/path_provider_windows/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 2.0.0
+## 0.0.5
 
-* Migrate to null safety
+* Add compatibility with Dart 2.12.
 
 ## 0.0.4+4
 

--- a/packages/path_provider/path_provider_windows/example/lib/main.dart
+++ b/packages/path_provider/path_provider_windows/example/lib/main.dart
@@ -20,10 +20,10 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-  String? _tempDirectory = 'Unknown';
-  String? _downloadsDirectory = 'Unknown';
-  String? _appSupportDirectory = 'Unknown';
-  String? _documentsDirectory = 'Unknown';
+  String _tempDirectory = 'Unknown';
+  String _downloadsDirectory = 'Unknown';
+  String _appSupportDirectory = 'Unknown';
+  String _documentsDirectory = 'Unknown';
 
   @override
   void initState() {
@@ -33,10 +33,10 @@ class _MyAppState extends State<MyApp> {
 
   // Platform messages are asynchronous, so we initialize in an async method.
   Future<void> initDirectories() async {
-    String? tempDirectory;
-    String? downloadsDirectory;
-    String? appSupportDirectory;
-    String? documentsDirectory;
+    String tempDirectory;
+    String downloadsDirectory;
+    String appSupportDirectory;
+    String documentsDirectory;
     final PathProviderWindows provider = PathProviderWindows();
 
     try {

--- a/packages/path_provider/path_provider_windows/example/pubspec.yaml
+++ b/packages/path_provider/path_provider_windows/example/pubspec.yaml
@@ -23,5 +23,5 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.11.0 <3.0.0"
   flutter: ">=1.20.0"

--- a/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_real.dart
+++ b/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_real.dart
@@ -22,7 +22,7 @@ import 'folders.dart';
 class VersionInfoQuerier {
   /// Returns the value for [key] in [versionInfo]s English strings section, or
   /// null if there is no such entry, or if versionInfo is null.
-  getStringValue(Pointer<Uint8>? versionInfo, key) {
+  getStringValue(Pointer<Uint8> versionInfo, key) {
     if (versionInfo == null) {
       return null;
     }
@@ -53,7 +53,7 @@ class PathProviderWindows extends PathProviderPlatform {
 
   /// This is typically the same as the TMP environment variable.
   @override
-  Future<String?> getTemporaryPath() async {
+  Future<String> getTemporaryPath() async {
     final buffer = calloc<Uint16>(MAX_PATH + 1).cast<Utf16>();
     String path;
 
@@ -87,7 +87,7 @@ class PathProviderWindows extends PathProviderPlatform {
   }
 
   @override
-  Future<String?> getApplicationSupportPath() async {
+  Future<String> getApplicationSupportPath() async {
     final appDataRoot = await getPath(WindowsKnownFolder.RoamingAppData);
     final directory = Directory(
         path.join(appDataRoot, _getApplicationSpecificSubdirectory()));
@@ -104,11 +104,11 @@ class PathProviderWindows extends PathProviderPlatform {
   }
 
   @override
-  Future<String?> getApplicationDocumentsPath() =>
+  Future<String> getApplicationDocumentsPath() =>
       getPath(WindowsKnownFolder.Documents);
 
   @override
-  Future<String?> getDownloadsPath() => getPath(WindowsKnownFolder.Downloads);
+  Future<String> getDownloadsPath() => getPath(WindowsKnownFolder.Downloads);
 
   /// Retrieve any known folder from Windows.
   ///
@@ -151,13 +151,13 @@ class PathProviderWindows extends PathProviderPlatform {
   /// - If the product name isn't there, it will use the exe's filename (without
   ///   extension).
   String _getApplicationSpecificSubdirectory() {
-    String? companyName;
-    String? productName;
+    String companyName;
+    String productName;
 
     final Pointer<Utf16> moduleNameBuffer =
         calloc<Uint16>(MAX_PATH + 1).cast<Utf16>();
     final Pointer<Uint32> unused = calloc<Uint32>();
-    Pointer<Uint8>? infoBuffer;
+    Pointer<Uint8> infoBuffer;
     try {
       // Get the module name.
       final moduleNameLength = GetModuleFileName(0, moduleNameBuffer, MAX_PATH);
@@ -203,7 +203,7 @@ class PathProviderWindows extends PathProviderPlatform {
   /// https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions
   ///
   /// If after sanitizing the string is empty, returns null.
-  String? _sanitizedDirectoryName(String? rawString) {
+  String _sanitizedDirectoryName(String rawString) {
     if (rawString == null) {
       return null;
     }

--- a/packages/path_provider/path_provider_windows/pubspec.yaml
+++ b/packages/path_provider/path_provider_windows/pubspec.yaml
@@ -1,7 +1,7 @@
 name: path_provider_windows
 description: Windows implementation of the path_provider plugin
 homepage: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider_windows
-version: 2.0.0
+version: 0.0.5
 
 flutter:
   plugin:
@@ -11,7 +11,7 @@ flutter:
         pluginClass: none
 
 dependencies:
-  path_provider_platform_interface: ^2.0.0
+  path_provider_platform_interface: ^1.0.3
   meta: ^1.3.0
   path: ^1.8.0
   flutter:
@@ -25,5 +25,5 @@ dev_dependencies:
   pedantic: ^1.10.0
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.11.0 <3.0.0"
   flutter: ">=1.20.0"

--- a/packages/path_provider/path_provider_windows/test/path_provider_windows_test.dart
+++ b/packages/path_provider/path_provider_windows/test/path_provider_windows_test.dart
@@ -13,7 +13,7 @@ class FakeVersionInfoQuerier implements VersionInfoQuerier {
 
   final Map<String, String> responses;
 
-  getStringValue(Pointer<Uint8>? versionInfo, key) => responses[key];
+  getStringValue(Pointer<Uint8> versionInfo, key) => responses[key];
 }
 
 void main() {


### PR DESCRIPTION
Anything with a transitive dependency on `path_provider` (which is a
lot) is broken on Flutter 1.26 due to Dart FFI changes. path_provider
2.0.0 doesn't have this problem, but for transitive dependencies that
means users need to force an override in their pubspec (and more
importantly, know that they need to do so).

This creates a new minor release to path_provider_windows that uses a
1.26-friendly version of FFI, but has the null safety changes and major
version bump backed out, so that transitive dependencies can safely
resolve to this working version just by doing a pub update.

Should help avoid issues like https://github.com/flutter/flutter/issues/76705

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
