### PR TITLE
[google_maps_flutter_web] Downgrade mockito in example app.

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_web/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
 dev_dependencies:
   google_maps: ^3.4.4
   http: ^0.13.0
-  mockito: ^5.0.0
+  mockito: ^4.1.4 # Update to ^5.0.0 as soon as this migrates to null-safety
   flutter_driver:
     sdk: flutter
   flutter_test:


### PR DESCRIPTION
Mockito 5 + integration_test from SDK in stable are not compatible:

```
google_maps_flutter_web/example$ flutter analyze

Because every version of integration_test from sdk depends on crypto 2.1.5 and analyzer >=1.0.0 depends on crypto ^3.0.0, integration_test from sdk is incompatible with analyzer >=1.0.0.
And because mockito 5.0.0 depends on analyzer ^1.0.0 and no versions of mockito match >5.0.0 <6.0.0, integration_test from sdk is incompatible with mockito ^5.0.0.
So, because google_maps_flutter_web_integration_tests depends on both mockito ^5.0.0 and integration_test any from sdk, version solving failed.

Running "flutter pub get" in example...                                 

pub get failed (1; So, because google_maps_flutter_web_integration_tests depends on both mockito ^5.0.0 and integration_test any from sdk, version solving failed.)
```

This is now apparent because the minimum flutter version that we have for "the next stable after 3/3" is ">=1.27.0", however we're now in "2.0.0" (so it passes, when it shouldn't. We now really mean ">=2.1.0", but that'd break CI in stable as well).

This PR downgrades the mockito dependency so it's compatible with the integration_test package that lives in the stable version of the SDK.

## Testing

* Ran tests, `flutter analyze` and `flutter build web` both in `stable` and `master` channels

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
