### PR TITLE
[android_alarm_manager] Migrate maven repo from jcenter to mavenCentral

### DIFF
--- a/packages/android_alarm_manager/CHANGELOG.md
+++ b/packages/android_alarm_manager/CHANGELOG.md
@@ -1,3 +1,7 @@
+##  2.0.1
+
+* Migrate maven repository from jcenter to mavenCentral.
+
 ##  2.0.0
 
 * Migrate to null safety.

--- a/packages/android_alarm_manager/android/build.gradle
+++ b/packages/android_alarm_manager/android/build.gradle
@@ -5,7 +5,7 @@ def args = ["-Xlint:deprecation","-Xlint:unchecked","-Werror"]
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -16,7 +16,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/packages/android_alarm_manager/example/android/build.gradle
+++ b/packages/android_alarm_manager/example/android/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -12,7 +12,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/packages/android_alarm_manager/pubspec.yaml
+++ b/packages/android_alarm_manager/pubspec.yaml
@@ -1,7 +1,7 @@
 name: android_alarm_manager
 description: Flutter plugin for accessing the Android AlarmManager service, and
   running Dart code in the background when alarms fire.
-version: 2.0.0
+version: 2.0.1
 homepage: https://github.com/flutter/plugins/tree/master/packages/android_alarm_manager
 
 dependencies:


### PR DESCRIPTION
The jcenter maven repository is being sunset and is currently readonly.  Migrate to mavenCentral.

android_alarm_manager part of https://github.com/flutter/flutter/issues/82847

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format](../script/tool/README.md#format-code))
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.