### PR TITLE
[webview_flutter] added onPullToRefresh to the WebView()

### DIFF
--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.3
+
+* Added native `pullToRefresh`.
+
 ## 2.0.2
 
 * Fixes bug where text fields are hidden behind the keyboard

--- a/packages/webview_flutter/android/build.gradle
+++ b/packages/webview_flutter/android/build.gradle
@@ -35,5 +35,6 @@ android {
     dependencies {
         implementation 'androidx.annotation:annotation:1.0.0'
         implementation 'androidx.webkit:webkit:1.0.0'
+        implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.0.0'
     }
 }

--- a/packages/webview_flutter/example/lib/main.dart
+++ b/packages/webview_flutter/example/lib/main.dart
@@ -82,6 +82,10 @@ class _WebViewExampleState extends State<WebViewExample> {
           onPageFinished: (String url) {
             print('Page finished loading: $url');
           },
+          onPullToRefresh: () {
+            print('Pull to refresh.');
+            return Future.delayed(Duration(seconds: 1));
+          },
           gestureNavigationEnabled: true,
         );
       }),

--- a/packages/webview_flutter/ios/Classes/FlutterWebView.m
+++ b/packages/webview_flutter/ios/Classes/FlutterWebView.m
@@ -117,6 +117,18 @@
     if ([initialUrl isKindOfClass:[NSString class]]) {
       [self loadUrl:initialUrl];
     }
+    
+    
+    BOOL hasPullToRefresh = [args[@"hasPullToRefresh"] boolValue];
+
+    if (hasPullToRefresh) {
+      UIRefreshControl *refreshControl = [[UIRefreshControl alloc] init];
+      [refreshControl setTintColor:[UIColor grayColor]];
+      [refreshControl addTarget:self action:@selector(refreshWebview) forControlEvents:UIControlEventValueChanged];
+      if (@available(iOS 10.0, *)) {
+        _webView.scrollView.refreshControl = refreshControl;
+      }
+    }
   }
   return self;
 }
@@ -129,6 +141,12 @@
 
 - (UIView*)view {
   return _webView;
+}
+
+- (void) refreshWebview {
+  if (@available(iOS 10.0, *)) {
+    [_channel invokeMethod:@"onPullToRefresh" arguments:NULL];
+  }
 }
 
 - (void)onMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
@@ -166,6 +184,10 @@
     [self getScrollX:call result:result];
   } else if ([[call method] isEqualToString:@"getScrollY"]) {
     [self getScrollY:call result:result];
+  } else if ([[call method] isEqualToString:@"endRefreshing"]){
+      if (@available(iOS 10.0, *)) {
+        [_webView.scrollView.refreshControl endRefreshing];
+      }
   } else {
     result(FlutterMethodNotImplemented);
   }

--- a/packages/webview_flutter/lib/platform_interface.dart
+++ b/packages/webview_flutter/lib/platform_interface.dart
@@ -34,6 +34,9 @@ abstract class WebViewPlatformCallbacksHandler {
   /// /// Only works when [WebSettings.hasProgressTracking] is set to `true`.
   void onProgress(int progress);
 
+  ///Invoked by [WebViewPlatformController] when a user is swiping to reload a webview. //@pullToRefresh
+  Future<void> onPullToRefresh(); //@pullToRefresh
+
   /// Report web resource loading error to the host application.
   void onWebResourceError(WebResourceError error);
 }
@@ -453,6 +456,7 @@ class CreationParams {
     this.webSettings,
     this.javascriptChannelNames = const <String>{},
     this.userAgent,
+    this.hasPullToRefresh = false,
     this.autoMediaPlaybackPolicy =
         AutoMediaPlaybackPolicy.require_user_action_for_all_media_types,
   }) : assert(autoMediaPlaybackPolicy != null);
@@ -485,12 +489,18 @@ class CreationParams {
   /// When null the platform's webview default is used for the User-Agent header.
   final String? userAgent;
 
+  ///This value is required by the platforms [iOS] and [Android] in order to know
+  ///if we should attach the [RefreshControl] or [SwiperLayout] to the native [WebView].
+  ///
+  ///The default value is false.
+  final bool? hasPullToRefresh;
+
   /// Which restrictions apply on automatic media playback.
   final AutoMediaPlaybackPolicy autoMediaPlaybackPolicy;
 
   @override
   String toString() {
-    return '$runtimeType(initialUrl: $initialUrl, settings: $webSettings, javascriptChannelNames: $javascriptChannelNames, UserAgent: $userAgent)';
+    return '$runtimeType(initialUrl: $initialUrl, settings: $webSettings, hasPullToRefresh: $hasPullToRefresh, javascriptChannelNames: $javascriptChannelNames, UserAgent: $userAgent)';
   }
 }
 

--- a/packages/webview_flutter/lib/src/webview_method_channel.dart
+++ b/packages/webview_flutter/lib/src/webview_method_channel.dart
@@ -46,6 +46,12 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
       case 'onPageStarted':
         _platformCallbacksHandler.onPageStarted(call.arguments['url']!);
         return null;
