### PR TITLE
[quick_actions] handle cold start on iOS correctly

### DIFF
--- a/packages/quick_actions/quick_actions/CHANGELOG.md
+++ b/packages/quick_actions/quick_actions/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.0+1
+
+* Correctly handle iOS Application lifecycle events on cold start of the App.
+
 ## 0.6.0
 
 * Migrate to federated architecture.

--- a/packages/quick_actions/quick_actions/example/ios/Runner/AppDelegate.m
+++ b/packages/quick_actions/quick_actions/example/ios/Runner/AppDelegate.m
@@ -11,7 +11,7 @@
     didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
   [GeneratedPluginRegistrant registerWithRegistry:self];
   // Override point for customization after application launch.
-  return [super application:application didFinishLaunchingWithOptions:launchOptions];
+  [super application:application didFinishLaunchingWithOptions:launchOptions];
+  return NO;
 }
-
 @end

--- a/packages/quick_actions/quick_actions/example/ios/RunnerUITests/RunnerUITests.m
+++ b/packages/quick_actions/quick_actions/example/ios/RunnerUITests/RunnerUITests.m
@@ -18,9 +18,45 @@ static const int kElementWaitingTime = 30;
   self.continueAfterFailure = NO;
 }
 
-- (void)testQuickAction {
+- (void)testQuickActionWithFreshStart {
   XCUIApplication *app = [[XCUIApplication alloc] init];
   [app launch];
+  [app terminate];
+
+  XCUIApplication *springboard =
+      [[XCUIApplication alloc] initWithBundleIdentifier:@"com.apple.springboard"];
+  XCUIElement *quickActionsAppIcon = springboard.icons[@"quick_actions_example"];
+  if (![quickActionsAppIcon waitForExistenceWithTimeout:kElementWaitingTime]) {
+    os_log_error(OS_LOG_DEFAULT, "%@", springboard.debugDescription);
+    XCTFail(@"Failed due to not able to find the example app from springboard with %@ seconds",
+            @(kElementWaitingTime));
+  }
+
+  [quickActionsAppIcon pressForDuration:2];
+  XCUIElement *actionTwo = springboard.buttons[@"Action two"];
+  if (![actionTwo waitForExistenceWithTimeout:kElementWaitingTime]) {
+    os_log_error(OS_LOG_DEFAULT, "%@", springboard.debugDescription);
+    XCTFail(@"Failed due to not able to find the actionTwo button from springboard with %@ seconds",
+            @(kElementWaitingTime));
+  }
+
+  [actionTwo tap];
+
+  XCUIElement *actionTwoConfirmation = app.otherElements[@"action_two"];
+  if (![actionTwoConfirmation waitForExistenceWithTimeout:kElementWaitingTime]) {
+    os_log_error(OS_LOG_DEFAULT, "%@", springboard.debugDescription);
+    XCTFail(@"Failed due to not able to find the actionTwoConfirmation in the app with %@ seconds",
+            @(kElementWaitingTime));
+  }
+  XCTAssertTrue(actionTwoConfirmation.exists);
+
+  [app terminate];
+}
+
+- (void)testQuickActionWhenAppIsInBackground {
+  XCUIApplication *app = [[XCUIApplication alloc] init];
+  [app launch];
+
   XCUIElement *actionsReady = app.otherElements[@"actions ready"];
   if (![actionsReady waitForExistenceWithTimeout:kElementWaitingTime]) {
     os_log_error(OS_LOG_DEFAULT, "%@", app.debugDescription);
@@ -56,6 +92,8 @@ static const int kElementWaitingTime = 30;
             @(kElementWaitingTime));
   }
   XCTAssertTrue(actionOneConfirmation.exists);
+
+  [app terminate];
 }
 
 @end

--- a/packages/quick_actions/quick_actions/ios/Classes/FLTQuickActionsPlugin.m
+++ b/packages/quick_actions/quick_actions/ios/Classes/FLTQuickActionsPlugin.m
@@ -8,11 +8,10 @@ static NSString *const CHANNEL_NAME = @"plugins.flutter.io/quick_actions";
 
 @interface FLTQuickActionsPlugin ()
 @property(nonatomic, retain) FlutterMethodChannel *channel;
+@property(nonatomic, retain) NSString *shortcutType;
 @end
 
-@implementation FLTQuickActionsPlugin {
-  NSString *shortcutType;
-}
+@implementation FLTQuickActionsPlugin
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
   FlutterMethodChannel *channel =
