### PR TITLE
[image_picker] Fix camera alert localization analyzer warning

### DIFF
--- a/packages/image_picker/image_picker/CHANGELOG.md
+++ b/packages/image_picker/image_picker/CHANGELOG.md
@@ -1,9 +1,12 @@
+## 0.7.5+3
+* Localize `UIAlertController` strings.
+
 ## 0.7.5+2
 * Implement `UIAlertController` with a preferredStyle of `UIAlertControllerStyleAlert` since `UIAlertView` is deprecated.
 
 ## 0.7.5+1
 
-* Fixes a rotation problem where Select Photos limited access is chosen but the image that is picked 
+* Fixes a rotation problem where Select Photos limited access is chosen but the image that is picked
 is not included selected photos and image is scaled.
 
 ## 0.7.5

--- a/packages/image_picker/image_picker/ios/Classes/FLTImagePickerPlugin.m
+++ b/packages/image_picker/image_picker/ios/Classes/FLTImagePickerPlugin.m
@@ -190,14 +190,17 @@ typedef NS_ENUM(NSInteger, ImagePickerClassType) { UIImagePickerClassType, PHPic
                                                       animated:YES
                                                     completion:nil];
   } else {
-    UIAlertController *cameraErrorAlert =
-        [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Error", @"Alert title when camera unavailable")
-                                            message:NSLocalizedString(@"Camera not available.", "Alert message when camera unavailable")
-                                     preferredStyle:UIAlertControllerStyleAlert];
-    [cameraErrorAlert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"OK", @"Alert button when camera unavailable")
-                                                         style:UIAlertActionStyleDefault
-                                                       handler:^(UIAlertAction *action){
-                                                       }]];
+    UIAlertController *cameraErrorAlert = [UIAlertController
+        alertControllerWithTitle:NSLocalizedString(@"Error", @"Alert title when camera unavailable")
+                         message:NSLocalizedString(@"Camera not available.",
+                                                   "Alert message when camera unavailable")
+                  preferredStyle:UIAlertControllerStyleAlert];
+    [cameraErrorAlert
+        addAction:[UIAlertAction actionWithTitle:NSLocalizedString(
+                                                     @"OK", @"Alert button when camera unavailable")
+                                           style:UIAlertActionStyleDefault
+                                         handler:^(UIAlertAction *action){
+                                         }]];
     [[self viewControllerWithWindow:nil] presentViewController:cameraErrorAlert
                                                       animated:YES
                                                     completion:nil];

--- a/packages/image_picker/image_picker/ios/Classes/FLTImagePickerPlugin.m
+++ b/packages/image_picker/image_picker/ios/Classes/FLTImagePickerPlugin.m
@@ -191,10 +191,10 @@ typedef NS_ENUM(NSInteger, ImagePickerClassType) { UIImagePickerClassType, PHPic
                                                     completion:nil];
   } else {
     UIAlertController *cameraErrorAlert =
-        [UIAlertController alertControllerWithTitle:@"Error"
-                                            message:@"Camera not available."
+        [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Error", @"Alert title when camera unavailable")
+                                            message:NSLocalizedString(@"Camera not available.", "Alert message when camera unavailable")
                                      preferredStyle:UIAlertControllerStyleAlert];
-    [cameraErrorAlert addAction:[UIAlertAction actionWithTitle:@"OK"
+    [cameraErrorAlert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"OK", @"Alert button when camera unavailable")
                                                          style:UIAlertActionStyleDefault
                                                        handler:^(UIAlertAction *action){
                                                        }]];

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker
 description: Flutter plugin for selecting images from the Android and iOS image
   library, and taking new pictures with the camera.
 homepage: https://github.com/flutter/plugins/tree/master/packages/image_picker/image_picker
-version: 0.7.5+2
+version: 0.7.5+3
 
 flutter:
   plugin:


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/82959.  Warning introduced in #3881.  There are already tests for this failing on master (I'm not sure why it succeeded on presubmit, `GCC_TREAT_WARNINGS_AS_ERRORS` is set to `YES`).

https://api.cirrus-ci.com/v1/task/6726759736410112/logs/xctest.log

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format](../script/tool/README.md#format-code))
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.