### PR TITLE
[video_player] Fix pointer value to boolean conversion analyzer warnings

### DIFF
--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.3
+
+* Fix pointer value to boolean conversion analyzer warnings.
+
 ## 2.1.2
 
 * Migrate maven repository from jcenter to mavenCentral.

--- a/packages/video_player/video_player/ios/Classes/messages.m
+++ b/packages/video_player/video_player/ios/Classes/messages.m
@@ -66,7 +66,7 @@ static NSDictionary<NSString *, id> *wrapResult(NSDictionary *result, FlutterErr
 }
 - (NSDictionary *)toMap {
   return
-      [NSDictionary dictionaryWithObjectsAndKeys:(self.textureId ? self.textureId : [NSNull null]),
+      [NSDictionary dictionaryWithObjectsAndKeys:(self.textureId != nil ? self.textureId : [NSNull null]),
                                                  @"textureId", nil];
 }
 @end
@@ -124,8 +124,8 @@ static NSDictionary<NSString *, id> *wrapResult(NSDictionary *result, FlutterErr
 }
 - (NSDictionary *)toMap {
   return [NSDictionary
-      dictionaryWithObjectsAndKeys:(self.textureId ? self.textureId : [NSNull null]), @"textureId",
-                                   (self.isLooping ? self.isLooping : [NSNull null]), @"isLooping",
+      dictionaryWithObjectsAndKeys:(self.textureId != nil ? self.textureId : [NSNull null]), @"textureId",
+                                   (self.isLooping != nil ? self.isLooping : [NSNull null]), @"isLooping",
                                    nil];
 }
 @end
@@ -145,8 +145,8 @@ static NSDictionary<NSString *, id> *wrapResult(NSDictionary *result, FlutterErr
 }
 - (NSDictionary *)toMap {
   return [NSDictionary
-      dictionaryWithObjectsAndKeys:(self.textureId ? self.textureId : [NSNull null]), @"textureId",
-                                   (self.volume ? self.volume : [NSNull null]), @"volume", nil];
+      dictionaryWithObjectsAndKeys:(self.textureId != nil ? self.textureId : [NSNull null]), @"textureId",
+                                   (self.volume != nil ? self.volume : [NSNull null]), @"volume", nil];
 }
 @end
 
@@ -165,8 +165,8 @@ static NSDictionary<NSString *, id> *wrapResult(NSDictionary *result, FlutterErr
 }
 - (NSDictionary *)toMap {
   return [NSDictionary
-      dictionaryWithObjectsAndKeys:(self.textureId ? self.textureId : [NSNull null]), @"textureId",
-                                   (self.speed ? self.speed : [NSNull null]), @"speed", nil];
+      dictionaryWithObjectsAndKeys:(self.textureId != nil ? self.textureId : [NSNull null]), @"textureId",
+                                   (self.speed != nil ? self.speed : [NSNull null]), @"speed", nil];
 }
 @end
 
@@ -185,8 +185,8 @@ static NSDictionary<NSString *, id> *wrapResult(NSDictionary *result, FlutterErr
 }
 - (NSDictionary *)toMap {
   return [NSDictionary
-      dictionaryWithObjectsAndKeys:(self.textureId ? self.textureId : [NSNull null]), @"textureId",
-                                   (self.position ? self.position : [NSNull null]), @"position",
+      dictionaryWithObjectsAndKeys:(self.textureId != nil ? self.textureId : [NSNull null]), @"textureId",
+                                   (self.position != nil ? self.position : [NSNull null]), @"position",
                                    nil];
 }
 @end
@@ -202,7 +202,7 @@ static NSDictionary<NSString *, id> *wrapResult(NSDictionary *result, FlutterErr
 }
 - (NSDictionary *)toMap {
   return [NSDictionary
-      dictionaryWithObjectsAndKeys:(self.mixWithOthers ? self.mixWithOthers : [NSNull null]),
+      dictionaryWithObjectsAndKeys:(self.mixWithOthers != nil ? self.mixWithOthers : [NSNull null]),
                                    @"mixWithOthers", nil];
 }
 @end

