### PR TITLE
[webview_flutter] Fix scroll bar position for Android non-hybrid WebViews

### DIFF
--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.3
+
+* Fixes bug where scroll bars on the Android non-hybrid WebView are rendered on
+the wrong side of the screen.
+
 ## 2.0.2
 
 * Fixes bug where text fields are hidden behind the keyboard

--- a/packages/webview_flutter/lib/src/webview_android.dart
+++ b/packages/webview_flutter/lib/src/webview_android.dart
@@ -47,10 +47,6 @@ class AndroidWebView implements WebViewPlatform {
               id, webViewPlatformCallbacksHandler));
         },
         gestureRecognizers: gestureRecognizers,
-        // WebView content is not affected by the Android view's layout direction,
-        // we explicitly set it here so that the widget doesn't require an ambient
-        // directionality.
-        layoutDirection: TextDirection.rtl,
         creationParams:
             MethodChannelWebViewPlatform.creationParamsToMap(creationParams),
         creationParamsCodec: const StandardMessageCodec(),

--- a/packages/webview_flutter/lib/src/webview_android.dart
+++ b/packages/webview_flutter/lib/src/webview_android.dart
@@ -46,6 +46,7 @@ class AndroidWebView implements WebViewPlatform {
           onWebViewPlatformCreated(MethodChannelWebViewPlatform(
               id, webViewPlatformCallbacksHandler));
         },
+        layoutDirection: Directionality.maybeOf(context) ?? TextDirection.rtl,
         gestureRecognizers: gestureRecognizers,
         creationParams:
             MethodChannelWebViewPlatform.creationParamsToMap(creationParams),

--- a/packages/webview_flutter/lib/src/webview_android.dart
+++ b/packages/webview_flutter/lib/src/webview_android.dart
@@ -46,8 +46,8 @@ class AndroidWebView implements WebViewPlatform {
           onWebViewPlatformCreated(MethodChannelWebViewPlatform(
               id, webViewPlatformCallbacksHandler));
         },
-        layoutDirection: Directionality.maybeOf(context) ?? TextDirection.rtl,
         gestureRecognizers: gestureRecognizers,
+        layoutDirection: Directionality.maybeOf(context) ?? TextDirection.rtl,
         creationParams:
             MethodChannelWebViewPlatform.creationParamsToMap(creationParams),
         creationParamsCodec: const StandardMessageCodec(),

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/webview_flutter
-version: 2.0.2
+version: 2.0.3
 
 environment:
   sdk: ">=2.12.0-259.9.beta <3.0.0"

