### PR TITLE
[in_app_purchase] Fix error message when trying to consume purchase on iOS

### DIFF
--- a/packages/in_app_purchase/in_app_purchase/AUTHORS
+++ b/packages/in_app_purchase/in_app_purchase/AUTHORS
@@ -64,3 +64,4 @@ Aleksandr Yurkovskiy <sanekyy@gmail.com>
 Anton Borries <mail@antonborri.es>
 Alex Li <google@alexv525.com>
 Rahul Raj <64.rahulraj@gmail.com>
+Maurits van Beusekom <maurits@baseflow.com>

--- a/packages/in_app_purchase/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.1+1
+
+* Fix error message when trying to consume purchase on iOS.
+
 ## 0.5.1
 
 * [iOS] Introduce `SKPaymentQueueWrapper.presentCodeRedemptionSheet` 

--- a/packages/in_app_purchase/in_app_purchase/lib/src/in_app_purchase/app_store_connection.dart
+++ b/packages/in_app_purchase/in_app_purchase/lib/src/in_app_purchase/app_store_connection.dart
@@ -97,7 +97,7 @@ class AppStoreConnection implements InAppPurchaseConnection {
 
   @override
   Future<BillingResultWrapper> consumePurchase(PurchaseDetails purchase) {
-    throw UnsupportedError('consume purchase is not available on Android');
+    throw UnsupportedError('consume purchase is not available on iOS');
   }
 
   @override

--- a/packages/in_app_purchase/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase/pubspec.yaml
@@ -1,7 +1,7 @@
 name: in_app_purchase
 description: A Flutter plugin for in-app purchases. Exposes APIs for making in-app purchases through the App Store and Google Play.
 homepage: https://github.com/flutter/plugins/tree/master/packages/in_app_purchase
-version: 0.5.1
+version: 0.5.1+1
 
 dependencies:
   flutter:

--- a/packages/in_app_purchase/in_app_purchase/test/in_app_purchase_connection/app_store_connection_test.dart
+++ b/packages/in_app_purchase/in_app_purchase/test/in_app_purchase_connection/app_store_connection_test.dart
@@ -294,9 +294,16 @@ void main() {
   group('consume purchase', () {
     test('should throw when calling consume purchase on iOS', () async {
       expect(
-          () => AppStoreConnection.instance
-              .consumePurchase(PurchaseDetails.fromPurchase(dummyPurchase)),
-          throwsUnsupportedError);
+        () => AppStoreConnection.instance
+            .consumePurchase(PurchaseDetails.fromPurchase(dummyPurchase)),
+        throwsA(
+          isA<UnsupportedError>().having(
+            (error) => error.message,
+            'message',
+            'consume purchase is not available on iOS',
+          ),
+        ),
+      );
     });
   });
 


### PR DESCRIPTION
Redo of #3750, now with correct version number.

Fixes the error message when trying to consume a "consumable product" on iOS. On iOS consuming products manually is not supported and therefore the `consumePurchase` method on iOS will result in a `UnsupportedError`. Unfortunately the error message of the error mentioned the "Android" platform:

> consume purchase is not available on Android

This PR updates the error message and also extended the unit test to ensure the correct platform is mentioned.

The problem is mentioned as part of issue flutter/flutter#60763 (see this [comment](https://github.com/flutter/flutter/issues/60763#issuecomment-796968009))

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
