### PR TITLE
[google_sign_in] Fix "pick account" on iOS

### DIFF
--- a/packages/google_sign_in/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 5.1.0
+## 5.0.2
 
 * Fix flutter/flutter#48602 iOS flow shows account selection, if user is signed in to Google on the device.
 

--- a/packages/google_sign_in/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.1.0
+
+* Fix flutter/flutter#48602 iOS flow shows account selection, if user is signed in to Google on the device.
+
 ## 5.0.1
 
 * Update platforms `init` function to prioritize `clientId` property when available;

--- a/packages/google_sign_in/google_sign_in/ios/Classes/FLTGoogleSignInPlugin.m
+++ b/packages/google_sign_in/google_sign_in/ios/Classes/FLTGoogleSignInPlugin.m
@@ -88,7 +88,11 @@ static FlutterError *getFlutterError(NSError *error) {
 
         [GIDSignIn sharedInstance].serverClientID = plist[kServerClientIdKey];
         [GIDSignIn sharedInstance].scopes = call.arguments[@"scopes"];
-        [GIDSignIn sharedInstance].hostedDomain = call.arguments[@"hostedDomain"];
+        if (call.arguments[@"hostedDomain"] == [NSNull null]) {
+          [GIDSignIn sharedInstance].hostedDomain = nil;
+        } else {
+          [GIDSignIn sharedInstance].hostedDomain = call.arguments[@"hostedDomain"];
+        }
         result(nil);
       } else {
         result([FlutterError errorWithCode:@"missing-config"

--- a/packages/google_sign_in/google_sign_in/ios/Tests/GoogleSignInPluginTest.m
+++ b/packages/google_sign_in/google_sign_in/ios/Tests/GoogleSignInPluginTest.m
@@ -153,4 +153,21 @@
   XCTAssertTrue([result boolValue]);
 }
 
+- (void)testHostedDomainIfMissed {
+  FlutterMethodCall *methodCall =
+      [FlutterMethodCall methodCallWithMethodName:@"init"
+                                        arguments:@{
+                                            @"signInOption" : @"SignInOption.standard"},
+                                            @"hostedDomain" : [NSNull null],
+                                        ];
+
+  XCTestExpectation *expectation = [self expectationWithDescription:@"expect hostedDomain equals nil"];
+  [self.plugin handleMethodCall:methodCall
+                         result:^(id r) {
+                           [expectation fulfill];
+                         }];
+  [self waitForExpectations:@[ expectation ] timeout:5];
+  XCTAssertTrue([self.mockSharedInstance.hostedDomain == nil]);
+}
+
 @end

--- a/packages/google_sign_in/google_sign_in/ios/Tests/GoogleSignInPluginTest.m
+++ b/packages/google_sign_in/google_sign_in/ios/Tests/GoogleSignInPluginTest.m
@@ -157,11 +157,12 @@
   FlutterMethodCall *methodCall =
       [FlutterMethodCall methodCallWithMethodName:@"init"
                                         arguments:@{
-                                            @"signInOption" : @"SignInOption.standard"},
-                                            @"hostedDomain" : [NSNull null],
-                                        ];
+                                          @"signInOption" : @"SignInOption.standard",
+                                          @"hostedDomain" : [NSNull null],
+                                        }];
 
-  XCTestExpectation *expectation = [self expectationWithDescription:@"expect hostedDomain equals nil"];
+  XCTestExpectation *expectation =
+      [self expectationWithDescription:@"expect hostedDomain equals nil"];
   [self.plugin handleMethodCall:methodCall
                          result:^(id r) {
                            [expectation fulfill];

--- a/packages/google_sign_in/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_sign_in
 description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android and iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_sign_in/google_sign_in
-version: 5.0.1
+version: 5.1.0
 
 flutter:
   plugin:

--- a/packages/google_sign_in/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_sign_in
 description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android and iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_sign_in/google_sign_in
-version: 5.1.0
+version: 5.0.2
 
 flutter:
   plugin:


### PR DESCRIPTION
iOS Google Sign-in flow was always forcing user to fill email and password, the null check fixes the account picker, so the flow suggest Google Accounts already signed-in on iOS device.

Fixes: flutter/flutter#48602

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
