### PR TITLE
[in_app_purchase] Make PurchaseDetails.status mandatory

### DIFF
--- a/packages/in_app_purchase/in_app_purchase_platform_interface/lib/src/types/purchase_details.dart
+++ b/packages/in_app_purchase/in_app_purchase_platform_interface/lib/src/types/purchase_details.dart
@@ -14,6 +14,7 @@ class PurchaseDetails {
     required this.productID,
     required this.verificationData,
     required this.transactionDate,
+    required this.status,
   });
 
   /// A unique identifier of the purchase.
@@ -37,7 +38,7 @@ class PurchaseDetails {
   final String? transactionDate;
 
   /// The status that this [PurchaseDetails] is currently on.
-  PurchaseStatus? status;
+  PurchaseStatus status;
 
   /// The error details when the [status] is [PurchaseStatus.error].
   ///


### PR DESCRIPTION
While implementing the new `in_app_purchase_platform_interface` I noticed that the `PurchaseDetails.status` property was migrated as a nullable field while the implementations always consider it as a mandatory (non-nullable) field. 

This PR corrects this mistakes and makes sure the `PurchaseDetails.status` field doesn't accept a `null` value and when a new instance is created a status value has to be supplied.

The original migration PR can be found here: #3781 

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format](../script/tool/README.md#format-code))
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
