### PR TITLE
Implemented 2860 and added Unit Test to test functionality

### DIFF
--- a/packages/image_picker/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
+++ b/packages/image_picker/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
@@ -23,8 +23,11 @@
 
 package io.flutter.plugins.imagepicker;
 
+import android.content.ContentResolver;
 import android.content.Context;
 import android.net.Uri;
+import android.webkit.MimeTypeMap;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -39,7 +42,7 @@ class FileUtils {
     OutputStream outputStream = null;
     boolean success = false;
     try {
-      String extension = getImageExtension(uri);
+      String extension = getImageExtension(context, uri);
       inputStream = context.getContentResolver().openInputStream(uri);
       file = File.createTempFile("image_picker", extension, context.getCacheDir());
       file.deleteOnExit();
@@ -67,13 +70,18 @@ class FileUtils {
   }
 
   /** @return extension of image with dot, or default .jpg if it none. */
-  private static String getImageExtension(Uri uriImage) {
+  private static String getImageExtension(Context context, Uri uriImage) {
     String extension = null;
 
     try {
       String imagePath = uriImage.getPath();
-      if (imagePath != null && imagePath.lastIndexOf(".") != -1) {
-        extension = imagePath.substring(imagePath.lastIndexOf(".") + 1);
+      if (uriImage.getScheme().equals(ContentResolver.SCHEME_CONTENT)) {
+        final MimeTypeMap mime = MimeTypeMap.getSingleton();
+        extension = mime.getExtensionFromMimeType(context.getContentResolver().getType(uriImage));
+      } else {
+        extension =
+                MimeTypeMap.getFileExtensionFromUrl(
+                        Uri.fromFile(new File(uriImage.getPath())).toString());
       }
     } catch (Exception e) {
       extension = null;

--- a/packages/image_picker/image_picker/example/android/app/src/test/java/io/flutter/plugins/imagepicker/FileUtilTest.java
+++ b/packages/image_picker/image_picker/example/android/app/src/test/java/io/flutter/plugins/imagepicker/FileUtilTest.java
@@ -16,6 +16,9 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Objects;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -53,5 +56,14 @@ public class FileUtilTest {
     assertTrue(bytes.length > 0);
     String imageStream = new String(bytes, UTF_8);
     assertTrue(imageStream.equals("imageStream"));
+  }
+
+  @Test
+  public void FileUtil_getImageExtension() throws IOException {
+    Uri uri = Uri.parse("content://dummy/dummy.png");
+    shadowContentResolver.registerInputStream(
+            uri, new ByteArrayInputStream("imageStream".getBytes(UTF_8)));
+    String path = fileUtils.getPathFromUri(context, uri);
+    assert(path.endsWith(".jpg"));
   }
 }


### PR DESCRIPTION
Fixes an issue where videos could be wrongly picked with `.jpg` extension.

## Description

When picking videos on Android devices, it will return file names ended with .jpg extension, regardless of the file being actually a video. This requires a workaround implementation, such as opening a File descriptor on Flutter side and rename it to .mp4 again.

The issue happens because some URI paths doesn't have an extension and it was being extracted just by splitting the file name from . and getting the last part, which make it not quite reliable for some scenarios. Right now, I've updated the source to retrieve the extension based on the URI content.

As a note, this doesn't happen with all Android devices, but I can see it easily replicable with Samsung phones.

## Related issues
Fixes [#52419](https://github.com/flutter/flutter/issues/52419)



## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
