### PR TITLE
Move all null safety packages' min dart sdk to 2.12.0

### DIFF
--- a/packages/android_alarm_manager/example/pubspec.yaml
+++ b/packages/android_alarm_manager/example/pubspec.yaml
@@ -29,5 +29,5 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: '>=2.12.0-259.9.beta <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
   flutter: ">=1.20.0"

--- a/packages/android_alarm_manager/pubspec.yaml
+++ b/packages/android_alarm_manager/pubspec.yaml
@@ -21,5 +21,5 @@ flutter:
         pluginClass: AndroidAlarmManagerPlugin
 
 environment:
-  sdk: '>=2.12.0-259.9.beta <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
   flutter: ">=1.20.0"

--- a/packages/android_intent/example/pubspec.yaml
+++ b/packages/android_intent/example/pubspec.yaml
@@ -25,5 +25,5 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"

--- a/packages/android_intent/pubspec.yaml
+++ b/packages/android_intent/pubspec.yaml
@@ -24,5 +24,5 @@ dev_dependencies:
   build_runner: ^1.11.1
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"

--- a/packages/battery/battery/example/pubspec.yaml
+++ b/packages/battery/battery/example/pubspec.yaml
@@ -24,5 +24,5 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.12.13+hotfix.5"

--- a/packages/battery/battery/pubspec.yaml
+++ b/packages/battery/battery/pubspec.yaml
@@ -29,5 +29,5 @@ dev_dependencies:
   test: ^1.16.3
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.12.13+hotfix.5"

--- a/packages/battery/battery_platform_interface/pubspec.yaml
+++ b/packages/battery/battery_platform_interface/pubspec.yaml
@@ -18,5 +18,5 @@ dev_dependencies:
   pedantic: ^1.10.0
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"

--- a/packages/camera/camera/example/pubspec.yaml
+++ b/packages/camera/camera/example/pubspec.yaml
@@ -28,5 +28,5 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.22.0"

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -38,5 +38,5 @@ flutter:
         pluginClass: CameraPlugin
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.22.0"

--- a/packages/camera/camera_platform_interface/pubspec.yaml
+++ b/packages/camera/camera_platform_interface/pubspec.yaml
@@ -20,5 +20,5 @@ dev_dependencies:
   pedantic: ^1.10.0
 
 environment:
-  sdk: '>=2.12.0-259.9.beta <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
   flutter: ">=1.22.0"

--- a/packages/connectivity/connectivity/example/pubspec.yaml
+++ b/packages/connectivity/connectivity/example/pubspec.yaml
@@ -25,5 +25,5 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.12.13+hotfix.5"

--- a/packages/connectivity/connectivity/pubspec.yaml
+++ b/packages/connectivity/connectivity/pubspec.yaml
@@ -37,5 +37,5 @@ dev_dependencies:
   pedantic: ^1.10.0
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.12.13+hotfix.5"

--- a/packages/connectivity/connectivity_for_web/example/pubspec.yaml
+++ b/packages/connectivity/connectivity_for_web/example/pubspec.yaml
@@ -17,5 +17,5 @@ dev_dependencies:
     sdk: flutter
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.27.0-0" # For integration_test from sdk

--- a/packages/connectivity/connectivity_for_web/pubspec.yaml
+++ b/packages/connectivity/connectivity_for_web/pubspec.yaml
@@ -22,5 +22,5 @@ dev_dependencies:
     sdk: flutter
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"

--- a/packages/connectivity/connectivity_macos/example/pubspec.yaml
+++ b/packages/connectivity/connectivity_macos/example/pubspec.yaml
@@ -25,5 +25,5 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.10.0"

--- a/packages/connectivity/connectivity_macos/pubspec.yaml
+++ b/packages/connectivity/connectivity_macos/pubspec.yaml
@@ -10,7 +10,7 @@ flutter:
         pluginClass: ConnectivityPlugin
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"
 
 dependencies:

