### PR TITLE
Skip pod lint tests

### DIFF
--- a/script/tool/lib/src/lint_podspecs_command.dart
+++ b/script/tool/lib/src/lint_podspecs_command.dart
@@ -123,6 +123,7 @@ class LintPodspecsCommand extends PluginCommand {
       'lint',
       podspecPath,
       '--configuration=Debug', // Release targets unsupported arm64 simulators. Use Debug to only build against targeted x86_64 simulator devices.
+      '--skip-tests',
       if (allowWarnings) '--allow-warnings',
       if (libraryLint) '--use-libraries'
     ];

--- a/script/tool/test/lint_podspecs_command_test.dart
+++ b/script/tool/test/lint_podspecs_command_test.dart
@@ -82,6 +82,7 @@ void main() {
                 'lint',
                 p.join(plugin1Dir.path, 'ios', 'plugin1.podspec'),
                 '--configuration=Debug',
+                '--skip-tests',
                 '--use-libraries'
               ],
               mockPackagesDir.path),
@@ -92,6 +93,7 @@ void main() {
                 'lint',
                 p.join(plugin1Dir.path, 'ios', 'plugin1.podspec'),
                 '--configuration=Debug',
+                '--skip-tests',
               ],
               mockPackagesDir.path),
         ]),
@@ -141,6 +143,7 @@ void main() {
                 'lint',
                 p.join(plugin1Dir.path, 'plugin1.podspec'),
                 '--configuration=Debug',
+                '--skip-tests',
                 '--allow-warnings',
                 '--use-libraries'
               ],
@@ -152,6 +155,7 @@ void main() {
                 'lint',
                 p.join(plugin1Dir.path, 'plugin1.podspec'),
                 '--configuration=Debug',
+                '--skip-tests',
                 '--allow-warnings',
               ],
               mockPackagesDir.path),


### PR DESCRIPTION
Now that the `xctest` command runs the `webview_flutter` #3664 and `image_picker` #3663 unit tests, skip them in the `pod lib lint` test to avoid doubling the work.

See https://github.com/flutter/plugins/pull/3667
Fixes https://github.com/flutter/flutter/issues/77661 (well, avoids it entirely).