### PR TITLE
[image_picker]Handle IllegalStateException of getPathFromUri

### DIFF
--- a/packages/image_picker/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
+++ b/packages/image_picker/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/FileUtils.java
@@ -51,6 +51,7 @@ class FileUtils {
         success = true;
       }
     } catch (IOException ignored) {
+    } catch (IllegalStateException ignored) {
     } finally {
       try {
         if (inputStream != null) inputStream.close();
@@ -62,6 +63,8 @@ class FileUtils {
         // If closing the output stream fails, we cannot be sure that the
         // target file was written in full. Flushing the stream merely moves
         // the bytes into the OS, not necessarily to the file.
+        success = false;
+      } catch (IllegalStateException ignored) {
         success = false;
       }
     }


### PR DESCRIPTION
*Resolve the crash of IllegalStateException when pick image which not owned by our app.*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

e.g. exception info
```
java.lang.RuntimeException: Failure delivering result ResultInfo{who=null, request=2342, result=-1, data=Intent { dat=content://com.android.providers.media.documents/document/image:2444 flg=0x1 }} to activity {tech.brainco.focusimprove/tech.brainco.focusimprove.MainActivity}: java.lang.IllegalStateException: Only owner is able to interact with pending media content://media/external/images/media/2444
	at android.app.ActivityThread.deliverResults(ActivityThread.java:5598)
	at android.app.ActivityThread.handleSendResult(ActivityThread.java:5639)
	at android.app.servertransaction.ActivityResultItem.execute(ActivityResultItem.java:51)
	at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:149)
	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:103)
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2462)
	at android.os.Handler.dispatchMessage(Handler.java:110)
	at android.os.Looper.loop(Looper.java:219)
	at android.app.ActivityThread.main(ActivityThread.java:8393)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:513)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1055)
Caused by: java.lang.IllegalStateException: Only owner is able to interact with pending media content://media/external/images/media/2444
	at android.os.Parcel.createException(Parcel.java:2079)
	at android.os.Parcel.readException(Parcel.java:2039)
	at android.database.DatabaseUtils.readExceptionFromParcel(DatabaseUtils.java:188)
	at android.database.DatabaseUtils.readExceptionWithFileNotFoundExceptionFromParcel(DatabaseUtils.java:151)
	at android.content.ContentProviderProxy.openTypedAssetFile(ContentProviderNative.java:705)
	at android.content.ContentResolver.openTypedAssetFileDescriptor(ContentResolver.java:1698)
	at android.content.ContentResolver.openAssetFileDescriptor(ContentResolver.java:1514)
	at android.content.ContentResolver.openInputStream(ContentResolver.java:1198)
	at io.flutter.plugins.imagepicker.FileUtils.getPathFromUri(FileUtils.java:43)
	at io.flutter.plugins.imagepicker.ImagePickerDelegate.handleChooseImageResult(ImagePickerDelegate.java:491)
	at io.flutter.plugins.imagepicker.ImagePickerDelegate.onActivityResult(ImagePickerDelegate.java:471)
	at io.flutter.embedding.engine.FlutterEnginePluginRegistry$FlutterEngineActivityPluginBinding.onActivityResult(FlutterEnginePluginRegistry.java:691)
	at io.flutter.embedding.engine.FlutterEnginePluginRegistry.onActivityResult(FlutterEnginePluginRegistry.java:378)
	at io.flutter.embedding.android.FlutterActivityAndFragmentDelegate.onActivityResult(FlutterActivityAndFragmentDelegate.java:625)
	at io.flutter.embedding.android.FlutterActivity.onActivityResult(FlutterActivity.java:583)
	at android.app.Activity.dispatchActivityResult(Activity.java:8448)
	at android.app.ActivityThread.deliverResults(ActivityThread.java:5591)
	... 11 more
java.lang.IllegalStateException: Only owner is able to interact with pending media content://media/external/images/media/2444
	at android.os.Parcel.createException(Parcel.java:2079)
	at android.os.Parcel.readException(Parcel.java:2039)
	at android.database.DatabaseUtils.readExceptionFromParcel(DatabaseUtils.java:188)
	at android.database.DatabaseUtils.readExceptionWithFileNotFoundExceptionFromParcel(DatabaseUtils.java:151)
	at android.content.ContentProviderProxy.openTypedAssetFile(ContentProviderNative.java:705)
	at android.content.ContentResolver.openTypedAssetFileDescriptor(ContentResolver.java:1698)
	at android.content.ContentResolver.openAssetFileDescriptor(ContentResolver.java:1514)
	at android.content.ContentResolver.openInputStream(ContentResolver.java:1198)
	at io.flutter.plugins.imagepicker.FileUtils.getPathFromUri(FileUtils.java:43)
	at io.flutter.plugins.imagepicker.ImagePickerDelegate.handleChooseImageResult(ImagePickerDelegate.java:491)
	at io.flutter.plugins.imagepicker.ImagePickerDelegate.onActivityResult(ImagePickerDelegate.java:471)
	at io.flutter.embedding.engine.FlutterEnginePluginRegistry$FlutterEngineActivityPluginBinding.onActivityResult(FlutterEnginePluginRegistry.java:691)
	at io.flutter.embedding.engine.FlutterEnginePluginRegistry.onActivityResult(FlutterEnginePluginRegistry.java:378)
	at io.flutter.embedding.android.FlutterActivityAndFragmentDelegate.onActivityResult(FlutterActivityAndFragmentDelegate.java:625)
	at io.flutter.embedding.android.FlutterActivity.onActivityResult(FlutterActivity.java:583)
	at android.app.Activity.dispatchActivityResult(Activity.java:8448)
	at android.app.ActivityThread.deliverResults(ActivityThread.java:5591)
	at android.app.ActivityThread.handleSendResult(ActivityThread.java:5639)
	at android.app.servertransaction.ActivityResultItem.execute(ActivityResultItem.java:51)
	at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:149)
	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:103)
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2462)
	at android.os.Handler.dispatchMessage(Handler.java:110)
	at android.os.Looper.loop(Looper.java:219)
	at android.app.ActivityThread.main(ActivityThread.java:8393)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:513)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1055)
```

