### PR TITLE
Skip flutter upgrade for pod linting Cirrus task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,23 +1,3 @@
-setup_tool_template: &SETUP_TOOL_TEMPLATE
-  setup_tool_script:
-    - git fetch origin master # To set FETCH_HEAD for "git merge-base" to work
-    - cd script/tool
-    - pub get
-
-flutter_upgrade_template: &FLUTTER_UPGRADE_TEMPLATE
-  upgrade_flutter_script:
-    - flutter channel $CHANNEL
-    - flutter upgrade
-  << : *SETUP_TOOL_TEMPLATE
-
-macos_template: &MACOS_TEMPLATE
-  # Only one macOS task can run in parallel without credits, so use them for
-  # PRs on macOS.
-  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
-  osx_instance:
-    image: big-sur-xcode-12.3
-  cocoapod_install_script: sudo gem install cocoapods
-
 # Don't run on release tags since it creates O(n^2) tasks where n is the
 # number of plugins
 only_if: $CIRRUS_TAG == ''
@@ -26,6 +6,26 @@ env:
   INTEGRATION_TEST_PATH: "./packages/integration_test"
   CHANNEL: "master" # Default to master when not explicitly set by a task.
   PLUGIN_TOOLS: "dart run ./script/tool/lib/src/main.dart"
+
+tool_setup_template: &TOOL_SETUP_TEMPLATE
+  tool_setup_script:
+    - git fetch origin master # To set FETCH_HEAD for "git merge-base" to work
+    - cd script/tool
+    - pub get
+
+flutter_upgrade_template: &FLUTTER_UPGRADE_TEMPLATE
+  upgrade_flutter_script:
+    - flutter channel $CHANNEL
+    - flutter upgrade
+  << : *TOOL_SETUP_TEMPLATE
+
+macos_template: &MACOS_TEMPLATE
+  # Only one macOS task can run in parallel without credits, so use them for
+  # PRs on macOS.
+  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
+  osx_instance:
+    image: big-sur-xcode-12.3
+  cocoapod_install_script: sudo gem install cocoapods
 
 # Light-workload Linux tasks.
 # These use default machines, with fewer CPUs, to reduce pressure on the
@@ -189,8 +189,8 @@ task:
 
 # macOS tasks.
 task:
-  << : *FLUTTER_UPGRADE_TEMPLATE
   << : *MACOS_TEMPLATE
+  << : *FLUTTER_UPGRADE_TEMPLATE
   matrix:
     ### iOS tasks ###
     - name: build_all_plugins_ipa
@@ -244,9 +244,9 @@ task:
         - ./script/incremental_build.sh drive-examples --macos
 
 task:
-  # Don't used FLUTTER_UPGRADE_TEMPLATE, Flutter tooling not needed.
+  # Don't use FLUTTER_UPGRADE_TEMPLATE, Flutter tooling not needed.
   << : *MACOS_TEMPLATE
-  << : *SETUP_TOOL_TEMPLATE
+  << : *TOOL_SETUP_TEMPLATE
   matrix:
     - name: lint_darwin_plugins
       script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,9 +1,14 @@
+setup_tool_template: &SETUP_TOOL_TEMPLATE
+  setup_tool_script:
+    - git fetch origin master # To set FETCH_HEAD for "git merge-base" to work
+    - cd script/tool
+    - pub get
+
 flutter_upgrade_template: &FLUTTER_UPGRADE_TEMPLATE
-  env:
-    CHANNEL: "master" # Default to master when not explicitly set by a task.
   upgrade_flutter_script:
     - flutter channel $CHANNEL
     - flutter upgrade
+  << : *SETUP_TOOL_TEMPLATE
 
 macos_template: &MACOS_TEMPLATE
   # Only one macOS task can run in parallel without credits, so use them for
@@ -19,11 +24,8 @@ only_if: $CIRRUS_TAG == ''
 use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
 env:
   INTEGRATION_TEST_PATH: "./packages/integration_test"
+  CHANNEL: "master" # Default to master when not explicitly set by a task.
   PLUGIN_TOOLS: "dart run ./script/tool/lib/src/main.dart"
-setup_tool_script:
-  - git fetch origin master # To set FETCH_HEAD for "git merge-base" to work
-  - cd script/tool
-  - pub get
 
 # Light-workload Linux tasks.
 # These use default machines, with fewer CPUs, to reduce pressure on the
@@ -244,6 +246,7 @@ task:
 task:
   # Don't used FLUTTER_UPGRADE_TEMPLATE, Flutter tooling not needed.
   << : *MACOS_TEMPLATE
+  << : *SETUP_TOOL_TEMPLATE
   matrix:
     - name: lint_darwin_plugins
       script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,25 +1,35 @@
-root_task_template: &ROOT_TASK_TEMPLATE
-  # Don't run on release tags since it creates O(n^2) tasks where n is the
-  # number of plugins
-  only_if: $CIRRUS_TAG == ''
-  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
+flutter_upgrade_template: &FLUTTER_UPGRADE_TEMPLATE
   env:
-    INTEGRATION_TEST_PATH: "./packages/integration_test"
     CHANNEL: "master" # Default to master when not explicitly set by a task.
