### PR TITLE
[path_provider_linux] When getApplicationDocumentsPath() is used, call getApplicationSupportPath()

### DIFF
--- a/packages/path_provider/path_provider_linux/lib/path_provider_linux.dart
+++ b/packages/path_provider/path_provider_linux/lib/path_provider_linux.dart
@@ -7,7 +7,6 @@ import 'dart:async';
 import 'package:xdg_directories/xdg_directories.dart' as xdg;
 import 'package:path/path.dart' as path;
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
-import 'package:package_info/package_info.dart';
 
 /// The linux implementation of [PathProviderPlatform]
 ///

--- a/packages/path_provider/path_provider_linux/lib/path_provider_linux.dart
+++ b/packages/path_provider/path_provider_linux/lib/path_provider_linux.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:xdg_directories/xdg_directories.dart' as xdg;
 import 'package:path/path.dart' as path;
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:package_info/package_info.dart';
 
 /// The linux implementation of [PathProviderPlatform]
 ///
@@ -35,9 +36,7 @@ class PathProviderLinux extends PathProviderPlatform {
   }
 
   @override
-  Future<String?> getApplicationDocumentsPath() {
-    return Future.value(xdg.getUserDirectory('DOCUMENTS')?.path);
-  }
+  Future<String?> getApplicationDocumentsPath() => getApplicationSupportPath();
 
   @override
   Future<String?> getDownloadsPath() {


### PR DESCRIPTION
Currently, `getApplicationDocumentsDirectory()` returns the documents directory on Linux (usually $HOME/Documents). This directory is used for the users documents and shouldn't really be used by programs for storing data. On mobile, `getApplicationDocumentsDirectory()` returns a directory that only the app can access, which will make the developer assume that they can store their app files in the directory returned by `getApplicationDocumentsDirectory()`. For example, [hive_flutter](https://pub.dev/packages/hive_flutter) uses `getApplicationDocumentsDirectory()` to store database files. On Linux, this causes Hive to dump database files in the user's documents directory instead of the app's own folder. In a best case scenario, this annoys the end user. In a worst case scenario, this could cause apps to have conflicts over file names. For example, if two apps saved the user's credentials in a file called `user.json`, those apps would keep overwriting each other, causing those apps to keep breaking.

The solution I've submitted here is kind of jank. `getApplicationSupportPath()` does what I'd expect `getApplicationDocumentsPath()` to do, so I've just made `getApplicationDocumentsPath()` call `getApplicationSupportPath()`. There may be better and more robust solutions to this, but the solution I've submitted is better than what we have now IMO.

![A screenshot of my Documents folder, which has the Hive databases for one of my apps](https://user-images.githubusercontent.com/44349936/110370266-5e687400-8043-11eb-8fbf-95ed1c7497db.png)

*List which issues are fixed by this PR. You must list at least one issue.*
Fixes https://github.com/flutter/flutter/issues/77628

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*
Didn't have to change anything, but this is a breaking change as some apps will now get a new documents directory. This may cause apps to lose their configuration/user data. Since Linux support is still very early, I doubt this will actually affect many people. Still, it'd probably need a big version bump or at least a mention in the changelog.

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [ ] I signed the [CLA].

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
