### PR TITLE
[url_launcher] Fix Link test breakage from shadow DOM changes

### DIFF
--- a/packages/url_launcher/url_launcher_web/example/integration_test/link_widget_test.dart
+++ b/packages/url_launcher/url_launcher_web/example/integration_test/link_widget_test.dart
@@ -113,15 +113,13 @@ html.Element _findSingleAnchor() {
     }
   }
 
-  // Search inside platform views with shadow roots as well.
-  for (final html.Element platformView
-      in html.document.querySelectorAll('flt-platform-view')) {
-    final html.ShadowRoot shadowRoot = platformView.shadowRoot!;
-    if (shadowRoot != null) {
-      for (final html.Element anchor in shadowRoot.querySelectorAll('a')) {
-        if (hasProperty(anchor, linkViewIdProperty)) {
-          foundAnchors.add(anchor);
-        }
+  // Search inside the shadow DOM as well.
+  final html.ShadowRoot? shadowRoot =
+      html.document.querySelector('flt-glass-pane')?.shadowRoot;
+  if (shadowRoot != null) {
+    for (final html.Element anchor in shadowRoot.querySelectorAll('a')) {
+      if (hasProperty(anchor, linkViewIdProperty)) {
+        foundAnchors.add(anchor);
       }
     }
   }


### PR DESCRIPTION
Replace the per-platform-view shadow dom query with a top-level shadow dom query.

Fixes breakage from https://github.com/flutter/engine/pull/25747

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format](../script/tool/README.md#format-code))
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
