### PR TITLE
[google_maps_flutter] add possibility to change animation duration

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.7
+
+* Add possibility to change animation duration
+
 ## 2.0.6
 
 * Migrate maven repo from jcenter to mavenCentral.

--- a/packages/google_maps_flutter/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
+++ b/packages/google_maps_flutter/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
@@ -118,8 +118,10 @@ final class GoogleMapController
     googleMap.moveCamera(cameraUpdate);
   }
 
-  private void animateCamera(CameraUpdate cameraUpdate) {
-    googleMap.animateCamera(cameraUpdate);
+  private void animateCamera(CameraUpdate cameraUpdate, Integer animationDuration) {
+    if(animationDuration != null)
+        googleMap.animateCamera(cameraUpdate, animationDuration, null);
+    else googleMap.animateCamera(cameraUpdate);
   }
 
   private CameraPosition getCameraPosition() {
@@ -238,7 +240,8 @@ final class GoogleMapController
         {
           final CameraUpdate cameraUpdate =
               Convert.toCameraUpdate(call.argument("cameraUpdate"), density);
-          animateCamera(cameraUpdate);
+          final Integer animationDuration = call.argument("animationDuration");
+          animateCamera(cameraUpdate, animationDuration);
           result.success(null);
           break;
         }

--- a/packages/google_maps_flutter/google_maps_flutter/ios/Classes/GoogleMapController.m
+++ b/packages/google_maps_flutter/google_maps_flutter/ios/Classes/GoogleMapController.m
@@ -162,7 +162,10 @@ static double ToDouble(NSNumber* data) { return [FLTGoogleMapJsonConversions toD
     [self hide];
     result(nil);
   } else if ([call.method isEqualToString:@"camera#animate"]) {
-    [self animateWithCameraUpdate:ToCameraUpdate(call.arguments[@"cameraUpdate"])];
+    NSNumber* animationDuration = call.arguments[@"animationDuration"];
+    if(![animationDuration isKindOfClass:[NSNull class]])
+        animationDuration = @([animationDuration floatValue] / 1000);
+    [self animateWithCameraUpdate:ToCameraUpdate(call.arguments[@"cameraUpdate"]) :animationDuration];
     result(nil);
   } else if ([call.method isEqualToString:@"camera#move"]) {
     [self moveWithCameraUpdate:ToCameraUpdate(call.arguments[@"cameraUpdate"])];
@@ -386,8 +389,12 @@ static double ToDouble(NSNumber* data) { return [FLTGoogleMapJsonConversions toD
   _mapView.hidden = YES;
 }
 
-- (void)animateWithCameraUpdate:(GMSCameraUpdate*)cameraUpdate {
+- (void)animateWithCameraUpdate:(GMSCameraUpdate*)cameraUpdate :(NSNumber*)animationDuration {
+  [CATransaction begin];
+  if(![animationDuration isKindOfClass:[NSNull class]])
+      [CATransaction setValue:animationDuration forKey:kCATransactionAnimationDuration];
   [_mapView animateWithCameraUpdate:cameraUpdate];
+  [CATransaction commit];
 }
 
 - (void)moveWithCameraUpdate:(GMSCameraUpdate*)cameraUpdate {

--- a/packages/google_maps_flutter/google_maps_flutter/lib/src/controller.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/lib/src/controller.dart
@@ -178,9 +178,11 @@ class GoogleMapController {
   ///
   /// The returned [Future] completes after the change has been started on the
   /// platform side.
-  Future<void> animateCamera(CameraUpdate cameraUpdate) {
+  Future<void> animateCamera(CameraUpdate cameraUpdate,
+      {Duration? animationDuration}) {
     return GoogleMapsFlutterPlatform.instance
-        .animateCamera(cameraUpdate, mapId: mapId);
+        .animateCamera(
+            cameraUpdate, mapId: mapId, animationDuration: animationDuration);
   }
 
   /// Changes the map camera position.

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -1,16 +1,13 @@
 name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter/google_maps_flutter
-version: 2.0.6
+version: 2.0.7
 
 dependencies:
   flutter:
     sdk: flutter
   flutter_plugin_android_lifecycle: ^2.0.1
-  google_maps_flutter_platform_interface: #^2.0.5?
-    git:
-      url: https://github.com/Milvintsiss/plugins.git
-      path: packages/google_maps_flutter/google_maps_flutter_platform_interface
+  google_maps_flutter_platform_interface: ^2.0.5
 
 dev_dependencies:
   flutter_test:

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -7,7 +7,10 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_plugin_android_lifecycle: ^2.0.1
-  google_maps_flutter_platform_interface: ^2.0.0
+  google_maps_flutter_platform_interface: #^2.0.5?
+    git:
+      url: https://github.com/Milvintsiss/plugins.git
+      path: packages/google_maps_flutter/google_maps_flutter_platform_interface
 
 dev_dependencies:
   flutter_test:

--- a/packages/google_maps_flutter/google_maps_flutter/test/map_creation_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/test/map_creation_test.dart
@@ -133,6 +133,7 @@ class TestGoogleMapsFlutterPlatform extends GoogleMapsFlutterPlatform {
   Future<void> animateCamera(
     CameraUpdate cameraUpdate, {
     required int mapId,
+    Duration? animationDuration
   }) async {}
 
   @override

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.5
+
+* Add possibility to change animation duration
+
 ## 2.0.4
 
 * Preserve the `TileProvider` when copying `TileOverlay`, fixing a

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/method_channel/method_channel_google_maps_flutter.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/method_channel/method_channel_google_maps_flutter.dart
@@ -333,9 +333,11 @@ class MethodChannelGoogleMapsFlutter extends GoogleMapsFlutterPlatform {
   Future<void> animateCamera(
     CameraUpdate cameraUpdate, {
     required int mapId,
+    Duration? animationDuration
   }) {
-    return channel(mapId).invokeMethod<void>('camera#animate', <String, Object>{
+    return channel(mapId).invokeMethod<void>('camera#animate', <String, dynamic>{
       'cameraUpdate': cameraUpdate.toJson(),
+      'animationDuration': animationDuration?.inMilliseconds,
     });
   }
 

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/platform_interface/google_maps_flutter_platform.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/platform_interface/google_maps_flutter_platform.dart
@@ -149,6 +149,7 @@ abstract class GoogleMapsFlutterPlatform extends PlatformInterface {
   Future<void> animateCamera(
     CameraUpdate cameraUpdate, {
     required int mapId,
+    Duration? animationDuration
   }) {
     throw UnimplementedError('animateCamera() has not been implemented.');
   }

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the google_maps_flutter plugin.
 homepage: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter/google_maps_flutter_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.0.4
+version: 2.0.5
 
 dependencies:
   flutter:


### PR DESCRIPTION
Fixes flutter/flutter#39810
* Add animationDuration optional parameter to animateCamera function for google_maps_flutter_platform_interface
* Add animationDuration to google_maps_flutter for both Android and iOS