### PR TITLE
[url_launcher_platform_interface] ChannelBuffers is actually async

### DIFF
--- a/packages/url_launcher/url_launcher_platform_interface/test/link_test.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/test/link_test.dart
@@ -20,7 +20,7 @@ void main() {
     ));
     expect(find.byKey(Key('home')), findsOneWidget);
     expect(find.byKey(Key('a')), findsNothing);
-    await pushRouteNameToFramework(null, '/a');
+    await tester.runAsync(() => pushRouteNameToFramework(null, '/a'));
     // start animation
     await tester.pump();
     // skip past animation (5s is arbitrary, just needs to be long enough)
@@ -36,7 +36,7 @@ void main() {
     ));
     expect(find.byKey(Key('/')), findsOneWidget);
     expect(find.byKey(Key('/a')), findsNothing);
-    await pushRouteNameToFramework(null, '/a');
+    await tester.runAsync(() => pushRouteNameToFramework(null, '/a'));
     // start animation
     await tester.pump();
     // skip past animation (5s is arbitrary, just needs to be long enough)


### PR DESCRIPTION
...so we have to run the test using runAsync otherwise the future will never complete.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format](../script/tool/README.md#format-code))
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