--- a/packages/connectivity/connectivity_platform_interface/pubspec.yaml
+++ b/packages/connectivity/connectivity_platform_interface/pubspec.yaml
@@ -17,5 +17,5 @@ dev_dependencies:
   pedantic: ^1.10.0
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.12.13+hotfix.5"

--- a/packages/device_info/device_info/example/pubspec.yaml
+++ b/packages/device_info/device_info/example/pubspec.yaml
@@ -24,5 +24,5 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.12.13+hotfix.5"

--- a/packages/device_info/device_info/pubspec.yaml
+++ b/packages/device_info/device_info/pubspec.yaml
@@ -24,5 +24,5 @@ dev_dependencies:
   pedantic: ^1.10.0
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.12.13+hotfix.5"

--- a/packages/device_info/device_info_platform_interface/pubspec.yaml
+++ b/packages/device_info/device_info_platform_interface/pubspec.yaml
@@ -18,5 +18,5 @@ dev_dependencies:
   pedantic: ^1.10.0
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.9.1+hotfix.4"

--- a/packages/espresso/example/pubspec.yaml
+++ b/packages/espresso/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates how to use the espresso plugin.
 publish_to: none
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"
 
 dependencies:

--- a/packages/espresso/pubspec.yaml
+++ b/packages/espresso/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.0
 homepage: https://github.com/flutter/plugins/espresso
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"
 
 dependencies:

--- a/packages/file_selector/file_selector/example/pubspec.yaml
+++ b/packages/file_selector/file_selector/example/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/packages/file_selector/file_selector/pubspec.yaml
+++ b/packages/file_selector/file_selector/pubspec.yaml
@@ -23,5 +23,5 @@ dev_dependencies:
   pedantic: ^1.10.0
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"

--- a/packages/file_selector/file_selector_platform_interface/pubspec.yaml
+++ b/packages/file_selector/file_selector_platform_interface/pubspec.yaml
@@ -20,5 +20,5 @@ dev_dependencies:
   pedantic: ^1.10.0
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"

--- a/packages/file_selector/file_selector_web/example/pubspec.yaml
+++ b/packages/file_selector/file_selector_web/example/pubspec.yaml
@@ -17,5 +17,5 @@ dev_dependencies:
     sdk: flutter
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.27.0-0" # For integration_test from sdk

--- a/packages/file_selector/file_selector_web/pubspec.yaml
+++ b/packages/file_selector/file_selector_web/pubspec.yaml
@@ -24,5 +24,5 @@ dev_dependencies:
   pedantic: ^1.10.0
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"

--- a/packages/flutter_plugin_android_lifecycle/example/pubspec.yaml
+++ b/packages/flutter_plugin_android_lifecycle/example/pubspec.yaml
@@ -21,7 +21,7 @@ dev_dependencies:
   pedantic: ^1.8.0
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 flutter:
   uses-material-design: true

--- a/packages/flutter_plugin_android_lifecycle/pubspec.yaml
+++ b/packages/flutter_plugin_android_lifecycle/pubspec.yaml
@@ -4,7 +4,7 @@ version: 2.0.1
 homepage: https://github.com/flutter/plugins/tree/master/packages/flutter_plugin_android_lifecycle
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"
 
 dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates how to use the google_maps_flutter plugin.
 publish_to: none
 
 environment:
-  sdk: '>=2.12.0-259.9.beta <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
   flutter: ">=1.22.0"
 
 dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -32,5 +32,5 @@ flutter:
         pluginClass: FLTGoogleMapsPlugin
 
 environment:
-  sdk: '>=2.12.0-259.9.beta <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
   flutter: ">=1.22.0"

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
@@ -20,5 +20,5 @@ dev_dependencies:
   pedantic: ^1.10.0
 
 environment:
-  sdk: '>=2.12.0-259.9.beta <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
   flutter: ">=1.9.1+hotfix.4"

