### PR TITLE
[image_picker] Removed redundant request for camera permission

### DIFF
--- a/packages/image_picker/image_picker/CHANGELOG.md
+++ b/packages/image_picker/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.1
+
+* Removed redundant request for camera permissions.
+
 ## 0.8.0
 
 * BREAKING CHANGE: Changed storage location for captured images and videos to internal cache on Android,

--- a/packages/image_picker/image_picker/CHANGELOG.md
+++ b/packages/image_picker/image_picker/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.8.1
+## 0.8.0+1
 
 * Removed redundant request for camera permissions.
 

--- a/packages/image_picker/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -192,11 +192,9 @@ public class ImagePickerPlugin
       // V1 embedding setup for activity listeners.
       application.registerActivityLifecycleCallbacks(observer);
       registrar.addActivityResultListener(delegate);
-      registrar.addRequestPermissionsResultListener(delegate);
     } else {
       // V2 embedding setup for activity listeners.
       activityBinding.addActivityResultListener(delegate);
-      activityBinding.addRequestPermissionsResultListener(delegate);
       lifecycle = FlutterLifecycleAdapter.getActivityLifecycle(activityBinding);
       lifecycle.addObserver(observer);
     }
@@ -204,7 +202,6 @@ public class ImagePickerPlugin
 
   private void tearDown() {
     activityBinding.removeActivityResultListener(delegate);
-    activityBinding.removeRequestPermissionsResultListener(delegate);
     activityBinding = null;
     lifecycle.removeObserver(observer);
     lifecycle = null;

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for selecting images from the Android and iOS image
   library, and taking new pictures with the camera.
 repository: https://github.com/flutter/plugins/tree/master/packages/image_picker/image_picker
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 0.8.1
+version: 0.8.0+1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for selecting images from the Android and iOS image
   library, and taking new pictures with the camera.
 repository: https://github.com/flutter/plugins/tree/master/packages/image_picker/image_picker
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 0.8.0
+version: 0.8.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
It was [pointed out](https://github.com/flutter/plugins/pull/3956#discussion_r643121136) that since the image picker plugin relies on the `ACTION_VIDEO_CAPTURE` and `ACTION_IMAGE_CAPTURE` intents for accessing the camera, it is [not required](https://developer.android.com/training/permissions/evaluating#take-photo) to request the camera permission.

This PR removes the request for camera permissions.

The permission requests for reading and writing external storage were already removed, and since after that the camera permission was the only remaining permission being requested by the plugin, I took out everything related to permissions as well. 

**Relevant issue:**
- flutter/flutter#83789

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format](../script/tool/README.md#format-code))
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.
