### PR TITLE
[google_sign_in] Fix issue obtaining serverAuthCode on Android and add forceCodeForRefreshToken parameter // Update

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -65,3 +65,5 @@ Anton Borries <mail@antonborri.es>
 Alex Li <google@alexv525.com>
 Rahul Raj <64.rahulraj@gmail.com>
 Daniel Roek <daniel.roek@gmail.com>
+Twin Sun, LLC <google-contrib@twinsunsolutions.com>
+Andrew Cardinot <andrewcardinot@gmail.com>

--- a/packages/google_sign_in/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.3
+
+* Add `force_code_for_refresh_token` option for Android, returns the right serverAuthCode
+
 ## 5.0.2
 
 * Fix flutter/flutter#48602 iOS flow shows account selection, if user is signed in to Google on the device.

--- a/packages/google_sign_in/google_sign_in/README.md
+++ b/packages/google_sign_in/google_sign_in/README.md
@@ -4,7 +4,7 @@
 
 A Flutter plugin for [Google Sign In](https://developers.google.com/identity/).
 
-*Note*: This plugin is still under development, and some APIs might not be available yet. [Feedback](https://github.com/flutter/flutter/issues) and [Pull Requests](https://github.com/flutter/plugins/pulls) are most welcome!
+_Note_: This plugin is still under development, and some APIs might not be available yet. [Feedback](https://github.com/flutter/flutter/issues) and [Pull Requests](https://github.com/flutter/plugins/pulls) are most welcome!
 
 ## Android integration
 
@@ -19,6 +19,8 @@ want to mimic the behavior of the Google Sign-In sample app, you'll need to
 enable the [Google People API](https://developers.google.com/people/).
 
 Make sure you've filled out all required fields in the console for [OAuth consent screen](https://console.developers.google.com/apis/credentials/consent). Otherwise, you may encounter `APIException` errors.
+
+If you need to force a server auth code to include a refresh token when exchanged for an access token, set `force_code_for_refresh_token` to true as in `google_sign_in/example/android/app/src/main/res/values/bools.xml`.
 
 ## iOS integration
 
@@ -63,9 +65,11 @@ plugin could be an option.
 ## Usage
 
 ### Import the package
+
 To use this plugin, follow the [plugin installation instructions](https://pub.dev/packages/google_sign_in#pub-pkg-tab-installing).
 
 ### Use the plugin
+
 Add the following import to your Dart code:
 
 ```dart
@@ -82,6 +86,7 @@ GoogleSignIn _googleSignIn = GoogleSignIn(
   ],
 );
 ```
+
 [Full list of available scopes](https://developers.google.com/identity/protocols/googlescopes).
 
 You can now use the `GoogleSignIn` class to authenticate in your Dart code, e.g.

--- a/packages/google_sign_in/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
+++ b/packages/google_sign_in/google_sign_in/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
@@ -348,7 +348,18 @@ public class GoogleSignInPlugin implements MethodCallHandler, FlutterPlugin, Act
           optionsBuilder.requestServerAuthCode(clientId);
         } else if (clientIdIdentifier != 0) {
           optionsBuilder.requestIdToken(context.getString(clientIdIdentifier));
-          optionsBuilder.requestServerAuthCode(context.getString(clientIdIdentifier));
+
+          boolean forceCodeForRefreshToken = false;
+          int forceCodeForRefreshTokenIdentifier =
+              context
+                  .getResources()
+                  .getIdentifier("force_code_for_refresh_token", "bool", context.getPackageName());
+          if (forceCodeForRefreshTokenIdentifier != 0) {
+            forceCodeForRefreshToken =
+                context.getResources().getBoolean(forceCodeForRefreshTokenIdentifier);
+          }
+          optionsBuilder.requestServerAuthCode(
+              context.getString(clientIdIdentifier), forceCodeForRefreshToken);
         }
         for (String scope : requestedScopes) {
           optionsBuilder.requestScopes(new Scope(scope));

--- a/packages/google_sign_in/google_sign_in/example/android/app/src/main/res/values/bools.xml
+++ b/packages/google_sign_in/google_sign_in/example/android/app/src/main/res/values/bools.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="force_code_for_refresh_token">false</bool>
+</resources>

--- a/packages/google_sign_in/google_sign_in/lib/google_sign_in.dart
+++ b/packages/google_sign_in/google_sign_in/lib/google_sign_in.dart
@@ -44,7 +44,8 @@ class GoogleSignInAccount implements GoogleIdentity {
         email = data.email,
         id = data.id,
         photoUrl = data.photoUrl,
-        _idToken = data.idToken {
+        _idToken = data.idToken,
+        _serverAuthCode = data.serverAuthCode {
     assert(id != null);
   }
 
@@ -70,6 +71,7 @@ class GoogleSignInAccount implements GoogleIdentity {
 
   final String? _idToken;
   final GoogleSignIn _googleSignIn;
+  final String _serverAuthCode;
 
   /// Retrieve [GoogleSignInAuthentication] for this account.
   ///
@@ -96,6 +98,9 @@ class GoogleSignInAccount implements GoogleIdentity {
     // the one we obtained on login.
     if (response.idToken == null) {
       response.idToken = _idToken;
+    }
+    if (response.serverAuthCode == null) {
+      response.serverAuthCode = _serverAuthCode;
     }
     return GoogleSignInAuthentication._(response);
   }

--- a/packages/google_sign_in/google_sign_in/lib/google_sign_in.dart
+++ b/packages/google_sign_in/google_sign_in/lib/google_sign_in.dart
@@ -71,7 +71,7 @@ class GoogleSignInAccount implements GoogleIdentity {
 
   final String? _idToken;
   final GoogleSignIn _googleSignIn;
-  final String _serverAuthCode;
+  final String? _serverAuthCode;
 
   /// Retrieve [GoogleSignInAuthentication] for this account.
   ///

--- a/packages/google_sign_in/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_sign_in
 description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android and iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_sign_in/google_sign_in
-version: 5.0.2
+version: 5.0.3
 
 flutter:
   plugin:

--- a/packages/google_sign_in/google_sign_in_platform_interface/lib/src/types.dart
+++ b/packages/google_sign_in/google_sign_in_platform_interface/lib/src/types.dart
@@ -31,7 +31,11 @@ class GoogleSignInUserData {
     this.displayName,
     this.photoUrl,
     this.idToken,
+    this.serverAuthCode
   });
+
+  /// Used to perform server-side actions with Google API
+  String? serverAuthCode;
 
   /// The display name of the signed in user.
   ///

--- a/packages/google_sign_in/google_sign_in_platform_interface/lib/src/utils.dart
+++ b/packages/google_sign_in/google_sign_in_platform_interface/lib/src/utils.dart
@@ -14,7 +14,8 @@ GoogleSignInUserData? getUserDataFromMap(Map<String, dynamic>? data) {
       id: data['id']!,
       displayName: data['displayName'],
       photoUrl: data['photoUrl'],
-      idToken: data['idToken']);
+      idToken: data['idToken'],
+      serverAuthCode: data['serverAuthCode']);
 }
 
 /// Converts token data coming from native code into the proper platform interface type.


### PR DESCRIPTION
This PR is a follow to #3356. It merges into the master keeping the master's preferences. It has been a long time since it was requested and the code has significantly changed. A few changes were needed to make it work with the current master. Therefore, I'm just updating #3356. The Pre-launch Checklist belongs to this PR, but the following info is a reference.

tl;dr `serverAuthCode` is returning the right value, not null. `forceCodeForRefreshToken` is now an option, it wasn't available before

To test it, sign in and get the `serverAuthCode`
`final user = await googleSignIn.signIn();`
`final googleAuth = await user.authentication;`
`final serverAuthCode = googleAuth.serverAuthCode`

To test `forceCodeForRefreshToken` update `values/bools.xml`
```
<?xml version="1.0" encoding="utf-8"?>
<resources>
    <bool name="force_code_for_refresh_token">false</bool>
</resources>
```
And refresh the sign in

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format](../script/tool/README.md#format-code))
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [X] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

### The description below comes from the previous #3356

## Description
This is a follow up to #2116 to fix the following issues:

- `serverAuthCode` is always null on Android because it is not passed to the `GoogleSignInAuthentication` object as that is created by the `getTokens` call rather than from the data obtained during the initial `signIn` call (which does contain a `serverAuthCode`, it's just not accessible anywhere that I can tell)

- A refresh token is only given to the server on the first sign in without the ability to set the `forceCodeForRefreshToken` parameter

## Related Issues

- flutter/flutter#17813

- flutter/flutter#14245

## Breaking Change
Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is not a breaking change.

## Festivus Note
As the season of Festivus is upon us, I do have a grievance to air from the last time I submitted a PR related to this plugin. I was told on #879 that my pull request to add the serverAuthCode (which worked on android, as a side note) would not be accepted without E2E tests using a test harness that wasn't even ready yet. You can imagine my surprise when #2116 was merged a few months later without them (no disrespect to the author of that PR, they did what was asked of them).