### PR TITLE
[quick-actions] Revert migrating integration tests to NNBD

### DIFF
--- a/packages/quick_actions/quick_actions/example/integration_test/quick_actions_test.dart
+++ b/packages/quick_actions/quick_actions/example/integration_test/quick_actions_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.9
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:quick_actions/quick_actions.dart';
@@ -11,7 +12,7 @@ void main() {
 
   testWidgets('Can set shortcuts', (WidgetTester tester) async {
     final QuickActions quickActions = QuickActions();
-    await quickActions.initialize((String shortcutType) => {});
+    await quickActions.initialize(null);
 
     const ShortcutItem shortCutItem = ShortcutItem(
       type: 'action_one',

--- a/packages/quick_actions/quick_actions/example/test_driver/integration_test.dart
+++ b/packages/quick_actions/quick_actions/example/test_driver/integration_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart=2.9
+
 import 'package:integration_test/integration_test_driver.dart';
 
 Future<void> main() => integrationDriver();

--- a/packages/quick_actions/quick_actions/pubspec.yaml
+++ b/packages/quick_actions/quick_actions/pubspec.yaml
@@ -27,6 +27,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: ^5.0.0
+  integration_test:
+    sdk: flutter
+  mockito: ^5.0.0-nullsafety.7
   pedantic: ^1.11.0
   plugin_platform_interface: ^2.0.0


### PR DESCRIPTION
Reverts the quick_action portion of:
"Move integration test to null safety for multiple plugins (#3932)"
(commit a864de25001baaea6596420cf2a3b79948e01825) since it seems to have
broken XCUITests.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format](../script/tool/README.md#format-code))
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
