### PR TITLE
Add xctest --xclogparser to test runner

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -197,7 +197,7 @@ task:
     - name: build-ipas+drive-examples
       env:
         PATH: $PATH:/usr/local/bin
-        XCLOGPARSER_OUTPUT: "${HOME}/xclogparser"
+        XCLOGPARSER_OUTPUT: "xclogparser"
         # in_app_purchase_ios is currently missing tests; see https://github.com/flutter/flutter/issues/81695
         # ios_platform_images is currently missing tests; see https://github.com/flutter/flutter/issues/82208
         # sensor hangs on CI.
@@ -222,7 +222,7 @@ task:
         - ./script/tool_runner.sh xctest --skip $PLUGINS_TO_SKIP_XCTESTS --ios-destination "platform=iOS Simulator,name=iPhone 11,OS=latest" --xclogparser $XCLOGPARSER_OUTPUT
       always:
         xclogparser_upload_artifacts:
-          path: "**/xclogparser/*.json"
+          path: "${XCLOGPARSER_OUTPUT}/*.json"
           type: text/json
           format: xclogparser
       drive_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -24,7 +24,7 @@ macos_template: &MACOS_TEMPLATE
   # PRs on macOS.
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   osx_instance:
-    image: big-sur-xcode-12.3
+    image: big-sur-xcode-12.5
   cocoapod_install_script: sudo gem install cocoapods
 
 # Light-workload Linux tasks.
@@ -213,13 +213,13 @@ task:
         SIMCTL_CHILD_MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
       create_simulator_script:
         - xcrun simctl list
-        - xcrun simctl create Flutter-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-11 com.apple.CoreSimulator.SimRuntime.iOS-14-3 | xargs xcrun simctl boot
+        - xcrun simctl create Flutter-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-11 com.apple.CoreSimulator.SimRuntime.iOS-14-5 | xargs xcrun simctl boot
       install_xclogparser_script:
         - brew install xclogparser
       build_script:
         - ./script/tool_runner.sh build-examples --ipa
       xctest_script:
-        - ./script/tool_runner.sh xctest --skip $PLUGINS_TO_SKIP_XCTESTS --ios-destination "platform=iOS Simulator,name=iPhone 11,OS=latest" --xclogparser $XCLOGPARSER_OUTPUT
+        - ./script/tool_runner.sh xctest --skip $PLUGINS_TO_SKIP_XCTESTS --ios-destination "platform=iOS Simulator,name=iPhone 11,OS=latest" --xclogparser "${XCLOGPARSER_OUTPUT}"
       always:
         xclogparser_upload_artifacts:
           path: "${XCLOGPARSER_OUTPUT}/*.json"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -24,7 +24,7 @@ macos_template: &MACOS_TEMPLATE
   # PRs on macOS.
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   osx_instance:
-    image: big-sur-xcode-12.5
+    image: big-sur-xcode-12.3
   cocoapod_install_script: sudo gem install cocoapods
 
 # Light-workload Linux tasks.
@@ -197,6 +197,7 @@ task:
     - name: build-ipas+drive-examples
       env:
         PATH: $PATH:/usr/local/bin
+        XCLOGPARSER_OUTPUT: "${HOME}/xclogparser"
         # in_app_purchase_ios is currently missing tests; see https://github.com/flutter/flutter/issues/81695
         # ios_platform_images is currently missing tests; see https://github.com/flutter/flutter/issues/82208
         # sensor hangs on CI.
@@ -212,11 +213,18 @@ task:
         SIMCTL_CHILD_MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
       create_simulator_script:
         - xcrun simctl list
-        - xcrun simctl create Flutter-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-11 com.apple.CoreSimulator.SimRuntime.iOS-14-5 | xargs xcrun simctl boot
+        - xcrun simctl create Flutter-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-11 com.apple.CoreSimulator.SimRuntime.iOS-14-3 | xargs xcrun simctl boot
+      install_xclogparser_script:
+        - brew install xclogparser
       build_script:
         - ./script/tool_runner.sh build-examples --ipa
       xctest_script:
-        - ./script/tool_runner.sh xctest --ios-destination "platform=iOS Simulator,name=iPhone 11,OS=latest"
+        - ./script/tool_runner.sh xctest --skip $PLUGINS_TO_SKIP_XCTESTS --ios-destination "platform=iOS Simulator,name=iPhone 11,OS=latest" --xclogparser $XCLOGPARSER_OUTPUT
+      always:
+        xclogparser_upload_artifacts:
+          path: "**/xclogparser/*.json"
+          type: text/json
+          format: xclogparser
       drive_script:
         # `drive-examples` contains integration tests, which changes the UI of the application.
         # This UI change sometimes affects `xctest`.

--- a/script/tool/README.md
+++ b/script/tool/README.md
@@ -79,8 +79,14 @@ dart run ./script/tool/lib/src/main.dart test --plugins plugin_name
 
 ```sh
 cd <repository root>
-dart run ./script/tool/lib/src/main.dart xctest --target RunnerUITests --skip <plugins_to_skip>
+dart run ./script/tool/lib/src/main.dart xctest --xclogparser <path/to/directory> --skip <plugins_to_skip>
 ```
+
+If XCLogParser is installed, optionally pass in a directory to `--xclogparser`
+to parse the xcodebuild output to json.
+
+To install XCLogParser locally, run `brew install xclogparser`.
+See also the [Cirrus XCLogParser documentation](https://cirrus-ci.org/examples/#xclogparser). 
 
 ### Publish a Release
 

--- a/script/tool/pubspec.yaml
+++ b/script/tool/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   meta: ^1.3.0
   path: ^1.8.0
   platform: ^3.0.0
+  process: ^4.2.0
   pub_semver: ^2.0.0
   pubspec_parse: ^1.0.0
   quiver: ^3.0.1

--- a/script/tool/test/util.dart
+++ b/script/tool/test/util.dart
@@ -17,7 +17,7 @@ import 'package:quiver/collection.dart';
 // TODO(stuartmorgan): Eliminate this in favor of setting up a clean filesystem
 // for each test, to eliminate the chance of files from one test interfering
 // with another test.
-FileSystem mockFileSystem = MemoryFileSystem(
+FileSystem mockFileSystem = MemoryFileSystem.test(
     style: const LocalPlatform().isWindows
         ? FileSystemStyle.windows
         : FileSystemStyle.posix);
@@ -244,12 +244,16 @@ class RecordingProcessRunner extends ProcessRunner {
   /// Populate for [io.ProcessResult] to use a String [stderr] instead of a [List] of [int].
   String? resultStderr;
 
+  /// Populate to return from [canRun].
+  bool canRunExecutables = true;
+
   @override
   Future<int> runAndStream(
     String executable,
     List<String> args, {
     Directory? workingDir,
     bool exitOnError = false,
+    Map<String, String>? environment,
   }) async {
     recordedCalls.add(ProcessCall(executable, args, workingDir?.path));
     return Future<int>.value(
@@ -283,6 +287,11 @@ class RecordingProcessRunner extends ProcessRunner {
       {Directory? workingDirectory}) async {
     recordedCalls.add(ProcessCall(executable, args, workingDirectory?.path));
     return Future<io.Process>.value(processToReturn);
+  }
+
+  @override
+  bool canRun(String executable, {String? workingDirectory}) {
+    return canRunExecutables;
   }
 }
 


### PR DESCRIPTION
Parse the `xcodebuild` output with XCLogParser, supported by Cirrus https://cirrus-ci.org/examples/#xclogparser
Update the Xcode version to latest available Cirrus image.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format](../script/tool/README.md#format-code))
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.