### PR TITLE
Update third_party license checking

### DIFF
--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1
+
+- Update the allowed third-party licenses for flutter/packages.
+
 ## 0.1.0+1
 
 - Re-add the bin/ directory.

--- a/script/tool/lib/src/license_check_command.dart
+++ b/script/tool/lib/src/license_check_command.dart
@@ -52,10 +52,14 @@ const Set<String> _ignoredFullBasenameList = <String>{
 final List<RegExp> _thirdPartyLicenseBlockRegexes = <RegExp>[
 // Third-party code used in url_launcher_web.
   RegExp(
-      r'^// Copyright 2017 Workiva Inc..*'
-      '^// Licensed under the Apache License, Version 2.0',
+      r'^// Copyright 2017 Workiva Inc\..*'
+      r'^// Licensed under the Apache License, Version 2\.0',
       multiLine: true,
       dotAll: true),
+  // bsdiff in flutter/packages.
+  RegExp(r'// Copyright 2003-2005 Colin Percival\. All rights reserved\.\n'
+      r'// Use of this source code is governed by a BSD-style license that can be\n'
+      r'// found in the LICENSE file\.\n'),
 ];
 
 // The exact format of the BSD license that our license files should contain.
@@ -158,16 +162,19 @@ class LicenseCheckCommand extends PluginCommand {
       _print('Checking ${file.path}');
       final String content = await file.readAsString();
 
+      final String firstParyLicense =
+          firstPartyLicenseBlockByExtension[p.extension(file.path)] ??
+              defaultFirstParyLicenseBlock;
       if (_isThirdParty(file)) {
+        // Third-party directories allow either known third-party licenses, our
+        // the first-party license, as there may be local additions.
         if (!_thirdPartyLicenseBlockRegexes
-            .any((RegExp regex) => regex.hasMatch(content))) {
+                .any((RegExp regex) => regex.hasMatch(content)) &&
+            !content.contains(firstParyLicense)) {
           unrecognizedThirdPartyFiles.add(file);
         }
       } else {
-        final String license =
-            firstPartyLicenseBlockByExtension[p.extension(file.path)] ??
-                defaultFirstParyLicenseBlock;
-        if (!content.contains(license)) {
+        if (!content.contains(firstParyLicense)) {
           incorrectFirstPartyFiles.add(file);
         }
       }

--- a/script/tool/pubspec.yaml
+++ b/script/tool/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_plugin_tools
 description: Productivity utils for flutter/plugins and flutter/packages
 repository: https://github.com/flutter/plugins/tree/master/script/tool
-version: 0.1.0+1
+version: 0.1.1
 
 dependencies:
   args: "^1.4.3"

--- a/script/tool/test/license_check_command_test.dart
+++ b/script/tool/test/license_check_command_test.dart
@@ -269,6 +269,24 @@ void main() {
       expect(printedMessages, contains('All source files passed validation!'));
     });
 
+    test('allows first-party code in a third_party directory', () async {
+      final File firstPartyFileInThirdParty = root
+          .childDirectory('a_plugin')
+          .childDirectory('lib')
+          .childDirectory('src')
+          .childDirectory('third_party')
+          .childFile('first_party.cc');
+      firstPartyFileInThirdParty.createSync(recursive: true);
+      _writeLicense(firstPartyFileInThirdParty);
+
+      await runner.run(<String>['license-check']);
+
+      // Sanity check that the test did actually check the file.
+      expect(printedMessages,
+          contains('Checking a_plugin/lib/src/third_party/first_party.cc'));
+      expect(printedMessages, contains('All source files passed validation!'));
+    });
+
     test('fails for licenses that the tool does not expect', () async {
       final File good = root.childFile('good.cc');
       good.createSync();


### PR DESCRIPTION
In preparation for enabling license checks in flutter/packages, update
the allowed licenses:
- Allow our license, for cases where we've locally added files
- Allow the license used by the bsdiff package

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format](../script/tool/README.md#format-code))
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
