### PR TITLE
[google_maps_flutter_platform_interface] Mark constructors as const for ids

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.2
+
+* Mark constructors for CameraUpdate, CircleId, MapsObjectId, MarkerId, PolygonId, PolylineId and TileOverlayId as const
+
 ## 2.0.1
 
 * Update platform_plugin_interface version requirement.

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/method_channel/method_channel_google_maps_flutter.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/method_channel/method_channel_google_maps_flutter.dart
@@ -5,13 +5,13 @@
 import 'dart:async';
 import 'dart:typed_data';
 
-import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter/gestures.dart';
-
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:google_maps_flutter_platform_interface/google_maps_flutter_platform_interface.dart';
 import 'package:stream_transform/stream_transform.dart';
+
 import '../types/tile_overlay_updates.dart';
 import '../types/utils/tile_overlay.dart';
 

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/camera.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/camera.dart
@@ -109,7 +109,7 @@ class CameraPosition {
 /// Defines a camera move, supporting absolute moves as well as moves relative
 /// the current position.
 class CameraUpdate {
-  CameraUpdate._(this._json);
+  const CameraUpdate._(this._json);
 
   /// Returns a camera update that moves the camera to the specified position.
   static CameraUpdate newCameraPosition(CameraPosition cameraPosition) {

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/camera.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/camera.dart
@@ -176,7 +176,7 @@ class CameraUpdate {
   ///
   /// Equivalent to the result of calling `zoomBy(1.0)`.
   static CameraUpdate zoomIn() {
-    return CameraUpdate._(<Object>['zoomIn']);
+    return const CameraUpdate._(<Object>['zoomIn']);
   }
 
   /// Returns a camera update that zooms the camera out, bringing the camera
@@ -184,7 +184,7 @@ class CameraUpdate {
   ///
   /// Equivalent to the result of calling `zoomBy(-1.0)`.
   static CameraUpdate zoomOut() {
-    return CameraUpdate._(<Object>['zoomOut']);
+    return const CameraUpdate._(<Object>['zoomOut']);
   }
 
   /// Returns a camera update that sets the camera zoom level.

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/circle.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/circle.dart
@@ -14,7 +14,7 @@ import 'types.dart';
 @immutable
 class CircleId extends MapsObjectId<Circle> {
   /// Creates an immutable identifier for a [Circle].
-  CircleId(String value) : super(value);
+  const CircleId(String value) : super(value);
 }
 
 /// Draws a circle on the map.

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/maps_object.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/maps_object.dart
@@ -14,7 +14,7 @@ class MapsObjectId<T> {
   /// Creates an immutable object representing a [T] among [GoogleMap] Ts.
   ///
   /// An [AssertionError] will be thrown if [value] is null.
-  MapsObjectId(this.value) : assert(value != null);
+  const MapsObjectId(this.value) : assert(value != null);
 
   /// The value of the id.
   final String value;

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/marker.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/marker.dart
@@ -104,7 +104,7 @@ class InfoWindow {
 @immutable
 class MarkerId extends MapsObjectId<Marker> {
   /// Creates an immutable identifier for a [Marker].
-  MarkerId(String value) : super(value);
+  const MarkerId(String value) : super(value);
 }
 
 /// Marks a geographical location on the map.

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/polygon.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/polygon.dart
@@ -167,7 +167,7 @@ class Polygon implements MapsObject {
         fillColor == typedOther.fillColor &&
         geodesic == typedOther.geodesic &&
         listEquals(points, typedOther.points) &&
-        DeepCollectionEquality().equals(holes, typedOther.holes) &&
+        const DeepCollectionEquality().equals(holes, typedOther.holes) &&
         visible == typedOther.visible &&
         strokeColor == typedOther.strokeColor &&
         strokeWidth == typedOther.strokeWidth &&

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/polygon.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/polygon.dart
@@ -15,7 +15,7 @@ import 'types.dart';
 @immutable
 class PolygonId extends MapsObjectId<Polygon> {
   /// Creates an immutable identifier for a [Polygon].
-  PolygonId(String value) : super(value);
+  const PolygonId(String value) : super(value);
 }
 
 /// Draws a polygon through geographical locations on the map.

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/polyline.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/polyline.dart
@@ -16,7 +16,7 @@ class PolylineId extends MapsObjectId<Polyline> {
   /// Creates an immutable object representing a [PolylineId] among [GoogleMap] polylines.
   ///
   /// An [AssertionError] will be thrown if [value] is null.
-  PolylineId(String value) : super(value);
+  const PolylineId(String value) : super(value);
 }
 
 /// Draws a line through geographical locations on the map.

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/tile_overlay.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/tile_overlay.dart
@@ -3,10 +3,11 @@
 // found in the LICENSE file.
 
 import 'dart:ui' show hashValues;
+
 import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart' show immutable;
 
 import 'types.dart';
-import 'package:meta/meta.dart' show immutable;
 
 /// Uniquely identifies a [TileOverlay] among [GoogleMap] tile overlays.
 @immutable

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/tile_overlay.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/tile_overlay.dart
@@ -12,7 +12,7 @@ import 'package:meta/meta.dart' show immutable;
 @immutable
 class TileOverlayId extends MapsObjectId<TileOverlay> {
   /// Creates an immutable identifier for a [TileOverlay].
-  TileOverlayId(String value) : super(value);
+  const TileOverlayId(String value) : super(value);
 }
 
 /// A set of images which are displayed on top of the base map tiles.

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the google_maps_flutter plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter/google_maps_flutter_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.0.1
+version: 2.0.2
 
 dependencies:
   flutter:

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/camera_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/camera_test.dart
@@ -3,14 +3,13 @@
 // found in the LICENSE file.
 
 import 'package:flutter_test/flutter_test.dart';
-
 import 'package:google_maps_flutter_platform_interface/google_maps_flutter_platform_interface.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   test('toMap / fromMap', () {
-    final cameraPosition = CameraPosition(
+    const cameraPosition = CameraPosition(
         target: LatLng(10.0, 15.0), bearing: 0.5, tilt: 30.0, zoom: 1.5);
     // Cast to <dynamic, dynamic> to ensure that recreating from JSON, where
     // type information will have likely been lost, still works.

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/maps_object_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/maps_object_test.dart
@@ -12,12 +12,12 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   test('keyByMapsObjectId', () async {
-    final MapsObjectId<TestMapsObject> id1 = MapsObjectId<TestMapsObject>('1');
-    final MapsObjectId<TestMapsObject> id2 = MapsObjectId<TestMapsObject>('2');
-    final MapsObjectId<TestMapsObject> id3 = MapsObjectId<TestMapsObject>('3');
-    final TestMapsObject object1 = TestMapsObject(id1);
-    final TestMapsObject object2 = TestMapsObject(id2, data: 2);
-    final TestMapsObject object3 = TestMapsObject(id3);
+    const MapsObjectId<TestMapsObject> id1 = MapsObjectId<TestMapsObject>('1');
+    const MapsObjectId<TestMapsObject> id2 = MapsObjectId<TestMapsObject>('2');
+    const MapsObjectId<TestMapsObject> id3 = MapsObjectId<TestMapsObject>('3');
+    const TestMapsObject object1 = TestMapsObject(id1);
+    const TestMapsObject object2 = TestMapsObject(id2, data: 2);
+    const TestMapsObject object3 = TestMapsObject(id3);
     expect(
         keyByMapsObjectId(<TestMapsObject>{object1, object2, object3}),
         <MapsObjectId<TestMapsObject>, TestMapsObject>{
@@ -28,12 +28,12 @@ void main() {
   });
 
   test('serializeMapsObjectSet', () async {
-    final MapsObjectId<TestMapsObject> id1 = MapsObjectId<TestMapsObject>('1');
-    final MapsObjectId<TestMapsObject> id2 = MapsObjectId<TestMapsObject>('2');
-    final MapsObjectId<TestMapsObject> id3 = MapsObjectId<TestMapsObject>('3');
-    final TestMapsObject object1 = TestMapsObject(id1);
-    final TestMapsObject object2 = TestMapsObject(id2, data: 2);
-    final TestMapsObject object3 = TestMapsObject(id3);
+    const MapsObjectId<TestMapsObject> id1 = MapsObjectId<TestMapsObject>('1');
+    const MapsObjectId<TestMapsObject> id2 = MapsObjectId<TestMapsObject>('2');
+    const MapsObjectId<TestMapsObject> id3 = MapsObjectId<TestMapsObject>('3');
+    const TestMapsObject object1 = TestMapsObject(id1);
+    const TestMapsObject object2 = TestMapsObject(id2, data: 2);
+    const TestMapsObject object3 = TestMapsObject(id3);
     expect(
         serializeMapsObjectSet(<TestMapsObject>{object1, object2, object3}),
         <Map<String, Object>>[

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/maps_object_updates_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/maps_object_updates_test.dart
@@ -6,9 +6,9 @@ import 'dart:ui' show hashValues, hashList;
 
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:google_maps_flutter_platform_interface/src/types/utils/maps_object.dart';
-import 'package:google_maps_flutter_platform_interface/src/types/maps_object_updates.dart';
 import 'package:google_maps_flutter_platform_interface/src/types/maps_object.dart';
+import 'package:google_maps_flutter_platform_interface/src/types/maps_object_updates.dart';
+import 'package:google_maps_flutter_platform_interface/src/types/utils/maps_object.dart';
 
 import 'test_maps_object.dart';
 
@@ -23,15 +23,15 @@ void main() {
 
   group('tile overlay updates tests', () {
     test('Correctly set toRemove, toAdd and toChange', () async {
-      final TestMapsObject to1 =
+      const TestMapsObject to1 =
           TestMapsObject(MapsObjectId<TestMapsObject>('id1'));
-      final TestMapsObject to2 =
+      const TestMapsObject to2 =
           TestMapsObject(MapsObjectId<TestMapsObject>('id2'));
-      final TestMapsObject to3 =
+      const TestMapsObject to3 =
           TestMapsObject(MapsObjectId<TestMapsObject>('id3'));
-      final TestMapsObject to3Changed =
+      const TestMapsObject to3Changed =
           TestMapsObject(MapsObjectId<TestMapsObject>('id3'), data: 2);
-      final TestMapsObject to4 =
+      const TestMapsObject to4 =
           TestMapsObject(MapsObjectId<TestMapsObject>('id4'));
       final Set<TestMapsObject> previous =
           Set.from(<TestMapsObject>[to1, to2, to3]);
@@ -40,8 +40,10 @@ void main() {
       final TestMapsObjectUpdate updates =
           TestMapsObjectUpdate.from(previous, current);
 
-      final Set<MapsObjectId<TestMapsObject>> toRemove = Set.from(
-          <MapsObjectId<TestMapsObject>>[MapsObjectId<TestMapsObject>('id1')]);
+      final Set<MapsObjectId<TestMapsObject>> toRemove =
+          Set.from(<MapsObjectId<TestMapsObject>>[
+        const MapsObjectId<TestMapsObject>('id1')
+      ]);
       expect(updates.objectIdsToRemove, toRemove);
 
       final Set<TestMapsObject> toAdd = Set.from(<TestMapsObject>[to4]);
@@ -53,15 +55,15 @@ void main() {
     });
 
     test('toJson', () async {
-      final TestMapsObject to1 =
+      const TestMapsObject to1 =
           TestMapsObject(MapsObjectId<TestMapsObject>('id1'));
-      final TestMapsObject to2 =
+      const TestMapsObject to2 =
           TestMapsObject(MapsObjectId<TestMapsObject>('id2'));
-      final TestMapsObject to3 =
+      const TestMapsObject to3 =
           TestMapsObject(MapsObjectId<TestMapsObject>('id3'));
-      final TestMapsObject to3Changed =
+      const TestMapsObject to3Changed =
           TestMapsObject(MapsObjectId<TestMapsObject>('id3'), data: 2);
-      final TestMapsObject to4 =
+      const TestMapsObject to4 =
           TestMapsObject(MapsObjectId<TestMapsObject>('id4'));
       final Set<TestMapsObject> previous =
           Set.from(<TestMapsObject>[to1, to2, to3]);
@@ -81,15 +83,15 @@ void main() {
     });
 
     test('equality', () async {
-      final TestMapsObject to1 =
+      const TestMapsObject to1 =
           TestMapsObject(MapsObjectId<TestMapsObject>('id1'));
-      final TestMapsObject to2 =
+      const TestMapsObject to2 =
           TestMapsObject(MapsObjectId<TestMapsObject>('id2'));
-      final TestMapsObject to3 =
+      const TestMapsObject to3 =
           TestMapsObject(MapsObjectId<TestMapsObject>('id3'));
-      final TestMapsObject to3Changed =
+      const TestMapsObject to3Changed =
           TestMapsObject(MapsObjectId<TestMapsObject>('id3'), data: 2);
-      final TestMapsObject to4 =
+      const TestMapsObject to4 =
           TestMapsObject(MapsObjectId<TestMapsObject>('id4'));
       final Set<TestMapsObject> previous =
           Set.from(<TestMapsObject>[to1, to2, to3]);
@@ -109,15 +111,15 @@ void main() {
     });
 
     test('hashCode', () async {
-      final TestMapsObject to1 =
+      const TestMapsObject to1 =
           TestMapsObject(MapsObjectId<TestMapsObject>('id1'));
-      final TestMapsObject to2 =
+      const TestMapsObject to2 =
           TestMapsObject(MapsObjectId<TestMapsObject>('id2'));
-      final TestMapsObject to3 =
+      const TestMapsObject to3 =
           TestMapsObject(MapsObjectId<TestMapsObject>('id3'));
-      final TestMapsObject to3Changed =
+      const TestMapsObject to3Changed =
           TestMapsObject(MapsObjectId<TestMapsObject>('id3'), data: 2);
-      final TestMapsObject to4 =
+      const TestMapsObject to4 =
           TestMapsObject(MapsObjectId<TestMapsObject>('id4'));
       final Set<TestMapsObject> previous =
           Set.from(<TestMapsObject>[to1, to2, to3]);
@@ -134,15 +136,15 @@ void main() {
     });
 
     test('toString', () async {
-      final TestMapsObject to1 =
+      const TestMapsObject to1 =
           TestMapsObject(MapsObjectId<TestMapsObject>('id1'));
-      final TestMapsObject to2 =
+      const TestMapsObject to2 =
           TestMapsObject(MapsObjectId<TestMapsObject>('id2'));
-      final TestMapsObject to3 =
+      const TestMapsObject to3 =
           TestMapsObject(MapsObjectId<TestMapsObject>('id3'));
-      final TestMapsObject to3Changed =
+      const TestMapsObject to3Changed =
           TestMapsObject(MapsObjectId<TestMapsObject>('id3'), data: 2);
-      final TestMapsObject to4 =
+      const TestMapsObject to4 =
           TestMapsObject(MapsObjectId<TestMapsObject>('id4'));
       final Set<TestMapsObject> previous =
           Set.from(<TestMapsObject>[to1, to2, to3]);

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/test_maps_object.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/test_maps_object.dart
@@ -3,13 +3,14 @@
 // found in the LICENSE file.
 
 import 'dart:ui' show hashValues;
+
 import 'package:flutter/rendering.dart';
-import 'package:google_maps_flutter_platform_interface/src/types/maps_object_updates.dart';
 import 'package:google_maps_flutter_platform_interface/src/types/maps_object.dart';
+import 'package:google_maps_flutter_platform_interface/src/types/maps_object_updates.dart';
 
 /// A trivial TestMapsObject implementation for testing updates with.
 class TestMapsObject implements MapsObject {
-  TestMapsObject(this.mapsId, {this.data = 1});
+  const TestMapsObject(this.mapsId, {this.data = 1});
 
   final MapsObjectId<TestMapsObject> mapsId;
 

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/tile_overlay_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/tile_overlay_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:ui' show hashValues;
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_maps_flutter_platform_interface/google_maps_flutter_platform_interface.dart';
 
@@ -11,22 +12,22 @@ void main() {
 
   group('tile overlay id tests', () {
     test('equality', () async {
-      final TileOverlayId id1 = TileOverlayId('1');
-      final TileOverlayId id2 = TileOverlayId('1');
-      final TileOverlayId id3 = TileOverlayId('2');
+      const TileOverlayId id1 = TileOverlayId('1');
+      const TileOverlayId id2 = TileOverlayId('1');
+      const TileOverlayId id3 = TileOverlayId('2');
       expect(id1, id2);
       expect(id1, isNot(id3));
     });
 
     test('toString', () async {
-      final TileOverlayId id1 = TileOverlayId('1');
+      const TileOverlayId id1 = TileOverlayId('1');
       expect(id1.toString(), 'TileOverlayId(1)');
     });
   });
 
   group('tile overlay tests', () {
     test('toJson returns correct format', () async {
-      final TileOverlay tileOverlay = TileOverlay(
+      const TileOverlay tileOverlay = TileOverlay(
           tileOverlayId: TileOverlayId('id'),
           fadeIn: false,
           tileProvider: null,
@@ -48,16 +49,16 @@ void main() {
     test('invalid transparency throws', () async {
       expect(
           () => TileOverlay(
-              tileOverlayId: TileOverlayId('id1'), transparency: -0.1),
+              tileOverlayId: const TileOverlayId('id1'), transparency: -0.1),
           throwsAssertionError);
       expect(
           () => TileOverlay(
-              tileOverlayId: TileOverlayId('id2'), transparency: 1.2),
+              tileOverlayId: const TileOverlayId('id2'), transparency: 1.2),
           throwsAssertionError);
     });
 
     test('equality', () async {
-      final TileOverlay tileOverlay1 = TileOverlay(
+      const TileOverlay tileOverlay1 = TileOverlay(
           tileOverlayId: TileOverlayId('id1'),
           fadeIn: false,
           tileProvider: null,
@@ -65,7 +66,7 @@ void main() {
           zIndex: 1,
           visible: false,
           tileSize: 128);
-      final TileOverlay tileOverlay2 = TileOverlay(
+      const TileOverlay tileOverlay2 = TileOverlay(
           tileOverlayId: TileOverlayId('id1'),
           fadeIn: false,
           tileProvider: null,
@@ -73,7 +74,7 @@ void main() {
           zIndex: 1,
           visible: false,
           tileSize: 128);
-      final TileOverlay tileOverlay3 = TileOverlay(
+      const TileOverlay tileOverlay3 = TileOverlay(
           tileOverlayId: TileOverlayId('id2'),
           fadeIn: false,
           tileProvider: null,
@@ -86,8 +87,8 @@ void main() {
     });
 
     test('hashCode', () async {
-      TileOverlayId id = TileOverlayId('id1');
-      final TileOverlay tileOverlay = TileOverlay(
+      const TileOverlayId id = TileOverlayId('id1');
+      const TileOverlay tileOverlay = TileOverlay(
           tileOverlayId: id,
           fadeIn: false,
           tileProvider: null,

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/tile_overlay_updates_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/tile_overlay_updates_test.dart
@@ -3,22 +3,23 @@
 // found in the LICENSE file.
 
 import 'dart:ui' show hashValues, hashList;
+
 import 'package:flutter_test/flutter_test.dart';
-import 'package:google_maps_flutter_platform_interface/src/types/utils/tile_overlay.dart';
-import 'package:google_maps_flutter_platform_interface/src/types/tile_overlay_updates.dart';
 import 'package:google_maps_flutter_platform_interface/src/types/tile_overlay.dart';
+import 'package:google_maps_flutter_platform_interface/src/types/tile_overlay_updates.dart';
+import 'package:google_maps_flutter_platform_interface/src/types/utils/tile_overlay.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('tile overlay updates tests', () {
     test('Correctly set toRemove, toAdd and toChange', () async {
-      final TileOverlay to1 = TileOverlay(tileOverlayId: TileOverlayId('id1'));
-      final TileOverlay to2 = TileOverlay(tileOverlayId: TileOverlayId('id2'));
-      final TileOverlay to3 = TileOverlay(tileOverlayId: TileOverlayId('id3'));
-      final TileOverlay to3Changed =
+      const TileOverlay to1 = TileOverlay(tileOverlayId: TileOverlayId('id1'));
+      const TileOverlay to2 = TileOverlay(tileOverlayId: TileOverlayId('id2'));
+      const TileOverlay to3 = TileOverlay(tileOverlayId: TileOverlayId('id3'));
+      const TileOverlay to3Changed =
           TileOverlay(tileOverlayId: TileOverlayId('id3'), transparency: 0.5);
-      final TileOverlay to4 = TileOverlay(tileOverlayId: TileOverlayId('id4'));
+      const TileOverlay to4 = TileOverlay(tileOverlayId: TileOverlayId('id4'));
       final Set<TileOverlay> previous = Set.from(<TileOverlay>[to1, to2, to3]);
       final Set<TileOverlay> current =
           Set.from(<TileOverlay>[to2, to3Changed, to4]);
@@ -26,7 +27,7 @@ void main() {
           TileOverlayUpdates.from(previous, current);
 
       final Set<TileOverlayId> toRemove =
-          Set.from(<TileOverlayId>[TileOverlayId('id1')]);
+          Set.from(<TileOverlayId>[const TileOverlayId('id1')]);
       expect(updates.tileOverlayIdsToRemove, toRemove);
 
       final Set<TileOverlay> toAdd = Set.from(<TileOverlay>[to4]);
@@ -37,12 +38,12 @@ void main() {
     });
 
     test('toJson', () async {
-      final TileOverlay to1 = TileOverlay(tileOverlayId: TileOverlayId('id1'));
-      final TileOverlay to2 = TileOverlay(tileOverlayId: TileOverlayId('id2'));
-      final TileOverlay to3 = TileOverlay(tileOverlayId: TileOverlayId('id3'));
-      final TileOverlay to3Changed =
+      const TileOverlay to1 = TileOverlay(tileOverlayId: TileOverlayId('id1'));
+      const TileOverlay to2 = TileOverlay(tileOverlayId: TileOverlayId('id2'));
+      const TileOverlay to3 = TileOverlay(tileOverlayId: TileOverlayId('id3'));
+      const TileOverlay to3Changed =
           TileOverlay(tileOverlayId: TileOverlayId('id3'), transparency: 0.5);
-      final TileOverlay to4 = TileOverlay(tileOverlayId: TileOverlayId('id4'));
+      const TileOverlay to4 = TileOverlay(tileOverlayId: TileOverlayId('id4'));
       final Set<TileOverlay> previous = Set.from(<TileOverlay>[to1, to2, to3]);
       final Set<TileOverlay> current =
           Set.from(<TileOverlay>[to2, to3Changed, to4]);
@@ -61,12 +62,12 @@ void main() {
     });
 
     test('equality', () async {
-      final TileOverlay to1 = TileOverlay(tileOverlayId: TileOverlayId('id1'));
-      final TileOverlay to2 = TileOverlay(tileOverlayId: TileOverlayId('id2'));
-      final TileOverlay to3 = TileOverlay(tileOverlayId: TileOverlayId('id3'));
-      final TileOverlay to3Changed =
+      const TileOverlay to1 = TileOverlay(tileOverlayId: TileOverlayId('id1'));
+      const TileOverlay to2 = TileOverlay(tileOverlayId: TileOverlayId('id2'));
+      const TileOverlay to3 = TileOverlay(tileOverlayId: TileOverlayId('id3'));
+      const TileOverlay to3Changed =
           TileOverlay(tileOverlayId: TileOverlayId('id3'), transparency: 0.5);
-      final TileOverlay to4 = TileOverlay(tileOverlayId: TileOverlayId('id4'));
+      const TileOverlay to4 = TileOverlay(tileOverlayId: TileOverlayId('id4'));
       final Set<TileOverlay> previous = Set.from(<TileOverlay>[to1, to2, to3]);
       final Set<TileOverlay> current1 =
           Set.from(<TileOverlay>[to2, to3Changed, to4]);
@@ -84,12 +85,12 @@ void main() {
     });
 
     test('hashCode', () async {
-      final TileOverlay to1 = TileOverlay(tileOverlayId: TileOverlayId('id1'));
-      final TileOverlay to2 = TileOverlay(tileOverlayId: TileOverlayId('id2'));
-      final TileOverlay to3 = TileOverlay(tileOverlayId: TileOverlayId('id3'));
-      final TileOverlay to3Changed =
+      const TileOverlay to1 = TileOverlay(tileOverlayId: TileOverlayId('id1'));
+      const TileOverlay to2 = TileOverlay(tileOverlayId: TileOverlayId('id2'));
+      const TileOverlay to3 = TileOverlay(tileOverlayId: TileOverlayId('id3'));
+      const TileOverlay to3Changed =
           TileOverlay(tileOverlayId: TileOverlayId('id3'), transparency: 0.5);
-      final TileOverlay to4 = TileOverlay(tileOverlayId: TileOverlayId('id4'));
+      const TileOverlay to4 = TileOverlay(tileOverlayId: TileOverlayId('id4'));
       final Set<TileOverlay> previous = Set.from(<TileOverlay>[to1, to2, to3]);
       final Set<TileOverlay> current =
           Set.from(<TileOverlay>[to2, to3Changed, to4]);
@@ -104,12 +105,12 @@ void main() {
     });
 
     test('toString', () async {
-      final TileOverlay to1 = TileOverlay(tileOverlayId: TileOverlayId('id1'));
-      final TileOverlay to2 = TileOverlay(tileOverlayId: TileOverlayId('id2'));
-      final TileOverlay to3 = TileOverlay(tileOverlayId: TileOverlayId('id3'));
-      final TileOverlay to3Changed =
+      const TileOverlay to1 = TileOverlay(tileOverlayId: TileOverlayId('id1'));
+      const TileOverlay to2 = TileOverlay(tileOverlayId: TileOverlayId('id2'));
+      const TileOverlay to3 = TileOverlay(tileOverlayId: TileOverlayId('id3'));
+      const TileOverlay to3Changed =
           TileOverlay(tileOverlayId: TileOverlayId('id3'), transparency: 0.5);
-      final TileOverlay to4 = TileOverlay(tileOverlayId: TileOverlayId('id4'));
+      const TileOverlay to4 = TileOverlay(tileOverlayId: TileOverlayId('id4'));
       final Set<TileOverlay> previous = Set.from(<TileOverlay>[to1, to2, to3]);
       final Set<TileOverlay> current =
           Set.from(<TileOverlay>[to2, to3Changed, to4]);

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/tile_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/tile_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:typed_data';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_maps_flutter_platform_interface/google_maps_flutter_platform_interface.dart';
 
@@ -22,7 +23,7 @@ void main() {
     });
 
     test('toJson handles null data', () async {
-      final Tile tile = Tile(0, 0, null);
+      const Tile tile = Tile(0, 0, null);
       final Object json = tile.toJson();
       expect(json, <String, Object>{
         'width': 0,


### PR DESCRIPTION
## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