--- a/packages/video_player/video_player/ios/Classes/messages.m
+++ b/packages/video_player/video_player/ios/Classes/messages.m
@@ -65,9 +65,9 @@ static NSDictionary<NSString *, id> *wrapResult(NSDictionary *result, FlutterErr
   return result;
 }
 - (NSDictionary *)toMap {
-  return
-      [NSDictionary dictionaryWithObjectsAndKeys:(self.textureId != nil ? self.textureId : [NSNull null]),
-                                                 @"textureId", nil];
+  return [NSDictionary
+      dictionaryWithObjectsAndKeys:(self.textureId != nil ? self.textureId : [NSNull null]),
+                                   @"textureId", nil];
 }
 @end
 
@@ -124,9 +124,10 @@ static NSDictionary<NSString *, id> *wrapResult(NSDictionary *result, FlutterErr
 }
 - (NSDictionary *)toMap {
   return [NSDictionary
-      dictionaryWithObjectsAndKeys:(self.textureId != nil ? self.textureId : [NSNull null]), @"textureId",
-                                   (self.isLooping != nil ? self.isLooping : [NSNull null]), @"isLooping",
-                                   nil];
+      dictionaryWithObjectsAndKeys:(self.textureId != nil ? self.textureId : [NSNull null]),
+                                   @"textureId",
+                                   (self.isLooping != nil ? self.isLooping : [NSNull null]),
+                                   @"isLooping", nil];
 }
 @end
 
@@ -145,8 +146,9 @@ static NSDictionary<NSString *, id> *wrapResult(NSDictionary *result, FlutterErr
 }
 - (NSDictionary *)toMap {
   return [NSDictionary
-      dictionaryWithObjectsAndKeys:(self.textureId != nil ? self.textureId : [NSNull null]), @"textureId",
-                                   (self.volume != nil ? self.volume : [NSNull null]), @"volume", nil];
+      dictionaryWithObjectsAndKeys:(self.textureId != nil ? self.textureId : [NSNull null]),
+                                   @"textureId", (self.volume != nil ? self.volume : [NSNull null]),
+                                   @"volume", nil];
 }
 @end
 
@@ -165,8 +167,9 @@ static NSDictionary<NSString *, id> *wrapResult(NSDictionary *result, FlutterErr
 }
 - (NSDictionary *)toMap {
   return [NSDictionary
-      dictionaryWithObjectsAndKeys:(self.textureId != nil ? self.textureId : [NSNull null]), @"textureId",
-                                   (self.speed != nil ? self.speed : [NSNull null]), @"speed", nil];
+      dictionaryWithObjectsAndKeys:(self.textureId != nil ? self.textureId : [NSNull null]),
+                                   @"textureId", (self.speed != nil ? self.speed : [NSNull null]),
+                                   @"speed", nil];
 }
 @end
 
@@ -185,9 +188,10 @@ static NSDictionary<NSString *, id> *wrapResult(NSDictionary *result, FlutterErr
 }
 - (NSDictionary *)toMap {
   return [NSDictionary
-      dictionaryWithObjectsAndKeys:(self.textureId != nil ? self.textureId : [NSNull null]), @"textureId",
-                                   (self.position != nil ? self.position : [NSNull null]), @"position",
-                                   nil];
+      dictionaryWithObjectsAndKeys:(self.textureId != nil ? self.textureId : [NSNull null]),
+                                   @"textureId",
+                                   (self.position != nil ? self.position : [NSNull null]),
+                                   @"position", nil];
 }
 @end
 

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -1,7 +1,7 @@
 name: video_player
 description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android, iOS, and web.
-version: 2.1.2
+version: 2.1.3
 homepage: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player
 
 flutter:


### PR DESCRIPTION
Fix `Converting a pointer value of type 'NSNumber * _Nullable' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue` analyzer warnings.

Fixes https://github.com/flutter/flutter/issues/82958

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format](../script/tool/README.md#format-code))
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.