### PR TITLE
Revert "[in_app_purchase] Fix error message when trying to consume purchase on iOS"

### DIFF
--- a/packages/in_app_purchase/in_app_purchase/AUTHORS
+++ b/packages/in_app_purchase/in_app_purchase/AUTHORS
@@ -64,4 +64,3 @@ Aleksandr Yurkovskiy <sanekyy@gmail.com>
 Anton Borries <mail@antonborri.es>
 Alex Li <google@alexv525.com>
 Rahul Raj <64.rahulraj@gmail.com>
-Maurits van Beusekom <maurits@baseflow.com>

--- a/packages/in_app_purchase/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 0.5.2
-
-* Fix error message when trying to consume purchase on iOS.
-
 ## 0.5.1
 
 * [iOS] Introduce `SKPaymentQueueWrapper.presentCodeRedemptionSheet` 

--- a/packages/in_app_purchase/in_app_purchase/lib/src/in_app_purchase/app_store_connection.dart
+++ b/packages/in_app_purchase/in_app_purchase/lib/src/in_app_purchase/app_store_connection.dart
@@ -97,7 +97,7 @@ class AppStoreConnection implements InAppPurchaseConnection {
 
   @override
   Future<BillingResultWrapper> consumePurchase(PurchaseDetails purchase) {
-    throw UnsupportedError('consume purchase is not available on iOS');
+    throw UnsupportedError('consume purchase is not available on Android');
   }
 
   @override

--- a/packages/in_app_purchase/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase/pubspec.yaml
@@ -1,7 +1,7 @@
 name: in_app_purchase
 description: A Flutter plugin for in-app purchases. Exposes APIs for making in-app purchases through the App Store and Google Play.
 homepage: https://github.com/flutter/plugins/tree/master/packages/in_app_purchase
-version: 0.5.2
+version: 0.5.1
 
 dependencies:
   flutter:

--- a/packages/in_app_purchase/in_app_purchase/test/in_app_purchase_connection/app_store_connection_test.dart
+++ b/packages/in_app_purchase/in_app_purchase/test/in_app_purchase_connection/app_store_connection_test.dart
@@ -294,16 +294,9 @@ void main() {
   group('consume purchase', () {
     test('should throw when calling consume purchase on iOS', () async {
       expect(
-        () => AppStoreConnection.instance
-            .consumePurchase(PurchaseDetails.fromPurchase(dummyPurchase)),
-        throwsA(
-          isA<UnsupportedError>().having(
-            (error) => error.message,
-            'message',
-            'consume purchase is not available on iOS',
-          ),
-        ),
-      );
+          () => AppStoreConnection.instance
+              .consumePurchase(PurchaseDetails.fromPurchase(dummyPurchase)),
+          throwsUnsupportedError);
     });
   });
 


### PR DESCRIPTION
Reverts flutter/plugins#3750

Reverting this PR since I updated with the wrong version number (should have been `0.5.1+1` instead of `0.5.2`). Will resubmit the PR with the correct version number.