--- a/packages/google_sign_in/google_sign_in/example/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in/example/pubspec.yaml
@@ -25,5 +25,5 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.12.13+hotfix.4"

--- a/packages/google_sign_in/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in/pubspec.yaml
@@ -33,5 +33,5 @@ dev_dependencies:
     sdk: flutter
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.12.13+hotfix.5"

--- a/packages/google_sign_in/google_sign_in_platform_interface/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_platform_interface/pubspec.yaml
@@ -18,5 +18,5 @@ dev_dependencies:
   pedantic: ^1.10.0
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.12.13+hotfix.5"

--- a/packages/google_sign_in/google_sign_in_web/example/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_web/example/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_sign_in_web_integration_tests
 publish_to: none
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.27.0-0" # For integration_test from sdk
 
 dependencies:

--- a/packages/google_sign_in/google_sign_in_web/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_web/pubspec.yaml
@@ -26,5 +26,5 @@ dev_dependencies:
   pedantic: ^1.10.0
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"

--- a/packages/image_picker/image_picker/example/pubspec.yaml
+++ b/packages/image_picker/image_picker/example/pubspec.yaml
@@ -26,5 +26,5 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.10.0"

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -32,5 +32,5 @@ dev_dependencies:
   plugin_platform_interface: ^2.0.0
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.10.0"

--- a/packages/image_picker/image_picker_for_web/pubspec.yaml
+++ b/packages/image_picker/image_picker_for_web/pubspec.yaml
@@ -25,5 +25,5 @@ dev_dependencies:
     sdk: flutter
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"

--- a/packages/image_picker/image_picker_platform_interface/pubspec.yaml
+++ b/packages/image_picker/image_picker_platform_interface/pubspec.yaml
@@ -18,5 +18,5 @@ dev_dependencies:
   pedantic: ^1.10.0
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.10.0"

--- a/packages/in_app_purchase/in_app_purchase/example/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase/example/pubspec.yaml
@@ -25,5 +25,5 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.9.1+hotfix.2"

--- a/packages/in_app_purchase/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase/pubspec.yaml
@@ -32,5 +32,5 @@ flutter:
         pluginClass: InAppPurchasePlugin
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.12.13+hotfix.5"

--- a/packages/ios_platform_images/example/pubspec.yaml
+++ b/packages/ios_platform_images/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 homepage: https://github.com/flutter/plugins/tree/master/packages/ios_platform_images/ios_platform_images
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/packages/ios_platform_images/pubspec.yaml
+++ b/packages/ios_platform_images/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.2.0
 homepage: https://github.com/flutter/plugins/tree/master/packages/ios_platform_images/ios_platform_images
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.12.13+hotfix.5"
 
 dependencies:

--- a/packages/local_auth/example/pubspec.yaml
+++ b/packages/local_auth/example/pubspec.yaml
@@ -24,5 +24,5 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.12.13+hotfix.5"

--- a/packages/local_auth/pubspec.yaml
+++ b/packages/local_auth/pubspec.yaml
@@ -31,5 +31,5 @@ dev_dependencies:
   pedantic: ^1.10.0
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.12.13+hotfix.5"

--- a/packages/package_info/example/pubspec.yaml
+++ b/packages/package_info/example/pubspec.yaml
@@ -24,5 +24,5 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.12.13+hotfix.5"

--- a/packages/package_info/pubspec.yaml
+++ b/packages/package_info/pubspec.yaml
@@ -29,5 +29,5 @@ dev_dependencies:
   pedantic: ^1.10.0
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.12.13+hotfix.5"

--- a/packages/path_provider/path_provider/example/pubspec.yaml
+++ b/packages/path_provider/path_provider/example/pubspec.yaml
@@ -24,5 +24,5 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.12.13+hotfix.5"

