### PR TITLE
[camera] Migrate maven repo from jcenter to mavenCentral

### DIFF
--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.8.2
+## 0.8.1+1
 
 * Migrate maven repository from jcenter to mavenCentral.
 

--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.2
+
+* Migrate maven repository from jcenter to mavenCentral.
+
 ## 0.8.1
 
 * Solved a rotation issue on iOS which caused the default preview to be displayed as landscape right instead of portrait.
@@ -15,7 +19,7 @@
 
 ## 0.7.0+3
 
-* Clockwise rotation of focus point in android 
+* Clockwise rotation of focus point in android
 
 ## 0.7.0+2
 
@@ -117,7 +121,7 @@ As part of implementing federated architecture and making the interface compatib
 
 Method changes in `CameraController`:
 - The `takePicture` method no longer accepts the `path` parameter, but instead returns the captured image as an instance of the `XFile` class;
-- The `startVideoRecording` method no longer accepts the `filePath`. Instead the recorded video is now returned as a `XFile` instance when the `stopVideoRecording` method completes; 
+- The `startVideoRecording` method no longer accepts the `filePath`. Instead the recorded video is now returned as a `XFile` instance when the `stopVideoRecording` method completes;
 - The `stopVideoRecording` method now returns the captured video when it completes;
 - Added the `buildPreview` method which is now used to implement the CameraPreview widget.
 

--- a/packages/camera/camera/android/build.gradle
+++ b/packages/camera/camera/android/build.gradle
@@ -5,7 +5,7 @@ def args = ["-Xlint:deprecation","-Xlint:unchecked","-Werror"]
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -16,7 +16,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/packages/camera/camera/example/android/build.gradle
+++ b/packages/camera/camera/example/android/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -12,10 +12,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
-        maven {
-            url 'https://google.bintray.com/exoplayer/'
-        }
+        mavenCentral()
     }
 }
 

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera
 description: A Flutter plugin for getting information about and controlling the
   camera on Android and iOS. Supports previewing the camera feed, capturing images, capturing video,
   and streaming image buffers to dart.
-version: 0.8.1
+version: 0.8.2
 homepage: https://github.com/flutter/plugins/tree/master/packages/camera/camera
 
 dependencies:
@@ -23,7 +23,7 @@ dev_dependencies:
 
   # TODO(mvanbeusekom): Update to stable 5.0.0 release when dependency conflict
   # with flutter_driver has been resolved:
-  # Because mockito >=5.0.0 depends on analyzer ^1.0.0 which depends on crypto ^3.0.0 
+  # Because mockito >=5.0.0 depends on analyzer ^1.0.0 which depends on crypto ^3.0.0
   # every version of flutter_driver from sdk depends on crypto 2.1.5.
   mockito: ^5.0.0-nullsafety.7
   plugin_platform_interface: ^2.0.0

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera
 description: A Flutter plugin for getting information about and controlling the
   camera on Android and iOS. Supports previewing the camera feed, capturing images, capturing video,
   and streaming image buffers to dart.
-version: 0.8.2
+version: 0.8.1+1
 homepage: https://github.com/flutter/plugins/tree/master/packages/camera/camera
 
 dependencies:


### PR DESCRIPTION
The jcenter maven repository is being sunset and is currently readonly.  Migrate to mavenCentral.

Remove `exoplayer` workaround introduced in #977.  See also https://github.com/google/ExoPlayer/issues/5246.
Remove trailing whitespace from CHANGELOG and pubspec.

camera part of https://github.com/flutter/flutter/issues/82847

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format](../script/tool/README.md#format-code))
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.