### PR TITLE
[sensors] Update Cirrus image to Xcode 12.5, fix sensors analyzer warning 

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -214,7 +214,7 @@ task:
         SIMCTL_CHILD_MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
       create_simulator_script:
         - xcrun simctl list
-        - xcrun simctl create Flutter-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-11 com.apple.CoreSimulator.SimRuntime.iOS-14-3 | xargs xcrun simctl boot
+        - xcrun simctl create Flutter-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-11 com.apple.CoreSimulator.SimRuntime.iOS-14-5 | xargs xcrun simctl boot
       build_script:
         - ./script/tool_runner.sh build-examples --ipa
       xctest_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -25,7 +25,7 @@ macos_template: &MACOS_TEMPLATE
   # PRs on macOS.
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   osx_instance:
-    image: big-sur-xcode-12.3
+    image: big-sur-xcode-12.5
   cocoapod_install_script: sudo gem install cocoapods
 
 # Light-workload Linux tasks.

--- a/packages/sensors/CHANGELOG.md
+++ b/packages/sensors/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.2
+
+* Fix -Wstrict-prototypes analyzer warning in iOS plugin.
+
 ## 2.0.1
 
 * Migrate maven repository from jcenter to mavenCentral.

--- a/packages/sensors/ios/Classes/FLTSensorsPlugin.m
+++ b/packages/sensors/ios/Classes/FLTSensorsPlugin.m
@@ -34,7 +34,7 @@
 const double GRAVITY = 9.8;
 CMMotionManager* _motionManager;
 
-void _initMotionManager() {
+void _initMotionManager(void) {
   if (!_motionManager) {
     _motionManager = [[CMMotionManager alloc] init];
   }

--- a/packages/sensors/pubspec.yaml
+++ b/packages/sensors/pubspec.yaml
@@ -2,7 +2,7 @@ name: sensors
 description: Flutter plugin for accessing the Android and iOS accelerometer and
   gyroscope sensors.
 homepage: https://github.com/flutter/plugins/tree/master/packages/sensors
-version: 2.0.1
+version: 2.0.2
 
 flutter:
   plugin:


### PR DESCRIPTION
Keep the Xcode version to latest available Cirrus image.
Fix new sensor plugin analyzer warning.  This is already tested by the analyzer linters.

Fixes https://github.com/flutter/flutter/issues/82953

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format](../script/tool/README.md#format-code))
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.