### PR TITLE
Fix and update version checks

### DIFF
--- a/packages/android_alarm_manager/example/pubspec.yaml
+++ b/packages/android_alarm_manager/example/pubspec.yaml
@@ -1,5 +1,6 @@
 name: android_alarm_manager_example
 description: Demonstrates how to use the android_alarm_manager plugin.
+publish_to: none
 
 dependencies:
   flutter:

--- a/packages/android_intent/example/pubspec.yaml
+++ b/packages/android_intent/example/pubspec.yaml
@@ -1,5 +1,6 @@
 name: android_intent_example
 description: Demonstrates how to use the android_intent plugin.
+publish_to: none
 
 dependencies:
   flutter:

--- a/packages/battery/battery/example/pubspec.yaml
+++ b/packages/battery/battery/example/pubspec.yaml
@@ -1,5 +1,6 @@
 name: battery_example
 description: Demonstrates how to use the battery plugin.
+publish_to: none
 
 dependencies:
   flutter:

--- a/packages/camera/camera/example/pubspec.yaml
+++ b/packages/camera/camera/example/pubspec.yaml
@@ -1,5 +1,6 @@
 name: camera_example
 description: Demonstrates how to use the camera plugin.
+publish_to: none
 
 dependencies:
   camera:

--- a/packages/connectivity/connectivity/example/pubspec.yaml
+++ b/packages/connectivity/connectivity/example/pubspec.yaml
@@ -1,5 +1,6 @@
 name: connectivity_example
 description: Demonstrates how to use the connectivity plugin.
+publish_to: none
 
 dependencies:
   flutter:

--- a/packages/connectivity/connectivity_macos/example/pubspec.yaml
+++ b/packages/connectivity/connectivity_macos/example/pubspec.yaml
@@ -1,5 +1,6 @@
 name: connectivity_example
 description: Demonstrates how to use the connectivity plugin.
+publish_to: none
 
 dependencies:
   flutter:

--- a/packages/device_info/device_info/example/pubspec.yaml
+++ b/packages/device_info/device_info/example/pubspec.yaml
@@ -1,5 +1,6 @@
 name: device_info_example
 description: Demonstrates how to use the device_info plugin.
+publish_to: none
 
 dependencies:
   flutter:

--- a/packages/device_info/device_info_platform_interface/lib/model/android_device_info.dart
+++ b/packages/device_info/device_info_platform_interface/lib/model/android_device_info.dart
@@ -29,7 +29,7 @@ class AndroidDeviceInfo {
     required this.isPhysicalDevice,
     required this.androidId,
     required List<String> systemFeatures,
-  })   : supported32BitAbis = List<String>.unmodifiable(supported32BitAbis),
+  })  : supported32BitAbis = List<String>.unmodifiable(supported32BitAbis),
         supported64BitAbis = List<String>.unmodifiable(supported64BitAbis),
         supportedAbis = List<String>.unmodifiable(supportedAbis),
         systemFeatures = List<String>.unmodifiable(systemFeatures);

--- a/packages/espresso/example/pubspec.yaml
+++ b/packages/espresso/example/pubspec.yaml
@@ -1,6 +1,6 @@
 name: espresso_example
 description: Demonstrates how to use the espresso plugin.
-publish_to: 'none'
+publish_to: none
 
 environment:
   sdk: ">=2.12.0-259.9.beta <3.0.0"

--- a/packages/file_selector/file_selector/example/pubspec.yaml
+++ b/packages/file_selector/file_selector/example/pubspec.yaml
@@ -1,7 +1,6 @@
 name: example
 description: A new Flutter project.
-
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: none
 
 version: 1.0.0+1
 

--- a/packages/flutter_plugin_android_lifecycle/example/pubspec.yaml
+++ b/packages/flutter_plugin_android_lifecycle/example/pubspec.yaml
@@ -1,5 +1,6 @@
 name: flutter_plugin_android_lifecycle_example
 description: Demonstrates how to use the flutter_plugin_android_lifecycle plugin.
+publish_to: none
 
 dependencies:
   flutter:

--- a/packages/google_maps_flutter/google_maps_flutter/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/example/pubspec.yaml
@@ -1,5 +1,6 @@
 name: google_maps_flutter_example
 description: Demonstrates how to use the google_maps_flutter plugin.
