### PR TITLE
[flutter_plugin_tools] Also look for Java tests in plugin path

### DIFF
--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/DartMessenger.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/DartMessenger.java
@@ -5,8 +5,8 @@
 package io.flutter.plugins.camera;
 
 import android.os.Handler;
-import android.os.Looper;
 import android.text.TextUtils;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import io.flutter.embedding.engine.systemchannels.PlatformChannel;
 import io.flutter.plugin.common.BinaryMessenger;
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 class DartMessenger {
+  @NonNull private final Handler handler;
   @Nullable private MethodChannel cameraChannel;
   @Nullable private MethodChannel deviceChannel;
 
@@ -41,9 +42,10 @@ class DartMessenger {
     }
   }
 
-  DartMessenger(BinaryMessenger messenger, long cameraId) {
+  DartMessenger(BinaryMessenger messenger, long cameraId, @NonNull Handler handler) {
     cameraChannel = new MethodChannel(messenger, "flutter.io/cameraPlugin/camera" + cameraId);
     deviceChannel = new MethodChannel(messenger, "flutter.io/cameraPlugin/device");
+    this.handler = handler;
   }
 
   void sendDeviceOrientationChangeEvent(PlatformChannel.DeviceOrientation orientation) {
@@ -106,14 +108,14 @@ class DartMessenger {
     if (cameraChannel == null) {
       return;
     }
-    new Handler(Looper.getMainLooper())
-        .post(
-            new Runnable() {
-              @Override
-              public void run() {
-                cameraChannel.invokeMethod(eventType.method, args);
-              }
-            });
+
+    handler.post(
+        new Runnable() {
+          @Override
+          public void run() {
+            cameraChannel.invokeMethod(eventType.method, args);
+          }
+        });
   }
 
   void send(DeviceEventType eventType) {
@@ -124,13 +126,13 @@ class DartMessenger {
     if (deviceChannel == null) {
       return;
     }
-    new Handler(Looper.getMainLooper())
-        .post(
-            new Runnable() {
-              @Override
-              public void run() {
-                deviceChannel.invokeMethod(eventType.method, args);
-              }
-            });
+
+    handler.post(
+        new Runnable() {
+          @Override
+          public void run() {
+            deviceChannel.invokeMethod(eventType.method, args);
+          }
+        });
   }
 }

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/MethodCallHandlerImpl.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/MethodCallHandlerImpl.java
@@ -6,6 +6,8 @@ package io.flutter.plugins.camera;
 
 import android.app.Activity;
 import android.hardware.camera2.CameraAccessException;
+import android.os.Handler;
+import android.os.Looper;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import io.flutter.embedding.engine.systemchannels.PlatformChannel;
@@ -353,7 +355,9 @@ final class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
     boolean enableAudio = call.argument("enableAudio");
     TextureRegistry.SurfaceTextureEntry flutterSurfaceTexture =
         textureRegistry.createSurfaceTexture();
-    DartMessenger dartMessenger = new DartMessenger(messenger, flutterSurfaceTexture.id());
+    DartMessenger dartMessenger =
+        new DartMessenger(
+            messenger, flutterSurfaceTexture.id(), new Handler(Looper.getMainLooper()));
     camera =
         new Camera(
             activity,

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/MethodCallHandlerImpl.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/MethodCallHandlerImpl.java
@@ -8,13 +8,8 @@ import android.app.Activity;
 import android.hardware.camera2.CameraAccessException;
 import android.os.Handler;
 import android.os.Looper;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-
-import java.util.HashMap;
-import java.util.Map;
-
 import io.flutter.embedding.engine.systemchannels.PlatformChannel;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.EventChannel;
@@ -26,6 +21,8 @@ import io.flutter.plugins.camera.types.ExposureMode;
 import io.flutter.plugins.camera.types.FlashMode;
 import io.flutter.plugins.camera.types.FocusMode;
 import io.flutter.view.TextureRegistry;
+import java.util.HashMap;
+import java.util.Map;
 
 final class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
   private final Activity activity;

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/MethodCallHandlerImpl.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/MethodCallHandlerImpl.java
@@ -8,8 +8,13 @@ import android.app.Activity;
 import android.hardware.camera2.CameraAccessException;
 import android.os.Handler;
 import android.os.Looper;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+
 import io.flutter.embedding.engine.systemchannels.PlatformChannel;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.EventChannel;
@@ -21,8 +26,6 @@ import io.flutter.plugins.camera.types.ExposureMode;
 import io.flutter.plugins.camera.types.FlashMode;
 import io.flutter.plugins.camera.types.FocusMode;
 import io.flutter.view.TextureRegistry;
-import java.util.HashMap;
-import java.util.Map;
 
 final class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
   private final Activity activity;

--- a/packages/camera/camera/android/src/test/java/io/flutter/plugins/camera/DartMessengerTest.java
+++ b/packages/camera/camera/android/src/test/java/io/flutter/plugins/camera/DartMessengerTest.java
@@ -6,7 +6,11 @@ package io.flutter.plugins.camera;
 
 import static junit.framework.TestCase.assertNull;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 
+import android.os.Handler;
 import androidx.annotation.NonNull;
 import io.flutter.embedding.engine.systemchannels.PlatformChannel;
 import io.flutter.plugin.common.BinaryMessenger;
@@ -19,6 +23,8 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 public class DartMessengerTest {
   /** A {@link BinaryMessenger} implementation that does nothing but save its messages. */
@@ -43,20 +49,24 @@ public class DartMessengerTest {
     }
   }
 
+  private Handler mockHandler;
   private DartMessenger dartMessenger;
   private FakeBinaryMessenger fakeBinaryMessenger;
 
   @Before
   public void setUp() {
+    mockHandler = mock(Handler.class);
     fakeBinaryMessenger = new FakeBinaryMessenger();
-    dartMessenger = new DartMessenger(fakeBinaryMessenger, 0);
+    dartMessenger = new DartMessenger(fakeBinaryMessenger, 0, mockHandler);
   }
 
   @Test
   public void sendCameraErrorEvent_includesErrorDescriptions() {
-    dartMessenger.sendCameraErrorEvent("error description");
+    doAnswer(createPostHandlerAnswer()).when(mockHandler).post(any(Runnable.class));
 
+    dartMessenger.sendCameraErrorEvent("error description");
     List<ByteBuffer> sentMessages = fakeBinaryMessenger.getMessages();
+
     assertEquals(1, sentMessages.size());
     MethodCall call = decodeSentMessage(sentMessages.get(0));
     assertEquals("error", call.method);
@@ -65,6 +75,7 @@ public class DartMessengerTest {
 
   @Test
   public void sendCameraInitializedEvent_includesPreviewSize() {
+    doAnswer(createPostHandlerAnswer()).when(mockHandler).post(any(Runnable.class));
     dartMessenger.sendCameraInitializedEvent(0, 0, ExposureMode.auto, FocusMode.auto, true, true);
 
     List<ByteBuffer> sentMessages = fakeBinaryMessenger.getMessages();
@@ -81,6 +92,7 @@ public class DartMessengerTest {
 
   @Test
   public void sendCameraClosingEvent() {
+    doAnswer(createPostHandlerAnswer()).when(mockHandler).post(any(Runnable.class));
     dartMessenger.sendCameraClosingEvent();
 
     List<ByteBuffer> sentMessages = fakeBinaryMessenger.getMessages();
@@ -92,6 +104,7 @@ public class DartMessengerTest {
 
   @Test
   public void sendDeviceOrientationChangedEvent() {
+    doAnswer(createPostHandlerAnswer()).when(mockHandler).post(any(Runnable.class));
     dartMessenger.sendDeviceOrientationChangeEvent(PlatformChannel.DeviceOrientation.PORTRAIT_UP);
 
     List<ByteBuffer> sentMessages = fakeBinaryMessenger.getMessages();
@@ -99,6 +112,19 @@ public class DartMessengerTest {
     MethodCall call = decodeSentMessage(sentMessages.get(0));
     assertEquals("orientation_changed", call.method);
     assertEquals(call.argument("orientation"), "portraitUp");
+  }
+
+  private static Answer<Boolean> createPostHandlerAnswer() {
+    return new Answer<Boolean>() {
+      @Override
+      public Boolean answer(InvocationOnMock invocation) throws Throwable {
+        Runnable runnable = invocation.getArgument(0, Runnable.class);
+        if (runnable != null) {
+          runnable.run();
+        }
+        return true;
+      }
+    };
   }
 
   private MethodCall decodeSentMessage(ByteBuffer sentMessage) {

--- a/script/tool/lib/src/java_test_command.dart
+++ b/script/tool/lib/src/java_test_command.dart
@@ -32,9 +32,12 @@ class JavaTestCommand extends PluginCommand {
     final Stream<Directory> examplesWithTests = getExamples().where(
         (Directory d) =>
             isFlutterPackage(d, fileSystem) &&
-            fileSystem
-                .directory(p.join(d.path, 'android', 'app', 'src', 'test'))
-                .existsSync());
+            (fileSystem
+                    .directory(p.join(d.path, 'android', 'app', 'src', 'test'))
+                    .existsSync() ||
+                fileSystem
+                    .directory(p.join(d.path, '..', 'android', 'src', 'test'))
+                    .existsSync()));
 
     final List<String> failingPackages = <String>[];
     final List<String> missingFlutterBuild = <String>[];

--- a/script/tool/test/java_test_command_test.dart
+++ b/script/tool/test/java_test_command_test.dart
@@ -1,0 +1,86 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:args/command_runner.dart';
+import 'package:file/file.dart';
+import 'package:flutter_plugin_tools/src/java_test_command.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import 'util.dart';
+
+void main() {
+  group('$JavaTestCommand', () {
+    CommandRunner<JavaTestCommand> runner;
+    final RecordingProcessRunner processRunner = RecordingProcessRunner();
+
+    setUp(() {
+      initializeFakePackages();
+      final JavaTestCommand command = JavaTestCommand(
+          mockPackagesDir, mockFileSystem,
+          processRunner: processRunner);
+
+      runner =
+          CommandRunner<Null>('java_test_test', 'Test for $JavaTestCommand');
+      runner.addCommand(command);
+    });
+
+    tearDown(() {
+      cleanupPackages();
+      processRunner.recordedCalls.clear();
+    });
+
+    test('Should run Java tests in Android implementation folder', () async {
+      final Directory plugin = createFakePlugin(
+        'plugin1',
+        isAndroidPlugin: true,
+        isFlutter: true,
+        withSingleExample: true,
+        withExtraFiles: <List<String>>[
+          <String>['example/android', 'gradlew'],
+          <String>['android/src/test', 'example_test.java'],
+        ],
+      );
+
+      await runner.run(<String>['java-test']);
+
+      expect(
+        processRunner.recordedCalls,
+        orderedEquals(<ProcessCall>[
+          ProcessCall(
+            p.join(plugin.path, 'example/android/gradlew'),
+            <String>['testDebugUnitTest', '--info'],
+            p.join(plugin.path, 'example/android'),
+          ),
+        ]),
+      );
+    });
+
+    test('Should run Java tests in example folder', () async {
+      final Directory plugin = createFakePlugin(
+        'plugin1',
+        isAndroidPlugin: true,
+        isFlutter: true,
+        withSingleExample: true,
+        withExtraFiles: <List<String>>[
+          <String>['example/android', 'gradlew'],
+          <String>['example/android/app/src/test', 'example_test.java'],
+        ],
+      );
+
+      await runner.run(<String>['java-test']);
+
+      expect(
+        processRunner.recordedCalls,
+        orderedEquals(<ProcessCall>[
+          ProcessCall(
+            p.join(plugin.path, 'example/android/gradlew'),
+            <String>['testDebugUnitTest', '--info'],
+            p.join(plugin.path, 'example/android'),
+          ),
+        ]),
+      );
+    });
+  });
+}


### PR DESCRIPTION
The current implementation of the `JavaTestCommand` only looks for a `test` folder under the `./example/android/app/src` folder for a plugin. There are plugins that have their Java tests defined as part of the plugin implementation code (on path `./android/src/test`) and don't have a `test` folder as part of the `./example/android/app/src` path. This means these tests are currently not executed by the plugin CI. Some examples would be:

- camera plugin
- flutter_plugin_android_lifecycle
- path_provider
- url_launcher

We discovered this issue when we where trying to move the Java tests of the "in_app_purchase" plugin from the `./example/android/app/src/test` folder to the `./android/src/test` folder and noticed that the CI suddenly doesn't execute Java tests anymore (see PR #3732).

Note that I have fixed some Java unit tests of the camera plugin which have been failing unnoticed.

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
  - The `flutter_plugin_tools` are not published anymore and doesn't include a version number.
- [ ] I updated CHANGELOG.md to add a description of the change.
  - The `flutter_plugin_tools` are not published anymore and doesn't keep track of changes in a CHANGELOG.md
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