--- a/packages/path_provider/path_provider/pubspec.yaml
+++ b/packages/path_provider/path_provider/pubspec.yaml
@@ -38,5 +38,5 @@ dev_dependencies:
   test: ^1.16.0
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.12.13+hotfix.5"

--- a/packages/path_provider/path_provider_linux/example/pubspec.yaml
+++ b/packages/path_provider/path_provider_linux/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates how to use the path_provider_linux plugin.
 publish_to: "none"
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"
 
 dependencies:

--- a/packages/path_provider/path_provider_linux/pubspec.yaml
+++ b/packages/path_provider/path_provider_linux/pubspec.yaml
@@ -11,7 +11,7 @@ flutter:
         pluginClass: none
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"
 
 dependencies:

--- a/packages/path_provider/path_provider_macos/example/pubspec.yaml
+++ b/packages/path_provider/path_provider_macos/example/pubspec.yaml
@@ -25,5 +25,5 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"

--- a/packages/path_provider/path_provider_macos/pubspec.yaml
+++ b/packages/path_provider/path_provider_macos/pubspec.yaml
@@ -10,7 +10,7 @@ flutter:
         pluginClass: PathProviderPlugin
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"
 
 dependencies:

--- a/packages/path_provider/path_provider_platform_interface/pubspec.yaml
+++ b/packages/path_provider/path_provider_platform_interface/pubspec.yaml
@@ -18,5 +18,5 @@ dev_dependencies:
   pedantic: ^1.10.0
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"

--- a/packages/path_provider/path_provider_windows/example/pubspec.yaml
+++ b/packages/path_provider/path_provider_windows/example/pubspec.yaml
@@ -24,5 +24,5 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"

--- a/packages/path_provider/path_provider_windows/pubspec.yaml
+++ b/packages/path_provider/path_provider_windows/pubspec.yaml
@@ -25,5 +25,5 @@ dev_dependencies:
   pedantic: ^1.10.0
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"

--- a/packages/plugin_platform_interface/pubspec.yaml
+++ b/packages/plugin_platform_interface/pubspec.yaml
@@ -17,7 +17,7 @@ version: 2.0.0
 repository: https://github.com/flutter/plugins/tree/master/packages/plugin_platform_interface
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   meta: ^1.3.0

--- a/packages/quick_actions/quick_actions/example/pubspec.yaml
+++ b/packages/quick_actions/quick_actions/example/pubspec.yaml
@@ -24,5 +24,5 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.9.1+hotfix.2"

--- a/packages/quick_actions/quick_actions_platform_interface/pubspec.yaml
+++ b/packages/quick_actions/quick_actions_platform_interface/pubspec.yaml
@@ -18,5 +18,5 @@ dev_dependencies:
   pedantic: ^1.11.0
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.22.0"

--- a/packages/sensors/example/pubspec.yaml
+++ b/packages/sensors/example/pubspec.yaml
@@ -24,5 +24,5 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"

--- a/packages/sensors/pubspec.yaml
+++ b/packages/sensors/pubspec.yaml
@@ -27,5 +27,5 @@ dev_dependencies:
   pedantic: ^1.10.0
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.12.13+hotfix.5"

--- a/packages/share/example/pubspec.yaml
+++ b/packages/share/example/pubspec.yaml
@@ -25,5 +25,5 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.9.1+hotfix.2"

--- a/packages/share/pubspec.yaml
+++ b/packages/share/pubspec.yaml
@@ -28,4 +28,4 @@ dev_dependencies:
 
 environment:
   flutter: ">=1.12.13+hotfix.5"
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"

--- a/packages/shared_preferences/shared_preferences/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences/example/pubspec.yaml
@@ -24,5 +24,5 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.9.1+hotfix.2"

--- a/packages/shared_preferences/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences/pubspec.yaml
@@ -46,5 +46,5 @@ dev_dependencies:
   pedantic: ^1.10.0
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.12.13+hotfix.5"