+publish_to: none
 
 environment:
   sdk: '>=2.12.0-259.9.beta <3.0.0'

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/circles.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/circles.dart
@@ -15,7 +15,7 @@ class CirclesController extends GeometryController {
   /// Initialize the cache. The [StreamController] comes from the [GoogleMapController], and is shared with other controllers.
   CirclesController({
     required StreamController<MapEvent> stream,
-  })   : _streamController = stream,
+  })  : _streamController = stream,
         _circleIdToController = Map<CircleId, CircleController>();
 
   /// Returns the cache of [CircleController]s. Test only.

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/markers.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/markers.dart
@@ -15,7 +15,7 @@ class MarkersController extends GeometryController {
   /// Initialize the cache. The [StreamController] comes from the [GoogleMapController], and is shared with other controllers.
   MarkersController({
     required StreamController<MapEvent> stream,
-  })   : _streamController = stream,
+  })  : _streamController = stream,
         _markerIdToController = Map<MarkerId, MarkerController>();
 
   /// Returns the cache of [MarkerController]s. Test only.

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/polygons.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/polygons.dart
@@ -15,7 +15,7 @@ class PolygonsController extends GeometryController {
   /// Initializes the cache. The [StreamController] comes from the [GoogleMapController], and is shared with other controllers.
   PolygonsController({
     required StreamController<MapEvent> stream,
-  })   : _streamController = stream,
+  })  : _streamController = stream,
         _polygonIdToController = Map<PolygonId, PolygonController>();
 
   /// Returns the cache of [PolygonController]s. Test only.

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/polylines.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/polylines.dart
@@ -15,7 +15,7 @@ class PolylinesController extends GeometryController {
   /// Initializes the cache. The [StreamController] comes from the [GoogleMapController], and is shared with other controllers.
   PolylinesController({
     required StreamController<MapEvent> stream,
-  })   : _streamController = stream,
+  })  : _streamController = stream,
         _polylineIdToController = Map<PolylineId, PolylineController>();
 
   /// Returns the cache of [PolylineContrller]s. Test only.

--- a/packages/google_sign_in/google_sign_in/example/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in/example/pubspec.yaml
@@ -1,5 +1,6 @@
 name: google_sign_in_example
 description: Example of Google Sign-In plugin.
+publish_to: none
 
 dependencies:
   flutter:

--- a/packages/image_picker/image_picker/example/pubspec.yaml
+++ b/packages/image_picker/image_picker/example/pubspec.yaml
@@ -1,6 +1,6 @@
 name: image_picker_example
 description: Demonstrates how to use the image_picker plugin.
-author: Flutter Team <flutter-dev@googlegroups.com>
+publish_to: none
 
 dependencies:
   video_player: ^2.0.0-nullsafety.7

--- a/packages/in_app_purchase/in_app_purchase/example/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase/example/pubspec.yaml
@@ -1,6 +1,6 @@
 name: in_app_purchase_example
 description: Demonstrates how to use the in_app_purchase plugin.
-author: Flutter Team <flutter-dev@googlegroups.com>
+publish_to: none
 
 dependencies:
   flutter:

--- a/packages/integration_test/example/pubspec.yaml
+++ b/packages/integration_test/example/pubspec.yaml
@@ -1,6 +1,6 @@
 name: integration_test_example
 description: Demonstrates how to use the integration_test plugin.
-publish_to: 'none'
+publish_to: none
 
 environment:
   sdk: ">=2.1.0 <3.0.0"

--- a/packages/ios_platform_images/example/pubspec.yaml
+++ b/packages/ios_platform_images/example/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ios_platform_images_example
 description: Demonstrates how to use the ios_platform_images plugin.
-publish_to: 'none'
+publish_to: none
 homepage: https://github.com/flutter/plugins/tree/master/packages/ios_platform_images/ios_platform_images
 
 environment:

--- a/packages/local_auth/example/pubspec.yaml
+++ b/packages/local_auth/example/pubspec.yaml
@@ -1,5 +1,6 @@
 name: local_auth_example
 description: Demonstrates how to use the local_auth plugin.
