### PR TITLE
[image_picker] Platform interface change for cleaner approach

### DIFF
--- a/packages/image_picker/image_picker_platform_interface/CHANGELOG.md
+++ b/packages/image_picker/image_picker_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.1
+
+* Refactor `_pickImagePath` method to get List from platforms.
+
 ## 2.1.0
 
 * Add `pickMultiImage` method.

--- a/packages/image_picker/image_picker_platform_interface/lib/src/method_channel/method_channel_image_picker.dart
+++ b/packages/image_picker/image_picker_platform_interface/lib/src/method_channel/method_channel_image_picker.dart
@@ -103,7 +103,7 @@ class MethodChannelImagePicker extends ImagePickerPlatform {
     if (maxHeight != null && maxHeight < 0) {
       throw ArgumentError.value(maxHeight, 'maxHeight', 'cannot be negative');
     }
-    List<String>? pathList = await _channel.invokeMethod<List<String>>(
+    List<dynamic>? pathList = await _channel.invokeMethod<List<dynamic>>(
       'pickImage',
       <String, dynamic>{
         'source': source.index,

--- a/packages/image_picker/image_picker_platform_interface/lib/src/method_channel/method_channel_image_picker.dart
+++ b/packages/image_picker/image_picker_platform_interface/lib/src/method_channel/method_channel_image_picker.dart
@@ -90,7 +90,7 @@ class MethodChannelImagePicker extends ImagePickerPlatform {
     double? maxHeight,
     int? imageQuality,
     CameraDevice preferredCameraDevice = CameraDevice.rear,
-  }) {
+  }) async {
     if (imageQuality != null && (imageQuality < 0 || imageQuality > 100)) {
       throw ArgumentError.value(
           imageQuality, 'imageQuality', 'must be between 0 and 100');
@@ -103,8 +103,7 @@ class MethodChannelImagePicker extends ImagePickerPlatform {
     if (maxHeight != null && maxHeight < 0) {
       throw ArgumentError.value(maxHeight, 'maxHeight', 'cannot be negative');
     }
-
-    return _channel.invokeMethod<String>(
+    List<String>? pathList = await _channel.invokeMethod<List<String>>(
       'pickImage',
       <String, dynamic>{
         'source': source.index,
@@ -114,6 +113,7 @@ class MethodChannelImagePicker extends ImagePickerPlatform {
         'cameraDevice': preferredCameraDevice.index
       },
     );
+    return pathList != null ? pathList.first : null;
   }
 
   @override

--- a/packages/image_picker/image_picker_platform_interface/pubspec.yaml
+++ b/packages/image_picker/image_picker_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/master/packages/image_picker
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.1.0
+version: 2.1.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/image_picker/image_picker_platform_interface/test/new_method_channel_image_picker_test.dart
+++ b/packages/image_picker/image_picker_platform_interface/test/new_method_channel_image_picker_test.dart
@@ -29,6 +29,7 @@ void main() {
 
     group('#pickImage', () {
       test('passes the image source argument correctly', () async {
+        returnValue = ['0', '1'];
         await picker.pickImage(source: ImageSource.camera);
         await picker.pickImage(source: ImageSource.gallery);
 
@@ -54,6 +55,7 @@ void main() {
       });
 
       test('passes the width and height arguments correctly', () async {
+        returnValue = ['0', '1'];
         await picker.pickImage(source: ImageSource.camera);
         await picker.pickImage(
           source: ImageSource.camera,
@@ -185,6 +187,7 @@ void main() {
       });
 
       test('camera position defaults to back', () async {
+        returnValue = ['0', '1'];
         await picker.pickImage(source: ImageSource.camera);
 
         expect(
@@ -202,6 +205,7 @@ void main() {
       });
 
       test('camera position can set to front', () async {
+        returnValue = ['0', '1'];
         await picker.pickImage(
             source: ImageSource.camera,
             preferredCameraDevice: CameraDevice.front);


### PR DESCRIPTION
This PR changes the`_pickImagePath` method to get `List<dynamic>` instead of `String` when the `pickImage` method call is invoked. This means there is no need to have additional methods and controls to send `String` when `pickImage` is invoked or to send `List<dynamic>` when `pickMultiImage` is invoked on native parts. In both cases, platform implementations will send `List<dynamic>` and this approach will make platform implementation cleaner.


*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format](../script/tool/README.md#format-code))
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
