### PR TITLE
[connectivity] Migrate maven repo from jcenter to mavenCentral

### DIFF
--- a/packages/connectivity/connectivity/CHANGELOG.md
+++ b/packages/connectivity/connectivity/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.4
+
+* Migrate maven repository from jcenter to mavenCentral.
+
 ## 3.0.3
 
 * Re-endorse connectivity_for_web

--- a/packages/connectivity/connectivity/android/build.gradle
+++ b/packages/connectivity/connectivity/android/build.gradle
@@ -5,7 +5,7 @@ def args = ["-Xlint:deprecation","-Xlint:unchecked","-Werror"]
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -16,7 +16,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/packages/connectivity/connectivity/example/android/build.gradle
+++ b/packages/connectivity/connectivity/example/android/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -12,7 +12,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/packages/connectivity/connectivity/pubspec.yaml
+++ b/packages/connectivity/connectivity/pubspec.yaml
@@ -2,7 +2,7 @@ name: connectivity
 description: Flutter plugin for discovering the state of the network (WiFi &
   mobile/cellular) connectivity on Android and iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/connectivity/connectivity
-version: 3.0.3
+version: 3.0.4
 
 flutter:
   plugin:


### PR DESCRIPTION
The jcenter maven repository is being sunset and is currently readonly.  Migrate to mavenCentral.

connectivity part of https://github.com/flutter/flutter/issues/82847

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format](../script/tool/README.md#format-code))
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.