### PR TITLE
let google_maps_flutter_web version solve for older mockito

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_web/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
 dev_dependencies:
   google_maps: ^3.4.4
   http: ^0.13.0
-  mockito: 4.1.1+1 # Update to ^5.0.0 as soon as this migrates to null-safety
+  mockito: ^4.1.1+1 # Update to ^5.0.0 as soon as this migrates to null-safety
   flutter_driver:
     sdk: flutter
   flutter_test:

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
 dev_dependencies:
   google_maps: ^3.4.4
   http: ^0.13.0
-  mockito: ^4.1.4 # Update to ^5.0.0 as soon as this migrates to null-safety
+  mockito: 4.1.1+1 # Update to ^5.0.0 as soon as this migrates to null-safety
   flutter_driver:
     sdk: flutter
   flutter_test:


### PR DESCRIPTION
This version of mockito is too new to solve with null safe test deps, but not new enough where it works with the latest versions of everything. Allow older versions so that we can guarantee a version solve once https://github.com/flutter/flutter/pull/79099 rolls in


Work towards https://github.com/flutter/flutter/issues/77856