+publish_to: none
 
 dependencies:
   flutter:

--- a/packages/package_info/example/pubspec.yaml
+++ b/packages/package_info/example/pubspec.yaml
@@ -1,5 +1,6 @@
 name: package_info_example
 description: Demonstrates how to use the package_info plugin.
+publish_to: none
 
 dependencies:
   flutter:

--- a/packages/path_provider/path_provider/example/pubspec.yaml
+++ b/packages/path_provider/path_provider/example/pubspec.yaml
@@ -1,5 +1,6 @@
 name: path_provider_example
 description: Demonstrates how to use the path_provider plugin.
+publish_to: none
 
 dependencies:
   flutter:

--- a/packages/path_provider/path_provider_macos/example/pubspec.yaml
+++ b/packages/path_provider/path_provider_macos/example/pubspec.yaml
@@ -2,7 +2,7 @@ name: path_provider_example
 description: Demonstrates how to use the path_provider plugin.
 publish_to: none
 
-dependencie:
+dependencies:
   flutter:
     sdk: flutter
   path_provider_macos:

--- a/packages/path_provider/path_provider_macos/example/pubspec.yaml
+++ b/packages/path_provider/path_provider_macos/example/pubspec.yaml
@@ -1,7 +1,8 @@
 name: path_provider_example
 description: Demonstrates how to use the path_provider plugin.
+publish_to: none
 
-dependencies:
+dependencie:
   flutter:
     sdk: flutter
   path_provider_macos:

--- a/packages/path_provider/path_provider_windows/example/pubspec.yaml
+++ b/packages/path_provider/path_provider_windows/example/pubspec.yaml
@@ -1,5 +1,6 @@
 name: path_provider_example
 description: Demonstrates how to use the path_provider plugin.
+publish_to: none
 
 dependencies:
   flutter:

--- a/packages/quick_actions/quick_actions/example/pubspec.yaml
+++ b/packages/quick_actions/quick_actions/example/pubspec.yaml
@@ -1,5 +1,6 @@
 name: quick_actions_example
 description: Demonstrates how to use the quick_actions plugin.
+publish_to: none
 
 dependencies:
   flutter:

--- a/packages/sensors/example/lib/snake.dart
+++ b/packages/sensors/example/lib/snake.dart
@@ -99,10 +99,10 @@ class SnakeState extends State<Snake> {
     final math.Point<int>? newDirection = currentAcceleration == null
         ? null
         : currentAcceleration.x.abs() < 1.0 && currentAcceleration.y.abs() < 1.0
-            ? null
-            : (currentAcceleration.x.abs() < currentAcceleration.y.abs())
-                ? math.Point<int>(0, currentAcceleration.y.sign.toInt())
-                : math.Point<int>(-currentAcceleration.x.sign.toInt(), 0);
+        ? null
+        : (currentAcceleration.x.abs() < currentAcceleration.y.abs())
+        ? math.Point<int>(0, currentAcceleration.y.sign.toInt())
+        : math.Point<int>(-currentAcceleration.x.sign.toInt(), 0);
     state.step(newDirection);
   }
 }

--- a/packages/sensors/example/pubspec.yaml
+++ b/packages/sensors/example/pubspec.yaml
@@ -1,5 +1,6 @@
 name: sensors_example
 description: Demonstrates how to use the sensors plugin.
+publish_to: none
 
 dependencies:
   flutter:

--- a/packages/share/example/pubspec.yaml
+++ b/packages/share/example/pubspec.yaml
@@ -1,5 +1,6 @@
 name: share_example
 description: Demonstrates how to use the share plugin.
+publish_to: none
 
 dependencies:
   flutter:

--- a/packages/shared_preferences/shared_preferences/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences/example/pubspec.yaml
@@ -1,5 +1,6 @@
 name: shared_preferences_example
 description: Demonstrates how to use the shared_preferences plugin.
+publish_to: none
 
 dependencies:
   flutter:

--- a/packages/shared_preferences/shared_preferences_linux/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_linux/example/pubspec.yaml
@@ -1,5 +1,6 @@
 name: shared_preferences_linux_example
 description: Demonstrates how to use the shared_preferences_linux plugin.
+publish_to: none
 
 dependencies:
   flutter:

