### PR TITLE
[google_maps_flutter] Fix TileOverlay cloning

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.4
+
+* Preserve the `TileProvider` when copying `TileOverlay`, fixing a
+  regression with tile overlays introduced in the null safety migration.
+
 ## 2.0.3
 
 * Fix type issues in `isMarkerInfoWindowShown` and `getZoomLevel` introduced

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/tile_overlay.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/tile_overlay.dart
@@ -92,6 +92,7 @@ class TileOverlay implements MapsObject {
   /// unless overwritten by the specified parameters.
   TileOverlay copyWith({
     bool? fadeInParam,
+    TileProvider? tileProviderParam,
     double? transparencyParam,
     int? zIndexParam,
     bool? visibleParam,
@@ -100,6 +101,7 @@ class TileOverlay implements MapsObject {
     return TileOverlay(
       tileOverlayId: tileOverlayId,
       fadeIn: fadeInParam ?? fadeIn,
+      tileProvider: tileProviderParam ?? tileProvider,
       transparency: transparencyParam ?? transparency,
       zIndex: zIndexParam ?? zIndex,
       visible: visibleParam ?? visible,
@@ -137,6 +139,7 @@ class TileOverlay implements MapsObject {
     return other is TileOverlay &&
         tileOverlayId == other.tileOverlayId &&
         fadeIn == other.fadeIn &&
+        tileProvider == other.tileProvider &&
         transparency == other.transparency &&
         zIndex == other.zIndex &&
         visible == other.visible &&
@@ -144,6 +147,6 @@ class TileOverlay implements MapsObject {
   }
 
   @override
-  int get hashCode => hashValues(
-      tileOverlayId, fadeIn, transparency, zIndex, visible, tileSize);
+  int get hashCode => hashValues(tileOverlayId, fadeIn, tileProvider,
+      transparency, zIndex, visible, tileSize);
 }

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the google_maps_flutter plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter/google_maps_flutter_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.0.3
+version: 2.0.4
 
 dependencies:
   flutter:

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/tile_overlay_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/tile_overlay_test.dart
@@ -7,6 +7,13 @@ import 'dart:ui' show hashValues;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_maps_flutter_platform_interface/google_maps_flutter_platform_interface.dart';
 
+class _TestTileProvider extends TileProvider {
+  @override
+  Future<Tile> getTile(int x, int y, int? zoom) async {
+    return Tile(0, 0, null);
+  }
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -58,40 +65,65 @@ void main() {
     });
 
     test('equality', () async {
-      const TileOverlay tileOverlay1 = TileOverlay(
+      final TileProvider tileProvider = _TestTileProvider();
+      final TileOverlay tileOverlay1 = TileOverlay(
           tileOverlayId: TileOverlayId('id1'),
           fadeIn: false,
-          tileProvider: null,
+          tileProvider: tileProvider,
           transparency: 0.1,
           zIndex: 1,
           visible: false,
           tileSize: 128);
-      const TileOverlay tileOverlay2 = TileOverlay(
+      final TileOverlay tileOverlaySameValues = TileOverlay(
           tileOverlayId: TileOverlayId('id1'),
           fadeIn: false,
-          tileProvider: null,
+          tileProvider: tileProvider,
           transparency: 0.1,
           zIndex: 1,
           visible: false,
           tileSize: 128);
-      const TileOverlay tileOverlay3 = TileOverlay(
+      final TileOverlay tileOverlayDifferentId = TileOverlay(
           tileOverlayId: TileOverlayId('id2'),
           fadeIn: false,
+          tileProvider: tileProvider,
+          transparency: 0.1,
+          zIndex: 1,
+          visible: false,
+          tileSize: 128);
+      final TileOverlay tileOverlayDifferentProvider = TileOverlay(
+          tileOverlayId: TileOverlayId('id1'),
+          fadeIn: false,
           tileProvider: null,
           transparency: 0.1,
           zIndex: 1,
           visible: false,
           tileSize: 128);
-      expect(tileOverlay1, tileOverlay2);
-      expect(tileOverlay1, isNot(tileOverlay3));
+      expect(tileOverlay1, tileOverlaySameValues);
+      expect(tileOverlay1, isNot(tileOverlayDifferentId));
+      expect(tileOverlay1, isNot(tileOverlayDifferentProvider));
+    });
+
+    test('clone', () async {
+      final TileProvider tileProvider = _TestTileProvider();
+      // Set non-default values for every parameter.
+      final TileOverlay tileOverlay = TileOverlay(
+          tileOverlayId: TileOverlayId('id1'),
+          fadeIn: false,
+          tileProvider: tileProvider,
+          transparency: 0.1,
+          zIndex: 1,
+          visible: false,
+          tileSize: 128);
+      expect(tileOverlay, tileOverlay.clone());
     });
 
     test('hashCode', () async {
+      final TileProvider tileProvider = _TestTileProvider();
       const TileOverlayId id = TileOverlayId('id1');
-      const TileOverlay tileOverlay = TileOverlay(
+      final TileOverlay tileOverlay = TileOverlay(
           tileOverlayId: id,
           fadeIn: false,
-          tileProvider: null,
+          tileProvider: tileProvider,
           transparency: 0.1,
           zIndex: 1,
           visible: false,
@@ -101,6 +133,7 @@ void main() {
           hashValues(
               tileOverlay.tileOverlayId,
               tileOverlay.fadeIn,
+              tileOverlay.tileProvider,
               tileOverlay.transparency,
               tileOverlay.zIndex,
               tileOverlay.visible,


### PR DESCRIPTION
TileOverlay was not copying its TileProvider. During the NNBD migration,
map object updates were refactored to share code, and in that
refactoring TileOverlay update construction was aligned with other map
objects to use clones, so certain operations involving TileOverlays
started dropping the TileProvider.

Fixes https://github.com/flutter/flutter/issues/77500

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
