### PR TITLE
[connectivity] Ignore Reachability pointer to int cast warning

### DIFF
--- a/packages/connectivity/connectivity/CHANGELOG.md
+++ b/packages/connectivity/connectivity/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.5
+
+* Ignore Reachability pointer to int cast warning.
+
 ## 3.0.4
 
 * Migrate maven repository from jcenter to mavenCentral.

--- a/packages/connectivity/connectivity/example/ios/Podfile
+++ b/packages/connectivity/connectivity/example/ios/Podfile
@@ -33,6 +33,12 @@ end
 
 post_install do |installer|
   installer.pods_project.targets.each do |target|
+    # Work around https://github.com/flutter/flutter/issues/82964.
+    if target.name == 'Reachability'
+      target.build_configurations.each do |config|
+        config.build_settings['WARNING_CFLAGS'] = '-Wno-pointer-to-int-cast'
+      end
+    end
     flutter_additional_ios_build_settings(target)
   end
 end

--- a/packages/connectivity/connectivity/pubspec.yaml
+++ b/packages/connectivity/connectivity/pubspec.yaml
@@ -2,7 +2,7 @@ name: connectivity
 description: Flutter plugin for discovering the state of the network (WiFi &
   mobile/cellular) connectivity on Android and iOS.
 homepage: https://github.com/flutter/plugins/tree/master/packages/connectivity/connectivity
-version: 3.0.4
+version: 3.0.5
 
 flutter:
   plugin:

--- a/packages/connectivity/connectivity_macos/CHANGELOG.md
+++ b/packages/connectivity/connectivity_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1+1
+
+* Ignore Reachability pointer to int cast warning.
+
 ## 0.2.1
 
 * Add `implements` to pubspec.yaml.

--- a/packages/connectivity/connectivity_macos/example/macos/Podfile
+++ b/packages/connectivity/connectivity_macos/example/macos/Podfile
@@ -35,6 +35,12 @@ end
 
 post_install do |installer|
   installer.pods_project.targets.each do |target|
+    # Work around https://github.com/flutter/flutter/issues/82964.
+    if target.name == 'Reachability'
+      target.build_configurations.each do |config|
+        config.build_settings['WARNING_CFLAGS'] = '-Wno-pointer-to-int-cast'
+      end
+    end
     flutter_additional_macos_build_settings(target)
   end
 end

--- a/packages/connectivity/connectivity_macos/pubspec.yaml
+++ b/packages/connectivity/connectivity_macos/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_macos
 description: macOS implementation of the connectivity plugin.
-version: 0.2.1
+version: 0.2.1+1
 homepage: https://github.com/flutter/plugins/tree/master/packages/connectivity/connectivity_macos
 
 flutter:


### PR DESCRIPTION
Suppress Reachability dependency warning in iOS and macOS example app.

Fixes https://github.com/flutter/flutter/issues/82964

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format](../script/tool/README.md#format-code))
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.