### PR TITLE
Use collection and box literals in ObjC code

### DIFF
--- a/packages/camera/camera/ios/Classes/CameraPlugin.m
+++ b/packages/camera/camera/ios/Classes/CameraPlugin.m
@@ -1169,12 +1169,12 @@ NSString *const errorMethod = @"error";
     acl.mChannelLayoutTag = kAudioChannelLayoutTag_Mono;
     NSDictionary *audioOutputSettings = nil;
     // Both type of audio inputs causes output video file to be corrupted.
-    audioOutputSettings = [NSDictionary
-        dictionaryWithObjectsAndKeys:[NSNumber numberWithInt:kAudioFormatMPEG4AAC], AVFormatIDKey,
-                                     [NSNumber numberWithFloat:44100.0], AVSampleRateKey,
-                                     [NSNumber numberWithInt:1], AVNumberOfChannelsKey,
-                                     [NSData dataWithBytes:&acl length:sizeof(acl)],
-                                     AVChannelLayoutKey, nil];
+    audioOutputSettings = @{
+      AVFormatIDKey : [NSNumber numberWithInt:kAudioFormatMPEG4AAC],
+      AVSampleRateKey : [NSNumber numberWithFloat:44100.0],
+      AVNumberOfChannelsKey : [NSNumber numberWithInt:1],
+      AVChannelLayoutKey : [NSData dataWithBytes:&acl length:sizeof(acl)],
+    };
     _audioWriterInput = [AVAssetWriterInput assetWriterInputWithMediaType:AVMediaTypeAudio
                                                            outputSettings:audioOutputSettings];
     _audioWriterInput.expectsMediaDataInRealTime = YES;

--- a/packages/google_maps_flutter/google_maps_flutter/ios/Classes/GoogleMapController.m
+++ b/packages/google_maps_flutter/google_maps_flutter/ios/Classes/GoogleMapController.m
@@ -329,7 +329,7 @@ static double ToDouble(NSNumber* data) { return [FLTGoogleMapJsonConversions toD
     NSNumber* isCompassEnabled = @(_mapView.settings.compassButton);
     result(isCompassEnabled);
   } else if ([call.method isEqualToString:@"map#isMapToolbarEnabled"]) {
-    NSNumber* isMapToolbarEnabled = [NSNumber numberWithBool:NO];
+    NSNumber* isMapToolbarEnabled = @NO;
     result(isMapToolbarEnabled);
   } else if ([call.method isEqualToString:@"map#getMinMaxZoomLevels"]) {
     NSArray* zoomLevels = @[ @(_mapView.minZoom), @(_mapView.maxZoom) ];
@@ -340,7 +340,7 @@ static double ToDouble(NSNumber* data) { return [FLTGoogleMapJsonConversions toD
     NSNumber* isZoomGesturesEnabled = @(_mapView.settings.zoomGestures);
     result(isZoomGesturesEnabled);
   } else if ([call.method isEqualToString:@"map#isZoomControlsEnabled"]) {
-    NSNumber* isZoomControlsEnabled = [NSNumber numberWithBool:NO];
+    NSNumber* isZoomControlsEnabled = @NO;
     result(isZoomControlsEnabled);
   } else if ([call.method isEqualToString:@"map#isTiltGesturesEnabled"]) {
     NSNumber* isTiltGesturesEnabled = @(_mapView.settings.tiltGestures);

--- a/packages/image_picker/image_picker/ios/Classes/FLTImagePickerPhotoAssetUtil.m
+++ b/packages/image_picker/image_picker/ios/Classes/FLTImagePickerPhotoAssetUtil.m
@@ -99,8 +99,8 @@
       (CFURLRef)[NSURL fileURLWithPath:path], kUTTypeGIF, gifInfo.images.count, NULL);
 
   NSDictionary *frameProperties = @{
-    (NSString *)kCGImagePropertyGIFDictionary : @{
-      (NSString *)kCGImagePropertyGIFDelayTime : [NSNumber numberWithFloat:gifInfo.interval],
+    (__bridge NSString *)kCGImagePropertyGIFDictionary : @{
+      (__bridge NSString *)kCGImagePropertyGIFDelayTime : @(gifInfo.interval),
     },
   };
 
@@ -111,7 +111,7 @@
     gifProperties = [NSMutableDictionary dictionary];
   }
 
-  gifProperties[(NSString *)kCGImagePropertyGIFLoopCount] = [NSNumber numberWithFloat:0];
+  gifProperties[(__bridge NSString *)kCGImagePropertyGIFLoopCount] = @0;
 
   CGImageDestinationSetProperties(destination, (CFDictionaryRef)gifMetaProperties);
 

--- a/packages/image_picker/image_picker/ios/Classes/FLTImagePickerPhotoAssetUtil.m
+++ b/packages/image_picker/image_picker/ios/Classes/FLTImagePickerPhotoAssetUtil.m
@@ -98,11 +98,11 @@
   CGImageDestinationRef destination = CGImageDestinationCreateWithURL(
       (CFURLRef)[NSURL fileURLWithPath:path], kUTTypeGIF, gifInfo.images.count, NULL);
 
-  NSDictionary *frameProperties = [NSDictionary
-      dictionaryWithObject:[NSDictionary
-                               dictionaryWithObject:[NSNumber numberWithFloat:gifInfo.interval]
-                                             forKey:(NSString *)kCGImagePropertyGIFDelayTime]
-                    forKey:(NSString *)kCGImagePropertyGIFDictionary];
+  NSDictionary *frameProperties = @{
+    (NSString *)kCGImagePropertyGIFDictionary : @{
+      (NSString *)kCGImagePropertyGIFDelayTime : [NSNumber numberWithFloat:gifInfo.interval],
+    },
+  };
 
   NSMutableDictionary *gifMetaProperties = [NSMutableDictionary dictionaryWithDictionary:metaData];
   NSMutableDictionary *gifProperties =

--- a/packages/image_picker/image_picker/ios/Classes/FLTImagePickerPlugin.m
+++ b/packages/image_picker/image_picker/ios/Classes/FLTImagePickerPlugin.m
@@ -348,7 +348,7 @@ typedef NS_ENUM(NSInteger, ImagePickerClassType) { UIImagePickerClassType, PHPic
   if (![imageQuality isKindOfClass:[NSNumber class]]) {
     imageQuality = @1;
   } else if (imageQuality.intValue < 0 || imageQuality.intValue > 100) {
-    imageQuality = [NSNumber numberWithInt:1];
+    imageQuality = @1;
   } else {
     imageQuality = @([imageQuality floatValue] / 100);
   }

--- a/packages/in_app_purchase/in_app_purchase_ios/ios/Classes/InAppPurchasePlugin.m
+++ b/packages/in_app_purchase/in_app_purchase_ios/ios/Classes/InAppPurchasePlugin.m
@@ -106,7 +106,7 @@
 }
 
 - (void)canMakePayments:(FlutterResult)result {
-  result([NSNumber numberWithBool:[SKPaymentQueue canMakePayments]]);
+  result(@([SKPaymentQueue canMakePayments]));
 }
 
 - (void)getPendingTransactions:(FlutterResult)result {

--- a/packages/in_app_purchase/in_app_purchase_ios/ios/Tests/InAppPurchasePluginTest.m
+++ b/packages/in_app_purchase/in_app_purchase_ios/ios/Tests/InAppPurchasePluginTest.m
@@ -51,7 +51,7 @@
                            result = r;
                          }];
   [self waitForExpectations:@[ expectation ] timeout:5];
-  XCTAssertEqual(result, [NSNumber numberWithBool:YES]);
+  XCTAssertEqual(result, @YES);
 }
 
 - (void)testGetProductResponse {

--- a/packages/webview_flutter/ios/Classes/FLTWKProgressionDelegate.m
+++ b/packages/webview_flutter/ios/Classes/FLTWKProgressionDelegate.m
@@ -34,8 +34,7 @@ NSString *const FLTWKEstimatedProgressKeyPath = @"estimatedProgress";
     NSNumber *newValue =
         change[NSKeyValueChangeNewKey] ?: 0;          // newValue is anywhere between 0.0 and 1.0
     int newValueAsInt = [newValue floatValue] * 100;  // Anywhere between 0 and 100
-    [_methodChannel invokeMethod:@"onProgress"
-                       arguments:@{@"progress" : @(newValueAsInt)}];
+    [_methodChannel invokeMethod:@"onProgress" arguments:@{@"progress" : @(newValueAsInt)}];
   }
 }
 