--- a/packages/shared_preferences/shared_preferences_linux/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_linux/example/pubspec.yaml
@@ -24,5 +24,5 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"

--- a/packages/shared_preferences/shared_preferences_linux/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_linux/pubspec.yaml
@@ -11,7 +11,7 @@ flutter:
         pluginClass: none
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"
 
 dependencies:

--- a/packages/shared_preferences/shared_preferences_macos/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_macos/example/pubspec.yaml
@@ -25,5 +25,5 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.12.8"

--- a/packages/shared_preferences/shared_preferences_macos/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_macos/pubspec.yaml
@@ -10,7 +10,7 @@ flutter:
         pluginClass: SharedPreferencesPlugin
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"
 
 dependencies:

--- a/packages/shared_preferences/shared_preferences_platform_interface/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_platform_interface/pubspec.yaml
@@ -13,5 +13,5 @@ dev_dependencies:
   pedantic: ^1.10.0
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.12.8"

--- a/packages/shared_preferences/shared_preferences_web/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_web/pubspec.yaml
@@ -24,5 +24,5 @@ dev_dependencies:
   pedantic: ^1.10.0
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"

--- a/packages/shared_preferences/shared_preferences_windows/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_windows/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates how to use the shared_preferences_windows plugin.
 publish_to: none
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"
 
 dependencies:

--- a/packages/shared_preferences/shared_preferences_windows/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_windows/pubspec.yaml
@@ -12,7 +12,7 @@ flutter:
         pluginClass: none
 
 environment:
-  sdk: '>=2.12.0-259.9.beta <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
   flutter: ">=1.20.0"
 
 dependencies:

--- a/packages/url_launcher/url_launcher/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/example/pubspec.yaml
@@ -26,5 +26,5 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.12.13+hotfix.5"

--- a/packages/url_launcher/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/pubspec.yaml
@@ -44,5 +44,5 @@ dev_dependencies:
   pedantic: ^1.10.0
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.12.13+hotfix.5"

--- a/packages/url_launcher/url_launcher_linux/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_linux/example/pubspec.yaml
@@ -25,5 +25,5 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"

--- a/packages/url_launcher/url_launcher_linux/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_linux/pubspec.yaml
@@ -11,7 +11,7 @@ flutter:
         pluginClass: UrlLauncherPlugin
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"
 
 dependencies:

--- a/packages/url_launcher/url_launcher_macos/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_macos/example/pubspec.yaml
@@ -25,5 +25,5 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"

--- a/packages/url_launcher/url_launcher_macos/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_macos/pubspec.yaml
@@ -12,7 +12,7 @@ flutter:
         fileName: url_launcher_macos.dart
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"
 
 dependencies:

--- a/packages/url_launcher/url_launcher_platform_interface/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_platform_interface/pubspec.yaml
@@ -17,5 +17,5 @@ dev_dependencies:
   pedantic: ^1.10.0
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.22.0"

--- a/packages/url_launcher/url_launcher_web/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_web/example/pubspec.yaml
@@ -18,5 +18,5 @@ dev_dependencies:
     sdk: flutter
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.26.0-0" # For integration_test from sdk

--- a/packages/url_launcher/url_launcher_web/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_web/pubspec.yaml
@@ -24,5 +24,5 @@ dev_dependencies:
     sdk: flutter
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"

--- a/packages/url_launcher/url_launcher_windows/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_windows/example/pubspec.yaml
@@ -25,5 +25,5 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"

--- a/packages/url_launcher/url_launcher_windows/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_windows/pubspec.yaml
@@ -11,7 +11,7 @@ flutter:
         pluginClass: UrlLauncherPlugin
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"
 
 dependencies:

--- a/packages/video_player/video_player/example/pubspec.yaml
+++ b/packages/video_player/video_player/example/pubspec.yaml
@@ -31,5 +31,5 @@ flutter:
    - assets/bumble_bee_captions.srt
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.12.13+hotfix.5"

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -37,5 +37,5 @@ dev_dependencies:
   pigeon: ^0.1.21
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.12.13+hotfix.5"

