### PR TITLE
[path_provider] Migrate all integration tests to NNBD

### DIFF
--- a/packages/path_provider/path_provider/example/integration_test/path_provider_test.dart
+++ b/packages/path_provider/path_provider/example/integration_test/path_provider_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
@@ -13,53 +11,54 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets('getTemporaryDirectory', (WidgetTester tester) async {
-    final Directory result = await getTemporaryDirectory();
+    final Directory? result = await getTemporaryDirectory();
     _verifySampleFile(result, 'temporaryDirectory');
   });
 
   testWidgets('getApplicationDocumentsDirectory', (WidgetTester tester) async {
-    final Directory result = await getApplicationDocumentsDirectory();
+    final Directory? result = await getApplicationDocumentsDirectory();
     _verifySampleFile(result, 'applicationDocuments');
   });
 
   testWidgets('getApplicationSupportDirectory', (WidgetTester tester) async {
-    final Directory result = await getApplicationSupportDirectory();
+    final Directory? result = await getApplicationSupportDirectory();
     _verifySampleFile(result, 'applicationSupport');
   });
 
   testWidgets('getLibraryDirectory', (WidgetTester tester) async {
     if (Platform.isIOS) {
-      final Directory result = await getLibraryDirectory();
+      final Directory? result = await getLibraryDirectory();
       _verifySampleFile(result, 'library');
     } else if (Platform.isAndroid) {
-      final Future<Directory> result = getLibraryDirectory();
+      final Future<Directory?> result = getLibraryDirectory();
       expect(result, throwsA(isInstanceOf<UnsupportedError>()));
     }
   });
 
   testWidgets('getExternalStorageDirectory', (WidgetTester tester) async {
     if (Platform.isIOS) {
-      final Future<Directory> result = getExternalStorageDirectory();
+      final Future<Directory?> result = getExternalStorageDirectory();
       expect(result, throwsA(isInstanceOf<UnsupportedError>()));
     } else if (Platform.isAndroid) {
-      final Directory result = await getExternalStorageDirectory();
+      final Directory? result = await getExternalStorageDirectory();
       _verifySampleFile(result, 'externalStorage');
     }
   });
 
   testWidgets('getExternalCacheDirectories', (WidgetTester tester) async {
     if (Platform.isIOS) {
-      final Future<List<Directory>> result = getExternalCacheDirectories();
+      final Future<List<Directory>?> result = getExternalCacheDirectories();
       expect(result, throwsA(isInstanceOf<UnsupportedError>()));
     } else if (Platform.isAndroid) {
-      final List<Directory> directories = await getExternalCacheDirectories();
-      for (final Directory result in directories) {
+      final List<Directory>? directories = await getExternalCacheDirectories();
+      expect(directories, isNotNull);
+      for (final Directory result in directories!) {
         _verifySampleFile(result, 'externalCache');
       }
     }
   });
 
-  final List<StorageDirectory> _allDirs = <StorageDirectory>[
+  final List<StorageDirectory?> _allDirs = <StorageDirectory?>[
     null,
     StorageDirectory.music,
     StorageDirectory.podcasts,
@@ -70,16 +69,17 @@ void main() {
     StorageDirectory.movies,
   ];
 
-  for (final StorageDirectory type in _allDirs) {
+  for (final StorageDirectory? type in _allDirs) {
     test('getExternalStorageDirectories (type: $type)', () async {
       if (Platform.isIOS) {
-        final Future<List<Directory>> result =
+        final Future<List<Directory>?> result =
             getExternalStorageDirectories(type: null);
         expect(result, throwsA(isInstanceOf<UnsupportedError>()));
       } else if (Platform.isAndroid) {
-        final List<Directory> directories =
+        final List<Directory>? directories =
             await getExternalStorageDirectories(type: type);
-        for (final Directory result in directories) {
+        expect(directories, isNotNull);
+        for (final Directory result in directories!) {
           _verifySampleFile(result, '$type');
         }
       }
@@ -89,7 +89,9 @@ void main() {
 
 /// Verify a file called [name] in [directory] by recreating it with test
 /// contents when necessary.
-void _verifySampleFile(Directory directory, String name) {
+void _verifySampleFile(Directory? directory, String name) {
+  expect(directory, isNotNull);
+  if (directory == null) return;
   final File file = File('${directory.path}/$name');
 
   if (file.existsSync()) {

--- a/packages/path_provider/path_provider/example/integration_test/path_provider_test.dart
+++ b/packages/path_provider/path_provider/example/integration_test/path_provider_test.dart
@@ -11,23 +11,23 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets('getTemporaryDirectory', (WidgetTester tester) async {
-    final Directory? result = await getTemporaryDirectory();
+    final Directory result = await getTemporaryDirectory();
     _verifySampleFile(result, 'temporaryDirectory');
   });
 
   testWidgets('getApplicationDocumentsDirectory', (WidgetTester tester) async {
-    final Directory? result = await getApplicationDocumentsDirectory();
+    final Directory result = await getApplicationDocumentsDirectory();
     _verifySampleFile(result, 'applicationDocuments');
   });
 
   testWidgets('getApplicationSupportDirectory', (WidgetTester tester) async {
-    final Directory? result = await getApplicationSupportDirectory();
+    final Directory result = await getApplicationSupportDirectory();
     _verifySampleFile(result, 'applicationSupport');
   });
 
   testWidgets('getLibraryDirectory', (WidgetTester tester) async {
     if (Platform.isIOS) {
-      final Directory? result = await getLibraryDirectory();
+      final Directory result = await getLibraryDirectory();
       _verifySampleFile(result, 'library');
     } else if (Platform.isAndroid) {
       final Future<Directory?> result = getLibraryDirectory();
@@ -91,7 +91,9 @@ void main() {
 /// contents when necessary.
 void _verifySampleFile(Directory? directory, String name) {
   expect(directory, isNotNull);
-  if (directory == null) return;
+  if (directory == null) {
+    return;
+  }
   final File file = File('${directory.path}/$name');
 
   if (file.existsSync()) {

--- a/packages/path_provider/path_provider/example/test_driver/integration_test.dart
+++ b/packages/path_provider/path_provider/example/test_driver/integration_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 import 'package:integration_test/integration_test_driver.dart';
 
 Future<void> main() => integrationDriver();

--- a/packages/path_provider/path_provider_linux/example/integration_test/path_provider_test.dart
+++ b/packages/path_provider/path_provider_linux/example/integration_test/path_provider_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
@@ -14,7 +12,7 @@ void main() {
 
   testWidgets('getTemporaryDirectory', (WidgetTester tester) async {
     final PathProviderLinux provider = PathProviderLinux();
-    final String result = await provider.getTemporaryPath();
+    final String? result = await provider.getTemporaryPath();
     _verifySampleFile(result, 'temporaryDirectory');
   });
 
@@ -23,26 +21,28 @@ void main() {
       return;
     }
     final PathProviderLinux provider = PathProviderLinux();
-    final String result = await provider.getDownloadsPath();
+    final String? result = await provider.getDownloadsPath();
     _verifySampleFile(result, 'downloadDirectory');
   });
 
   testWidgets('getApplicationDocumentsDirectory', (WidgetTester tester) async {
     final PathProviderLinux provider = PathProviderLinux();
-    final String result = await provider.getApplicationDocumentsPath();
+    final String? result = await provider.getApplicationDocumentsPath();
     _verifySampleFile(result, 'applicationDocuments');
   });
 
   testWidgets('getApplicationSupportDirectory', (WidgetTester tester) async {
     final PathProviderLinux provider = PathProviderLinux();
-    final String result = await provider.getApplicationSupportPath();
+    final String? result = await provider.getApplicationSupportPath();
     _verifySampleFile(result, 'applicationSupport');
   });
 }
 
 /// Verify a file called [name] in [directoryPath] by recreating it with test
 /// contents when necessary.
-void _verifySampleFile(String directoryPath, String name) {
+void _verifySampleFile(String? directoryPath, String name) {
+  expect(directoryPath, isNotNull);
+  if (directoryPath == null) return;
   final Directory directory = Directory(directoryPath);
   final File file = File('${directory.path}${Platform.pathSeparator}$name');
 

--- a/packages/path_provider/path_provider_linux/example/integration_test/path_provider_test.dart
+++ b/packages/path_provider/path_provider_linux/example/integration_test/path_provider_test.dart
@@ -42,7 +42,9 @@ void main() {
 /// contents when necessary.
 void _verifySampleFile(String? directoryPath, String name) {
   expect(directoryPath, isNotNull);
-  if (directoryPath == null) return;
+  if (directoryPath == null) {
+    return;
+  }
   final Directory directory = Directory(directoryPath);
   final File file = File('${directory.path}${Platform.pathSeparator}$name');
 

--- a/packages/path_provider/path_provider_linux/example/test_driver/integration_test.dart
+++ b/packages/path_provider/path_provider_linux/example/test_driver/integration_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 import 'package:integration_test/integration_test_driver.dart';
 
 Future<void> main() => integrationDriver();

--- a/packages/path_provider/path_provider_macos/example/integration_test/path_provider_test.dart
+++ b/packages/path_provider/path_provider_macos/example/integration_test/path_provider_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
@@ -14,31 +12,31 @@ void main() {
 
   testWidgets('getTemporaryDirectory', (WidgetTester tester) async {
     final PathProviderPlatform provider = PathProviderPlatform.instance;
-    final String result = await provider.getTemporaryPath();
+    final String? result = await provider.getTemporaryPath();
     _verifySampleFile(result, 'temporaryDirectory');
   });
 
   testWidgets('getApplicationDocumentsDirectory', (WidgetTester tester) async {
     final PathProviderPlatform provider = PathProviderPlatform.instance;
-    final String result = await provider.getApplicationDocumentsPath();
+    final String? result = await provider.getApplicationDocumentsPath();
     _verifySampleFile(result, 'applicationDocuments');
   });
 
   testWidgets('getApplicationSupportDirectory', (WidgetTester tester) async {
     final PathProviderPlatform provider = PathProviderPlatform.instance;
-    final String result = await provider.getApplicationSupportPath();
+    final String? result = await provider.getApplicationSupportPath();
     _verifySampleFile(result, 'applicationSupport');
   });
 
   testWidgets('getLibraryDirectory', (WidgetTester tester) async {
     final PathProviderPlatform provider = PathProviderPlatform.instance;
-    final String result = await provider.getLibraryPath();
+    final String? result = await provider.getLibraryPath();
     _verifySampleFile(result, 'library');
   });
 
   testWidgets('getDownloadsDirectory', (WidgetTester tester) async {
     final PathProviderPlatform provider = PathProviderPlatform.instance;
-    final String result = await provider.getDownloadsPath();
+    final String? result = await provider.getDownloadsPath();
     // _verifySampleFile causes hangs in driver for some reason, so just
     // validate that a non-empty path was returned.
     expect(result, isNotEmpty);
@@ -49,7 +47,9 @@ void main() {
 /// contents when necessary.
 ///
 /// If [createDirectory] is true, the directory will be created if missing.
-void _verifySampleFile(String directoryPath, String name) {
+void _verifySampleFile(String? directoryPath, String name) {
+  expect(directoryPath, isNotNull);
+  if (directoryPath == null) return;
   final Directory directory = Directory(directoryPath);
   final File file = File('${directory.path}${Platform.pathSeparator}$name');
 

--- a/packages/path_provider/path_provider_macos/example/integration_test/path_provider_test.dart
+++ b/packages/path_provider/path_provider_macos/example/integration_test/path_provider_test.dart
@@ -49,7 +49,9 @@ void main() {
 /// If [createDirectory] is true, the directory will be created if missing.
 void _verifySampleFile(String? directoryPath, String name) {
   expect(directoryPath, isNotNull);
-  if (directoryPath == null) return;
+  if (directoryPath == null) {
+    return;
+  }
   final Directory directory = Directory(directoryPath);
   final File file = File('${directory.path}${Platform.pathSeparator}$name');
 

--- a/packages/path_provider/path_provider_macos/example/test_driver/integration_test.dart
+++ b/packages/path_provider/path_provider_macos/example/test_driver/integration_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 import 'package:integration_test/integration_test_driver.dart';
 
 Future<void> main() => integrationDriver();

--- a/packages/path_provider/path_provider_windows/example/integration_test/path_provider_test.dart
+++ b/packages/path_provider/path_provider_windows/example/integration_test/path_provider_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
@@ -14,32 +12,34 @@ void main() {
 
   testWidgets('getTemporaryDirectory', (WidgetTester tester) async {
     final PathProviderWindows provider = PathProviderWindows();
-    final String result = await provider.getTemporaryPath();
+    final String? result = await provider.getTemporaryPath();
     _verifySampleFile(result, 'temporaryDirectory');
   });
 
   testWidgets('getApplicationDocumentsDirectory', (WidgetTester tester) async {
     final PathProviderWindows provider = PathProviderWindows();
-    final String result = await provider.getApplicationDocumentsPath();
+    final String? result = await provider.getApplicationDocumentsPath();
     _verifySampleFile(result, 'applicationDocuments');
   });
 
   testWidgets('getApplicationSupportDirectory', (WidgetTester tester) async {
     final PathProviderWindows provider = PathProviderWindows();
-    final String result = await provider.getApplicationSupportPath();
+    final String? result = await provider.getApplicationSupportPath();
     _verifySampleFile(result, 'applicationSupport');
   });
 
   testWidgets('getDownloadsDirectory', (WidgetTester tester) async {
     final PathProviderWindows provider = PathProviderWindows();
-    final String result = await provider.getDownloadsPath();
+    final String? result = await provider.getDownloadsPath();
     _verifySampleFile(result, 'downloads');
   });
 }
 
 /// Verify a file called [name] in [directoryPath] by recreating it with test
 /// contents when necessary.
-void _verifySampleFile(String directoryPath, String name) {
+void _verifySampleFile(String? directoryPath, String name) {
+  expect(directoryPath, isNotNull);
+  if (directoryPath == null) return;
   final Directory directory = Directory(directoryPath);
   final File file = File('${directory.path}${Platform.pathSeparator}$name');
 

--- a/packages/path_provider/path_provider_windows/example/integration_test/path_provider_test.dart
+++ b/packages/path_provider/path_provider_windows/example/integration_test/path_provider_test.dart
@@ -39,7 +39,9 @@ void main() {
 /// contents when necessary.
 void _verifySampleFile(String? directoryPath, String name) {
   expect(directoryPath, isNotNull);
-  if (directoryPath == null) return;
+  if (directoryPath == null) {
+    return;
+  }
   final Directory directory = Directory(directoryPath);
   final File file = File('${directory.path}${Platform.pathSeparator}$name');
 

--- a/packages/path_provider/path_provider_windows/example/test_driver/integration_test.dart
+++ b/packages/path_provider/path_provider_windows/example/test_driver/integration_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 import 'package:integration_test/integration_test_driver.dart';
 
 Future<void> main() => integrationDriver();


### PR DESCRIPTION
Updates #3644 from the branch where we were experimenting with null-safe integration tests for changes on master.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format](../script/tool/README.md#format-code))
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
