### PR TITLE
[local_auth]: Add option to only use strong biometric authentication systems on Android

### DIFF
--- a/packages/local_auth/CHANGELOG.md
+++ b/packages/local_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.5
+
+* Add `strongAuthenticatorsOnly` flag to prevent authentication with weak biometric systems on Android.
+
 ## 1.1.4
 
 * Add debug assertion that `localizedReason` in `LocalAuthentication.authenticateWithBiometrics`  must not be empty.

--- a/packages/local_auth/android/src/main/java/io/flutter/plugins/localauth/AuthenticationHelper.java
+++ b/packages/local_auth/android/src/main/java/io/flutter/plugins/localauth/AuthenticationHelper.java
@@ -20,6 +20,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
+import androidx.biometric.BiometricManager.Authenticators;
 import androidx.biometric.BiometricPrompt;
 import androidx.fragment.app.FragmentActivity;
 import androidx.lifecycle.DefaultLifecycleObserver;
@@ -87,8 +88,11 @@ class AuthenticationHelper extends BiometricPrompt.AuthenticationCallback
             .setDescription((String) call.argument("localizedReason"))
             .setTitle((String) call.argument("signInTitle"))
             .setSubtitle((String) call.argument("biometricHint"))
-            .setConfirmationRequired((Boolean) call.argument("sensitiveTransaction"))
             .setConfirmationRequired((Boolean) call.argument("sensitiveTransaction"));
+
+    if ((boolean) call.argument("strongAuthenticatorsOnly")) {
+      promptBuilder.setAllowedAuthenticators(Authenticators.BIOMETRIC_STRONG);
+    }
 
     if (allowCredentials) {
       promptBuilder.setDeviceCredentialAllowed(true);

--- a/packages/local_auth/example/lib/main.dart
+++ b/packages/local_auth/example/lib/main.dart
@@ -95,7 +95,7 @@ class _MyAppState extends State<MyApp> {
         () => _authorized = authenticated ? 'Authorized' : 'Not Authorized');
   }
 
-  Future<void> _authenticateWithBiometrics() async {
+  Future<void> _authenticateWithBiometrics({bool strongOnly = true}) async {
     bool authenticated = false;
     try {
       setState(() {
@@ -103,11 +103,13 @@ class _MyAppState extends State<MyApp> {
         _authorized = 'Authenticating';
       });
       authenticated = await auth.authenticate(
-          localizedReason:
-              'Scan your fingerprint (or face or whatever) to authenticate',
-          useErrorDialogs: true,
-          stickyAuth: true,
-          biometricOnly: true);
+        localizedReason:
+            'Scan your fingerprint (or face or whatever) to authenticate',
+        useErrorDialogs: true,
+        stickyAuth: true,
+        biometricOnly: true,
+        strongAuthenticatorsOnly: strongOnly,
+      );
       setState(() {
         _isAuthenticating = false;
         _authorized = 'Authenticating';
@@ -199,7 +201,23 @@ class _MyAppState extends State<MyApp> {
                                 Icon(Icons.fingerprint),
                               ],
                             ),
-                            onPressed: _authenticateWithBiometrics,
+                            onPressed: () => _authenticateWithBiometrics(
+                              strongOnly: false,
+                            ),
+                          ),
+                          ElevatedButton(
+                            child: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Text(_isAuthenticating
+                                    ? 'Cancel'
+                                    : 'Authenticate: strong biometrics only'),
+                                Icon(Icons.fingerprint),
+                              ],
+                            ),
+                            onPressed: () => _authenticateWithBiometrics(
+                              strongOnly: true,
+                            ),
                           ),
                         ],
                       ),