-    PLUGIN_TOOLS: "dart run ./script/tool/lib/src/main.dart"
-  setup_script:
+  upgrade_flutter_script:
     - flutter channel $CHANNEL
     - flutter upgrade
-    - git fetch origin master # To set FETCH_HEAD for "git merge-base" to work
-    - cd script/tool
-    - pub get
 
+macos_template: &MACOS_TEMPLATE
+  # Only one macOS task can run in parallel without credits, so use them for
+  # PRs on macOS.
+  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
+  osx_instance:
+    image: big-sur-xcode-12.3
+  cocoapod_install_script: sudo gem install cocoapods
+
+# Don't run on release tags since it creates O(n^2) tasks where n is the
+# number of plugins
+only_if: $CIRRUS_TAG == ''
+use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' && $CIRRUS_PR == ''
+env:
+  INTEGRATION_TEST_PATH: "./packages/integration_test"
+  PLUGIN_TOOLS: "dart run ./script/tool/lib/src/main.dart"
+setup_tool_script:
+  - git fetch origin master # To set FETCH_HEAD for "git merge-base" to work
+  - cd script/tool
+  - pub get
 
 # Light-workload Linux tasks.
 # These use default machines, with fewer CPUs, to reduce pressure on the
 # concurrency limits.
 task:
-  << : *ROOT_TASK_TEMPLATE
+  << : *FLUTTER_UPGRADE_TEMPLATE
   container:
     dockerfile: .ci/Dockerfile
   matrix:
@@ -109,7 +119,7 @@ task:
 # tasks" block above once web_installers has been updated to support Chrome 89
 # (which is what the current image generated from .ci/Dockerfile has).
 task:
-  << : *ROOT_TASK_TEMPLATE
+  << : *FLUTTER_UPGRADE_TEMPLATE
   container:
     dockerfile: .ci/Dockerfile-LegacyChrome
   matrix:
@@ -134,7 +144,7 @@ task:
 # These use machines with more CPUs and memory, so will reduce parallelization
 # for non-credit runs.
 task:
-  << : *ROOT_TASK_TEMPLATE
+  << : *FLUTTER_UPGRADE_TEMPLATE
   container:
     dockerfile: .ci/Dockerfile
     cpu: 4
@@ -177,24 +187,9 @@ task:
 
 # macOS tasks.
 task:
-  << : *ROOT_TASK_TEMPLATE
-  # Only one macOS task can run in parallel without credits, so use them for
-  # PRs on macOS.
-  use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
-  osx_instance:
-    image: big-sur-xcode-12.3
-  cocoapod_install_script: sudo gem install cocoapods
+  << : *FLUTTER_UPGRADE_TEMPLATE
+  << : *MACOS_TEMPLATE
   matrix:
-    ### Platform-agnostic tasks ###
-    - name: lint_darwin_plugins
-      env:
-        matrix:
-          PLUGIN_SHARDING: "--shardIndex 0 --shardCount 2"
-          PLUGIN_SHARDING: "--shardIndex 1 --shardCount 2"
-      script:
-        # TODO(jmagman): Lint macOS podspecs but skip any that fail library validation.
-        - find . -name "*.podspec" | xargs grep -l "osx" | xargs rm
-        - ./script/incremental_build.sh podspecs
     ### iOS tasks ###
     - name: build_all_plugins_ipa
       env:
@@ -245,3 +240,13 @@ task:
         - flutter config --enable-macos-desktop
         - ./script/incremental_build.sh build-examples --macos --no-ipa
         - ./script/incremental_build.sh drive-examples --macos
+
+task:
+  # Don't used FLUTTER_UPGRADE_TEMPLATE, Flutter tooling not needed.
+  << : *MACOS_TEMPLATE
+  matrix:
+    - name: lint_darwin_plugins
+      script:
+        # TODO(jmagman): Lint macOS podspecs but skip any that fail library validation.
+        - find . -name "*.podspec" | xargs grep -l "osx" | xargs rm
+        - ./script/incremental_build.sh podspecs


### PR DESCRIPTION
- Hoist common properties like `only_if`, `use_compute_credits`, and `env` to top of tasks, out of root template.
- Rename `ROOT_TASK_TEMPLATE` to `FLUTTER_UPGRADE_TEMPLATE`.
- Pull `lint_darwin_plugins` out from the other macOS tasks and don't apply `FLUTTER_UPGRADE_TEMPLATE` since it doesn't use `flutter` tooling, so shouldn't waste the 40 seconds and I/O upgrading.
- Remove `lint_darwin_plugins` subsharding.  Each subshard takes about 4 minutes, so combining them together the 8 minutes is well within the time length of other tests (especially now that they won't upgrade flutter), and avoid scheduling a second Mac machine. https://cirrus-ci.com/task/6550328981061632
- Pull `tool_setup_script` out of `flutter_upgrade_template` so it can be used directly by the `lint_darwin_plugins` task.
- Create `MACOS_TEMPLATE` and use for both macOS image tasks.

Related to https://github.com/flutter/plugins/pull/3697

## Pre-launch Checklist

- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.