### PR TITLE
[camera] Add web support

### DIFF
--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -10,6 +10,8 @@ dependencies:
     sdk: flutter
 
   camera_platform_interface: ^2.0.0
+  camera_web:
+    path: ../camera_web
 
   pedantic: ^1.10.0
   quiver: ^3.0.0
@@ -36,6 +38,8 @@ flutter:
         pluginClass: CameraPlugin
       ios:
         pluginClass: CameraPlugin
+      web:
+        default_package: camera_web
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -10,6 +10,8 @@ dependencies:
     sdk: flutter
 
   camera_platform_interface: ^2.0.0
+
+  #TODO: Not sure on which version the plugin is going to be published.
   camera_web:
     path: ../camera_web
 
@@ -29,6 +31,7 @@ dev_dependencies:
   # every version of flutter_driver from sdk depends on crypto 2.1.5.
   mockito: ^5.0.0-nullsafety.7
   plugin_platform_interface: ^2.0.0
+
 
 flutter:
   plugin:

--- a/packages/camera/camera_web/lib/camera_web.dart
+++ b/packages/camera/camera_web/lib/camera_web.dart
@@ -66,6 +66,11 @@ class CameraPlugin extends CameraPlatform {
 
   // This is needed before every call to ensure to have the devices description.
   Future<void> _requestPermission() async {
+    if (window.navigator.mediaDevices == null) {
+      throw CameraException(
+          'MediaDevice API not supported in this browser!', '');
+    }
+
     try {
       await window.navigator.mediaDevices!.getUserMedia({'video': true});
     } on DomException catch (e) {
@@ -275,9 +280,27 @@ class CameraPlugin extends CameraPlatform {
 
   @override
   Future<void> lockCaptureOrientation(
-      int cameraId, DeviceOrientation orientation) {
-    // TODO: implement lockCaptureOrientation
-    throw UnimplementedError();
+      int cameraId, DeviceOrientation deviceOrientation) async {
+    if (window.screen == null || window.screen!.orientation == null) {
+      throw CameraException('Screen API not available in this browser.', '');
+    }
+
+    late final String orientation;
+    switch (deviceOrientation) {
+      case DeviceOrientation.portraitUp:
+        orientation = 'portrait-primary';
+        break;
+      case DeviceOrientation.landscapeLeft:
+        orientation = 'landscape-primary';
+        break;
+      case DeviceOrientation.portraitDown:
+        orientation = 'portrait-secondary';
+        break;
+      case DeviceOrientation.landscapeRight:
+        orientation = 'landscape-secondary';
+        break;
+    }
+    await window.screen!.orientation!.lock(orientation);
   }
 
   @override
@@ -374,12 +397,6 @@ class CameraPlugin extends CameraPlatform {
   }
 
   @override
-  Future<void> setFocusPoint(int cameraId, Point<double>? point) {
-    // TODO: implement setFocusPoint
-    throw UnimplementedError();
-  }
-
-  @override
   Future<void> setZoomLevel(int cameraId, double zoom) async {
     final stream = _cameras.get(cameraId).stream!;
 
@@ -454,8 +471,11 @@ class CameraPlugin extends CameraPlatform {
   }
 
   @override
-  Future<void> unlockCaptureOrientation(int cameraId) {
-    // TODO: implement unlockCaptureOrientation
-    throw UnimplementedError();
+  Future<void> unlockCaptureOrientation(int cameraId) async {
+    if (window.screen == null || window.screen!.orientation == null) {
+      throw CameraException('Screen API not available in this browser.', '');
+    }
+
+    window.screen!.orientation!.unlock();
   }
 }

--- a/packages/camera/camera_web/lib/camera_web.dart
+++ b/packages/camera/camera_web/lib/camera_web.dart
@@ -398,9 +398,15 @@ class CameraPlugin extends CameraPlatform {
   }
 
   @override
-  Future<void> setFlashMode(int cameraId, FlashMode mode) {
-    // TODO: implement setFlashMode
-    throw UnimplementedError();
+  Future<void> setFlashMode(int cameraId, FlashMode mode) async {
+    final stream = _cameras.get(cameraId).stream!;
+
+    final track = stream.getVideoTracks().first;
+    await track.applyConstraints({
+      'advanced': [
+        {'torch': mode == FlashMode.off ? false : true}
+      ]
+    });
   }
 
   @override

--- a/packages/camera/camera_web/lib/camera_web.dart
+++ b/packages/camera/camera_web/lib/camera_web.dart
@@ -386,9 +386,19 @@ class CameraPlugin extends CameraPlatform {
   }
 
   @override
-  Future<double> setExposureOffset(int cameraId, double offset) {
-    // TODO: implement setExposureOffset
-    throw UnimplementedError();
+  Future<double> setExposureOffset(int cameraId, double offset) async {
+    final stream = _cameras.get(cameraId).stream!;
+    //TODO: Validate the offset
+
+    final track = stream.getVideoTracks().first;
+    await track.applyConstraints({
+      'advanced': [
+        {'exposureTime': offset}
+      ]
+    });
+
+    //TODO: Get the set offset from `track.getSettings()`.
+    return offset;
   }
 
   @override

--- a/packages/camera/camera_web/lib/camera_web.dart
+++ b/packages/camera/camera_web/lib/camera_web.dart
@@ -1,0 +1,307 @@
+import 'dart:async';
+import 'dart:html';
+import 'dart:ui' as ui;
+
+import 'package:camera_platform_interface/camera_platform_interface.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_web_plugins/flutter_web_plugins.dart';
+import 'package:tuple/tuple.dart';
+
+import 'media_track_capabilities.dart';
+
+///
+class CameraPlugin extends CameraPlatform {
+  int _nextId = 1;
+  
+  // Maybe use a tuple for these two values as well.
+  final _devices = <int, MediaDeviceInfo>{};
+  final _previewEl = <int, VideoElement>{};
+  
+  final _camInitializer = StreamController<Tuple2<int, MediaStream>>.broadcast();
+
+  /// Registers this class as the default instance of [CameraPlatform].
+  static void registerWith(Registrar registrar) {
+    CameraPlatform.instance = CameraPlugin();
+  }
+
+  // This is needed before every call to ensure to have the devices description.
+  Future<void> _requestPermission() async {
+    try {
+      await window.navigator.mediaDevices!.getUserMedia({'video': true});
+    } on DomException catch (e) {
+      throw CameraException(e.name, e.message);
+    }
+  }
+
+  @override
+  Future<List<CameraDescription>> availableCameras() async {
+    await _requestPermission();
+
+    final devices = (await window.navigator.mediaDevices!.enumerateDevices())
+        .cast<MediaDeviceInfo>();
+
+    //TODO: Call 'getCapabilities' to get lensDirection.
+    return devices
+        .where((e) => e.kind == 'videoinput')
+        .map((e) => CameraDescription(
+            name: e.label ?? '',
+            lensDirection: CameraLensDirection.external,
+            sensorOrientation: 0))
+        .toList();
+  }
+
+  @override
+  Widget buildPreview(int cameraId) {
+    //TODO: Throw if not initialized.
+
+    return HtmlElementView(viewType: 'video-view-$cameraId');
+  }
+
+  @override
+  Future<int> createCamera(
+      CameraDescription cameraDescription, ResolutionPreset? resolutionPreset,
+      {bool enableAudio = false}) async {
+    // TODO: implement enableAudio and resolutionPreset.
+    await _requestPermission();
+
+    final devices = (await window.navigator.mediaDevices!.enumerateDevices())
+        .cast<MediaDeviceInfo>();
+
+    final l = devices.where(
+        (e) => e.kind == 'videoinput' && e.label == cameraDescription.name);
+    if (l.isEmpty) {
+      throw CameraException('Camera not found',
+          'Couldn\'t find a camera labeled: ${cameraDescription.name}');
+    }
+
+    final device = l.first;
+    final id = _nextId++;
+    _devices[id] = device;
+
+    return id;
+  }
+
+  @override
+  Future<void> dispose(int cameraId) async {
+    _devices.remove(cameraId);
+    _previewEl.remove(cameraId)?.remove();
+  }
+
+  @override
+  Future<double> getExposureOffsetStepSize(int cameraId) {
+    // TODO: implement getExposureOffsetStepSize
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<double> getMaxExposureOffset(int cameraId) {
+    // TODO: implement getMaxExposureOffset
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<double> getMaxZoomLevel(int cameraId) {
+    // TODO: implement getMaxZoomLevel
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<double> getMinExposureOffset(int cameraId) {
+    // TODO: implement getMinExposureOffset
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<double> getMinZoomLevel(int cameraId) {
+    // TODO: implement getMinZoomLevel
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> initializeCamera(int cameraId,
+      {ImageFormatGroup imageFormatGroup = ImageFormatGroup.unknown}) async {
+    final device = _devices[cameraId];
+    if (device == null) {
+      throw CameraException(
+          'CameraId not found.', 'No camera with $cameraId was found');
+    }
+
+    if (_previewEl[cameraId] != null) {
+      return;
+    }
+
+    late MediaStream userMedia;
+    try {
+      userMedia = await window.navigator.mediaDevices!.getUserMedia({
+        'video': {
+          'deviceId': {'exact': device.deviceId}
+        },
+        'audio': false
+      });
+    } on OverconstrainedError catch (e) {
+      throw CameraException(e.name ?? 'OverconstrainedError',
+          'Invalid constraint: ${e.constraint}');
+    }
+
+    final video = VideoElement();
+    ui.platformViewRegistry
+        .registerViewFactory('video-view-$cameraId', (int viewId) => video);
+
+    _previewEl[cameraId] = video;
+
+    video.srcObject = userMedia;
+    await video.play();
+
+    _camInitializer.add(Tuple2(cameraId, userMedia));
+  }
+
+  @override
+  Future<void> lockCaptureOrientation(
+      int cameraId, DeviceOrientation orientation) {
+    // TODO: implement lockCaptureOrientation
+    throw UnimplementedError();
+  }
+
+  @override
+  Stream<CameraClosingEvent> onCameraClosing(int cameraId) {
+    // TODO: implement onCameraClosing
+    throw UnimplementedError();
+  }
+
+  @override
+  Stream<CameraErrorEvent> onCameraError(int cameraId) {
+    // TODO: implement onCameraError
+    throw UnimplementedError();
+  }
+
+
+  @override
+  Stream<CameraInitializedEvent> onCameraInitialized(int cameraId) {
+    final device = _devices[cameraId];
+    if (device == null) {
+      throw CameraException(
+          'CameraId not found.', 'No camera with $cameraId was found');
+    }
+
+    return _camInitializer.stream.where((e) => e.item1 == cameraId).map((e) {
+      final userMedia = e.item2;
+
+      final videoTrack = userMedia.getVideoTracks().first;
+      final capabilities =
+          MediaTrackCapabilities.fromObject(videoTrack.getCapabilities());
+      return CameraInitializedEvent(
+          cameraId,
+          //TODO: Not sure if using width and height .max is correct here.
+          capabilities?.width?.max ?? 0,
+          capabilities?.height?.max ?? 0,
+          //TODO: Maybe use capabilities.exposureMode
+          ExposureMode.auto,
+          false,
+          //TODO: Maybe use capabilities.focusMode
+          FocusMode.auto,
+          false);
+    });
+  }
+
+  @override
+  Stream<CameraResolutionChangedEvent> onCameraResolutionChanged(int cameraId) {
+    // TODO: implement onCameraResolutionChanged
+    throw UnimplementedError();
+  }
+
+  @override
+  Stream<DeviceOrientationChangedEvent> onDeviceOrientationChanged() async* {
+    // Just to implement this
+  }
+
+  @override
+  Stream<VideoRecordedEvent> onVideoRecordedEvent(int cameraId) {
+    // TODO: implement onVideoRecordedEvent
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> pauseVideoRecording(int cameraId) {
+    // TODO: implement pauseVideoRecording
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> prepareForVideoRecording() {
+    // TODO: implement prepareForVideoRecording
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> resumeVideoRecording(int cameraId) {
+    // TODO: implement resumeVideoRecording
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> setExposureMode(int cameraId, ExposureMode mode) {
+    // TODO: implement setExposureMode
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<double> setExposureOffset(int cameraId, double offset) {
+    // TODO: implement setExposureOffset
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> setExposurePoint(int cameraId, Point<double>? point) {
+    // TODO: implement setExposurePoint
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> setFlashMode(int cameraId, FlashMode mode) {
+    // TODO: implement setFlashMode
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> setFocusMode(int cameraId, FocusMode mode) {
+    // TODO: implement setFocusMode
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> setFocusPoint(int cameraId, Point<double>? point) {
+    // TODO: implement setFocusPoint
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> setZoomLevel(int cameraId, double zoom) {
+    // TODO: implement setZoomLevel
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> startVideoRecording(int cameraId, {Duration? maxVideoDuration}) {
+    // TODO: implement startVideoRecording
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<XFile> stopVideoRecording(int cameraId) {
+    // TODO: implement stopVideoRecording
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<XFile> takePicture(int cameraId) {
+    // TODO: implement takePicture
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> unlockCaptureOrientation(int cameraId) {
+    // TODO: implement unlockCaptureOrientation
+    throw UnimplementedError();
+  }
+}

--- a/packages/camera/camera_web/lib/media_track_capabilities.dart
+++ b/packages/camera/camera_web/lib/media_track_capabilities.dart
@@ -27,6 +27,7 @@ class MediaTrackCapabilities {
   final List<String>? whiteBalanceMode;
   final DoubleRangeStep? focusDistance;
   final List<String>? focusMode;
+  final DoubleRangeStep? zoom;
 
   const MediaTrackCapabilities(
       this.aspectRatio,
@@ -53,7 +54,8 @@ class MediaTrackCapabilities {
       this.exposureMode,
       this.whiteBalanceMode,
       this.focusDistance,
-      this.focusMode);
+      this.focusMode,
+      this.zoom);
 
   static MediaTrackCapabilities? fromObject(Map<dynamic, dynamic> obj) {
     final aspectRatio = DoubleRange.decode(obj, 'aspectRatio');
@@ -82,6 +84,7 @@ class MediaTrackCapabilities {
     final whiteBalanceMode = nullOrType<List<dynamic>>(obj, 'whiteBalanceMode');
     final focusDistance = DoubleRangeStep.decode(obj, 'focusDistance');
     final focusMode = nullOrType<List<dynamic>>(obj, 'focusMode');
+    final zoom = nullOrType<DoubleRangeStep>(obj, 'zoom');
 
     return MediaTrackCapabilities(
         aspectRatio,
@@ -108,7 +111,7 @@ class MediaTrackCapabilities {
         exposureMode?.cast<String>(),
         whiteBalanceMode?.cast<String>(),
         focusDistance,
-        focusMode?.cast<String>());
+        focusMode?.cast<String>(), zoom);
   }
 
   @override
@@ -187,13 +190,16 @@ class MediaTrackCapabilities {
     if (focusMode != null) {
       buffer.writeln('FocusMode: $focusMode');
     }
+    if (zoom != null) {
+      buffer.writeln('Zoom: $zoom');
+    }
     return buffer.toString();
   }
 }
 
 class DoubleRange {
-  final double max;
-  final double min;
+  final num max;
+  final num min;
 
   const DoubleRange(this.max, this.min);
 
@@ -214,9 +220,9 @@ class DoubleRange {
 }
 
 class DoubleRangeStep {
-  final double max;
-  final double min;
-  final int step;
+  final num max;
+  final num min;
+  final num step;
 
   const DoubleRangeStep(this.max, this.min, this.step);
 

--- a/packages/camera/camera_web/lib/media_track_capabilities.dart
+++ b/packages/camera/camera_web/lib/media_track_capabilities.dart
@@ -84,7 +84,7 @@ class MediaTrackCapabilities {
     final whiteBalanceMode = nullOrType<List<dynamic>>(obj, 'whiteBalanceMode');
     final focusDistance = DoubleRangeStep.decode(obj, 'focusDistance');
     final focusMode = nullOrType<List<dynamic>>(obj, 'focusMode');
-    final zoom = nullOrType<DoubleRangeStep>(obj, 'zoom');
+    final zoom = DoubleRangeStep.decode(obj, 'zoom');
 
     return MediaTrackCapabilities(
         aspectRatio,

--- a/packages/camera/camera_web/lib/media_track_capabilities.dart
+++ b/packages/camera/camera_web/lib/media_track_capabilities.dart
@@ -57,7 +57,7 @@ class MediaTrackCapabilities {
       this.focusMode,
       this.zoom);
 
-  static MediaTrackCapabilities? fromObject(Map<dynamic, dynamic> obj) {
+  static MediaTrackCapabilities fromObject(Map<dynamic, dynamic> obj) {
     final aspectRatio = DoubleRange.decode(obj, 'aspectRatio');
     final autoGainControl = nullOrType<List<bool>>(obj, 'autoGainControl');
     final channelCount = DoubleRange.decode(obj, 'channelCount');

--- a/packages/camera/camera_web/lib/media_track_capabilities.dart
+++ b/packages/camera/camera_web/lib/media_track_capabilities.dart
@@ -1,0 +1,246 @@
+// ignore_for_file: public_member_api_docs
+import 'dart:js_util' as js_util;
+
+class MediaTrackCapabilities {
+  final DoubleRange? aspectRatio;
+  final List<bool>? autoGainControl;
+  final DoubleRange? channelCount;
+  final String? deviceId;
+  final List<bool>? echoCancellation;
+  final List<String>? facingMode;
+  final DoubleRange? frameRate;
+  final String? groupId;
+  final DoubleRange? height;
+  final DoubleRange? latency;
+  final List<bool>? noiseSuppression;
+  final List<String>? resizeMode;
+  final DoubleRange? sampleRate;
+  final DoubleRange? sampleSize;
+  final DoubleRange? width;
+  final DoubleRangeStep? brightness;
+  final DoubleRangeStep? colorTemperature;
+  final DoubleRangeStep? contrast;
+  final DoubleRangeStep? exposureTime;
+  final DoubleRangeStep? saturation;
+  final DoubleRangeStep? sharpness;
+  final List<String>? exposureMode;
+  final List<String>? whiteBalanceMode;
+  final DoubleRangeStep? focusDistance;
+  final List<String>? focusMode;
+
+  const MediaTrackCapabilities(
+      this.aspectRatio,
+      this.autoGainControl,
+      this.channelCount,
+      this.deviceId,
+      this.echoCancellation,
+      this.facingMode,
+      this.frameRate,
+      this.groupId,
+      this.height,
+      this.latency,
+      this.noiseSuppression,
+      this.resizeMode,
+      this.sampleRate,
+      this.sampleSize,
+      this.width,
+      this.brightness,
+      this.colorTemperature,
+      this.contrast,
+      this.exposureTime,
+      this.saturation,
+      this.sharpness,
+      this.exposureMode,
+      this.whiteBalanceMode,
+      this.focusDistance,
+      this.focusMode);
+
+  static MediaTrackCapabilities? fromObject(Map<dynamic, dynamic> obj) {
+    final aspectRatio = DoubleRange.decode(obj, 'aspectRatio');
+    final autoGainControl = nullOrType<List<bool>>(obj, 'autoGainControl');
+    final channelCount = DoubleRange.decode(obj, 'channelCount');
+    final deviceId = nullOrType<String>(obj, 'deviceId');
+    final echoCancellation = nullOrType<List<bool>>(obj, 'echoCancellation');
+    final facingMode = nullOrType<List<dynamic>>(obj, 'facingMode');
+    final frameRate = DoubleRange.decode(obj, 'frameRate');
+    final groupId = nullOrType<String>(obj, 'groupId');
+    final height = DoubleRange.decode(obj, 'height');
+    final latency = DoubleRange.decode(obj, 'latency');
+    final noiseSuppression = nullOrType<List<bool>>(obj, 'noiseSuppression');
+    final resizeMode = nullOrType<List<dynamic>>(obj, 'resizeMode');
+    final sampleRate = DoubleRange.decode(obj, 'sampleRate');
+    final sampleSize = DoubleRange.decode(obj, 'sampleSize');
+    final width = DoubleRange.decode(obj, 'width');
+    final brightness = DoubleRangeStep.decode(obj, 'brightness');
+    final colorTemperature = DoubleRangeStep.decode(obj, 'colorTemperature');
+
+    final contrast = DoubleRangeStep.decode(obj, 'contrast');
+    final exposureTime = DoubleRangeStep.decode(obj, 'exposureTime');
+    final saturation = DoubleRangeStep.decode(obj, 'saturation');
+    final sharpness = DoubleRangeStep.decode(obj, 'sharpness');
+    final exposureMode = nullOrType<List<dynamic>>(obj, 'exposureMode');
+    final whiteBalanceMode = nullOrType<List<dynamic>>(obj, 'whiteBalanceMode');
+    final focusDistance = DoubleRangeStep.decode(obj, 'focusDistance');
+    final focusMode = nullOrType<List<dynamic>>(obj, 'focusMode');
+
+    return MediaTrackCapabilities(
+        aspectRatio,
+        autoGainControl,
+        channelCount,
+        deviceId,
+        echoCancellation,
+        facingMode?.cast<String>(),
+        frameRate,
+        groupId,
+        height,
+        latency,
+        noiseSuppression,
+        resizeMode?.cast<String>(),
+        sampleRate,
+        sampleSize,
+        width,
+        brightness,
+        colorTemperature,
+        contrast,
+        exposureTime,
+        saturation,
+        sharpness,
+        exposureMode?.cast<String>(),
+        whiteBalanceMode?.cast<String>(),
+        focusDistance,
+        focusMode?.cast<String>());
+  }
+
+  @override
+  String toString() {
+    var buffer = StringBuffer();
+    if (aspectRatio != null) {
+      buffer.writeln('AspectRatio: $aspectRatio');
+    }
+    if (autoGainControl != null) {
+      buffer.writeln('AutoGainControl: $autoGainControl');
+    }
+    if (channelCount != null) {
+      buffer.writeln('ChannelCount: $channelCount');
+    }
+    if (deviceId != null) {
+      buffer.writeln('DeviceId: $deviceId');
+    }
+    if (echoCancellation != null) {
+      buffer.writeln('EchoCancellation: $echoCancellation');
+    }
+    if (facingMode != null) {
+      buffer.writeln('FacingMode: $facingMode');
+    }
+    if (frameRate != null) {
+      buffer.writeln('FrameRate: $frameRate');
+    }
+    if (noiseSuppression != null) {
+      buffer.writeln('NoiseSuppression: $noiseSuppression');
+    }
+    if (height != null) {
+      buffer.writeln('Height: $height');
+    }
+    if (latency != null) {
+      buffer.writeln('Latency: $latency');
+    }
+    if (resizeMode != null) {
+      buffer.writeln('ResizeMode: $resizeMode');
+    }
+    if (sampleRate != null) {
+      buffer.writeln('SampleRate: $sampleRate');
+    }
+    if (sampleSize != null) {
+      buffer.writeln('SampleSize: $sampleSize');
+    }
+    if (width != null) {
+      buffer.writeln('Width: $width');
+    }
+    if (brightness != null) {
+      buffer.writeln('Brightness: $brightness');
+    }
+    if (colorTemperature != null) {
+      buffer.writeln('ColorTemperature: $colorTemperature');
+    }
+
+    if (contrast != null) {
+      buffer.writeln('Contrast: $contrast');
+    }
+    if (exposureTime != null) {
+      buffer.writeln('ExposureTime: $exposureTime');
+    }
+    if (saturation != null) {
+      buffer.writeln('Saturation: $saturation');
+    }
+    if (sharpness != null) {
+      buffer.writeln('Sharpness: $sharpness');
+    }
+    if (exposureMode != null) {
+      buffer.writeln('ExposureMode: $exposureMode');
+    }
+    if (whiteBalanceMode != null) {
+      buffer.writeln('WhiteBalanceMode: $whiteBalanceMode');
+    }
+    if (focusDistance != null) {
+      buffer.writeln('FocusDistance: $focusDistance');
+    }
+    if (focusMode != null) {
+      buffer.writeln('FocusMode: $focusMode');
+    }
+    return buffer.toString();
+  }
+}
+
+class DoubleRange {
+  final double max;
+  final double min;
+
+  const DoubleRange(this.max, this.min);
+
+  DoubleRange.fromObject(dynamic obj)
+      : max = js_util.getProperty(obj, 'max'),
+        min = js_util.getProperty(obj, 'min');
+
+  static DoubleRange? decode(dynamic obj, String key) {
+    final val = obj[key];
+    if (val == null) {
+      return null;
+    }
+    return DoubleRange.fromObject(val);
+  }
+
+  @override
+  String toString() => 'DoubleRange($max - $min)';
+}
+
+class DoubleRangeStep {
+  final double max;
+  final double min;
+  final int step;
+
+  const DoubleRangeStep(this.max, this.min, this.step);
+
+  DoubleRangeStep.fromObject(dynamic obj)
+      : max = js_util.getProperty(obj, 'max'),
+        min = js_util.getProperty(obj, 'min'),
+        step = js_util.getProperty(obj, 'step');
+
+  static DoubleRangeStep? decode(dynamic obj, String key) {
+    final val = obj[key];
+    if (val == null) {
+      return null;
+    }
+    return DoubleRangeStep.fromObject(val);
+  }
+
+  @override
+  String toString() => 'DoubleRangeStep($max - $min : $step)';
+}
+
+T? nullOrType<T>(dynamic obj, String key) {
+  final val = obj[key];
+  if (val == null) {
+    return null;
+  }
+  return val as T;
+}

--- a/packages/camera/camera_web/pubspec.yaml
+++ b/packages/camera/camera_web/pubspec.yaml
@@ -1,0 +1,30 @@
+name: camera_web
+description: Web platform implementation of camera
+homepage: https://github.com/flutter/plugins/tree/master/packages/camera/camera_web
+
+version: 2.0.0
+
+flutter:
+  plugin:
+    platforms:
+      web:
+        pluginClass: CameraPlugin
+        fileName: camera_web.dart
+
+dependencies:
+  camera_platform_interface: ^2.0.0
+  meta: ^1.3.0
+  flutter:
+    sdk: flutter
+  flutter_web_plugins:
+    sdk: flutter
+  tuple: ^2.0.0
+
+dev_dependencies:
+  pedantic: ^1.11.0
+  flutter_test:
+    sdk: flutter
+
+environment:
+  sdk: ">=2.12.0 <3.0.0"
+  flutter: ">=1.22.0"

--- a/packages/camera/camera_web/pubspec.yaml
+++ b/packages/camera/camera_web/pubspec.yaml
@@ -12,13 +12,12 @@ flutter:
         fileName: camera_web.dart
 
 dependencies:
-  camera_platform_interface: ^2.0.0
+  camera_platform_interface: ^2.0.1
   meta: ^1.3.0
   flutter:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  tuple: ^2.0.0
 
 dev_dependencies:
   pedantic: ^1.11.0


### PR DESCRIPTION
This PR implements the web support for the camera plugin ( https://github.com/flutter/flutter/issues/45297 ), it is not yet complete.

I tested ([this sample](https://gist.github.com/Hexer10/b6a5a5327c4e84fd0d562be3c4385b02)) both in chrome and firefox in desktop and mobile and the implementation worked fine.

What's implemented:

- Available cameras.
- Camera video preview.
- Initialize and create camera APIs,
- Exposure offset API. This uses capabilities.exposureTime and I'm not sure if this is the correct implementation or can be implemented at all.
- Set/Get zoom level.
- Lock/Unlock capture orientation. This uses the [Screen API](https://developer.mozilla.org/en-US/docs/Web/API/Screen) which locks the orientation of the whole screen AFAIK. This also requires that the app is in fullscreen so maybe it's not really a good solution.
- Video recording.
- onCameraInitialized, onVideoRecordedEvent 
- Set flash mode.

What's missing:
- onCameraClosing, onCameraError, onCameraResolutionChanged, onDeviceOrientationChanged. (The latest two are implemented but don't ever yield any value).
- Exposure mode and Focus mode. (Not sure if these can be implemented in web).
- `enableAudio` and `resolutionPreset` in createCamera have no effect.
- Integration tests. I'm not really into writing tests, especially on web, so any help would be appreciated.

A few caveats:
- `window.navigator.mediaDevices({'video': true, 'audio': false})` should be included before using any function provided from the plugin to request the camera access.
- The analyzer returns an error on `ui.platformViewRegistry.registerViewFactory` due to https://github.com/flutter/flutter/issues/41563 .
- Only in chrome and when testing the build (`flutter build`) `video.play()` throws this error: `AbortError: the play() request was interrupted by a call to pause()` (Line 270 camera_web.dart). Simply catching that error seem to solve the issue.
- settings.exposureMode and settings.focusMode might be used to fetch the right `ExposureMode` and `FocusMode` (Line 268 camera_web.dart).
- The takePicture supports only the `image/png` media type.
- The recording currently only supports the `video/webm;codecs=VP8`. Probably it would be a good idea to use `MediaRecoreder.isTypeSupported()` to check if the media type is supported in the current browser. The downloaded file has no video length tough so it not possible to navigate around the video, I'm not sure there is a fix at the moment.
- The MediaTrackCapabilities class is just an utility to parse all the video capabilities, it the future it can be stripped out the APIs that are not needed.
- Calls to `video.play()` fail on iPhone devices with the following error: `NotAllowedError: The request is not allowd by the user agent or the platform in the current context, possibly because the user denined permission.`.


There are serveral TODOs around the code you might want to checkout as well.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format](../script/tool/README.md#format-code))
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [ ] All existing and new tests are passing.
