### PR TITLE
[tool] add `all` and `dry-run` flags to publish-plugin command

### DIFF
--- a/script/tool/lib/src/publish_plugin_command.dart
+++ b/script/tool/lib/src/publish_plugin_command.dart
@@ -215,7 +215,7 @@ class PublishPluginCommand extends PluginCommand {
     }
     if (packagesFailed.isNotEmpty) {
       _print(
-          'Packages failed to release: ${packagesFailed.join(', ')}, see above for details.');
+          'Failed to release the following packages: ${packagesFailed.join(', ')}, see above for details.');
     }
     return packagesFailed.isEmpty;
   }
@@ -247,7 +247,7 @@ class PublishPluginCommand extends PluginCommand {
     return true;
   }
 
-  // Returns `true` if needs to release the version, `false` if needs to skip
+  // Returns a [_CheckNeedsReleaseResult] that indicates the result.
   Future<_CheckNeedsReleaseResult> _checkNeedsRelease({
     @required File pubspecFile,
     @required GitVersionFinder gitVersionFinder,
@@ -267,9 +267,7 @@ Safe to ignore if the package is deleted in this commit.
     }
 
     if (pubspec.version == null) {
-      _print('No version found. A package that '
-          'intentionally has no version should be marked '
-          '"publish_to: none".');
+      _print('No version found. A package that intentionally has no version should be marked "publish_to: none"');
       return _CheckNeedsReleaseResult.failure;
     }
 
@@ -484,6 +482,6 @@ enum _CheckNeedsReleaseResult {
   // The package does not need to be released.
   noRelease,
 
-  // There's an error when trying to access if the package needs to be released.
+  // There's an error when trying to determine whether the package needs to be released.
   failure,
 }

--- a/script/tool/test/util.dart
+++ b/script/tool/test/util.dart
@@ -49,6 +49,7 @@ Directory createFakePlugin(
   bool isWindowsPlugin = false,
   bool includeChangeLog = false,
   bool includeVersion = false,
+  String version = '0.0.1',
   String parentDirectoryName = '',
   Directory packagesDirectory,
 }) {
@@ -73,6 +74,7 @@ Directory createFakePlugin(
     isMacOsPlugin: isMacOsPlugin,
     isWindowsPlugin: isWindowsPlugin,
     includeVersion: includeVersion,
+    version: version
   );
   if (includeChangeLog) {
     createFakeCHANGELOG(pluginDirectory, '''
@@ -85,14 +87,14 @@ Directory createFakePlugin(
     final Directory exampleDir = pluginDirectory.childDirectory('example')
       ..createSync();
     createFakePubspec(exampleDir,
-        name: '${name}_example', isFlutter: isFlutter);
+        name: '${name}_example', isFlutter: isFlutter, includeVersion: false, publish_to: 'none');
   } else if (withExamples.isNotEmpty) {
     final Directory exampleDir = pluginDirectory.childDirectory('example')
       ..createSync();
     for (final String example in withExamples) {
       final Directory currentExample = exampleDir.childDirectory(example)
         ..createSync();
-      createFakePubspec(currentExample, name: example, isFlutter: isFlutter);
+      createFakePubspec(currentExample, name: example, isFlutter: isFlutter, includeVersion: false, publish_to: 'none');
     }
   }
 
@@ -123,6 +125,7 @@ void createFakePubspec(
   bool isLinuxPlugin = false,
   bool isMacOsPlugin = false,
   bool isWindowsPlugin = false,
+  String publish_to = 'http://no_pub_server.com',
   String version = '0.0.1',
 }) {
   parent.childFile('pubspec.yaml').createSync();
@@ -180,7 +183,11 @@ dependencies:
   if (includeVersion) {
     yaml += '''
 version: $version
-publish_to: http://no_pub_server.com # Hardcoded safeguard to prevent this from somehow being published by a broken test.
+''';
+  }
+  if (publish_to.isNotEmpty) {
+     yaml += '''
+publish_to: $publish_to # Hardcoded safeguard to prevent this from somehow being published by a broken test.
 ''';
   }
   parent.childFile('pubspec.yaml').writeAsStringSync(yaml);

--- a/script/tool/test/util.dart
+++ b/script/tool/test/util.dart
@@ -87,14 +87,14 @@ Directory createFakePlugin(
     final Directory exampleDir = pluginDirectory.childDirectory('example')
       ..createSync();
     createFakePubspec(exampleDir,
-        name: '${name}_example', isFlutter: isFlutter, includeVersion: false, publish_to: 'none');
+        name: '${name}_example', isFlutter: isFlutter, includeVersion: false, publishTo: 'none');
   } else if (withExamples.isNotEmpty) {
     final Directory exampleDir = pluginDirectory.childDirectory('example')
       ..createSync();
     for (final String example in withExamples) {
       final Directory currentExample = exampleDir.childDirectory(example)
         ..createSync();
-      createFakePubspec(currentExample, name: example, isFlutter: isFlutter, includeVersion: false, publish_to: 'none');
+      createFakePubspec(currentExample, name: example, isFlutter: isFlutter, includeVersion: false, publishTo: 'none');
     }
   }
 
@@ -125,7 +125,7 @@ void createFakePubspec(
   bool isLinuxPlugin = false,
   bool isMacOsPlugin = false,
   bool isWindowsPlugin = false,
-  String publish_to = 'http://no_pub_server.com',
+  String publishTo = 'http://no_pub_server.com',
   String version = '0.0.1',
 }) {
   parent.childFile('pubspec.yaml').createSync();
@@ -185,9 +185,9 @@ dependencies:
 version: $version
 ''';
   }
-  if (publish_to.isNotEmpty) {
+  if (publishTo.isNotEmpty) {
      yaml += '''
-publish_to: $publish_to # Hardcoded safeguard to prevent this from somehow being published by a broken test.
+publish_to: $publishTo # Hardcoded safeguard to prevent this from somehow being published by a broken test.
 ''';
   }
   parent.childFile('pubspec.yaml').writeAsStringSync(yaml);


### PR DESCRIPTION
Add a new `all` flag  to the `publish plugin` command does the following:
1. Look for all the pubspec changes in the current commit and determine what plugin(s) need to be released.  If the new version is lower than the existing latest tagged version, skip. 
1. Release the plugin as how `publish-plugin` works: publishing to pub, git tag release etc. 

Add a new `dry-run` flag to dry-run the publish and tag release process. This is for testing locally and ci without actually publishing or git tag anything.

This command is going to be part of auto-publish workflow.

part of https://github.com/flutter/flutter/issues/79830

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
