### PR TITLE
Fix publish-check output

### DIFF
--- a/script/tool/lib/src/publish_check_command.dart
+++ b/script/tool/lib/src/publish_check_command.dart
@@ -175,7 +175,10 @@ class PublishCheckCommand extends PluginCommand {
       (List<int> event) {
         final String output = String.fromCharCodes(event);
         if (output.isNotEmpty) {
-          _printImportantStatusMessage(output, isError: true);
+          // The final result is always printed on stderr, whether success or
+          // failure.
+          final bool isError = !output.contains('has 0 warnings');
+          _printImportantStatusMessage(output, isError: isError);
           outputBuffer.write(output);
         }
       },

--- a/script/tool/test/publish_check_command_test.dart
+++ b/script/tool/test/publish_check_command_test.dart
@@ -132,6 +132,26 @@ void main() {
       expect(runner.run(<String>['publish-check']), throwsA(isA<ToolExit>()));
     });
 
+    test('Success message on stderr is not printed as an error', () async {
+      createFakePlugin('d');
+
+      const String publishOutput = 'Package has 0 warnings.';
+
+      final MockProcess process = MockProcess();
+      process.stderrController.add(publishOutput.codeUnits);
+      process.stdoutController.close(); // ignore: unawaited_futures
+      process.stderrController.close(); // ignore: unawaited_futures
+
+      process.exitCodeCompleter.complete(0);
+
+      processRunner.processesToReturn.add(process);
+
+      final List<String> output = await runCapturingPrint(
+          runner, <String>['publish-check']);
+
+      expect(output, isNot(contains(contains('ERROR:'))));
+    });
+
     test(
         '--machine: Log JSON with status:no-publish and correct human message, if there are no packages need to be published. ',
         () async {


### PR DESCRIPTION
pub publish --dry-run always prints output on stderr, so the output of
the tool's publish check was printing "Packages has 0 warnings." as if
it were an error. This fixes that to highlight it as a success message
instead of an error.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format](../script/tool/README.md#format-code))
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