--- a/packages/shared_preferences/shared_preferences_macos/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_macos/example/pubspec.yaml
@@ -1,5 +1,6 @@
 name: shared_preferences_example
 description: Demonstrates how to use the shared_preferences plugin.
+publish_to: none
 
 dependencies:
   flutter:

--- a/packages/shared_preferences/shared_preferences_windows/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_windows/example/pubspec.yaml
@@ -1,5 +1,6 @@
 name: shared_preferences_windows_example
 description: Demonstrates how to use the shared_preferences_windows plugin.
+publish_to: none
 
 environment:
   sdk: ">=2.12.0-259.9.beta <3.0.0"

--- a/packages/url_launcher/url_launcher/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/example/pubspec.yaml
@@ -1,5 +1,6 @@
 name: url_launcher_example
 description: Demonstrates how to use the url_launcher plugin.
+publish_to: none
 
 dependencies:
   flutter:

--- a/packages/url_launcher/url_launcher_linux/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_linux/example/pubspec.yaml
@@ -1,5 +1,6 @@
 name: url_launcher_example
 description: Demonstrates how to use the url_launcher plugin.
+publish_to: none
 
 dependencies:
   flutter:

--- a/packages/url_launcher/url_launcher_macos/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_macos/example/pubspec.yaml
@@ -1,5 +1,6 @@
 name: url_launcher_example
 description: Demonstrates how to use the url_launcher plugin.
+publish_to: none
 
 dependencies:
   flutter:

--- a/packages/url_launcher/url_launcher_windows/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_windows/example/pubspec.yaml
@@ -1,5 +1,6 @@
 name: url_launcher_example
 description: Demonstrates the Windows implementation of the url_launcher plugin.
+publish_to: none
 
 dependencies:
   flutter:

--- a/packages/video_player/video_player/example/pubspec.yaml
+++ b/packages/video_player/video_player/example/pubspec.yaml
@@ -1,6 +1,5 @@
 name: video_player_example
 description: Demonstrates how to use the video_player plugin.
-version: 0.0.1
 publish_to: none
 
 dependencies:

--- a/packages/webview_flutter/example/pubspec.yaml
+++ b/packages/webview_flutter/example/pubspec.yaml
@@ -1,5 +1,6 @@
 name: webview_flutter_example
 description: Demonstrates how to use the webview_flutter plugin.
+publish_to: none
 
 environment:
   sdk: ">=2.12.0-259.9.beta <3.0.0"

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -180,7 +180,7 @@ class JavascriptChannel {
   JavascriptChannel({
     required this.name,
     required this.onMessageReceived,
-  })   : assert(name != null),
+  })  : assert(name != null),
         assert(onMessageReceived != null),
         assert(_validChannelNames.hasMatch(name));
 

--- a/packages/wifi_info_flutter/wifi_info_flutter/example/pubspec.yaml
+++ b/packages/wifi_info_flutter/wifi_info_flutter/example/pubspec.yaml
@@ -1,6 +1,6 @@
 name: wifi_info_flutter_example
 description: Demonstrates how to use the wifi_info_flutter plugin.
-publish_to: 'none'
+publish_to: none
 
 environment:
   sdk: ">=2.12.0-259.9.beta <3.0.0"

--- a/script/tool/lib/src/common.dart
+++ b/script/tool/lib/src/common.dart
@@ -596,10 +596,12 @@ class GitVersionFinder {
     return changedFiles.toList();
   }
 
