### PR TITLE
[script/tool] speed up the repo analysis command

### DIFF
--- a/analysis_options_legacy.yaml
+++ b/analysis_options_legacy.yaml
@@ -1,4 +1,6 @@
-include: package:pedantic/analysis_options.1.8.0.yaml
+# The pedantic 1.8.0 rules are in-lined below; see the 'linter' section.
+# include: package:pedantic/analysis_options.1.8.0.yaml
+
 analyzer:
   exclude:
     # Ignore generated files
@@ -8,6 +10,37 @@ analyzer:
   errors:
     always_require_non_null_named_parameters: false # not needed with nnbd
     unnecessary_null_comparison: false # Turned as long as nnbd mix-mode is supported.
+
 linter:
   rules:
     - public_member_api_docs
+    # In-lined from pedantic 1.8.0.
+    - avoid_empty_else
+    - avoid_init_to_null
+    - avoid_relative_lib_imports
+    - avoid_return_types_on_setters
+    - avoid_shadowing_type_parameters
+    - avoid_types_as_parameter_names
+    - curly_braces_in_flow_control_structures
+    - empty_catches
+    - empty_constructor_bodies
+    - library_names
+    - library_prefixes
+    - no_duplicate_case_values
+    - null_closures
+    - prefer_contains
+    - prefer_equal_for_default_values
+    - prefer_is_empty
+    - prefer_is_not_empty
+    - prefer_iterable_whereType
+    - recursive_getters
+    - slash_for_doc_comments
+    - type_init_formals
+    - unawaited_futures
+    - unnecessary_const
+    - unnecessary_new
+    - unnecessary_null_in_if_null_operators
+    - unrelated_type_equality_checks
+    - use_rethrow_when_possible
+    - valid_regexps
+

--- a/script/tool/lib/src/common.dart
+++ b/script/tool/lib/src/common.dart
@@ -535,8 +535,10 @@ class ProcessRunner {
     Directory? workingDir,
     bool exitOnError = false,
   }) async {
-    print(
-        'Running command: "$executable ${args.join(' ')}" in ${workingDir?.path ?? io.Directory.current.path}');
+    final String pathName = workingDir == null
+        ? io.Directory.current.path
+        : p.relative(workingDir.path);
+    print('Running "$executable ${args.join(' ')}" in $pathName');
     final io.Process process = await io.Process.start(executable, args,
         workingDirectory: workingDir?.path);
     await io.stdout.addStream(process.stdout);


### PR DESCRIPTION
This PR speeds up the repo's `analyze` command. It's currently a proposal - no tests as yet, and may not be something we want to land.

This PR:
- in-lines the content from pedantic 1.8.0 into the top level analysis options file
- groups the plugin packages into packages related to each plugin (so, grouping all the 6 `url_launcher` related packages together)
- runs `dart analyze` at that plugin granularity instead of individually for each package

From the times below:
- the analysis times are roughly 90% faster w/ this PR, however
- even before this PR (and definitely after), the CI time is dominated by the `pub get` times

Some thoughts:
- the code to get the list of package and plugins (common.dart, getPackages() and getPlugins()) is pretty complicated, w/ some ways to influence then via the command line, and logic to shard things up
- we should have a higher level concept of a 'Plugin' here (a set of related packages), implemented in common.dart, that people can call instead of needing to do some post-processing
- perhaps the sharding can be based on the plugins, and people can just act on all the plugins they get back from the common.dart call


```
--- before PR ---

[pub time    ] 130.87s
[analyze time] 106.947s

[pub time    ] 132.62s
[analyze time] 99.753s

--- after PR ---

[pub time    ] 145.714s
[analyze time] 55.715s

[pub time    ] 133.109s
[analyze time] 51.134s

[pub time    ] 132.943s
[analyze time] 51.523s
```