### PR TITLE
[ci] Do not use empty exclude directories in analyze_command.

### DIFF
--- a/script/incremental_build.sh
+++ b/script/incremental_build.sh
@@ -19,8 +19,39 @@ ALL_EXCLUDED=("")
 # because we adopted stricter analysis rules recently and needed to exclude
 # already failing packages to start linting the repo as a whole.
 #
-# TODO(mklim): Remove everything from this list. https://github.com/flutter/flutter/issues/45440
+# Finding all: `find packages -name analysis_options.yaml | sort | cut -d/ -f2`
+#
+# TODO(ecosystem): Remove everything from this list. https://github.com/flutter/flutter/issues/76229
 CUSTOM_ANALYSIS_PLUGINS=(
+  android_alarm_manager
+  android_intent
+  battery
+  camera
+  connectivity
+  cross_file
+  device_info
+  e2e
+  espresso
+  file_selector
+  flutter_plugin_android_lifecycle
+  google_maps_flutter
+  google_sign_in
+  image_picker
+  in_app_purchase
+  integration_test
+  ios_platform_images
+  local_auth
+  package_info
+  path_provider
+  plugin_platform_interface
+  quick_actions
+  sensors
+  share
+  shared_preferences
+  url_launcher
+  video_player
+  webview_flutter
+  wifi_info_flutter
 )
 
 # Comma-separated string of the list above

--- a/script/tool/lib/src/analyze_command.dart
+++ b/script/tool/lib/src/analyze_command.dart
@@ -42,10 +42,12 @@ class AnalyzeCommand extends PluginCommand {
         continue;
       }
 
-      final bool whitelisted = argResults[_customAnalysisFlag].any(
+      final bool allowed = argResults[_customAnalysisFlag].any(
           (String directory) =>
+              directory != null &&
+              directory.isNotEmpty &&
               p.isWithin(p.join(packagesDir.path, directory), file.path));
-      if (whitelisted) {
+      if (allowed) {
         continue;
       }
 

--- a/script/tool/test/analyze_command_test.dart
+++ b/script/tool/test/analyze_command_test.dart
@@ -93,5 +93,20 @@ void main() {
                 pluginDir.path),
           ]));
     });
+
+    // See: https://github.com/flutter/flutter/issues/78994
+    test('takes an empty allow list', () async {
+      await createFakePlugin('foo', withExtraFiles: <List<String>>[
+        <String>['analysis_options.yaml']
+      ]);
+
+      final MockProcess mockProcess = MockProcess();
+      mockProcess.exitCodeCompleter.complete(0);
+      processRunner.processToReturn = mockProcess;
+
+      await expectLater(
+          () => runner.run(<String>['analyze', '--custom-analysis', '']),
+          throwsA(const TypeMatcher<ToolExit>()));
+    });
   });
 }


### PR DESCRIPTION
The current incremental_script.sh is invoking the analyze_command incorrectly (passing an empty value to the `--custom-analysis` parameter)

This is causing the analysis not to run correctly in CI.

Related to https://github.com/flutter/flutter/issues/78994

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
