### PR TITLE
[wifi_info_flutter] Ignore Reachability pointer to int cast warning

### DIFF
--- a/packages/wifi_info_flutter/wifi_info_flutter/example/ios/Podfile
+++ b/packages/wifi_info_flutter/wifi_info_flutter/example/ios/Podfile
@@ -33,6 +33,12 @@ end
 
 post_install do |installer|
   installer.pods_project.targets.each do |target|
+    # Work around https://github.com/flutter/flutter/issues/82964.
+    if target.name == 'Reachability'
+      target.build_configurations.each do |config|
+        config.build_settings['WARNING_CFLAGS'] = '-Wno-pointer-to-int-cast'
+      end
+    end
     flutter_additional_ios_build_settings(target)
   end
 end


### PR DESCRIPTION
Suppress Reachability dependency warning in iOS example app.

This is https://github.com/flutter/plugins/pull/3941 but applied to wifi_info_flutter

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format](../script/tool/README.md#format-code))
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