+      case 'onPullToRefresh':
+        final Future<void> refreshResult =
+            _platformCallbacksHandler.onPullToRefresh();
+        await refreshResult;
+        await _channel.invokeMethod('endRefreshing', null);
+        return null;
       case 'onWebResourceError':
         _platformCallbacksHandler.onWebResourceError(
           WebResourceError(
@@ -211,6 +217,7 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
       'userAgent': creationParams.userAgent,
       'autoMediaPlaybackPolicy': creationParams.autoMediaPlaybackPolicy.index,
       'usesHybridComposition': usesHybridComposition,
+      'hasPullToRefresh': creationParams.hasPullToRefresh,
     };
   }
 }

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -224,6 +224,7 @@ class WebView extends StatefulWidget {
     this.onPageStarted,
     this.onPageFinished,
     this.onProgress,
+    this.onPullToRefresh, //@pullToRefresh
     this.onWebResourceError,
     this.debuggingEnabled = false,
     this.gestureNavigationEnabled = false,
@@ -367,6 +368,12 @@ class WebView extends StatefulWidget {
   /// Invoked when a page is loading.
   final PageLoadingCallback? onProgress;
 
+  ///Invoked when a user is swiping to refresh.
+  ///
+  ///When the user swipes down he will trigger the refresh animation
+  ///To end the animation you need to complete the cycle by returning a [Future]
+  final Future<void> Function()? onPullToRefresh; //@pullToRefresh
+
   /// Invoked when a web resource has failed to load.
   ///
   /// This can be called for any resource (iframe, image, etc.), not just for
@@ -478,6 +485,7 @@ CreationParams _creationParamsfromWidget(WebView widget) {
     webSettings: _webSettingsFromWidget(widget),
     javascriptChannelNames: _extractChannelNames(widget.javascriptChannels),
     userAgent: widget.userAgent,
+    hasPullToRefresh: widget.onPullToRefresh != null,
     autoMediaPlaybackPolicy: widget.initialMediaPlaybackPolicy,
   );
 }
@@ -591,6 +599,13 @@ class _PlatformCallbacksHandler implements WebViewPlatformCallbacksHandler {
   void onProgress(int progress) {
     if (_widget.onProgress != null) {
       _widget.onProgress!(progress);
+    }
+  }
+
+  @override
+  Future<void> onPullToRefresh() async {
+    if (_widget.onPullToRefresh != null) {
+      await _widget.onPullToRefresh!();
     }
   }
 

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/webview_flutter
-version: 2.0.2
+version: 2.0.3
 
 environment:
   sdk: ">=2.12.0-259.9.beta <3.0.0"


### PR DESCRIPTION
# Pull-to-refresh for [webview_flutter] plugin

- In this PR I added the code required for native pull to refresh for both Android and iOS
- At a high level I added the ```onPullToRefresh``` to the ```WebView``` class
- When ```onPullToRefresh``` is not null (it returns a ```Future```), the native webviews will have refresh indicators.
- For iOS then refresh indicator will be attached to the existing ```ScrollView``` of the ```WKWebView```.
- For Android a ```SwiperLayout``` will be created to which the existing ```WKWebView``` is attached to, then the ```SwiperLayout``` containing the ```WKWebView``` is returned in the ```getView()``` method.
- In both cases when these indicators are activated, the channel method ```onPullToRefresh``` is called and the Future is completed.
- Once this future is complete, the ```endRefreshing``` channel method is called and that will hide the refresh indicator.
- If ```onPullToRefresh``` is ```null``` then no refresh indicators will be attached to the native webviews.

## Limitations

- The refresh indicator is added in the initial phases, meaning that once the refresh indicator is added to the WebView you cannot removed by simply changing the state of the WebView. However, considering the use case for this functionality I consider this to be an acceptable trade off, since this is more of static feature than something to change on the fly.

## Testing

- There are three implementations test that check:
  1. pull-to-refresh is null, does not add the refresh indicator
  2. pull-to-refresh is not null, adds the refresh indicator
  3. pull-to-refresh reseting the refresh indicator for the platform webviews once it complete the future
- Although I did attempt to write an integration test, I did not manage to replicate the Swipe down effect on the WebView. I would hope is not required or someone can help me with it, since I got hard stuck at it.

```
testWidgets('onPullToRefresh intergration', (WidgetTester tester) async {
    final String scrollTestPage = '''<!DOCTYPE html>
      <html>
        <head>
            <style>
                body {
                    height: 100%;
                    width: 100%;
      
                #container {
                    width: 1000px;
                    height: 1000px;
                    width: 100%;
                }
            </style>
        </head>
        <body>
            <div id="container"></div>
        </body>
      </html>''';
    final String scrollTestPageBase64 =
        base64Encode(const Utf8Encoder().convert(scrollTestPage));

    final future = Future<int>.value(1);
    var initialValue = 0;

    await tester.pumpWidget(Directionality(
      textDirection: TextDirection.ltr,
      child: SizedBox(
        width: 200,
        height: 200,
        child: WebView(
          initialUrl:
              'data:text/html;charset=utf-8;base64,$scrollTestPageBase64',
          javascriptMode: JavascriptMode.unrestricted,
          onPullToRefresh: () async {
            initialValue = await future;
            return;
          },
        ),
      ),
    ));
    await tester.pumpAndSettle();
    await tester.fling(find.byType(WebView), Offset(0, 200), 400);
    await tester.pumpAndSettle();
    await Future.delayed(Duration(seconds: 1));
    expect(initialValue, 1);
  });
```

## Issue

Fix for #https://github.com/flutter/flutter/issues/71341

## Pre-launch Checklist

- [✔️] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [✔️] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [✔️] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [✔️] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [✔️] I listed at least one issue that this PR fixes in the description above.
- [✔️] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [✔️] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [✔️] I updated CHANGELOG.md to add a description of the change.
- [✔️] I updated/added relevant documentation (doc comments with `///`).
- [✔️] I signed the [CLA].
- [✔️] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning


## Formating

I did attempt to format the files, however, it failed due to:

#https://github.com/flutter/flutter/issues/33964