### PR TITLE
Exclude some missing integration tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -168,7 +168,8 @@ task:
     - name: build-web+drive-examples
       env:
         # Currently missing; see https://github.com/flutter/flutter/issues/81982
-        PLUGINS_TO_EXCLUDE_INTEGRATION_TESTS: "image_picker_for_web,shared_preferences_web,video_player_web"
+        # and https://github.com/flutter/flutter/issues/82211
+        PLUGINS_TO_EXCLUDE_INTEGRATION_TESTS: "file_selector,image_picker_for_web,shared_preferences_web,video_player_web"
         matrix:
           CHANNEL: "master"
           CHANNEL: "stable"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -206,8 +206,9 @@ task:
         PATH: $PATH:/usr/local/bin
         PLUGINS_TO_SKIP_XCTESTS: "integration_test"
         # in_app_purchase_ios is currently missing tests; see https://github.com/flutter/flutter/issues/81695
+        # ios_platform_images is currently missing tests; see https://github.com/flutter/flutter/issues/82208
         # sensor hangs on CI.
-        PLUGINS_TO_EXCLUDE_INTEGRATION_TESTS: "in_app_purchase_ios,sensors"
+        PLUGINS_TO_EXCLUDE_INTEGRATION_TESTS: "in_app_purchase_ios,ios_platform_images,sensors"
         matrix:
           PLUGIN_SHARDING: "--shardIndex 0 --shardCount 4"
           PLUGIN_SHARDING: "--shardIndex 1 --shardCount 4"


### PR DESCRIPTION
ios_platform_images does not currently have an integration test, and file_chooser does not have a web integration test, so both must be explicitly excluded due to recent tooling changes.

See:
https://github.com/flutter/flutter/issues/82208
https://github.com/flutter/flutter/issues/82211

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format](../script/tool/README.md#format-code))
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
