### PR TITLE
Allow reverts when checking versions

### DIFF
--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.1.3
+
+- Cosmetic fix to `publish-check` output
+- Add a --dart-sdk option to `analyze`
+- Allow reverts in `version-check`
+
 ## 0.1.2
 
 - Add `against-pub` flag for version-check, which allows the command to check version with pub.

--- a/script/tool/lib/src/version_check_command.dart
+++ b/script/tool/lib/src/version_check_command.dart
@@ -179,6 +179,20 @@ ${indentation}HTTP response: ${pubVersionFinderResponse.httpResponse.body}
         continue;
       }
 
+      // Check for reverts when doing local validation.
+      if (!getBoolArg(_againstPubFlag) && headVersion < sourceVersion) {
+        final Map<Version, NextVersionType> possibleVersionsFromNewVersion =
+            getAllowedNextVersions(headVersion, sourceVersion);
+        // Since this skips validation, try to ensure that it really is likely
+        // to be a revert rather than a typo by checking that the transition
+        // from the lower version to the new version would have been valid.
+        if (possibleVersionsFromNewVersion.containsKey(sourceVersion)) {
+          print('${indentation}New version is lower than previous version. '
+              'This is assumed to be a revert.');
+          continue;
+        }
+      }
+
       final Map<Version, NextVersionType> allowedNextVersions =
           getAllowedNextVersions(sourceVersion, headVersion);
 

--- a/script/tool/pubspec.yaml
+++ b/script/tool/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_plugin_tools
 description: Productivity utils for flutter/plugins and flutter/packages
 repository: https://github.com/flutter/plugins/tree/master/script/tool
-version: 0.1.2
+version: 0.1.3
 
 dependencies:
   args: ^2.1.0


### PR DESCRIPTION
If a new version is lower than the current checked-in version, and the
transition from the new version to the old version is valid (indicating
that it could have been the previous version), allow the change.

This prevents the version check from failing when reverting a PR.
This is not fool-proof (e.g., it would allow a revert of an
already-published PR); if we have issues in practice we can further
restrict the check (by checking that the new version is the current pub
version, for instance).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format](../script/tool/README.md#format-code))
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