--- a/packages/webview_flutter/test/webview_flutter_test.dart
+++ b/packages/webview_flutter/test/webview_flutter_test.dart
@@ -139,7 +139,7 @@ void main() {
 
   testWidgets("Can't go back before loading a page",
       (WidgetTester tester) async {
-        WebViewController? controller;
+    WebViewController? controller;
     await _pumpWebView(
       tester,
       WebView(

--- a/packages/webview_flutter/test/webview_flutter_test.dart
+++ b/packages/webview_flutter/test/webview_flutter_test.dart
@@ -36,12 +36,13 @@ void main() {
   });
 
   testWidgets('Create WebView', (WidgetTester tester) async {
-    await tester.pumpWidget(const WebView());
+    await _pumpWebView(tester, const WebView());
   });
 
   testWidgets('Initial url', (WidgetTester tester) async {
     late WebViewController controller;
-    await tester.pumpWidget(
+    await _pumpWebView(
+      tester,
       WebView(
         initialUrl: 'https://youtube.com',
         onWebViewCreated: (WebViewController webViewController) {
@@ -54,26 +55,31 @@ void main() {
   });
 
   testWidgets('Javascript mode', (WidgetTester tester) async {
-    await tester.pumpWidget(const WebView(
-      initialUrl: 'https://youtube.com',
-      javascriptMode: JavascriptMode.unrestricted,
-    ));
+    await _pumpWebView(
+        tester,
+        const WebView(
+          initialUrl: 'https://youtube.com',
+          javascriptMode: JavascriptMode.unrestricted,
+        ));
 
     final FakePlatformWebView platformWebView =
         fakePlatformViewsController.lastCreatedView!;
 
     expect(platformWebView.javascriptMode, JavascriptMode.unrestricted);
 
-    await tester.pumpWidget(const WebView(
-      initialUrl: 'https://youtube.com',
-      javascriptMode: JavascriptMode.disabled,
-    ));
+    await _pumpWebView(
+        tester,
+        const WebView(
+          initialUrl: 'https://youtube.com',
+          javascriptMode: JavascriptMode.disabled,
+        ));
     expect(platformWebView.javascriptMode, JavascriptMode.disabled);
   });
 
   testWidgets('Load url', (WidgetTester tester) async {
     WebViewController? controller;
-    await tester.pumpWidget(
+    await _pumpWebView(
+      tester,
       WebView(
         onWebViewCreated: (WebViewController webViewController) {
           controller = webViewController;
@@ -90,7 +96,8 @@ void main() {
 
   testWidgets('Invalid urls', (WidgetTester tester) async {
     WebViewController? controller;
-    await tester.pumpWidget(
+    await _pumpWebView(
+      tester,
       WebView(
         onWebViewCreated: (WebViewController webViewController) {
           controller = webViewController;
@@ -112,7 +119,8 @@ void main() {
 
   testWidgets('Headers in loadUrl', (WidgetTester tester) async {
     WebViewController? controller;
-    await tester.pumpWidget(
+    await _pumpWebView(
+      tester,
       WebView(
         onWebViewCreated: (WebViewController webViewController) {
           controller = webViewController;
@@ -131,8 +139,9 @@ void main() {
 
   testWidgets("Can't go back before loading a page",
       (WidgetTester tester) async {
-    WebViewController? controller;
-    await tester.pumpWidget(
+        WebViewController? controller;
+    await _pumpWebView(
+      tester,
       WebView(
         onWebViewCreated: (WebViewController webViewController) {
           controller = webViewController;
@@ -149,7 +158,8 @@ void main() {
 
   testWidgets("Clear Cache", (WidgetTester tester) async {
     WebViewController? controller;
-    await tester.pumpWidget(
+    await _pumpWebView(
+      tester,
       WebView(
         onWebViewCreated: (WebViewController webViewController) {
           controller = webViewController;
@@ -167,7 +177,8 @@ void main() {
 
   testWidgets("Can't go back with no history", (WidgetTester tester) async {
     WebViewController? controller;
-    await tester.pumpWidget(
+    await _pumpWebView(
+      tester,
       WebView(
         initialUrl: 'https://flutter.io',
         onWebViewCreated: (WebViewController webViewController) {
@@ -184,7 +195,8 @@ void main() {
 
   testWidgets('Can go back', (WidgetTester tester) async {
     WebViewController? controller;
-    await tester.pumpWidget(
+    await _pumpWebView(
+      tester,
       WebView(
         initialUrl: 'https://flutter.io',
         onWebViewCreated: (WebViewController webViewController) {
@@ -203,8 +215,9 @@ void main() {
 
   testWidgets("Can't go forward before loading a page",
       (WidgetTester tester) async {
-    WebViewController? controller;
-    await tester.pumpWidget(
+        WebViewController? controller;
+    await _pumpWebView(
+      tester,
       WebView(
         onWebViewCreated: (WebViewController webViewController) {
           controller = webViewController;
@@ -221,7 +234,8 @@ void main() {
 
   testWidgets("Can't go forward with no history", (WidgetTester tester) async {
     WebViewController? controller;
-    await tester.pumpWidget(
+    await _pumpWebView(
+      tester,
       WebView(
         initialUrl: 'https://flutter.io',
         onWebViewCreated: (WebViewController webViewController) {
@@ -238,7 +252,8 @@ void main() {
 
   testWidgets('Can go forward', (WidgetTester tester) async {
     WebViewController? controller;
-    await tester.pumpWidget(
+    await _pumpWebView(
+      tester,
       WebView(
         initialUrl: 'https://flutter.io',
         onWebViewCreated: (WebViewController webViewController) {
@@ -258,7 +273,8 @@ void main() {
 
   testWidgets('Go back', (WidgetTester tester) async {
     WebViewController? controller;
-    await tester.pumpWidget(
+    await _pumpWebView(
+      tester,
       WebView(
         initialUrl: 'https://youtube.com',
         onWebViewCreated: (WebViewController webViewController) {
@@ -282,7 +298,8 @@ void main() {
 
   testWidgets('Go forward', (WidgetTester tester) async {
     WebViewController? controller;
-    await tester.pumpWidget(
+    await _pumpWebView(
+      tester,
       WebView(
         initialUrl: 'https://youtube.com',
         onWebViewCreated: (WebViewController webViewController) {
@@ -310,7 +327,8 @@ void main() {
 
   testWidgets('Current URL', (WidgetTester tester) async {
     WebViewController? controller;
-    await tester.pumpWidget(
+    await _pumpWebView(
+      tester,
       WebView(
         onWebViewCreated: (WebViewController webViewController) {
           controller = webViewController;
@@ -335,7 +353,8 @@ void main() {
 
   testWidgets('Reload url', (WidgetTester tester) async {
     late WebViewController controller;
-    await tester.pumpWidget(
+    await _pumpWebView(
+      tester,
       WebView(
         initialUrl: 'https://flutter.io',
         onWebViewCreated: (WebViewController webViewController) {
@@ -362,7 +381,8 @@ void main() {
 
   testWidgets('evaluate Javascript', (WidgetTester tester) async {
     late WebViewController controller;
-    await tester.pumpWidget(
+    await _pumpWebView(
+      tester,
       WebView(
         initialUrl: 'https://flutter.io',
         javascriptMode: JavascriptMode.unrestricted,
@@ -378,8 +398,9 @@ void main() {
 
   testWidgets('evaluate Javascript with JavascriptMode disabled',
       (WidgetTester tester) async {
-    late WebViewController controller;
-    await tester.pumpWidget(
+        late WebViewController controller;
+    await _pumpWebView(
+      tester,
       WebView(
         initialUrl: 'https://flutter.io',
         javascriptMode: JavascriptMode.disabled,
@@ -395,7 +416,8 @@ void main() {
   });
 
   testWidgets('Cookies can be cleared once', (WidgetTester tester) async {
-    await tester.pumpWidget(
+    await _pumpWebView(
+      tester,
       const WebView(
         initialUrl: 'https://flutter.io',
       ),
@@ -407,7 +429,8 @@ void main() {
 
   testWidgets('Second cookie clear does not have cookies',
       (WidgetTester tester) async {
-    await tester.pumpWidget(
+    await _pumpWebView(
+      tester,
       const WebView(
         initialUrl: 'https://flutter.io',
       ),
@@ -420,7 +443,8 @@ void main() {
   });
 
   testWidgets('Initial JavaScript channels', (WidgetTester tester) async {
-    await tester.pumpWidget(
+    await _pumpWebView(
+      tester,
       WebView(
         initialUrl: 'https://youtube.com',
         javascriptChannels: <JavascriptChannel>{
@@ -458,7 +482,8 @@ void main() {
 
   testWidgets('Unique JavaScript channel names are required',
       (WidgetTester tester) async {
-    await tester.pumpWidget(
+    await _pumpWebView(
+      tester,
       WebView(
         initialUrl: 'https://youtube.com',
         javascriptChannels: <JavascriptChannel>{
@@ -473,7 +498,8 @@ void main() {
   });
 
   testWidgets('JavaScript channels update', (WidgetTester tester) async {
-    await tester.pumpWidget(
+    await _pumpWebView(
+      tester,
       WebView(
         initialUrl: 'https://youtube.com',
         javascriptChannels: <JavascriptChannel>{
@@ -485,7 +511,8 @@ void main() {
       ),
     );
 
-    await tester.pumpWidget(
+    await _pumpWebView(
+      tester,
       WebView(
         initialUrl: 'https://youtube.com',
         javascriptChannels: <JavascriptChannel>{
@@ -512,7 +539,8 @@ void main() {
     // updating it again with a subset of the previously registered channels fails as the
     // widget's cache of current channel wasn't properly updated when updating javascriptChannels to
     // null.
-    await tester.pumpWidget(
+    await _pumpWebView(
+      tester,
       WebView(
         initialUrl: 'https://youtube.com',
         javascriptChannels: <JavascriptChannel>{
@@ -522,13 +550,15 @@ void main() {
       ),
     );
 
-    await tester.pumpWidget(
+    await _pumpWebView(
+      tester,
       const WebView(
         initialUrl: 'https://youtube.com',
       ),
     );
 
-    await tester.pumpWidget(
+    await _pumpWebView(
+      tester,
       WebView(
         initialUrl: 'https://youtube.com',
         javascriptChannels: <JavascriptChannel>{
@@ -548,7 +578,8 @@ void main() {
   testWidgets('JavaScript channel messages', (WidgetTester tester) async {
     final List<String> ttsMessagesReceived = <String>[];
     final List<String> alarmMessagesReceived = <String>[];
-    await tester.pumpWidget(
+    await _pumpWebView(
+      tester,
       WebView(
         initialUrl: 'https://youtube.com',
         javascriptChannels: <JavascriptChannel>{
@@ -582,12 +613,14 @@ void main() {
     testWidgets('onPageStarted is not null', (WidgetTester tester) async {
       String? returnedUrl;
 
-      await tester.pumpWidget(WebView(
-        initialUrl: 'https://youtube.com',
-        onPageStarted: (String url) {
-          returnedUrl = url;
-        },
-      ));
+      await _pumpWebView(
+          tester,
+          WebView(
+            initialUrl: 'https://youtube.com',
+            onPageStarted: (String url) {
+              returnedUrl = url;
+            },
+          ));
 
       final FakePlatformWebView platformWebView =
           fakePlatformViewsController.lastCreatedView!;
@@ -598,10 +631,12 @@ void main() {
     });
 
     testWidgets('onPageStarted is null', (WidgetTester tester) async {
-      await tester.pumpWidget(const WebView(
-        initialUrl: 'https://youtube.com',
-        onPageStarted: null,
-      ));
+      await _pumpWebView(
+          tester,
+          const WebView(
+            initialUrl: 'https://youtube.com',
+            onPageStarted: null,
+          ));
 
       final FakePlatformWebView platformWebView =
           fakePlatformViewsController.lastCreatedView!;
@@ -614,17 +649,21 @@ void main() {
     testWidgets('onPageStarted changed', (WidgetTester tester) async {
       String? returnedUrl;
 
-      await tester.pumpWidget(WebView(
-        initialUrl: 'https://youtube.com',
-        onPageStarted: (String url) {},
-      ));
+      await _pumpWebView(
+          tester,
+          WebView(
+            initialUrl: 'https://youtube.com',
+            onPageStarted: (String url) {},
+          ));
 
-      await tester.pumpWidget(WebView(
-        initialUrl: 'https://youtube.com',
-        onPageStarted: (String url) {
-          returnedUrl = url;
-        },
-      ));
+      await _pumpWebView(
+          tester,
+          WebView(
+            initialUrl: 'https://youtube.com',
+            onPageStarted: (String url) {
+              returnedUrl = url;
+            },
+          ));
 
       final FakePlatformWebView platformWebView =
           fakePlatformViewsController.lastCreatedView!;
@@ -639,12 +678,14 @@ void main() {
     testWidgets('onPageFinished is not null', (WidgetTester tester) async {
       String? returnedUrl;
 
-      await tester.pumpWidget(WebView(
-        initialUrl: 'https://youtube.com',
-        onPageFinished: (String url) {
-          returnedUrl = url;
-        },
-      ));
+      await _pumpWebView(
+          tester,
+          WebView(
+            initialUrl: 'https://youtube.com',
+            onPageFinished: (String url) {
+              returnedUrl = url;
+            },
+          ));
 
       final FakePlatformWebView platformWebView =
           fakePlatformViewsController.lastCreatedView!;
@@ -655,10 +696,12 @@ void main() {
     });
 
     testWidgets('onPageFinished is null', (WidgetTester tester) async {
-      await tester.pumpWidget(const WebView(
-        initialUrl: 'https://youtube.com',
-        onPageFinished: null,
-      ));
+      await _pumpWebView(
+          tester,
+          const WebView(
+            initialUrl: 'https://youtube.com',
+            onPageFinished: null,
+          ));
 
       final FakePlatformWebView platformWebView =
           fakePlatformViewsController.lastCreatedView!;
@@ -671,17 +714,21 @@ void main() {
     testWidgets('onPageFinished changed', (WidgetTester tester) async {
       String? returnedUrl;
 
-      await tester.pumpWidget(WebView(
-        initialUrl: 'https://youtube.com',
-        onPageFinished: (String url) {},
-      ));
+      await _pumpWebView(
+          tester,
+          WebView(
+            initialUrl: 'https://youtube.com',
+            onPageFinished: (String url) {},
+          ));
 
-      await tester.pumpWidget(WebView(
-        initialUrl: 'https://youtube.com',
-        onPageFinished: (String url) {
-          returnedUrl = url;
-        },
-      ));
+      await _pumpWebView(
+          tester,
+          WebView(
+            initialUrl: 'https://youtube.com',
+            onPageFinished: (String url) {
+              returnedUrl = url;
+            },
+          ));
 
       final FakePlatformWebView platformWebView =
           fakePlatformViewsController.lastCreatedView!;
@@ -696,12 +743,14 @@ void main() {
     testWidgets('onLoadingProgress is not null', (WidgetTester tester) async {
       int? loadingProgress;
 
-      await tester.pumpWidget(WebView(
-        initialUrl: 'https://youtube.com',
-        onProgress: (int progress) {
-          loadingProgress = progress;
-        },
-      ));
+      await _pumpWebView(
+          tester,
+          WebView(
+            initialUrl: 'https://youtube.com',
+            onProgress: (int progress) {
+              loadingProgress = progress;
+            },
+          ));
 
       final FakePlatformWebView? platformWebView =
           fakePlatformViewsController.lastCreatedView;
@@ -712,10 +761,12 @@ void main() {
     });
 
     testWidgets('onLoadingProgress is null', (WidgetTester tester) async {
-      await tester.pumpWidget(const WebView(
-        initialUrl: 'https://youtube.com',
-        onProgress: null,
-      ));
+      await _pumpWebView(
+          tester,
+          const WebView(
+            initialUrl: 'https://youtube.com',
+            onProgress: null,
+          ));
 
       final FakePlatformWebView platformWebView =
           fakePlatformViewsController.lastCreatedView!;
@@ -727,17 +778,21 @@ void main() {
     testWidgets('onLoadingProgress changed', (WidgetTester tester) async {
       int? loadingProgress;
 
-      await tester.pumpWidget(WebView(
-        initialUrl: 'https://youtube.com',
-        onProgress: (int progress) {},
-      ));
+      await _pumpWebView(
+          tester,
+          WebView(
+            initialUrl: 'https://youtube.com',
+            onProgress: (int progress) {},
+          ));
 
-      await tester.pumpWidget(WebView(
-        initialUrl: 'https://youtube.com',
-        onProgress: (int progress) {
-          loadingProgress = progress;
-        },
-      ));
+      await _pumpWebView(
+          tester,
+          WebView(
+            initialUrl: 'https://youtube.com',
+            onProgress: (int progress) {
+              loadingProgress = progress;
+            },
+          ));
 
       final FakePlatformWebView platformWebView =
           fakePlatformViewsController.lastCreatedView!;
@@ -750,20 +805,24 @@ void main() {
 
   group('navigationDelegate', () {
     testWidgets('hasNavigationDelegate', (WidgetTester tester) async {
-      await tester.pumpWidget(const WebView(
-        initialUrl: 'https://youtube.com',
-      ));
+      await _pumpWebView(
+          tester,
+          const WebView(
+            initialUrl: 'https://youtube.com',
+          ));
 
       final FakePlatformWebView platformWebView =
           fakePlatformViewsController.lastCreatedView!;
 
       expect(platformWebView.hasNavigationDelegate, false);
 
-      await tester.pumpWidget(WebView(
-        initialUrl: 'https://youtube.com',
-        navigationDelegate: (NavigationRequest r) =>
-            NavigationDecision.navigate,
-      ));
+      await _pumpWebView(
+          tester,
+          WebView(
+            initialUrl: 'https://youtube.com',
+            navigationDelegate: (NavigationRequest r) =>
+                NavigationDecision.navigate,
+          ));
 
       expect(platformWebView.hasNavigationDelegate, true);
     });
@@ -771,15 +830,17 @@ void main() {
     testWidgets('Block navigation', (WidgetTester tester) async {
       final List<NavigationRequest> navigationRequests = <NavigationRequest>[];
 
-      await tester.pumpWidget(WebView(
-          initialUrl: 'https://youtube.com',
-          navigationDelegate: (NavigationRequest request) {
-            navigationRequests.add(request);
-            // Only allow navigating to https://flutter.dev
-            return request.url == 'https://flutter.dev'
-                ? NavigationDecision.navigate
-                : NavigationDecision.prevent;
-          }));
+      await _pumpWebView(
+          tester,
+          WebView(
+              initialUrl: 'https://youtube.com',
+              navigationDelegate: (NavigationRequest request) {
+                navigationRequests.add(request);
+                // Only allow navigating to https://flutter.dev
+                return request.url == 'https://flutter.dev'
+                    ? NavigationDecision.navigate
+                    : NavigationDecision.prevent;
+              }));
 
       final FakePlatformWebView platformWebView =
           fakePlatformViewsController.lastCreatedView!;
@@ -802,9 +863,11 @@ void main() {
 
   group('debuggingEnabled', () {
     testWidgets('enable debugging', (WidgetTester tester) async {
-      await tester.pumpWidget(const WebView(
-        debuggingEnabled: true,
-      ));
+      await _pumpWebView(
+          tester,
+          const WebView(
+            debuggingEnabled: true,
+          ));
 
       final FakePlatformWebView platformWebView =
           fakePlatformViewsController.lastCreatedView!;
@@ -813,7 +876,7 @@ void main() {
     });
 
     testWidgets('defaults to false', (WidgetTester tester) async {
-      await tester.pumpWidget(const WebView());
+      await _pumpWebView(tester, const WebView());
 
       final FakePlatformWebView platformWebView =
           fakePlatformViewsController.lastCreatedView!;
@@ -823,22 +886,26 @@ void main() {
 
     testWidgets('can be changed', (WidgetTester tester) async {
       final GlobalKey key = GlobalKey();
-      await tester.pumpWidget(WebView(key: key));
+      await _pumpWebView(tester, WebView(key: key));
 
       final FakePlatformWebView platformWebView =
           fakePlatformViewsController.lastCreatedView!;
 
-      await tester.pumpWidget(WebView(
-        key: key,
-        debuggingEnabled: true,
-      ));
+      await _pumpWebView(
+          tester,
+          WebView(
+            key: key,
+            debuggingEnabled: true,
+          ));
 
       expect(platformWebView.debuggingEnabled, true);
 
-      await tester.pumpWidget(WebView(
-        key: key,
-        debuggingEnabled: false,
-      ));
+      await _pumpWebView(
+          tester,
+          WebView(
+            key: key,
+            debuggingEnabled: false,
+          ));
 
       expect(platformWebView.debuggingEnabled, false);
     });
@@ -853,7 +920,8 @@ void main() {
     });
 
     testWidgets('creation', (WidgetTester tester) async {
-      await tester.pumpWidget(
+      await _pumpWebView(
+        tester,
         const WebView(
           initialUrl: 'https://youtube.com',
           gestureNavigationEnabled: true,
@@ -879,7 +947,8 @@ void main() {
 
     testWidgets('loadUrl', (WidgetTester tester) async {
       late WebViewController controller;
-      await tester.pumpWidget(
+      await _pumpWebView(
+        tester,
         WebView(
           initialUrl: 'https://youtube.com',
           onWebViewCreated: (WebViewController webViewController) {
@@ -902,24 +971,33 @@ void main() {
     });
   });
   testWidgets('Set UserAgent', (WidgetTester tester) async {
-    await tester.pumpWidget(const WebView(
-      initialUrl: 'https://youtube.com',
-      javascriptMode: JavascriptMode.unrestricted,
-    ));
+    await _pumpWebView(
+        tester,
+        const WebView(
+          initialUrl: 'https://youtube.com',
+          javascriptMode: JavascriptMode.unrestricted,
+        ));
 
     final FakePlatformWebView platformWebView =
         fakePlatformViewsController.lastCreatedView!;
 
     expect(platformWebView.userAgent, isNull);
 
-    await tester.pumpWidget(const WebView(
-      initialUrl: 'https://youtube.com',
-      javascriptMode: JavascriptMode.unrestricted,
-      userAgent: 'UA',
-    ));
+    await _pumpWebView(
+        tester,
+        const WebView(
+          initialUrl: 'https://youtube.com',
+          javascriptMode: JavascriptMode.unrestricted,
+          userAgent: 'UA',
+        ));
 
     expect(platformWebView.userAgent, 'UA');
   });
+}
+
+Future<void> _pumpWebView(WidgetTester tester, WebView webView) {
+  return tester.pumpWidget(
+      Directionality(textDirection: TextDirection.rtl, child: webView));
 }
 
 class FakePlatformWebView {

--- a/packages/webview_flutter/test/webview_flutter_test.dart
+++ b/packages/webview_flutter/test/webview_flutter_test.dart
@@ -36,13 +36,12 @@ void main() {
   });
 
   testWidgets('Create WebView', (WidgetTester tester) async {
-    await _pumpWebView(tester, const WebView());
+    await tester.pumpWidget(const WebView());
   });
 
   testWidgets('Initial url', (WidgetTester tester) async {
     late WebViewController controller;
-    await _pumpWebView(
-      tester,
+    await tester.pumpWidget(
       WebView(
         initialUrl: 'https://youtube.com',
         onWebViewCreated: (WebViewController webViewController) {
@@ -55,31 +54,26 @@ void main() {
   });
 
   testWidgets('Javascript mode', (WidgetTester tester) async {
-    await _pumpWebView(
-        tester,
-        const WebView(
-          initialUrl: 'https://youtube.com',
-          javascriptMode: JavascriptMode.unrestricted,
-        ));
+    await tester.pumpWidget(const WebView(
+      initialUrl: 'https://youtube.com',
+      javascriptMode: JavascriptMode.unrestricted,
+    ));
 
     final FakePlatformWebView platformWebView =
         fakePlatformViewsController.lastCreatedView!;
 
     expect(platformWebView.javascriptMode, JavascriptMode.unrestricted);
 
-    await _pumpWebView(
-        tester,
-        const WebView(
-          initialUrl: 'https://youtube.com',
-          javascriptMode: JavascriptMode.disabled,
-        ));
+    await tester.pumpWidget(const WebView(
+      initialUrl: 'https://youtube.com',
+      javascriptMode: JavascriptMode.disabled,
+    ));
     expect(platformWebView.javascriptMode, JavascriptMode.disabled);
   });
 
   testWidgets('Load url', (WidgetTester tester) async {
     WebViewController? controller;
-    await _pumpWebView(
-      tester,
+    await tester.pumpWidget(
       WebView(
         onWebViewCreated: (WebViewController webViewController) {
           controller = webViewController;
@@ -96,8 +90,7 @@ void main() {
 
   testWidgets('Invalid urls', (WidgetTester tester) async {
     WebViewController? controller;
-    await _pumpWebView(
-      tester,
+    await tester.pumpWidget(
       WebView(
         onWebViewCreated: (WebViewController webViewController) {
           controller = webViewController;
@@ -119,8 +112,7 @@ void main() {
 
   testWidgets('Headers in loadUrl', (WidgetTester tester) async {
     WebViewController? controller;
-    await _pumpWebView(
-      tester,
+    await tester.pumpWidget(
       WebView(
         onWebViewCreated: (WebViewController webViewController) {
           controller = webViewController;
@@ -140,8 +132,7 @@ void main() {
   testWidgets("Can't go back before loading a page",
       (WidgetTester tester) async {
     WebViewController? controller;
-    await _pumpWebView(
-      tester,
+    await tester.pumpWidget(
       WebView(
         onWebViewCreated: (WebViewController webViewController) {
           controller = webViewController;
@@ -158,8 +149,7 @@ void main() {
 
   testWidgets("Clear Cache", (WidgetTester tester) async {
     WebViewController? controller;
-    await _pumpWebView(
-      tester,
+    await tester.pumpWidget(
       WebView(
         onWebViewCreated: (WebViewController webViewController) {
           controller = webViewController;
@@ -177,8 +167,7 @@ void main() {
 
   testWidgets("Can't go back with no history", (WidgetTester tester) async {
     WebViewController? controller;
-    await _pumpWebView(
-      tester,
+    await tester.pumpWidget(
       WebView(
         initialUrl: 'https://flutter.io',
         onWebViewCreated: (WebViewController webViewController) {
@@ -195,8 +184,7 @@ void main() {
 
   testWidgets('Can go back', (WidgetTester tester) async {
     WebViewController? controller;
-    await _pumpWebView(
-      tester,
+    await tester.pumpWidget(
       WebView(
         initialUrl: 'https://flutter.io',
         onWebViewCreated: (WebViewController webViewController) {
@@ -216,8 +204,7 @@ void main() {
   testWidgets("Can't go forward before loading a page",
       (WidgetTester tester) async {
     WebViewController? controller;
-    await _pumpWebView(
-      tester,
+    await tester.pumpWidget(
       WebView(
         onWebViewCreated: (WebViewController webViewController) {
           controller = webViewController;
@@ -234,8 +221,7 @@ void main() {
 
   testWidgets("Can't go forward with no history", (WidgetTester tester) async {
     WebViewController? controller;
-    await _pumpWebView(
-      tester,
+    await tester.pumpWidget(
       WebView(
         initialUrl: 'https://flutter.io',
         onWebViewCreated: (WebViewController webViewController) {
@@ -252,8 +238,7 @@ void main() {
 
   testWidgets('Can go forward', (WidgetTester tester) async {
     WebViewController? controller;
-    await _pumpWebView(
-      tester,
+    await tester.pumpWidget(
       WebView(
         initialUrl: 'https://flutter.io',
         onWebViewCreated: (WebViewController webViewController) {
@@ -273,8 +258,7 @@ void main() {
 
   testWidgets('Go back', (WidgetTester tester) async {
     WebViewController? controller;
-    await _pumpWebView(
-      tester,
+    await tester.pumpWidget(
       WebView(
         initialUrl: 'https://youtube.com',
         onWebViewCreated: (WebViewController webViewController) {
@@ -298,8 +282,7 @@ void main() {
 
   testWidgets('Go forward', (WidgetTester tester) async {
     WebViewController? controller;
-    await _pumpWebView(
-      tester,
+    await tester.pumpWidget(
       WebView(
         initialUrl: 'https://youtube.com',
         onWebViewCreated: (WebViewController webViewController) {
@@ -327,8 +310,7 @@ void main() {
 
   testWidgets('Current URL', (WidgetTester tester) async {
     WebViewController? controller;
-    await _pumpWebView(
-      tester,
+    await tester.pumpWidget(
       WebView(
         onWebViewCreated: (WebViewController webViewController) {
           controller = webViewController;
@@ -353,8 +335,7 @@ void main() {
 
   testWidgets('Reload url', (WidgetTester tester) async {
     late WebViewController controller;
-    await _pumpWebView(
-      tester,
+    await tester.pumpWidget(
       WebView(
         initialUrl: 'https://flutter.io',
         onWebViewCreated: (WebViewController webViewController) {
@@ -381,8 +362,7 @@ void main() {
 
   testWidgets('evaluate Javascript', (WidgetTester tester) async {
     late WebViewController controller;
-    await _pumpWebView(
-      tester,
+    await tester.pumpWidget(
       WebView(
         initialUrl: 'https://flutter.io',
         javascriptMode: JavascriptMode.unrestricted,
@@ -399,8 +379,7 @@ void main() {
   testWidgets('evaluate Javascript with JavascriptMode disabled',
       (WidgetTester tester) async {
     late WebViewController controller;
-    await _pumpWebView(
-      tester,
+    await tester.pumpWidget(
       WebView(
         initialUrl: 'https://flutter.io',
         javascriptMode: JavascriptMode.disabled,
@@ -416,8 +395,7 @@ void main() {
   });
 
   testWidgets('Cookies can be cleared once', (WidgetTester tester) async {
-    await _pumpWebView(
-      tester,
+    await tester.pumpWidget(
       const WebView(
         initialUrl: 'https://flutter.io',
       ),
@@ -429,8 +407,7 @@ void main() {
 
   testWidgets('Second cookie clear does not have cookies',
       (WidgetTester tester) async {
-    await _pumpWebView(
-      tester,
+    await tester.pumpWidget(
       const WebView(
         initialUrl: 'https://flutter.io',
       ),
@@ -443,8 +420,7 @@ void main() {
   });
 
   testWidgets('Initial JavaScript channels', (WidgetTester tester) async {
-    await _pumpWebView(
-      tester,
+    await tester.pumpWidget(
       WebView(
         initialUrl: 'https://youtube.com',
         javascriptChannels: <JavascriptChannel>{
@@ -482,8 +458,7 @@ void main() {
 
   testWidgets('Unique JavaScript channel names are required',
       (WidgetTester tester) async {
-    await _pumpWebView(
-      tester,
+    await tester.pumpWidget(
       WebView(
         initialUrl: 'https://youtube.com',
         javascriptChannels: <JavascriptChannel>{
@@ -498,8 +473,7 @@ void main() {
   });
 
   testWidgets('JavaScript channels update', (WidgetTester tester) async {
-    await _pumpWebView(
-      tester,
+    await tester.pumpWidget(
       WebView(
         initialUrl: 'https://youtube.com',
         javascriptChannels: <JavascriptChannel>{
@@ -511,8 +485,7 @@ void main() {
       ),
     );
 
-    await _pumpWebView(
-      tester,
+    await tester.pumpWidget(
       WebView(
         initialUrl: 'https://youtube.com',
         javascriptChannels: <JavascriptChannel>{
@@ -539,8 +512,7 @@ void main() {
     // updating it again with a subset of the previously registered channels fails as the
     // widget's cache of current channel wasn't properly updated when updating javascriptChannels to
     // null.
-    await _pumpWebView(
-      tester,
+    await tester.pumpWidget(
       WebView(
         initialUrl: 'https://youtube.com',
         javascriptChannels: <JavascriptChannel>{
@@ -550,15 +522,13 @@ void main() {
       ),
     );
 
-    await _pumpWebView(
-      tester,
+    await tester.pumpWidget(
       const WebView(
         initialUrl: 'https://youtube.com',
       ),
     );
 
-    await _pumpWebView(
-      tester,
+    await tester.pumpWidget(
       WebView(
         initialUrl: 'https://youtube.com',
         javascriptChannels: <JavascriptChannel>{
@@ -578,8 +548,7 @@ void main() {
   testWidgets('JavaScript channel messages', (WidgetTester tester) async {
     final List<String> ttsMessagesReceived = <String>[];
     final List<String> alarmMessagesReceived = <String>[];
-    await _pumpWebView(
-      tester,
+    await tester.pumpWidget(
       WebView(
         initialUrl: 'https://youtube.com',
         javascriptChannels: <JavascriptChannel>{
@@ -613,14 +582,12 @@ void main() {
     testWidgets('onPageStarted is not null', (WidgetTester tester) async {
       String? returnedUrl;
 
-      await _pumpWebView(
-          tester,
-          WebView(
-            initialUrl: 'https://youtube.com',
-            onPageStarted: (String url) {
-              returnedUrl = url;
-            },
-          ));
+      await tester.pumpWidget(WebView(
+        initialUrl: 'https://youtube.com',
+        onPageStarted: (String url) {
+          returnedUrl = url;
+        },
+      ));
 
       final FakePlatformWebView platformWebView =
           fakePlatformViewsController.lastCreatedView!;
@@ -631,12 +598,10 @@ void main() {
     });
 
     testWidgets('onPageStarted is null', (WidgetTester tester) async {
-      await _pumpWebView(
-          tester,
-          const WebView(
-            initialUrl: 'https://youtube.com',
-            onPageStarted: null,
-          ));
+      await tester.pumpWidget(const WebView(
+        initialUrl: 'https://youtube.com',
+        onPageStarted: null,
+      ));
 
       final FakePlatformWebView platformWebView =
           fakePlatformViewsController.lastCreatedView!;
@@ -649,21 +614,17 @@ void main() {
     testWidgets('onPageStarted changed', (WidgetTester tester) async {
       String? returnedUrl;
 
-      await _pumpWebView(
-          tester,
-          WebView(
-            initialUrl: 'https://youtube.com',
-            onPageStarted: (String url) {},
-          ));
+      await tester.pumpWidget(WebView(
+        initialUrl: 'https://youtube.com',
+        onPageStarted: (String url) {},
+      ));
 
-      await _pumpWebView(
-          tester,
-          WebView(
-            initialUrl: 'https://youtube.com',
-            onPageStarted: (String url) {
-              returnedUrl = url;
-            },
-          ));
+      await tester.pumpWidget(WebView(
+        initialUrl: 'https://youtube.com',
+        onPageStarted: (String url) {
+          returnedUrl = url;
+        },
+      ));
 
       final FakePlatformWebView platformWebView =
           fakePlatformViewsController.lastCreatedView!;
@@ -678,14 +639,12 @@ void main() {
     testWidgets('onPageFinished is not null', (WidgetTester tester) async {
       String? returnedUrl;
 
-      await _pumpWebView(
-          tester,
-          WebView(
-            initialUrl: 'https://youtube.com',
-            onPageFinished: (String url) {
-              returnedUrl = url;
-            },
-          ));
+      await tester.pumpWidget(WebView(
+        initialUrl: 'https://youtube.com',
+        onPageFinished: (String url) {
+          returnedUrl = url;
+        },
+      ));
 
       final FakePlatformWebView platformWebView =
           fakePlatformViewsController.lastCreatedView!;
@@ -696,12 +655,10 @@ void main() {
     });
 
     testWidgets('onPageFinished is null', (WidgetTester tester) async {
-      await _pumpWebView(
-          tester,
-          const WebView(
-            initialUrl: 'https://youtube.com',
-            onPageFinished: null,
-          ));
+      await tester.pumpWidget(const WebView(
+        initialUrl: 'https://youtube.com',
+        onPageFinished: null,
+      ));
 
       final FakePlatformWebView platformWebView =
           fakePlatformViewsController.lastCreatedView!;
@@ -714,21 +671,17 @@ void main() {
     testWidgets('onPageFinished changed', (WidgetTester tester) async {
       String? returnedUrl;
 
-      await _pumpWebView(
-          tester,
-          WebView(
-            initialUrl: 'https://youtube.com',
-            onPageFinished: (String url) {},
-          ));
+      await tester.pumpWidget(WebView(
+        initialUrl: 'https://youtube.com',
+        onPageFinished: (String url) {},
+      ));
 
-      await _pumpWebView(
-          tester,
-          WebView(
-            initialUrl: 'https://youtube.com',
-            onPageFinished: (String url) {
-              returnedUrl = url;
-            },
-          ));
+      await tester.pumpWidget(WebView(
+        initialUrl: 'https://youtube.com',
+        onPageFinished: (String url) {
+          returnedUrl = url;
+        },
+      ));
 
       final FakePlatformWebView platformWebView =
           fakePlatformViewsController.lastCreatedView!;
@@ -743,14 +696,12 @@ void main() {
     testWidgets('onLoadingProgress is not null', (WidgetTester tester) async {
       int? loadingProgress;
 
-      await _pumpWebView(
-          tester,
-          WebView(
-            initialUrl: 'https://youtube.com',
-            onProgress: (int progress) {
-              loadingProgress = progress;
-            },
-          ));
+      await tester.pumpWidget(WebView(
+        initialUrl: 'https://youtube.com',
+        onProgress: (int progress) {
+          loadingProgress = progress;
+        },
+      ));
 
       final FakePlatformWebView? platformWebView =
           fakePlatformViewsController.lastCreatedView;
@@ -761,12 +712,10 @@ void main() {
     });
 
     testWidgets('onLoadingProgress is null', (WidgetTester tester) async {
-      await _pumpWebView(
-          tester,
-          const WebView(
-            initialUrl: 'https://youtube.com',
-            onProgress: null,
-          ));
+      await tester.pumpWidget(const WebView(
+        initialUrl: 'https://youtube.com',
+        onProgress: null,
+      ));
 
       final FakePlatformWebView platformWebView =
           fakePlatformViewsController.lastCreatedView!;
@@ -778,21 +727,17 @@ void main() {
     testWidgets('onLoadingProgress changed', (WidgetTester tester) async {
       int? loadingProgress;
 
-      await _pumpWebView(
-          tester,
-          WebView(
-            initialUrl: 'https://youtube.com',
-            onProgress: (int progress) {},
-          ));
+      await tester.pumpWidget(WebView(
+        initialUrl: 'https://youtube.com',
+        onProgress: (int progress) {},
+      ));
 
-      await _pumpWebView(
-          tester,
-          WebView(
-            initialUrl: 'https://youtube.com',
-            onProgress: (int progress) {
-              loadingProgress = progress;
-            },
-          ));
+      await tester.pumpWidget(WebView(
+        initialUrl: 'https://youtube.com',
+        onProgress: (int progress) {
+          loadingProgress = progress;
+        },
+      ));
 
       final FakePlatformWebView platformWebView =
           fakePlatformViewsController.lastCreatedView!;
@@ -805,24 +750,20 @@ void main() {
 
   group('navigationDelegate', () {
     testWidgets('hasNavigationDelegate', (WidgetTester tester) async {
-      await _pumpWebView(
-          tester,
-          const WebView(
-            initialUrl: 'https://youtube.com',
-          ));
+      await tester.pumpWidget(const WebView(
+        initialUrl: 'https://youtube.com',
+      ));
 
       final FakePlatformWebView platformWebView =
           fakePlatformViewsController.lastCreatedView!;
 
       expect(platformWebView.hasNavigationDelegate, false);
 
-      await _pumpWebView(
-          tester,
-          WebView(
-            initialUrl: 'https://youtube.com',
-            navigationDelegate: (NavigationRequest r) =>
-                NavigationDecision.navigate,
-          ));
+      await tester.pumpWidget(WebView(
+        initialUrl: 'https://youtube.com',
+        navigationDelegate: (NavigationRequest r) =>
+            NavigationDecision.navigate,
+      ));
 
       expect(platformWebView.hasNavigationDelegate, true);
     });
@@ -830,17 +771,15 @@ void main() {
     testWidgets('Block navigation', (WidgetTester tester) async {
       final List<NavigationRequest> navigationRequests = <NavigationRequest>[];
 
-      await _pumpWebView(
-          tester,
-          WebView(
-              initialUrl: 'https://youtube.com',
-              navigationDelegate: (NavigationRequest request) {
-                navigationRequests.add(request);
-                // Only allow navigating to https://flutter.dev
-                return request.url == 'https://flutter.dev'
-                    ? NavigationDecision.navigate
-                    : NavigationDecision.prevent;
-              }));
+      await tester.pumpWidget(WebView(
+          initialUrl: 'https://youtube.com',
+          navigationDelegate: (NavigationRequest request) {
+            navigationRequests.add(request);
+            // Only allow navigating to https://flutter.dev
+            return request.url == 'https://flutter.dev'
+                ? NavigationDecision.navigate
+                : NavigationDecision.prevent;
+          }));
 
       final FakePlatformWebView platformWebView =
           fakePlatformViewsController.lastCreatedView!;
@@ -863,11 +802,9 @@ void main() {
 
   group('debuggingEnabled', () {
     testWidgets('enable debugging', (WidgetTester tester) async {
-      await _pumpWebView(
-          tester,
-          const WebView(
-            debuggingEnabled: true,
-          ));
+      await tester.pumpWidget(const WebView(
+        debuggingEnabled: true,
+      ));
 
       final FakePlatformWebView platformWebView =
           fakePlatformViewsController.lastCreatedView!;
@@ -876,7 +813,7 @@ void main() {
     });
 
     testWidgets('defaults to false', (WidgetTester tester) async {
-      await _pumpWebView(tester, const WebView());
+      await tester.pumpWidget(const WebView());
 
       final FakePlatformWebView platformWebView =
           fakePlatformViewsController.lastCreatedView!;
@@ -886,26 +823,22 @@ void main() {
 
     testWidgets('can be changed', (WidgetTester tester) async {
       final GlobalKey key = GlobalKey();
-      await _pumpWebView(tester, WebView(key: key));
+      await tester.pumpWidget(WebView(key: key));
 
       final FakePlatformWebView platformWebView =
           fakePlatformViewsController.lastCreatedView!;
 
-      await _pumpWebView(
-          tester,
-          WebView(
-            key: key,
-            debuggingEnabled: true,
-          ));
+      await tester.pumpWidget(WebView(
+        key: key,
+        debuggingEnabled: true,
+      ));
 
       expect(platformWebView.debuggingEnabled, true);
 
-      await _pumpWebView(
-          tester,
-          WebView(
-            key: key,
-            debuggingEnabled: false,
-          ));
+      await tester.pumpWidget(WebView(
+        key: key,
+        debuggingEnabled: false,
+      ));
 
       expect(platformWebView.debuggingEnabled, false);
     });
@@ -920,8 +853,7 @@ void main() {
     });
 
     testWidgets('creation', (WidgetTester tester) async {
-      await _pumpWebView(
-        tester,
+      await tester.pumpWidget(
         const WebView(
           initialUrl: 'https://youtube.com',
           gestureNavigationEnabled: true,
@@ -947,8 +879,7 @@ void main() {
 
     testWidgets('loadUrl', (WidgetTester tester) async {
       late WebViewController controller;
-      await _pumpWebView(
-        tester,
+      await tester.pumpWidget(
         WebView(
           initialUrl: 'https://youtube.com',
           onWebViewCreated: (WebViewController webViewController) {
@@ -971,33 +902,24 @@ void main() {
     });
   });
   testWidgets('Set UserAgent', (WidgetTester tester) async {
-    await _pumpWebView(
-        tester,
-        const WebView(
-          initialUrl: 'https://youtube.com',
-          javascriptMode: JavascriptMode.unrestricted,
-        ));
+    await tester.pumpWidget(const WebView(
+      initialUrl: 'https://youtube.com',
+      javascriptMode: JavascriptMode.unrestricted,
+    ));
 
     final FakePlatformWebView platformWebView =
         fakePlatformViewsController.lastCreatedView!;
 
     expect(platformWebView.userAgent, isNull);
 
-    await _pumpWebView(
-        tester,
-        const WebView(
-          initialUrl: 'https://youtube.com',
-          javascriptMode: JavascriptMode.unrestricted,
-          userAgent: 'UA',
-        ));
+    await tester.pumpWidget(const WebView(
+      initialUrl: 'https://youtube.com',
+      javascriptMode: JavascriptMode.unrestricted,
+      userAgent: 'UA',
+    ));
 
     expect(platformWebView.userAgent, 'UA');
   });
-}
-
-Future<void> _pumpWebView(WidgetTester tester, WebView webView) {
-  return tester.pumpWidget(
-      Directionality(textDirection: TextDirection.rtl, child: webView));
 }
 
 class FakePlatformWebView {

--- a/packages/webview_flutter/test/webview_flutter_test.dart
+++ b/packages/webview_flutter/test/webview_flutter_test.dart
@@ -215,7 +215,7 @@ void main() {
 
   testWidgets("Can't go forward before loading a page",
       (WidgetTester tester) async {
-        WebViewController? controller;
+    WebViewController? controller;
     await _pumpWebView(
       tester,
       WebView(
@@ -398,7 +398,7 @@ void main() {
 
   testWidgets('evaluate Javascript with JavascriptMode disabled',
       (WidgetTester tester) async {
-        late WebViewController controller;
+    late WebViewController controller;
     await _pumpWebView(
       tester,
       WebView(


### PR DESCRIPTION
Fixes a bug where scroll bars on the Android non-hybrid WebView are rendered on the wrong side of the screen.

https://github.com/flutter/flutter/issues/79312

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
