### PR TITLE
Skip flutter upgrade for pod linting Cirrus task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,10 +7,10 @@ root_task_template: &ROOT_TASK_TEMPLATE
     INTEGRATION_TEST_PATH: "./packages/integration_test"
     CHANNEL: "master" # Default to master when not explicitly set by a task.
   setup_script:
+    - git fetch origin master # To set FETCH_HEAD for "git merge-base" to work
+  upgrade_flutter_script:
     - flutter channel $CHANNEL
     - flutter upgrade
-    - git fetch origin master # To set FETCH_HEAD for "git merge-base" to work
-
 
 # Light-workload Linux tasks.
 # These use default machines, with fewer CPUs, to reduce pressure on the
@@ -184,6 +184,7 @@ task:
         matrix:
           PLUGIN_SHARDING: "--shardIndex 0 --shardCount 2"
           PLUGIN_SHARDING: "--shardIndex 1 --shardCount 2"
+      upgrade_flutter_script: # overridden, Flutter not a dependency.
       script:
         # TODO(jmagman): Lint macOS podspecs but skip any that fail library validation.
         - find . -name "*.podspec" | xargs grep -l "osx" | xargs rm


### PR DESCRIPTION
Changing flutter channels and upgrading can take a few minutes per Cirrus task.  Skip it the pod linting task, which doesn't use `flutter`.

## Pre-launch Checklist

- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.