### PR TITLE
[script/tool] Use 'dart pub' instead of deprecated 'pub'

### DIFF
--- a/script/tool/lib/src/test_command.dart
+++ b/script/tool/lib/src/test_command.dart
@@ -66,14 +66,15 @@ class TestCommand extends PluginCommand {
         );
       } else {
         exitCode = await processRunner.runAndStream(
-          'pub',
-          <String>['get'],
+          'dart',
+          <String>['pub', 'get'],
           workingDir: packageDir,
         );
         if (exitCode == 0) {
           exitCode = await processRunner.runAndStream(
-            'pub',
+            'dart',
             <String>[
+              'pub',
               'run',
               if (enableExperiment.isNotEmpty)
                 '--enable-experiment=$enableExperiment',

--- a/script/tool/test/test_command_test.dart
+++ b/script/tool/test/test_command_test.dart
@@ -94,10 +94,10 @@ void main() {
               'flutter',
               const <String>['test', '--color', '--enable-experiment=exp1'],
               plugin1Dir.path),
-          ProcessCall('pub', const <String>['get'], plugin2Dir.path),
+          ProcessCall('dart', const <String>['pub', 'get'], plugin2Dir.path),
           ProcessCall(
-              'pub',
-              const <String>['run', '--enable-experiment=exp1', 'test'],
+              'dart',
+              const <String>['pub', 'run', '--enable-experiment=exp1', 'test'],
               plugin2Dir.path),
         ]),
       );
@@ -149,10 +149,10 @@ void main() {
               'flutter',
               const <String>['test', '--color', '--enable-experiment=exp1'],
               plugin1Dir.path),
-          ProcessCall('pub', const <String>['get'], plugin2Dir.path),
+          ProcessCall('dart', const <String>['pub', 'get'], plugin2Dir.path),
           ProcessCall(
-              'pub',
-              const <String>['run', '--enable-experiment=exp1', 'test'],
+              'dart',
+              const <String>['pub', 'run', '--enable-experiment=exp1', 'test'],
               plugin2Dir.path),
         ]),
       );


### PR DESCRIPTION
Because I'm new to dart and flutter, I never had a `pub` binary installed. Running `dart run script/tool/lib/src/main.dart test` crashed on the `plugin_platform_interface` tests because that package doesn't qualify as a `flutter` package. The log message at the point of failure hinted at the cause:

```
RUNNING plugin_platform_interface tests...
Running command: "pub get" in /Users/aj/dev/flutter_plugins/packages/plugin_platform_interface
Unhandled exception:
ProcessException: No such file or directory
  Command: pub get
#0      _ProcessImpl._start (dart:io-patch/process_patch.dart:390:33)
#1      Process.start (dart:io-patch/process_patch.dart:36:20)
#2      ProcessRunner.runAndStream (package:flutter_plugin_tools/src/common.dart:540:49)
#3      TestCommand.run (package:flutter_plugin_tools/src/test_command.dart:68:40)
<asynchronous suspension>
#4      CommandRunner.runCommand (package:args/command_runner.dart:196:13)
<asynchronous suspension>
#5      main.<anonymous closure> (package:flutter_plugin_tools/src/main.dart)
<asynchronous suspension>
```

*List which issues are fixed by this PR. You must list at least one issue.*
I couldn't find one. This is a test/tool infrastructure fix.

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format](../script/tool/README.md#format-code))
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
