### PR TITLE
Migrate some tool commands to NNBD

### DIFF
--- a/script/tool/lib/src/analyze_command.dart
+++ b/script/tool/lib/src/analyze_command.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 import 'dart:async';
 
 import 'package:file/file.dart';

--- a/script/tool/lib/src/build_examples_command.dart
+++ b/script/tool/lib/src/build_examples_command.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 import 'dart:async';
 import 'dart:io' as io;
 
@@ -52,11 +50,7 @@ class BuildExamplesCommand extends PluginCommand {
       kWeb,
       kWindows,
     ];
-    final Map<String, bool> platforms = <String, bool>{
-      for (final String platform in platformSwitches)
-        platform: getBoolArg(platform)
-    };
-    if (!platforms.values.any((bool enabled) => enabled)) {
+    if (!platformSwitches.any((String platform) => getBoolArg(platform))) {
       print(
           'None of ${platformSwitches.map((String platform) => '--$platform').join(', ')} '
           'were specified, so not building anything.');
@@ -73,7 +67,7 @@ class BuildExamplesCommand extends PluginCommand {
         final String packageName =
             p.relative(example.path, from: packagesDir.path);
 
-        if (platforms[kLinux]) {
+        if (getBoolArg(kLinux)) {
           print('\nBUILDING Linux for $packageName');
           if (isLinuxPlugin(plugin, fileSystem)) {
             final int buildExitCode = await processRunner.runAndStream(
@@ -93,7 +87,7 @@ class BuildExamplesCommand extends PluginCommand {
           }
         }
 
-        if (platforms[kMacos]) {
+        if (getBoolArg(kMacos)) {
           print('\nBUILDING macOS for $packageName');
           if (isMacOsPlugin(plugin, fileSystem)) {
             final int exitCode = await processRunner.runAndStream(
@@ -113,7 +107,7 @@ class BuildExamplesCommand extends PluginCommand {
           }
         }
 
-        if (platforms[kWeb]) {
+        if (getBoolArg(kWeb)) {
           print('\nBUILDING web for $packageName');
           if (isWebPlugin(plugin, fileSystem)) {
             final int buildExitCode = await processRunner.runAndStream(
@@ -133,7 +127,7 @@ class BuildExamplesCommand extends PluginCommand {
           }
         }
 
-        if (platforms[kWindows]) {
+        if (getBoolArg(kWindows)) {
           print('\nBUILDING Windows for $packageName');
           if (isWindowsPlugin(plugin, fileSystem)) {
             final int buildExitCode = await processRunner.runAndStream(
@@ -153,7 +147,7 @@ class BuildExamplesCommand extends PluginCommand {
           }
         }
 
-        if (platforms[kIpa]) {
+        if (getBoolArg(kIpa)) {
           print('\nBUILDING IPA for $packageName');
           if (isIosPlugin(plugin, fileSystem)) {
             final int exitCode = await processRunner.runAndStream(
@@ -174,7 +168,7 @@ class BuildExamplesCommand extends PluginCommand {
           }
         }
 
-        if (platforms[kApk]) {
+        if (getBoolArg(kApk)) {
           print('\nBUILDING APK for $packageName');
           if (isAndroidPlugin(plugin, fileSystem)) {
             final int exitCode = await processRunner.runAndStream(

--- a/script/tool/lib/src/drive_examples_command.dart
+++ b/script/tool/lib/src/drive_examples_command.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 import 'dart:async';
 import 'package:file/file.dart';
 import 'package:path/path.dart' as p;

--- a/script/tool/lib/src/format_command.dart
+++ b/script/tool/lib/src/format_command.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io' as io;

--- a/script/tool/lib/src/java_test_command.dart
+++ b/script/tool/lib/src/java_test_command.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 import 'dart:async';
 
 import 'package:file/file.dart';

--- a/script/tool/lib/src/license_check_command.dart
+++ b/script/tool/lib/src/license_check_command.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 import 'dart:async';
 
 import 'package:file/file.dart';

--- a/script/tool/lib/src/list_command.dart
+++ b/script/tool/lib/src/list_command.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 import 'dart:async';
 
 import 'package:file/file.dart';

--- a/script/tool/lib/src/test_command.dart
+++ b/script/tool/lib/src/test_command.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 import 'dart:async';
 
 import 'package:file/file.dart';

--- a/script/tool/test/analyze_command_test.dart
+++ b/script/tool/test/analyze_command_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
 import 'package:flutter_plugin_tools/src/analyze_command.dart';
@@ -14,8 +12,8 @@ import 'mocks.dart';
 import 'util.dart';
 
 void main() {
-  RecordingProcessRunner processRunner;
-  CommandRunner<void> runner;
+  late RecordingProcessRunner processRunner;
+  late CommandRunner<void> runner;
 
   setUp(() {
     initializeFakePackages();

--- a/script/tool/test/build_examples_command_test.dart
+++ b/script/tool/test/build_examples_command_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
 import 'package:flutter_plugin_tools/src/build_examples_command.dart';
@@ -15,8 +13,8 @@ import 'util.dart';
 
 void main() {
   group('test build_example_command', () {
-    CommandRunner<void> runner;
-    RecordingProcessRunner processRunner;
+    late CommandRunner<void> runner;
+    late RecordingProcessRunner processRunner;
     final String flutterCommand =
         const LocalPlatform().isWindows ? 'flutter.bat' : 'flutter';
 

--- a/script/tool/test/drive_examples_command_test.dart
+++ b/script/tool/test/drive_examples_command_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
 import 'package:flutter_plugin_tools/src/common.dart';
@@ -16,8 +14,8 @@ import 'util.dart';
 
 void main() {
   group('test drive_example_command', () {
-    CommandRunner<void> runner;
-    RecordingProcessRunner processRunner;
+    late CommandRunner<void> runner;
+    late RecordingProcessRunner processRunner;
     final String flutterCommand =
         const LocalPlatform().isWindows ? 'flutter.bat' : 'flutter';
     setUp(() {

--- a/script/tool/test/java_test_command_test.dart
+++ b/script/tool/test/java_test_command_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
 import 'package:flutter_plugin_tools/src/java_test_command.dart';
@@ -14,7 +12,7 @@ import 'util.dart';
 
 void main() {
   group('$JavaTestCommand', () {
-    CommandRunner<void> runner;
+    late CommandRunner<void> runner;
     final RecordingProcessRunner processRunner = RecordingProcessRunner();
 
     setUp(() {

--- a/script/tool/test/license_check_command_test.dart
+++ b/script/tool/test/license_check_command_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
@@ -13,10 +11,10 @@ import 'package:test/test.dart';
 
 void main() {
   group('$LicenseCheckCommand', () {
-    CommandRunner<void> runner;
-    FileSystem fileSystem;
-    List<String> printedMessages;
-    Directory root;
+    late CommandRunner<void> runner;
+    late FileSystem fileSystem;
+    late List<String> printedMessages;
+    late Directory root;
 
     setUp(() {
       fileSystem = MemoryFileSystem();
@@ -28,7 +26,7 @@ void main() {
       final LicenseCheckCommand command = LicenseCheckCommand(
         packagesDir,
         fileSystem,
-        print: (Object message) => printedMessages.add(message.toString()),
+        print: (Object? message) => printedMessages.add(message.toString()),
       );
       runner =
           CommandRunner<void>('license_test', 'Test for $LicenseCheckCommand');

--- a/script/tool/test/list_command_test.dart
+++ b/script/tool/test/list_command_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
 import 'package:flutter_plugin_tools/src/list_command.dart';
@@ -13,7 +11,7 @@ import 'util.dart';
 
 void main() {
   group('$ListCommand', () {
-    CommandRunner<void> runner;
+    late CommandRunner<void> runner;
 
     setUp(() {
       initializeFakePackages();

--- a/script/tool/test/mocks.dart
+++ b/script/tool/test/mocks.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 import 'dart:async';
 import 'dart:io' as io;
 
@@ -35,5 +33,5 @@ class MockIOSink extends Mock implements IOSink {
   List<String> lines = <String>[];
 
   @override
-  void writeln([Object obj = '']) => lines.add(obj.toString());
+  void writeln([Object? obj = '']) => lines.add(obj.toString());
 }

--- a/script/tool/test/test_command_test.dart
+++ b/script/tool/test/test_command_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
 import 'package:flutter_plugin_tools/src/test_command.dart';
@@ -13,7 +11,7 @@ import 'util.dart';
 
 void main() {
   group('$TestCommand', () {
-    CommandRunner<void> runner;
+    late CommandRunner<void> runner;
     final RecordingProcessRunner processRunner = RecordingProcessRunner();
 
     setUp(() {


### PR DESCRIPTION
Now that individual commands can be migrated, migrate several commands
that are trivially migratable (along with their tests).

Part of https://github.com/flutter/flutter/issues/81912

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format](../script/tool/README.md#format-code))
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