@@ -52,7 +51,7 @@ static NSString *const CHANNEL_NAME = @"plugins.flutter.io/quick_actions";
     performActionForShortcutItem:(UIApplicationShortcutItem *)shortcutItem
                completionHandler:(void (^)(BOOL succeeded))completionHandler
     API_AVAILABLE(ios(9.0)) {
-  [self _handleShortcut:shortcutItem.type];
+  [self handleShortcut:shortcutItem.type];
   return YES;
 }
 
@@ -62,7 +61,7 @@ static NSString *const CHANNEL_NAME = @"plugins.flutter.io/quick_actions";
     UIApplicationShortcutItem *shortcutItem =
         launchOptions[UIApplicationLaunchOptionsShortcutItemKey];
     if (shortcutItem) {
-      shortcutType = shortcutItem.type;
+      self.shortcutType = shortcutItem.type;
       return NO;
     }
   }
@@ -70,15 +69,15 @@ static NSString *const CHANNEL_NAME = @"plugins.flutter.io/quick_actions";
 }
 
 - (void)applicationDidBecomeActive:(UIApplication *)application {
-  if (shortcutType) {
-    [self _handleShortcut:shortcutType];
-    shortcutType = nil;
+  if (self.shortcutType) {
+    [self handleShortcut:self.shortcutType];
+    self.shortcutType = nil;
   }
 }
 
 #pragma mark Private functions
 
-- (void)_handleShortcut:(NSString *)shortcut {
+- (void)handleShortcut:(NSString *)shortcut {
   [self.channel invokeMethod:@"launch" arguments:shortcut];
 }
 

--- a/packages/quick_actions/quick_actions/ios/Classes/FLTQuickActionsPlugin.m
+++ b/packages/quick_actions/quick_actions/ios/Classes/FLTQuickActionsPlugin.m
@@ -61,7 +61,15 @@ static NSString *const CHANNEL_NAME = @"plugins.flutter.io/quick_actions";
     UIApplicationShortcutItem *shortcutItem =
         launchOptions[UIApplicationLaunchOptionsShortcutItemKey];
     if (shortcutItem) {
+      // Keep hold of the shortcut type and handle it in the
+      // `applicationDidBecomeActure:` method once the Dart MethodChannel
+      // is initialized.
       self.shortcutType = shortcutItem.type;
+
+      // Return NO to indicate we handled the quick action to ensure
+      // the `application:performActionFor:` method is not called (as
+      // per Apple's documentation:
+      // https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1622935-application?language=objc).
       return NO;
     }
   }

--- a/packages/quick_actions/quick_actions/pubspec.yaml
+++ b/packages/quick_actions/quick_actions/pubspec.yaml
@@ -2,7 +2,7 @@ name: quick_actions
 description: Flutter plugin for creating shortcuts on home screen, also known as
   Quick Actions on iOS and App Shortcuts on Android.
 homepage: https://github.com/flutter/plugins/tree/master/packages/quick_actions
-version: 0.6.0
+version: 0.6.0+1
 
 flutter:
   plugin:


### PR DESCRIPTION
According to Apple's documentation (see the "Discussion" section [here](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623032-application?language=objc)) the `application:performActionForShortcutItem:` method is not executed when the `willFinishLaunchingWithOptions:` or the `didFinishLaunchingWithOptions:` return `NO`. In these cases the `willFinishLaunchingWithOptions:` or `didFinishLaunchingWithOptions:` method are responsible for handling quick actions.

Basic Flutter applications will always return `YES` for the `willFinishLaunchingWithOptions:` and `didFinishLaunchingWithOptions:` methods, however in more advanced cases developers might override these methods and provide custom implementations which might result in one of these method to return `NO`. In these situations the current implementation of the quick_actions plugin will not work. 

This PR will solve the problem and correctly handle quick actions in the `didFinishLaunchingWithOptions:` delegate of the plugin. It also contains an additional XCUITest to proof this method is working correctly. To be able to simulate the situation the `didFinishLaunchingWithOptions:` method in the `example/ios/Runner/AppDelegate.m` is updated to always return `NO`. 

Running the XCUITest on the current codebase will fail if you update the `didFinishLaunchingWithOptions:` method in the `example/ios/Runner/AppDelegate.m` to return `NO`. Running the same test on the code modified in this PR the test will succeed.

- Fixes flutter/flutter#13634
- Closes #2887

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
