### PR TITLE
[google_maps_flutter_web] Make google_maps_flutter_web work with latest plugins 

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.2.0
 
 * Make this plugin compatible with the rest of null-safe plugins.
+* Noop tile overlays methods, so they don't crash on web.
 
 **NOTE**: This plugin is **not** null-safe yet!
 

--- a/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.0
+
+* Make this plugin compatible with the rest of null-safe plugins.
+
+**NOTE**: This plugin is **not** null-safe yet!
+
 ## 0.1.2
 
 * Update min Flutter SDK to 1.20.0.

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/convert.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/convert.dart
@@ -59,41 +59,39 @@ double _getCssOpacity(Color color) {
 // buildingsEnabled seems to not have an equivalent in web
 // padding seems to behave differently in web than mobile. You can't move UI elements in web.
 gmaps.MapOptions _rawOptionsToGmapsOptions(Map<String, dynamic> rawOptions) {
-  Map<String, dynamic> optionsUpdate = rawOptions['options'] ?? {};
-
   gmaps.MapOptions options = gmaps.MapOptions();
 
-  if (_mapTypeToMapTypeId.containsKey(optionsUpdate['mapType'])) {
-    options.mapTypeId = _mapTypeToMapTypeId[optionsUpdate['mapType']];
+  if (_mapTypeToMapTypeId.containsKey(rawOptions['mapType'])) {
+    options.mapTypeId = _mapTypeToMapTypeId[rawOptions['mapType']];
   }
 
-  if (optionsUpdate['minMaxZoomPreference'] != null) {
+  if (rawOptions['minMaxZoomPreference'] != null) {
     options
-      ..minZoom = optionsUpdate['minMaxZoomPreference'][0]
-      ..maxZoom = optionsUpdate['minMaxZoomPreference'][1];
+      ..minZoom = rawOptions['minMaxZoomPreference'][0]
+      ..maxZoom = rawOptions['minMaxZoomPreference'][1];
   }
 
-  if (optionsUpdate['cameraTargetBounds'] != null) {
+  if (rawOptions['cameraTargetBounds'] != null) {
     // Needs gmaps.MapOptions.restriction and gmaps.MapRestriction
     // see: https://developers.google.com/maps/documentation/javascript/reference/map#MapOptions.restriction
   }
 
-  if (optionsUpdate['zoomControlsEnabled'] != null) {
-    options.zoomControl = optionsUpdate['zoomControlsEnabled'];
+  if (rawOptions['zoomControlsEnabled'] != null) {
+    options.zoomControl = rawOptions['zoomControlsEnabled'];
   }
 
-  if (optionsUpdate['styles'] != null) {
-    options.styles = optionsUpdate['styles'];
+  if (rawOptions['styles'] != null) {
+    options.styles = rawOptions['styles'];
   }
 
-  if (optionsUpdate['scrollGesturesEnabled'] == false ||
-      optionsUpdate['zoomGesturesEnabled'] == false) {
+  if (rawOptions['scrollGesturesEnabled'] == false ||
+      rawOptions['zoomGesturesEnabled'] == false) {
     options.gestureHandling = 'none';
   } else {
     options.gestureHandling = 'auto';
   }
 
-  // These don't have any optionUpdate entry, but they seem to be off in the native maps.
+  // These don't have any rawOptions entry, but they seem to be off in the native maps.
   options.mapTypeControl = false;
   options.fullscreenControl = false;
   options.streetViewControl = false;
@@ -102,11 +100,10 @@ gmaps.MapOptions _rawOptionsToGmapsOptions(Map<String, dynamic> rawOptions) {
 }
 
 gmaps.MapOptions _applyInitialPosition(
-  Map<String, dynamic> rawOptions,
+  CameraPosition initialPosition,
   gmaps.MapOptions options,
 ) {
   // Adjust the initial position, if passed...
-  Map<String, dynamic> initialPosition = rawOptions['initialCameraPosition'];
   if (initialPosition != null) {
     final position = CameraPosition.fromMap(initialPosition);
     options.zoom = position.zoom;
@@ -118,10 +115,7 @@ gmaps.MapOptions _applyInitialPosition(
 
 // Extracts the status of the traffic layer from the rawOptions map.
 bool _isTrafficLayerEnabled(Map<String, dynamic> rawOptions) {
-  if (rawOptions['options'] == null) {
-    return false;
-  }
-  return rawOptions['options']['trafficEnabled'] ?? false;
+  return rawOptions['trafficEnabled'] ?? false;
 }
 
 // Coverts the incoming JSON object into a List of MapTypeStyler objects.
@@ -255,126 +249,6 @@ CameraPosition _gmViewportToCameraPosition(gmaps.GMap map) {
     tilt: map.tilt ?? 0,
     zoom: map.zoom?.toDouble() ?? 10,
   );
-}
-
-Set<Marker> _rawOptionsToInitialMarkers(Map<String, dynamic> rawOptions) {
-  final List<Map<String, dynamic>> list = rawOptions['markersToAdd'];
-  Set<Marker> markers = {};
-  markers.addAll(list?.map((rawMarker) {
-        Offset offset;
-        LatLng position;
-        InfoWindow infoWindow;
-        BitmapDescriptor icon;
-        if (rawMarker['anchor'] != null) {
-          offset = Offset((rawMarker['anchor'][0]), (rawMarker['anchor'][1]));
-        }
-        if (rawMarker['position'] != null) {
-          position = LatLng.fromJson(rawMarker['position']);
-        }
-        if (rawMarker['infoWindow'] != null) {
-          final String title = rawMarker['infoWindow']['title'];
-          final String snippet = rawMarker['infoWindow']['snippet'];
-          if (title != null || snippet != null) {
-            infoWindow = InfoWindow(
-              title: title ?? '',
-              snippet: snippet ?? '',
-            );
-          }
-        }
-        if (rawMarker['icon'] != null) {
-          icon = BitmapDescriptor.fromJson(rawMarker['icon']);
-        }
-        return Marker(
-          markerId: MarkerId(rawMarker['markerId']),
-          alpha: rawMarker['alpha'],
-          anchor: offset,
-          consumeTapEvents: rawMarker['consumeTapEvents'],
-          draggable: rawMarker['draggable'],
-          flat: rawMarker['flat'],
-          icon: icon,
-          infoWindow: infoWindow,
-          position: position ?? _nullLatLng,
-          rotation: rawMarker['rotation'],
-          visible: rawMarker['visible'],
-          zIndex: rawMarker['zIndex'],
-        );
-      }) ??
-      []);
-  return markers;
-}
-
-Set<Circle> _rawOptionsToInitialCircles(Map<String, dynamic> rawOptions) {
-  final List<Map<String, dynamic>> list = rawOptions['circlesToAdd'];
-  Set<Circle> circles = {};
-  circles.addAll(list?.map((rawCircle) {
-        LatLng center;
-        if (rawCircle['center'] != null) {
-          center = LatLng.fromJson(rawCircle['center']);
-        }
-        return Circle(
-          circleId: CircleId(rawCircle['circleId']),
-          consumeTapEvents: rawCircle['consumeTapEvents'],
-          fillColor: Color(rawCircle['fillColor'] ?? _defaultFillColor),
-          center: center ?? _nullLatLng,
-          radius: rawCircle['radius'],
-          strokeColor: Color(rawCircle['strokeColor'] ?? _defaultStrokeColor),
-          strokeWidth: rawCircle['strokeWidth'],
-          visible: rawCircle['visible'],
-          zIndex: rawCircle['zIndex'],
-        );
-      }) ??
-      []);
-  return circles;
-}
-
-// Unsupported on the web: endCap, jointType, patterns and startCap.
-Set<Polyline> _rawOptionsToInitialPolylines(Map<String, dynamic> rawOptions) {
-  final List<Map<String, dynamic>> list = rawOptions['polylinesToAdd'];
-  Set<Polyline> polylines = {};
-  polylines.addAll(list?.map((rawPolyline) {
-        return Polyline(
-          polylineId: PolylineId(rawPolyline['polylineId']),
-          consumeTapEvents: rawPolyline['consumeTapEvents'],
-          color: Color(rawPolyline['color'] ?? _defaultStrokeColor),
-          geodesic: rawPolyline['geodesic'],
-          visible: rawPolyline['visible'],
-          zIndex: rawPolyline['zIndex'],
-          width: rawPolyline['width'],
-          points: rawPolyline['points']
-              ?.map<LatLng>((rawPoint) => LatLng.fromJson(rawPoint))
-              ?.toList(),
-        );
-      }) ??
-      []);
-  return polylines;
-}
-
-Set<Polygon> _rawOptionsToInitialPolygons(Map<String, dynamic> rawOptions) {
-  final List<Map<String, dynamic>> list = rawOptions['polygonsToAdd'];
-  Set<Polygon> polygons = {};
-
-  polygons.addAll(list?.map((rawPolygon) {
-        return Polygon(
-          polygonId: PolygonId(rawPolygon['polygonId']),
-          consumeTapEvents: rawPolygon['consumeTapEvents'],
-          fillColor: Color(rawPolygon['fillColor'] ?? _defaultFillColor),
-          geodesic: rawPolygon['geodesic'],
-          strokeColor: Color(rawPolygon['strokeColor'] ?? _defaultStrokeColor),
-          strokeWidth: rawPolygon['strokeWidth'],
-          visible: rawPolygon['visible'],
-          zIndex: rawPolygon['zIndex'],
-          points: rawPolygon['points']
-              ?.map<LatLng>((rawPoint) => LatLng.fromJson(rawPoint))
-              ?.toList(),
-          holes: rawPolygon['holes']
-              ?.map<List<LatLng>>((List hole) => hole
-                  ?.map<LatLng>((rawPoint) => LatLng.fromJson(rawPoint))
-                  ?.toList())
-              ?.toList(),
-        );
-      }) ??
-      []);
-  return polygons;
 }
 
 // Convert plugin objects to gmaps.Options objects
@@ -550,7 +424,7 @@ gmaps.PolylineOptions _polylineOptionsFromPolyline(
 
 // Translates a [CameraUpdate] into operations on a [gmaps.GMap].
 void _applyCameraUpdate(gmaps.GMap map, CameraUpdate update) {
-  final json = update.toJson();
+  final json = update.toJson() as List<dynamic>;
   switch (json[0]) {
     case 'newCameraPosition':
       map.heading = json[1]['bearing'];

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/convert.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/convert.dart
@@ -106,8 +106,8 @@ gmaps.MapOptions _applyInitialPosition(
   // Adjust the initial position, if passed...
   if (initialPosition != null) {
     options.zoom = initialPosition.zoom;
-    options.center =
-        gmaps.LatLng(initialPosition.target.latitude, initialPosition.target.longitude);
+    options.center = gmaps.LatLng(
+        initialPosition.target.latitude, initialPosition.target.longitude);
   }
   return options;
 }

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/convert.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/convert.dart
@@ -11,8 +11,6 @@ final _nullLatLngBounds = LatLngBounds(
 );
 
 // Defaults taken from the Google Maps Platform SDK documentation.
-final _defaultStrokeColor = Colors.black.value;
-final _defaultFillColor = Colors.transparent.value;
 final _defaultCssColor = '#000000';
 final _defaultCssOpacity = 0.0;
 

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/convert.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/convert.dart
@@ -105,10 +105,9 @@ gmaps.MapOptions _applyInitialPosition(
 ) {
   // Adjust the initial position, if passed...
   if (initialPosition != null) {
-    final position = CameraPosition.fromMap(initialPosition);
-    options.zoom = position.zoom;
+    options.zoom = initialPosition.zoom;
     options.center =
-        gmaps.LatLng(position.target.latitude, position.target.longitude);
+        gmaps.LatLng(initialPosition.target.latitude, initialPosition.target.longitude);
   }
   return options;
 }

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/google_maps_flutter_web.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/google_maps_flutter_web.dart
@@ -260,31 +260,42 @@ class GoogleMapsPlugin extends GoogleMapsFlutterPlatform {
 
   @override
   Widget buildView(
-      Map<String, dynamic> creationParams,
-      Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers,
-      PlatformViewCreatedCallback onPlatformViewCreated) {
-    int mapId = creationParams.remove('_webOnlyMapCreationId');
-
-    assert(mapId != null,
+    int creationId,
+    PlatformViewCreatedCallback onPlatformViewCreated, {
+    @required CameraPosition initialCameraPosition,
+    Set<Marker> markers = const <Marker>{},
+    Set<Polygon> polygons = const <Polygon>{},
+    Set<Polyline> polylines = const <Polyline>{},
+    Set<Circle> circles = const <Circle>{},
+    Set<TileOverlay> tileOverlays = const <TileOverlay>{},
+    Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers =
+        const <Factory<OneSequenceGestureRecognizer>>{},
+    Map<String, dynamic> mapOptions = const <String, dynamic>{},
+  }) {
+    assert(creationId != null,
         'buildView needs a `_webOnlyMapCreationId` in its creationParams to prevent widget reloads in web.');
 
-    // Bail fast if we've already rendered this mapId...
-    if (_mapById[mapId]?.widget != null) {
-      return _mapById[mapId].widget;
+    // Bail fast if we've already rendered this map ID...
+    if (_mapById[creationId]?.widget != null) {
+      return _mapById[creationId].widget;
     }
 
     final StreamController<MapEvent> controller =
         StreamController<MapEvent>.broadcast();
 
     final mapController = GoogleMapController(
-      mapId: mapId,
+      mapId: creationId,
       streamController: controller,
-      rawOptions: creationParams,
+      markers: markers,
+      polygons: polygons,
+      polylines: polylines,
+      circles: circles,
+      mapOptions: mapOptions,
     );
 
-    _mapById[mapId] = mapController;
+    _mapById[creationId] = mapController;
 
-    onPlatformViewCreated.call(mapId);
+    onPlatformViewCreated.call(creationId);
 
     return mapController.widget;
   }

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/google_maps_flutter_web.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/google_maps_flutter_web.dart
@@ -86,6 +86,22 @@ class GoogleMapsPlugin extends GoogleMapsFlutterPlatform {
     _map(mapId).updateCircles(circleUpdates);
   }
 
+  @override
+  Future<void> updateTileOverlays({
+    @required Set<TileOverlay> newTileOverlays,
+    @required int mapId,
+  }) async {
+    return; // Noop for now!
+  }
+
+  @override
+  Future<void> clearTileCache(
+    TileOverlayId tileOverlayId, {
+    @required int mapId,
+  }) async {
+    return; // Noop for now!
+  }
+
   /// Applies the given `cameraUpdate` to the current viewport (with animation).
   @override
   Future<void> animateCamera(

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/google_maps_flutter_web.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/google_maps_flutter_web.dart
@@ -300,6 +300,7 @@ class GoogleMapsPlugin extends GoogleMapsFlutterPlatform {
         StreamController<MapEvent>.broadcast();
 
     final mapController = GoogleMapController(
+      initialCameraPosition: initialCameraPosition,
       mapId: creationId,
       streamController: controller,
       markers: markers,

--- a/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
@@ -16,18 +16,18 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   meta: ^1.1.7
-  google_maps_flutter_platform_interface: ^1.1.0
+  google_maps_flutter_platform_interface: ^2.0.1
   google_maps: ^3.4.5
-  stream_transform: ^1.2.0
-  sanitize_html: ^1.4.1
+  stream_transform: ^2.0.0
+  sanitize_html: ^2.0.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  http: ^0.12.2
-  url_launcher: ^5.2.5
+  http: ^0.13.0
+  url_launcher: ^6.0.2
   pedantic: ^1.8.0
-  mockito: ^4.1.1
+  mockito: ^5.0.0
   integration_test:
     path: ../../integration_test
 

--- a/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: google_maps_flutter_web
 description: Web platform implementation of google_maps_flutter
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter
-version: 0.1.2
+version: 0.2.0
 
 flutter:
   plugin:
@@ -15,7 +15,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  meta: ^1.1.7
+  meta: ^1.3.0
   google_maps_flutter_platform_interface: ^2.0.1
   google_maps: ^3.4.5
   stream_transform: ^2.0.0

--- a/packages/google_maps_flutter/google_maps_flutter_web/test/test_driver/google_maps_controller_integration.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/test/test_driver/google_maps_controller_integration.dart
@@ -51,19 +51,22 @@ void main() {
 
     // Creates a controller with the default mapId and stream controller, and any `options` needed.
     GoogleMapController _createController({
-    CameraPosition initialCameraPosition = const CameraPosition(target: LatLng(0,0)),
-    Set<Marker> markers = const <Marker>{},
-    Set<Polygon> polygons = const <Polygon>{},
-    Set<Polyline> polylines = const <Polyline>{},
-    Set<Circle> circles = const <Circle>{},Map<String, dynamic> options,}) {
+      CameraPosition initialCameraPosition =
+          const CameraPosition(target: LatLng(0, 0)),
+      Set<Marker> markers = const <Marker>{},
+      Set<Polygon> polygons = const <Polygon>{},
+      Set<Polyline> polylines = const <Polyline>{},
+      Set<Circle> circles = const <Circle>{},
+      Map<String, dynamic> options,
+    }) {
       return GoogleMapController(
           mapId: mapId,
           streamController: stream,
           initialCameraPosition: initialCameraPosition,
           markers: markers,
           polygons: polygons,
-polylines: polylines,
-circles: circles,
+          polylines: polylines,
+          circles: circles,
           mapOptions: options ?? <String, dynamic>{});
     }
 
@@ -153,50 +156,45 @@ circles: circles,
       });
 
       testWidgets('renders initial geometry', (WidgetTester tester) async {
-        controller = _createController(
-          circles: <Circle>{Circle(circleId:CircleId('circle-1'))},
-          markers: <Marker>{Marker(markerId:MarkerId('marker-1'), infoWindow: InfoWindow(title:'title for test',snippet: 'snippet for test'))},
-
-          options: {
-          'polygonsToAdd': [
-            {
-              'polygonId': 'polygon-1',
-              'points': [
-                [43.355114, -5.851333],
-                [43.354797, -5.851860],
-                [43.354469, -5.851318],
-                [43.354762, -5.850824],
-              ],
-            },
-            {
-              'polygonId': 'polygon-2-with-holes',
-              'points': [
-                [43.355114, -5.851333],
-                [43.354797, -5.851860],
-                [43.354469, -5.851318],
-                [43.354762, -5.850824],
-              ],
-              'holes': [
-                [
-                  [41.354797, -6.851860],
-                  [41.354469, -6.851318],
-                  [41.354762, -6.850824],
-                ]
+        controller = _createController(circles: <Circle>{
+          Circle(circleId: CircleId('circle-1'))
+        }, markers: <Marker>{
+          Marker(
+              markerId: MarkerId('marker-1'),
+              infoWindow: InfoWindow(
+                  title: 'title for test', snippet: 'snippet for test'))
+        }, polygons: {
+          Polygon(polygonId: PolygonId('polygon-1'), points: [
+            LatLng(43.355114, -5.851333),
+            LatLng(43.354797, -5.851860),
+            LatLng(43.354469, -5.851318),
+            LatLng(43.354762, -5.850824),
+          ]),
+          Polygon(
+            polygonId: PolygonId('polygon-2-with-holes'),
+            points: [
+              LatLng(43.355114, -5.851333),
+              LatLng(43.354797, -5.851860),
+              LatLng(43.354469, -5.851318),
+              LatLng(43.354762, -5.850824),
+            ],
+            holes: [
+              [
+                LatLng(41.354797, -6.851860),
+                LatLng(41.354469, -6.851318),
+                LatLng(41.354762, -6.850824),
               ]
-            },
-          ],
-          'polylinesToAdd': [
-            {
-              'polylineId': 'polyline-1',
-              'points': [
-                [43.355114, -5.851333],
-                [43.354797, -5.851860],
-                [43.354469, -5.851318],
-                [43.354762, -5.850824],
-              ],
-            },
-          ],
+            ],
+          ),
+        }, polylines: {
+          Polyline(polylineId: PolylineId('polyline-1'), points: [
+            LatLng(43.355114, -5.851333),
+            LatLng(43.354797, -5.851860),
+            LatLng(43.354469, -5.851318),
+            LatLng(43.354762, -5.850824),
+          ])
         });
+
         controller.debugSetOverrides(
           circles: circles,
           markers: markers,
@@ -228,14 +226,10 @@ circles: circles,
 
       testWidgets('empty infoWindow does not create InfoWindow instance.',
           (WidgetTester tester) async {
-        controller = _createController(options: {XXX
-          'markersToAdd': [
-            {
-              'markerId': 'marker-1',
-              'infoWindow': {},
-            },
-          ],
+        controller = _createController(markers: {
+          Marker(markerId: MarkerId('marker-1'), infoWindow: null),
         });
+
         controller.debugSetOverrides(
           markers: markers,
         );
@@ -255,8 +249,8 @@ circles: circles,
         });
         testWidgets('translates initial options', (WidgetTester tester) async {
           controller = _createController(options: {
-              'mapType': 2,
-              'zoomControlsEnabled': true,
+            'mapType': 2,
+            'zoomControlsEnabled': true,
           });
           controller.debugSetOverrides(createMap: (_, options) {
             capturedOptions = options;
@@ -276,7 +270,7 @@ circles: circles,
         testWidgets('disables gestureHandling with scrollGesturesEnabled false',
             (WidgetTester tester) async {
           controller = _createController(options: {
-              'scrollGesturesEnabled': false,
+            'scrollGesturesEnabled': false,
           });
           controller.debugSetOverrides(createMap: (_, options) {
             capturedOptions = options;
@@ -294,7 +288,7 @@ circles: circles,
         testWidgets('disables gestureHandling with zoomGesturesEnabled false',
             (WidgetTester tester) async {
           controller = _createController(options: {
-              'zoomGesturesEnabled': false,
+            'zoomGesturesEnabled': false,
           });
           controller.debugSetOverrides(createMap: (_, options) {
             capturedOptions = options;
@@ -311,7 +305,10 @@ circles: circles,
 
         testWidgets('does not set initial position if absent',
             (WidgetTester tester) async {
-          controller = _createController();
+          controller = _createController(
+            initialCameraPosition: null,
+          );
+
           controller.debugSetOverrides(createMap: (_, options) {
             capturedOptions = options;
             return map;
@@ -326,14 +323,15 @@ circles: circles,
 
         testWidgets('sets initial position when passed',
             (WidgetTester tester) async {
-          controller = _createController(options: {
-            'initialCameraPosition': {XXX
-              'target': [43.308, -5.6910],
-              'zoom': 12,
-              'bearing': 0,
-              'tilt': 0,
-            }
-          });
+          controller = _createController(
+            initialCameraPosition: CameraPosition(
+              target: LatLng(43.308, -5.6910),
+              zoom: 12,
+              bearing: 0,
+              tilt: 0,
+            ),
+          );
+
           controller.debugSetOverrides(createMap: (_, options) {
             capturedOptions = options;
             return map;
@@ -357,7 +355,7 @@ circles: circles,
         testWidgets('initializes with traffic layer',
             (WidgetTester tester) async {
           controller = _createController(options: {
-              'trafficEnabled': true,
+            'trafficEnabled': true,
           });
           controller.debugSetOverrides(createMap: (_, __) => map);
           controller.init();

--- a/packages/google_maps_flutter/google_maps_flutter_web/test/test_driver/google_maps_controller_integration.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/test/test_driver/google_maps_controller_integration.dart
@@ -50,11 +50,21 @@ void main() {
     StreamController<MapEvent> stream;
 
     // Creates a controller with the default mapId and stream controller, and any `options` needed.
-    GoogleMapController _createController({Map<String, dynamic> options}) {
+    GoogleMapController _createController({
+    CameraPosition initialCameraPosition = const CameraPosition(target: LatLng(0,0)),
+    Set<Marker> markers = const <Marker>{},
+    Set<Polygon> polygons = const <Polygon>{},
+    Set<Polyline> polylines = const <Polyline>{},
+    Set<Circle> circles = const <Circle>{},Map<String, dynamic> options,}) {
       return GoogleMapController(
           mapId: mapId,
           streamController: stream,
-          rawOptions: options ?? <String, dynamic>{});
+          initialCameraPosition: initialCameraPosition,
+          markers: markers,
+          polygons: polygons,
+polylines: polylines,
+circles: circles,
+          mapOptions: options ?? <String, dynamic>{});
     }
 
     setUp(() {
@@ -143,19 +153,11 @@ void main() {
       });
 
       testWidgets('renders initial geometry', (WidgetTester tester) async {
-        controller = _createController(options: {
-          'circlesToAdd': [
-            {'circleId': 'circle-1'}
-          ],
-          'markersToAdd': [
-            {
-              'markerId': 'marker-1',
-              'infoWindow': {
-                'title': 'title for test',
-                'snippet': 'snippet for test',
-              },
-            },
-          ],
+        controller = _createController(
+          circles: <Circle>{Circle(circleId:CircleId('circle-1'))},
+          markers: <Marker>{Marker(markerId:MarkerId('marker-1'), infoWindow: InfoWindow(title:'title for test',snippet: 'snippet for test'))},
+
+          options: {
           'polygonsToAdd': [
             {
               'polygonId': 'polygon-1',
@@ -226,7 +228,7 @@ void main() {
 
       testWidgets('empty infoWindow does not create InfoWindow instance.',
           (WidgetTester tester) async {
-        controller = _createController(options: {
+        controller = _createController(options: {XXX
           'markersToAdd': [
             {
               'markerId': 'marker-1',
@@ -253,10 +255,8 @@ void main() {
         });
         testWidgets('translates initial options', (WidgetTester tester) async {
           controller = _createController(options: {
-            'options': {
               'mapType': 2,
               'zoomControlsEnabled': true,
-            }
           });
           controller.debugSetOverrides(createMap: (_, options) {
             capturedOptions = options;
@@ -276,9 +276,7 @@ void main() {
         testWidgets('disables gestureHandling with scrollGesturesEnabled false',
             (WidgetTester tester) async {
           controller = _createController(options: {
-            'options': {
               'scrollGesturesEnabled': false,
-            }
           });
           controller.debugSetOverrides(createMap: (_, options) {
             capturedOptions = options;
@@ -296,9 +294,7 @@ void main() {
         testWidgets('disables gestureHandling with zoomGesturesEnabled false',
             (WidgetTester tester) async {
           controller = _createController(options: {
-            'options': {
               'zoomGesturesEnabled': false,
-            }
           });
           controller.debugSetOverrides(createMap: (_, options) {
             capturedOptions = options;
@@ -331,7 +327,7 @@ void main() {
         testWidgets('sets initial position when passed',
             (WidgetTester tester) async {
           controller = _createController(options: {
-            'initialCameraPosition': {
+            'initialCameraPosition': {XXX
               'target': [43.308, -5.6910],
               'zoom': 12,
               'bearing': 0,
@@ -361,9 +357,7 @@ void main() {
         testWidgets('initializes with traffic layer',
             (WidgetTester tester) async {
           controller = _createController(options: {
-            'options': {
               'trafficEnabled': true,
-            }
           });
           controller.debugSetOverrides(createMap: (_, __) => map);
           controller.init();

--- a/packages/google_maps_flutter/google_maps_flutter_web/test/test_driver/google_maps_plugin_integration.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/test/test_driver/google_maps_plugin_integration.dart
@@ -175,11 +175,13 @@ void main() {
       });
       // Options
       testWidgets('updateTileOverlays', (WidgetTester tester) async {
-        final update = plugin.updateTileOverlays(mapId: mapId, newTileOverlays: {});
+        final update =
+            plugin.updateTileOverlays(mapId: mapId, newTileOverlays: {});
         expect(update, completion(null));
       });
       testWidgets('updateTileOverlays', (WidgetTester tester) async {
-        final update = plugin.clearTileCache(TileOverlayId('any'), mapId: mapId);
+        final update =
+            plugin.clearTileCache(TileOverlayId('any'), mapId: mapId);
         expect(update, completion(null));
       });
     });

--- a/packages/google_maps_flutter/google_maps_flutter_web/test/test_driver/google_maps_plugin_integration.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/test/test_driver/google_maps_plugin_integration.dart
@@ -70,11 +70,16 @@ void main() {
 
     group('buildView', () {
       final testMapId = 33930;
+      final initialCameraPosition = CameraPosition(target: LatLng(0, 0));
 
       testWidgets('throws without _webOnlyMapCreationId',
           (WidgetTester tester) async {
         expect(
-          () => plugin.buildView({}, null, onPlatformViewCreated),
+          () => plugin.buildView(
+            null,
+            onPlatformViewCreated,
+            initialCameraPosition: initialCameraPosition,
+          ),
           throwsAssertionError,
           reason:
               '_webOnlyMapCreationId is mandatory to prevent unnecessary reloads in web.',
@@ -87,9 +92,11 @@ void main() {
         final Map<int, GoogleMapController> cache = {};
         plugin.debugSetMapById(cache);
 
-        final HtmlElementView widget = plugin.buildView({
-          '_webOnlyMapCreationId': testMapId,
-        }, null, onPlatformViewCreated);
+        final HtmlElementView widget = plugin.buildView(
+          testMapId,
+          onPlatformViewCreated,
+          initialCameraPosition: initialCameraPosition,
+        );
 
         expect(
           widget.viewType,
@@ -116,9 +123,11 @@ void main() {
         when(controller.widget).thenReturn(expected);
         plugin.debugSetMapById({testMapId: controller});
 
-        final widget = plugin.buildView({
-          '_webOnlyMapCreationId': testMapId,
-        }, null, onPlatformViewCreated);
+        final widget = plugin.buildView(
+          testMapId,
+          onPlatformViewCreated,
+          initialCameraPosition: initialCameraPosition,
+        );
 
         expect(widget, equals(expected));
         expect(
@@ -176,28 +185,28 @@ void main() {
       });
       // Geometry
       testWidgets('updateMarkers', (WidgetTester tester) async {
-        final expectedUpdates = MarkerUpdates.from(null, null);
+        final expectedUpdates = MarkerUpdates.from({}, {});
 
         await plugin.updateMarkers(expectedUpdates, mapId: mapId);
 
         verify(controller.updateMarkers(expectedUpdates));
       });
       testWidgets('updatePolygons', (WidgetTester tester) async {
-        final expectedUpdates = PolygonUpdates.from(null, null);
+        final expectedUpdates = PolygonUpdates.from({}, {});
 
         await plugin.updatePolygons(expectedUpdates, mapId: mapId);
 
         verify(controller.updatePolygons(expectedUpdates));
       });
       testWidgets('updatePolylines', (WidgetTester tester) async {
-        final expectedUpdates = PolylineUpdates.from(null, null);
+        final expectedUpdates = PolylineUpdates.from({}, {});
 
         await plugin.updatePolylines(expectedUpdates, mapId: mapId);
 
         verify(controller.updatePolylines(expectedUpdates));
       });
       testWidgets('updateCircles', (WidgetTester tester) async {
-        final expectedUpdates = CircleUpdates.from(null, null);
+        final expectedUpdates = CircleUpdates.from({}, {});
 
         await plugin.updateCircles(expectedUpdates, mapId: mapId);
 

--- a/packages/google_maps_flutter/google_maps_flutter_web/test/test_driver/google_maps_plugin_integration.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/test/test_driver/google_maps_plugin_integration.dart
@@ -168,6 +168,22 @@ void main() {
       });
     });
 
+    group('Noop methods:', () {
+      int mapId = 0;
+      setUp(() {
+        plugin.debugSetMapById({mapId: controller});
+      });
+      // Options
+      testWidgets('updateTileOverlays', (WidgetTester tester) async {
+        final update = plugin.updateTileOverlays(mapId: mapId, newTileOverlays: {});
+        expect(update, completion(null));
+      });
+      testWidgets('updateTileOverlays', (WidgetTester tester) async {
+        final update = plugin.clearTileCache(TileOverlayId('any'), mapId: mapId);
+        expect(update, completion(null));
+      });
+    });
+
     // These methods only pass-through values from the plugin to the controller
     // so we verify them all together here...
     group('Pass-through methods:', () {

--- a/script/nnbd_plugins.sh
+++ b/script/nnbd_plugins.sh
@@ -34,7 +34,6 @@ readonly NNBD_PLUGINS_LIST=(
   "webview_flutter"
   "wifi_info_flutter"
   "in_app_purchase"
-  "extension_google_sign_in_as_googleapis_auth"
   "google_maps_flutter_web" # Not yet migrated, but compatible with others
 )
 
@@ -43,6 +42,7 @@ readonly NNBD_PLUGINS_LIST=(
 # building the all plugins app. This list should be kept empty.
 
 readonly NON_NNBD_PLUGINS_LIST=(
+  "extension_google_sign_in_as_googleapis_auth" # Some deps are still clashing
 )
 
 export EXCLUDED_PLUGINS_FROM_STABLE=$(IFS=, ; echo "${NNBD_PLUGINS_LIST[*]}")

--- a/script/nnbd_plugins.sh
+++ b/script/nnbd_plugins.sh
@@ -34,6 +34,8 @@ readonly NNBD_PLUGINS_LIST=(
   "webview_flutter"
   "wifi_info_flutter"
   "in_app_purchase"
+  "extension_google_sign_in_as_googleapis_auth"
+  "google_maps_flutter_web" # Not yet migrated, but compatible with others
 )
 
 # This list contains the list of plugins that have *not* been
@@ -41,8 +43,6 @@ readonly NNBD_PLUGINS_LIST=(
 # building the all plugins app. This list should be kept empty.
 
 readonly NON_NNBD_PLUGINS_LIST=(
-  "extension_google_sign_in_as_googleapis_auth"
-  "google_maps_flutter_web" # Not yet migrated.
 )
 
 export EXCLUDED_PLUGINS_FROM_STABLE=$(IFS=, ; echo "${NNBD_PLUGINS_LIST[*]}")


### PR DESCRIPTION
google_maps_flutter_web NNBD migration is currently blocked, but this is an attempt to make a non-NNBD version that's uses the NNBD version of all dependencies for compatibility with the latest versions of other plugins.


## Testing

* Tested manually in google_maps_flutter example app, with `// @dart=2.9` in its main.dart file.
* All tests pass:

<details>

<summary>Output</summary>

```
plugins/packages/google_maps_flutter/google_maps_flutter_web/test$ ./run_test

chromedriver is running.
No target specified, running all tests...
xargs: warning: options --max-args and --replace/-I/-i are mutually exclusive, ignoring previous --max-args value
flutter drive -d web-server '--web-port=7357' '--browser-name=chrome' '--target=test_driver/marker_integration.dart'
Running "flutter pub get" in test...                               773ms
Launching test_driver/marker_integration.dart on Web Server in debug mode...
Waiting for connection from debug service on Web Server...         18.7s
test_driver/marker_integration.dart is being served at http://localhost:7357
The web-server device requires the Dart Debug Chrome extension for debugging. Consider using the Chrome or Edge devices for an improved development workflow.
Application finished.
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +0: MarkerController onTap gets called"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +1: MarkerController onDragEnd gets called"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +2: MarkerController update"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +3: MarkerController infoWindow null, showInfoWindow."
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +4: MarkerController showInfoWindow"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +5: MarkerController hideInfoWindow"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +6: (tearDownAll)"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "Warning: integration_test test plugin was not detected."
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +7: All tests passed!"
All tests passed.
flutter drive -d web-server '--web-port=7357' '--browser-name=chrome' '--target=test_driver/markers_integration.dart'
Running "flutter pub get" in test...                               822ms
Launching test_driver/markers_integration.dart on Web Server in debug mode...
Waiting for connection from debug service on Web Server...         18.6s
test_driver/markers_integration.dart is being served at http://localhost:7357
The web-server device requires the Dart Debug Chrome extension for debugging. Consider using the Chrome or Edge devices for an improved development workflow.
Application finished.
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +0: MarkersController addMarkers"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +1: MarkersController changeMarkers"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +2: MarkersController removeMarkers"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +3: MarkersController InfoWindow show/hide"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +4: MarkersController only single InfoWindow is visible"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +5: MarkersController markers with icon:null work"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +6: MarkersController markers with custom bitmap icon work"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +7: MarkersController InfoWindow snippet can have links"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +8: MarkersController InfoWindow content is clickable"
All tests passed.
flutter drive -d web-server '--web-port=7357' '--browser-name=chrome' '--target=test_driver/shape_integration.dart'
Running "flutter pub get" in test...                               794ms
Launching test_driver/shape_integration.dart on Web Server in debug mode...
Waiting for connection from debug service on Web Server...         18.3s
test_driver/shape_integration.dart is being served at http://localhost:7357
The web-server device requires the Dart Debug Chrome extension for debugging. Consider using the Chrome or Edge devices for an improved development workflow.
Application finished.
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +0: CircleController onTap gets called"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +1: CircleController update"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +2: PolygonController onTap gets called"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +3: PolygonController update"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +4: PolylineController onTap gets called"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +5: PolylineController update"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +6: (tearDownAll)"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "Warning: integration_test test plugin was not detected."
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +7: All tests passed!"
All tests passed.
flutter drive -d web-server '--web-port=7357' '--browser-name=chrome' '--target=test_driver/shapes_integration.dart'
Running "flutter pub get" in test...                               729ms
Launching test_driver/shapes_integration.dart on Web Server in debug mode...
Waiting for connection from debug service on Web Server...         18.7s
test_driver/shapes_integration.dart is being served at http://localhost:7357
The web-server device requires the Dart Debug Chrome extension for debugging. Consider using the Chrome or Edge devices for an improved development workflow.
Application finished.
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +0: CirclesController addCircles"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +1: CirclesController changeCircles"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +2: CirclesController removeCircles"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +3: CirclesController Converts colors to CSS"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +4: PolygonsController addPolygons"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +5: PolygonsController changePolygons"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +6: PolygonsController removePolygons"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +7: PolygonsController Converts colors to CSS"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +8: PolygonsController Handle Polygons with holes"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +9: PolygonsController Polygon with hole has a hole"
All tests passed.
flutter drive -d web-server '--web-port=7357' '--browser-name=chrome' '--target=test_driver/google_maps_plugin_integration.dart'
Running "flutter pub get" in test...                               817ms
Launching test_driver/google_maps_plugin_integration.dart on Web Server in debug mode...
Waiting for connection from debug service on Web Server...         19.0s
test_driver/google_maps_plugin_integration.dart is being served at http://localhost:7357
The web-server device requires the Dart Debug Chrome extension for debugging. Consider using the Chrome or Edge devices for an improved development workflow.
Application finished.
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +0: GoogleMapsPlugin init/dispose before buildWidget init throws assertion"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +1: GoogleMapsPlugin init/dispose after buildWidget init initializes controller"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +2: GoogleMapsPlugin init/dispose after buildWidget cannot call methods after dispose"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +3: GoogleMapsPlugin buildView throws without _webOnlyMapCreationId"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +4: GoogleMapsPlugin buildView returns an HtmlElementView and caches the controller for later"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +5: GoogleMapsPlugin buildView returns cached instance if it already exists"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +6: GoogleMapsPlugin setMapStyles translates styles for controller"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +7: GoogleMapsPlugin Noop methods: updateTileOverlays"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +8: GoogleMapsPlugin Noop methods: updateTileOverlays"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +9: GoogleMapsPlugin Pass-through methods: updateMapOptions"
All tests passed.
flutter drive -d web-server '--web-port=7357' '--browser-name=chrome' '--target=test_driver/google_maps_controller_integration.dart'
Running "flutter pub get" in test...                               816ms
Launching test_driver/google_maps_controller_integration.dart on Web Server in debug mode...
Waiting for connection from debug service on Web Server...         18.4s
test_driver/google_maps_controller_integration.dart is being served at http://localhost:7357
The web-server device requires the Dart Debug Chrome extension for debugging. Consider using the Chrome or Edge devices for an improved development workflow.
Application finished.
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +0: GoogleMapController construct/dispose constructor creates widget"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +1: GoogleMapController construct/dispose widget is cached when reused"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +2: GoogleMapController construct/dispose dispose closes the stream and removes the widget"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +3: GoogleMapController init listens to map events"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +4: GoogleMapController init binds geometry controllers to map's"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +5: GoogleMapController init renders initial geometry"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +6: GoogleMapController init empty infoWindow does not create InfoWindow instance."
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +7: GoogleMapController init Initialization options translates initial options"
[INFO]: http://localhost:7357/dart_sdk.js 28041:14 "00:00 +8: GoogleMapController init Initialization options disables gestureHandling with scrollGesturesEnabled false"
All tests passed.

```

</details>


## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
