### PR TITLE
Remove exoplayer workaround from everything but video_player

### DIFF
--- a/packages/camera/camera/example/android/build.gradle
+++ b/packages/camera/camera/example/android/build.gradle
@@ -13,9 +13,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        maven {
-            url 'https://google.bintray.com/exoplayer/'
-        }
     }
 }
 

--- a/packages/camera/camera/example/pubspec.yaml
+++ b/packages/camera/camera/example/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   path_provider: ^2.0.0
   flutter:
     sdk: flutter
-  video_player: ^2.0.0
+  video_player: ^2.1.4
 
 dev_dependencies:
   flutter_test:

--- a/packages/image_picker/image_picker/android/build.gradle
+++ b/packages/image_picker/image_picker/android/build.gradle
@@ -16,9 +16,6 @@ rootProject.allprojects {
     repositories {
         google()
         jcenter()
-        maven {
-            url 'https://google.bintray.com/exoplayer/'
-        }
     }
 }
 

--- a/packages/image_picker/image_picker/example/pubspec.yaml
+++ b/packages/image_picker/image_picker/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates how to use the image_picker plugin.
 publish_to: none
 
 dependencies:
-  video_player: ^2.0.0
+  video_player: ^2.1.4
   flutter:
     sdk: flutter
   flutter_plugin_android_lifecycle: ^2.0.1


### PR DESCRIPTION
Now that video_player includes this workaround at the plugin level, it's no longer necessary in the examples that use it.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format](../script/tool/README.md#format-code))
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
