### PR TITLE
[path_provider] Switch to new analysis options

### DIFF
--- a/packages/path_provider/analysis_options.yaml
+++ b/packages/path_provider/analysis_options.yaml
@@ -1,1 +1,0 @@
-include: ../../analysis_options_legacy.yaml

--- a/packages/path_provider/path_provider/example/integration_test/path_provider_test.dart
+++ b/packages/path_provider/path_provider/example/integration_test/path_provider_test.dart
@@ -4,8 +4,6 @@
 
 // @dart=2.9
 
-import 'dart:async';
-
 import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path_provider/path_provider.dart';

--- a/packages/path_provider/path_provider/example/integration_test/path_provider_test.dart
+++ b/packages/path_provider/path_provider/example/integration_test/path_provider_test.dart
@@ -55,7 +55,7 @@ void main() {
       expect(result, throwsA(isInstanceOf<UnsupportedError>()));
     } else if (Platform.isAndroid) {
       final List<Directory> directories = await getExternalCacheDirectories();
-      for (Directory result in directories) {
+      for (final Directory result in directories) {
         _verifySampleFile(result, 'externalCache');
       }
     }
@@ -72,7 +72,7 @@ void main() {
     StorageDirectory.movies,
   ];
 
-  for (StorageDirectory type in _allDirs) {
+  for (final StorageDirectory type in _allDirs) {
     test('getExternalStorageDirectories (type: $type)', () async {
       if (Platform.isIOS) {
         final Future<List<Directory>> result =
@@ -81,7 +81,7 @@ void main() {
       } else if (Platform.isAndroid) {
         final List<Directory> directories =
             await getExternalStorageDirectories(type: type);
-        for (Directory result in directories) {
+        for (final Directory result in directories) {
           _verifySampleFile(result, '$type');
         }
       }

--- a/packages/path_provider/path_provider/example/lib/main.dart
+++ b/packages/path_provider/path_provider/example/lib/main.dart
@@ -22,7 +22,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      home: MyHomePage(title: 'Path Provider'),
+      home: const MyHomePage(title: 'Path Provider'),
     );
   }
 }
@@ -166,8 +166,9 @@ class _MyHomePageState extends State<MyHomePage> {
             Padding(
               padding: const EdgeInsets.all(16.0),
               child: ElevatedButton(
-                child: Text(
-                    Platform.isIOS ? 'External directories are unavailable ' 'on iOS' : 'Get External Storage Directory'),
+                child: Text(Platform.isIOS
+                    ? 'External directories are unavailable ' 'on iOS'
+                    : 'Get External Storage Directory'),
                 onPressed:
                     Platform.isIOS ? null : _requestExternalStorageDirectory,
               ),
@@ -178,8 +179,9 @@ class _MyHomePageState extends State<MyHomePage> {
               Padding(
                 padding: const EdgeInsets.all(16.0),
                 child: ElevatedButton(
-                  child: Text(
-                      Platform.isIOS ? 'External directories are unavailable ' 'on iOS' : 'Get External Storage Directories'),
+                  child: Text(Platform.isIOS
+                      ? 'External directories are unavailable ' 'on iOS'
+                      : 'Get External Storage Directories'),
                   onPressed: Platform.isIOS
                       ? null
                       : () {
@@ -197,8 +199,9 @@ class _MyHomePageState extends State<MyHomePage> {
               Padding(
                 padding: const EdgeInsets.all(16.0),
                 child: ElevatedButton(
-                  child: Text(
-                      Platform.isIOS ? 'External directories are unavailable ' 'on iOS' : 'Get External Cache Directories'),
+                  child: Text(Platform.isIOS
+                      ? 'External directories are unavailable ' 'on iOS'
+                      : 'Get External Cache Directories'),
                   onPressed:
                       Platform.isIOS ? null : _requestExternalCacheDirectories,
                 ),

--- a/packages/path_provider/path_provider/example/lib/main.dart
+++ b/packages/path_provider/path_provider/example/lib/main.dart
@@ -28,7 +28,7 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatefulWidget {
-  MyHomePage({Key? key, required this.title}) : super(key: key);
+  const MyHomePage({Key? key, required this.title}) : super(key: key);
   final String title;
 
   @override
@@ -167,7 +167,7 @@ class _MyHomePageState extends State<MyHomePage> {
               padding: const EdgeInsets.all(16.0),
               child: ElevatedButton(
                 child: Text(
-                    '${Platform.isIOS ? "External directories are unavailable " "on iOS" : "Get External Storage Directory"}'),
+                    Platform.isIOS ? 'External directories are unavailable ' 'on iOS' : 'Get External Storage Directory'),
                 onPressed:
                     Platform.isIOS ? null : _requestExternalStorageDirectory,
               ),
@@ -179,7 +179,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 padding: const EdgeInsets.all(16.0),
                 child: ElevatedButton(
                   child: Text(
-                      '${Platform.isIOS ? "External directories are unavailable " "on iOS" : "Get External Storage Directories"}'),
+                      Platform.isIOS ? 'External directories are unavailable ' 'on iOS' : 'Get External Storage Directories'),
                   onPressed: Platform.isIOS
                       ? null
                       : () {
@@ -198,7 +198,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 padding: const EdgeInsets.all(16.0),
                 child: ElevatedButton(
                   child: Text(
-                      '${Platform.isIOS ? "External directories are unavailable " "on iOS" : "Get External Cache Directories"}'),
+                      Platform.isIOS ? 'External directories are unavailable ' 'on iOS' : 'Get External Cache Directories'),
                   onPressed:
                       Platform.isIOS ? null : _requestExternalCacheDirectories,
                 ),

--- a/packages/path_provider/path_provider/example/lib/main.dart
+++ b/packages/path_provider/path_provider/example/lib/main.dart
@@ -4,7 +4,6 @@
 
 // ignore_for_file: public_member_api_docs
 
-import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -167,7 +166,7 @@ class _MyHomePageState extends State<MyHomePage> {
               padding: const EdgeInsets.all(16.0),
               child: ElevatedButton(
                 child: Text(Platform.isIOS
-                    ? 'External directories are unavailable ' 'on iOS'
+                    ? 'External directories are unavailable on iOS'
                     : 'Get External Storage Directory'),
                 onPressed:
                     Platform.isIOS ? null : _requestExternalStorageDirectory,
@@ -180,7 +179,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 padding: const EdgeInsets.all(16.0),
                 child: ElevatedButton(
                   child: Text(Platform.isIOS
-                      ? 'External directories are unavailable ' 'on iOS'
+                      ? 'External directories are unavailable on iOS'
                       : 'Get External Storage Directories'),
                   onPressed: Platform.isIOS
                       ? null
@@ -200,7 +199,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 padding: const EdgeInsets.all(16.0),
                 child: ElevatedButton(
                   child: Text(Platform.isIOS
-                      ? 'External directories are unavailable ' 'on iOS'
+                      ? 'External directories are unavailable on iOS'
                       : 'Get External Cache Directories'),
                   onPressed:
                       Platform.isIOS ? null : _requestExternalCacheDirectories,

--- a/packages/path_provider/path_provider/example/test_driver/integration_test.dart
+++ b/packages/path_provider/path_provider/example/test_driver/integration_test.dart
@@ -4,7 +4,6 @@
 
 // @dart=2.9
 
-import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'package:flutter_driver/flutter_driver.dart';

--- a/packages/path_provider/path_provider/example/test_driver/integration_test.dart
+++ b/packages/path_provider/path_provider/example/test_driver/integration_test.dart
@@ -14,6 +14,6 @@ Future<void> main() async {
   final String data =
       await driver.requestData(null, timeout: const Duration(minutes: 1));
   await driver.close();
-  final Map<String, dynamic> result = jsonDecode(data);
+  final Map<String, dynamic> result = jsonDecode(data) as Map<String, dynamic>;
   exit(result['result'] == 'true' ? 0 : 1);
 }

--- a/packages/path_provider/path_provider/lib/path_provider.dart
+++ b/packages/path_provider/path_provider/lib/path_provider.dart
@@ -9,6 +9,7 @@ import 'package:flutter/foundation.dart' show kIsWeb, visibleForTesting;
 import 'package:path_provider_linux/path_provider_linux.dart';
 import 'package:path_provider_windows/path_provider_windows.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+// ignore: implementation_imports
 import 'package:path_provider_platform_interface/src/method_channel_path_provider.dart';
 
 export 'package:path_provider_platform_interface/path_provider_platform_interface.dart'

--- a/packages/path_provider/path_provider/lib/path_provider.dart
+++ b/packages/path_provider/path_provider/lib/path_provider.dart
@@ -36,7 +36,7 @@ class MissingPlatformDirectoryException implements Exception {
 
   @override
   String toString() {
-    String detailsAddition = details == null ? '' : ': $details';
+    final String detailsAddition = details == null ? '' : ': $details';
     return 'MissingPlatformDirectoryException($message)$detailsAddition';
   }
 }

--- a/packages/path_provider/path_provider/lib/path_provider.dart
+++ b/packages/path_provider/path_provider/lib/path_provider.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:io' show Directory, Platform;
 
 import 'package:flutter/foundation.dart' show kIsWeb, visibleForTesting;

--- a/packages/path_provider/path_provider/test/path_provider_test.dart
+++ b/packages/path_provider/path_provider/test/path_provider_test.dart
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io' show Directory;
 import 'dart:async';
+import 'dart:io' show Directory;
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path_provider/path_provider.dart';

--- a/packages/path_provider/path_provider/test/path_provider_test.dart
+++ b/packages/path_provider/path_provider/test/path_provider_test.dart
@@ -27,44 +27,44 @@ void main() {
     });
 
     test('getTemporaryDirectory', () async {
-      Directory result = await getTemporaryDirectory();
+      final Directory result = await getTemporaryDirectory();
       expect(result.path, kTemporaryPath);
     });
 
     test('getApplicationSupportDirectory', () async {
-      Directory result = await getApplicationSupportDirectory();
+      final Directory result = await getApplicationSupportDirectory();
       expect(result.path, kApplicationSupportPath);
     });
 
     test('getLibraryDirectory', () async {
-      Directory result = await getLibraryDirectory();
+      final Directory result = await getLibraryDirectory();
       expect(result.path, kLibraryPath);
     });
 
     test('getApplicationDocumentsDirectory', () async {
-      Directory result = await getApplicationDocumentsDirectory();
+      final Directory result = await getApplicationDocumentsDirectory();
       expect(result.path, kApplicationDocumentsPath);
     });
 
     test('getExternalStorageDirectory', () async {
-      Directory? result = await getExternalStorageDirectory();
+      final Directory? result = await getExternalStorageDirectory();
       expect(result?.path, kExternalStoragePath);
     });
 
     test('getExternalCacheDirectories', () async {
-      List<Directory>? result = await getExternalCacheDirectories();
+      final List<Directory>? result = await getExternalCacheDirectories();
       expect(result?.length, 1);
       expect(result?.first.path, kExternalCachePath);
     });
 
     test('getExternalStorageDirectories', () async {
-      List<Directory>? result = await getExternalStorageDirectories();
+      final List<Directory>? result = await getExternalStorageDirectories();
       expect(result?.length, 1);
       expect(result?.first.path, kExternalStoragePath);
     });
 
     test('getDownloadsDirectory', () async {
-      Directory? result = await getDownloadsDirectory();
+      final Directory? result = await getDownloadsDirectory();
       expect(result?.path, kDownloadsPath);
     });
   });
@@ -95,22 +95,22 @@ void main() {
     });
 
     test('getExternalStorageDirectory passes null through', () async {
-      Directory? result = await getExternalStorageDirectory();
+      final Directory? result = await getExternalStorageDirectory();
       expect(result, isNull);
     });
 
     test('getExternalCacheDirectories passes null through', () async {
-      List<Directory>? result = await getExternalCacheDirectories();
+      final List<Directory>? result = await getExternalCacheDirectories();
       expect(result, isNull);
     });
 
     test('getExternalStorageDirectories passes null through', () async {
-      List<Directory>? result = await getExternalStorageDirectories();
+      final List<Directory>? result = await getExternalStorageDirectories();
       expect(result, isNull);
     });
 
     test('getDownloadsDirectory passses null through', () async {
-      Directory? result = await getDownloadsDirectory();
+      final Directory? result = await getDownloadsDirectory();
       expect(result, isNull);
     });
   });
@@ -119,36 +119,44 @@ void main() {
 class FakePathProviderPlatform extends Fake
     with MockPlatformInterfaceMixin
     implements PathProviderPlatform {
+  @override
   Future<String?> getTemporaryPath() async {
     return kTemporaryPath;
   }
 
+  @override
   Future<String?> getApplicationSupportPath() async {
     return kApplicationSupportPath;
   }
 
+  @override
   Future<String?> getLibraryPath() async {
     return kLibraryPath;
   }
 
+  @override
   Future<String?> getApplicationDocumentsPath() async {
     return kApplicationDocumentsPath;
   }
 
+  @override
   Future<String?> getExternalStoragePath() async {
     return kExternalStoragePath;
   }
 
+  @override
   Future<List<String>?> getExternalCachePaths() async {
     return <String>[kExternalCachePath];
   }
 
+  @override
   Future<List<String>?> getExternalStoragePaths({
     StorageDirectory? type,
   }) async {
     return <String>[kExternalStoragePath];
   }
 
+  @override
   Future<String?> getDownloadsPath() async {
     return kDownloadsPath;
   }
@@ -157,36 +165,44 @@ class FakePathProviderPlatform extends Fake
 class AllNullFakePathProviderPlatform extends Fake
     with MockPlatformInterfaceMixin
     implements PathProviderPlatform {
+  @override
   Future<String?> getTemporaryPath() async {
     return null;
   }
 
+  @override
   Future<String?> getApplicationSupportPath() async {
     return null;
   }
 
+  @override
   Future<String?> getLibraryPath() async {
     return null;
   }
 
+  @override
   Future<String?> getApplicationDocumentsPath() async {
     return null;
   }
 
+  @override
   Future<String?> getExternalStoragePath() async {
     return null;
   }
 
+  @override
   Future<List<String>?> getExternalCachePaths() async {
     return null;
   }
 
+  @override
   Future<List<String>?> getExternalStoragePaths({
     StorageDirectory? type,
   }) async {
     return null;
   }
 
+  @override
   Future<String?> getDownloadsPath() async {
     return null;
   }

--- a/packages/path_provider/path_provider/test/path_provider_test.dart
+++ b/packages/path_provider/path_provider/test/path_provider_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:io' show Directory;
 
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/path_provider/path_provider_linux/example/lib/main.dart
+++ b/packages/path_provider/path_provider_linux/example/lib/main.dart
@@ -3,8 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'dart:async';
-
 import 'package:flutter/services.dart';
 import 'package:path_provider_linux/path_provider_linux.dart';
 
@@ -67,7 +65,9 @@ class _MyAppState extends State<MyApp> {
     // If the widget was removed from the tree while the asynchronous platform
     // message was in flight, we want to discard the reply rather than calling
     // setState to update our non-existent appearance.
-    if (!mounted) return;
+    if (!mounted) {
+      return;
+    }
 
     setState(() {
       _tempDirectory = tempDirectory;
@@ -86,7 +86,7 @@ class _MyAppState extends State<MyApp> {
         ),
         body: Center(
           child: Column(
-            children: [
+            children: <Widget>[
               Text('Temp Directory: $_tempDirectory\n'),
               Text('Documents Directory: $_documentsDirectory\n'),
               Text('Downloads Directory: $_downloadsDirectory\n'),

--- a/packages/path_provider/path_provider_linux/example/test/widget_test.dart
+++ b/packages/path_provider/path_provider_linux/example/test/widget_test.dart
@@ -26,7 +26,7 @@ void main() {
       // Build our app and trigger a frame.
       await tester.runAsync(() async {
         await tester.pumpWidget(MyApp());
-        await Future.delayed(Duration(milliseconds: 20));
+        await Future<void>.delayed(const Duration(milliseconds: 20));
         await tester.pump();
 
         // Verify that temporary directory is retrieved.
@@ -44,7 +44,7 @@ void main() {
       // Build our app and trigger a frame.
       await tester.runAsync(() async {
         await tester.pumpWidget(MyApp());
-        await Future.delayed(Duration(milliseconds: 20));
+        await Future<void>.delayed(const Duration(milliseconds: 20));
         await tester.pump();
 
         // Verify that documents directory is retrieved.
@@ -62,7 +62,7 @@ void main() {
       // Build our app and trigger a frame.
       await tester.runAsync(() async {
         await tester.pumpWidget(MyApp());
-        await Future.delayed(Duration(milliseconds: 20));
+        await Future<void>.delayed(const Duration(milliseconds: 20));
         await tester.pump();
 
         // Verify that downloads directory is retrieved.
@@ -81,7 +81,7 @@ void main() {
       // Build our app and trigger a frame.
       await tester.runAsync(() async {
         await tester.pumpWidget(MyApp());
-        await Future.delayed(Duration(milliseconds: 20));
+        await Future<void>.delayed(const Duration(milliseconds: 20));
         await tester.pump();
 
         // Verify that Application Support Directory is retrieved.

--- a/packages/path_provider/path_provider_linux/example/test/widget_test.dart
+++ b/packages/path_provider/path_provider_linux/example/test/widget_test.dart
@@ -19,7 +19,7 @@ import 'package:pathproviderexample/main.dart';
 void main() {
   group('Test linux path provider example', () {
     setUpAll(() async {
-      await WidgetsFlutterBinding.ensureInitialized();
+      WidgetsFlutterBinding.ensureInitialized();
     });
 
     testWidgets('Finds tmp directory', (WidgetTester tester) async {

--- a/packages/path_provider/path_provider_linux/example/test/widget_test.dart
+++ b/packages/path_provider/path_provider_linux/example/test/widget_test.dart
@@ -9,8 +9,6 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/packages/path_provider/path_provider_linux/example/test_driver/integration_test.dart
+++ b/packages/path_provider/path_provider_linux/example/test_driver/integration_test.dart
@@ -4,7 +4,6 @@
 
 // @dart=2.9
 
-import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'package:flutter_driver/flutter_driver.dart';

--- a/packages/path_provider/path_provider_linux/example/test_driver/integration_test.dart
+++ b/packages/path_provider/path_provider_linux/example/test_driver/integration_test.dart
@@ -14,6 +14,6 @@ Future<void> main() async {
   final String data =
       await driver.requestData(null, timeout: const Duration(minutes: 1));
   await driver.close();
-  final Map<String, dynamic> result = jsonDecode(data);
+  final Map<String, dynamic> result = jsonDecode(data) as Map<String, dynamic>;
   exit(result['result'] == 'true' ? 0 : 1);
 }

--- a/packages/path_provider/path_provider_linux/lib/path_provider_linux.dart
+++ b/packages/path_provider/path_provider_linux/lib/path_provider_linux.dart
@@ -1,7 +1,7 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-import 'dart:async';
+
 import 'dart:io';
 
 import 'package:path/path.dart' as path;

--- a/packages/path_provider/path_provider_linux/lib/path_provider_linux.dart
+++ b/packages/path_provider/path_provider_linux/lib/path_provider_linux.dart
@@ -1,12 +1,12 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-import 'dart:io';
 import 'dart:async';
+import 'dart:io';
 
-import 'package:xdg_directories/xdg_directories.dart' as xdg;
 import 'package:path/path.dart' as path;
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:xdg_directories/xdg_directories.dart' as xdg;
 
 /// The linux implementation of [PathProviderPlatform]
 ///
@@ -19,16 +19,17 @@ class PathProviderLinux extends PathProviderPlatform {
 
   @override
   Future<String?> getTemporaryPath() {
-    return Future.value('/tmp');
+    return Future<String?>.value('/tmp');
   }
 
   @override
   Future<String?> getApplicationSupportPath() async {
-    final processName = path.basenameWithoutExtension(
+    final String processName = path.basenameWithoutExtension(
         await File('/proc/self/exe').resolveSymbolicLinks());
-    final directory = Directory(path.join(xdg.dataHome.path, processName));
+    final Directory directory =
+        Directory(path.join(xdg.dataHome.path, processName));
     // Creating the directory if it doesn't exist, because mobile implementations assume the directory exists
-    if (!await directory.exists()) {
+    if (!directory.existsSync()) {
       await directory.create(recursive: true);
     }
     return directory.path;
@@ -36,11 +37,11 @@ class PathProviderLinux extends PathProviderPlatform {
 
   @override
   Future<String?> getApplicationDocumentsPath() {
-    return Future.value(xdg.getUserDirectory('DOCUMENTS')?.path);
+    return Future<String?>.value(xdg.getUserDirectory('DOCUMENTS')?.path);
   }
 
   @override
   Future<String?> getDownloadsPath() {
-    return Future.value(xdg.getUserDirectory('DOWNLOAD')?.path);
+    return Future<String?>.value(xdg.getUserDirectory('DOWNLOAD')?.path);
   }
 }

--- a/packages/path_provider/path_provider_linux/lib/path_provider_linux.dart
+++ b/packages/path_provider/path_provider_linux/lib/path_provider_linux.dart
@@ -19,7 +19,7 @@ class PathProviderLinux extends PathProviderPlatform {
 
   @override
   Future<String?> getTemporaryPath() {
-    return Future.value("/tmp");
+    return Future.value('/tmp');
   }
 
   @override

--- a/packages/path_provider/path_provider_linux/test/path_provider_linux_test.dart
+++ b/packages/path_provider/path_provider_linux/test/path_provider_linux_test.dart
@@ -14,7 +14,7 @@ void main() {
   tearDown(() {});
 
   test('getTemporaryPath', () async {
-    final plugin = PathProviderPlatform.instance;
+    final PathProviderPlatform plugin = PathProviderPlatform.instance;
     expect(await plugin.getTemporaryPath(), '/tmp');
   });
 }

--- a/packages/path_provider/path_provider_macos/example/lib/main.dart
+++ b/packages/path_provider/path_provider_macos/example/lib/main.dart
@@ -4,8 +4,6 @@
 
 // ignore_for_file: public_member_api_docs
 
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 

--- a/packages/path_provider/path_provider_macos/example/lib/main.dart
+++ b/packages/path_provider/path_provider_macos/example/lib/main.dart
@@ -79,7 +79,7 @@ class _MyAppState extends State<MyApp> {
         ),
         body: Center(
           child: Column(
-            children: [
+            children: <Widget>[
               Text('Temp Directory: $_tempDirectory\n'),
               Text('Documents Directory: $_documentsDirectory\n'),
               Text('Downloads Directory: $_downloadsDirectory\n'),

--- a/packages/path_provider/path_provider_macos/example/test_driver/integration_test.dart
+++ b/packages/path_provider/path_provider_macos/example/test_driver/integration_test.dart
@@ -4,7 +4,6 @@
 
 // @dart=2.9
 
-import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'package:flutter_driver/flutter_driver.dart';

--- a/packages/path_provider/path_provider_macos/example/test_driver/integration_test.dart
+++ b/packages/path_provider/path_provider_macos/example/test_driver/integration_test.dart
@@ -14,6 +14,6 @@ Future<void> main() async {
   final String data =
       await driver.requestData(null, timeout: const Duration(minutes: 1));
   await driver.close();
-  final Map<String, dynamic> result = jsonDecode(data);
+  final Map<String, dynamic> result = jsonDecode(data) as Map<String, dynamic>;
   exit(result['result'] == 'true' ? 0 : 1);
 }

--- a/packages/path_provider/path_provider_platform_interface/lib/path_provider_platform_interface.dart
+++ b/packages/path_provider/path_provider_platform_interface/lib/path_provider_platform_interface.dart
@@ -4,12 +4,10 @@
 
 import 'dart:async';
 
-import 'src/enums.dart';
-import 'src/method_channel_path_provider.dart';
-
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
-export 'src/enums.dart';
+import 'src/enums.dart';
+import 'src/method_channel_path_provider.dart';
 
 /// The interface that implementations of path_provider must implement.
 ///

--- a/packages/path_provider/path_provider_platform_interface/lib/path_provider_platform_interface.dart
+++ b/packages/path_provider/path_provider_platform_interface/lib/path_provider_platform_interface.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 import 'src/enums.dart';

--- a/packages/path_provider/path_provider_platform_interface/lib/src/method_channel_path_provider.dart
+++ b/packages/path_provider/path_provider_platform_interface/lib/src/method_channel_path_provider.dart
@@ -30,14 +30,17 @@ class MethodChannelPathProvider extends PathProviderPlatform {
     _platform = platform;
   }
 
+  @override
   Future<String?> getTemporaryPath() {
     return methodChannel.invokeMethod<String>('getTemporaryDirectory');
   }
 
+  @override
   Future<String?> getApplicationSupportPath() {
     return methodChannel.invokeMethod<String>('getApplicationSupportDirectory');
   }
 
+  @override
   Future<String?> getLibraryPath() {
     if (!_platform.isIOS && !_platform.isMacOS) {
       throw UnsupportedError('Functionality only available on iOS/macOS');
@@ -45,11 +48,13 @@ class MethodChannelPathProvider extends PathProviderPlatform {
     return methodChannel.invokeMethod<String>('getLibraryDirectory');
   }
 
+  @override
   Future<String?> getApplicationDocumentsPath() {
     return methodChannel
         .invokeMethod<String>('getApplicationDocumentsDirectory');
   }
 
+  @override
   Future<String?> getExternalStoragePath() {
     if (!_platform.isAndroid) {
       throw UnsupportedError('Functionality only available on Android');
@@ -57,6 +62,7 @@ class MethodChannelPathProvider extends PathProviderPlatform {
     return methodChannel.invokeMethod<String>('getStorageDirectory');
   }
 
+  @override
   Future<List<String>?> getExternalCachePaths() {
     if (!_platform.isAndroid) {
       throw UnsupportedError('Functionality only available on Android');
@@ -65,6 +71,7 @@ class MethodChannelPathProvider extends PathProviderPlatform {
         .invokeListMethod<String>('getExternalCacheDirectories');
   }
 
+  @override
   Future<List<String>?> getExternalStoragePaths({
     StorageDirectory? type,
   }) async {
@@ -77,6 +84,7 @@ class MethodChannelPathProvider extends PathProviderPlatform {
     );
   }
 
+  @override
   Future<String?> getDownloadsPath() {
     if (!_platform.isMacOS) {
       throw UnsupportedError('Functionality only available on macOS');

--- a/packages/path_provider/path_provider_platform_interface/lib/src/method_channel_path_provider.dart
+++ b/packages/path_provider/path_provider_platform_interface/lib/src/method_channel_path_provider.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:flutter/services.dart';
 import 'package:meta/meta.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';

--- a/packages/path_provider/path_provider_platform_interface/lib/src/method_channel_path_provider.dart
+++ b/packages/path_provider/path_provider_platform_interface/lib/src/method_channel_path_provider.dart
@@ -4,19 +4,19 @@
 
 import 'dart:async';
 
-import 'enums.dart';
-
 import 'package:flutter/services.dart';
 import 'package:meta/meta.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:platform/platform.dart';
+
+import 'enums.dart';
 
 /// An implementation of [PathProviderPlatform] that uses method channels.
 class MethodChannelPathProvider extends PathProviderPlatform {
   /// The method channel used to interact with the native platform.
   @visibleForTesting
   MethodChannel methodChannel =
-      MethodChannel('plugins.flutter.io/path_provider');
+      const MethodChannel('plugins.flutter.io/path_provider');
 
   // Ideally, this property shouldn't exist, and each platform should
   // just implement the supported methods. Once all the platforms are

--- a/packages/path_provider/path_provider_platform_interface/test/method_channel_path_provider_test.dart
+++ b/packages/path_provider/path_provider_platform_interface/test/method_channel_path_provider_test.dart
@@ -147,7 +147,7 @@ void main() {
       }
     });
 
-    for (StorageDirectory? type in <StorageDirectory?>[
+    for (final StorageDirectory? type in <StorageDirectory?>[
       null,
       ...StorageDirectory.values
     ]) {

--- a/packages/path_provider/path_provider_windows/example/lib/main.dart
+++ b/packages/path_provider/path_provider_windows/example/lib/main.dart
@@ -4,8 +4,6 @@
 
 // ignore_for_file: public_member_api_docs
 
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:path_provider_windows/path_provider_windows.dart';
 

--- a/packages/path_provider/path_provider_windows/example/lib/main.dart
+++ b/packages/path_provider/path_provider_windows/example/lib/main.dart
@@ -79,7 +79,7 @@ class _MyAppState extends State<MyApp> {
         ),
         body: Center(
           child: Column(
-            children: [
+            children: <Widget>[
               Text('Temp Directory: $_tempDirectory\n'),
               Text('Documents Directory: $_documentsDirectory\n'),
               Text('Downloads Directory: $_downloadsDirectory\n'),

--- a/packages/path_provider/path_provider_windows/example/test_driver/integration_test.dart
+++ b/packages/path_provider/path_provider_windows/example/test_driver/integration_test.dart
@@ -4,7 +4,6 @@
 
 // @dart=2.9
 
-import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'package:flutter_driver/flutter_driver.dart';

--- a/packages/path_provider/path_provider_windows/example/test_driver/integration_test.dart
+++ b/packages/path_provider/path_provider_windows/example/test_driver/integration_test.dart
@@ -14,6 +14,6 @@ Future<void> main() async {
   final String data =
       await driver.requestData(null, timeout: const Duration(minutes: 1));
   await driver.close();
-  final Map<String, dynamic> result = jsonDecode(data);
+  final Map<String, dynamic> result = jsonDecode(data) as Map<String, dynamic>;
   exit(result['result'] == 'true' ? 0 : 1);
 }

--- a/packages/path_provider/path_provider_windows/lib/src/folders.dart
+++ b/packages/path_provider/path_provider_windows/lib/src/folders.dart
@@ -4,6 +4,9 @@
 
 import 'package:win32/win32.dart';
 
+// ignore_for_file: non_constant_identifier_names
+
+// ignore: avoid_classes_with_only_static_members
 /// A class containing the GUID references for each of the documented Windows
 /// known folders. A property of this class may be passed to the `getPath`
 /// method in the [PathProvidersWindows] class to retrieve a known folder from

--- a/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_real.dart
+++ b/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_real.dart
@@ -3,8 +3,8 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 import 'dart:ffi';
+import 'dart:io';
 
 import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
@@ -22,14 +22,15 @@ import 'folders.dart';
 class VersionInfoQuerier {
   /// Returns the value for [key] in [versionInfo]s English strings section, or
   /// null if there is no such entry, or if versionInfo is null.
-  getStringValue(Pointer<Uint8>? versionInfo, key) {
+  String? getStringValue(Pointer<Uint8>? versionInfo, String key) {
     if (versionInfo == null) {
       return null;
     }
-    const kEnUsLanguageCode = '040904e4';
-    final keyPath = TEXT('\\StringFileInfo\\$kEnUsLanguageCode\\$key');
-    final length = calloc<Uint32>();
-    final valueAddress = calloc<Pointer<Utf16>>();
+    const String kEnUsLanguageCode = '040904e4';
+    final Pointer<Utf16> keyPath =
+        TEXT('\\StringFileInfo\\$kEnUsLanguageCode\\$key');
+    final Pointer<Uint32> length = calloc<Uint32>();
+    final Pointer<Pointer<Utf16>> valueAddress = calloc<Pointer<Utf16>>();
     try {
       if (VerQueryValue(versionInfo, keyPath, valueAddress, length) == 0) {
         return null;
@@ -54,14 +55,14 @@ class PathProviderWindows extends PathProviderPlatform {
   /// This is typically the same as the TMP environment variable.
   @override
   Future<String?> getTemporaryPath() async {
-    final buffer = calloc<Uint16>(MAX_PATH + 1).cast<Utf16>();
+    final Pointer<Utf16> buffer = calloc<Uint16>(MAX_PATH + 1).cast<Utf16>();
     String path;
 
     try {
-      final length = GetTempPath(MAX_PATH, buffer);
+      final int length = GetTempPath(MAX_PATH, buffer);
 
       if (length == 0) {
-        final error = GetLastError();
+        final int error = GetLastError();
         throw WindowsException(error);
       } else {
         path = buffer.toDartString();
@@ -69,18 +70,18 @@ class PathProviderWindows extends PathProviderPlatform {
         // GetTempPath adds a trailing backslash, but SHGetKnownFolderPath does
         // not. Strip off trailing backslash for consistency with other methods
         // here.
-        if (path.endsWith('\\')) {
+        if (path.endsWith(r'\')) {
           path = path.substring(0, path.length - 1);
         }
       }
 
       // Ensure that the directory exists, since GetTempPath doesn't.
-      final directory = Directory(path);
+      final Directory directory = Directory(path);
       if (!directory.existsSync()) {
         await directory.create(recursive: true);
       }
 
-      return Future.value(path);
+      return path;
     } finally {
       calloc.free(buffer);
     }
@@ -88,8 +89,8 @@ class PathProviderWindows extends PathProviderPlatform {
 
   @override
   Future<String?> getApplicationSupportPath() async {
-    final appDataRoot = await getPath(WindowsKnownFolder.RoamingAppData);
-    final directory = Directory(
+    final String appDataRoot = await getPath(WindowsKnownFolder.RoamingAppData);
+    final Directory directory = Directory(
         path.join(appDataRoot, _getApplicationSpecificSubdirectory()));
     // Ensure that the directory exists if possible, since it will on other
     // platforms. If the name is longer than MAXPATH, creating will fail, so
@@ -115,11 +116,11 @@ class PathProviderWindows extends PathProviderPlatform {
   /// folderID is a GUID that represents a specific known folder ID, drawn from
   /// [WindowsKnownFolder].
   Future<String> getPath(String folderID) {
-    final pathPtrPtr = calloc<Pointer<Utf16>>();
+    final Pointer<Pointer<Utf16>> pathPtrPtr = calloc<Pointer<Utf16>>();
     final Pointer<GUID> knownFolderID = calloc<GUID>()..ref.setGUID(folderID);
 
     try {
-      final hr = SHGetKnownFolderPath(
+      final int hr = SHGetKnownFolderPath(
         knownFolderID,
         KF_FLAG_DEFAULT,
         NULL,
@@ -132,8 +133,8 @@ class PathProviderWindows extends PathProviderPlatform {
         }
       }
 
-      final path = pathPtrPtr.value.toDartString();
-      return Future.value(path);
+      final String path = pathPtrPtr.value.toDartString();
+      return Future<String>.value(path);
     } finally {
       calloc.free(pathPtrPtr);
       calloc.free(knownFolderID);
@@ -160,9 +161,10 @@ class PathProviderWindows extends PathProviderPlatform {
     Pointer<Uint8>? infoBuffer;
     try {
       // Get the module name.
-      final moduleNameLength = GetModuleFileName(0, moduleNameBuffer, MAX_PATH);
+      final int moduleNameLength =
+          GetModuleFileName(0, moduleNameBuffer, MAX_PATH);
       if (moduleNameLength == 0) {
-        final error = GetLastError();
+        final int error = GetLastError();
         throw WindowsException(error);
       }
 
@@ -182,7 +184,8 @@ class PathProviderWindows extends PathProviderPlatform {
           versionInfoQuerier.getStringValue(infoBuffer, 'ProductName'));
 
       // If there was no product name, use the executable name.
-      productName ??= path.basenameWithoutExtension(moduleNameBuffer.toDartString());
+      productName ??=
+          path.basenameWithoutExtension(moduleNameBuffer.toDartString());
 
       return companyName != null
           ? path.join(companyName, productName)
@@ -211,7 +214,7 @@ class PathProviderWindows extends PathProviderPlatform {
         .trimRight()
         // Ensure that it does not end with a '.'.
         .replaceAll(RegExp(r'[.]+$'), '');
-    const kMaxComponentLength = 255;
+    const int kMaxComponentLength = 255;
     if (sanitized.length > kMaxComponentLength) {
       sanitized = sanitized.substring(0, kMaxComponentLength);
     }

--- a/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_real.dart
+++ b/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_real.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:ffi';
 import 'dart:io';
 

--- a/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_real.dart
+++ b/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_real.dart
@@ -167,7 +167,7 @@ class PathProviderWindows extends PathProviderPlatform {
       }
 
       // From that, load the VERSIONINFO resource
-      int infoSize = GetFileVersionInfoSize(moduleNameBuffer, unused);
+      final int infoSize = GetFileVersionInfoSize(moduleNameBuffer, unused);
       if (infoSize != 0) {
         infoBuffer = calloc<Uint8>(infoSize);
         if (GetFileVersionInfo(moduleNameBuffer, 0, infoSize, infoBuffer) ==
@@ -182,10 +182,7 @@ class PathProviderWindows extends PathProviderPlatform {
           versionInfoQuerier.getStringValue(infoBuffer, 'ProductName'));
 
       // If there was no product name, use the executable name.
-      if (productName == null) {
-        productName =
-            path.basenameWithoutExtension(moduleNameBuffer.toDartString());
-      }
+      productName ??= path.basenameWithoutExtension(moduleNameBuffer.toDartString());
 
       return companyName != null
           ? path.join(companyName, productName)

--- a/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_stub.dart
+++ b/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_stub.dart
@@ -14,9 +14,7 @@ import 'package:path_provider_platform_interface/path_provider_platform_interfac
 class PathProviderWindows extends PathProviderPlatform {
   /// Errors on attempted instantiation of the stub. It exists only to satisfy
   /// compile-time dependencies, and should never actually be created.
-  PathProviderWindows() {
-    assert(false);
-  }
+  PathProviderWindows() : assert(false);
 
   /// Stub; see comment on VersionInfoQuerier.
   VersionInfoQuerier versionInfoQuerier = VersionInfoQuerier();

--- a/packages/path_provider/path_provider_windows/test/path_provider_windows_test.dart
+++ b/packages/path_provider/path_provider_windows/test/path_provider_windows_test.dart
@@ -13,20 +13,21 @@ class FakeVersionInfoQuerier implements VersionInfoQuerier {
 
   final Map<String, String> responses;
 
-  getStringValue(Pointer<Uint8>? versionInfo, key) => responses[key];
+  String? getStringValue(Pointer<Uint8>? versionInfo, String key) =>
+      responses[key];
 }
 
 void main() {
   test('getTemporaryPath', () async {
-    final pathProvider = PathProviderWindows();
+    final PathProviderWindows pathProvider = PathProviderWindows();
     expect(await pathProvider.getTemporaryPath(), contains(r'C:\'));
   }, skip: !Platform.isWindows);
 
   test('getApplicationSupportPath with no version info', () async {
-    final pathProvider = PathProviderWindows();
+    final PathProviderWindows pathProvider = PathProviderWindows();
     pathProvider.versionInfoQuerier =
         FakeVersionInfoQuerier(<String, String>{});
-    final path = await pathProvider.getApplicationSupportPath();
+    final String? path = await pathProvider.getApplicationSupportPath();
     expect(path, contains(r'C:\'));
     expect(path, contains(r'AppData'));
     // The last path component should be the executable name.
@@ -34,12 +35,12 @@ void main() {
   }, skip: !Platform.isWindows);
 
   test('getApplicationSupportPath with full version info', () async {
-    final pathProvider = PathProviderWindows();
+    final PathProviderWindows pathProvider = PathProviderWindows();
     pathProvider.versionInfoQuerier = FakeVersionInfoQuerier(<String, String>{
       'CompanyName': 'A Company',
       'ProductName': 'Amazing App',
     });
-    final path = await pathProvider.getApplicationSupportPath();
+    final String? path = await pathProvider.getApplicationSupportPath();
     expect(path, isNotNull);
     if (path != null) {
       expect(path, endsWith(r'AppData\Roaming\A Company\Amazing App'));
@@ -48,11 +49,11 @@ void main() {
   }, skip: !Platform.isWindows);
 
   test('getApplicationSupportPath with missing company', () async {
-    final pathProvider = PathProviderWindows();
+    final PathProviderWindows pathProvider = PathProviderWindows();
     pathProvider.versionInfoQuerier = FakeVersionInfoQuerier(<String, String>{
       'ProductName': 'Amazing App',
     });
-    final path = await pathProvider.getApplicationSupportPath();
+    final String? path = await pathProvider.getApplicationSupportPath();
     expect(path, isNotNull);
     if (path != null) {
       expect(path, endsWith(r'AppData\Roaming\Amazing App'));
@@ -61,12 +62,12 @@ void main() {
   }, skip: !Platform.isWindows);
 
   test('getApplicationSupportPath with problematic values', () async {
-    final pathProvider = PathProviderWindows();
+    final PathProviderWindows pathProvider = PathProviderWindows();
     pathProvider.versionInfoQuerier = FakeVersionInfoQuerier(<String, String>{
       'CompanyName': r'A <Bad> Company: Name.',
       'ProductName': r'A"/Terrible\|App?*Name',
     });
-    final path = await pathProvider.getApplicationSupportPath();
+    final String? path = await pathProvider.getApplicationSupportPath();
     expect(path, isNotNull);
     if (path != null) {
       expect(
@@ -79,12 +80,12 @@ void main() {
   }, skip: !Platform.isWindows);
 
   test('getApplicationSupportPath with a completely invalid company', () async {
-    final pathProvider = PathProviderWindows();
+    final PathProviderWindows pathProvider = PathProviderWindows();
     pathProvider.versionInfoQuerier = FakeVersionInfoQuerier(<String, String>{
       'CompanyName': r'..',
       'ProductName': r'Amazing App',
     });
-    final path = await pathProvider.getApplicationSupportPath();
+    final String? path = await pathProvider.getApplicationSupportPath();
     expect(path, isNotNull);
     if (path != null) {
       expect(path, endsWith(r'AppData\Roaming\Amazing App'));
@@ -93,28 +94,28 @@ void main() {
   }, skip: !Platform.isWindows);
 
   test('getApplicationSupportPath with very long app name', () async {
-    final pathProvider = PathProviderWindows();
-    final truncatedName = 'A' * 255;
+    final PathProviderWindows pathProvider = PathProviderWindows();
+    final String truncatedName = 'A' * 255;
     pathProvider.versionInfoQuerier = FakeVersionInfoQuerier(<String, String>{
       'CompanyName': 'A Company',
       'ProductName': truncatedName * 2,
     });
-    final path = await pathProvider.getApplicationSupportPath();
+    final String? path = await pathProvider.getApplicationSupportPath();
     expect(path, endsWith('\\$truncatedName'));
     // The directory won't exist, since it's longer than MAXPATH, so don't check
     // that here.
   }, skip: !Platform.isWindows);
 
   test('getApplicationDocumentsPath', () async {
-    final pathProvider = PathProviderWindows();
-    final path = await pathProvider.getApplicationDocumentsPath();
+    final PathProviderWindows pathProvider = PathProviderWindows();
+    final String? path = await pathProvider.getApplicationDocumentsPath();
     expect(path, contains(r'C:\'));
     expect(path, contains(r'Documents'));
   }, skip: !Platform.isWindows);
 
   test('getDownloadsPath', () async {
-    final pathProvider = PathProviderWindows();
-    final path = await pathProvider.getDownloadsPath();
+    final PathProviderWindows pathProvider = PathProviderWindows();
+    final String? path = await pathProvider.getDownloadsPath();
     expect(path, contains(r'C:\'));
     expect(path, contains(r'Downloads'));
   }, skip: !Platform.isWindows);

--- a/script/incremental_build.sh
+++ b/script/incremental_build.sh
@@ -42,7 +42,6 @@ CUSTOM_ANALYSIS_PLUGINS=(
   ios_platform_images
   local_auth
   package_info
-  path_provider
   plugin_platform_interface
   quick_actions
   sensors


### PR DESCRIPTION
Removes the override to use the legacy analysis, and fixes all resulting issues.

Part of https://github.com/flutter/flutter/issues/76229

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