--- a/packages/local_auth/lib/local_auth.dart
+++ b/packages/local_auth/lib/local_auth.dart
@@ -87,6 +87,11 @@ class LocalAuthentication {
   /// Setting [biometricOnly] to true prevents authenticates from using non-biometric
   /// local authentication such as pin, passcode, and passcode.
   ///
+  /// Setting [strongAuthenticatorsOnly] to true disables biometric authentication
+  /// mechanisms on Android that are not deemed secure. For instance, many Android
+  /// facial recognition systems are easily fooled, and should not be considered
+  /// secure.
+  ///
   /// Throws an [PlatformException] if there were technical problems with local
   /// authentication (e.g. lack of relevant hardware). This might throw
   /// [PlatformException] with error code [otherOperatingSystem] on the iOS
@@ -98,6 +103,7 @@ class LocalAuthentication {
     AndroidAuthMessages androidAuthStrings = const AndroidAuthMessages(),
     IOSAuthMessages iOSAuthStrings = const IOSAuthMessages(),
     bool sensitiveTransaction = true,
+    bool strongAuthenticatorsOnly = false,
     bool biometricOnly = false,
   }) async {
     assert(localizedReason.isNotEmpty);
@@ -107,6 +113,7 @@ class LocalAuthentication {
       'useErrorDialogs': useErrorDialogs,
       'stickyAuth': stickyAuth,
       'sensitiveTransaction': sensitiveTransaction,
+      'strongAuthenticatorsOnly': strongAuthenticatorsOnly,
       'biometricOnly': biometricOnly,
     };
     if (_platform.isIOS) {

--- a/packages/local_auth/pubspec.yaml
+++ b/packages/local_auth/pubspec.yaml
@@ -2,7 +2,7 @@ name: local_auth
 description: Flutter plugin for Android and iOS devices to allow local
   authentication via fingerprint, touch ID, face ID, passcode, pin, or pattern.
 homepage: https://github.com/flutter/plugins/tree/master/packages/local_auth
-version: 1.1.4
+version: 1.1.5
 
 flutter:
   plugin:

--- a/packages/local_auth/test/local_auth_test.dart
+++ b/packages/local_auth/test/local_auth_test.dart
@@ -47,6 +47,7 @@ void main() {
                   'stickyAuth': false,
                   'sensitiveTransaction': true,
                   'biometricOnly': true,
+                  'strongAuthenticatorsOnly': false,
                 }..addAll(const AndroidAuthMessages().args)),
           ],
         );
@@ -68,6 +69,7 @@ void main() {
                   'stickyAuth': false,
                   'sensitiveTransaction': true,
                   'biometricOnly': true,
+                  'strongAuthenticatorsOnly': false,
                 }..addAll(const IOSAuthMessages().args)),
           ],
         );
@@ -102,6 +104,7 @@ void main() {
                   'stickyAuth': false,
                   'sensitiveTransaction': false,
                   'biometricOnly': true,
+                  'strongAuthenticatorsOnly': false,
                 }..addAll(const AndroidAuthMessages().args)),
           ],
         );
@@ -124,6 +127,7 @@ void main() {
                   'stickyAuth': false,
                   'sensitiveTransaction': true,
                   'biometricOnly': false,
+                  'strongAuthenticatorsOnly': false,
                 }..addAll(const AndroidAuthMessages().args)),
           ],
         );
@@ -144,6 +148,7 @@ void main() {
                   'stickyAuth': false,
                   'sensitiveTransaction': true,
                   'biometricOnly': false,
+                  'strongAuthenticatorsOnly': false,
                 }..addAll(const IOSAuthMessages().args)),
           ],
         );
@@ -166,6 +171,31 @@ void main() {
                   'stickyAuth': false,
                   'sensitiveTransaction': false,
                   'biometricOnly': false,
+                  'strongAuthenticatorsOnly': false,
+                }..addAll(const AndroidAuthMessages().args)),
+          ],
+        );
+      });
+
+      test('authenticate with strong authenticators.', () async {
+        setMockPathProviderPlatform(FakePlatform(operatingSystem: 'android'));
+        await localAuthentication.authenticate(
+          localizedReason: 'Insecure',
+          sensitiveTransaction: false,
+          useErrorDialogs: false,
+          strongAuthenticatorsOnly: true,
+        );
+        expect(
+          log,
+          <Matcher>[
+            isMethodCall('authenticate',
+                arguments: <String, dynamic>{
+                  'localizedReason': 'Insecure',
+                  'useErrorDialogs': false,
+                  'stickyAuth': false,
+                  'sensitiveTransaction': false,
+                  'biometricOnly': false,
+                  'strongAuthenticatorsOnly': true,
                 }..addAll(const AndroidAuthMessages().args)),
           ],
         );


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/81169.

Adds a new `strongAuthenticatorsOnly` flag that instructs Android to only allow secure biometric authentication mechanisms.

For instance, many Android devices use weak implementations of facial recognition, and in my experience most apps will only allow me to authenticate via fingerprint.

This change is backward compatible; omitting the flag will allow weak authentication as before.

Photo of `strongAuthenticatorsOnly=false` and `strongAuthenticatorsOnly=true`. This couldn't be a screenshot sorry, my phone won't allow me to screenshot the auth popup.
![strongAuthenticatorsOnly](https://user-images.githubusercontent.com/13063119/114651599-a310ba80-9d27-11eb-8564-5232713365e7.jpg)

**Note:** I'm not sure how this will fit into the `availableBiometrics` method. At the moment I haven't made any changes there.
If the user has no secure methods available, a `NoHardware` or `NotEnrolled` should be returned.

*List which issues are fixed by this PR. You must list at least one issue.*
New feature.

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*
N/A

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.
