### PR TITLE
Update build-all test for null-safe template

### DIFF
--- a/script/build_all_plugins_app.sh
+++ b/script/build_all_plugins_app.sh
@@ -39,6 +39,12 @@ echo "Excluding the following plugins: $ALL_EXCLUDED"
 
 (cd "$REPO_DIR" && plugin_tools all-plugins-app --exclude $ALL_EXCLUDED)
 
+# Master now creates null-safe app code by default; migrate stable so both
+# branches are building in the same mode.
+if [[ "${BRANCH_NAME}" == "stable" ]]; then
+  (cd $REPO_DIR/all_plugins && dart migrate --apply-changes)
+fi
+
 function error() {
   echo "$@" 1>&2
 }

--- a/script/build_all_plugins_app.sh
+++ b/script/build_all_plugins_app.sh
@@ -59,7 +59,7 @@ fi
 
 for version in "${BUILD_MODES[@]}"; do
   echo "Building $version..."
-  (cd $REPO_DIR/all_plugins && flutter build $@ --$version)
+  (cd $REPO_DIR/all_plugins && flutter build $@ --$version --no-sound-null-safety)
 
   if [ $? -eq 0 ]; then
     echo "Successfully built $version all_plugins app."

--- a/script/build_all_plugins_app.sh
+++ b/script/build_all_plugins_app.sh
@@ -41,6 +41,7 @@ echo "Excluding the following plugins: $ALL_EXCLUDED"
 
 # Master now creates null-safe app code by default; migrate stable so both
 # branches are building in the same mode.
+BRANCH_NAME="${BRANCH_NAME:-"$(git rev-parse --abbrev-ref HEAD)"}"
 if [[ "${BRANCH_NAME}" == "stable" ]]; then
   (cd $REPO_DIR/all_plugins && dart migrate --apply-changes)
 fi

--- a/script/build_all_plugins_app.sh
+++ b/script/build_all_plugins_app.sh
@@ -41,9 +41,7 @@ echo "Excluding the following plugins: $ALL_EXCLUDED"
 
 # Master now creates null-safe app code by default; migrate stable so both
 # branches are building in the same mode.
-BRANCH_NAME="${BRANCH_NAME:-"$(git rev-parse --abbrev-ref HEAD)"}"
-echo "On branch '${BRANCH_NAME}'"
-if [[ "${BRANCH_NAME}" == "stable" ]]; then
+if [[ "${CHANNEL}" == "stable" ]]; then
   (cd $REPO_DIR/all_plugins && dart migrate --apply-changes)
 fi
 

--- a/script/build_all_plugins_app.sh
+++ b/script/build_all_plugins_app.sh
@@ -42,6 +42,7 @@ echo "Excluding the following plugins: $ALL_EXCLUDED"
 # Master now creates null-safe app code by default; migrate stable so both
 # branches are building in the same mode.
 BRANCH_NAME="${BRANCH_NAME:-"$(git rev-parse --abbrev-ref HEAD)"}"
+echo "On branch '${BRANCH_NAME}'"
 if [[ "${BRANCH_NAME}" == "stable" ]]; then
   (cd $REPO_DIR/all_plugins && dart migrate --apply-changes)
 fi

