### PR TITLE
[quick_actions] Optimised UI test to prevent flaky CI failures

### DIFF
--- a/packages/quick_actions/quick_actions/example/ios/RunnerUITests/RunnerUITests.m
+++ b/packages/quick_actions/quick_actions/example/ios/RunnerUITests/RunnerUITests.m
@@ -11,11 +11,20 @@ static const int kElementWaitingTime = 30;
 
 @end
 
-@implementation RunnerUITests
+@implementation RunnerUITests {
+  XCUIApplication *_exampleApp;
+}
 
 - (void)setUp {
   [super setUp];
   self.continueAfterFailure = NO;
+  _exampleApp = [[XCUIApplication alloc] initWithBundleIdentifier:@"io.flutter.plugins.quickActionsExample"];
+}
+
+- (void)tearDown {
+  [super tearDown];
+  [_exampleApp terminate];
+  _exampleApp = nil;
 }
 
 - (void)testQuickActionWithFreshStart {
@@ -38,26 +47,21 @@ static const int kElementWaitingTime = 30;
 
   [actionTwo tap];
   
-  XCUIApplication *exampleApp =
-      [[XCUIApplication alloc] initWithBundleIdentifier:@"io.flutter.plugins.quickActionsExample"];
-  XCUIElement *actionTwoConfirmation = exampleApp.otherElements[@"action_two"];
+  XCUIElement *actionTwoConfirmation = _exampleApp.otherElements[@"action_two"];
   if (![actionTwoConfirmation waitForExistenceWithTimeout:kElementWaitingTime]) {
     os_log_error(OS_LOG_DEFAULT, "%@", springboard.debugDescription);
     XCTFail(@"Failed due to not able to find the actionTwoConfirmation in the app with %@ seconds",
             @(kElementWaitingTime));
   }
   XCTAssertTrue(actionTwoConfirmation.exists);
-
-  [exampleApp terminate];
 }
 
 - (void)testQuickActionWhenAppIsInBackground {
-  XCUIApplication *app = [[XCUIApplication alloc] init];
-  [app launch];
+  [_exampleApp launch];
 
-  XCUIElement *actionsReady = app.otherElements[@"actions ready"];
+  XCUIElement *actionsReady = _exampleApp.otherElements[@"actions ready"];
   if (![actionsReady waitForExistenceWithTimeout:kElementWaitingTime]) {
-    os_log_error(OS_LOG_DEFAULT, "%@", app.debugDescription);
+    os_log_error(OS_LOG_DEFAULT, "%@", _exampleApp.debugDescription);
     XCTFail(@"Failed due to not able to find the actionsReady in the app with %@ seconds",
             @(kElementWaitingTime));
   }
@@ -83,15 +87,13 @@ static const int kElementWaitingTime = 30;
 
   [actionOne tap];
 
-  XCUIElement *actionOneConfirmation = app.otherElements[@"action_one"];
+  XCUIElement *actionOneConfirmation = _exampleApp.otherElements[@"action_one"];
   if (![actionOneConfirmation waitForExistenceWithTimeout:kElementWaitingTime]) {
     os_log_error(OS_LOG_DEFAULT, "%@", springboard.debugDescription);
     XCTFail(@"Failed due to not able to find the actionOneConfirmation in the app with %@ seconds",
             @(kElementWaitingTime));
   }
   XCTAssertTrue(actionOneConfirmation.exists);
-
-  [app terminate];
 }
 
 @end

--- a/packages/quick_actions/quick_actions/example/ios/RunnerUITests/RunnerUITests.m
+++ b/packages/quick_actions/quick_actions/example/ios/RunnerUITests/RunnerUITests.m
@@ -19,10 +19,6 @@ static const int kElementWaitingTime = 30;
 }
 
 - (void)testQuickActionWithFreshStart {
-  XCUIApplication *app = [[XCUIApplication alloc] init];
-  [app launch];
-  [app terminate];
-
   XCUIApplication *springboard =
       [[XCUIApplication alloc] initWithBundleIdentifier:@"com.apple.springboard"];
   XCUIElement *quickActionsAppIcon = springboard.icons[@"quick_actions_example"];
@@ -41,8 +37,10 @@ static const int kElementWaitingTime = 30;
   }
 
   [actionTwo tap];