--- a/packages/video_player/video_player_platform_interface/pubspec.yaml
+++ b/packages/video_player/video_player_platform_interface/pubspec.yaml
@@ -16,5 +16,5 @@ dev_dependencies:
   pedantic: ^1.10.0
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"

--- a/packages/video_player/video_player_web/pubspec.yaml
+++ b/packages/video_player/video_player_web/pubspec.yaml
@@ -24,5 +24,5 @@ dev_dependencies:
   pedantic: ^1.10.0
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"

--- a/packages/webview_flutter/example/pubspec.yaml
+++ b/packages/webview_flutter/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates how to use the webview_flutter plugin.
 publish_to: none
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/flutter/plugins/tree/master/packages/webview_flutte
 version: 2.0.4
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.22.0"
 
 dependencies:

--- a/packages/wifi_info_flutter/wifi_info_flutter/example/pubspec.yaml
+++ b/packages/wifi_info_flutter/wifi_info_flutter/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates how to use the wifi_info_flutter plugin.
 publish_to: none
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   connectivity: ^3.0.0

--- a/packages/wifi_info_flutter/wifi_info_flutter/pubspec.yaml
+++ b/packages/wifi_info_flutter/wifi_info_flutter/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/flutter/plugins/tree/master/packages/wifi_info_flut
 version: 2.0.0
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"
 
 dependencies:

--- a/packages/wifi_info_flutter/wifi_info_flutter_platform_interface/pubspec.yaml
+++ b/packages/wifi_info_flutter/wifi_info_flutter_platform_interface/pubspec.yaml
@@ -6,7 +6,7 @@ version: 2.0.1
 homepage: https://github.com/flutter/plugins/tree/master/packages/wifi_info_flutter/wifi_info_flutter_platform_interface
 
 environment:
-  sdk: ">=2.12.0-259.9.beta <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.17.0"
 
 dependencies:

--- a/script/tool/lib/src/publish_check_command.dart
+++ b/script/tool/lib/src/publish_check_command.dart
@@ -22,7 +22,7 @@ class PublishCheckCommand extends PluginCommand {
     argParser.addFlag(
       _allowPrereleaseFlag,
       help: 'Allows the pre-release SDK warning to pass.\n'
-          'When enabled, a pub warning, which asks to publish the package as a pre-release version when'
+          'When enabled, a pub warning, which asks to publish the package as a pre-release version when '
           'the SDK constraint is a pre-release version, is ignored.',
       defaultsTo: false,
     );

--- a/script/tool/lib/src/publish_check_command.dart
+++ b/script/tool/lib/src/publish_check_command.dart
@@ -74,37 +74,8 @@ class PublishCheckCommand extends PluginCommand {
       workingDirectory: package,
     );
 
-    final StringBuffer outputBuffer = StringBuffer();
 
-    final Completer<void> stdOutCompleter = Completer<void>();
-    process.stdout.listen(
-      (List<int> event) {
-        io.stdout.add(event);
-        outputBuffer.write(String.fromCharCodes(event));
-      },
-      onDone: () => stdOutCompleter.complete(),
-    );
-
-    final Completer<void> stdInCompleter = Completer<void>();
-    process.stderr.listen(
-      (List<int> event) {
-        io.stderr.add(event);
-        outputBuffer.write(String.fromCharCodes(event));
-      },
-      onDone: () => stdInCompleter.complete(),
-    );
-
-    if (await process.exitCode == 0) {
-      return true;
-    }
-
-    await stdOutCompleter.future;
-    await stdInCompleter.future;
-
-    final String output = outputBuffer.toString();
-    return output.contains('Package has 1 warning') &&
-        output.contains(
-            'Packages with an SDK constraint on a pre-release of the Dart SDK should themselves be published as a pre-release version.');
+    return await process.exitCode == 0;
   }
 
   Future<bool> _passesPublishCheck(Directory package) async {

--- a/script/tool/lib/src/publish_check_command.dart
+++ b/script/tool/lib/src/publish_check_command.dart
@@ -21,7 +21,7 @@ class PublishCheckCommand extends PluginCommand {
   }) : super(packagesDir, fileSystem, processRunner: processRunner) {
     argParser.addFlag(
       _allowPrereleaseFlag,
-      help: 'Allows the pre-release SDK warning to pass.'
+      help: 'Allows the pre-release SDK warning to pass.\n'
           'When enabled, a pub warning, which asks to publish the package as a pre-release version when'
           'the SDK constraint is a pre-release version, is ignored.',
       defaultsTo: false,

--- a/script/tool/lib/src/publish_check_command.dart
+++ b/script/tool/lib/src/publish_check_command.dart
@@ -18,7 +18,17 @@ class PublishCheckCommand extends PluginCommand {
     Directory packagesDir,
     FileSystem fileSystem, {
     ProcessRunner processRunner = const ProcessRunner(),
-  }) : super(packagesDir, fileSystem, processRunner: processRunner);
+  }) : super(packagesDir, fileSystem, processRunner: processRunner) {
+    argParser.addFlag(
+      _allowPrereleaseFlag,
+      help: 'Allows the pre-release SDK warning to pass.'
+          'When enabled, a pub warning, which asks to publish the package as a pre-release version when'
+          'the SDK constraint is a pre-release version, is ignored.',
+      defaultsTo: false,
+    );
+  }
+
+  static const String _allowPrereleaseFlag = 'allow-pre-release';
 
   @override
   final String name = 'publish-check';