--- a/script/tool/test/create_all_plugins_app_command_test.dart
+++ b/script/tool/test/create_all_plugins_app_command_test.dart
@@ -1,0 +1,91 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:args/command_runner.dart';
+import 'package:file/file.dart';
+import 'package:file/local.dart';
+import 'package:flutter_plugin_tools/src/create_all_plugins_app_command.dart';
+import 'package:test/test.dart';
+
+import 'util.dart';
+
+void main() {
+  group('$CreateAllPluginsAppCommand', () {
+    CommandRunner<Null> runner;
+    FileSystem fileSystem;
+    Directory testRoot;
+    Directory packagesDir;
+    Directory appDir;
+
+    setUp(() {
+      // Since the core of this command is a call to 'flutter create', the test
+      // has to use the real filesystem. Put everything possible in a unique
+      // temporary to minimize affect on the host system.
+      fileSystem = LocalFileSystem();
+      testRoot = fileSystem.systemTempDirectory.createTempSync();
+      packagesDir = testRoot.childDirectory('packages');
+
+      final CreateAllPluginsAppCommand command = CreateAllPluginsAppCommand(
+        packagesDir,
+        fileSystem,
+        pluginsRoot: testRoot,
+      );
+      appDir = command.appDirectory;
+      runner = CommandRunner<Null>(
+          'create_all_test', 'Test for $CreateAllPluginsAppCommand');
+      runner.addCommand(command);
+    });
+
+    tearDown(() {
+      testRoot.deleteSync(recursive: true);
+    });
+
+    test('pubspec includes all plugins', () async {
+      createFakePlugin('plugina', packagesDirectory: packagesDir);
+      createFakePlugin('pluginb', packagesDirectory: packagesDir);
+      createFakePlugin('pluginc', packagesDirectory: packagesDir);
+
+      await runner.run(<String>['all-plugins-app']);
+      final List<String> pubspec =
+          appDir.childFile('pubspec.yaml').readAsLinesSync();
+
+      expect(
+          pubspec,
+          containsAll(<Matcher>[
+            contains(RegExp('path: .*/packages/plugina')),
+            contains(RegExp('path: .*/packages/pluginb')),
+            contains(RegExp('path: .*/packages/pluginc')),
+          ]));
+    });
+
+    test('pubspec has overrides for all plugins', () async {
+      createFakePlugin('plugina', packagesDirectory: packagesDir);
+      createFakePlugin('pluginb', packagesDirectory: packagesDir);
+      createFakePlugin('pluginc', packagesDirectory: packagesDir);
+
+      await runner.run(<String>['all-plugins-app']);
+      final List<String> pubspec =
+          appDir.childFile('pubspec.yaml').readAsLinesSync();
+
+      expect(
+          pubspec,
+          containsAllInOrder(<Matcher>[
+            contains('dependency_overrides:'),
+            contains(RegExp('path: .*/packages/plugina')),
+            contains(RegExp('path: .*/packages/pluginb')),
+            contains(RegExp('path: .*/packages/pluginc')),
+          ]));
+    });
+
+    test('pubspec is compatible with null-safe app code', () async {
+      createFakePlugin('plugina', packagesDirectory: packagesDir);
+
+      await runner.run(<String>['all-plugins-app']);
+      final String pubspec =
+          appDir.childFile('pubspec.yaml').readAsStringSync();
+
+      expect(pubspec, contains(RegExp('sdk:\\s*(?:["\']>=|[^])2\\.12\\.')));
+    });
+  });
+}

--- a/script/tool/test/util.dart
+++ b/script/tool/test/util.dart
@@ -12,6 +12,9 @@ import 'package:platform/platform.dart';
 import 'package:flutter_plugin_tools/src/common.dart';
 import 'package:quiver/collection.dart';
 
+// TODO(stuartmorgan): Eliminate this in favor of setting up a clean filesystem
+// for each test, to eliminate the chance of files from one test interfering
+// with another test.
 FileSystem mockFileSystem = MemoryFileSystem(
     style: LocalPlatform().isWindows
         ? FileSystemStyle.windows
@@ -28,7 +31,8 @@ void initializeFakePackages({Directory parentDir}) {
   mockPackagesDir.createSync();
 }
 
-/// Creates a plugin package with the given [name] in [mockPackagesDir].
+/// Creates a plugin package with the given [name] in [packagesDirectory],
+/// defaulting to [mockPackagesDir].
 Directory createFakePlugin(
   String name, {
   bool withSingleExample = false,
@@ -44,13 +48,16 @@ Directory createFakePlugin(
   bool includeChangeLog = false,
   bool includeVersion = false,
   String parentDirectoryName = '',
+  Directory packagesDirectory,
 }) {
   assert(!(withSingleExample && withExamples.isNotEmpty),
       'cannot pass withSingleExample and withExamples simultaneously');
 
-  final Directory pluginDirectory = (parentDirectoryName != '')
-      ? mockPackagesDir.childDirectory(parentDirectoryName).childDirectory(name)
-      : mockPackagesDir.childDirectory(name);
+  Directory parentDirectory = packagesDirectory ?? mockPackagesDir;
+  if (parentDirectoryName != '') {
+    parentDirectory = parentDirectory.childDirectory(parentDirectoryName);
+  }
+  final Directory pluginDirectory = parentDirectory.childDirectory(name);
   pluginDirectory.createSync(recursive: true);
 
   createFakePubspec(


### PR DESCRIPTION
Flutter master now creates NNBD code when running 'flutter create', so
the generated pubspec for build_all needs to use a compatible SDK
version. This updates from 2.0.0 to 2.12.0.

Also includes a test for this, which involved setting up tests for the
file, and doing some refactoring to make the command testable. As a
result, this fixes https://github.com/flutter/flutter/issues/61049
(although more test backfill is needed).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
