### PR TITLE
[google_maps_flutter] Unpin iOS GoogleMaps pod dependency version

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.4
+
+* Unpin iOS GoogleMaps pod dependency version.
+
 ## 2.0.3
 
 * Fix incorrect typecast in TileOverlay example.

--- a/packages/google_maps_flutter/google_maps_flutter/ios/google_maps_flutter.podspec
+++ b/packages/google_maps_flutter/google_maps_flutter/ios/google_maps_flutter.podspec
@@ -17,8 +17,7 @@ Downloaded by pub (not CocoaPods).
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  # TODO: Unpin this once the fix for b/163474612 or b/163359804 rolls (avoid v3.10!)
-  s.dependency 'GoogleMaps', '< 3.10'
+  s.dependency 'GoogleMaps'
   s.static_framework = true
   s.platform = :ios, '8.0'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter/google_maps_flutter
-version: 2.0.3
+version: 2.0.4
 
 dependencies:
   flutter:


### PR DESCRIPTION
The plugins infrastructure has migrated past Xcode 11.5, which is related to the original reason this was pinned.

This is already tested in presubmit and a failure will look like the original reported https://github.com/flutter/flutter/issues/63447.

Fixes https://github.com/flutter/flutter/issues/63530.  
See also https://github.com/flutter/plugins/pull/2924