### PR TITLE
[webview_flutter] add COMMON support for Android WebView initializing

### DIFF
--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.3
+
+* Add common support for Android WebView initializing(`FlutterWebView.setCommonIniter()`) [flutter/issues/70731](https://github.com/flutter/flutter/issues/70731).
+
 ## 2.0.2
 
 * Fixes bug where text fields are hidden behind the keyboard

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -29,6 +29,20 @@ import java.util.Map;
 
 public class FlutterWebView implements PlatformView, MethodCallHandler {
   private static final String JS_CHANNEL_NAMES_FIELD = "javascriptChannelNames";
+  private static FlutterWebViewIniter commonIniter;
+
+  /**
+   * Set common initializing logic for all Flutter WebView's. When the WebView is created and the
+   * original initialization is done, {@link FlutterWebViewIniter#initWebView(WebView)} would be
+   * called.
+   *
+   * <p>Suggestion: you can call this method in {@link android.app.Application} to avoid memory
+   * leak.
+   */
+  public static void setCommonIniter(FlutterWebViewIniter initer) {
+    FlutterWebView.commonIniter = initer;
+  }
+
   private final WebView webView;
   private final MethodChannel methodChannel;
   private final FlutterWebViewClient flutterWebViewClient;
@@ -128,6 +142,7 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
       String userAgent = (String) params.get("userAgent");
       updateUserAgent(userAgent);
     }
+    if (commonIniter != null) commonIniter.initWebView(webView);
     if (params.containsKey("initialUrl")) {
       String url = (String) params.get("initialUrl");
       webView.loadUrl(url);

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewIniter.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewIniter.java
@@ -1,0 +1,23 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.plugins.webviewflutter;
+
+import android.webkit.WebView;
+
+/**
+ * Interface to initialize Flutter WebView in native Android code.
+ *
+ * <p>Why? In most cases, an APP has custom COMMON WebView initialization logic, like {@link
+ * android.webkit.WebSettings#setBuiltInZoomControls(boolean)}, {@link
+ * android.webkit.WebSettings#setMixedContentMode(int)}, {@link
+ * android.webkit.WebSettings#setTextZoom(int)} etc.
+ *
+ * <p>Adding all these settings to Flutter WebView params is tedious, and unnecessary mostly, so we
+ * can put these initialization on our APP's self native code as you like.
+ */
+public interface FlutterWebViewIniter {
+  /** How to initialize WebView */
+  void initWebView(WebView webView);
+}

--- a/packages/webview_flutter/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/webview_flutter/example/android/app/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
   <application
     android:icon="@mipmap/ic_launcher"
     android:label="webview_flutter_example"
-    android:name="io.flutter.app.FlutterApplication">
+    android:name=".App">
     <meta-data
         android:name="flutterEmbedding"
         android:value="2" />

--- a/packages/webview_flutter/example/android/app/src/main/java/io/flutter/plugins/webviewflutterexample/App.java
+++ b/packages/webview_flutter/example/android/app/src/main/java/io/flutter/plugins/webviewflutterexample/App.java
@@ -1,0 +1,28 @@
+package io.flutter.plugins.webviewflutterexample;
+
+import android.os.Build;
+import android.webkit.WebSettings;
+import android.webkit.WebView;
+import io.flutter.app.FlutterApplication;
+import io.flutter.plugins.webviewflutter.FlutterWebView;
+import io.flutter.plugins.webviewflutter.FlutterWebViewIniter;
+
+public class App extends FlutterApplication implements FlutterWebViewIniter {
+  @Override
+  public void onCreate() {
+    super.onCreate();
+
+    FlutterWebView.setCommonIniter(this);
+  }
+
+  @Override
+  public void initWebView(WebView webView) {
+    WebSettings settings = webView.getSettings();
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      settings.setMixedContentMode(WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE);
+    }
+    settings.setSupportZoom(true);
+    settings.setBuiltInZoomControls(true);
+    settings.setDisplayZoomControls(false);
+  }
+}

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/webview_flutter
-version: 2.0.2
+version: 2.0.3
 
 environment:
   sdk: ">=2.12.0-259.9.beta <3.0.0"


### PR DESCRIPTION
Add a **common** way to initialize Android WebView (make more settings) in Android code.

In most cases, an APP has custom common WebView initialization logic, like `WebSettings#setBuiltInZoomControls(boolean)`, `WebSettings#setMixedContentMode(int)`, `WebSettings#setTextZoom(int)` etc.
Adding all these settings to Flutter WebView params is tedious, and unnecessary mostly,
or else we can put these initialization on our APP's self native code as below:

```java
FlutterWebView.setCommonIniter(new FlutterWebViewIniter() {
    @Override
    public void initWebView(WebView webView) {
        WebSettings settings = webView.getSettings();
        settings.setMixedContentMode(WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE);
        settings.setSupportZoom(true);
        settings.setBuiltInZoomControls(true);
        settings.setDisplayZoomControls(false);
    }
});
```

Fix https://github.com/flutter/flutter/issues/70731, https://github.com/flutter/flutter/issues/48283, https://github.com/flutter/flutter/issues/43595, etc.
Related PRs: https://github.com/flutter/plugins/pull/2468, https://github.com/flutter/plugins/pull/3325, https://github.com/flutter/plugins/pull/3701, https://github.com/flutter/plugins/pull/2451


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