@@ -96,6 +106,10 @@ class PublishCheckCommand extends PluginCommand {
 
     if (await process.exitCode == 0) {
       return true;
+    }
+
+    if (!(argResults[_allowPrereleaseFlag] as bool)) {
+      return false;
     }
 
     await stdOutCompleter.future;

--- a/script/tool/lib/src/publish_check_command.dart
+++ b/script/tool/lib/src/publish_check_command.dart
@@ -74,8 +74,37 @@ class PublishCheckCommand extends PluginCommand {
       workingDirectory: package,
     );
 
+    final StringBuffer outputBuffer = StringBuffer();
 
-    return await process.exitCode == 0;
+    final Completer<void> stdOutCompleter = Completer<void>();
+    process.stdout.listen(
+      (List<int> event) {
+        io.stdout.add(event);
+        outputBuffer.write(String.fromCharCodes(event));
+      },
+      onDone: () => stdOutCompleter.complete(),
+    );
+
+    final Completer<void> stdInCompleter = Completer<void>();
+    process.stderr.listen(
+      (List<int> event) {
+        io.stderr.add(event);
+        outputBuffer.write(String.fromCharCodes(event));
+      },
+      onDone: () => stdInCompleter.complete(),
+    );
+
+    if (await process.exitCode == 0) {
+      return true;
+    }
+
+    await stdOutCompleter.future;
+    await stdInCompleter.future;
+
+    final String output = outputBuffer.toString();
+    return output.contains('Package has 1 warning') &&
+        output.contains(
+            'Packages with an SDK constraint on a pre-release of the Dart SDK should themselves be published as a pre-release version.');
   }
 
   Future<bool> _passesPublishCheck(Directory package) async {

--- a/script/tool/test/publish_check_command_test.dart
+++ b/script/tool/test/publish_check_command_test.dart
@@ -89,24 +89,6 @@ void main() {
       expect(() => runner.run(<String>['publish-check']),
           throwsA(isA<ToolExit>()));
     });
