### PR TITLE
[video_player] dont hardcode video fps to 30 on ios

### DIFF
--- a/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m
@@ -142,10 +142,17 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
   }
   videoComposition.renderSize = CGSizeMake(width, height);
 
-  // TODO(@recastrodiaz): should we use videoTrack.nominalFrameRate ?
-  // Currently set at a constant 30 FPS
-  videoComposition.frameDuration = CMTimeMake(1, 30);
+  float nominalFrameRate = videoTrack.nominalFrameRate;
+  
+  int fps = 30;
 
+  if (nominalFrameRate > 0)
+  {
+    fps = (int) ceil(nominalFrameRate);
+  }
+  
+  videoComposition.frameDuration = CMTimeMake(1, fps);
+  
   return videoComposition;
 }
 


### PR DESCRIPTION
Videos on iOS were playing at 30 fps regardless of what the fps was according to the media file. This PR fixes that. It will now try to read the fps from the media file, if it fails it falls back on 30 fps.

https://github.com/flutter/flutter/issues/78210
