### PR TITLE
[google_maps_flutter] Fix NNBD migration mistake in example

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.2
+
+* Fix incorrect typecast in TileOverlay example.
+
 ## 2.0.1
 
 * Update platform_plugin_interface version requirement.

--- a/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.2
+## 2.0.2-dev
 
 * Fix incorrect typecast in TileOverlay example.
 

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/tile_overlay.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/tile_overlay.dart
@@ -67,8 +67,8 @@ class TileOverlayBodyState extends State<TileOverlayBody> {
 
   @override
   Widget build(BuildContext context) {
-    Set<TileOverlay?> overlays = <TileOverlay?>{
-      if (_tileOverlay != null) _tileOverlay,
+    Set<TileOverlay> overlays = <TileOverlay>{
+      if (_tileOverlay != null) _tileOverlay!,
     };
     return Column(
       mainAxisSize: MainAxisSize.min,
@@ -84,7 +84,7 @@ class TileOverlayBodyState extends State<TileOverlayBody> {
                 target: LatLng(59.935460, 30.325177),
                 zoom: 7.0,
               ),
-              tileOverlays: overlays as Set<TileOverlay>,
+              tileOverlays: overlays,
               onMapCreated: _onMapCreated,
             ),
           ),

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter/google_maps_flutter
-version: 2.0.2
+version: 2.0.2-dev
 
 dependencies:
   flutter:

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter/google_maps_flutter
-version: 2.0.1
+version: 2.0.2
 
 dependencies:
   flutter:


### PR DESCRIPTION
The TileOverlay portion of the example app incorrectly constructed a
Set<TileOverlay?> and then attempted to cast it to a Set<TileOverlay>,
rather than making a set of non-nullable types as required by the API.

Fixes https://github.com/flutter/flutter/issues/79242

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
