### PR TITLE
[camera] Take picture with max resolution

### DIFF
--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
@@ -4,8 +4,6 @@
 
 package io.flutter.plugins.camera;
 
-import static io.flutter.plugins.camera.CameraUtils.computeBestPreviewSize;
-
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.app.Activity;
@@ -85,6 +83,7 @@ public class Camera {
   private final String cameraName;
   private final Size captureSize;
   private final Size previewSize;
+  private final boolean takePictureWithMaxResolution;
   private final boolean enableAudio;
   private final Context applicationContext;
   private final CamcorderProfile recordingProfile;
@@ -125,12 +124,14 @@ public class Camera {
       final DartMessenger dartMessenger,
       final String cameraName,
       final String resolutionPreset,
+      final boolean takePictureWithMaxResolution,
       final boolean enableAudio)
       throws CameraAccessException {
     if (activity == null) {
       throw new IllegalStateException("No activity available!");
     }
     this.cameraName = cameraName;
+    this.takePictureWithMaxResolution = takePictureWithMaxResolution;
     this.enableAudio = enableAudio;
     this.flutterTexture = flutterTexture;
     this.dartMessenger = dartMessenger;
@@ -151,7 +152,7 @@ public class Camera {
     recordingProfile =
         CameraUtils.getBestAvailableCamcorderProfileForResolutionPreset(cameraName, preset);
     captureSize = new Size(recordingProfile.videoFrameWidth, recordingProfile.videoFrameHeight);
-    previewSize = computeBestPreviewSize(cameraName, preset);
+    previewSize = new Size(recordingProfile.videoFrameWidth, recordingProfile.videoFrameHeight);
     cameraZoom =
         new CameraZoom(
             cameraCharacteristics.get(CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE),

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
@@ -4,6 +4,8 @@
 
 package io.flutter.plugins.camera;
 
+import static io.flutter.plugins.camera.CameraUtils.computeBestCaptureSize;
+
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.app.Activity;
@@ -83,7 +85,7 @@ public class Camera {
   private final String cameraName;
   private final Size captureSize;
   private final Size previewSize;
-  private final boolean takePictureWithMaxResolution;
+  private final boolean enableTakePictureWithMaxResolution;
   private final boolean enableAudio;
   private final Context applicationContext;
   private final CamcorderProfile recordingProfile;
@@ -124,14 +126,14 @@ public class Camera {
       final DartMessenger dartMessenger,
       final String cameraName,
       final String resolutionPreset,
-      final boolean takePictureWithMaxResolution,
+      final boolean enableTakePictureWithMaxResolution,
       final boolean enableAudio)
       throws CameraAccessException {
     if (activity == null) {
       throw new IllegalStateException("No activity available!");
     }
     this.cameraName = cameraName;
-    this.takePictureWithMaxResolution = takePictureWithMaxResolution;
+    this.enableTakePictureWithMaxResolution = enableTakePictureWithMaxResolution;
     this.enableAudio = enableAudio;
     this.flutterTexture = flutterTexture;
     this.dartMessenger = dartMessenger;
@@ -151,8 +153,20 @@ public class Camera {
     ResolutionPreset preset = ResolutionPreset.valueOf(resolutionPreset);
     recordingProfile =
         CameraUtils.getBestAvailableCamcorderProfileForResolutionPreset(cameraName, preset);
-    captureSize = new Size(recordingProfile.videoFrameWidth, recordingProfile.videoFrameHeight);
     previewSize = new Size(recordingProfile.videoFrameWidth, recordingProfile.videoFrameHeight);
+    if(enableTakePictureWithMaxResolution)
+    {
+      captureSize = computeBestCaptureSize(cameraCharacteristics
+            .get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP));
+      Log.i("Camera", "enableTakePictureWithMaxResolution");
+    }
+    else
+    {
+      captureSize = new Size(recordingProfile.videoFrameWidth, recordingProfile.videoFrameHeight);
+    }
+    Log.i("Camera", "[Preview Resolution] :" + previewSize);
+    Log.i("Camera", "[Capture Resolution] :" + captureSize);
+    
     cameraZoom =
         new CameraZoom(
             cameraCharacteristics.get(CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE),
@@ -318,7 +332,7 @@ public class Camera {
             }
             cameraCaptureSession = session;
 
-            updateFpsRange();
+            updateFpsRange(); 
             updateFocus(focusMode);
             updateFlash(flashMode);
             updateExposure(exposureMode);

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
@@ -154,19 +154,17 @@ public class Camera {
     recordingProfile =
         CameraUtils.getBestAvailableCamcorderProfileForResolutionPreset(cameraName, preset);
     previewSize = new Size(recordingProfile.videoFrameWidth, recordingProfile.videoFrameHeight);
-    if(enableTakePictureWithMaxResolution)
-    {
-      captureSize = computeBestCaptureSize(cameraCharacteristics
-            .get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP));
+    if (enableTakePictureWithMaxResolution) {
+      captureSize =
+          computeBestCaptureSize(
+              cameraCharacteristics.get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP));
       Log.i("Camera", "enableTakePictureWithMaxResolution");
-    }
-    else
-    {
+    } else {
       captureSize = new Size(recordingProfile.videoFrameWidth, recordingProfile.videoFrameHeight);
     }
     Log.i("Camera", "[Preview Resolution] :" + previewSize);
     Log.i("Camera", "[Capture Resolution] :" + captureSize);
-    
+
     cameraZoom =
         new CameraZoom(
             cameraCharacteristics.get(CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE),
@@ -332,7 +330,7 @@ public class Camera {
             }
             cameraCaptureSession = session;
 
-            updateFpsRange(); 
+            updateFpsRange();
             updateFocus(focusMode);
             updateFlash(flashMode);
             updateExposure(exposureMode);

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/CameraUtils.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/CameraUtils.java
@@ -82,16 +82,6 @@ public final class CameraUtils {
     }
   }
 
-  static Size computeBestPreviewSize(String cameraName, ResolutionPreset preset) {
-    if (preset.ordinal() > ResolutionPreset.high.ordinal()) {
-      preset = ResolutionPreset.high;
-    }
-
-    CamcorderProfile profile =
-        getBestAvailableCamcorderProfileForResolutionPreset(cameraName, preset);
-    return new Size(profile.videoFrameWidth, profile.videoFrameHeight);
-  }
-
   static Size computeBestCaptureSize(StreamConfigurationMap streamConfigurationMap) {
     // For still image captures, we use the largest available size.
     return Collections.max(

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/MethodCallHandlerImpl.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/MethodCallHandlerImpl.java
@@ -352,7 +352,8 @@ final class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
   private void instantiateCamera(MethodCall call, Result result) throws CameraAccessException {
     String cameraName = call.argument("cameraName");
     String resolutionPreset = call.argument("resolutionPreset");
-    boolean enableTakePictureWithMaxResolution = call.argument("enableTakePictureWithMaxResolution");
+    boolean enableTakePictureWithMaxResolution =
+        call.argument("enableTakePictureWithMaxResolution");
     boolean enableAudio = call.argument("enableAudio");
     TextureRegistry.SurfaceTextureEntry flutterSurfaceTexture =
         textureRegistry.createSurfaceTexture();

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/MethodCallHandlerImpl.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/MethodCallHandlerImpl.java
@@ -352,6 +352,7 @@ final class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
   private void instantiateCamera(MethodCall call, Result result) throws CameraAccessException {
     String cameraName = call.argument("cameraName");
     String resolutionPreset = call.argument("resolutionPreset");
+    boolean enableTakePictureWithMaxResolution = call.argument("enableTakePictureWithMaxResolution");
     boolean enableAudio = call.argument("enableAudio");
     TextureRegistry.SurfaceTextureEntry flutterSurfaceTexture =
         textureRegistry.createSurfaceTexture();
@@ -365,6 +366,7 @@ final class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
             dartMessenger,
             cameraName,
             resolutionPreset,
+            enableTakePictureWithMaxResolution,
             enableAudio);
 
     Map<String, Object> reply = new HashMap<>();

--- a/packages/camera/camera/ios/Classes/CameraPlugin.m
+++ b/packages/camera/camera/ios/Classes/CameraPlugin.m
@@ -306,6 +306,7 @@ static ResolutionPreset getResolutionPresetForString(NSString *preset) {
                               AVCaptureAudioDataOutputSampleBufferDelegate>
 @property(readonly, nonatomic) int64_t textureId;
 @property(nonatomic, copy) void (^onFrameAvailable)(void);
+@property BOOL enableTakePictureWithMaxResolution;
 @property BOOL enableAudio;
 @property(nonatomic) FLTImageStreamHandler *imageStreamHandler;
 @property(nonatomic) FlutterMethodChannel *methodChannel;
@@ -353,6 +354,7 @@ NSString *const errorMethod = @"error";
 
 - (instancetype)initWithCameraName:(NSString *)cameraName
                   resolutionPreset:(NSString *)resolutionPreset
+enableTakePictureWithMaxResolution:(BOOL)enableTakePictureWithMaxResolution
                        enableAudio:(BOOL)enableAudio
                        orientation:(UIDeviceOrientation)orientation
                      dispatchQueue:(dispatch_queue_t)dispatchQueue
@@ -364,6 +366,7 @@ NSString *const errorMethod = @"error";
   } @catch (NSError *e) {
     *error = e;
   }
+  _enableTakePictureWithMaxResolution = enableTakePictureWithMaxResolution;
   _enableAudio = enableAudio;
   _dispatchQueue = dispatchQueue;
   _captureSession = [[AVCaptureSession alloc] init];
@@ -459,7 +462,8 @@ NSString *const errorMethod = @"error";
 
 - (void)captureToFile:(FlutterResult)result API_AVAILABLE(ios(10)) {
   AVCapturePhotoSettings *settings = [AVCapturePhotoSettings photoSettings];
-  if (_resolutionPreset == max) {
+  if (_resolutionPreset == max || _enableTakePictureWithMaxResolution == true) {
+    NSLog(@"setHighResolutionPhotoEnabled");
     [settings setHighResolutionPhotoEnabled:YES];
   }
 
@@ -1332,10 +1336,12 @@ NSString *const errorMethod = @"error";
   } else if ([@"create" isEqualToString:call.method]) {
     NSString *cameraName = call.arguments[@"cameraName"];
     NSString *resolutionPreset = call.arguments[@"resolutionPreset"];
+    NSNumber *enableTakePictureWithMaxResolution = call.arguments[@"enableTakePictureWithMaxResolution"];
     NSNumber *enableAudio = call.arguments[@"enableAudio"];
     NSError *error;
     FLTCam *cam = [[FLTCam alloc] initWithCameraName:cameraName
                                     resolutionPreset:resolutionPreset
+                  enableTakePictureWithMaxResolution:[enableTakePictureWithMaxResolution boolValue]
                                          enableAudio:[enableAudio boolValue]
                                          orientation:[[UIDevice currentDevice] orientation]
                                        dispatchQueue:_dispatchQueue

--- a/packages/camera/camera/lib/src/camera_controller.dart
+++ b/packages/camera/camera/lib/src/camera_controller.dart
@@ -206,6 +206,7 @@ class CameraController extends ValueNotifier<CameraValue> {
   CameraController(
     this.description,
     this.resolutionPreset, {
+    this.enableTakePictureWithMaxResolution = false,
     this.enableAudio = true,
     this.imageFormatGroup,
   }) : super(const CameraValue.uninitialized());
@@ -220,6 +221,11 @@ class CameraController extends ValueNotifier<CameraValue> {
   ///
   /// See also: [ResolutionPreset].
   final ResolutionPreset resolutionPreset;
+
+  /// Whether to use max resolution for takePicture method,
+  /// It may be higher than ResolutionPreset.max, because the max resolution is for still image.
+  /// When the value is false, resolution set in resolutionPreset will be used for takePicture.
+  final bool enableTakePictureWithMaxResolution;
 
   /// Whether to include audio when recording a video.
   final bool enableAudio;
@@ -272,6 +278,7 @@ class CameraController extends ValueNotifier<CameraValue> {
       _cameraId = await CameraPlatform.instance.createCamera(
         description,
         resolutionPreset,
+        enableTakePictureWithMaxResolution: enableTakePictureWithMaxResolution,
         enableAudio: enableAudio,
       );
 


### PR DESCRIPTION
For using camera imageStream with low resolution, and take picture with high resolution, additional argument enableTakePictureWithMaxResolution is added.

Originally, what I want to modify was separate resolution control for preview and capture, however, in iOS multiple resolution in a single AVCaptureSession seems not available, except max resolution in capture using setHighResolutionPhotoEnabled option.

So, I propose enableTakePictureWithMaxResolution argument in CameraController to take a picture with max resolution.

Because this PR added an argument, camera_platform_interface should be modified accordingly.
~I will make another PR soon.~ https://github.com/flutter/plugins/pull/3856

With this modification, I removed preview resolution limit in android to match behavior of iOS. 

*List which issues are fixed by this PR. You must list at least one issue.*
https://github.com/flutter/flutter/issues/46082
https://github.com/flutter/plugins/pull/1952#discussion_r311785855
https://github.com/flutter/plugins/pull/3843

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format](../script/tool/README.md#format-code))
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
