### PR TITLE
[local_auth] fix: local_auth plugin wrongly reports available methods on android

### DIFF
--- a/packages/local_auth/android/build.gradle
+++ b/packages/local_auth/android/build.gradle
@@ -35,7 +35,7 @@ android {
 
 dependencies {
     api "androidx.core:core:1.1.0-beta01"
-    api "androidx.biometric:biometric:1.0.0-beta01"
+    api "androidx.biometric:biometric:1.2.0-alpha03"
     api "androidx.fragment:fragment:1.1.0-alpha06"
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test:rules:1.2.0'

--- a/packages/local_auth/android/src/main/java/io/flutter/plugins/localauth/LocalAuthPlugin.java
+++ b/packages/local_auth/android/src/main/java/io/flutter/plugins/localauth/LocalAuthPlugin.java
@@ -6,6 +6,8 @@ package io.flutter.plugins.localauth;
 
 import static android.app.Activity.RESULT_OK;
 import static android.content.Context.KEYGUARD_SERVICE;
+import static androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_STRONG;
+import static androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_WEAK;
 
 import android.app.Activity;
 import android.app.KeyguardManager;
@@ -14,6 +16,8 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.hardware.fingerprint.FingerprintManager;
 import android.os.Build;
+import android.util.Log;
+
 import androidx.annotation.NonNull;
 import androidx.biometric.BiometricManager;
 import androidx.fragment.app.FragmentActivity;
@@ -269,16 +273,20 @@ public class LocalAuthPlugin implements MethodCallHandler, FlutterPlugin, Activi
       return biometrics;
     }
     PackageManager packageManager = activity.getPackageManager();
-    if (Build.VERSION.SDK_INT >= 23) {
-      if (packageManager.hasSystemFeature(PackageManager.FEATURE_FINGERPRINT)) {
+    if (Build.VERSION.SDK_INT >= 23 && Build.VERSION.SDK_INT <= 27 && fingerprintManager != null) {
+      if (fingerprintManager.hasEnrolledFingerprints()) {
         biometrics.add("fingerprint");
       }
     }
-    if (Build.VERSION.SDK_INT >= 29) {
-      if (packageManager.hasSystemFeature(PackageManager.FEATURE_FACE)) {
+    if (Build.VERSION.SDK_INT >= 28) {
+      BiometricManager biometricManager = BiometricManager.from(activity.getApplicationContext());
+      if (packageManager.hasSystemFeature(PackageManager.FEATURE_FACE) && (biometricManager.canAuthenticate( BIOMETRIC_STRONG | BIOMETRIC_WEAK) == BiometricManager.BIOMETRIC_SUCCESS)) {
         biometrics.add("face");
       }
-      if (packageManager.hasSystemFeature(PackageManager.FEATURE_IRIS)) {
+      if (packageManager.hasSystemFeature(PackageManager.FEATURE_FINGERPRINT) && (biometricManager.canAuthenticate(BIOMETRIC_STRONG | BIOMETRIC_WEAK) == BiometricManager.BIOMETRIC_SUCCESS)) {
+        biometrics.add("fingerprint");
+      }
+      if (packageManager.hasSystemFeature(PackageManager.FEATURE_IRIS)  && (biometricManager.canAuthenticate(BIOMETRIC_STRONG | BIOMETRIC_WEAK) == BiometricManager.BIOMETRIC_SUCCESS)) {
         biometrics.add("iris");
       }
     }


### PR DESCRIPTION
This fixes [#77799](https://github.com/flutter/flutter/issues/77799)
*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
