### PR TITLE
Feature/greedy gestures

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/lib/src/google_map.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/lib/src/google_map.dart
@@ -529,6 +529,7 @@ class _GoogleMapOptions {
       'indoorEnabled': indoorViewEnabled,
       'trafficEnabled': trafficEnabled,
       'buildingsEnabled': buildingsEnabled,
+      'gestureHandling': 'greedy',
     };
   }
 

--- a/packages/google_maps_flutter/google_maps_flutter/lib/src/google_map.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/lib/src/google_map.dart
@@ -529,7 +529,6 @@ class _GoogleMapOptions {
       'indoorEnabled': indoorViewEnabled,
       'trafficEnabled': trafficEnabled,
       'buildingsEnabled': buildingsEnabled,
-      'gestureHandling': 'greedy',
     };
   }
 

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/convert.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/convert.dart
@@ -85,7 +85,7 @@ gmaps.MapOptions _rawOptionsToGmapsOptions(Map<String, dynamic> rawOptions) {
       rawOptions['zoomGesturesEnabled'] == false) {
     options.gestureHandling = 'none';
   } else {
-    options.gestureHandling = 'auto';
+    options.gestureHandling = 'greedy';
   }
 
   // These don't have any rawOptions entry, but they seem to be off in the native maps.


### PR DESCRIPTION
Use greedy gesture handling so the map does not require 2 fingers to pan on mobile web browser. I really don't see why that would ever be what anyone wants. This probably isn't a good implementation of this, but the ability to do this definitely needs to be implemented somehow.

This fixes MY ISSUE and probably a lot of other people's issues.