### PR TITLE
Add support for third_party packages in Dart code

### DIFF
--- a/script/tool/lib/src/common.dart
+++ b/script/tool/lib/src/common.dart
@@ -300,8 +300,8 @@ abstract class PluginCommand extends Command<void> {
   /// Returns the root Dart package folders of the plugins involved in this
   /// command execution, assuming there is only one shard.
   ///
-  /// Plugin packages can exist in one of two places relative to the packages
-  /// directory.
+  /// Plugin packages can exist in the following places relative to the packages
+  /// directory:
   ///
   /// 1. As a Dart package in a directory which is a direct child of the
   ///    packages directory. This is a plugin where all of the implementations
@@ -311,6 +311,9 @@ abstract class PluginCommand extends Command<void> {
   ///    packages which implement a single plugin. This directory contains a
   ///    "client library" package, which declares the API for the plugin, as
   ///    well as one or more platform-specific implementations.
+  /// 3./4. Either of the above, but in a third_party/packages/ directory that
+  ///    is a sibling of the packages directory. This is used for a small number
+  ///    of packages in the flutter/packages repository.
   Stream<Directory> _getAllPlugins() async* {
     Set<String> plugins =
         Set<String>.from(argResults[_pluginsArg] as List<String>);
@@ -322,33 +325,42 @@ abstract class PluginCommand extends Command<void> {
       plugins = await _getChangedPackages();
     }
 
-    await for (final FileSystemEntity entity
-        in packagesDir.list(followLinks: false)) {
-      // A top-level Dart package is a plugin package.
-      if (_isDartPackage(entity)) {
-        if (!excludedPlugins.contains(entity.basename) &&
-            (plugins.isEmpty || plugins.contains(p.basename(entity.path)))) {
-          yield entity as Directory;
-        }
-      } else if (entity is Directory) {
-        // Look for Dart packages under this top-level directory.
-        await for (final FileSystemEntity subdir
-            in entity.list(followLinks: false)) {
-          if (_isDartPackage(subdir)) {
-            // If --plugin=my_plugin is passed, then match all federated
-            // plugins under 'my_plugin'. Also match if the exact plugin is
-            // passed.
-            final String relativePath =
-                p.relative(subdir.path, from: packagesDir.path);
-            final String packageName = p.basename(subdir.path);
-            final String basenamePath = p.basename(entity.path);
-            if (!excludedPlugins.contains(basenamePath) &&
-                !excludedPlugins.contains(packageName) &&
-                !excludedPlugins.contains(relativePath) &&
-                (plugins.isEmpty ||
-                    plugins.contains(relativePath) ||
-                    plugins.contains(basenamePath))) {
-              yield subdir as Directory;
+    final Directory thirdPartyPackagesDirectory = packagesDir.parent
+        .childDirectory('third_party')
+        .childDirectory('packages');
+
+    for (final Directory dir in <Directory>[
+      packagesDir,
+      if (thirdPartyPackagesDirectory.existsSync()) thirdPartyPackagesDirectory,
+    ]) {
+      await for (final FileSystemEntity entity
+          in dir.list(followLinks: false)) {
+        // A top-level Dart package is a plugin package.
+        if (_isDartPackage(entity)) {
+          if (!excludedPlugins.contains(entity.basename) &&
+              (plugins.isEmpty || plugins.contains(p.basename(entity.path)))) {
+            yield entity as Directory;
+          }
+        } else if (entity is Directory) {
+          // Look for Dart packages under this top-level directory.
+          await for (final FileSystemEntity subdir
+              in entity.list(followLinks: false)) {
+            if (_isDartPackage(subdir)) {
+              // If --plugin=my_plugin is passed, then match all federated
+              // plugins under 'my_plugin'. Also match if the exact plugin is
+              // passed.
+              final String relativePath =
+                  p.relative(subdir.path, from: dir.path);
+              final String packageName = p.basename(subdir.path);
+              final String basenamePath = p.basename(entity.path);
+              if (!excludedPlugins.contains(basenamePath) &&
+                  !excludedPlugins.contains(packageName) &&
+                  !excludedPlugins.contains(relativePath) &&
+                  (plugins.isEmpty ||
+                      plugins.contains(relativePath) ||
+                      plugins.contains(basenamePath))) {
+                yield subdir as Directory;
+              }
             }
           }
         }
@@ -449,8 +461,9 @@ abstract class PluginCommand extends Command<void> {
     if (packages.isNotEmpty) {
       final String changedPackages = packages.join(',');
       print(changedPackages);
+    } else {
+      print('No changed packages.');
     }
-    print('No changed packages.');
     return packages;
   }
 }

--- a/script/tool/test/util.dart
+++ b/script/tool/test/util.dart
@@ -63,19 +63,17 @@ Directory createFakePlugin(
   final Directory pluginDirectory = parentDirectory.childDirectory(name);
   pluginDirectory.createSync(recursive: true);
 
-  createFakePubspec(
-    pluginDirectory,
-    name: name,
-    isFlutter: isFlutter,
-    isAndroidPlugin: isAndroidPlugin,
-    isIosPlugin: isIosPlugin,
-    isWebPlugin: isWebPlugin,
-    isLinuxPlugin: isLinuxPlugin,
-    isMacOsPlugin: isMacOsPlugin,
-    isWindowsPlugin: isWindowsPlugin,
-    includeVersion: includeVersion,
-    version: version
-  );
+  createFakePubspec(pluginDirectory,
+      name: name,
+      isFlutter: isFlutter,
+      isAndroidPlugin: isAndroidPlugin,
+      isIosPlugin: isIosPlugin,
+      isWebPlugin: isWebPlugin,
+      isLinuxPlugin: isLinuxPlugin,
+      isMacOsPlugin: isMacOsPlugin,
+      isWindowsPlugin: isWindowsPlugin,
+      includeVersion: includeVersion,
+      version: version);
   if (includeChangeLog) {
     createFakeCHANGELOG(pluginDirectory, '''
 ## 0.0.1
@@ -87,21 +85,28 @@ Directory createFakePlugin(
     final Directory exampleDir = pluginDirectory.childDirectory('example')
       ..createSync();
     createFakePubspec(exampleDir,
-        name: '${name}_example', isFlutter: isFlutter, includeVersion: false, publishTo: 'none');
+        name: '${name}_example',
+        isFlutter: isFlutter,
+        includeVersion: false,
+        publishTo: 'none');
   } else if (withExamples.isNotEmpty) {
     final Directory exampleDir = pluginDirectory.childDirectory('example')
       ..createSync();
     for (final String example in withExamples) {
       final Directory currentExample = exampleDir.childDirectory(example)
         ..createSync();
-      createFakePubspec(currentExample, name: example, isFlutter: isFlutter, includeVersion: false, publishTo: 'none');
+      createFakePubspec(currentExample,
+          name: example,
+          isFlutter: isFlutter,
+          includeVersion: false,
+          publishTo: 'none');
     }
   }
 
+  final FileSystem fileSystem = pluginDirectory.fileSystem;
   for (final List<String> file in withExtraFiles) {
     final List<String> newFilePath = <String>[pluginDirectory.path, ...file];
-    final File newFile =
-        mockFileSystem.file(mockFileSystem.path.joinAll(newFilePath));
+    final File newFile = fileSystem.file(fileSystem.path.joinAll(newFilePath));
     newFile.createSync(recursive: true);
   }
 
@@ -186,7 +191,7 @@ version: $version
 ''';
   }
   if (publishTo.isNotEmpty) {
-     yaml += '''
+    yaml += '''
 publish_to: $publishTo # Hardcoded safeguard to prevent this from somehow being published by a broken test.
 ''';
   }


### PR DESCRIPTION
flutter/packages has two packages in third_party/packages/, which wasn't something our tooling recognized, so no package-based CI checks are running on them. This adds knowledge that there can be a third_party/packages/ directory as a sibling of the primary packages directory.

Also migrates common_tests off of the shared (now deprecated) mock filesystem and onto a test-local mock filesystem.

Fixes https://github.com/flutter/flutter/issues/81570

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format](../script/tool/README.md#format-code))
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
