### PR TITLE
Make run-on-changed-packages flag handle repo-level changes

### DIFF
--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -1,8 +1,10 @@
-## NEXT
+## 0.1.2
 
 - Add `against-pub` flag for version-check, which allows the command to check version with pub.
 - Add `machine` flag for publish-check, which replaces outputs to something parsable by machines.
 - Add `skip-conformation` flag to publish-plugin to allow auto publishing.
+- Change `run-on-changed-packages` to consider all packages as changed if any
+  files have been changed that could affect the entire repository.
 
 ## 0.1.1
 

--- a/script/tool/lib/src/common.dart
+++ b/script/tool/lib/src/common.dart
@@ -491,7 +491,7 @@ abstract class PluginCommand extends Command<void> {
     final GitVersionFinder gitVersionFinder = await retrieveVersionFinder();
 
     const List<String> specialFiles = <String>[
-      '.ci.yaml', // LUCI congfig.
+      '.ci.yaml', // LUCI config.
       '.cirrus.yml', // Cirrus config.
       '.clang-format', // ObjC and C/C++ formatting options.
       'analysis_options.yaml', // Dart analysis settings.

--- a/script/tool/pubspec.yaml
+++ b/script/tool/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_plugin_tools
 description: Productivity utils for flutter/plugins and flutter/packages
 repository: https://github.com/flutter/plugins/tree/master/script/tool
-version: 0.1.1
+version: 0.1.2
 
 dependencies:
   args: ^2.1.0

--- a/script/tool/test/common_test.dart
+++ b/script/tool/test/common_test.dart
@@ -145,7 +145,103 @@ void main() {
 
     test('all plugins should be tested if there are no plugin related changes.',
         () async {
-      gitDiffResponse = '.cirrus';
+      gitDiffResponse = 'AUTHORS';
+      final Directory plugin1 =
+          createFakePlugin('plugin1', packagesDirectory: packagesDir);
+      final Directory plugin2 =
+          createFakePlugin('plugin2', packagesDirectory: packagesDir);
+      await runner.run(
+          <String>['sample', '--base-sha=master', '--run-on-changed-packages']);
+
+      expect(plugins, unorderedEquals(<String>[plugin1.path, plugin2.path]));
+    });
+
+    test('all plugins should be tested if .cirrus.yml changes.',
+        () async {
+      gitDiffResponse = '''
+.cirrus.yml
+packages/plugin1/CHANGELOG
+''';
+      final Directory plugin1 =
+          createFakePlugin('plugin1', packagesDirectory: packagesDir);
+      final Directory plugin2 =
+          createFakePlugin('plugin2', packagesDirectory: packagesDir);
+      await runner.run(
+          <String>['sample', '--base-sha=master', '--run-on-changed-packages']);
+
+      expect(plugins, unorderedEquals(<String>[plugin1.path, plugin2.path]));
+    });
+
+    test('all plugins should be tested if .ci.yaml changes',
+        () async {
+      gitDiffResponse = '''
+.ci.yaml
+packages/plugin1/CHANGELOG
+''';
+      final Directory plugin1 =
+          createFakePlugin('plugin1', packagesDirectory: packagesDir);
+      final Directory plugin2 =
+          createFakePlugin('plugin2', packagesDirectory: packagesDir);
+      await runner.run(
+          <String>['sample', '--base-sha=master', '--run-on-changed-packages']);
+
+      expect(plugins, unorderedEquals(<String>[plugin1.path, plugin2.path]));
+    });
+
+    test('all plugins should be tested if anything in .ci/ changes',
+        () async {
+      gitDiffResponse = '''
+.ci/Dockerfile
+packages/plugin1/CHANGELOG
+''';
+      final Directory plugin1 =
+          createFakePlugin('plugin1', packagesDirectory: packagesDir);
+      final Directory plugin2 =
+          createFakePlugin('plugin2', packagesDirectory: packagesDir);
+      await runner.run(
+          <String>['sample', '--base-sha=master', '--run-on-changed-packages']);
+
+      expect(plugins, unorderedEquals(<String>[plugin1.path, plugin2.path]));
+    });
+
+    test('all plugins should be tested if anything in script changes.',
+        () async {
+      gitDiffResponse = '''
+script/tool_runner.sh
+packages/plugin1/CHANGELOG
+''';
+      final Directory plugin1 =
+          createFakePlugin('plugin1', packagesDirectory: packagesDir);
+      final Directory plugin2 =
+          createFakePlugin('plugin2', packagesDirectory: packagesDir);
+      await runner.run(
+          <String>['sample', '--base-sha=master', '--run-on-changed-packages']);
+
+      expect(plugins, unorderedEquals(<String>[plugin1.path, plugin2.path]));
+    });
+
+    test('all plugins should be tested if the root analysis options change.',
+        () async {
+      gitDiffResponse = '''
+analysis_options.yaml
+packages/plugin1/CHANGELOG
+''';
+      final Directory plugin1 =
+          createFakePlugin('plugin1', packagesDirectory: packagesDir);
+      final Directory plugin2 =
+          createFakePlugin('plugin2', packagesDirectory: packagesDir);
+      await runner.run(
+          <String>['sample', '--base-sha=master', '--run-on-changed-packages']);
+
+      expect(plugins, unorderedEquals(<String>[plugin1.path, plugin2.path]));
+    });
+
+    test('all plugins should be tested if formatting options change.',
+        () async {
+      gitDiffResponse = '''
+.clang-format
+packages/plugin1/CHANGELOG
+''';
       final Directory plugin1 =
           createFakePlugin('plugin1', packagesDirectory: packagesDir);
       final Directory plugin2 =


### PR DESCRIPTION
Changes to some files (e.g., CI scripts) have the potential to cause
failures in any packages, without changes to those packages themselves.
This updates the --run-on-changed-packages to consider all packages as
changed if any of those files are changed, to avoid issues where a
change that changes both some repo-level files and some package-specific
files only run presubmit tests on the packages that are directly
changed, causing post-submit-only failures.

Fixes https://github.com/flutter/flutter/issues/82965

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format](../script/tool/README.md#format-code))
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
