### PR TITLE
[integration_test]: migrate to null-safety

### DIFF
--- a/packages/integration_test/CHANGELOG.md
+++ b/packages/integration_test/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.3
+
+* Migrate to null-safety
+
 ## 1.0.2+3
 
 * Update README to reflect deprecation.

--- a/packages/integration_test/lib/_callback_io.dart
+++ b/packages/integration_test/lib/_callback_io.dart
@@ -21,7 +21,7 @@ class IOCallbackManager implements CallbackManager {
   @override
   Future<Map<String, dynamic>> callback(
       Map<String, String> params, IntegrationTestResults testRunner) async {
-    final String command = params['command'];
+    final String? command = params['command'];
     Map<String, String> response;
     switch (command) {
       case 'request_data':

--- a/packages/integration_test/lib/_callback_web.dart
+++ b/packages/integration_test/lib/_callback_web.dart
@@ -75,7 +75,7 @@ class WebCallbackManager implements CallbackManager {
   @override
   Future<Map<String, dynamic>> callback(
       Map<String, String> params, IntegrationTestResults testRunner) async {
-    final String command = params['command'];
+    final String? command = params['command'];
     Map<String, String> response;
     switch (command) {
       case 'request_data':
@@ -96,7 +96,7 @@ class WebCallbackManager implements CallbackManager {
   }
 
   Future<Map<String, dynamic>> _requestDataWithMessage(
-      String extraMessage, IntegrationTestResults testRunner) async {
+      String? extraMessage, IntegrationTestResults testRunner) async {
     Map<String, String> response;
     // Driver side tests' status is added as an extra message.
     final DriverTestMessage message =

--- a/packages/integration_test/lib/common.dart
+++ b/packages/integration_test/lib/common.dart
@@ -11,12 +11,12 @@ import 'dart:convert';
 /// An object sent from integration_test back to the Flutter Driver in response to
 /// `request_data` command.
 class Response {
-  final List<Failure> _failureDetails;
+  final List<Failure>? _failureDetails;
 
   final bool _allTestsPassed;
 
   /// The extra information to be added along side the test result.
-  Map<String, dynamic> data;
+  Map<String, dynamic>? data;
 
   /// Constructor to use for positive response.
   Response.allTestsPassed({this.data})
@@ -28,7 +28,7 @@ class Response {
       : this._allTestsPassed = false;
 
   /// Constructor for failure response.
-  Response.toolException({String ex})
+  Response.toolException({String? ex})
       : this._allTestsPassed = false,
         this._failureDetails = [Failure('ToolException', ex)];
 
@@ -42,10 +42,10 @@ class Response {
 
   /// If the result are failures get the formatted details.
   String get formattedFailureDetails =>
-      _allTestsPassed ? '' : formatFailures(_failureDetails);
+      _allTestsPassed ? '' : formatFailures(_failureDetails!);
 
   /// Failure details as a list.
-  List<Failure> get failureDetails => _failureDetails;
+  List<Failure>? get failureDetails => _failureDetails;
 
   /// Serializes this message to a JSON map.
   String toJson() => json.encode(<String, dynamic>{
@@ -57,7 +57,7 @@ class Response {
   /// Deserializes the result from JSON.
   static Response fromJson(String source) {
     final Map<String, dynamic> responseJson = json.decode(source);
-    if (responseJson['result'] as String == 'true') {
+    if (responseJson['result']! as String == 'true') {
       return Response.allTestsPassed(data: responseJson['data']);
     } else {
       return Response.someTestsFailed(
@@ -87,11 +87,11 @@ class Response {
   /// Create a list of Strings from [_failureDetails].
   List<String> _failureDetailsAsString() {
     final List<String> list = <String>[];
-    if (_failureDetails == null || _failureDetails.isEmpty) {
+    if (_failureDetails == null || _failureDetails!.isEmpty) {
       return list;
     }
 
-    _failureDetails.forEach((Failure f) {
+    _failureDetails!.forEach((Failure f) {
       list.add(f.toJson());
     });
 
@@ -112,17 +112,17 @@ class Response {
 /// Representing a failure includes the method name and the failure details.
 class Failure {
   /// The name of the test method which failed.
-  final String methodName;
+  final String? methodName;
 
   /// The details of the failure such as stack trace.
-  final String details;
+  final String? details;
 
   /// Constructor requiring all fields during initialization.
   Failure(this.methodName, this.details);
 
   /// Serializes the object to JSON.
   String toJson() {
-    return json.encode(<String, String>{
+    return json.encode(<String, String?>{
       'methodName': methodName,
       'details': details,
     });
@@ -194,7 +194,7 @@ class DriverTestMessage {
   }
 
   /// Return a DriverTestMessage depending on `status`.
-  static DriverTestMessage fromString(String status) {
+  static DriverTestMessage fromString(String? status) {
     switch (status) {
       case 'error':
         return DriverTestMessage.error();
@@ -294,7 +294,7 @@ abstract class IntegrationTestResults {
   List<Failure> get failureMethodsDetails;
 
   /// The extra data for the reported result.
-  Map<String, dynamic> get reportData;
+  Map<String, dynamic>? get reportData;
 
   /// Whether all the test methods completed succesfully.
   Completer<bool> get allTestsPassed;

--- a/packages/integration_test/lib/integration_test.dart
+++ b/packages/integration_test/lib/integration_test.dart
@@ -11,7 +11,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
+// ignore: import_of_legacy_library_into_null_safe
 import 'package:vm_service/vm_service.dart' as vm;
+// ignore: import_of_legacy_library_into_null_safe
 import 'package:vm_service/vm_service_io.dart' as vm_io;
 
 import 'common.dart';
@@ -80,7 +82,7 @@ class IntegrationTestWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding
   @override
   bool get registerTestTextInput => false;
 
-  Size _surfaceSize;
+  Size? _surfaceSize;
 
   // This flag is used to print warning messages when tracking performance
   // under debug mode.
@@ -91,7 +93,7 @@ class IntegrationTestWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding
   ///
   /// Set to null to use the default surface size.
   @override
-  Future<void> setSurfaceSize(Size size) {
+  Future<void> setSurfaceSize(Size? size) {
     return TestAsyncUtils.guard<void>(() async {
       assert(inTest);
       if (_surfaceSize == size) {
@@ -123,7 +125,7 @@ class IntegrationTestWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding
   ///
   /// Returns an instance of the [IntegrationTestWidgetsFlutterBinding], creating and
   /// initializing it if necessary.
-  static WidgetsBinding ensureInitialized() {
+  static WidgetsBinding? ensureInitialized() {
     if (WidgetsBinding.instance == null) {
       IntegrationTestWidgetsFlutterBinding();
     }
@@ -150,9 +152,9 @@ class IntegrationTestWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding
   ///
   /// The default value is `null`.
   @override
-  Map<String, dynamic> get reportData => _reportData;
-  Map<String, dynamic> _reportData;
-  set reportData(Map<String, dynamic> data) => this._reportData = data;
+  Map<String, dynamic>? get reportData => _reportData;
+  Map<String, dynamic>? _reportData;
+  set reportData(Map<String, dynamic>? data) => this._reportData = data;
 
   /// Manages callbacks received from driver side and commands send to driver
   /// side.
@@ -189,7 +191,7 @@ class IntegrationTestWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding
     Future<void> testBody(),
     VoidCallback invariantTester, {
     String description = '',
-    Duration timeout,
+    Duration? timeout,
   }) async {
     await super.runTest(
       testBody,
@@ -200,13 +202,13 @@ class IntegrationTestWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding
     results[description] ??= _success;
   }
 
-  vm.VmService _vmService;
+  vm.VmService? _vmService;
 
   /// Initialize the [vm.VmService] settings for the timeline.
   @visibleForTesting
   Future<void> enableTimeline({
     List<String> streams = const <String>['all'],
-    @visibleForTesting vm.VmService vmService,
+    @visibleForTesting vm.VmService? vmService,
   }) async {
     assert(streams != null);
     assert(streams.isNotEmpty);
@@ -218,10 +220,10 @@ class IntegrationTestWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding
           await developer.Service.getInfo();
       assert(info.serverUri != null);
       _vmService = await vm_io.vmServiceConnectUri(
-        'ws://localhost:${info.serverUri.port}${info.serverUri.path}ws',
+        'ws://localhost:${info.serverUri!.port}${info.serverUri!.path}ws',
       );
     }
-    await _vmService.setVMTimelineFlags(streams);
+    await _vmService!.setVMTimelineFlags(streams);
   }
 
   /// Runs [action] and returns a [vm.Timeline] trace for it.
@@ -245,14 +247,14 @@ class IntegrationTestWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding
     await enableTimeline(streams: streams);
     if (retainPriorEvents) {
       await action();
-      return await _vmService.getVMTimeline();
+      return await _vmService!.getVMTimeline();
     }
 
-    await _vmService.clearVMTimeline();
-    final vm.Timestamp startTime = await _vmService.getVMTimelineMicros();
+    await _vmService!.clearVMTimeline();
+    final vm.Timestamp startTime = await _vmService!.getVMTimelineMicros();
     await action();
-    final vm.Timestamp endTime = await _vmService.getVMTimelineMicros();
-    return await _vmService.getVMTimeline(
+    final vm.Timestamp endTime = await _vmService!.getVMTimelineMicros();
+    return await _vmService!.getVMTimeline(
       timeOriginMicros: startTime.timestamp,
       timeExtentMicros: endTime.timestamp,
     );
@@ -285,7 +287,7 @@ class IntegrationTestWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding
       retainPriorEvents: retainPriorEvents,
     );
     reportData ??= <String, dynamic>{};
-    reportData[reportKey] = timeline.toJson();
+    reportData![reportKey] = timeline.toJson();
   }
 
   /// Watches the [FrameTiming] during `action` and report it to the binding
@@ -324,6 +326,6 @@ class IntegrationTestWidgetsFlutterBinding extends LiveTestWidgetsFlutterBinding
     final FrameTimingSummarizer frameTimes =
         FrameTimingSummarizer(frameTimings);
     reportData ??= <String, dynamic>{};
-    reportData[reportKey] = frameTimes.summary;
+    reportData![reportKey] = frameTimes.summary;
   }
 }

--- a/packages/integration_test/lib/integration_test_driver.dart
+++ b/packages/integration_test/lib/integration_test_driver.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+// ignore: import_of_legacy_library_into_null_safe
 import 'package:flutter_driver/flutter_driver.dart';
 
 import 'package:integration_test/common.dart';
@@ -21,16 +22,16 @@ String testOutputsDirectory =
 
 /// The callback type to handle [integration_test.Response.data] after the test
 /// succeeds.
-typedef ResponseDataCallback = FutureOr<void> Function(Map<String, dynamic>);
+typedef ResponseDataCallback = FutureOr<void> Function(Map<String, dynamic>?);
 
 /// Writes a json-serializable json data to to
 /// [testOutputsDirectory]/`testOutputFilename.json`.
 ///
 /// This is the default `responseDataCallback` in [integrationDriver].
 Future<void> writeResponseData(
-  Map<String, dynamic> data, {
+  Map<String, dynamic>? data, {
   String testOutputFilename = 'integration_response_data',
-  String destinationDirectory,
+  String? destinationDirectory,
 }) async {
   assert(testOutputFilename != null);
   destinationDirectory ??= testOutputsDirectory;
@@ -86,6 +87,6 @@ Future<void> integrationDriver({
 
 const JsonEncoder _prettyEncoder = JsonEncoder.withIndent('  ');
 
-String _encodeJson(Map<String, dynamic> jsonObject, bool pretty) {
+String _encodeJson(Map<String, dynamic>? jsonObject, bool pretty) {
   return pretty ? _prettyEncoder.convert(jsonObject) : json.encode(jsonObject);
 }

--- a/packages/integration_test/lib/integration_test_driver_extended.dart
+++ b/packages/integration_test/lib/integration_test_driver_extended.dart
@@ -5,14 +5,15 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'common.dart';
-
+// ignore: import_of_legacy_library_into_null_safe
 import 'package:flutter_driver/flutter_driver.dart';
+
+import 'common.dart';
 
 /// Example Integration Test which can also run WebDriver command depending on
 /// the requests coming from the test methods.
 Future<void> integrationDriver(
-    {FlutterDriver driver, Function onScreenshot}) async {
+    {FlutterDriver? driver, Function? onScreenshot}) async {
   if (driver == null) {
     driver = await FlutterDriver.connect();
   }
@@ -27,16 +28,16 @@ Future<void> integrationDriver(
   // Until `integration_test` returns a [WebDriverCommandType.noop], keep
   // executing WebDriver commands.
   while (response.data != null &&
-      response.data['web_driver_command'] != null &&
-      response.data['web_driver_command'] != '${WebDriverCommandType.noop}') {
-    final String webDriverCommand = response.data['web_driver_command'];
+      response.data!['web_driver_command'] != null &&
+      response.data!['web_driver_command'] != '${WebDriverCommandType.noop}') {
+    final String? webDriverCommand = response.data!['web_driver_command'];
     if (webDriverCommand == '${WebDriverCommandType.screenshot}') {
       // Use `driver.screenshot()` method to get a screenshot of the web page.
       final List<int> screenshotImage = await driver.screenshot();
-      final String screenshotName = response.data['screenshot_name'];
+      final String? screenshotName = response.data!['screenshot_name'];
 
       final bool screenshotSuccess =
-          await onScreenshot(screenshotName, screenshotImage);
+          await onScreenshot!(screenshotName, screenshotImage);
       if (screenshotSuccess) {
         jsonResponse =
             await driver.requestData(DriverTestMessage.complete().toString());
@@ -59,8 +60,8 @@ Future<void> integrationDriver(
 
   // If No-op command is sent, ask for the result of all tests.
   if (response.data != null &&
-      response.data['web_driver_command'] != null &&
-      response.data['web_driver_command'] == '${WebDriverCommandType.noop}') {
+      response.data!['web_driver_command'] != null &&
+      response.data!['web_driver_command'] == '${WebDriverCommandType.noop}') {
     jsonResponse = await driver.requestData(null);
 
     response = Response.fromJson(jsonResponse);

--- a/packages/integration_test/pubspec.yaml
+++ b/packages/integration_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: integration_test
 description: Runs tests that use the flutter_test API as integration tests.
-version: 1.0.2+3
+version: 1.0.3
 homepage: https://github.com/flutter/plugins/tree/master/packages/integration_test
 
 environment:

--- a/packages/integration_test/pubspec.yaml
+++ b/packages/integration_test/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.2+3
 homepage: https://github.com/flutter/plugins/tree/master/packages/integration_test
 
 environment:
-  sdk: ">=2.2.2 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
   flutter: ">=1.12.13+hotfix.5"
 
 dependencies:
@@ -14,14 +14,14 @@ dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
-  path: ^1.6.4
+  path: ^1.8.0
   # TODO(dnfield): This is a problem - flutter_driver and flutter_tools depend
-  # on this packkage, and so does integration_test. When this gets rev'd in the
+  # on this package, and so does integration_test. When this gets rev'd in the
   # SDK, it has to be rev'd here too so integration tests in the SDK can use it.
   vm_service: ">= 4.2.0 <7.0.0"
 
 dev_dependencies:
-  pedantic: ^1.8.0
+  pedantic: ^1.11.0
   mockito: ^4.1.1
 
 flutter:

--- a/packages/integration_test/test/binding_fail_test.dart
+++ b/packages/integration_test/test/binding_fail_test.dart
@@ -17,7 +17,7 @@ const String _failureExcerpt = 'Expected: <false>\\n  Actual: <true>';
 void main() async {
   group('Integration binding result', () {
     test('when multiple tests pass', () async {
-      final Map<String, dynamic> results =
+      final Map<String, dynamic>? results =
           await _runTest('test/data/pass_test_script.dart');
 
       expect(
@@ -29,7 +29,7 @@ void main() async {
     });
 
     test('when multiple tests fail', () async {
-      final Map<String, dynamic> results =
+      final Map<String, dynamic>? results =
           await _runTest('test/data/fail_test_script.dart');
 
       expect(results, hasLength(2));
@@ -40,7 +40,7 @@ void main() async {
     });
 
     test('when one test passes, then another fails', () async {
-      final Map<String, dynamic> results =
+      final Map<String, dynamic>? results =
           await _runTest('test/data/pass_then_fail_test_script.dart');
 
       expect(results, hasLength(2));
@@ -53,7 +53,7 @@ void main() async {
 /// Runs a test script and returns the [IntegrationTestWidgetsFlutterBinding.result].
 ///
 /// [scriptPath] is relative to the package root.
-Future<Map<String, dynamic>> _runTest(String scriptPath) async {
+Future<Map<String, dynamic>?> _runTest(String scriptPath) async {
   final Process process =
       await Process.start(_flutterBin, ['test', '--machine', scriptPath]);
 
@@ -72,16 +72,16 @@ Future<Map<String, dynamic>> _runTest(String scriptPath) async {
               // Only interested in test events which are JSON.
             }
           })
-          .expand<Map<String, dynamic>>((dynamic json) {
+          .expand<Map<String, dynamic>?>((dynamic json) {
             return json is List<dynamic>
                 ? json.cast()
-                : <Map<String, dynamic>>[json as Map<String, dynamic>];
+                : <Map<String, dynamic>?>[json as Map<String, dynamic>];
           })
           .where((dynamic testEvent) =>
               testEvent != null && testEvent['type'] == 'print')
-          .map((dynamic printEvent) => printEvent['message'] as String)
-          .firstWhere((String message) =>
-              message.startsWith(_integrationResultsPrefix)))
+          .map((dynamic printEvent) => printEvent['message'] as String?)
+          .firstWhere((String? message) =>
+              message!.startsWith(_integrationResultsPrefix)))!
       .replaceAll(_integrationResultsPrefix, '');
 
   return jsonDecode(testResults);

--- a/packages/integration_test/test/binding_test.dart
+++ b/packages/integration_test/test/binding_test.dart
@@ -5,11 +5,12 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
-
-import 'package:integration_test/integration_test.dart';
-import 'package:integration_test/common.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/common.dart';
+import 'package:integration_test/integration_test.dart';
+// ignore: import_of_legacy_library_into_null_safe
 import 'package:mockito/mockito.dart';
+// ignore: import_of_legacy_library_into_null_safe
 import 'package:vm_service/vm_service.dart' as vm;
 
 vm.Timeline _ktimelines = vm.Timeline(
@@ -19,16 +20,16 @@ vm.Timeline _ktimelines = vm.Timeline(
 );
 
 void main() async {
-  Future<Map<String, dynamic>> request;
+  Future<Map<String, dynamic>>? request;
 
   group('Test Integration binding', () {
     final WidgetsBinding binding =
-        IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+        IntegrationTestWidgetsFlutterBinding.ensureInitialized()!;
     assert(binding is IntegrationTestWidgetsFlutterBinding);
     final IntegrationTestWidgetsFlutterBinding integrationBinding =
         binding as IntegrationTestWidgetsFlutterBinding;
 
-    MockVM mockVM;
+    MockVM? mockVM;
     List<int> clockTimes = [100, 200];
 
     setUp(() {
@@ -36,11 +37,11 @@ void main() async {
         'command': 'request_data',
       });
       mockVM = MockVM();
-      when(mockVM.getVMTimeline(
+      when(mockVM!.getVMTimeline(
         timeOriginMicros: anyNamed('timeOriginMicros'),
         timeExtentMicros: anyNamed('timeExtentMicros'),
       )).thenAnswer((_) => Future.value(_ktimelines));
-      when(mockVM.getVMTimelineMicros()).thenAnswer(
+      when(mockVM!.getVMTimelineMicros()).thenAnswer(
         (_) => Future.value(vm.Timestamp(timestamp: clockTimes.removeAt(0))),
       );
     });
@@ -83,9 +84,9 @@ void main() async {
       await integrationBinding.enableTimeline(vmService: mockVM);
       await integrationBinding.traceAction(() async {});
       expect(integrationBinding.reportData, isNotNull);
-      expect(integrationBinding.reportData.containsKey('timeline'), true);
+      expect(integrationBinding.reportData!.containsKey('timeline'), true);
       expect(
-        json.encode(integrationBinding.reportData['timeline']),
+        json.encode(integrationBinding.reportData!['timeline']),
         json.encode(_ktimelines),
       );
     });
@@ -96,10 +97,10 @@ void main() async {
     // part of the `tearDownAll` registerred in the group during
     // `IntegrationTestWidgetsFlutterBinding` initialization.
     final Map<String, dynamic> response =
-        (await request)['response'] as Map<String, dynamic>;
+        (await request)!['response'] as Map<String, dynamic>;
     final String message = response['message'] as String;
     Response result = Response.fromJson(message);
-    assert(result.data['answer'] == 42);
+    assert(result.data!['answer'] == 42);
   });
 }
 

--- a/packages/integration_test/test/data/fail_test_script.dart
+++ b/packages/integration_test/test/data/fail_test_script.dart
@@ -8,8 +8,8 @@ import 'package:integration_test/integration_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() async {
-  final IntegrationTestWidgetsFlutterBinding binding =
-      IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  final IntegrationTestWidgetsFlutterBinding? binding =
+      IntegrationTestWidgetsFlutterBinding.ensureInitialized() as IntegrationTestWidgetsFlutterBinding?;
 
   testWidgets('failing test 1', (WidgetTester tester) async {
     expect(true, false);
@@ -21,6 +21,6 @@ void main() async {
 
   tearDownAll(() {
     print(
-        'IntegrationTestWidgetsFlutterBinding test results: ${jsonEncode(binding.results)}');
+        'IntegrationTestWidgetsFlutterBinding test results: ${jsonEncode(binding!.results)}');
   });
 }

--- a/packages/integration_test/test/data/pass_test_script.dart
+++ b/packages/integration_test/test/data/pass_test_script.dart
@@ -8,8 +8,8 @@ import 'package:integration_test/integration_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() async {
-  final IntegrationTestWidgetsFlutterBinding binding =
-      IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  final IntegrationTestWidgetsFlutterBinding? binding =
+      IntegrationTestWidgetsFlutterBinding.ensureInitialized() as IntegrationTestWidgetsFlutterBinding?;
 
   testWidgets('passing test 1', (WidgetTester tester) async {
     expect(true, true);
@@ -21,6 +21,6 @@ void main() async {
 
   tearDownAll(() {
     print(
-        'IntegrationTestWidgetsFlutterBinding test results: ${jsonEncode(binding.results)}');
+        'IntegrationTestWidgetsFlutterBinding test results: ${jsonEncode(binding!.results)}');
   });
 }

--- a/packages/integration_test/test/data/pass_then_fail_test_script.dart
+++ b/packages/integration_test/test/data/pass_then_fail_test_script.dart
@@ -8,8 +8,8 @@ import 'package:integration_test/integration_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() async {
-  final IntegrationTestWidgetsFlutterBinding binding =
-      IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  final IntegrationTestWidgetsFlutterBinding? binding =
+      IntegrationTestWidgetsFlutterBinding.ensureInitialized() as IntegrationTestWidgetsFlutterBinding?;
 
   testWidgets('passing test', (WidgetTester tester) async {
     expect(true, true);
@@ -21,6 +21,6 @@ void main() async {
 
   tearDownAll(() {
     print(
-        'IntegrationTestWidgetsFlutterBinding test results: ${jsonEncode(binding.results)}');
+        'IntegrationTestWidgetsFlutterBinding test results: ${jsonEncode(binding!.results)}');
   });
 }

--- a/packages/integration_test/test/response_serialization_test.dart
+++ b/packages/integration_test/test/response_serialization_test.dart
@@ -39,13 +39,13 @@ void main() {
     response = Response.allTestsPassed(data: data);
     jsonString = response.toJson();
     restored = Response.fromJson(jsonString);
-    expect(restored.data.keys, ['aaa']);
-    expect(restored.data.values, ['bbb']);
+    expect(restored.data!.keys, ['aaa']);
+    expect(restored.data!.values, ['bbb']);
 
     response = Response.someTestsFailed([fail, fail2], data: data);
     jsonString = response.toJson();
     restored = Response.fromJson(jsonString);
-    expect(restored.data.keys, ['aaa']);
-    expect(restored.data.values, ['bbb']);
+    expect(restored.data!.keys, ['aaa']);
+    expect(restored.data!.values, ['bbb']);
   });
 }


### PR DESCRIPTION
Integration-Test will be hereby migrated to null-safety.

```bash
Applying changes:
  test/response_serialization_test.dart (13 changes)
  test/binding_fail_test.dart (29 changes)
  test/binding_test.dart (38 changes)
  test/data/pass_then_fail_test_script.dart (5 changes)
  test/data/pass_test_script.dart (5 changes)
  test/data/fail_test_script.dart (5 changes)
  lib/integration_test_driver.dart (24 changes)
  lib/integration_test_driver_extended.dart (18 changes)
  lib/_extension_web.dart (18 changes)
  lib/_extension_io.dart (7 changes)
  lib/_callback_io.dart (21 changes)
  lib/common.dart (79 changes)
  lib/integration_test.dart (99 changes)
  lib/_callback_web.dart (65 changes)
  pubspec.yaml (1 change)
  .dart_tool/package_config.json (1 change)

Applied 16 edits.
```

Furthermore I double-checked the actual packages in pubspec.yaml and updated some of them, which were already null-safe.

Closes:
- https://github.com/flutter/flutter/issues/78713

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [ ] All existing and new tests are passing.

-> mockito and vm_service aren't null-safe so actual tests are failing with 5 failed tests. With `--no-sound-null-safety` 3 tests are failing.

<details><summary>Test results</summary>
❯ flutter test --no-sound-null-safety
00:08 +5: /Users/rebar/Development/plugins/packages/integration_test/test/binding_test.dart: Test Integration binding (tearDownAll)                                                       
Warning: integration_test test plugin was not detected.
00:10 +5 -1: /Users/rebar/Development/plugins/packages/integration_test/test/binding_fail_test.dart: Integration binding result when multiple tests pass [E]                              
  Bad state: No element
  dart:async                         Stream.firstWhere
  test/binding_fail_test.dart 83:12  _runTest
  ===== asynchronous gap ===========================
  dart:async                         _asyncThenWrapperHelper
  test/binding_fail_test.dart 21:17  main.<fn>.<fn>
  test/binding_fail_test.dart 19:38  main.<fn>.<fn>
  
00:12 +5 -2: /Users/rebar/Development/plugins/packages/integration_test/test/binding_fail_test.dart: Integration binding result when multiple tests fail [E]                              
  Bad state: No element
  dart:async                         Stream.firstWhere
  test/binding_fail_test.dart 83:12  _runTest
  ===== asynchronous gap ===========================
  dart:async                         _asyncThenWrapperHelper
  test/binding_fail_test.dart 33:17  main.<fn>.<fn>
  test/binding_fail_test.dart 31:38  main.<fn>.<fn>
  
00:15 +5 -3: /Users/rebar/Development/plugins/packages/integration_test/test/binding_fail_test.dart: Integration binding result when one test passes, then another fails [E]              
  Bad state: No element
  dart:async                         Stream.firstWhere
  test/binding_fail_test.dart 83:12  _runTest
  ===== asynchronous gap ===========================
  dart:async                         _asyncThenWrapperHelper
  test/binding_fail_test.dart 44:17  main.<fn>.<fn>
  test/binding_fail_test.dart 42:54  main.<fn>.<fn>
  
00:15 +5 -3: Some tests failed.
</details>
