### PR TITLE
Make sure androidx.lifecycle classes aren't R8'ed away when using flutter_plugin_android_lifecycle

### DIFF
--- a/packages/flutter_plugin_android_lifecycle/CHANGELOG.md
+++ b/packages/flutter_plugin_android_lifecycle/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.1
+* Make sure androidx.lifecycle.DefaultLifecycleObservable doesn't get shrunk
+  away.
 ## 2.0.0
 
 * Bump Dart SDK for null-safety compatibility.

--- a/packages/flutter_plugin_android_lifecycle/CHANGELOG.md
+++ b/packages/flutter_plugin_android_lifecycle/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.0.1
 * Make sure androidx.lifecycle.DefaultLifecycleObservable doesn't get shrunk
   away.
+
 ## 2.0.0
 
 * Bump Dart SDK for null-safety compatibility.

--- a/packages/flutter_plugin_android_lifecycle/android/build.gradle
+++ b/packages/flutter_plugin_android_lifecycle/android/build.gradle
@@ -27,6 +27,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles 'proguard.txt'
     }
     lintOptions {
         disable 'InvalidPackage'

--- a/packages/flutter_plugin_android_lifecycle/android/proguard.txt
+++ b/packages/flutter_plugin_android_lifecycle/android/proguard.txt
@@ -1,4 +1,9 @@
 # The point of this package is to specify that a dependent plugin intends to
 # use the AndroidX lifecycle classes. Make sure no R8 heuristics shrink classes
 # brought in by the embedding's pom.
+#
+# This isn't strictly needed since by definition, plugins using Android
+# lifecycles should implement DefaultLifecycleObserver and therefore keep it
+# from being shrunk. But there seems to be an R8 bug so this needs to stay
+# https://issuetracker.google.com/issues/142778206.
 -keep class androidx.lifecycle.DefaultLifecycleObserver

--- a/packages/flutter_plugin_android_lifecycle/android/proguard.txt
+++ b/packages/flutter_plugin_android_lifecycle/android/proguard.txt
@@ -1,0 +1,4 @@
+# The point of this package is to specify that a dependent plugin intends to
+# use the AndroidX lifecycle classes. Make sure no R8 heuristics shrink classes
+# brought in by the embedding's pom.
+-keep class androidx.lifecycle.DefaultLifecycleObserver

--- a/packages/flutter_plugin_android_lifecycle/pubspec.yaml
+++ b/packages/flutter_plugin_android_lifecycle/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_plugin_android_lifecycle
 description: Flutter plugin for accessing an Android Lifecycle within other plugins.
-version: 2.0.0
+version: 2.0.1
 homepage: https://github.com/flutter/plugins/tree/master/packages/flutter_plugin_android_lifecycle
 
 environment:


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/78625
Fixes https://github.com/flutter/flutter/issues/69820
Fixes https://github.com/flutter/flutter/issues/58479
Fixes https://github.com/flutter/flutter/issues/77622
