### PR TITLE
Check in regenerated C++ example registrants

### DIFF
--- a/packages/path_provider/path_provider/example/linux/flutter/generated_plugin_registrant.cc
+++ b/packages/path_provider/path_provider/example/linux/flutter/generated_plugin_registrant.cc
@@ -2,6 +2,10 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #include "generated_plugin_registrant.h"
 
-void fl_register_plugins(FlPluginRegistry* registry) {}
+
+void fl_register_plugins(FlPluginRegistry* registry) {
+}

--- a/packages/path_provider/path_provider/example/linux/flutter/generated_plugin_registrant.h
+++ b/packages/path_provider/path_provider/example/linux/flutter/generated_plugin_registrant.h
@@ -2,6 +2,8 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #ifndef GENERATED_PLUGIN_REGISTRANT_
 #define GENERATED_PLUGIN_REGISTRANT_
 

--- a/packages/path_provider/path_provider/example/windows/flutter/generated_plugin_registrant.cc
+++ b/packages/path_provider/path_provider/example/windows/flutter/generated_plugin_registrant.cc
@@ -2,6 +2,10 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #include "generated_plugin_registrant.h"
 
-void RegisterPlugins(flutter::PluginRegistry* registry) {}
+
+void RegisterPlugins(flutter::PluginRegistry* registry) {
+}

--- a/packages/path_provider/path_provider/example/windows/flutter/generated_plugin_registrant.h
+++ b/packages/path_provider/path_provider/example/windows/flutter/generated_plugin_registrant.h
@@ -2,6 +2,8 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #ifndef GENERATED_PLUGIN_REGISTRANT_
 #define GENERATED_PLUGIN_REGISTRANT_
 

--- a/packages/path_provider/path_provider_linux/example/linux/flutter/generated_plugin_registrant.cc
+++ b/packages/path_provider/path_provider_linux/example/linux/flutter/generated_plugin_registrant.cc
@@ -2,6 +2,10 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #include "generated_plugin_registrant.h"
 
-void fl_register_plugins(FlPluginRegistry* registry) {}
+
+void fl_register_plugins(FlPluginRegistry* registry) {
+}

--- a/packages/path_provider/path_provider_linux/example/linux/flutter/generated_plugin_registrant.h
+++ b/packages/path_provider/path_provider_linux/example/linux/flutter/generated_plugin_registrant.h
@@ -2,6 +2,8 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #ifndef GENERATED_PLUGIN_REGISTRANT_
 #define GENERATED_PLUGIN_REGISTRANT_
 

--- a/packages/path_provider/path_provider_windows/example/windows/flutter/generated_plugin_registrant.cc
+++ b/packages/path_provider/path_provider_windows/example/windows/flutter/generated_plugin_registrant.cc
@@ -2,6 +2,10 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #include "generated_plugin_registrant.h"
 
-void RegisterPlugins(flutter::PluginRegistry* registry) {}
+
+void RegisterPlugins(flutter::PluginRegistry* registry) {
+}

--- a/packages/path_provider/path_provider_windows/example/windows/flutter/generated_plugin_registrant.h
+++ b/packages/path_provider/path_provider_windows/example/windows/flutter/generated_plugin_registrant.h
@@ -2,6 +2,8 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #ifndef GENERATED_PLUGIN_REGISTRANT_
 #define GENERATED_PLUGIN_REGISTRANT_
 

--- a/packages/shared_preferences/shared_preferences/example/linux/flutter/generated_plugin_registrant.cc
+++ b/packages/shared_preferences/shared_preferences/example/linux/flutter/generated_plugin_registrant.cc
@@ -2,6 +2,10 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #include "generated_plugin_registrant.h"
 
-void fl_register_plugins(FlPluginRegistry* registry) {}
+
+void fl_register_plugins(FlPluginRegistry* registry) {
+}

--- a/packages/shared_preferences/shared_preferences/example/linux/flutter/generated_plugin_registrant.h
+++ b/packages/shared_preferences/shared_preferences/example/linux/flutter/generated_plugin_registrant.h
@@ -2,6 +2,8 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #ifndef GENERATED_PLUGIN_REGISTRANT_
 #define GENERATED_PLUGIN_REGISTRANT_
 

--- a/packages/shared_preferences/shared_preferences/example/windows/flutter/generated_plugin_registrant.cc
+++ b/packages/shared_preferences/shared_preferences/example/windows/flutter/generated_plugin_registrant.cc
@@ -2,6 +2,10 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #include "generated_plugin_registrant.h"
 
-void RegisterPlugins(flutter::PluginRegistry* registry) {}
+
+void RegisterPlugins(flutter::PluginRegistry* registry) {
+}

--- a/packages/shared_preferences/shared_preferences/example/windows/flutter/generated_plugin_registrant.h
+++ b/packages/shared_preferences/shared_preferences/example/windows/flutter/generated_plugin_registrant.h
@@ -2,6 +2,8 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #ifndef GENERATED_PLUGIN_REGISTRANT_
 #define GENERATED_PLUGIN_REGISTRANT_
 

