### PR TITLE
Some small documentation fixes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@
 
 - [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
 - [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
-- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format](../script/tool/README.md#format-code))
+- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format])
 - [ ] I signed the [CLA].
 - [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
 - [ ] I listed at least one issue that this PR fixes in the description above.
@@ -30,3 +30,4 @@ If you need help, consider asking for advice on the #hackers-new channel on [Dis
 [breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
 [Discord]: https://github.com/flutter/flutter/wiki/Chat
 [pub versioning philosophy]: https://dart.dev/tools/pub/versioning
+[plugin_tool format]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ _See also: [Flutter's code of conduct](https://github.com/flutter/flutter/blob/m
 ## Welcome
 
 For an introduction to contributing to Flutter, see [our contributor
-guide][https://github.com/flutter/flutter/blob/master/CONTRIBUTING.md].
+guide](https://github.com/flutter/flutter/blob/master/CONTRIBUTING.md).
 
 Additional resources specific to the plugins repository:
 - [Setting up the Plugins development

--- a/script/tool/README.md
+++ b/script/tool/README.md
@@ -58,7 +58,7 @@ Note that the `plugins` argument, despite the name, applies to any package.
 
 ```sh
 cd <repository root>
-dart run /script/tool/lib/src/main.dart format --plugins plugin_name
+dart run ./script/tool/lib/src/main.dart format --plugins plugin_name
 ```
 
 ### Run the Dart Static Analyzer


### PR DESCRIPTION
When working on the plugins I encountered some very minor issues in the documentation.

A wrongly formatted url
![image](https://user-images.githubusercontent.com/15101411/120448681-14660480-c38c-11eb-9af7-9161308efff6.png)

A missing dot:
![image](https://user-images.githubusercontent.com/15101411/120448788-32cc0000-c38c-11eb-9d63-d9a4c88d5b5a.png)

A broken link in the PR template: the plugin_tool format links to https://github.com/flutter/plugins/script/tool/README.md#format-code
![image](https://user-images.githubusercontent.com/15101411/120453648-842bbd80-c393-11eb-8c85-18386a9be21b.png)


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format](../script/tool/README.md#format-code))
- [X] I signed the [CLA].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
