### PR TITLE
[video_player] Migrate integration tests to NNBD

### DIFF
--- a/packages/video_player/video_player/example/integration_test/video_player_test.dart
+++ b/packages/video_player/video_player/example/integration_test/video_player_test.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(amirh): Remove this once flutter_driver supports null safety.
-// https://github.com/flutter/flutter/issues/71379
-// @dart = 2.9
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
@@ -17,7 +14,7 @@ const Duration _playDuration = Duration(seconds: 1);
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
-  VideoPlayerController _controller;
+  late VideoPlayerController _controller;
   tearDown(() async => _controller.dispose());
 
   group('asset videos', () {

--- a/packages/video_player/video_player/example/test_driver/integration_test.dart
+++ b/packages/video_player/video_player/example/test_driver/integration_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 import 'package:integration_test/integration_test_driver.dart';
 
 Future<void> main() => integrationDriver();

--- a/packages/video_player/video_player/example/test_driver/video_player.dart
+++ b/packages/video_player/video_player/example/test_driver/video_player.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(egarciad): Remove once Flutter driver is migrated to null safety.
-// @dart = 2.9
-
 import 'package:flutter_driver/driver_extension.dart';
 import 'package:video_player_example/main.dart' as app;
 

--- a/packages/video_player/video_player/example/test_driver/video_player_test.dart
+++ b/packages/video_player/video_player/example/test_driver/video_player_test.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(egarciad): Remove once Flutter driver is migrated to null safety.
-// @dart = 2.9
-
 import 'dart:async';
 import 'package:flutter_driver/flutter_driver.dart';
 import 'package:test/test.dart';


### PR DESCRIPTION
Enables null safety for integration tests now that it is supported on master.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format](../script/tool/README.md#format-code))
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