-  /// Get the package version specified in the pubspec file in `pubspecPath` and at the revision of `gitRef`.
-  Future<Version> getPackageVersion(String pubspecPath, String gitRef) async {
+  /// Get the package version specified in the pubspec file in `pubspecPath` and
+  /// at the revision of `gitRef` (defaulting to the base if not provided).
+  Future<Version> getPackageVersion(String pubspecPath, {String gitRef}) async {
+    final String ref = gitRef ?? (await _getBaseSha());
     final io.ProcessResult gitShow =
-        await baseGitDir.runCommand(<String>['show', '$gitRef:$pubspecPath']);
+        await baseGitDir.runCommand(<String>['show', '$ref:$pubspecPath']);
     final String fileContent = gitShow.stdout as String;
     final String versionString = loadYaml(fileContent)['version'] as String;
     return versionString == null ? null : Version.parse(versionString);

--- a/script/tool/lib/src/common.dart
+++ b/script/tool/lib/src/common.dart
@@ -600,8 +600,14 @@ class GitVersionFinder {
   /// at the revision of `gitRef` (defaulting to the base if not provided).
   Future<Version> getPackageVersion(String pubspecPath, {String gitRef}) async {
     final String ref = gitRef ?? (await _getBaseSha());
-    final io.ProcessResult gitShow =
-        await baseGitDir.runCommand(<String>['show', '$ref:$pubspecPath']);
+
+    io.ProcessResult gitShow;
+    try {
+      gitShow =
+          await baseGitDir.runCommand(<String>['show', '$ref:$pubspecPath']);
+    } on io.ProcessException {
+      return null;
+    }
     final String fileContent = gitShow.stdout as String;
     final String versionString = loadYaml(fileContent)['version'] as String;
     return versionString == null ? null : Version.parse(versionString);

--- a/script/tool/lib/src/version_check_command.dart
+++ b/script/tool/lib/src/version_check_command.dart
@@ -13,8 +13,6 @@ import 'package:pubspec_parse/pubspec_parse.dart';
 
 import 'common.dart';
 
-const String _kBaseSha = 'base-sha';
-
 /// Categories of version change types.
 enum NextVersionType {
   /// A breaking change.
@@ -96,48 +94,59 @@ class VersionCheckCommand extends PluginCommand {
     final List<String> changedPubspecs =
         await gitVersionFinder.getChangedPubSpecs();
 
-    final String baseSha = argResults[_kBaseSha] as String;
     for (final String pubspecPath in changedPubspecs) {
+      print('Checking versions for $pubspecPath...');
+      final File pubspecFile = fileSystem.file(pubspecPath);
+      if (!pubspecFile.existsSync()) {
+        print('  Deleted; skipping.');
+        continue;
+      }
+      final Pubspec pubspec = Pubspec.parse(pubspecFile.readAsStringSync());
+      if (pubspec.publishTo == 'none') {
+        print('  Found "publish_to: none"; skipping.');
+        continue;
+      }
+
+      Version masterVersion;
       try {
-        final File pubspecFile = fileSystem.file(pubspecPath);
-        if (!pubspecFile.existsSync()) {
-          continue;
-        }
-        final Pubspec pubspec = Pubspec.parse(pubspecFile.readAsStringSync());
-        if (pubspec.publishTo == 'none') {
-          continue;
-        }
-
-        final Version masterVersion =
-            await gitVersionFinder.getPackageVersion(pubspecPath, baseSha);
-        final Version headVersion =
-            await gitVersionFinder.getPackageVersion(pubspecPath, 'HEAD');
-        if (headVersion == null) {
-          continue; // Example apps don't have versions
-        }
-
-        final Map<Version, NextVersionType> allowedNextVersions =
-            getAllowedNextVersions(masterVersion, headVersion);
-
-        if (!allowedNextVersions.containsKey(headVersion)) {
-          final String error = '$pubspecPath incorrectly updated version.\n'
-              'HEAD: $headVersion, master: $masterVersion.\n'
-              'Allowed versions: $allowedNextVersions';
-          printErrorAndExit(errorMessage: error);
-        }
-
-        final bool isPlatformInterface =
-            pubspec.name.endsWith('_platform_interface');
-        if (isPlatformInterface &&
-            allowedNextVersions[headVersion] ==
-                NextVersionType.BREAKING_MAJOR) {
-          final String error = '$pubspecPath breaking change detected.\n'
-              'Breaking changes to platform interfaces are strongly discouraged.\n';
-          printErrorAndExit(errorMessage: error);
-        }
+        masterVersion = await gitVersionFinder.getPackageVersion(pubspecPath);
       } on io.ProcessException {
-        print('Unable to find pubspec in master for $pubspecPath.'
-            ' Safe to ignore if the project is new.');
+        print('  Unable to find pubspec in master. '
+            'Safe to ignore if the project is new.');
+      }
+      final Version headVersion =
+          await gitVersionFinder.getPackageVersion(pubspecPath, gitRef: 'HEAD');
+      if (headVersion == null) {
+        printErrorAndExit(
+            errorMessage: 'No version found. A package that '
+                'intentionally has no version should be marked '
+                '"publish_to: none".');
+      }
+
+      if (masterVersion == headVersion) {
+        print('  No version change.');
+        continue;
+      }
+
+      final Map<Version, NextVersionType> allowedNextVersions =
+          getAllowedNextVersions(masterVersion, headVersion);
+
+      if (!allowedNextVersions.containsKey(headVersion)) {
+        final String error = '$pubspecPath incorrectly updated version.\n'
+            'HEAD: $headVersion, master: $masterVersion.\n'
+            'Allowed versions: $allowedNextVersions';
+        printErrorAndExit(errorMessage: error);
+      } else {
+        print('  $headVersion -> $masterVersion');
+      }
+
+      final bool isPlatformInterface =
+          pubspec.name.endsWith('_platform_interface');
+      if (isPlatformInterface &&
+          allowedNextVersions[headVersion] == NextVersionType.BREAKING_MAJOR) {
+        final String error = '$pubspecPath breaking change detected.\n'
+            'Breaking changes to platform interfaces are strongly discouraged.\n';
+        printErrorAndExit(errorMessage: error);
       }
     }
 
@@ -153,7 +162,7 @@ class VersionCheckCommand extends PluginCommand {
     final String packageName = plugin.basename;
     print('-----------------------------------------');
     print(
-        'Checking the first version listed in CHANGELOG.MD matches the version in pubspec.yaml for $packageName.');
+        'Checking the first version listed in CHANGELOG.md matches the version in pubspec.yaml for $packageName.');
 
     final Pubspec pubspec = _tryParsePubspec(plugin);
     if (pubspec == null) {
@@ -175,6 +184,14 @@ class VersionCheckCommand extends PluginCommand {
     }
     // Remove all leading mark down syntax from the version line.
     final String versionString = firstLineWithText.split(' ').last;
+
+    // Skip validation for the special NEXT version that's used to accumulate
+    // changes that don't warrant publishing on their own.
+    if (versionString == 'NEXT') {
+      print('Skipping validation for NEXT.');
+      return;
+    }
+
     final Version fromChangeLog = Version.parse(versionString);
     if (fromChangeLog == null) {
       final String error =
@@ -190,6 +207,15 @@ The first version listed in CHANGELOG.md is $fromChangeLog.
 ''';
       printErrorAndExit(errorMessage: error);
     }
+
+    final RegExp nextRegex = RegExp(r'^#*\s*NEXT\s*$');
+    if (lines.any((String line) => nextRegex.hasMatch(line))) {
+      printErrorAndExit(errorMessage: '''
+When bumping the version for release, the NEXT section should be incorporated
+into the new version's release notes.
+      ''');
+    }
+
     print('$packageName passed version check');
   }
 

--- a/script/tool/pubspec.yaml
+++ b/script/tool/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_plugin_tools
 description: Productivity utils for hosting multiple plugins within one repository.
-publish_to: 'none'
+publish_to: none
 
 dependencies:
   args: "^1.4.3"


### PR DESCRIPTION
Currently our version update checks aren't actually working; the script doesn't work correctly if no explicit --base-sha is passed, but that's always how CI is calling it.

Fixes https://github.com/flutter/flutter/issues/79823 (and version checks in general)

This makes a number of changes:
- Fixes it to work without --base-sha
- Adds tests that it works in that mode
  - And tightens existing tests to require ToolExit, not just any error, to reduce false-positive test success
- Adds verbose logging of the checks being done, to make it easier to debug this kind of issue in the future
- Tightens the exception handling for missing previous versions to just the line that's expected to fail in that case
- Only allows missing versions when "publish_to: none" is set
  - Adds that everywhere it's missing
  - Standardize the format in the repo to "none" (instead of also having "'none'").
- Allows the use of NEXT in CHANGELOG as a way of gathering changes that are worth noting, but not
  doing a publish cycle for. (Replaces the plan of using -dev versions, since that's actually harder to implement,
  and more confusing.)
  - Ensures that we don't forget to clean up NEXT entries when bumping versions

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
