### PR TITLE
[in_app_purchase_platform_interface] Added additional fields to ProductDetails

### DIFF
--- a/packages/in_app_purchase/in_app_purchase_platform_interface/lib/src/types/product_details.dart
+++ b/packages/in_app_purchase/in_app_purchase_platform_interface/lib/src/types/product_details.dart
@@ -10,6 +10,8 @@ class ProductDetails {
     required this.title,
     required this.description,
     required this.price,
+    required this.rawPrice,
+    required this.currencyCode,
   });
 
   /// The identifier of the product.
@@ -31,4 +33,13 @@ class ProductDetails {
   ///
   /// For example, on iOS it is specified in App Store Connect; on Android, it is specified in Google Play Console.
   final String price;
+
+  /// The unformatted price of the product, specified in the App Store Connect or Sku in Google Play console based on the platform.
+  /// The currency unit for this value can be found in the [currencyCode] property.
+  /// The value always describes full units of the currency. (e.g. 2.45 in the case of $2.45)
+  final double rawPrice;
+
+  /// The currency code for the price of the product.
+  /// Based on the price specified in the App Store Connect or Sku in Google Play console based on the platform.
+  final String currencyCode;
 }

--- a/packages/in_app_purchase/in_app_purchase_platform_interface/test/src/types/product_details_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_platform_interface/test/src/types/product_details_test.dart
@@ -1,0 +1,29 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:in_app_purchase_platform_interface/in_app_purchase_platform_interface.dart';
+
+void main() {
+  group('Constructor Tests', () {
+    test(
+        'fromSkProduct should correctly parse data from a SKProductWrapper instance.',
+        () {
+      final ProductDetails productDetails = ProductDetails(
+        id: 'id',
+        title: 'title',
+        description: 'description',
+        price: '13.37',
+        currencyCode: 'USD',
+        rawPrice: 13.37
+      );
+
+      expect(productDetails.id, 'id');
+      expect(productDetails.title, 'title');
+      expect(productDetails.description, 'description');
+      expect(productDetails.rawPrice, 13.37);
+      expect(productDetails.currencyCode, 'USD');
+    });
+  });
+}

--- a/packages/in_app_purchase/in_app_purchase_platform_interface/test/src/types/product_details_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_platform_interface/test/src/types/product_details_test.dart
@@ -11,13 +11,12 @@ void main() {
         'fromSkProduct should correctly parse data from a SKProductWrapper instance.',
         () {
       final ProductDetails productDetails = ProductDetails(
-        id: 'id',
-        title: 'title',
-        description: 'description',
-        price: '13.37',
-        currencyCode: 'USD',
-        rawPrice: 13.37
-      );
+          id: 'id',
+          title: 'title',
+          description: 'description',
+          price: '13.37',
+          currencyCode: 'USD',
+          rawPrice: 13.37);
 
       expect(productDetails.id, 'id');
       expect(productDetails.title, 'title');


### PR DESCRIPTION
Adds the `rawPrice` and `currencyCode` fields to the `ProductDetails` class defined in the "in_app_purchase_platform_interface" package. 

These fields were added to the "in_app_purchase" package as part of PR #3794, but never made it in the initial definition of the "in_app_purchase_platform_interface".

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format](../script/tool/README.md#format-code))
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