--- a/packages/shared_preferences/shared_preferences_linux/example/linux/flutter/generated_plugin_registrant.cc
+++ b/packages/shared_preferences/shared_preferences_linux/example/linux/flutter/generated_plugin_registrant.cc
@@ -2,6 +2,10 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #include "generated_plugin_registrant.h"
 
-void fl_register_plugins(FlPluginRegistry* registry) {}
+
+void fl_register_plugins(FlPluginRegistry* registry) {
+}

--- a/packages/shared_preferences/shared_preferences_linux/example/linux/flutter/generated_plugin_registrant.h
+++ b/packages/shared_preferences/shared_preferences_linux/example/linux/flutter/generated_plugin_registrant.h
@@ -2,6 +2,8 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #ifndef GENERATED_PLUGIN_REGISTRANT_
 #define GENERATED_PLUGIN_REGISTRANT_
 

--- a/packages/shared_preferences/shared_preferences_windows/example/windows/flutter/generated_plugin_registrant.cc
+++ b/packages/shared_preferences/shared_preferences_windows/example/windows/flutter/generated_plugin_registrant.cc
@@ -2,6 +2,10 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #include "generated_plugin_registrant.h"
 
-void RegisterPlugins(flutter::PluginRegistry* registry) {}
+
+void RegisterPlugins(flutter::PluginRegistry* registry) {
+}

--- a/packages/shared_preferences/shared_preferences_windows/example/windows/flutter/generated_plugin_registrant.h
+++ b/packages/shared_preferences/shared_preferences_windows/example/windows/flutter/generated_plugin_registrant.h
@@ -2,6 +2,8 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #ifndef GENERATED_PLUGIN_REGISTRANT_
 #define GENERATED_PLUGIN_REGISTRANT_
 

--- a/packages/url_launcher/url_launcher/example/linux/flutter/generated_plugin_registrant.cc
+++ b/packages/url_launcher/url_launcher/example/linux/flutter/generated_plugin_registrant.cc
@@ -2,13 +2,14 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #include "generated_plugin_registrant.h"
 
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry,
-                                                  "UrlLauncherPlugin");
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
 }

--- a/packages/url_launcher/url_launcher/example/linux/flutter/generated_plugin_registrant.h
+++ b/packages/url_launcher/url_launcher/example/linux/flutter/generated_plugin_registrant.h
@@ -2,6 +2,8 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #ifndef GENERATED_PLUGIN_REGISTRANT_
 #define GENERATED_PLUGIN_REGISTRANT_
 

--- a/packages/url_launcher/url_launcher/example/windows/flutter/generated_plugin_registrant.cc
+++ b/packages/url_launcher/url_launcher/example/windows/flutter/generated_plugin_registrant.cc
@@ -2,6 +2,8 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #include "generated_plugin_registrant.h"
 
 #include <url_launcher_windows/url_launcher_plugin.h>

--- a/packages/url_launcher/url_launcher/example/windows/flutter/generated_plugin_registrant.h
+++ b/packages/url_launcher/url_launcher/example/windows/flutter/generated_plugin_registrant.h
@@ -2,6 +2,8 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #ifndef GENERATED_PLUGIN_REGISTRANT_
 #define GENERATED_PLUGIN_REGISTRANT_
 

--- a/packages/url_launcher/url_launcher_linux/example/linux/flutter/generated_plugin_registrant.cc
+++ b/packages/url_launcher/url_launcher_linux/example/linux/flutter/generated_plugin_registrant.cc
@@ -2,13 +2,14 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #include "generated_plugin_registrant.h"
 
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry,
-                                                  "UrlLauncherPlugin");
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
 }

--- a/packages/url_launcher/url_launcher_linux/example/linux/flutter/generated_plugin_registrant.h
+++ b/packages/url_launcher/url_launcher_linux/example/linux/flutter/generated_plugin_registrant.h
@@ -2,6 +2,8 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #ifndef GENERATED_PLUGIN_REGISTRANT_
 #define GENERATED_PLUGIN_REGISTRANT_
 

--- a/packages/url_launcher/url_launcher_windows/example/windows/flutter/generated_plugin_registrant.cc
+++ b/packages/url_launcher/url_launcher_windows/example/windows/flutter/generated_plugin_registrant.cc
@@ -2,6 +2,8 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #include "generated_plugin_registrant.h"
 
 #include <url_launcher_windows/url_launcher_plugin.h>

--- a/packages/url_launcher/url_launcher_windows/example/windows/flutter/generated_plugin_registrant.h
+++ b/packages/url_launcher/url_launcher_windows/example/windows/flutter/generated_plugin_registrant.h
@@ -2,6 +2,8 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #ifndef GENERATED_PLUGIN_REGISTRANT_
 #define GENERATED_PLUGIN_REGISTRANT_
 


### PR DESCRIPTION
The Flutter-generated C++ plugin registrants use a format that doesn't
match what this repo's clang-format settings wanted, so every time they
were regenerated it created a local diff that couldn't be checked in
without failing the CI format check.

The templates are now generated with a directive to disable
clang-format; this checks in that version of all of the files to avoid
the local edit problem in the future.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format])
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[plugin_tool format]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
