### PR TITLE
[plugin_tools] allow `version-check` to fail if latest version is not published; Enable `against-pub` flag on `version-check`.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -47,7 +47,7 @@ task:
         - CIRRUS_BUILD_ID=null pub run test
     - name: publishable
       script:
-        - ./script/tool_runner.sh version-check
+        - ./script/tool_runner.sh version-check against-pub
         - ./script/tool_runner.sh publish-check
     - name: format
       format_script: ./script/tool_runner.sh format --fail-on-change

--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.5
+
+- Ask `version-check` to make sure the latest version has been published when `against-pub` flag is enabled.
+- Enable `against-pub` flag on ci.
+
 ## 0.1.4
 
 - Add a `pubspec-check` command

--- a/script/tool/pubspec.yaml
+++ b/script/tool/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_plugin_tools
 description: Productivity utils for flutter/plugins and flutter/packages
 repository: https://github.com/flutter/plugins/tree/master/script/tool
-version: 0.1.4
+version: 0.1.5
 
 dependencies:
   args: ^2.1.0


### PR DESCRIPTION
1. Make `version-check` to fail if the version on base SHA has not been published.
This is to prevent mistakenly skipping a version on manual or auto publishing workflow.
1. Enable the `against-pub` flag on version-check ci.

Fixes https://github.com/flutter/flutter/issues/83998

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format])
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[plugin_tool format]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