--- a/packages/webview_flutter/ios/Classes/FLTWKProgressionDelegate.m
+++ b/packages/webview_flutter/ios/Classes/FLTWKProgressionDelegate.m
@@ -35,7 +35,7 @@ NSString *const FLTWKEstimatedProgressKeyPath = @"estimatedProgress";
         change[NSKeyValueChangeNewKey] ?: 0;          // newValue is anywhere between 0.0 and 1.0
     int newValueAsInt = [newValue floatValue] * 100;  // Anywhere between 0 and 100
     [_methodChannel invokeMethod:@"onProgress"
-                       arguments:@{@"progress" : [NSNumber numberWithInt:newValueAsInt]}];
+                       arguments:@{@"progress" : @(newValueAsInt)}];
   }
 }
 

--- a/packages/webview_flutter/ios/Classes/FlutterWebView.m
+++ b/packages/webview_flutter/ios/Classes/FlutterWebView.m
@@ -194,12 +194,12 @@
 
 - (void)onCanGoBack:(FlutterMethodCall*)call result:(FlutterResult)result {
   BOOL canGoBack = [_webView canGoBack];
-  result([NSNumber numberWithBool:canGoBack]);
+  result(@(canGoBack));
 }
 
 - (void)onCanGoForward:(FlutterMethodCall*)call result:(FlutterResult)result {
   BOOL canGoForward = [_webView canGoForward];
-  result([NSNumber numberWithBool:canGoForward]);
+  result(@(canGoForward));
 }
 
 - (void)onGoBack:(FlutterMethodCall*)call result:(FlutterResult)result {
@@ -314,12 +314,12 @@
 
 - (void)getScrollX:(FlutterMethodCall*)call result:(FlutterResult)result {
   int offsetX = _webView.scrollView.contentOffset.x;
-  result([NSNumber numberWithInt:offsetX]);
+  result(@(offsetX));
 }
 
 - (void)getScrollY:(FlutterMethodCall*)call result:(FlutterResult)result {
   int offsetY = _webView.scrollView.contentOffset.y;
-  result([NSNumber numberWithInt:offsetY]);
+  result(@(offsetY));
 }
 
 // Returns nil when successful, or an error message when one or more keys are unknown.


### PR DESCRIPTION
Replaces the harder-to-read and more-error-prone
dictionaryWithObjectsAndKeys: and dictionaryWithObject:forKey: with
modern dictionary literals.

Also replaces numberWith*: with boxed literal syntax.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format](../script/tool/README.md#format-code))
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
