### PR TITLE
Clean up cruft in pubspec.yaml files

### DIFF
--- a/packages/battery/battery_platform_interface/pubspec.yaml
+++ b/packages/battery/battery_platform_interface/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: ^5.0.0-nullsafety.0
+  mockito: ^5.0.0
   pedantic: ^1.10.0
 
 environment:

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -31,10 +31,6 @@ dev_dependencies:
     sdk: flutter
   flutter_driver:
     sdk: flutter
-  # TODO(mvanbeusekom): Update to stable 5.0.0 release when dependency conflict
-  # with flutter_driver has been resolved:
-  # Because mockito >=5.0.0 depends on analyzer ^1.0.0 which depends on crypto ^3.0.0
-  # every version of flutter_driver from sdk depends on crypto 2.1.5.
-  mockito: ^5.0.0-nullsafety.7
+  mockito: ^5.0.0
   plugin_platform_interface: ^2.0.0
   video_player: ^2.0.0

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
@@ -21,5 +21,5 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: ^5.0.0-nullsafety.0
+  mockito: ^5.0.0
   pedantic: ^1.10.0

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/pubspec.yaml
@@ -4,12 +4,7 @@ publish_to: none
 # Tests require flutter beta or greater to run.
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0" 
-  # Actually, Flutter 2.0.0 shipped with a slightly older version of integration_test that
-  # did *not* support null safety. This flutter constraint should be changed to >=2.1.0 when
-  # that version (or greater) is shipped to the `stable` channel.
-  # This causes integration tests to *not* work in `stable`, for now. Please, run integration tests
-  # in `beta` or newer (flutter/plugins runs these tests in `master`).
+  flutter: ">=2.1.0" 
 
 dependencies:
   google_maps_flutter_web:
@@ -28,9 +23,3 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-
-# Remove these once environment flutter is set to ">=2.1.0".
-# Used to reconcile mockito ^5.0.0 with flutter 2.0.x (current stable).
-dependency_overrides:
-  crypto: ^3.0.0
-  convert: ^3.0.0

--- a/packages/google_sign_in/google_sign_in_platform_interface/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_platform_interface/pubspec.yaml
@@ -19,5 +19,5 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: ^5.0.0-nullsafety.1
+  mockito: ^5.0.0
   pedantic: ^1.10.0

--- a/packages/google_sign_in/google_sign_in_web/example/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_web/example/pubspec.yaml
@@ -8,6 +8,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  google_sign_in_web:
+    path: ../
 
 dev_dependencies:
   http: ^0.13.0
@@ -18,7 +20,3 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-
-dependency_overrides:
-  google_sign_in_web:
-    path: ../

--- a/packages/image_picker/image_picker/example/pubspec.yaml
+++ b/packages/image_picker/image_picker/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates how to use the image_picker plugin.
 publish_to: none
 
 dependencies:
-  video_player: ^2.0.0-nullsafety.7
+  video_player: ^2.0.0
   flutter:
     sdk: flutter
   flutter_plugin_android_lifecycle: ^2.0.1

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -30,6 +30,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: ^5.0.0-nullsafety.7
+  mockito: ^5.0.0
   pedantic: ^1.10.0
   plugin_platform_interface: ^2.0.0

--- a/packages/in_app_purchase/in_app_purchase/example/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase/example/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 dependencies:
   flutter:
     sdk: flutter
-  shared_preferences: ^2.0.0-nullsafety.1
+  shared_preferences: ^2.0.0
 
   in_app_purchase:
     # When depending on this package from a real application you should use:

--- a/packages/in_app_purchase/in_app_purchase_platform_interface/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_platform_interface/pubspec.yaml
@@ -18,5 +18,5 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: ^5.0.0-nullsafety.7
+  mockito: ^5.0.0
   pedantic: ^1.10.0

--- a/packages/plugin_platform_interface/pubspec.yaml
+++ b/packages/plugin_platform_interface/pubspec.yaml
@@ -22,6 +22,6 @@ dependencies:
   meta: ^1.3.0
 
 dev_dependencies:
-  mockito: ^5.0.0-nullsafety.7
+  mockito: ^5.0.0
   test: ^1.16.0
   pedantic: ^1.10.0

--- a/packages/sensors/pubspec.yaml
+++ b/packages/sensors/pubspec.yaml
@@ -23,7 +23,7 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  mockito: ^5.0.0-nullsafety.0
+  mockito: ^5.0.0
   pedantic: ^1.10.0
 
 environment:

--- a/packages/shared_preferences/shared_preferences_windows/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_windows/example/pubspec.yaml
@@ -9,9 +9,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  shared_preferences_windows: ^2.0.0
-
-dependency_overrides:
   shared_preferences_windows:
     # When depending on this package from a real application you should use:
     #   shared_preferences_windows: ^x.y.z

--- a/packages/url_launcher/url_launcher/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/example/pubspec.yaml
@@ -19,7 +19,7 @@ dev_dependencies:
   flutter_driver:
     sdk: flutter
   pedantic: ^1.10.0
-  mockito: ^5.0.0-nullsafety.7
+  mockito: ^5.0.0
   plugin_platform_interface: ^2.0.0
 
 flutter:

--- a/packages/url_launcher/url_launcher_platform_interface/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_platform_interface/pubspec.yaml
@@ -18,5 +18,5 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: ^5.0.0-nullsafety.7
+  mockito: ^5.0.0
   pedantic: ^1.10.0

--- a/packages/url_launcher/url_launcher_web/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_web/example/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^1.10.0
-  mockito: ^5.0.0-nullsafety.5
+  mockito: ^5.0.0
   url_launcher_web:
     path: ../
   flutter_driver:


### PR DESCRIPTION
- Standardize on mockito 5.0 now that the conflicts with SDK packages is
  resolved on stable.
- Removes overrides that were only needed for Flutter 2.0
- Update a -nullsafe inter-package dependency
- Update some older federated examples that used dependency_overrides to
  depend on its encloding package by path to the now-standard option of
  listing that path-based dependency directly.

Does not update versions since these changes are all to dev_dependencies and/or examples, so don't need to be published.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format](../script/tool/README.md#format-code))
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
