### PR TITLE
[tool] refactor publish plugin command

### DIFF
--- a/script/tool/lib/src/common.dart
+++ b/script/tool/lib/src/common.dart
@@ -526,7 +526,7 @@ class ProcessRunner {
     Directory workingDir,
   }) async {
     final io.ProcessResult result = await io.Process.run(executable, args,
-        workingDirectory: workingDir?.path, runInShell: true);
+        workingDirectory: workingDir?.path);
     if (result.exitCode != 0) {
       final String error =
           _getErrorString(executable, args, workingDir: workingDir);

--- a/script/tool/lib/src/common.dart
+++ b/script/tool/lib/src/common.dart
@@ -527,8 +527,6 @@ class ProcessRunner {
   }) async {
     final io.ProcessResult result = await io.Process.run(executable, args,
         workingDirectory: workingDir?.path, runInShell: true);
-    print(result.stderr);
-    print(result.stdout);
     if (result.exitCode != 0) {
       final String error =
           _getErrorString(executable, args, workingDir: workingDir);

--- a/script/tool/lib/src/common.dart
+++ b/script/tool/lib/src/common.dart
@@ -526,7 +526,9 @@ class ProcessRunner {
     Directory workingDir,
   }) async {
     final io.ProcessResult result = await io.Process.run(executable, args,
-        workingDirectory: workingDir?.path);
+        workingDirectory: workingDir?.path, runInShell: true);
+    print(result.stderr);
+    print(result.stdout);
     if (result.exitCode != 0) {
       final String error =
           _getErrorString(executable, args, workingDir: workingDir);

--- a/script/tool/lib/src/publish_plugin_command.dart
+++ b/script/tool/lib/src/publish_plugin_command.dart
@@ -120,7 +120,7 @@ class PublishPluginCommand extends PluginCommand {
     _print('Local repo is ready!');
 
     final Directory packageDir = _checkPackageDir(package);
-    await _publishPlugin(packageDir: packagesDir);
+    await _publishPlugin(packageDir: packageDir);
     await _tagRelease(packageDir: packageDir, remote: remote, remoteUrl: remoteUrl, shouldPushTag: shouldPushTag);
     await _finishSuccesfully();
   }

--- a/script/tool/lib/src/publish_plugin_command.dart
+++ b/script/tool/lib/src/publish_plugin_command.dart
@@ -105,6 +105,7 @@ class PublishPluginCommand extends PluginCommand {
       throw ToolExit(1);
     }
 
+    _print('Checking local repo...');
     if (!await GitDir.isGitDir(packagesDir.path)) {
       _print('$packagesDir is not a valid Git repository.');
       throw ToolExit(1);
@@ -116,6 +117,7 @@ class PublishPluginCommand extends PluginCommand {
     if (shouldPushTag) {
       remoteUrl = await _verifyRemote(remote);
     }
+    _print('Local repo is ready!');
 
     final Directory packageDir = _checkPackageDir(package);
     await _publishPlugin(packageDir: packagesDir);
@@ -124,9 +126,7 @@ class PublishPluginCommand extends PluginCommand {
   }
 
   Future<void> _publishPlugin({@required Directory packageDir}) async {
-    _print('Checking local repo...');
     await _checkGitStatus(packageDir);
-    _print('Local repo is ready!');
     await _publish(packageDir);
     _print('Package published!');
   }

--- a/script/tool/lib/src/publish_plugin_command.dart
+++ b/script/tool/lib/src/publish_plugin_command.dart
@@ -119,7 +119,6 @@ class PublishPluginCommand extends PluginCommand {
 
     final Directory packageDir = _checkPackageDir(package);
     await _publishPlugin(packageDir: packagesDir);
-
     await _tagRelease(packageDir: packageDir, remote: remote, remoteUrl: remoteUrl, shouldPushTag: shouldPushTag);
     await _finishSuccesfully();
   }

--- a/script/tool/test/publish_plugin_command_test.dart
+++ b/script/tool/test/publish_plugin_command_test.dart
@@ -42,8 +42,8 @@ void main() {
     assert(pluginDir != null && pluginDir.existsSync());
     createFakePubspec(pluginDir, includeVersion: true);
     io.Process.runSync('git', <String>['init'],
-        workingDirectory: parentDir.path);
-    gitDir = await GitDir.fromExisting(parentDir.path);
+        workingDirectory: mockPackagesDir.path);
+    gitDir = await GitDir.fromExisting(mockPackagesDir.path);
     await gitDir.runCommand(<String>['add', '-A']);
     await gitDir.runCommand(<String>['commit', '-m', 'Initial commit']);
     processRunner = TestProcessRunner();

--- a/script/tool/test/publish_plugin_command_test.dart
+++ b/script/tool/test/publish_plugin_command_test.dart
@@ -97,7 +97,7 @@ void main() {
           () => commandRunner
               .run(<String>['publish-plugin', '--package', testPluginName]),
           throwsA(const TypeMatcher<ToolExit>()));
-      expect(processRunner.results.last.stdout, contains("No such remote"));
+      expect(processRunner.results.last.stderr, contains("No such remote"));
     });
 
     test("doesn't validate the remote if it's not pushing tags", () async {


### PR DESCRIPTION
Refactoring publish plugin command to get ready for a new feature to publish and tag release based on git diff.

See https://github.com/flutter/plugins/pull/3776#issuecomment-811574215

behavioral change: The command now validate the git remote first before checking package directory. Because when we change this command later to run multiple publishes, the git remote validation only needs to happen once. 