### PR TITLE
[tools] fix version check command not working for new packages

### DIFF
--- a/script/tool/lib/src/common.dart
+++ b/script/tool/lib/src/common.dart
@@ -609,7 +609,6 @@ class GitVersionFinder {
       return null;
     }
     final String fileContent = gitShow.stdout as String;
-    print('xx $fileContent');
     final String versionString = loadYaml(fileContent)['version'] as String;
     return versionString == null ? null : Version.parse(versionString);
   }

--- a/script/tool/lib/src/common.dart
+++ b/script/tool/lib/src/common.dart
@@ -609,6 +609,7 @@ class GitVersionFinder {
       return null;
     }
     final String fileContent = gitShow.stdout as String;
+    print('xx $fileContent');
     final String versionString = loadYaml(fileContent)['version'] as String;
     return versionString == null ? null : Version.parse(versionString);
   }

--- a/script/tool/lib/src/version_check_command.dart
+++ b/script/tool/lib/src/version_check_command.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io' as io;
 
 import 'package:meta/meta.dart';
 import 'package:file/file.dart';
@@ -116,11 +115,14 @@ class VersionCheckCommand extends PluginCommand {
                 'intentionally has no version should be marked '
                 '"publish_to: none".');
       }
-      final Version masterVersion =
+      Version masterVersion =
           await gitVersionFinder.getPackageVersion(pubspecPath);
       if (masterVersion == null) {
+        // If no masterVersion, set it to 0.0.0 so new package can calculate valid versions.
+        masterVersion = Version.none;
         print('${indentation}Unable to find pubspec in master. '
             'Safe to ignore if the project is new.');
+        print(masterVersion);
       }
 
       if (masterVersion == headVersion) {

--- a/script/tool/lib/src/version_check_command.dart
+++ b/script/tool/lib/src/version_check_command.dart
@@ -122,7 +122,6 @@ class VersionCheckCommand extends PluginCommand {
         masterVersion = Version.none;
         print('${indentation}Unable to find pubspec in master. '
             'Safe to ignore if the project is new.');
-        print(masterVersion);
       }
 
       if (masterVersion == headVersion) {

--- a/script/tool/lib/src/version_check_command.dart
+++ b/script/tool/lib/src/version_check_command.dart
@@ -115,13 +115,12 @@ class VersionCheckCommand extends PluginCommand {
                 'intentionally has no version should be marked '
                 '"publish_to: none".');
       }
-      Version masterVersion =
+      final Version masterVersion =
           await gitVersionFinder.getPackageVersion(pubspecPath);
       if (masterVersion == null) {
-        // If no masterVersion, set it to 0.0.0 so new package can calculate valid versions.
-        masterVersion = Version.none;
         print('${indentation}Unable to find pubspec in master. '
             'Safe to ignore if the project is new.');
+        continue;
       }
 
       if (masterVersion == headVersion) {

--- a/script/tool/test/version_check_test.dart
+++ b/script/tool/test/version_check_test.dart
@@ -61,6 +61,9 @@ void main() {
         } else if (invocation.positionalArguments[0][0] == 'show') {
           final String response =
               gitShowResponses[invocation.positionalArguments[0][1]];
+          if (response == null) {
+            throw const io.ProcessException('git', <String>['show']);
+          }
           when<String>(mockProcessResult.stdout as String).thenReturn(response);
         } else if (invocation.positionalArguments[0][0] == 'merge-base') {
           when<String>(mockProcessResult.stdout as String).thenReturn('abc123');
@@ -138,6 +141,23 @@ void main() {
       gitShowResponses = <String, String>{
         'abc123:packages/plugin/pubspec.yaml': 'version: 1.0.0',
         'HEAD:packages/plugin/pubspec.yaml': 'version: 2.0.0',
+      };
+      final List<String> output =
+          await runCapturingPrint(runner, <String>['version-check']);
+
+      expect(
+        output,
+        containsAllInOrder(<String>[
+          'No version check errors found!',
+        ]),
+      );
+    });
+
+    test('allows valid version for new package.', () async {
+      createFakePlugin('plugin', includeChangeLog: true, includeVersion: true);
+      gitDiffResponse = 'packages/plugin/pubspec.yaml';
+      gitShowResponses = <String, String>{
+        'HEAD:packages/plugin/pubspec.yaml': 'version: 1.0.0',
       };
       final List<String> output =
           await runCapturingPrint(runner, <String>['version-check']);


### PR DESCRIPTION
Allow versions for new packages. Skip version check if master version is null.

Failure here: https://cirrus-ci.com/task/6433272113659904

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format](../script/tool/README.md#format-code))
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
