### PR TITLE
[in_app_purchase] Added currency code and numerical price to product detail model.

### DIFF
--- a/packages/in_app_purchase/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.2
+
+* Added `rawPrice` and `currencyCode` to the ProductDetails model.
+
 ## 0.5.1+2
 
 * Update README to provide a better instruction of the plugin.

--- a/packages/in_app_purchase/in_app_purchase/lib/src/in_app_purchase/product_details.dart
+++ b/packages/in_app_purchase/in_app_purchase/lib/src/in_app_purchase/product_details.dart
@@ -35,11 +35,11 @@ class ProductDetails {
   /// Formatted with currency symbol ("$0.99").
   final String price;
 
-  // The unformatted price of the product, specified in the App Store Connect or Sku in Google Play console based on the platform.
+  /// The unformatted price of the product, specified in the App Store Connect or Sku in Google Play console based on the platform.
   final double rawPrice;
 
-  // The currency code for the price of the product.
-  // Based on the price specified in the App Store Connect or Sku in Google Play console based on the platform.
+  /// The currency code for the price of the product.
+  /// Based on the price specified in the App Store Connect or Sku in Google Play console based on the platform.
   final String currencyCode;
 
   /// Points back to the `StoreKits`'s [SKProductWrapper] object that generated this [ProductDetails] object.

--- a/packages/in_app_purchase/in_app_purchase/lib/src/in_app_purchase/product_details.dart
+++ b/packages/in_app_purchase/in_app_purchase/lib/src/in_app_purchase/product_details.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:in_app_purchase/store_kit_wrappers.dart';
 import 'package:in_app_purchase/billing_client_wrappers.dart';
 import 'in_app_purchase_connection.dart';
@@ -17,6 +19,8 @@ class ProductDetails {
       required this.title,
       required this.description,
       required this.price,
+      required this.rawPrice,
+      required this.currencyCode,
       this.skProduct,
       this.skuDetail});
 
@@ -32,6 +36,13 @@ class ProductDetails {
   /// The price of the product, specified in the App Store Connect or Sku in Google Play console based on the platform.
   /// Formatted with currency symbol ("$0.99").
   final String price;
+
+  // The unformatted price of the product, specified in the App Store Connect or Sku in Google Play console based on the platform.
+  final double rawPrice;
+
+  // The currency code for the price of the product.
+  // Based on the price specified in the App Store Connect or Sku in Google Play console based on the platform.
+  final String currencyCode;
 
   /// Points back to the `StoreKits`'s [SKProductWrapper] object that generated this [ProductDetails] object.
   ///
@@ -49,6 +60,8 @@ class ProductDetails {
         this.title = product.localizedTitle,
         this.description = product.localizedDescription,
         this.price = product.priceLocale.currencySymbol + product.price,
+        this.rawPrice = double.tryParse(product.price) ?? 0,
+        this.currencyCode = product.priceLocale.currencyCode,
         this.skProduct = product,
         this.skuDetail = null;
 
@@ -58,6 +71,8 @@ class ProductDetails {
         this.title = skuDetails.title,
         this.description = skuDetails.description,
         this.price = skuDetails.price,
+        this.rawPrice = ((skuDetails.priceAmountMicros) / 1000000.0).toDouble(),
+        this.currencyCode = skuDetails.priceCurrencyCode,
         this.skProduct = null,
         this.skuDetail = skuDetails;
 }

--- a/packages/in_app_purchase/in_app_purchase/lib/src/in_app_purchase/product_details.dart
+++ b/packages/in_app_purchase/in_app_purchase/lib/src/in_app_purchase/product_details.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:in_app_purchase/store_kit_wrappers.dart';
 import 'package:in_app_purchase/billing_client_wrappers.dart';
 import 'in_app_purchase_connection.dart';

--- a/packages/in_app_purchase/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase/pubspec.yaml
@@ -1,7 +1,7 @@
 name: in_app_purchase
 description: A Flutter plugin for in-app purchases. Exposes APIs for making in-app purchases through the App Store and Google Play.
 homepage: https://github.com/flutter/plugins/tree/master/packages/in_app_purchase
-version: 0.5.1+2
+version: 0.5.2
 
 dependencies:
   flutter:

--- a/packages/in_app_purchase/in_app_purchase/test/in_app_purchase_connection/product_details_test.dart
+++ b/packages/in_app_purchase/in_app_purchase/test/in_app_purchase_connection/product_details_test.dart
@@ -1,0 +1,51 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:in_app_purchase/in_app_purchase.dart';
+import 'package:in_app_purchase/src/store_kit_wrappers/sk_product_wrapper.dart';
+
+void main() {
+  group('Constructor Tests', () {
+    test('fromSkProduct should correctly parse the price data', () {
+      final SKProductWrapper dummyProductWrapper = SKProductWrapper(
+        productIdentifier: 'id',
+        localizedTitle: 'title',
+        localizedDescription: 'description',
+        priceLocale:
+            SKPriceLocaleWrapper(currencySymbol: '\$', currencyCode: 'USD'),
+        subscriptionGroupIdentifier: 'com.group',
+        price: '13.37',
+      );
+
+      ProductDetails productDetails =
+          ProductDetails.fromSKProduct(dummyProductWrapper);
+      expect(productDetails.rawPrice, equals(13.37));
+    });
+
+    test('fromSkuDetails should correctly parse the price data', () {
+      final SkuDetailsWrapper dummyDetailWRapper = SkuDetailsWrapper(
+        description: 'description',
+        freeTrialPeriod: 'freeTrialPeriod',
+        introductoryPrice: 'introductoryPrice',
+        introductoryPriceMicros: 'introductoryPriceMicros',
+        introductoryPriceCycles: 1,
+        introductoryPricePeriod: 'introductoryPricePeriod',
+        price: '13.37',
+        priceAmountMicros: 13370000,
+        priceCurrencyCode: 'usd',
+        sku: 'sku',
+        subscriptionPeriod: 'subscriptionPeriod',
+        title: 'title',
+        type: SkuType.inapp,
+        originalPrice: 'originalPrice',
+        originalPriceAmountMicros: 1000,
+      );
+
+      ProductDetails productDetails =
+          ProductDetails.fromSkuDetails(dummyDetailWRapper);
+      expect(productDetails.rawPrice, equals(13.37));
+    });
+  });
+}

--- a/packages/in_app_purchase/in_app_purchase/test/in_app_purchase_connection/product_details_test.dart
+++ b/packages/in_app_purchase/in_app_purchase/test/in_app_purchase_connection/product_details_test.dart
@@ -25,7 +25,7 @@ void main() {
     });
 
     test('fromSkuDetails should correctly parse the price data', () {
-      final SkuDetailsWrapper dummyDetailWRapper = SkuDetailsWrapper(
+      final SkuDetailsWrapper dummyDetailWrapper = SkuDetailsWrapper(
         description: 'description',
         freeTrialPeriod: 'freeTrialPeriod',
         introductoryPrice: 'introductoryPrice',
@@ -44,7 +44,7 @@ void main() {
       );
 
       ProductDetails productDetails =
-          ProductDetails.fromSkuDetails(dummyDetailWRapper);
+          ProductDetails.fromSkuDetails(dummyDetailWrapper);
       expect(productDetails.rawPrice, equals(13.37));
     });
   });


### PR DESCRIPTION
Adds the currency code and numerical price to the ProductDetail model, so users of the plugin are able to take care of formatting.

Solves flutter/flutter#65758

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