-
-  XCUIElement *actionTwoConfirmation = app.otherElements[@"action_two"];
+  
+  XCUIApplication *exampleApp =
+      [[XCUIApplication alloc] initWithBundleIdentifier:@"io.flutter.plugins.quickActionsExample"];
+  XCUIElement *actionTwoConfirmation = exampleApp.otherElements[@"action_two"];
   if (![actionTwoConfirmation waitForExistenceWithTimeout:kElementWaitingTime]) {
     os_log_error(OS_LOG_DEFAULT, "%@", springboard.debugDescription);
     XCTFail(@"Failed due to not able to find the actionTwoConfirmation in the app with %@ seconds",
@@ -50,7 +48,7 @@ static const int kElementWaitingTime = 30;
   }
   XCTAssertTrue(actionTwoConfirmation.exists);
 
-  [app terminate];
+  [exampleApp terminate];
 }
 
 - (void)testQuickActionWhenAppIsInBackground {

--- a/packages/quick_actions/quick_actions/example/ios/RunnerUITests/RunnerUITests.m
+++ b/packages/quick_actions/quick_actions/example/ios/RunnerUITests/RunnerUITests.m
@@ -18,8 +18,7 @@ static const int kElementWaitingTime = 30;
 - (void)setUp {
   [super setUp];
   self.continueAfterFailure = NO;
-  _exampleApp =
-      [[XCUIApplication alloc] initWithBundleIdentifier:@"io.flutter.plugins.quickActionsExample"];
+  _exampleApp = [[XCUIApplication alloc] init];
 }
 
 - (void)tearDown {

--- a/packages/quick_actions/quick_actions/example/ios/RunnerUITests/RunnerUITests.m
+++ b/packages/quick_actions/quick_actions/example/ios/RunnerUITests/RunnerUITests.m
@@ -29,14 +29,14 @@ static const int kElementWaitingTime = 30;
 
 - (void)testQuickActionWithFreshStart {
   XCUIApplication *springboard =
-      [[XCUIApplication alloc] initWithBundleIdentifier:@"com.apple.springboard"];
+  [[XCUIApplication alloc] initWithBundleIdentifier:@"com.apple.springboard"];
   XCUIElement *quickActionsAppIcon = springboard.icons[@"quick_actions_example"];
   if (![quickActionsAppIcon waitForExistenceWithTimeout:kElementWaitingTime]) {
     os_log_error(OS_LOG_DEFAULT, "%@", springboard.debugDescription);
     XCTFail(@"Failed due to not able to find the example app from springboard with %@ seconds",
             @(kElementWaitingTime));
   }
-
+  
   [quickActionsAppIcon pressForDuration:2];
   XCUIElement *actionTwo = springboard.buttons[@"Action two"];
   if (![actionTwo waitForExistenceWithTimeout:kElementWaitingTime]) {
@@ -44,7 +44,7 @@ static const int kElementWaitingTime = 30;
     XCTFail(@"Failed due to not able to find the actionTwo button from springboard with %@ seconds",
             @(kElementWaitingTime));
   }
-
+  
   [actionTwo tap];
   
   XCUIElement *actionTwoConfirmation = _exampleApp.otherElements[@"action_two"];
@@ -58,25 +58,25 @@ static const int kElementWaitingTime = 30;
 
 - (void)testQuickActionWhenAppIsInBackground {
   [_exampleApp launch];
-
+  
   XCUIElement *actionsReady = _exampleApp.otherElements[@"actions ready"];
   if (![actionsReady waitForExistenceWithTimeout:kElementWaitingTime]) {
     os_log_error(OS_LOG_DEFAULT, "%@", _exampleApp.debugDescription);
     XCTFail(@"Failed due to not able to find the actionsReady in the app with %@ seconds",
             @(kElementWaitingTime));
   }
-
+  
   [[XCUIDevice sharedDevice] pressButton:XCUIDeviceButtonHome];
-
+  
   XCUIApplication *springboard =
-      [[XCUIApplication alloc] initWithBundleIdentifier:@"com.apple.springboard"];
+  [[XCUIApplication alloc] initWithBundleIdentifier:@"com.apple.springboard"];
   XCUIElement *quickActionsAppIcon = springboard.icons[@"quick_actions_example"];
   if (![quickActionsAppIcon waitForExistenceWithTimeout:kElementWaitingTime]) {
     os_log_error(OS_LOG_DEFAULT, "%@", springboard.debugDescription);
     XCTFail(@"Failed due to not able to find the example app from springboard with %@ seconds",
             @(kElementWaitingTime));
   }
-
+  
   [quickActionsAppIcon pressForDuration:2];
   XCUIElement *actionOne = springboard.buttons[@"Action one"];
   if (![actionOne waitForExistenceWithTimeout:kElementWaitingTime]) {
@@ -84,9 +84,9 @@ static const int kElementWaitingTime = 30;
     XCTFail(@"Failed due to not able to find the actionOne button from springboard with %@ seconds",
             @(kElementWaitingTime));
   }
-
+  
   [actionOne tap];
-
+  
   XCUIElement *actionOneConfirmation = _exampleApp.otherElements[@"action_one"];
   if (![actionOneConfirmation waitForExistenceWithTimeout:kElementWaitingTime]) {
     os_log_error(OS_LOG_DEFAULT, "%@", springboard.debugDescription);

--- a/packages/quick_actions/quick_actions/example/ios/RunnerUITests/RunnerUITests.m
+++ b/packages/quick_actions/quick_actions/example/ios/RunnerUITests/RunnerUITests.m
@@ -18,7 +18,8 @@ static const int kElementWaitingTime = 30;
 - (void)setUp {
   [super setUp];
   self.continueAfterFailure = NO;
-  _exampleApp = [[XCUIApplication alloc] initWithBundleIdentifier:@"io.flutter.plugins.quickActionsExample"];
+  _exampleApp =
+      [[XCUIApplication alloc] initWithBundleIdentifier:@"io.flutter.plugins.quickActionsExample"];
 }
 
 - (void)tearDown {
@@ -29,14 +30,14 @@ static const int kElementWaitingTime = 30;
 
 - (void)testQuickActionWithFreshStart {
   XCUIApplication *springboard =
-  [[XCUIApplication alloc] initWithBundleIdentifier:@"com.apple.springboard"];
+      [[XCUIApplication alloc] initWithBundleIdentifier:@"com.apple.springboard"];
   XCUIElement *quickActionsAppIcon = springboard.icons[@"quick_actions_example"];
   if (![quickActionsAppIcon waitForExistenceWithTimeout:kElementWaitingTime]) {
     os_log_error(OS_LOG_DEFAULT, "%@", springboard.debugDescription);
     XCTFail(@"Failed due to not able to find the example app from springboard with %@ seconds",
             @(kElementWaitingTime));
   }
-  
+
   [quickActionsAppIcon pressForDuration:2];
   XCUIElement *actionTwo = springboard.buttons[@"Action two"];
   if (![actionTwo waitForExistenceWithTimeout:kElementWaitingTime]) {
@@ -44,9 +45,9 @@ static const int kElementWaitingTime = 30;
     XCTFail(@"Failed due to not able to find the actionTwo button from springboard with %@ seconds",
             @(kElementWaitingTime));
   }
-  
+
   [actionTwo tap];
-  
+
   XCUIElement *actionTwoConfirmation = _exampleApp.otherElements[@"action_two"];
   if (![actionTwoConfirmation waitForExistenceWithTimeout:kElementWaitingTime]) {
     os_log_error(OS_LOG_DEFAULT, "%@", springboard.debugDescription);
@@ -58,25 +59,25 @@ static const int kElementWaitingTime = 30;
 
 - (void)testQuickActionWhenAppIsInBackground {
   [_exampleApp launch];
-  
+
   XCUIElement *actionsReady = _exampleApp.otherElements[@"actions ready"];
   if (![actionsReady waitForExistenceWithTimeout:kElementWaitingTime]) {
     os_log_error(OS_LOG_DEFAULT, "%@", _exampleApp.debugDescription);
     XCTFail(@"Failed due to not able to find the actionsReady in the app with %@ seconds",
             @(kElementWaitingTime));
   }
-  
+
   [[XCUIDevice sharedDevice] pressButton:XCUIDeviceButtonHome];
-  
+
   XCUIApplication *springboard =
-  [[XCUIApplication alloc] initWithBundleIdentifier:@"com.apple.springboard"];
+      [[XCUIApplication alloc] initWithBundleIdentifier:@"com.apple.springboard"];
   XCUIElement *quickActionsAppIcon = springboard.icons[@"quick_actions_example"];
   if (![quickActionsAppIcon waitForExistenceWithTimeout:kElementWaitingTime]) {
     os_log_error(OS_LOG_DEFAULT, "%@", springboard.debugDescription);
     XCTFail(@"Failed due to not able to find the example app from springboard with %@ seconds",
             @(kElementWaitingTime));
   }
-  
+
   [quickActionsAppIcon pressForDuration:2];
   XCUIElement *actionOne = springboard.buttons[@"Action one"];
   if (![actionOne waitForExistenceWithTimeout:kElementWaitingTime]) {
@@ -84,9 +85,9 @@ static const int kElementWaitingTime = 30;
     XCTFail(@"Failed due to not able to find the actionOne button from springboard with %@ seconds",
             @(kElementWaitingTime));
   }
-  
+
   [actionOne tap];
-  
+
   XCUIElement *actionOneConfirmation = _exampleApp.otherElements[@"action_one"];
   if (![actionOneConfirmation waitForExistenceWithTimeout:kElementWaitingTime]) {
     os_log_error(OS_LOG_DEFAULT, "%@", springboard.debugDescription);


### PR DESCRIPTION
This PR will hopefully fixes the flaky `testQuickActionWithFreshStart` iOS UI test (see flutter/flutter#83483).

Since I wasn't able to reproduce the issue on my local environment it is difficult to determine if this really resolves the problem. However the test was launching and terminating the app under test and I think this was interfering to the point where the app is terminated right before the test to check for the "action-two" screen shows up.

I have restructured the test script to ensure the app under test is terminated after each test so the environment should start in a fresh state for each of the tests.

Added benefit is that is makes the UI Test logic easier to read and understand and less prone to mistakes when additional tests are added.

- flutter/flutter#83483

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format])
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
  - The version number is not updated since this PR only restructured an existing UI Test so it would run more stable. In my opinion this change didn't warrant a new release to be published.
- [ ] I updated CHANGELOG.md to add a description of the change.
  - The version number is not updated since this PR only restructured an existing UI Test so it would run more stable.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[plugin_tool format]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
