### PR TITLE
[google_maps_flutter] TileOverlay fix - null tileProvider caused TileOverlay to not be displayed on the map

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/tile_overlay.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/tile_overlay.dart
@@ -67,8 +67,8 @@ class TileOverlayBodyState extends State<TileOverlayBody> {
 
   @override
   Widget build(BuildContext context) {
-    Set<TileOverlay?> overlays = <TileOverlay?>{
-      if (_tileOverlay != null) _tileOverlay,
+    Set<TileOverlay> overlays = <TileOverlay>{
+      if (_tileOverlay != null) _tileOverlay!,
     };
     return Column(
       mainAxisSize: MainAxisSize.min,
@@ -84,7 +84,7 @@ class TileOverlayBodyState extends State<TileOverlayBody> {
                 target: LatLng(59.935460, 30.325177),
                 zoom: 7.0,
               ),
-              tileOverlays: overlays as Set<TileOverlay>,
+              tileOverlays: overlays,
               onMapCreated: _onMapCreated,
             ),
           ),

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -7,7 +7,10 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_plugin_android_lifecycle: ^2.0.0
-  google_maps_flutter_platform_interface: ^2.0.0
+  google_maps_flutter_platform_interface:
+    git:
+      url: https://github.com/liorboyango/plugins.git
+      path: packages/google_maps_flutter/google_maps_flutter_platform_interface
 
 dev_dependencies:
   flutter_test:

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -7,10 +7,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_plugin_android_lifecycle: ^2.0.0
-  google_maps_flutter_platform_interface:
-    git:
-      url: https://github.com/liorboyango/plugins.git
-      path: packages/google_maps_flutter/google_maps_flutter_platform_interface
+  google_maps_flutter_platform_interface: ^2.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/tile_overlay.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/tile_overlay.dart
@@ -91,6 +91,7 @@ class TileOverlay implements MapsObject {
   /// unless overwritten by the specified parameters.
   TileOverlay copyWith({
     bool? fadeInParam,
+    TileProvider? tileProviderParam,
     double? transparencyParam,
     int? zIndexParam,
     bool? visibleParam,
@@ -99,6 +100,7 @@ class TileOverlay implements MapsObject {
     return TileOverlay(
       tileOverlayId: tileOverlayId,
       fadeIn: fadeInParam ?? fadeIn,
+      tileProvider: tileProviderParam ?? tileProvider,
       transparency: transparencyParam ?? transparency,
       zIndex: zIndexParam ?? zIndex,
       visible: visibleParam ?? visible,


### PR DESCRIPTION
Added tileProvider to TileOverlay#copyWith - this fixes tileProvider not being cloned inside the TileOverlay object, which broke the TileOverlay;

Fixed a runtime cast exception in the example tile_overlay.dart;

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
