### PR TITLE
[connectivity] Removed unnecessary parentheses in readme example

### DIFF
--- a/packages/connectivity/connectivity/README.md
+++ b/packages/connectivity/connectivity/README.md
@@ -14,7 +14,7 @@ Sample usage to check current status:
 ```dart
 import 'package:connectivity/connectivity.dart';
 
-var connectivityResult = await (Connectivity().checkConnectivity());
+var connectivityResult = await Connectivity().checkConnectivity();
 if (connectivityResult == ConnectivityResult.mobile) {
   // I am connected to a mobile network.
 } else if (connectivityResult == ConnectivityResult.wifi) {


### PR DESCRIPTION
Just a little change in the example so you can copy and paste without removing the parentheses.
