### PR TITLE
[quick_actions] example fix

### DIFF
--- a/packages/quick_actions/quick_actions/CHANGELOG.md
+++ b/packages/quick_actions/quick_actions/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.0+1
+
+* Updated example app implementation. 
+
 ## 0.5.0
 
 * Migrate to null safety.

--- a/packages/quick_actions/quick_actions/example/lib/main.dart
+++ b/packages/quick_actions/quick_actions/example/lib/main.dart
@@ -32,7 +32,7 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  String shortcut = "no action set";
+  String shortcut = 'no action set';
 
   @override
   void initState() {

--- a/packages/quick_actions/quick_actions/example/lib/main.dart
+++ b/packages/quick_actions/quick_actions/example/lib/main.dart
@@ -63,7 +63,9 @@ class _MyHomePageState extends State<MyHomePage> {
           icon: 'ic_launcher'),
     ]).then((value) {
       setState(() {
-        shortcut = "actions ready";
+        if(shortcut == 'no action set') {
+          shortcut = "actions ready";
+        }
       });
     });
   }

--- a/packages/quick_actions/quick_actions/example/lib/main.dart
+++ b/packages/quick_actions/quick_actions/example/lib/main.dart
@@ -63,7 +63,7 @@ class _MyHomePageState extends State<MyHomePage> {
           icon: 'ic_launcher'),
     ]).then((value) {
       setState(() {
-        if(shortcut == 'no action set') {
+        if (shortcut == 'no action set') {
           shortcut = "actions ready";
         }
       });

--- a/packages/quick_actions/quick_actions/example/lib/main.dart
+++ b/packages/quick_actions/quick_actions/example/lib/main.dart
@@ -64,7 +64,7 @@ class _MyHomePageState extends State<MyHomePage> {
     ]).then((value) {
       setState(() {
         if (shortcut == 'no action set') {
-          shortcut = "actions ready";
+          shortcut = 'actions ready';
         }
       });
     });

--- a/packages/quick_actions/quick_actions/pubspec.yaml
+++ b/packages/quick_actions/quick_actions/pubspec.yaml
@@ -2,7 +2,7 @@ name: quick_actions
 description: Flutter plugin for creating shortcuts on home screen, also known as
   Quick Actions on iOS and App Shortcuts on Android.
 homepage: https://github.com/flutter/plugins/tree/master/packages/quick_actions
-version: 0.5.0
+version: 0.5.0+1
 
 flutter:
   plugin:


### PR DESCRIPTION
Title now gets replaced immediately after getting set. This way we can't actually see if the plugin works. This fixes this problem by checking if the String has been changed, before setting the "actions ready" value.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
