### PR TITLE
[camera] Limit camera preview size to take high quality picture with startImageStream

### DIFF
--- a/packages/camera/camera/ios/Classes/CameraPlugin.m
+++ b/packages/camera/camera/ios/Classes/CameraPlugin.m
@@ -534,21 +534,19 @@ NSString *const errorMethod = @"error";
       if (@available(iOS 9.0, *)) {
         if ([_captureSession canSetSessionPreset:AVCaptureSessionPreset3840x2160]) {
           _captureSession.sessionPreset = AVCaptureSessionPreset3840x2160;
-          _previewSize = CGSizeMake(3840, 2160);
+          _previewSize = CGSizeMake(1280, 720); // Limit preview resolution to resolutionPreset.high
           break;
         }
       }
       if ([_captureSession canSetSessionPreset:AVCaptureSessionPresetHigh]) {
         _captureSession.sessionPreset = AVCaptureSessionPresetHigh;
-        _previewSize =
-            CGSizeMake(_captureDevice.activeFormat.highResolutionStillImageDimensions.width,
-                       _captureDevice.activeFormat.highResolutionStillImageDimensions.height);
+        _previewSize = CGSizeMake(1280, 720); // Limit preview resolution to resolutionPreset.high
         break;
       }
     case veryHigh:
       if ([_captureSession canSetSessionPreset:AVCaptureSessionPreset1920x1080]) {
         _captureSession.sessionPreset = AVCaptureSessionPreset1920x1080;
-        _previewSize = CGSizeMake(1920, 1080);
+        _previewSize = CGSizeMake(1280, 720); // Limit preview resolution to resolutionPreset.high
         break;
       }
     case high:


### PR DESCRIPTION
This is related to the issue, https://github.com/flutter/flutter/issues/46082.
This is an important issue to enable real-time image analysis and take a picture in a Flutter app. 

In iOS, I tried to apply head pose estimation and taking a picture in a proper pose automatically, however, when I tried CameraController.startImageStream with ResolutionPreset.max for capture high quality picture, the app crashed unexpectedly. To resolve the problem, I should limit the resolution to ResolutionPreset.high, but in this case, generated pictures also have low resolution (which is 1280x720). 

In Android, the preview resolution is limited to 1280x720 (resolutionPreset.high) in the function computeBestPreviewSize in CameraUtils.java. Like this, I can resolve the problem by limiting _previewSize in iOS. So, I propose this PR. 

In the future, I recommend to set different resolution for preview and taking a picture by getting some arguments for flexibilities of the camera package.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format](../script/tool/README.md#format-code))
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
