### PR TITLE
[in_app_purchase] Add InAppPurchaseException to platform interface

### DIFF
--- a/packages/in_app_purchase/in_app_purchase_platform_interface/lib/in_app_purchase_platform_interface.dart
+++ b/packages/in_app_purchase/in_app_purchase_platform_interface/lib/in_app_purchase_platform_interface.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+export 'src/errors/errors.dart';
 export 'src/in_app_purchase_platform.dart';
 export 'src/in_app_purchase_platform_addition.dart';
 export 'src/in_app_purchase_platform_addition_provider.dart';

--- a/packages/in_app_purchase/in_app_purchase_platform_interface/lib/src/errors/errors.dart
+++ b/packages/in_app_purchase/in_app_purchase_platform_interface/lib/src/errors/errors.dart
@@ -1,0 +1,5 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+export 'errors.dart';

--- a/packages/in_app_purchase/in_app_purchase_platform_interface/lib/src/errors/in_app_purchase_exception.dart
+++ b/packages/in_app_purchase/in_app_purchase_platform_interface/lib/src/errors/in_app_purchase_exception.dart
@@ -1,0 +1,27 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// Thrown to indicate that an action failed while interacting with the
+/// in_app_purchase plugin.
+class InAppPurchaseException implements Exception {
+  /// Creates a [InAppPurchaseException] with the specified source and error
+  /// [code] and optional [message].
+  InAppPurchaseException({
+    required this.source,
+    required this.code,
+    this.message,
+  }) : assert(code != null);
+
+  /// An error code.
+  final String code;
+
+  /// A human-readable error message, possibly null.
+  final String? message;
+
+  /// Which source is the error on.
+  final String source;
+
+  @override
+  String toString() => 'InAppPurchaseException($code, $message, $source)';
+}

--- a/packages/in_app_purchase/in_app_purchase_platform_interface/test/src/errors/in_app_purchase_exception_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_platform_interface/test/src/errors/in_app_purchase_exception_test.dart
@@ -1,0 +1,23 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:in_app_purchase_platform_interface/src/errors/in_app_purchase_exception.dart';
+
+void main() {
+  test('toString: Should return a description of the exception', () {
+    final InAppPurchaseException exception = InAppPurchaseException(
+      code: 'error_code',
+      message: 'dummy message',
+      source: 'dummy_source',
+    );
+
+    // Act
+    final String actual = exception.toString();
+
+    // Assert
+    expect(actual,
+        'InAppPurchaseException(error_code, dummy message, dummy_source)');
+  });
+}


### PR DESCRIPTION
This PR adds the `InAppPurchaseException` class to the in_app_purchase_platform_interface exception as discussed in this comment: https://github.com/flutter/plugins/pull/3841#discussion_r625234328

When this is merged I will remove the `InAppPurchaseException` from the in_app_platform_android implementation that is currently part of PR #3841.

This PR is part of the effort to migrate the in_app_purchase plugin to the Federated plugin architecture: flutter/flutter#78525

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format](../script/tool/README.md#format-code))
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
  - This change will be part of version 1.0.0 which is already merged into master but not yet published. 
- [ ] I updated CHANGELOG.md to add a description of the change.
  - This change will be part of version 1.0.0 which is already merged into master but not yet published. 
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
