### PR TITLE
[flutter_plugin_tools] Simplify filesystem usage

### DIFF
--- a/script/tool/lib/src/analyze_command.dart
+++ b/script/tool/lib/src/analyze_command.dart
@@ -13,8 +13,7 @@ import 'common.dart';
 class AnalyzeCommand extends PluginCommand {
   /// Creates a analysis command instance.
   AnalyzeCommand(
-    Directory packagesDir,
-    FileSystem fileSystem, {
+    Directory packagesDir, {
     ProcessRunner processRunner = const ProcessRunner(),
   }) : super(packagesDir, processRunner: processRunner) {
     argParser.addMultiOption(_customAnalysisFlag,

--- a/script/tool/lib/src/analyze_command.dart
+++ b/script/tool/lib/src/analyze_command.dart
@@ -16,7 +16,7 @@ class AnalyzeCommand extends PluginCommand {
     Directory packagesDir,
     FileSystem fileSystem, {
     ProcessRunner processRunner = const ProcessRunner(),
-  }) : super(packagesDir, fileSystem, processRunner: processRunner) {
+  }) : super(packagesDir, processRunner: processRunner) {
     argParser.addMultiOption(_customAnalysisFlag,
         help:
             'Directories (comma separated) that are allowed to have their own analysis options.',

--- a/script/tool/lib/src/build_examples_command.dart
+++ b/script/tool/lib/src/build_examples_command.dart
@@ -18,7 +18,7 @@ class BuildExamplesCommand extends PluginCommand {
     Directory packagesDir,
     FileSystem fileSystem, {
     ProcessRunner processRunner = const ProcessRunner(),
-  }) : super(packagesDir, fileSystem, processRunner: processRunner) {
+  }) : super(packagesDir, processRunner: processRunner) {
     argParser.addFlag(kLinux, defaultsTo: false);
     argParser.addFlag(kMacos, defaultsTo: false);
     argParser.addFlag(kWeb, defaultsTo: false);
@@ -69,7 +69,7 @@ class BuildExamplesCommand extends PluginCommand {
 
         if (getBoolArg(kLinux)) {
           print('\nBUILDING Linux for $packageName');
-          if (isLinuxPlugin(plugin, fileSystem)) {
+          if (isLinuxPlugin(plugin)) {
             final int buildExitCode = await processRunner.runAndStream(
                 flutterCommand,
                 <String>[
@@ -89,7 +89,7 @@ class BuildExamplesCommand extends PluginCommand {
 
         if (getBoolArg(kMacos)) {
           print('\nBUILDING macOS for $packageName');
-          if (isMacOsPlugin(plugin, fileSystem)) {
+          if (isMacOsPlugin(plugin)) {
             final int exitCode = await processRunner.runAndStream(
                 flutterCommand,
                 <String>[
@@ -109,7 +109,7 @@ class BuildExamplesCommand extends PluginCommand {
 
         if (getBoolArg(kWeb)) {
           print('\nBUILDING web for $packageName');
-          if (isWebPlugin(plugin, fileSystem)) {
+          if (isWebPlugin(plugin)) {
             final int buildExitCode = await processRunner.runAndStream(
                 flutterCommand,
                 <String>[
@@ -129,7 +129,7 @@ class BuildExamplesCommand extends PluginCommand {
 
         if (getBoolArg(kWindows)) {
           print('\nBUILDING Windows for $packageName');
-          if (isWindowsPlugin(plugin, fileSystem)) {
+          if (isWindowsPlugin(plugin)) {
             final int buildExitCode = await processRunner.runAndStream(
                 flutterCommand,
                 <String>[
@@ -149,7 +149,7 @@ class BuildExamplesCommand extends PluginCommand {
 
         if (getBoolArg(kIpa)) {
           print('\nBUILDING IPA for $packageName');
-          if (isIosPlugin(plugin, fileSystem)) {
+          if (isIosPlugin(plugin)) {
             final int exitCode = await processRunner.runAndStream(
                 flutterCommand,
                 <String>[
@@ -170,7 +170,7 @@ class BuildExamplesCommand extends PluginCommand {
 
         if (getBoolArg(kApk)) {
           print('\nBUILDING APK for $packageName');
-          if (isAndroidPlugin(plugin, fileSystem)) {
+          if (isAndroidPlugin(plugin)) {
             final int exitCode = await processRunner.runAndStream(
                 flutterCommand,
                 <String>[

--- a/script/tool/lib/src/build_examples_command.dart
+++ b/script/tool/lib/src/build_examples_command.dart
@@ -15,8 +15,7 @@ import 'common.dart';
 class BuildExamplesCommand extends PluginCommand {
   /// Creates an instance of the build command.
   BuildExamplesCommand(
-    Directory packagesDir,
-    FileSystem fileSystem, {
+    Directory packagesDir, {
     ProcessRunner processRunner = const ProcessRunner(),
   }) : super(packagesDir, processRunner: processRunner) {
     argParser.addFlag(kLinux, defaultsTo: false);

--- a/script/tool/lib/src/common.dart
+++ b/script/tool/lib/src/common.dart
@@ -48,14 +48,13 @@ const String kApk = 'apk';
 const String kEnableExperiment = 'enable-experiment';
 
 /// Returns whether the given directory contains a Flutter package.
-bool isFlutterPackage(FileSystemEntity entity, FileSystem fileSystem) {
+bool isFlutterPackage(FileSystemEntity entity) {
   if (entity is! Directory) {
     return false;
   }
 
   try {
-    final File pubspecFile =
-        fileSystem.file(p.join(entity.path, 'pubspec.yaml'));
+    final File pubspecFile = entity.childFile('pubspec.yaml');
     final YamlMap pubspecYaml =
         loadYaml(pubspecFile.readAsStringSync()) as YamlMap;
     final YamlMap? dependencies = pubspecYaml['dependencies'] as YamlMap?;
@@ -78,8 +77,7 @@ bool isFlutterPackage(FileSystemEntity entity, FileSystem fileSystem) {
 ///       plugin:
 ///         platforms:
 ///           [platform]:
-bool pluginSupportsPlatform(
-    String platform, FileSystemEntity entity, FileSystem fileSystem) {
+bool pluginSupportsPlatform(String platform, FileSystemEntity entity) {
   assert(platform == kIos ||
       platform == kAndroid ||
       platform == kWeb ||
@@ -91,8 +89,7 @@ bool pluginSupportsPlatform(
   }
 
   try {
-    final File pubspecFile =
-        fileSystem.file(p.join(entity.path, 'pubspec.yaml'));
+    final File pubspecFile = entity.childFile('pubspec.yaml');
     final YamlMap pubspecYaml =
         loadYaml(pubspecFile.readAsStringSync()) as YamlMap;
     final YamlMap? flutterSection = pubspecYaml['flutter'] as YamlMap?;
@@ -120,33 +117,33 @@ bool pluginSupportsPlatform(
 }
 
 /// Returns whether the given directory contains a Flutter Android plugin.
-bool isAndroidPlugin(FileSystemEntity entity, FileSystem fileSystem) {
-  return pluginSupportsPlatform(kAndroid, entity, fileSystem);
+bool isAndroidPlugin(FileSystemEntity entity) {
+  return pluginSupportsPlatform(kAndroid, entity);
 }
 
 /// Returns whether the given directory contains a Flutter iOS plugin.
-bool isIosPlugin(FileSystemEntity entity, FileSystem fileSystem) {
-  return pluginSupportsPlatform(kIos, entity, fileSystem);
+bool isIosPlugin(FileSystemEntity entity) {
+  return pluginSupportsPlatform(kIos, entity);
 }
 
 /// Returns whether the given directory contains a Flutter web plugin.
-bool isWebPlugin(FileSystemEntity entity, FileSystem fileSystem) {
-  return pluginSupportsPlatform(kWeb, entity, fileSystem);
+bool isWebPlugin(FileSystemEntity entity) {
+  return pluginSupportsPlatform(kWeb, entity);
 }
 
 /// Returns whether the given directory contains a Flutter Windows plugin.
-bool isWindowsPlugin(FileSystemEntity entity, FileSystem fileSystem) {
-  return pluginSupportsPlatform(kWindows, entity, fileSystem);
+bool isWindowsPlugin(FileSystemEntity entity) {
+  return pluginSupportsPlatform(kWindows, entity);
 }
 
 /// Returns whether the given directory contains a Flutter macOS plugin.
-bool isMacOsPlugin(FileSystemEntity entity, FileSystem fileSystem) {
-  return pluginSupportsPlatform(kMacos, entity, fileSystem);
+bool isMacOsPlugin(FileSystemEntity entity) {
+  return pluginSupportsPlatform(kMacos, entity);
 }
 
 /// Returns whether the given directory contains a Flutter linux plugin.
-bool isLinuxPlugin(FileSystemEntity entity, FileSystem fileSystem) {
-  return pluginSupportsPlatform(kLinux, entity, fileSystem);
+bool isLinuxPlugin(FileSystemEntity entity) {
+  return pluginSupportsPlatform(kLinux, entity);
 }
 
 /// Throws a [ToolExit] with `exitCode` and log the `errorMessage` in red.
@@ -169,8 +166,7 @@ class ToolExit extends Error {
 abstract class PluginCommand extends Command<void> {
   /// Creates a command to operate on [packagesDir] with the given environment.
   PluginCommand(
-    this.packagesDir,
-    this.fileSystem, {
+    this.packagesDir, {
     this.processRunner = const ProcessRunner(),
     this.gitDir,
   }) {
@@ -222,11 +218,6 @@ abstract class PluginCommand extends Command<void> {
 
   /// The directory containing the plugin packages.
   final Directory packagesDir;
-
-  /// The file system.
-  ///
-  /// This can be overridden for testing.
-  final FileSystem fileSystem;
 
   /// The process runner.
   ///
@@ -414,19 +405,17 @@ abstract class PluginCommand extends Command<void> {
   /// Returns whether the specified entity is a directory containing a
   /// `pubspec.yaml` file.
   bool _isDartPackage(FileSystemEntity entity) {
-    return entity is Directory &&
-        fileSystem.file(p.join(entity.path, 'pubspec.yaml')).existsSync();
+    return entity is Directory && entity.childFile('pubspec.yaml').existsSync();
   }
 
   /// Returns the example Dart packages contained in the specified plugin, or
   /// an empty List, if the plugin has no examples.
   Iterable<Directory> getExamplesForPlugin(Directory plugin) {
-    final Directory exampleFolder =
-        fileSystem.directory(p.join(plugin.path, 'example'));
+    final Directory exampleFolder = plugin.childDirectory('example');
     if (!exampleFolder.existsSync()) {
       return <Directory>[];
     }
-    if (isFlutterPackage(exampleFolder, fileSystem)) {
+    if (isFlutterPackage(exampleFolder)) {
       return <Directory>[exampleFolder];
     }
     // Only look at the subdirectories of the example directory if the example
@@ -434,8 +423,7 @@ abstract class PluginCommand extends Command<void> {
     // example directory for other dart packages.
     return exampleFolder
         .listSync()
-        .where(
-            (FileSystemEntity entity) => isFlutterPackage(entity, fileSystem))
+        .where((FileSystemEntity entity) => isFlutterPackage(entity))
         .cast<Directory>();
   }
 

--- a/script/tool/lib/src/create_all_plugins_app_command.dart
+++ b/script/tool/lib/src/create_all_plugins_app_command.dart
@@ -8,7 +8,6 @@ import 'dart:async';
 import 'dart:io' as io;
 
 import 'package:file/file.dart';
-import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
 

--- a/script/tool/lib/src/create_all_plugins_app_command.dart
+++ b/script/tool/lib/src/create_all_plugins_app_command.dart
@@ -21,7 +21,7 @@ class CreateAllPluginsAppCommand extends PluginCommand {
     Directory packagesDir,
     FileSystem fileSystem, {
     this.pluginsRoot,
-  }) : super(packagesDir, fileSystem) {
+  }) : super(packagesDir) {
     pluginsRoot ??= fileSystem.currentDirectory;
     appDirectory = pluginsRoot.childDirectory('all_plugins');
   }
@@ -161,8 +161,7 @@ class CreateAllPluginsAppCommand extends PluginCommand {
 
     await for (final Directory package in getPlugins()) {
       final String pluginName = package.path.split('/').last;
-      final File pubspecFile =
-          fileSystem.file(p.join(package.path, 'pubspec.yaml'));
+      final File pubspecFile = package.childFile('pubspec.yaml');
       final Pubspec pubspec = Pubspec.parse(pubspecFile.readAsStringSync());
 
       if (pubspec.publishTo != 'none') {

--- a/script/tool/lib/src/create_all_plugins_app_command.dart
+++ b/script/tool/lib/src/create_all_plugins_app_command.dart
@@ -18,11 +18,10 @@ import 'common.dart';
 class CreateAllPluginsAppCommand extends PluginCommand {
   /// Creates an instance of the builder command.
   CreateAllPluginsAppCommand(
-    Directory packagesDir,
-    FileSystem fileSystem, {
+    Directory packagesDir, {
     this.pluginsRoot,
   }) : super(packagesDir) {
-    pluginsRoot ??= fileSystem.currentDirectory;
+    pluginsRoot ??= packagesDir.fileSystem.currentDirectory;
     appDirectory = pluginsRoot.childDirectory('all_plugins');
   }
 

--- a/script/tool/lib/src/drive_examples_command.dart
+++ b/script/tool/lib/src/drive_examples_command.dart
@@ -12,8 +12,7 @@ import 'common.dart';
 class DriveExamplesCommand extends PluginCommand {
   /// Creates an instance of the drive command.
   DriveExamplesCommand(
-    Directory packagesDir,
-    FileSystem fileSystem, {
+    Directory packagesDir, {
     ProcessRunner processRunner = const ProcessRunner(),
   }) : super(packagesDir, processRunner: processRunner) {
     argParser.addFlag(kAndroid,

--- a/script/tool/lib/src/drive_examples_command.dart
+++ b/script/tool/lib/src/drive_examples_command.dart
@@ -15,7 +15,7 @@ class DriveExamplesCommand extends PluginCommand {
     Directory packagesDir,
     FileSystem fileSystem, {
     ProcessRunner processRunner = const ProcessRunner(),
-  }) : super(packagesDir, fileSystem, processRunner: processRunner) {
+  }) : super(packagesDir, processRunner: processRunner) {
     argParser.addFlag(kAndroid,
         help: 'Runs the Android implementation of the examples');
     argParser.addFlag(kIos,
@@ -67,7 +67,7 @@ class DriveExamplesCommand extends PluginCommand {
         continue;
       }
       print('\n==========\nChecking $pluginName...');
-      if (!(await _pluginSupportedOnCurrentPlatform(plugin, fileSystem))) {
+      if (!(await _pluginSupportedOnCurrentPlatform(plugin))) {
         print('Not supported for the target platform; skipping.');
         continue;
       }
@@ -79,8 +79,7 @@ class DriveExamplesCommand extends PluginCommand {
         ++examplesFound;
         final String packageName =
             p.relative(example.path, from: packagesDir.path);
-        final Directory driverTests =
-            fileSystem.directory(p.join(example.path, 'test_driver'));
+        final Directory driverTests = example.childDirectory('test_driver');
         if (!driverTests.existsSync()) {
           print('No driver tests found for $packageName');
           continue;
@@ -98,7 +97,7 @@ class DriveExamplesCommand extends PluginCommand {
             '.dart',
           );
           String deviceTestPath = p.join('test', deviceTestName);
-          if (!fileSystem
+          if (!example.fileSystem
               .file(p.join(example.path, deviceTestPath))
               .existsSync()) {
             // If the app isn't in test/ folder, look in test_driver/ instead.
@@ -106,13 +105,13 @@ class DriveExamplesCommand extends PluginCommand {
           }
 
           final List<String> targetPaths = <String>[];
-          if (fileSystem
+          if (example.fileSystem
               .file(p.join(example.path, deviceTestPath))
               .existsSync()) {
             targetPaths.add(deviceTestPath);
           } else {
             final Directory integrationTests =
-                fileSystem.directory(p.join(example.path, 'integration_test'));
+                example.childDirectory('integration_test');
 
             if (await integrationTests.exists()) {
               await for (final FileSystemEntity integrationTest
@@ -145,19 +144,19 @@ Tried searching for the following:
             driveArgs.add('--enable-experiment=$enableExperiment');
           }
 
-          if (isLinux && isLinuxPlugin(plugin, fileSystem)) {
+          if (isLinux && isLinuxPlugin(plugin)) {
             driveArgs.addAll(<String>[
               '-d',
               'linux',
             ]);
           }
-          if (isMacos && isMacOsPlugin(plugin, fileSystem)) {
+          if (isMacos && isMacOsPlugin(plugin)) {
             driveArgs.addAll(<String>[
               '-d',
               'macos',
             ]);
           }
-          if (isWeb && isWebPlugin(plugin, fileSystem)) {
+          if (isWeb && isWebPlugin(plugin)) {
             driveArgs.addAll(<String>[
               '-d',
               'web-server',
@@ -165,7 +164,7 @@ Tried searching for the following:
               '--browser-name=chrome',
             ]);
           }
-          if (isWindows && isWindowsPlugin(plugin, fileSystem)) {
+          if (isWindows && isWindowsPlugin(plugin)) {
             driveArgs.addAll(<String>[
               '-d',
               'windows',
@@ -220,7 +219,7 @@ Tried searching for the following:
   }
 
   Future<bool> _pluginSupportedOnCurrentPlatform(
-      FileSystemEntity plugin, FileSystem fileSystem) async {
+      FileSystemEntity plugin) async {
     final bool isAndroid = getBoolArg(kAndroid);
     final bool isIOS = getBoolArg(kIos);
     final bool isLinux = getBoolArg(kLinux);
@@ -228,27 +227,27 @@ Tried searching for the following:
     final bool isWeb = getBoolArg(kWeb);
     final bool isWindows = getBoolArg(kWindows);
     if (isAndroid) {
-      return isAndroidPlugin(plugin, fileSystem);
+      return isAndroidPlugin(plugin);
     }
     if (isIOS) {
-      return isIosPlugin(plugin, fileSystem);
+      return isIosPlugin(plugin);
     }
     if (isLinux) {
-      return isLinuxPlugin(plugin, fileSystem);
+      return isLinuxPlugin(plugin);
     }
     if (isMacos) {
-      return isMacOsPlugin(plugin, fileSystem);
+      return isMacOsPlugin(plugin);
     }
     if (isWeb) {
-      return isWebPlugin(plugin, fileSystem);
+      return isWebPlugin(plugin);
     }
     if (isWindows) {
-      return isWindowsPlugin(plugin, fileSystem);
+      return isWindowsPlugin(plugin);
     }
     // When we are here, no flags are specified. Only return true if the plugin
     // supports Android for legacy command support.
     // TODO(cyanglaz): Make Android flag also required like other platforms
     // (breaking change). https://github.com/flutter/flutter/issues/58285
-    return isAndroidPlugin(plugin, fileSystem);
+    return isAndroidPlugin(plugin);
   }
 }

--- a/script/tool/lib/src/firebase_test_lab_command.dart
+++ b/script/tool/lib/src/firebase_test_lab_command.dart
@@ -17,8 +17,7 @@ import 'common.dart';
 class FirebaseTestLabCommand extends PluginCommand {
   /// Creates an instance of the test runner command.
   FirebaseTestLabCommand(
-    Directory packagesDir,
-    FileSystem fileSystem, {
+    Directory packagesDir, {
     ProcessRunner processRunner = const ProcessRunner(),
     Print print = print,
   })  : _print = print,

--- a/script/tool/lib/src/firebase_test_lab_command.dart
+++ b/script/tool/lib/src/firebase_test_lab_command.dart
@@ -22,7 +22,7 @@ class FirebaseTestLabCommand extends PluginCommand {
     ProcessRunner processRunner = const ProcessRunner(),
     Print print = print,
   })  : _print = print,
-        super(packagesDir, fileSystem, processRunner: processRunner) {
+        super(packagesDir, processRunner: processRunner) {
     argParser.addOption(
       'project',
       defaultsTo: 'flutter-infra',
@@ -105,10 +105,13 @@ class FirebaseTestLabCommand extends PluginCommand {
   Future<void> run() async {
     final Stream<Directory> packagesWithTests = getPackages().where(
         (Directory d) =>
-            isFlutterPackage(d, fileSystem) &&
-            fileSystem
-                .directory(p.join(
-                    d.path, 'example', 'android', 'app', 'src', 'androidTest'))
+            isFlutterPackage(d) &&
+            d
+                .childDirectory('example')
+                .childDirectory('android')
+                .childDirectory('app')
+                .childDirectory('src')
+                .childDirectory('androidTest')
                 .existsSync());
 
     final List<String> failingPackages = <String>[];
@@ -118,23 +121,20 @@ class FirebaseTestLabCommand extends PluginCommand {
     await for (final Directory package in packagesWithTests) {
       // See https://github.com/flutter/flutter/issues/38983
 
-      final Directory exampleDirectory =
-          fileSystem.directory(p.join(package.path, 'example'));
+      final Directory exampleDirectory = package.childDirectory('example');
       final String packageName =
           p.relative(package.path, from: packagesDir.path);
       _print('\nRUNNING FIREBASE TEST LAB TESTS for $packageName');
 
       final Directory androidDirectory =
-          fileSystem.directory(p.join(exampleDirectory.path, 'android'));
+          exampleDirectory.childDirectory('android');
 
       final String enableExperiment = getStringArg(kEnableExperiment);
       final String encodedEnableExperiment =
           Uri.encodeComponent('--enable-experiment=$enableExperiment');
 
       // Ensures that gradle wrapper exists
-      if (!fileSystem
-          .file(p.join(androidDirectory.path, _gradleWrapper))
-          .existsSync()) {
+      if (!androidDirectory.childFile(_gradleWrapper).existsSync()) {
         final int exitCode = await processRunner.runAndStream(
             'flutter',
             <String>[
@@ -181,8 +181,7 @@ class FirebaseTestLabCommand extends PluginCommand {
 
       final List<Directory> testDirs =
           package.listSync().where(isTestDir).cast<Directory>().toList();
-      final Directory example =
-          fileSystem.directory(p.join(package.path, 'example'));
+      final Directory example = package.childDirectory('example');
       testDirs.addAll(
           example.listSync().where(isTestDir).cast<Directory>().toList());
       for (final Directory testDir in testDirs) {

--- a/script/tool/lib/src/format_command.dart
+++ b/script/tool/lib/src/format_command.dart
@@ -20,8 +20,7 @@ final Uri _googleFormatterUrl = Uri.https('github.com',
 class FormatCommand extends PluginCommand {
   /// Creates an instance of the format command.
   FormatCommand(
-    Directory packagesDir,
-    FileSystem fileSystem, {
+    Directory packagesDir, {
     ProcessRunner processRunner = const ProcessRunner(),
   }) : super(packagesDir, processRunner: processRunner) {
     argParser.addFlag('fail-on-change', hide: true);

--- a/script/tool/lib/src/format_command.dart
+++ b/script/tool/lib/src/format_command.dart
@@ -23,7 +23,7 @@ class FormatCommand extends PluginCommand {
     Directory packagesDir,
     FileSystem fileSystem, {
     ProcessRunner processRunner = const ProcessRunner(),
-  }) : super(packagesDir, fileSystem, processRunner: processRunner) {
+  }) : super(packagesDir, processRunner: processRunner) {
     argParser.addFlag('fail-on-change', hide: true);
     argParser.addOption('clang-format',
         defaultsTo: 'clang-format',
@@ -144,7 +144,8 @@ class FormatCommand extends PluginCommand {
     final String javaFormatterPath = p.join(
         p.dirname(p.fromUri(io.Platform.script)),
         'google-java-format-1.3-all-deps.jar');
-    final File javaFormatterFile = fileSystem.file(javaFormatterPath);
+    final File javaFormatterFile =
+        packagesDir.fileSystem.file(javaFormatterPath);
 
     if (!javaFormatterFile.existsSync()) {
       print('Downloading Google Java Format...');

--- a/script/tool/lib/src/java_test_command.dart
+++ b/script/tool/lib/src/java_test_command.dart
@@ -16,7 +16,7 @@ class JavaTestCommand extends PluginCommand {
     Directory packagesDir,
     FileSystem fileSystem, {
     ProcessRunner processRunner = const ProcessRunner(),
-  }) : super(packagesDir, fileSystem, processRunner: processRunner);
+  }) : super(packagesDir, processRunner: processRunner);
 
   @override
   final String name = 'java-test';
@@ -32,12 +32,17 @@ class JavaTestCommand extends PluginCommand {
   Future<void> run() async {
     final Stream<Directory> examplesWithTests = getExamples().where(
         (Directory d) =>
-            isFlutterPackage(d, fileSystem) &&
-            (fileSystem
-                    .directory(p.join(d.path, 'android', 'app', 'src', 'test'))
+            isFlutterPackage(d) &&
+            (d
+                    .childDirectory('android')
+                    .childDirectory('app')
+                    .childDirectory('src')
+                    .childDirectory('test')
                     .existsSync() ||
-                fileSystem
-                    .directory(p.join(d.path, '..', 'android', 'src', 'test'))
+                d.parent
+                    .childDirectory('android')
+                    .childDirectory('src')
+                    .childDirectory('test')
                     .existsSync()));
 
     final List<String> failingPackages = <String>[];
@@ -47,11 +52,8 @@ class JavaTestCommand extends PluginCommand {
           p.relative(example.path, from: packagesDir.path);
       print('\nRUNNING JAVA TESTS for $packageName');
 
-      final Directory androidDirectory =
-          fileSystem.directory(p.join(example.path, 'android'));
-      if (!fileSystem
-          .file(p.join(androidDirectory.path, _gradleWrapper))
-          .existsSync()) {
+      final Directory androidDirectory = example.childDirectory('android');
+      if (!androidDirectory.childFile(_gradleWrapper).existsSync()) {
         print('ERROR: Run "flutter build apk" on example app of $packageName'
             'before executing tests.');
         missingFlutterBuild.add(packageName);

--- a/script/tool/lib/src/java_test_command.dart
+++ b/script/tool/lib/src/java_test_command.dart
@@ -13,8 +13,7 @@ import 'common.dart';
 class JavaTestCommand extends PluginCommand {
   /// Creates an instance of the test runner.
   JavaTestCommand(
-    Directory packagesDir,
-    FileSystem fileSystem, {
+    Directory packagesDir, {
     ProcessRunner processRunner = const ProcessRunner(),
   }) : super(packagesDir, processRunner: processRunner);
 

--- a/script/tool/lib/src/license_check_command.dart
+++ b/script/tool/lib/src/license_check_command.dart
@@ -98,8 +98,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 class LicenseCheckCommand extends PluginCommand {
   /// Creates a new license check command for [packagesDir].
   LicenseCheckCommand(
-    Directory packagesDir,
-    FileSystem fileSystem, {
+    Directory packagesDir, {
     Print print = print,
   })  : _print = print,
         super(packagesDir);

--- a/script/tool/lib/src/license_check_command.dart
+++ b/script/tool/lib/src/license_check_command.dart
@@ -102,7 +102,7 @@ class LicenseCheckCommand extends PluginCommand {
     FileSystem fileSystem, {
     Print print = print,
   })  : _print = print,
-        super(packagesDir, fileSystem);
+        super(packagesDir);
 
   final Print _print;
 

--- a/script/tool/lib/src/lint_podspecs_command.dart
+++ b/script/tool/lib/src/lint_podspecs_command.dart
@@ -20,8 +20,7 @@ import 'common.dart';
 class LintPodspecsCommand extends PluginCommand {
   /// Creates an instance of the linter command.
   LintPodspecsCommand(
-    Directory packagesDir,
-    FileSystem fileSystem, {
+    Directory packagesDir, {
     ProcessRunner processRunner = const ProcessRunner(),
     Platform platform = const LocalPlatform(),
     Print print = print,

--- a/script/tool/lib/src/lint_podspecs_command.dart
+++ b/script/tool/lib/src/lint_podspecs_command.dart
@@ -27,7 +27,7 @@ class LintPodspecsCommand extends PluginCommand {
     Print print = print,
   })  : _platform = platform,
         _print = print,
-        super(packagesDir, fileSystem, processRunner: processRunner) {
+        super(packagesDir, processRunner: processRunner) {
     argParser.addMultiOption('skip',
         help:
             'Skip all linting for podspecs with this basename (example: federated plugins with placeholder podspecs)',

--- a/script/tool/lib/src/list_command.dart
+++ b/script/tool/lib/src/list_command.dart
@@ -12,8 +12,7 @@ import 'common.dart';
 class ListCommand extends PluginCommand {
   /// Creates an instance of the list command, whose behavior depends on the
   /// 'type' argument it provides.
-  ListCommand(Directory packagesDir, FileSystem fileSystem)
-      : super(packagesDir) {
+  ListCommand(Directory packagesDir) : super(packagesDir) {
     argParser.addOption(
       _type,
       defaultsTo: _plugin,

--- a/script/tool/lib/src/list_command.dart
+++ b/script/tool/lib/src/list_command.dart
@@ -13,7 +13,7 @@ class ListCommand extends PluginCommand {
   /// Creates an instance of the list command, whose behavior depends on the
   /// 'type' argument it provides.
   ListCommand(Directory packagesDir, FileSystem fileSystem)
-      : super(packagesDir, fileSystem) {
+      : super(packagesDir) {
     argParser.addOption(
       _type,
       defaultsTo: _plugin,

--- a/script/tool/lib/src/main.dart
+++ b/script/tool/lib/src/main.dart
@@ -9,7 +9,6 @@ import 'dart:io' as io;
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
 import 'package:file/local.dart';
-import 'package:path/path.dart' as p;
 
 import 'analyze_command.dart';
 import 'build_examples_command.dart';

--- a/script/tool/lib/src/main.dart
+++ b/script/tool/lib/src/main.dart
@@ -32,11 +32,11 @@ import 'xctest_command.dart';
 void main(List<String> args) {
   const FileSystem fileSystem = LocalFileSystem();
 
-  Directory packagesDir = fileSystem
-      .directory(p.join(fileSystem.currentDirectory.path, 'packages'));
+  Directory packagesDir =
+      fileSystem.currentDirectory.childDirectory('packages');
 
   if (!packagesDir.existsSync()) {
-    if (p.basename(fileSystem.currentDirectory.path) == 'packages') {
+    if (fileSystem.currentDirectory.basename == 'packages') {
       packagesDir = fileSystem.currentDirectory;
     } else {
       print('Error: Cannot find a "packages" sub-directory');

--- a/script/tool/lib/src/main.dart
+++ b/script/tool/lib/src/main.dart
@@ -47,22 +47,22 @@ void main(List<String> args) {
   final CommandRunner<void> commandRunner = CommandRunner<void>(
       'pub global run flutter_plugin_tools',
       'Productivity utils for hosting multiple plugins within one repository.')
-    ..addCommand(AnalyzeCommand(packagesDir, fileSystem))
-    ..addCommand(BuildExamplesCommand(packagesDir, fileSystem))
-    ..addCommand(CreateAllPluginsAppCommand(packagesDir, fileSystem))
-    ..addCommand(DriveExamplesCommand(packagesDir, fileSystem))
-    ..addCommand(FirebaseTestLabCommand(packagesDir, fileSystem))
-    ..addCommand(FormatCommand(packagesDir, fileSystem))
-    ..addCommand(JavaTestCommand(packagesDir, fileSystem))
-    ..addCommand(LicenseCheckCommand(packagesDir, fileSystem))
-    ..addCommand(LintPodspecsCommand(packagesDir, fileSystem))
-    ..addCommand(ListCommand(packagesDir, fileSystem))
-    ..addCommand(PublishCheckCommand(packagesDir, fileSystem))
-    ..addCommand(PublishPluginCommand(packagesDir, fileSystem))
-    ..addCommand(PubspecCheckCommand(packagesDir, fileSystem))
-    ..addCommand(TestCommand(packagesDir, fileSystem))
-    ..addCommand(VersionCheckCommand(packagesDir, fileSystem))
-    ..addCommand(XCTestCommand(packagesDir, fileSystem));
+    ..addCommand(AnalyzeCommand(packagesDir))
+    ..addCommand(BuildExamplesCommand(packagesDir))
+    ..addCommand(CreateAllPluginsAppCommand(packagesDir))
+    ..addCommand(DriveExamplesCommand(packagesDir))
+    ..addCommand(FirebaseTestLabCommand(packagesDir))
+    ..addCommand(FormatCommand(packagesDir))
+    ..addCommand(JavaTestCommand(packagesDir))
+    ..addCommand(LicenseCheckCommand(packagesDir))
+    ..addCommand(LintPodspecsCommand(packagesDir))
+    ..addCommand(ListCommand(packagesDir))
+    ..addCommand(PublishCheckCommand(packagesDir))
+    ..addCommand(PublishPluginCommand(packagesDir))
+    ..addCommand(PubspecCheckCommand(packagesDir))
+    ..addCommand(TestCommand(packagesDir))
+    ..addCommand(VersionCheckCommand(packagesDir))
+    ..addCommand(XCTestCommand(packagesDir));
 
   commandRunner.run(args).catchError((Object e) {
     final ToolExit toolExit = e as ToolExit;

--- a/script/tool/lib/src/publish_check_command.dart
+++ b/script/tool/lib/src/publish_check_command.dart
@@ -27,7 +27,7 @@ class PublishCheckCommand extends PluginCommand {
     this.httpClient,
   })  : _pubVersionFinder =
             PubVersionFinder(httpClient: httpClient ?? http.Client()),
-        super(packagesDir, fileSystem, processRunner: processRunner) {
+        super(packagesDir, processRunner: processRunner) {
     argParser.addFlag(
       _allowPrereleaseFlag,
       help: 'Allows the pre-release SDK warning to pass.\n'

--- a/script/tool/lib/src/publish_check_command.dart
+++ b/script/tool/lib/src/publish_check_command.dart
@@ -21,8 +21,7 @@ import 'common.dart';
 class PublishCheckCommand extends PluginCommand {
   /// Creates an instance of the publish command.
   PublishCheckCommand(
-    Directory packagesDir,
-    FileSystem fileSystem, {
+    Directory packagesDir, {
     ProcessRunner processRunner = const ProcessRunner(),
     this.httpClient,
   })  : _pubVersionFinder =

--- a/script/tool/lib/src/publish_plugin_command.dart
+++ b/script/tool/lib/src/publish_plugin_command.dart
@@ -40,8 +40,7 @@ class PublishPluginCommand extends PluginCommand {
     GitDir gitDir,
   })  : _print = print,
         _stdin = stdinput ?? io.stdin,
-        super(packagesDir, fileSystem,
-            processRunner: processRunner, gitDir: gitDir) {
+        super(packagesDir, processRunner: processRunner, gitDir: gitDir) {
     argParser.addOption(
       _packageOption,
       help: 'The package to publish.'
@@ -133,12 +132,15 @@ class PublishPluginCommand extends PluginCommand {
     }
 
     _print('Checking local repo...');
-    if (!await GitDir.isGitDir(packagesDir.path)) {
-      _print('$packagesDir is not a valid Git repository.');
+    // Ensure there are no symlinks in the path, as it can break
+    // GitDir's allowSubdirectory:true.
+    final String packagesPath = packagesDir.resolveSymbolicLinksSync();
+    if (!await GitDir.isGitDir(packagesPath)) {
+      _print('$packagesPath is not a valid Git repository.');
       throw ToolExit(1);
     }
     final GitDir baseGitDir =
-        await GitDir.fromExisting(packagesDir.path, allowSubdirectory: true);
+        await GitDir.fromExisting(packagesPath, allowSubdirectory: true);
 
     final bool shouldPushTag = getBoolArg(_pushTagsOption);
     final String remote = getStringArg(_remoteOption);
@@ -194,8 +196,9 @@ class PublishPluginCommand extends PluginCommand {
     final List<String> packagesFailed = <String>[];
 
     for (final String pubspecPath in changedPubspecs) {
-      final File pubspecFile =
-          fileSystem.directory(baseGitDir.path).childFile(pubspecPath);
+      final File pubspecFile = packagesDir.fileSystem
+          .directory(baseGitDir.path)
+          .childFile(pubspecPath);
       final _CheckNeedsReleaseResult result = await _checkNeedsRelease(
         pubspecFile: pubspecFile,
         gitVersionFinder: gitVersionFinder,
@@ -453,8 +456,7 @@ Safe to ignore if the package is deleted in this commit.
   }
 
   String _getTag(Directory packageDir) {
-    final File pubspecFile =
-        fileSystem.file(p.join(packageDir.path, 'pubspec.yaml'));
+    final File pubspecFile = packageDir.childFile('pubspec.yaml');
     final YamlMap pubspecYaml =
         loadYaml(pubspecFile.readAsStringSync()) as YamlMap;
     final String name = pubspecYaml['name'] as String;
@@ -499,7 +501,7 @@ Safe to ignore if the package is deleted in this commit.
   }
 
   void _ensureValidPubCredential() {
-    final File credentialFile = fileSystem.file(_credentialsPath);
+    final File credentialFile = packagesDir.fileSystem.file(_credentialsPath);
     if (credentialFile.existsSync() &&
         credentialFile.readAsStringSync().isNotEmpty) {
       return;

--- a/script/tool/lib/src/publish_plugin_command.dart
+++ b/script/tool/lib/src/publish_plugin_command.dart
@@ -32,8 +32,7 @@ import 'common.dart';
 class PublishPluginCommand extends PluginCommand {
   /// Creates an instance of the publish command.
   PublishPluginCommand(
-    Directory packagesDir,
-    FileSystem fileSystem, {
+    Directory packagesDir, {
     ProcessRunner processRunner = const ProcessRunner(),
     Print print = print,
     io.Stdin stdinput,

--- a/script/tool/lib/src/pubspec_check_command.dart
+++ b/script/tool/lib/src/pubspec_check_command.dart
@@ -23,8 +23,7 @@ class PubspecCheckCommand extends PluginCommand {
     FileSystem fileSystem, {
     ProcessRunner processRunner = const ProcessRunner(),
     GitDir? gitDir,
-  }) : super(packagesDir, fileSystem,
-            processRunner: processRunner, gitDir: gitDir);
+  }) : super(packagesDir, processRunner: processRunner, gitDir: gitDir);
 
   // Section order for plugins. Because the 'flutter' section is critical
   // information for plugins, and usually small, it goes near the top unlike in

--- a/script/tool/lib/src/pubspec_check_command.dart
+++ b/script/tool/lib/src/pubspec_check_command.dart
@@ -19,8 +19,7 @@ import 'common.dart';
 class PubspecCheckCommand extends PluginCommand {
   /// Creates an instance of the version check command.
   PubspecCheckCommand(
-    Directory packagesDir,
-    FileSystem fileSystem, {
+    Directory packagesDir, {
     ProcessRunner processRunner = const ProcessRunner(),
     GitDir? gitDir,
   }) : super(packagesDir, processRunner: processRunner, gitDir: gitDir);

--- a/script/tool/lib/src/test_command.dart
+++ b/script/tool/lib/src/test_command.dart
@@ -13,8 +13,7 @@ import 'common.dart';
 class TestCommand extends PluginCommand {
   /// Creates an instance of the test command.
   TestCommand(
-    Directory packagesDir,
-    FileSystem fileSystem, {
+    Directory packagesDir, {
     ProcessRunner processRunner = const ProcessRunner(),
   }) : super(packagesDir, processRunner: processRunner) {
     argParser.addOption(

--- a/script/tool/lib/src/test_command.dart
+++ b/script/tool/lib/src/test_command.dart
@@ -16,7 +16,7 @@ class TestCommand extends PluginCommand {
     Directory packagesDir,
     FileSystem fileSystem, {
     ProcessRunner processRunner = const ProcessRunner(),
-  }) : super(packagesDir, fileSystem, processRunner: processRunner) {
+  }) : super(packagesDir, processRunner: processRunner) {
     argParser.addOption(
       kEnableExperiment,
       defaultsTo: '',
@@ -37,7 +37,7 @@ class TestCommand extends PluginCommand {
     await for (final Directory packageDir in getPackages()) {
       final String packageName =
           p.relative(packageDir.path, from: packagesDir.path);
-      if (!fileSystem.directory(p.join(packageDir.path, 'test')).existsSync()) {
+      if (!packageDir.childDirectory('test').existsSync()) {
         print('SKIPPING $packageName - no test subdirectory');
         continue;
       }
@@ -48,7 +48,7 @@ class TestCommand extends PluginCommand {
 
       // `flutter test` automatically gets packages.  `pub run test` does not.  :(
       int exitCode = 0;
-      if (isFlutterPackage(packageDir, fileSystem)) {
+      if (isFlutterPackage(packageDir)) {
         final List<String> args = <String>[
           'test',
           '--color',
@@ -56,7 +56,7 @@ class TestCommand extends PluginCommand {
             '--enable-experiment=$enableExperiment',
         ];
 
-        if (isWebPlugin(packageDir, fileSystem)) {
+        if (isWebPlugin(packageDir)) {
           args.add('--platform=chrome');
         }
         exitCode = await processRunner.runAndStream(

--- a/script/tool/lib/src/version_check_command.dart
+++ b/script/tool/lib/src/version_check_command.dart
@@ -73,8 +73,7 @@ Map<Version, NextVersionType> getAllowedNextVersions(
 class VersionCheckCommand extends PluginCommand {
   /// Creates an instance of the version check command.
   VersionCheckCommand(
-    Directory packagesDir,
-    FileSystem fileSystem, {
+    Directory packagesDir, {
     ProcessRunner processRunner = const ProcessRunner(),
     GitDir gitDir,
     this.httpClient,

--- a/script/tool/lib/src/version_check_command.dart
+++ b/script/tool/lib/src/version_check_command.dart
@@ -80,8 +80,7 @@ class VersionCheckCommand extends PluginCommand {
     this.httpClient,
   })  : _pubVersionFinder =
             PubVersionFinder(httpClient: httpClient ?? http.Client()),
-        super(packagesDir, fileSystem,
-            processRunner: processRunner, gitDir: gitDir) {
+        super(packagesDir, processRunner: processRunner, gitDir: gitDir) {
     argParser.addFlag(
       _againstPubFlag,
       help: 'Whether the version check should run against the version on pub.\n'
@@ -117,7 +116,7 @@ class VersionCheckCommand extends PluginCommand {
     const String indentation = '  ';
     for (final String pubspecPath in changedPubspecs) {
       print('Checking versions for $pubspecPath...');
-      final File pubspecFile = fileSystem.file(pubspecPath);
+      final File pubspecFile = packagesDir.fileSystem.file(pubspecPath);
       if (!pubspecFile.existsSync()) {
         print('${indentation}Deleted; skipping.');
         continue;

--- a/script/tool/lib/src/xctest_command.dart
+++ b/script/tool/lib/src/xctest_command.dart
@@ -26,8 +26,7 @@ const String _kFoundNoSimulatorsMessage =
 class XCTestCommand extends PluginCommand {
   /// Creates an instance of the test command.
   XCTestCommand(
-    Directory packagesDir,
-    FileSystem fileSystem, {
+    Directory packagesDir, {
     ProcessRunner processRunner = const ProcessRunner(),
   }) : super(packagesDir, processRunner: processRunner) {
     argParser.addOption(

--- a/script/tool/lib/src/xctest_command.dart
+++ b/script/tool/lib/src/xctest_command.dart
@@ -29,7 +29,7 @@ class XCTestCommand extends PluginCommand {
     Directory packagesDir,
     FileSystem fileSystem, {
     ProcessRunner processRunner = const ProcessRunner(),
-  }) : super(packagesDir, fileSystem, processRunner: processRunner) {
+  }) : super(packagesDir, processRunner: processRunner) {
     argParser.addOption(
       _kiOSDestination,
       help:
@@ -68,7 +68,7 @@ class XCTestCommand extends PluginCommand {
       final String packageName =
           p.relative(plugin.path, from: packagesDir.path);
       print('Start running for $packageName ...');
-      if (!isIosPlugin(plugin, fileSystem)) {
+      if (!isIosPlugin(plugin)) {
         print('iOS is not supported by this plugin.');
         print('\n\n');
         continue;

--- a/script/tool/test/analyze_command_test.dart
+++ b/script/tool/test/analyze_command_test.dart
@@ -18,9 +18,8 @@ void main() {
   setUp(() {
     initializeFakePackages();
     processRunner = RecordingProcessRunner();
-    final AnalyzeCommand analyzeCommand = AnalyzeCommand(
-        mockPackagesDir, mockFileSystem,
-        processRunner: processRunner);
+    final AnalyzeCommand analyzeCommand =
+        AnalyzeCommand(mockPackagesDir, processRunner: processRunner);
 
     runner = CommandRunner<void>('analyze_command', 'Test for analyze_command');
     runner.addCommand(analyzeCommand);

--- a/script/tool/test/build_examples_command_test.dart
+++ b/script/tool/test/build_examples_command_test.dart
@@ -21,9 +21,8 @@ void main() {
     setUp(() {
       initializeFakePackages();
       processRunner = RecordingProcessRunner();
-      final BuildExamplesCommand command = BuildExamplesCommand(
-          mockPackagesDir, mockFileSystem,
-          processRunner: processRunner);
+      final BuildExamplesCommand command =
+          BuildExamplesCommand(mockPackagesDir, processRunner: processRunner);
 
       runner = CommandRunner<void>(
           'build_examples_command', 'Test for build_example_command');

--- a/script/tool/test/common_test.dart
+++ b/script/tool/test/common_test.dart
@@ -58,7 +58,6 @@ void main() {
     final SamplePluginCommand samplePluginCommand = SamplePluginCommand(
       plugins,
       packagesDir,
-      fileSystem,
       processRunner: processRunner,
       gitDir: gitDir,
     );
@@ -517,8 +516,7 @@ file2/file2.cc
 class SamplePluginCommand extends PluginCommand {
   SamplePluginCommand(
     this._plugins,
-    Directory packagesDir,
-    FileSystem fileSystem, {
+    Directory packagesDir, {
     ProcessRunner processRunner = const ProcessRunner(),
     GitDir? gitDir,
   }) : super(packagesDir, processRunner: processRunner, gitDir: gitDir);

--- a/script/tool/test/common_test.dart
+++ b/script/tool/test/common_test.dart
@@ -156,8 +156,7 @@ void main() {
       expect(plugins, unorderedEquals(<String>[plugin1.path, plugin2.path]));
     });
 
-    test('all plugins should be tested if .cirrus.yml changes.',
-        () async {
+    test('all plugins should be tested if .cirrus.yml changes.', () async {
       gitDiffResponse = '''
 .cirrus.yml
 packages/plugin1/CHANGELOG
@@ -172,8 +171,7 @@ packages/plugin1/CHANGELOG
       expect(plugins, unorderedEquals(<String>[plugin1.path, plugin2.path]));
     });
 
-    test('all plugins should be tested if .ci.yaml changes',
-        () async {
+    test('all plugins should be tested if .ci.yaml changes', () async {
       gitDiffResponse = '''
 .ci.yaml
 packages/plugin1/CHANGELOG
@@ -188,8 +186,7 @@ packages/plugin1/CHANGELOG
       expect(plugins, unorderedEquals(<String>[plugin1.path, plugin2.path]));
     });
 
-    test('all plugins should be tested if anything in .ci/ changes',
-        () async {
+    test('all plugins should be tested if anything in .ci/ changes', () async {
       gitDiffResponse = '''
 .ci/Dockerfile
 packages/plugin1/CHANGELOG
@@ -524,8 +521,7 @@ class SamplePluginCommand extends PluginCommand {
     FileSystem fileSystem, {
     ProcessRunner processRunner = const ProcessRunner(),
     GitDir? gitDir,
-  }) : super(packagesDir, fileSystem,
-            processRunner: processRunner, gitDir: gitDir);
+  }) : super(packagesDir, processRunner: processRunner, gitDir: gitDir);
 
   final List<String> _plugins;
 

--- a/script/tool/test/create_all_plugins_app_command_test.dart
+++ b/script/tool/test/create_all_plugins_app_command_test.dart
@@ -30,7 +30,6 @@ void main() {
 
       final CreateAllPluginsAppCommand command = CreateAllPluginsAppCommand(
         packagesDir,
-        fileSystem,
         pluginsRoot: testRoot,
       );
       appDir = command.appDirectory;

--- a/script/tool/test/drive_examples_command_test.dart
+++ b/script/tool/test/drive_examples_command_test.dart
@@ -21,9 +21,8 @@ void main() {
     setUp(() {
       initializeFakePackages();
       processRunner = RecordingProcessRunner();
-      final DriveExamplesCommand command = DriveExamplesCommand(
-          mockPackagesDir, mockFileSystem,
-          processRunner: processRunner);
+      final DriveExamplesCommand command =
+          DriveExamplesCommand(mockPackagesDir, processRunner: processRunner);
 
       runner = CommandRunner<void>(
           'drive_examples_command', 'Test for drive_example_command');

--- a/script/tool/test/firebase_test_lab_test.dart
+++ b/script/tool/test/firebase_test_lab_test.dart
@@ -24,7 +24,7 @@ void main() {
       initializeFakePackages();
       processRunner = RecordingProcessRunner();
       final FirebaseTestLabCommand command = FirebaseTestLabCommand(
-          mockPackagesDir, mockFileSystem,
+          mockPackagesDir,
           processRunner: processRunner,
           print: (Object message) => printedMessages.add(message.toString()));
 

--- a/script/tool/test/java_test_command_test.dart
+++ b/script/tool/test/java_test_command_test.dart
@@ -17,9 +17,8 @@ void main() {
 
     setUp(() {
       initializeFakePackages();
-      final JavaTestCommand command = JavaTestCommand(
-          mockPackagesDir, mockFileSystem,
-          processRunner: processRunner);
+      final JavaTestCommand command =
+          JavaTestCommand(mockPackagesDir, processRunner: processRunner);
 
       runner =
           CommandRunner<void>('java_test_test', 'Test for $JavaTestCommand');

--- a/script/tool/test/license_check_command_test.dart
+++ b/script/tool/test/license_check_command_test.dart
@@ -25,7 +25,6 @@ void main() {
       printedMessages = <String>[];
       final LicenseCheckCommand command = LicenseCheckCommand(
         packagesDir,
-        fileSystem,
         print: (Object? message) => printedMessages.add(message.toString()),
       );
       runner =

--- a/script/tool/test/lint_podspecs_command_test.dart
+++ b/script/tool/test/lint_podspecs_command_test.dart
@@ -30,7 +30,6 @@ void main() {
       when(mockPlatform.isMacOS).thenReturn(true);
       final LintPodspecsCommand command = LintPodspecsCommand(
         mockPackagesDir,
-        mockFileSystem,
         processRunner: processRunner,
         platform: mockPlatform,
         print: (Object message) => printedMessages.add(message.toString()),

--- a/script/tool/test/list_command_test.dart
+++ b/script/tool/test/list_command_test.dart
@@ -15,7 +15,7 @@ void main() {
 
     setUp(() {
       initializeFakePackages();
-      final ListCommand command = ListCommand(mockPackagesDir, mockFileSystem);
+      final ListCommand command = ListCommand(mockPackagesDir);
 
       runner = CommandRunner<void>('list_test', 'Test for $ListCommand');
       runner.addCommand(command);

--- a/script/tool/test/publish_check_command_test.dart
+++ b/script/tool/test/publish_check_command_test.dart
@@ -27,9 +27,8 @@ void main() {
     setUp(() {
       initializeFakePackages();
       processRunner = PublishCheckProcessRunner();
-      final PublishCheckCommand publishCheckCommand = PublishCheckCommand(
-          mockPackagesDir, mockFileSystem,
-          processRunner: processRunner);
+      final PublishCheckCommand publishCheckCommand =
+          PublishCheckCommand(mockPackagesDir, processRunner: processRunner);
 
       runner = CommandRunner<void>(
         'publish_check_command',
@@ -146,8 +145,8 @@ void main() {
 
       processRunner.processesToReturn.add(process);
 
-      final List<String> output = await runCapturingPrint(
-          runner, <String>['publish-check']);
+      final List<String> output =
+          await runCapturingPrint(runner, <String>['publish-check']);
 
       expect(output, isNot(contains(contains('ERROR:'))));
     });
@@ -180,8 +179,7 @@ void main() {
         }
         return null;
       });
-      final PublishCheckCommand command = PublishCheckCommand(
-          mockPackagesDir, mockFileSystem,
+      final PublishCheckCommand command = PublishCheckCommand(mockPackagesDir,
           processRunner: processRunner, httpClient: mockClient);
 
       runner = CommandRunner<void>(
@@ -247,8 +245,7 @@ void main() {
         }
         return null;
       });
-      final PublishCheckCommand command = PublishCheckCommand(
-          mockPackagesDir, mockFileSystem,
+      final PublishCheckCommand command = PublishCheckCommand(mockPackagesDir,
           processRunner: processRunner, httpClient: mockClient);
 
       runner = CommandRunner<void>(
@@ -317,8 +314,7 @@ void main() {
         }
         return null;
       });
-      final PublishCheckCommand command = PublishCheckCommand(
-          mockPackagesDir, mockFileSystem,
+      final PublishCheckCommand command = PublishCheckCommand(mockPackagesDir,
           processRunner: processRunner, httpClient: mockClient);
 
       runner = CommandRunner<void>(

--- a/script/tool/test/publish_plugin_command_test.dart
+++ b/script/tool/test/publish_plugin_command_test.dart
@@ -59,7 +59,7 @@ void main() {
     processRunner = TestProcessRunner();
     mockStdin = MockStdin();
     commandRunner = CommandRunner<void>('tester', '')
-      ..addCommand(PublishPluginCommand(parentDir, fileSystem,
+      ..addCommand(PublishPluginCommand(parentDir,
           processRunner: processRunner,
           print: (Object message) => printedMessages.add(message.toString()),
           stdinput: mockStdin,

--- a/script/tool/test/publish_plugin_command_test.dart
+++ b/script/tool/test/publish_plugin_command_test.dart
@@ -46,6 +46,9 @@ void main() {
   setUp(() async {
     parentDir = fileSystem.systemTempDirectory
         .createTempSync('publish_plugin_command_test-');
+    // The temp directory can have symbolic links, which won't match git output;
+    // use a fully resolved version to avoid potential path comparison issues.
+    parentDir = fileSystem.directory(parentDir.resolveSymbolicLinksSync());
     initializeFakePackages(parentDir: parentDir);
     pluginDir = createFakePlugin(testPluginName,
         withSingleExample: false, packagesDirectory: parentDir);

--- a/script/tool/test/pubspec_check_command_test.dart
+++ b/script/tool/test/pubspec_check_command_test.dart
@@ -23,9 +23,8 @@ void main() {
       packagesDir = fileSystem.currentDirectory.childDirectory('packages');
       initializeFakePackages(parentDir: packagesDir.parent);
       processRunner = RecordingProcessRunner();
-      final PubspecCheckCommand command = PubspecCheckCommand(
-          packagesDir, fileSystem,
-          processRunner: processRunner);
+      final PubspecCheckCommand command =
+          PubspecCheckCommand(packagesDir, processRunner: processRunner);
 
       runner = CommandRunner<void>(
           'pubspec_check_command', 'Test for pubspec_check_command');

--- a/script/tool/test/test_command_test.dart
+++ b/script/tool/test/test_command_test.dart
@@ -16,8 +16,8 @@ void main() {
 
     setUp(() {
       initializeFakePackages();
-      final TestCommand command = TestCommand(mockPackagesDir, mockFileSystem,
-          processRunner: processRunner);
+      final TestCommand command =
+          TestCommand(mockPackagesDir, processRunner: processRunner);
 
       runner = CommandRunner<void>('test_test', 'Test for $TestCommand');
       runner.addCommand(command);

--- a/script/tool/test/version_check_test.dart
+++ b/script/tool/test/version_check_test.dart
@@ -88,8 +88,7 @@ void main() {
       });
       initializeFakePackages();
       processRunner = RecordingProcessRunner();
-      final VersionCheckCommand command = VersionCheckCommand(
-          mockPackagesDir, mockFileSystem,
+      final VersionCheckCommand command = VersionCheckCommand(mockPackagesDir,
           processRunner: processRunner, gitDir: gitDir);
 
       runner = CommandRunner<void>(
@@ -238,13 +237,10 @@ void main() {
     });
 
     test('gracefully handles missing pubspec.yaml', () async {
-      createFakePlugin('plugin', includeChangeLog: true, includeVersion: true);
+      final Directory pluginDir = createFakePlugin('plugin',
+          includeChangeLog: true, includeVersion: true);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
-      mockFileSystem.currentDirectory
-          .childDirectory('packages')
-          .childDirectory('plugin')
-          .childFile('pubspec.yaml')
-          .deleteSync();
+      pluginDir.childFile('pubspec.yaml').deleteSync();
       final List<String> output = await runCapturingPrint(
           runner, <String>['version-check', '--base-sha=master']);
 
@@ -600,8 +596,7 @@ The first version listed in CHANGELOG.md is 1.0.0.
       final MockClient mockClient = MockClient((http.Request request) async {
         return http.Response(json.encode(httpResponse), 200);
       });
-      final VersionCheckCommand command = VersionCheckCommand(
-          mockPackagesDir, mockFileSystem,
+      final VersionCheckCommand command = VersionCheckCommand(mockPackagesDir,
           processRunner: processRunner, gitDir: gitDir, httpClient: mockClient);
 
       runner = CommandRunner<void>(
@@ -637,8 +632,7 @@ The first version listed in CHANGELOG.md is 1.0.0.
       final MockClient mockClient = MockClient((http.Request request) async {
         return http.Response(json.encode(httpResponse), 200);
       });
-      final VersionCheckCommand command = VersionCheckCommand(
-          mockPackagesDir, mockFileSystem,
+      final VersionCheckCommand command = VersionCheckCommand(mockPackagesDir,
           processRunner: processRunner, gitDir: gitDir, httpClient: mockClient);
 
       runner = CommandRunner<void>(
@@ -682,8 +676,7 @@ ${indentation}Allowed versions: {1.0.0: NextVersionType.BREAKING_MAJOR, 0.1.0: N
       final MockClient mockClient = MockClient((http.Request request) async {
         return http.Response('xx', 400);
       });
-      final VersionCheckCommand command = VersionCheckCommand(
-          mockPackagesDir, mockFileSystem,
+      final VersionCheckCommand command = VersionCheckCommand(mockPackagesDir,
           processRunner: processRunner, gitDir: gitDir, httpClient: mockClient);
 
       runner = CommandRunner<void>(
@@ -726,8 +719,7 @@ ${indentation}HTTP response: xx
       final MockClient mockClient = MockClient((http.Request request) async {
         return http.Response('xx', 404);
       });
-      final VersionCheckCommand command = VersionCheckCommand(
-          mockPackagesDir, mockFileSystem,
+      final VersionCheckCommand command = VersionCheckCommand(mockPackagesDir,
           processRunner: processRunner, gitDir: gitDir, httpClient: mockClient);
 
       runner = CommandRunner<void>(

--- a/script/tool/test/xctest_command_test.dart
+++ b/script/tool/test/xctest_command_test.dart
@@ -91,9 +91,8 @@ void main() {
     setUp(() {
       initializeFakePackages();
       processRunner = RecordingProcessRunner();
-      final XCTestCommand command = XCTestCommand(
-          mockPackagesDir, mockFileSystem,
-          processRunner: processRunner);
+      final XCTestCommand command =
+          XCTestCommand(mockPackagesDir, processRunner: processRunner);
 
       runner = CommandRunner<void>('xctest_command', 'Test for xctest_command');
       runner.addCommand(command);


### PR DESCRIPTION
- Replaces most explicit use of `fileSystem` with path construction using the `child*` utility methods
- Removes explicit passing of a filesystem to the commands; we're already passing a `Directory` for the
  root where the tool operates, and we should never be using a different filesystem than that directory's
  filesystem, so passing it was both redundant, and a potential source of test bugs.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format])
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[plugin_tool format]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
