### PR TITLE
[video_player] Add URL for exoplayer to maven for all dependents

### DIFF
--- a/packages/camera/camera/example/android/build.gradle
+++ b/packages/camera/camera/example/android/build.gradle
@@ -13,6 +13,9 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url 'https://google.bintray.com/exoplayer/'
+        }
     }
 }
 

--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.4
+
+* Add an exoplayer URL to the maven repositories to address
+  a possible build regression in 2.1.2.
+
 ## 2.1.3
 
 * Fix pointer value to boolean conversion analyzer warnings.

--- a/packages/video_player/video_player/android/build.gradle
+++ b/packages/video_player/video_player/android/build.gradle
@@ -17,6 +17,12 @@ rootProject.allprojects {
     repositories {
         google()
         mavenCentral()
+        // Gradle versions older than 2.13.3 aren't published to the servers
+        // above, so add this URL as a workaround until upgrading past that
+        // version.
+        maven {
+            url 'https://google.bintray.com/exoplayer/'
+        }
     }
 }
 

--- a/packages/video_player/video_player/example/android/build.gradle
+++ b/packages/video_player/video_player/example/android/build.gradle
@@ -13,9 +13,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        maven {
-            url 'https://google.bintray.com/exoplayer/'
-        }
     }
 }
 

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android, iOS, and web.
 repository: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.1.3
+version: 2.1.4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
JCenter has the older version of ExoPlayer that the plugin currently uses, but Google's maven server doesn't so we need to add a workaround in the short term for the removal of JCenter in #3924 to avoid breaking clients of video_player.

This was not caught in presubmit because the video_player example had this same workaround left over from an issue several years ago that caused JCenter not to have that version either; that issue was since fixed, but the workaround was never removed. This removes the example-level workaround so the example won't mask exoplayer maven issues in the future.

(Also temporarily re-adds the workaround to the camera example, which broke post-publishing, to fix the tree. All example workarounds should be removable once this change is published.)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format](../script/tool/README.md#format-code))
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