-
-    test('pass on prerelease', () async {
-      createFakePlugin('d');
-
-      const String preReleaseOutput = 'Package has 1 warning.'
-          'Packages with an SDK constraint on a pre-release of the Dart SDK should themselves be published as a pre-release version.';
-
-      final MockProcess process = MockProcess();
-      process.stdoutController.add(preReleaseOutput.codeUnits);
-      process.stdoutController.close(); // ignore: unawaited_futures
-      process.stderrController.close(); // ignore: unawaited_futures
-
-      process.exitCodeCompleter.complete(1);
-
-      processRunner.processesToReturn.add(process);
-
-      expect(runner.run(<String>['publish-check']), completes);
-    });
   });
 }
 

--- a/script/tool/test/publish_check_command_test.dart
+++ b/script/tool/test/publish_check_command_test.dart
@@ -90,7 +90,7 @@ void main() {
           throwsA(isA<ToolExit>()));
     });
 
-    test('pass on prerelease is --allow-pre-release flag is on', () async {
+    test('pass on prerelease if --allow-pre-release flag is on', () async {
       createFakePlugin('d');
 
       const String preReleaseOutput = 'Package has 1 warning.'
@@ -107,6 +107,24 @@ void main() {
 
       expect(runner.run(<String>['publish-check', '--allow-pre-release']),
           completes);
+    });
+
+    test('fail on prerelease if --allow-pre-release flag is off', () async {
+      createFakePlugin('d');
+
+      const String preReleaseOutput = 'Package has 1 warning.'
+          'Packages with an SDK constraint on a pre-release of the Dart SDK should themselves be published as a pre-release version.';
+
+      final MockProcess process = MockProcess();
+      process.stdoutController.add(preReleaseOutput.codeUnits);
+      process.stdoutController.close(); // ignore: unawaited_futures
+      process.stderrController.close(); // ignore: unawaited_futures
+
+      process.exitCodeCompleter.complete(1);
+
+      processRunner.processesToReturn.add(process);
+
+      expect(runner.run(<String>['publish-check']), throwsA(isA<ToolExit>()));
     });
   });
 }

--- a/script/tool/test/publish_check_command_test.dart
+++ b/script/tool/test/publish_check_command_test.dart
@@ -89,6 +89,24 @@ void main() {
       expect(() => runner.run(<String>['publish-check']),
           throwsA(isA<ToolExit>()));
     });
+
+    test('fail on prerelease', () async {
+      createFakePlugin('d');
+
+      const String preReleaseOutput = 'Package has 1 warning.'
+          'Packages with an SDK constraint on a pre-release of the Dart SDK should themselves be published as a pre-release version.';
+
+      final MockProcess process = MockProcess();
+      process.stdoutController.add(preReleaseOutput.codeUnits);
+      process.stdoutController.close(); // ignore: unawaited_futures
+      process.stderrController.close(); // ignore: unawaited_futures
+
+      process.exitCodeCompleter.complete(1);
+
+      processRunner.processesToReturn.add(process);
+
+      expect(runner.run(<String>['publish-check']), throwsA(isA<ToolExit>()));
+    });
   });
 }
 

--- a/script/tool/test/publish_check_command_test.dart
+++ b/script/tool/test/publish_check_command_test.dart
@@ -90,7 +90,7 @@ void main() {
           throwsA(isA<ToolExit>()));
     });
 
-    test('fail on prerelease', () async {
+    test('pass on prerelease is --allow-pre-release flag is on', () async {
       createFakePlugin('d');
 
       const String preReleaseOutput = 'Package has 1 warning.'
@@ -105,7 +105,8 @@ void main() {
 
       processRunner.processesToReturn.add(process);
 
-      expect(runner.run(<String>['publish-check']), throwsA(isA<ToolExit>()));
+      expect(runner.run(<String>['publish-check', '--allow-pre-release']),
+          completes);
     });
   });
 }


### PR DESCRIPTION
This is mainly to remove the warning when `pub publish`. We can skip publishing this change for now.  