### PR TITLE
[in_app_purchases]specify cannot test on ios simulator.

### DIFF
--- a/packages/in_app_purchase/README.md
+++ b/packages/in_app_purchase/README.md
@@ -201,6 +201,9 @@ PurchaseParam purchaseParam = PurchaseParam(
 InAppPurchaseConnection.instance
     .buyNonConsumable(purchaseParam: purchaseParam);
 ```
+**Note**
+
+To test your In App functionality against the In App Purchase sandbox, connect your device to your development workstation then choose iPhone Device as the Active SDK—the StoreKit APIs are not available in the iPhone simulator.
 
 ## Development
 


### PR DESCRIPTION
Adds API docs and readme to tell the user that In-app Purchases cannot be tested on a simulator as StoreKit API is not supported on the simulator 

closes flutter/flutter#74181

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [ x I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

