### PR TITLE
Pin iOS xctest to an earlier stable

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -212,6 +212,13 @@ task:
           CHANNEL: "master"
           CHANNEL: "stable"
         SIMCTL_CHILD_MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
+      override_stable_script:
+        # Force an earlier version of stable as a temporary workaround for https://github.com/flutter/flutter/issues/83048
+        - if [[ "$CHANNEL" == "stable" ]]; then
+        -   cd /Users/admin/flutter/
+        -   git fetch --tags
+        -   git checkout 2.2.0-10.0.pre
+        - fi
       create_simulator_script:
         - xcrun simctl list
         - xcrun simctl create Flutter-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-11 com.apple.CoreSimulator.SimRuntime.iOS-14-5 | xargs xcrun simctl boot

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -215,7 +215,7 @@ task:
       override_stable_script:
         # Force an earlier version of stable as a temporary workaround for https://github.com/flutter/flutter/issues/83048
         - if [[ "$CHANNEL" == "stable" ]]; then
-        -   cd /Users/admin/flutter/
+        -   cd "${HOME}/flutter/"
         -   git fetch --tags
         -   git checkout 2.2.0-10.0.pre
         - fi


### PR DESCRIPTION
Current stable (2.2.0) breaks iOS tests, as described in
https://github.com/flutter/flutter/issues/83048

This pins those tests on stable to use the last non-broken prerelease
version as a temporary workaround, to allow re-opening the tree without
completely losing iOS stable testing.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format](../script/tool/README.md#format-code))
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
