### PR TITLE
[flutter_plugin_tools] Remove global state from tests

### DIFF
--- a/script/tool/test/analyze_command_test.dart
+++ b/script/tool/test/analyze_command_test.dart
@@ -14,12 +14,13 @@ import 'util.dart';
 
 void main() {
   late FileSystem fileSystem;
+  late Directory packagesDir;
   late RecordingProcessRunner processRunner;
   late CommandRunner<void> runner;
 
   setUp(() {
     fileSystem = MemoryFileSystem();
-    final Directory packagesDir =
+    packagesDir =
         initializeFakePackages(parentDir: fileSystem.currentDirectory);
     processRunner = RecordingProcessRunner();
     final AnalyzeCommand analyzeCommand =
@@ -30,8 +31,8 @@ void main() {
   });
 
   test('analyzes all packages', () async {
-    final Directory plugin1Dir = createFakePlugin('a');
-    final Directory plugin2Dir = createFakePlugin('b');
+    final Directory plugin1Dir = createFakePlugin('a', packagesDir);
+    final Directory plugin2Dir = createFakePlugin('b', packagesDir);
 
     final MockProcess mockProcess = MockProcess();
     mockProcess.exitCodeCompleter.complete(0);
@@ -53,7 +54,8 @@ void main() {
   });
 
   test('skips flutter pub get for examples', () async {
-    final Directory plugin1Dir = createFakePlugin('a', withSingleExample: true);
+    final Directory plugin1Dir =
+        createFakePlugin('a', packagesDir, withSingleExample: true);
 
     final MockProcess mockProcess = MockProcess();
     mockProcess.exitCodeCompleter.complete(0);
@@ -71,8 +73,8 @@ void main() {
   });
 
   test('don\'t elide a non-contained example package', () async {
-    final Directory plugin1Dir = createFakePlugin('a');
-    final Directory plugin2Dir = createFakePlugin('example');
+    final Directory plugin1Dir = createFakePlugin('a', packagesDir);
+    final Directory plugin2Dir = createFakePlugin('example', packagesDir);
 
     final MockProcess mockProcess = MockProcess();
     mockProcess.exitCodeCompleter.complete(0);
@@ -94,7 +96,7 @@ void main() {
   });
 
   test('uses a separate analysis sdk', () async {
-    final Directory pluginDir = createFakePlugin('a');
+    final Directory pluginDir = createFakePlugin('a', packagesDir);
 
     final MockProcess mockProcess = MockProcess();
     mockProcess.exitCodeCompleter.complete(0);
@@ -120,7 +122,7 @@ void main() {
 
   group('verifies analysis settings', () {
     test('fails analysis_options.yaml', () async {
-      createFakePlugin('foo', withExtraFiles: <List<String>>[
+      createFakePlugin('foo', packagesDir, withExtraFiles: <List<String>>[
         <String>['analysis_options.yaml']
       ]);
 
@@ -129,7 +131,7 @@ void main() {
     });
 
     test('fails .analysis_options', () async {
-      createFakePlugin('foo', withExtraFiles: <List<String>>[
+      createFakePlugin('foo', packagesDir, withExtraFiles: <List<String>>[
         <String>['.analysis_options']
       ]);
 
@@ -139,7 +141,7 @@ void main() {
 
     test('takes an allow list', () async {
       final Directory pluginDir =
-          createFakePlugin('foo', withExtraFiles: <List<String>>[
+          createFakePlugin('foo', packagesDir, withExtraFiles: <List<String>>[
         <String>['analysis_options.yaml']
       ]);
 
@@ -160,7 +162,7 @@ void main() {
 
     // See: https://github.com/flutter/flutter/issues/78994
     test('takes an empty allow list', () async {
-      createFakePlugin('foo', withExtraFiles: <List<String>>[
+      createFakePlugin('foo', packagesDir, withExtraFiles: <List<String>>[
         <String>['analysis_options.yaml']
       ]);
 

--- a/script/tool/test/analyze_command_test.dart
+++ b/script/tool/test/analyze_command_test.dart
@@ -19,17 +19,14 @@ void main() {
 
   setUp(() {
     fileSystem = MemoryFileSystem();
-    initializeFakePackages(parentDir: fileSystem.currentDirectory);
+    final Directory packagesDir =
+        initializeFakePackages(parentDir: fileSystem.currentDirectory);
     processRunner = RecordingProcessRunner();
     final AnalyzeCommand analyzeCommand =
-        AnalyzeCommand(mockPackagesDir, processRunner: processRunner);
+        AnalyzeCommand(packagesDir, processRunner: processRunner);
 
     runner = CommandRunner<void>('analyze_command', 'Test for analyze_command');
     runner.addCommand(analyzeCommand);
-  });
-
-  tearDown(() {
-    mockPackagesDir.deleteSync(recursive: true);
   });
 
   test('analyzes all packages', () async {

--- a/script/tool/test/analyze_command_test.dart
+++ b/script/tool/test/analyze_command_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
+import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/analyze_command.dart';
 import 'package:flutter_plugin_tools/src/common.dart';
 import 'package:test/test.dart';
@@ -12,11 +13,13 @@ import 'mocks.dart';
 import 'util.dart';
 
 void main() {
+  late FileSystem fileSystem;
   late RecordingProcessRunner processRunner;
   late CommandRunner<void> runner;
 
   setUp(() {
-    initializeFakePackages();
+    fileSystem = MemoryFileSystem();
+    initializeFakePackages(parentDir: fileSystem.currentDirectory);
     processRunner = RecordingProcessRunner();
     final AnalyzeCommand analyzeCommand =
         AnalyzeCommand(mockPackagesDir, processRunner: processRunner);

--- a/script/tool/test/analyze_command_test.dart
+++ b/script/tool/test/analyze_command_test.dart
@@ -20,8 +20,7 @@ void main() {
 
   setUp(() {
     fileSystem = MemoryFileSystem();
-    packagesDir =
-        initializeFakePackages(parentDir: fileSystem.currentDirectory);
+    packagesDir = createPackagesDirectory(fileSystem: fileSystem);
     processRunner = RecordingProcessRunner();
     final AnalyzeCommand analyzeCommand =
         AnalyzeCommand(packagesDir, processRunner: processRunner);

--- a/script/tool/test/build_examples_command_test.dart
+++ b/script/tool/test/build_examples_command_test.dart
@@ -36,7 +36,7 @@ void main() {
 
     test('building for iOS when plugin is not set up for iOS results in no-op',
         () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
@@ -68,7 +68,7 @@ void main() {
     });
 
     test('building for ios', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
@@ -115,7 +115,7 @@ void main() {
     test(
         'building for Linux when plugin is not set up for Linux results in no-op',
         () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
@@ -147,7 +147,7 @@ void main() {
     });
 
     test('building for Linux', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
@@ -182,10 +182,10 @@ void main() {
 
     test('building for macos with no implementation results in no-op',
         () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', withExtraFiles: <List<String>>[
-        <String>['example', 'test'],
-      ]);
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+          withExtraFiles: <List<String>>[
+            <String>['example', 'test'],
+          ]);
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -213,7 +213,7 @@ void main() {
     });
 
     test('building for macos', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
             <String>['example', 'macos', 'macos.swift'],
@@ -248,10 +248,10 @@ void main() {
     });
 
     test('building for web with no implementation results in no-op', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', withExtraFiles: <List<String>>[
-        <String>['example', 'test'],
-      ]);
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+          withExtraFiles: <List<String>>[
+            <String>['example', 'test'],
+          ]);
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -279,7 +279,7 @@ void main() {
     });
 
     test('building for web', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
             <String>['example', 'web', 'index.html'],
@@ -316,7 +316,7 @@ void main() {
     test(
         'building for Windows when plugin is not set up for Windows results in no-op',
         () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
@@ -348,7 +348,7 @@ void main() {
     });
 
     test('building for windows', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
@@ -384,7 +384,7 @@ void main() {
     test(
         'building for Android when plugin is not set up for Android results in no-op',
         () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
@@ -416,7 +416,7 @@ void main() {
     });
 
     test('building for android', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
@@ -454,7 +454,7 @@ void main() {
     });
 
     test('enable-experiment flag for Android', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
@@ -484,7 +484,7 @@ void main() {
     });
 
     test('enable-experiment flag for ios', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],

--- a/script/tool/test/build_examples_command_test.dart
+++ b/script/tool/test/build_examples_command_test.dart
@@ -23,8 +23,7 @@ void main() {
 
     setUp(() {
       fileSystem = MemoryFileSystem();
-      packagesDir =
-          initializeFakePackages(parentDir: fileSystem.currentDirectory);
+      packagesDir = createPackagesDirectory(fileSystem: fileSystem);
       processRunner = RecordingProcessRunner();
       final BuildExamplesCommand command =
           BuildExamplesCommand(packagesDir, processRunner: processRunner);

--- a/script/tool/test/build_examples_command_test.dart
+++ b/script/tool/test/build_examples_command_test.dart
@@ -36,14 +36,14 @@ void main() {
 
     test('building for iOS when plugin is not set up for iOS results in no-op',
         () async {
-      createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin',
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
           isLinuxPlugin: false);
 
       final Directory pluginExampleDirectory =
-          packagesDir.childDirectory('plugin').childDirectory('example');
+          pluginDirectory.childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -68,14 +68,14 @@ void main() {
     });
 
     test('building for ios', () async {
-      createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin',
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
           isIosPlugin: true);
 
       final Directory pluginExampleDirectory =
-          packagesDir.childDirectory('plugin').childDirectory('example');
+          pluginDirectory.childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -115,14 +115,14 @@ void main() {
     test(
         'building for Linux when plugin is not set up for Linux results in no-op',
         () async {
-      createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin',
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
           isLinuxPlugin: false);
 
       final Directory pluginExampleDirectory =
-          packagesDir.childDirectory('plugin').childDirectory('example');
+          pluginDirectory.childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -147,14 +147,14 @@ void main() {
     });
 
     test('building for Linux', () async {
-      createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin',
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
           isLinuxPlugin: true);
 
       final Directory pluginExampleDirectory =
-          packagesDir.childDirectory('plugin').childDirectory('example');
+          pluginDirectory.childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -182,12 +182,13 @@ void main() {
 
     test('building for macos with no implementation results in no-op',
         () async {
-      createFakePlugin('plugin', withExtraFiles: <List<String>>[
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', withExtraFiles: <List<String>>[
         <String>['example', 'test'],
       ]);
 
       final Directory pluginExampleDirectory =
-          packagesDir.childDirectory('plugin').childDirectory('example');
+          pluginDirectory.childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -212,7 +213,7 @@ void main() {
     });
 
     test('building for macos', () async {
-      createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin',
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
             <String>['example', 'macos', 'macos.swift'],
@@ -220,7 +221,7 @@ void main() {
           isMacOsPlugin: true);
 
       final Directory pluginExampleDirectory =
-          packagesDir.childDirectory('plugin').childDirectory('example');
+          pluginDirectory.childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -247,12 +248,13 @@ void main() {
     });
 
     test('building for web with no implementation results in no-op', () async {
-      createFakePlugin('plugin', withExtraFiles: <List<String>>[
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', withExtraFiles: <List<String>>[
         <String>['example', 'test'],
       ]);
 
       final Directory pluginExampleDirectory =
-          packagesDir.childDirectory('plugin').childDirectory('example');
+          pluginDirectory.childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -277,7 +279,7 @@ void main() {
     });
 
     test('building for web', () async {
-      createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin',
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
             <String>['example', 'web', 'index.html'],
@@ -285,7 +287,7 @@ void main() {
           isWebPlugin: true);
 
       final Directory pluginExampleDirectory =
-          packagesDir.childDirectory('plugin').childDirectory('example');
+          pluginDirectory.childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -314,14 +316,14 @@ void main() {
     test(
         'building for Windows when plugin is not set up for Windows results in no-op',
         () async {
-      createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin',
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
           isWindowsPlugin: false);
 
       final Directory pluginExampleDirectory =
-          packagesDir.childDirectory('plugin').childDirectory('example');
+          pluginDirectory.childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -346,14 +348,14 @@ void main() {
     });
 
     test('building for windows', () async {
-      createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin',
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
           isWindowsPlugin: true);
 
       final Directory pluginExampleDirectory =
-          packagesDir.childDirectory('plugin').childDirectory('example');
+          pluginDirectory.childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -382,14 +384,14 @@ void main() {
     test(
         'building for Android when plugin is not set up for Android results in no-op',
         () async {
-      createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin',
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
           isLinuxPlugin: false);
 
       final Directory pluginExampleDirectory =
-          packagesDir.childDirectory('plugin').childDirectory('example');
+          pluginDirectory.childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -414,14 +416,14 @@ void main() {
     });
 
     test('building for android', () async {
-      createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin',
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
           isAndroidPlugin: true);
 
       final Directory pluginExampleDirectory =
-          packagesDir.childDirectory('plugin').childDirectory('example');
+          pluginDirectory.childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -452,14 +454,14 @@ void main() {
     });
 
     test('enable-experiment flag for Android', () async {
-      createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin',
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
           isAndroidPlugin: true);
 
       final Directory pluginExampleDirectory =
-          packagesDir.childDirectory('plugin').childDirectory('example');
+          pluginDirectory.childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -482,14 +484,14 @@ void main() {
     });
 
     test('enable-experiment flag for ios', () async {
-      createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin',
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
           isIosPlugin: true);
 
       final Directory pluginExampleDirectory =
-          packagesDir.childDirectory('plugin').childDirectory('example');
+          pluginDirectory.childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 

--- a/script/tool/test/build_examples_command_test.dart
+++ b/script/tool/test/build_examples_command_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
+import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/build_examples_command.dart';
 import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
@@ -13,13 +14,15 @@ import 'util.dart';
 
 void main() {
   group('test build_example_command', () {
+    late FileSystem fileSystem;
     late CommandRunner<void> runner;
     late RecordingProcessRunner processRunner;
     final String flutterCommand =
         const LocalPlatform().isWindows ? 'flutter.bat' : 'flutter';
 
     setUp(() {
-      initializeFakePackages();
+      fileSystem = MemoryFileSystem();
+      initializeFakePackages(parentDir: fileSystem.currentDirectory);
       processRunner = RecordingProcessRunner();
       final BuildExamplesCommand command =
           BuildExamplesCommand(mockPackagesDir, processRunner: processRunner);
@@ -27,7 +30,6 @@ void main() {
       runner = CommandRunner<void>(
           'build_examples_command', 'Test for build_example_command');
       runner.addCommand(command);
-      cleanupPackages();
     });
 
     test('building for iOS when plugin is not set up for iOS results in no-op',
@@ -61,7 +63,6 @@ void main() {
       // Output should be empty since running build-examples --macos with no macos
       // implementation is a no-op.
       expect(processRunner.recordedCalls, orderedEquals(<ProcessCall>[]));
-      cleanupPackages();
     });
 
     test('building for ios', () async {
@@ -107,7 +108,6 @@ void main() {
                 ],
                 pluginExampleDirectory.path),
           ]));
-      cleanupPackages();
     });
 
     test(
@@ -142,7 +142,6 @@ void main() {
       // Output should be empty since running build-examples --linux with no
       // Linux implementation is a no-op.
       expect(processRunner.recordedCalls, orderedEquals(<ProcessCall>[]));
-      cleanupPackages();
     });
 
     test('building for Linux', () async {
@@ -177,7 +176,6 @@ void main() {
             ProcessCall(flutterCommand, const <String>['build', 'linux'],
                 pluginExampleDirectory.path),
           ]));
-      cleanupPackages();
     });
 
     test('building for macos with no implementation results in no-op',
@@ -209,7 +207,6 @@ void main() {
       // Output should be empty since running build-examples --macos with no macos
       // implementation is a no-op.
       expect(processRunner.recordedCalls, orderedEquals(<ProcessCall>[]));
-      cleanupPackages();
     });
 
     test('building for macos', () async {
@@ -245,7 +242,6 @@ void main() {
             ProcessCall(flutterCommand, const <String>['build', 'macos'],
                 pluginExampleDirectory.path),
           ]));
-      cleanupPackages();
     });
 
     test('building for web with no implementation results in no-op', () async {
@@ -276,7 +272,6 @@ void main() {
       // Output should be empty since running build-examples --macos with no macos
       // implementation is a no-op.
       expect(processRunner.recordedCalls, orderedEquals(<ProcessCall>[]));
-      cleanupPackages();
     });
 
     test('building for web', () async {
@@ -312,7 +307,6 @@ void main() {
             ProcessCall(flutterCommand, const <String>['build', 'web'],
                 pluginExampleDirectory.path),
           ]));
-      cleanupPackages();
     });
 
     test(
@@ -347,7 +341,6 @@ void main() {
       // Output should be empty since running build-examples --macos with no macos
       // implementation is a no-op.
       expect(processRunner.recordedCalls, orderedEquals(<ProcessCall>[]));
-      cleanupPackages();
     });
 
     test('building for windows', () async {
@@ -382,7 +375,6 @@ void main() {
             ProcessCall(flutterCommand, const <String>['build', 'windows'],
                 pluginExampleDirectory.path),
           ]));
-      cleanupPackages();
     });
 
     test(
@@ -417,7 +409,6 @@ void main() {
       // Output should be empty since running build-examples --macos with no macos
       // implementation is a no-op.
       expect(processRunner.recordedCalls, orderedEquals(<ProcessCall>[]));
-      cleanupPackages();
     });
 
     test('building for android', () async {
@@ -456,7 +447,6 @@ void main() {
             ProcessCall(flutterCommand, const <String>['build', 'apk'],
                 pluginExampleDirectory.path),
           ]));
-      cleanupPackages();
     });
 
     test('enable-experiment flag for Android', () async {
@@ -487,7 +477,6 @@ void main() {
                 const <String>['build', 'apk', '--enable-experiment=exp1'],
                 pluginExampleDirectory.path),
           ]));
-      cleanupPackages();
     });
 
     test('enable-experiment flag for ios', () async {
@@ -521,7 +510,6 @@ void main() {
                 ],
                 pluginExampleDirectory.path),
           ]));
-      cleanupPackages();
     });
   });
 }

--- a/script/tool/test/build_examples_command_test.dart
+++ b/script/tool/test/build_examples_command_test.dart
@@ -15,6 +15,7 @@ import 'util.dart';
 void main() {
   group('test build_example_command', () {
     late FileSystem fileSystem;
+    late Directory packagesDir;
     late CommandRunner<void> runner;
     late RecordingProcessRunner processRunner;
     final String flutterCommand =
@@ -22,10 +23,11 @@ void main() {
 
     setUp(() {
       fileSystem = MemoryFileSystem();
-      initializeFakePackages(parentDir: fileSystem.currentDirectory);
+      packagesDir =
+          initializeFakePackages(parentDir: fileSystem.currentDirectory);
       processRunner = RecordingProcessRunner();
       final BuildExamplesCommand command =
-          BuildExamplesCommand(mockPackagesDir, processRunner: processRunner);
+          BuildExamplesCommand(packagesDir, processRunner: processRunner);
 
       runner = CommandRunner<void>(
           'build_examples_command', 'Test for build_example_command');
@@ -41,14 +43,14 @@ void main() {
           isLinuxPlugin: false);
 
       final Directory pluginExampleDirectory =
-          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+          packagesDir.childDirectory('plugin').childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(
           runner, <String>['build-examples', '--ipa', '--no-macos']);
       final String packageName =
-          p.relative(pluginExampleDirectory.path, from: mockPackagesDir.path);
+          p.relative(pluginExampleDirectory.path, from: packagesDir.path);
 
       expect(
         output,
@@ -73,7 +75,7 @@ void main() {
           isIosPlugin: true);
 
       final Directory pluginExampleDirectory =
-          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+          packagesDir.childDirectory('plugin').childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -84,7 +86,7 @@ void main() {
         '--enable-experiment=exp1'
       ]);
       final String packageName =
-          p.relative(pluginExampleDirectory.path, from: mockPackagesDir.path);
+          p.relative(pluginExampleDirectory.path, from: packagesDir.path);
 
       expect(
         output,
@@ -120,14 +122,14 @@ void main() {
           isLinuxPlugin: false);
 
       final Directory pluginExampleDirectory =
-          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+          packagesDir.childDirectory('plugin').childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(
           runner, <String>['build-examples', '--no-ipa', '--linux']);
       final String packageName =
-          p.relative(pluginExampleDirectory.path, from: mockPackagesDir.path);
+          p.relative(pluginExampleDirectory.path, from: packagesDir.path);
 
       expect(
         output,
@@ -152,14 +154,14 @@ void main() {
           isLinuxPlugin: true);
 
       final Directory pluginExampleDirectory =
-          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+          packagesDir.childDirectory('plugin').childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(
           runner, <String>['build-examples', '--no-ipa', '--linux']);
       final String packageName =
-          p.relative(pluginExampleDirectory.path, from: mockPackagesDir.path);
+          p.relative(pluginExampleDirectory.path, from: packagesDir.path);
 
       expect(
         output,
@@ -185,14 +187,14 @@ void main() {
       ]);
 
       final Directory pluginExampleDirectory =
-          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+          packagesDir.childDirectory('plugin').childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(
           runner, <String>['build-examples', '--no-ipa', '--macos']);
       final String packageName =
-          p.relative(pluginExampleDirectory.path, from: mockPackagesDir.path);
+          p.relative(pluginExampleDirectory.path, from: packagesDir.path);
 
       expect(
         output,
@@ -218,14 +220,14 @@ void main() {
           isMacOsPlugin: true);
 
       final Directory pluginExampleDirectory =
-          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+          packagesDir.childDirectory('plugin').childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(
           runner, <String>['build-examples', '--no-ipa', '--macos']);
       final String packageName =
-          p.relative(pluginExampleDirectory.path, from: mockPackagesDir.path);
+          p.relative(pluginExampleDirectory.path, from: packagesDir.path);
 
       expect(
         output,
@@ -250,14 +252,14 @@ void main() {
       ]);
 
       final Directory pluginExampleDirectory =
-          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+          packagesDir.childDirectory('plugin').childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(
           runner, <String>['build-examples', '--no-ipa', '--web']);
       final String packageName =
-          p.relative(pluginExampleDirectory.path, from: mockPackagesDir.path);
+          p.relative(pluginExampleDirectory.path, from: packagesDir.path);
 
       expect(
         output,
@@ -283,14 +285,14 @@ void main() {
           isWebPlugin: true);
 
       final Directory pluginExampleDirectory =
-          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+          packagesDir.childDirectory('plugin').childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(
           runner, <String>['build-examples', '--no-ipa', '--web']);
       final String packageName =
-          p.relative(pluginExampleDirectory.path, from: mockPackagesDir.path);
+          p.relative(pluginExampleDirectory.path, from: packagesDir.path);
 
       expect(
         output,
@@ -319,14 +321,14 @@ void main() {
           isWindowsPlugin: false);
 
       final Directory pluginExampleDirectory =
-          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+          packagesDir.childDirectory('plugin').childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(
           runner, <String>['build-examples', '--no-ipa', '--windows']);
       final String packageName =
-          p.relative(pluginExampleDirectory.path, from: mockPackagesDir.path);
+          p.relative(pluginExampleDirectory.path, from: packagesDir.path);
 
       expect(
         output,
@@ -351,14 +353,14 @@ void main() {
           isWindowsPlugin: true);
 
       final Directory pluginExampleDirectory =
-          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+          packagesDir.childDirectory('plugin').childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(
           runner, <String>['build-examples', '--no-ipa', '--windows']);
       final String packageName =
-          p.relative(pluginExampleDirectory.path, from: mockPackagesDir.path);
+          p.relative(pluginExampleDirectory.path, from: packagesDir.path);
 
       expect(
         output,
@@ -387,14 +389,14 @@ void main() {
           isLinuxPlugin: false);
 
       final Directory pluginExampleDirectory =
-          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+          packagesDir.childDirectory('plugin').childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(
           runner, <String>['build-examples', '--apk', '--no-ipa']);
       final String packageName =
-          p.relative(pluginExampleDirectory.path, from: mockPackagesDir.path);
+          p.relative(pluginExampleDirectory.path, from: packagesDir.path);
 
       expect(
         output,
@@ -419,7 +421,7 @@ void main() {
           isAndroidPlugin: true);
 
       final Directory pluginExampleDirectory =
-          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+          packagesDir.childDirectory('plugin').childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -430,7 +432,7 @@ void main() {
         '--no-macos',
       ]);
       final String packageName =
-          p.relative(pluginExampleDirectory.path, from: mockPackagesDir.path);
+          p.relative(pluginExampleDirectory.path, from: packagesDir.path);
 
       expect(
         output,
@@ -457,7 +459,7 @@ void main() {
           isAndroidPlugin: true);
 
       final Directory pluginExampleDirectory =
-          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+          packagesDir.childDirectory('plugin').childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -487,7 +489,7 @@ void main() {
           isIosPlugin: true);
 
       final Directory pluginExampleDirectory =
-          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+          packagesDir.childDirectory('plugin').childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 

--- a/script/tool/test/common_test.dart
+++ b/script/tool/test/common_test.dart
@@ -34,8 +34,7 @@ void main() {
 
   setUp(() {
     fileSystem = MemoryFileSystem();
-    packagesDir =
-        initializeFakePackages(parentDir: fileSystem.currentDirectory);
+    packagesDir = createPackagesDirectory(fileSystem: fileSystem);
     thirdPartyPackagesDir = packagesDir.parent
         .childDirectory('third_party')
         .childDirectory('packages');
@@ -330,7 +329,7 @@ packages/plugin3/plugin3.dart
 
     setUp(() {
       fileSystem = MemoryFileSystem();
-      initializeFakePackages(parentDir: fileSystem.currentDirectory);
+      createPackagesDirectory(fileSystem: fileSystem);
       gitDirCommands = <List<String>?>[];
       gitDiffResponse = '';
       gitDir = MockGitDir();

--- a/script/tool/test/common_test.dart
+++ b/script/tool/test/common_test.dart
@@ -34,7 +34,8 @@ void main() {
 
   setUp(() {
     fileSystem = MemoryFileSystem();
-    packagesDir = fileSystem.currentDirectory.childDirectory('packages');
+    packagesDir =
+        initializeFakePackages(parentDir: fileSystem.currentDirectory);
     thirdPartyPackagesDir = packagesDir.parent
         .childDirectory('third_party')
         .childDirectory('packages');
@@ -52,7 +53,6 @@ void main() {
       }
       return Future<ProcessResult>.value(mockProcessResult);
     });
-    initializeFakePackages(parentDir: packagesDir.parent);
     processRunner = RecordingProcessRunner();
     plugins = <String>[];
     final SamplePluginCommand samplePluginCommand = SamplePluginCommand(
@@ -352,12 +352,15 @@ packages/plugin3/plugin3.dart
   });
 
   group('$GitVersionFinder', () {
+    late FileSystem fileSystem;
     late List<List<String>?> gitDirCommands;
     late String gitDiffResponse;
     String? mergeBaseResponse;
     late MockGitDir gitDir;
 
     setUp(() {
+      fileSystem = MemoryFileSystem();
+      initializeFakePackages(parentDir: fileSystem.currentDirectory);
       gitDirCommands = <List<String>?>[];
       gitDiffResponse = '';
       gitDir = MockGitDir();
@@ -374,12 +377,7 @@ packages/plugin3/plugin3.dart
         }
         return Future<ProcessResult>.value(mockProcessResult);
       });
-      initializeFakePackages();
       processRunner = RecordingProcessRunner();
-    });
-
-    tearDown(() {
-      cleanupPackages();
     });
 
     test('No git diff should result no files changed', () async {

--- a/script/tool/test/common_test.dart
+++ b/script/tool/test/common_test.dart
@@ -67,47 +67,40 @@ void main() {
   });
 
   test('all plugins from file system', () async {
-    final Directory plugin1 =
-        createFakePlugin('plugin1', packagesDirectory: packagesDir);
-    final Directory plugin2 =
-        createFakePlugin('plugin2', packagesDirectory: packagesDir);
+    final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
+    final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
     await runner.run(<String>['sample']);
     expect(plugins, unorderedEquals(<String>[plugin1.path, plugin2.path]));
   });
 
   test('all plugins includes third_party/packages', () async {
-    final Directory plugin1 =
-        createFakePlugin('plugin1', packagesDirectory: packagesDir);
-    final Directory plugin2 =
-        createFakePlugin('plugin2', packagesDirectory: packagesDir);
+    final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
+    final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
     final Directory plugin3 =
-        createFakePlugin('plugin3', packagesDirectory: thirdPartyPackagesDir);
+        createFakePlugin('plugin3', thirdPartyPackagesDir);
     await runner.run(<String>['sample']);
     expect(plugins,
         unorderedEquals(<String>[plugin1.path, plugin2.path, plugin3.path]));
   });
 
   test('exclude plugins when plugins flag is specified', () async {
-    createFakePlugin('plugin1', packagesDirectory: packagesDir);
-    final Directory plugin2 =
-        createFakePlugin('plugin2', packagesDirectory: packagesDir);
+    createFakePlugin('plugin1', packagesDir);
+    final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
     await runner.run(
         <String>['sample', '--plugins=plugin1,plugin2', '--exclude=plugin1']);
     expect(plugins, unorderedEquals(<String>[plugin2.path]));
   });
 
   test('exclude plugins when plugins flag isn\'t specified', () async {
-    createFakePlugin('plugin1', packagesDirectory: packagesDir);
-    createFakePlugin('plugin2', packagesDirectory: packagesDir);
+    createFakePlugin('plugin1', packagesDir);
+    createFakePlugin('plugin2', packagesDir);
     await runner.run(<String>['sample', '--exclude=plugin1,plugin2']);
     expect(plugins, unorderedEquals(<String>[]));
   });
 
   test('exclude federated plugins when plugins flag is specified', () async {
-    createFakePlugin('plugin1',
-        parentDirectoryName: 'federated', packagesDirectory: packagesDir);
-    final Directory plugin2 =
-        createFakePlugin('plugin2', packagesDirectory: packagesDir);
+    createFakePlugin('plugin1', packagesDir, parentDirectoryName: 'federated');
+    final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
     await runner.run(<String>[
       'sample',
       '--plugins=federated/plugin1,plugin2',
@@ -118,10 +111,8 @@ void main() {
 
   test('exclude entire federated plugins when plugins flag is specified',
       () async {
-    createFakePlugin('plugin1',
-        parentDirectoryName: 'federated', packagesDirectory: packagesDir);
-    final Directory plugin2 =
-        createFakePlugin('plugin2', packagesDirectory: packagesDir);
+    createFakePlugin('plugin1', packagesDir, parentDirectoryName: 'federated');
+    final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
     await runner.run(<String>[
       'sample',
       '--plugins=federated/plugin1,plugin2',
@@ -132,10 +123,8 @@ void main() {
 
   group('test run-on-changed-packages', () {
     test('all plugins should be tested if there are no changes.', () async {
-      final Directory plugin1 =
-          createFakePlugin('plugin1', packagesDirectory: packagesDir);
-      final Directory plugin2 =
-          createFakePlugin('plugin2', packagesDirectory: packagesDir);
+      final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
+      final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
       await runner.run(
           <String>['sample', '--base-sha=master', '--run-on-changed-packages']);
 
@@ -145,10 +134,8 @@ void main() {
     test('all plugins should be tested if there are no plugin related changes.',
         () async {
       gitDiffResponse = 'AUTHORS';
-      final Directory plugin1 =
-          createFakePlugin('plugin1', packagesDirectory: packagesDir);
-      final Directory plugin2 =
-          createFakePlugin('plugin2', packagesDirectory: packagesDir);
+      final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
+      final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
       await runner.run(
           <String>['sample', '--base-sha=master', '--run-on-changed-packages']);
 
@@ -160,10 +147,8 @@ void main() {
 .cirrus.yml
 packages/plugin1/CHANGELOG
 ''';
-      final Directory plugin1 =
-          createFakePlugin('plugin1', packagesDirectory: packagesDir);
-      final Directory plugin2 =
-          createFakePlugin('plugin2', packagesDirectory: packagesDir);
+      final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
+      final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
       await runner.run(
           <String>['sample', '--base-sha=master', '--run-on-changed-packages']);
 
@@ -175,10 +160,8 @@ packages/plugin1/CHANGELOG
 .ci.yaml
 packages/plugin1/CHANGELOG
 ''';
-      final Directory plugin1 =
-          createFakePlugin('plugin1', packagesDirectory: packagesDir);
-      final Directory plugin2 =
-          createFakePlugin('plugin2', packagesDirectory: packagesDir);
+      final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
+      final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
       await runner.run(
           <String>['sample', '--base-sha=master', '--run-on-changed-packages']);
 
@@ -190,10 +173,8 @@ packages/plugin1/CHANGELOG
 .ci/Dockerfile
 packages/plugin1/CHANGELOG
 ''';
-      final Directory plugin1 =
-          createFakePlugin('plugin1', packagesDirectory: packagesDir);
-      final Directory plugin2 =
-          createFakePlugin('plugin2', packagesDirectory: packagesDir);
+      final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
+      final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
       await runner.run(
           <String>['sample', '--base-sha=master', '--run-on-changed-packages']);
 
@@ -206,10 +187,8 @@ packages/plugin1/CHANGELOG
 script/tool_runner.sh
 packages/plugin1/CHANGELOG
 ''';
-      final Directory plugin1 =
-          createFakePlugin('plugin1', packagesDirectory: packagesDir);
-      final Directory plugin2 =
-          createFakePlugin('plugin2', packagesDirectory: packagesDir);
+      final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
+      final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
       await runner.run(
           <String>['sample', '--base-sha=master', '--run-on-changed-packages']);
 
@@ -222,10 +201,8 @@ packages/plugin1/CHANGELOG
 analysis_options.yaml
 packages/plugin1/CHANGELOG
 ''';
-      final Directory plugin1 =
-          createFakePlugin('plugin1', packagesDirectory: packagesDir);
-      final Directory plugin2 =
-          createFakePlugin('plugin2', packagesDirectory: packagesDir);
+      final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
+      final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
       await runner.run(
           <String>['sample', '--base-sha=master', '--run-on-changed-packages']);
 
@@ -238,10 +215,8 @@ packages/plugin1/CHANGELOG
 .clang-format
 packages/plugin1/CHANGELOG
 ''';
-      final Directory plugin1 =
-          createFakePlugin('plugin1', packagesDirectory: packagesDir);
-      final Directory plugin2 =
-          createFakePlugin('plugin2', packagesDirectory: packagesDir);
+      final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
+      final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
       await runner.run(
           <String>['sample', '--base-sha=master', '--run-on-changed-packages']);
 
@@ -250,9 +225,8 @@ packages/plugin1/CHANGELOG
 
     test('Only changed plugin should be tested.', () async {
       gitDiffResponse = 'packages/plugin1/plugin1.dart';
-      final Directory plugin1 =
-          createFakePlugin('plugin1', packagesDirectory: packagesDir);
-      createFakePlugin('plugin2', packagesDirectory: packagesDir);
+      final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
+      createFakePlugin('plugin2', packagesDir);
       await runner.run(
           <String>['sample', '--base-sha=master', '--run-on-changed-packages']);
 
@@ -264,9 +238,8 @@ packages/plugin1/CHANGELOG
 packages/plugin1/plugin1.dart
 packages/plugin1/ios/plugin1.m
 ''';
-      final Directory plugin1 =
-          createFakePlugin('plugin1', packagesDirectory: packagesDir);
-      createFakePlugin('plugin2', packagesDirectory: packagesDir);
+      final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
+      createFakePlugin('plugin2', packagesDir);
       await runner.run(
           <String>['sample', '--base-sha=master', '--run-on-changed-packages']);
 
@@ -279,11 +252,9 @@ packages/plugin1/ios/plugin1.m
 packages/plugin1/plugin1.dart
 packages/plugin2/ios/plugin2.m
 ''';
-      final Directory plugin1 =
-          createFakePlugin('plugin1', packagesDirectory: packagesDir);
-      final Directory plugin2 =
-          createFakePlugin('plugin2', packagesDirectory: packagesDir);
-      createFakePlugin('plugin3', packagesDirectory: packagesDir);
+      final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
+      final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
+      createFakePlugin('plugin3', packagesDir);
       await runner.run(
           <String>['sample', '--base-sha=master', '--run-on-changed-packages']);
 
@@ -298,10 +269,10 @@ packages/plugin1/plugin1/plugin1.dart
 packages/plugin1/plugin1_platform_interface/plugin1_platform_interface.dart
 packages/plugin1/plugin1_web/plugin1_web.dart
 ''';
-      final Directory plugin1 = createFakePlugin('plugin1',
-          parentDirectoryName: 'plugin1', packagesDirectory: packagesDir);
-      createFakePlugin('plugin2', packagesDirectory: packagesDir);
-      createFakePlugin('plugin3', packagesDirectory: packagesDir);
+      final Directory plugin1 = createFakePlugin('plugin1', packagesDir,
+          parentDirectoryName: 'plugin1');
+      createFakePlugin('plugin2', packagesDir);
+      createFakePlugin('plugin3', packagesDir);
       await runner.run(
           <String>['sample', '--base-sha=master', '--run-on-changed-packages']);
 
@@ -315,11 +286,10 @@ packages/plugin1/plugin1.dart
 packages/plugin2/ios/plugin2.m
 packages/plugin3/plugin3.dart
 ''';
-      final Directory plugin1 = createFakePlugin('plugin1',
-          parentDirectoryName: 'plugin1', packagesDirectory: packagesDir);
-      final Directory plugin2 =
-          createFakePlugin('plugin2', packagesDirectory: packagesDir);
-      createFakePlugin('plugin3', packagesDirectory: packagesDir);
+      final Directory plugin1 = createFakePlugin('plugin1', packagesDir,
+          parentDirectoryName: 'plugin1');
+      final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
+      createFakePlugin('plugin3', packagesDir);
       await runner.run(<String>[
         'sample',
         '--plugins=plugin1,plugin2',
@@ -336,10 +306,10 @@ packages/plugin1/plugin1.dart
 packages/plugin2/ios/plugin2.m
 packages/plugin3/plugin3.dart
 ''';
-      final Directory plugin1 = createFakePlugin('plugin1',
-          parentDirectoryName: 'plugin1', packagesDirectory: packagesDir);
-      createFakePlugin('plugin2', packagesDirectory: packagesDir);
-      createFakePlugin('plugin3', packagesDirectory: packagesDir);
+      final Directory plugin1 = createFakePlugin('plugin1', packagesDir,
+          parentDirectoryName: 'plugin1');
+      createFakePlugin('plugin2', packagesDir);
+      createFakePlugin('plugin3', packagesDir);
       await runner.run(<String>[
         'sample',
         '--exclude=plugin2,plugin3',

--- a/script/tool/test/create_all_plugins_app_command_test.dart
+++ b/script/tool/test/create_all_plugins_app_command_test.dart
@@ -38,10 +38,6 @@ void main() {
       runner.addCommand(command);
     });
 
-    tearDown(() {
-      testRoot.deleteSync(recursive: true);
-    });
-
     test('pubspec includes all plugins', () async {
       createFakePlugin('plugina', packagesDirectory: packagesDir);
       createFakePlugin('pluginb', packagesDirectory: packagesDir);

--- a/script/tool/test/create_all_plugins_app_command_test.dart
+++ b/script/tool/test/create_all_plugins_app_command_test.dart
@@ -38,6 +38,10 @@ void main() {
       runner.addCommand(command);
     });
 
+    tearDown(() {
+      testRoot.deleteSync(recursive: true);
+    });
+
     test('pubspec includes all plugins', () async {
       createFakePlugin('plugina', packagesDir);
       createFakePlugin('pluginb', packagesDir);

--- a/script/tool/test/create_all_plugins_app_command_test.dart
+++ b/script/tool/test/create_all_plugins_app_command_test.dart
@@ -39,9 +39,9 @@ void main() {
     });
 
     test('pubspec includes all plugins', () async {
-      createFakePlugin('plugina', packagesDirectory: packagesDir);
-      createFakePlugin('pluginb', packagesDirectory: packagesDir);
-      createFakePlugin('pluginc', packagesDirectory: packagesDir);
+      createFakePlugin('plugina', packagesDir);
+      createFakePlugin('pluginb', packagesDir);
+      createFakePlugin('pluginc', packagesDir);
 
       await runner.run(<String>['all-plugins-app']);
       final List<String> pubspec =
@@ -57,9 +57,9 @@ void main() {
     });
 
     test('pubspec has overrides for all plugins', () async {
-      createFakePlugin('plugina', packagesDirectory: packagesDir);
-      createFakePlugin('pluginb', packagesDirectory: packagesDir);
-      createFakePlugin('pluginc', packagesDirectory: packagesDir);
+      createFakePlugin('plugina', packagesDir);
+      createFakePlugin('pluginb', packagesDir);
+      createFakePlugin('pluginc', packagesDir);
 
       await runner.run(<String>['all-plugins-app']);
       final List<String> pubspec =
@@ -76,7 +76,7 @@ void main() {
     });
 
     test('pubspec is compatible with null-safe app code', () async {
-      createFakePlugin('plugina', packagesDirectory: packagesDir);
+      createFakePlugin('plugina', packagesDir);
 
       await runner.run(<String>['all-plugins-app']);
       final String pubspec =

--- a/script/tool/test/drive_examples_command_test.dart
+++ b/script/tool/test/drive_examples_command_test.dart
@@ -16,6 +16,7 @@ import 'util.dart';
 void main() {
   group('test drive_example_command', () {
     late FileSystem fileSystem;
+    late Directory packagesDir;
     late CommandRunner<void> runner;
     late RecordingProcessRunner processRunner;
     final String flutterCommand =
@@ -23,10 +24,11 @@ void main() {
 
     setUp(() {
       fileSystem = MemoryFileSystem();
-      initializeFakePackages(parentDir: fileSystem.currentDirectory);
+      packagesDir =
+          initializeFakePackages(parentDir: fileSystem.currentDirectory);
       processRunner = RecordingProcessRunner();
       final DriveExamplesCommand command =
-          DriveExamplesCommand(mockPackagesDir, processRunner: processRunner);
+          DriveExamplesCommand(packagesDir, processRunner: processRunner);
 
       runner = CommandRunner<void>(
           'drive_examples_command', 'Test for drive_example_command');
@@ -43,7 +45,7 @@ void main() {
           isAndroidPlugin: true);
 
       final Directory pluginExampleDirectory =
-          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+          packagesDir.childDirectory('plugin').childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -88,7 +90,7 @@ void main() {
           isIosPlugin: true);
 
       final Directory pluginExampleDirectory =
-          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+          packagesDir.childDirectory('plugin').childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -133,7 +135,7 @@ void main() {
           isIosPlugin: true);
 
       final Directory pluginExampleDirectory =
-          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+          packagesDir.childDirectory('plugin').childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -152,7 +154,7 @@ void main() {
           isIosPlugin: true);
 
       final Directory pluginExampleDirectory =
-          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+          packagesDir.childDirectory('plugin').childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -175,7 +177,7 @@ void main() {
           isIosPlugin: true);
 
       final Directory pluginExampleDirectory =
-          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+          packagesDir.childDirectory('plugin').childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -229,7 +231,7 @@ void main() {
           isMacOsPlugin: false);
 
       final Directory pluginExampleDirectory =
-          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+          packagesDir.childDirectory('plugin').childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -262,7 +264,7 @@ void main() {
           isLinuxPlugin: true);
 
       final Directory pluginExampleDirectory =
-          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+          packagesDir.childDirectory('plugin').childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -307,7 +309,7 @@ void main() {
       ]);
 
       final Directory pluginExampleDirectory =
-          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+          packagesDir.childDirectory('plugin').childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -340,7 +342,7 @@ void main() {
           isMacOsPlugin: true);
 
       final Directory pluginExampleDirectory =
-          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+          packagesDir.childDirectory('plugin').childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -387,7 +389,7 @@ void main() {
           isWebPlugin: false);
 
       final Directory pluginExampleDirectory =
-          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+          packagesDir.childDirectory('plugin').childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -420,7 +422,7 @@ void main() {
           isWebPlugin: true);
 
       final Directory pluginExampleDirectory =
-          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+          packagesDir.childDirectory('plugin').childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -469,7 +471,7 @@ void main() {
           isWindowsPlugin: false);
 
       final Directory pluginExampleDirectory =
-          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+          packagesDir.childDirectory('plugin').childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -502,7 +504,7 @@ void main() {
           isWindowsPlugin: true);
 
       final Directory pluginExampleDirectory =
-          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+          packagesDir.childDirectory('plugin').childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -549,7 +551,7 @@ void main() {
           isMacOsPlugin: true);
 
       final Directory pluginExampleDirectory =
-          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+          packagesDir.childDirectory('plugin').childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -602,7 +604,7 @@ void main() {
           isAndroidPlugin: true);
 
       final Directory pluginExampleDirectory =
-          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+          packagesDir.childDirectory('plugin').childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 

--- a/script/tool/test/drive_examples_command_test.dart
+++ b/script/tool/test/drive_examples_command_test.dart
@@ -36,7 +36,7 @@ void main() {
     });
 
     test('driving under folder "test"', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test', 'plugin.dart'],
@@ -81,7 +81,7 @@ void main() {
     });
 
     test('driving under folder "test_driver"', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test_driver', 'plugin.dart'],
@@ -127,7 +127,7 @@ void main() {
 
     test('driving under folder "test_driver" when test files are missing"',
         () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
           ],
@@ -146,7 +146,7 @@ void main() {
 
     test('a plugin without any integration test files is reported as an error',
         () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           withExtraFiles: <List<String>>[
             <String>['example', 'lib', 'main.dart'],
           ],
@@ -166,7 +166,7 @@ void main() {
     test(
         'driving under folder "test_driver" when targets are under "integration_test"',
         () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'integration_test.dart'],
             <String>['example', 'integration_test', 'bar_test.dart'],
@@ -223,7 +223,7 @@ void main() {
     });
 
     test('driving when plugin does not support Linux is a no-op', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test_driver', 'plugin.dart'],
@@ -256,7 +256,7 @@ void main() {
     });
 
     test('driving on a Linux plugin', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test_driver', 'plugin.dart'],
@@ -303,11 +303,11 @@ void main() {
     });
 
     test('driving when plugin does not suppport macOS is a no-op', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', withExtraFiles: <List<String>>[
-        <String>['example', 'test_driver', 'plugin_test.dart'],
-        <String>['example', 'test_driver', 'plugin.dart'],
-      ]);
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+          withExtraFiles: <List<String>>[
+            <String>['example', 'test_driver', 'plugin_test.dart'],
+            <String>['example', 'test_driver', 'plugin.dart'],
+          ]);
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -334,7 +334,7 @@ void main() {
       expect(processRunner.recordedCalls, <ProcessCall>[]);
     });
     test('driving on a macOS plugin', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test_driver', 'plugin.dart'],
@@ -382,7 +382,7 @@ void main() {
     });
 
     test('driving when plugin does not suppport web is a no-op', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test_driver', 'plugin.dart'],
@@ -415,7 +415,7 @@ void main() {
     });
 
     test('driving a web plugin', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test_driver', 'plugin.dart'],
@@ -464,7 +464,7 @@ void main() {
     });
 
     test('driving when plugin does not suppport Windows is a no-op', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test_driver', 'plugin.dart'],
@@ -497,7 +497,7 @@ void main() {
     });
 
     test('driving on a Windows plugin', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test_driver', 'plugin.dart'],
@@ -544,7 +544,7 @@ void main() {
     });
 
     test('driving when plugin does not support mobile is no-op', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test_driver', 'plugin.dart'],
@@ -576,7 +576,7 @@ void main() {
     });
 
     test('platform interface plugins are silently skipped', () async {
-      createFakePlugin('aplugin_platform_interface');
+      createFakePlugin('aplugin_platform_interface', packagesDir);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'drive-examples',
@@ -596,7 +596,7 @@ void main() {
     });
 
     test('enable-experiment flag', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test', 'plugin.dart'],

--- a/script/tool/test/drive_examples_command_test.dart
+++ b/script/tool/test/drive_examples_command_test.dart
@@ -24,8 +24,7 @@ void main() {
 
     setUp(() {
       fileSystem = MemoryFileSystem();
-      packagesDir =
-          initializeFakePackages(parentDir: fileSystem.currentDirectory);
+      packagesDir = createPackagesDirectory(fileSystem: fileSystem);
       processRunner = RecordingProcessRunner();
       final DriveExamplesCommand command =
           DriveExamplesCommand(packagesDir, processRunner: processRunner);

--- a/script/tool/test/drive_examples_command_test.dart
+++ b/script/tool/test/drive_examples_command_test.dart
@@ -36,7 +36,7 @@ void main() {
     });
 
     test('driving under folder "test"', () async {
-      createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin',
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test', 'plugin.dart'],
@@ -45,7 +45,7 @@ void main() {
           isAndroidPlugin: true);
 
       final Directory pluginExampleDirectory =
-          packagesDir.childDirectory('plugin').childDirectory('example');
+          pluginDirectory.childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -81,7 +81,7 @@ void main() {
     });
 
     test('driving under folder "test_driver"', () async {
-      createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin',
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test_driver', 'plugin.dart'],
@@ -90,7 +90,7 @@ void main() {
           isIosPlugin: true);
 
       final Directory pluginExampleDirectory =
-          packagesDir.childDirectory('plugin').childDirectory('example');
+          pluginDirectory.childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -127,7 +127,7 @@ void main() {
 
     test('driving under folder "test_driver" when test files are missing"',
         () async {
-      createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin',
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
           ],
@@ -135,7 +135,7 @@ void main() {
           isIosPlugin: true);
 
       final Directory pluginExampleDirectory =
-          packagesDir.childDirectory('plugin').childDirectory('example');
+          pluginDirectory.childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -146,7 +146,7 @@ void main() {
 
     test('a plugin without any integration test files is reported as an error',
         () async {
-      createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin',
           withExtraFiles: <List<String>>[
             <String>['example', 'lib', 'main.dart'],
           ],
@@ -154,7 +154,7 @@ void main() {
           isIosPlugin: true);
 
       final Directory pluginExampleDirectory =
-          packagesDir.childDirectory('plugin').childDirectory('example');
+          pluginDirectory.childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -166,7 +166,7 @@ void main() {
     test(
         'driving under folder "test_driver" when targets are under "integration_test"',
         () async {
-      createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin',
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'integration_test.dart'],
             <String>['example', 'integration_test', 'bar_test.dart'],
@@ -177,7 +177,7 @@ void main() {
           isIosPlugin: true);
 
       final Directory pluginExampleDirectory =
-          packagesDir.childDirectory('plugin').childDirectory('example');
+          pluginDirectory.childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -223,7 +223,7 @@ void main() {
     });
 
     test('driving when plugin does not support Linux is a no-op', () async {
-      createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin',
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test_driver', 'plugin.dart'],
@@ -231,7 +231,7 @@ void main() {
           isMacOsPlugin: false);
 
       final Directory pluginExampleDirectory =
-          packagesDir.childDirectory('plugin').childDirectory('example');
+          pluginDirectory.childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -256,7 +256,7 @@ void main() {
     });
 
     test('driving on a Linux plugin', () async {
-      createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin',
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test_driver', 'plugin.dart'],
@@ -264,7 +264,7 @@ void main() {
           isLinuxPlugin: true);
 
       final Directory pluginExampleDirectory =
-          packagesDir.childDirectory('plugin').childDirectory('example');
+          pluginDirectory.childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -303,13 +303,14 @@ void main() {
     });
 
     test('driving when plugin does not suppport macOS is a no-op', () async {
-      createFakePlugin('plugin', withExtraFiles: <List<String>>[
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', withExtraFiles: <List<String>>[
         <String>['example', 'test_driver', 'plugin_test.dart'],
         <String>['example', 'test_driver', 'plugin.dart'],
       ]);
 
       final Directory pluginExampleDirectory =
-          packagesDir.childDirectory('plugin').childDirectory('example');
+          pluginDirectory.childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -333,7 +334,7 @@ void main() {
       expect(processRunner.recordedCalls, <ProcessCall>[]);
     });
     test('driving on a macOS plugin', () async {
-      createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin',
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test_driver', 'plugin.dart'],
@@ -342,7 +343,7 @@ void main() {
           isMacOsPlugin: true);
 
       final Directory pluginExampleDirectory =
-          packagesDir.childDirectory('plugin').childDirectory('example');
+          pluginDirectory.childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -381,7 +382,7 @@ void main() {
     });
 
     test('driving when plugin does not suppport web is a no-op', () async {
-      createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin',
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test_driver', 'plugin.dart'],
@@ -389,7 +390,7 @@ void main() {
           isWebPlugin: false);
 
       final Directory pluginExampleDirectory =
-          packagesDir.childDirectory('plugin').childDirectory('example');
+          pluginDirectory.childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -414,7 +415,7 @@ void main() {
     });
 
     test('driving a web plugin', () async {
-      createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin',
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test_driver', 'plugin.dart'],
@@ -422,7 +423,7 @@ void main() {
           isWebPlugin: true);
 
       final Directory pluginExampleDirectory =
-          packagesDir.childDirectory('plugin').childDirectory('example');
+          pluginDirectory.childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -463,7 +464,7 @@ void main() {
     });
 
     test('driving when plugin does not suppport Windows is a no-op', () async {
-      createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin',
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test_driver', 'plugin.dart'],
@@ -471,7 +472,7 @@ void main() {
           isWindowsPlugin: false);
 
       final Directory pluginExampleDirectory =
-          packagesDir.childDirectory('plugin').childDirectory('example');
+          pluginDirectory.childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -496,7 +497,7 @@ void main() {
     });
 
     test('driving on a Windows plugin', () async {
-      createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin',
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test_driver', 'plugin.dart'],
@@ -504,7 +505,7 @@ void main() {
           isWindowsPlugin: true);
 
       final Directory pluginExampleDirectory =
-          packagesDir.childDirectory('plugin').childDirectory('example');
+          pluginDirectory.childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -543,7 +544,7 @@ void main() {
     });
 
     test('driving when plugin does not support mobile is no-op', () async {
-      createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin',
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test_driver', 'plugin.dart'],
@@ -551,7 +552,7 @@ void main() {
           isMacOsPlugin: true);
 
       final Directory pluginExampleDirectory =
-          packagesDir.childDirectory('plugin').childDirectory('example');
+          pluginDirectory.childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -595,7 +596,7 @@ void main() {
     });
 
     test('enable-experiment flag', () async {
-      createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin',
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test', 'plugin.dart'],
@@ -604,7 +605,7 @@ void main() {
           isAndroidPlugin: true);
 
       final Directory pluginExampleDirectory =
-          packagesDir.childDirectory('plugin').childDirectory('example');
+          pluginDirectory.childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 

--- a/script/tool/test/drive_examples_command_test.dart
+++ b/script/tool/test/drive_examples_command_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
+import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common.dart';
 import 'package:flutter_plugin_tools/src/drive_examples_command.dart';
 import 'package:path/path.dart' as p;
@@ -14,12 +15,15 @@ import 'util.dart';
 
 void main() {
   group('test drive_example_command', () {
+    late FileSystem fileSystem;
     late CommandRunner<void> runner;
     late RecordingProcessRunner processRunner;
     final String flutterCommand =
         const LocalPlatform().isWindows ? 'flutter.bat' : 'flutter';
+
     setUp(() {
-      initializeFakePackages();
+      fileSystem = MemoryFileSystem();
+      initializeFakePackages(parentDir: fileSystem.currentDirectory);
       processRunner = RecordingProcessRunner();
       final DriveExamplesCommand command =
           DriveExamplesCommand(mockPackagesDir, processRunner: processRunner);
@@ -27,10 +31,6 @@ void main() {
       runner = CommandRunner<void>(
           'drive_examples_command', 'Test for drive_example_command');
       runner.addCommand(command);
-    });
-
-    tearDown(() {
-      cleanupPackages();
     });
 
     test('driving under folder "test"', () async {

--- a/script/tool/test/firebase_test_lab_test.dart
+++ b/script/tool/test/firebase_test_lab_test.dart
@@ -19,13 +19,14 @@ import 'util.dart';
 void main() {
   group('$FirebaseTestLabCommand', () {
     FileSystem fileSystem;
+    Directory packagesDir;
     List<String> printedMessages;
     CommandRunner<void> runner;
     RecordingProcessRunner processRunner;
 
     setUp(() {
       fileSystem = MemoryFileSystem();
-      final Directory packagesDir =
+      packagesDir =
           initializeFakePackages(parentDir: fileSystem.currentDirectory);
       printedMessages = <String>[];
       processRunner = RecordingProcessRunner();
@@ -42,7 +43,7 @@ void main() {
       final MockProcess mockProcess = MockProcess();
       mockProcess.exitCodeCompleter.complete(1);
       processRunner.processToReturn = mockProcess;
-      createFakePlugin('plugin', withExtraFiles: <List<String>>[
+      createFakePlugin('plugin', packagesDir, withExtraFiles: <List<String>>[
         <String>['lib/test/should_not_run_e2e.dart'],
         <String>['example', 'test_driver', 'plugin_e2e.dart'],
         <String>['example', 'test_driver', 'plugin_e2e_test.dart'],
@@ -67,7 +68,7 @@ void main() {
     });
 
     test('runs e2e tests', () async {
-      createFakePlugin('plugin', withExtraFiles: <List<String>>[
+      createFakePlugin('plugin', packagesDir, withExtraFiles: <List<String>>[
         <String>['test', 'plugin_test.dart'],
         <String>['test', 'plugin_e2e.dart'],
         <String>['should_not_run_e2e.dart'],
@@ -168,7 +169,7 @@ void main() {
     });
 
     test('experimental flag', () async {
-      createFakePlugin('plugin', withExtraFiles: <List<String>>[
+      createFakePlugin('plugin', packagesDir, withExtraFiles: <List<String>>[
         <String>['test', 'plugin_test.dart'],
         <String>['test', 'plugin_e2e.dart'],
         <String>['should_not_run_e2e.dart'],

--- a/script/tool/test/firebase_test_lab_test.dart
+++ b/script/tool/test/firebase_test_lab_test.dart
@@ -25,10 +25,10 @@ void main() {
 
     setUp(() {
       fileSystem = MemoryFileSystem();
-      initializeFakePackages(parentDir: fileSystem.currentDirectory);
+      final Directory packagesDir =
+          initializeFakePackages(parentDir: fileSystem.currentDirectory);
       processRunner = RecordingProcessRunner();
-      final FirebaseTestLabCommand command = FirebaseTestLabCommand(
-          mockPackagesDir,
+      final FirebaseTestLabCommand command = FirebaseTestLabCommand(packagesDir,
           processRunner: processRunner,
           print: (Object message) => printedMessages.add(message.toString()));
 

--- a/script/tool/test/firebase_test_lab_test.dart
+++ b/script/tool/test/firebase_test_lab_test.dart
@@ -7,6 +7,8 @@
 import 'dart:io';
 
 import 'package:args/command_runner.dart';
+import 'package:file/file.dart';
+import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common.dart';
 import 'package:flutter_plugin_tools/src/firebase_test_lab_command.dart';
 import 'package:test/test.dart';
@@ -16,12 +18,14 @@ import 'util.dart';
 
 void main() {
   group('$FirebaseTestLabCommand', () {
+    FileSystem fileSystem;
     final List<String> printedMessages = <String>[];
     CommandRunner<void> runner;
     RecordingProcessRunner processRunner;
 
     setUp(() {
-      initializeFakePackages();
+      fileSystem = MemoryFileSystem();
+      initializeFakePackages(parentDir: fileSystem.currentDirectory);
       processRunner = RecordingProcessRunner();
       final FirebaseTestLabCommand command = FirebaseTestLabCommand(
           mockPackagesDir,
@@ -134,7 +138,7 @@ void main() {
               '/packages/plugin/example'),
           ProcessCall(
               '/packages/plugin/example/android/gradlew',
-              'app:assembleDebug -Pverbose=true -Ptarget=/packages/plugin/example/test_driver/plugin_e2e.dart'
+              'app:assembleDebug -Pverbose=true -Ptarget=/packages/plugin/example/test/plugin_e2e.dart'
                   .split(' '),
               '/packages/plugin/example/android'),
           ProcessCall(
@@ -144,7 +148,7 @@ void main() {
               '/packages/plugin/example'),
           ProcessCall(
               '/packages/plugin/example/android/gradlew',
-              'app:assembleDebug -Pverbose=true -Ptarget=/packages/plugin/example/test/plugin_e2e.dart'
+              'app:assembleDebug -Pverbose=true -Ptarget=/packages/plugin/example/test_driver/plugin_e2e.dart'
                   .split(' '),
               '/packages/plugin/example/android'),
           ProcessCall(
@@ -225,7 +229,7 @@ void main() {
               '/packages/plugin/example'),
           ProcessCall(
               '/packages/plugin/example/android/gradlew',
-              'app:assembleDebug -Pverbose=true -Ptarget=/packages/plugin/example/test_driver/plugin_e2e.dart -Pextra-front-end-options=--enable-experiment%3Dexp1 -Pextra-gen-snapshot-options=--enable-experiment%3Dexp1'
+              'app:assembleDebug -Pverbose=true -Ptarget=/packages/plugin/example/test/plugin_e2e.dart -Pextra-front-end-options=--enable-experiment%3Dexp1 -Pextra-gen-snapshot-options=--enable-experiment%3Dexp1'
                   .split(' '),
               '/packages/plugin/example/android'),
           ProcessCall(
@@ -235,7 +239,7 @@ void main() {
               '/packages/plugin/example'),
           ProcessCall(
               '/packages/plugin/example/android/gradlew',
-              'app:assembleDebug -Pverbose=true -Ptarget=/packages/plugin/example/test/plugin_e2e.dart -Pextra-front-end-options=--enable-experiment%3Dexp1 -Pextra-gen-snapshot-options=--enable-experiment%3Dexp1'
+              'app:assembleDebug -Pverbose=true -Ptarget=/packages/plugin/example/test_driver/plugin_e2e.dart -Pextra-front-end-options=--enable-experiment%3Dexp1 -Pextra-gen-snapshot-options=--enable-experiment%3Dexp1'
                   .split(' '),
               '/packages/plugin/example/android'),
           ProcessCall(
@@ -255,8 +259,6 @@ void main() {
               '/packages/plugin/example'),
         ]),
       );
-
-      cleanupPackages();
     });
   });
 }

--- a/script/tool/test/firebase_test_lab_test.dart
+++ b/script/tool/test/firebase_test_lab_test.dart
@@ -26,8 +26,7 @@ void main() {
 
     setUp(() {
       fileSystem = MemoryFileSystem();
-      packagesDir =
-          initializeFakePackages(parentDir: fileSystem.currentDirectory);
+      packagesDir = createPackagesDirectory(fileSystem: fileSystem);
       printedMessages = <String>[];
       processRunner = RecordingProcessRunner();
       final FirebaseTestLabCommand command = FirebaseTestLabCommand(packagesDir,

--- a/script/tool/test/firebase_test_lab_test.dart
+++ b/script/tool/test/firebase_test_lab_test.dart
@@ -19,7 +19,7 @@ import 'util.dart';
 void main() {
   group('$FirebaseTestLabCommand', () {
     FileSystem fileSystem;
-    final List<String> printedMessages = <String>[];
+    List<String> printedMessages;
     CommandRunner<void> runner;
     RecordingProcessRunner processRunner;
 
@@ -27,6 +27,7 @@ void main() {
       fileSystem = MemoryFileSystem();
       final Directory packagesDir =
           initializeFakePackages(parentDir: fileSystem.currentDirectory);
+      printedMessages = <String>[];
       processRunner = RecordingProcessRunner();
       final FirebaseTestLabCommand command = FirebaseTestLabCommand(packagesDir,
           processRunner: processRunner,
@@ -35,10 +36,6 @@ void main() {
       runner = CommandRunner<void>(
           'firebase_test_lab_command', 'Test for $FirebaseTestLabCommand');
       runner.addCommand(command);
-    });
-
-    tearDown(() {
-      printedMessages.clear();
     });
 
     test('retries gcloud set', () async {

--- a/script/tool/test/java_test_command_test.dart
+++ b/script/tool/test/java_test_command_test.dart
@@ -14,12 +14,13 @@ import 'util.dart';
 void main() {
   group('$JavaTestCommand', () {
     late FileSystem fileSystem;
+    late Directory packagesDir;
     late CommandRunner<void> runner;
     late RecordingProcessRunner processRunner;
 
     setUp(() {
       fileSystem = MemoryFileSystem();
-      final Directory packagesDir =
+      packagesDir =
           initializeFakePackages(parentDir: fileSystem.currentDirectory);
       processRunner = RecordingProcessRunner();
       final JavaTestCommand command =
@@ -33,6 +34,7 @@ void main() {
     test('Should run Java tests in Android implementation folder', () async {
       final Directory plugin = createFakePlugin(
         'plugin1',
+        packagesDir,
         isAndroidPlugin: true,
         isFlutter: true,
         withSingleExample: true,
@@ -59,6 +61,7 @@ void main() {
     test('Should run Java tests in example folder', () async {
       final Directory plugin = createFakePlugin(
         'plugin1',
+        packagesDir,
         isAndroidPlugin: true,
         isFlutter: true,
         withSingleExample: true,

--- a/script/tool/test/java_test_command_test.dart
+++ b/script/tool/test/java_test_command_test.dart
@@ -19,9 +19,10 @@ void main() {
 
     setUp(() {
       fileSystem = MemoryFileSystem();
-      initializeFakePackages(parentDir: fileSystem.currentDirectory);
+      final Directory packagesDir =
+          initializeFakePackages(parentDir: fileSystem.currentDirectory);
       final JavaTestCommand command =
-          JavaTestCommand(mockPackagesDir, processRunner: processRunner);
+          JavaTestCommand(packagesDir, processRunner: processRunner);
 
       runner =
           CommandRunner<void>('java_test_test', 'Test for $JavaTestCommand');

--- a/script/tool/test/java_test_command_test.dart
+++ b/script/tool/test/java_test_command_test.dart
@@ -20,8 +20,7 @@ void main() {
 
     setUp(() {
       fileSystem = MemoryFileSystem();
-      packagesDir =
-          initializeFakePackages(parentDir: fileSystem.currentDirectory);
+      packagesDir = createPackagesDirectory(fileSystem: fileSystem);
       processRunner = RecordingProcessRunner();
       final JavaTestCommand command =
           JavaTestCommand(packagesDir, processRunner: processRunner);

--- a/script/tool/test/java_test_command_test.dart
+++ b/script/tool/test/java_test_command_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
+import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/java_test_command.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
@@ -12,11 +13,13 @@ import 'util.dart';
 
 void main() {
   group('$JavaTestCommand', () {
+    late FileSystem fileSystem;
     late CommandRunner<void> runner;
     final RecordingProcessRunner processRunner = RecordingProcessRunner();
 
     setUp(() {
-      initializeFakePackages();
+      fileSystem = MemoryFileSystem();
+      initializeFakePackages(parentDir: fileSystem.currentDirectory);
       final JavaTestCommand command =
           JavaTestCommand(mockPackagesDir, processRunner: processRunner);
 
@@ -26,7 +29,6 @@ void main() {
     });
 
     tearDown(() {
-      cleanupPackages();
       processRunner.recordedCalls.clear();
     });
 

--- a/script/tool/test/java_test_command_test.dart
+++ b/script/tool/test/java_test_command_test.dart
@@ -15,22 +15,19 @@ void main() {
   group('$JavaTestCommand', () {
     late FileSystem fileSystem;
     late CommandRunner<void> runner;
-    final RecordingProcessRunner processRunner = RecordingProcessRunner();
+    late RecordingProcessRunner processRunner;
 
     setUp(() {
       fileSystem = MemoryFileSystem();
       final Directory packagesDir =
           initializeFakePackages(parentDir: fileSystem.currentDirectory);
+      processRunner = RecordingProcessRunner();
       final JavaTestCommand command =
           JavaTestCommand(packagesDir, processRunner: processRunner);
 
       runner =
           CommandRunner<void>('java_test_test', 'Test for $JavaTestCommand');
       runner.addCommand(command);
-    });
-
-    tearDown(() {
-      processRunner.recordedCalls.clear();
     });
 
     test('Should run Java tests in Android implementation folder', () async {

--- a/script/tool/test/lint_podspecs_command_test.dart
+++ b/script/tool/test/lint_podspecs_command_test.dart
@@ -6,6 +6,7 @@
 
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
+import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/lint_podspecs_command.dart';
 import 'package:mockito/mockito.dart';
 import 'package:path/path.dart' as p;
@@ -17,13 +18,15 @@ import 'util.dart';
 
 void main() {
   group('$LintPodspecsCommand', () {
+    FileSystem fileSystem;
     CommandRunner<void> runner;
     MockPlatform mockPlatform;
     final RecordingProcessRunner processRunner = RecordingProcessRunner();
     List<String> printedMessages;
 
     setUp(() {
-      initializeFakePackages();
+      fileSystem = MemoryFileSystem();
+      initializeFakePackages(parentDir: fileSystem.currentDirectory);
 
       printedMessages = <String>[];
       mockPlatform = MockPlatform();
@@ -42,10 +45,6 @@ void main() {
       mockLintProcess.exitCodeCompleter.complete(0);
       processRunner.processToReturn = mockLintProcess;
       processRunner.recordedCalls.clear();
-    });
-
-    tearDown(() {
-      cleanupPackages();
     });
 
     test('only runs on macOS', () async {

--- a/script/tool/test/lint_podspecs_command_test.dart
+++ b/script/tool/test/lint_podspecs_command_test.dart
@@ -19,6 +19,7 @@ import 'util.dart';
 void main() {
   group('$LintPodspecsCommand', () {
     FileSystem fileSystem;
+    Directory packagesDir;
     CommandRunner<void> runner;
     MockPlatform mockPlatform;
     final RecordingProcessRunner processRunner = RecordingProcessRunner();
@@ -26,13 +27,14 @@ void main() {
 
     setUp(() {
       fileSystem = MemoryFileSystem();
-      initializeFakePackages(parentDir: fileSystem.currentDirectory);
+      packagesDir =
+          initializeFakePackages(parentDir: fileSystem.currentDirectory);
 
       printedMessages = <String>[];
       mockPlatform = MockPlatform();
       when(mockPlatform.isMacOS).thenReturn(true);
       final LintPodspecsCommand command = LintPodspecsCommand(
-        mockPackagesDir,
+        packagesDir,
         processRunner: processRunner,
         platform: mockPlatform,
         print: (Object message) => printedMessages.add(message.toString()),
@@ -76,7 +78,7 @@ void main() {
       expect(
         processRunner.recordedCalls,
         orderedEquals(<ProcessCall>[
-          ProcessCall('which', const <String>['pod'], mockPackagesDir.path),
+          ProcessCall('which', const <String>['pod'], packagesDir.path),
           ProcessCall(
               'pod',
               <String>[
@@ -88,7 +90,7 @@ void main() {
                 '--use-modular-headers',
                 '--use-libraries'
               ],
-              mockPackagesDir.path),
+              packagesDir.path),
           ProcessCall(
               'pod',
               <String>[
@@ -99,7 +101,7 @@ void main() {
                 '--skip-tests',
                 '--use-modular-headers',
               ],
-              mockPackagesDir.path),
+              packagesDir.path),
         ]),
       );
 
@@ -122,7 +124,7 @@ void main() {
       expect(
         processRunner.recordedCalls,
         orderedEquals(<ProcessCall>[
-          ProcessCall('which', const <String>['pod'], mockPackagesDir.path),
+          ProcessCall('which', const <String>['pod'], packagesDir.path),
         ]),
       );
     });
@@ -138,7 +140,7 @@ void main() {
       expect(
         processRunner.recordedCalls,
         orderedEquals(<ProcessCall>[
-          ProcessCall('which', const <String>['pod'], mockPackagesDir.path),
+          ProcessCall('which', const <String>['pod'], packagesDir.path),
           ProcessCall(
               'pod',
               <String>[
@@ -151,7 +153,7 @@ void main() {
                 '--allow-warnings',
                 '--use-libraries'
               ],
-              mockPackagesDir.path),
+              packagesDir.path),
           ProcessCall(
               'pod',
               <String>[
@@ -163,7 +165,7 @@ void main() {
                 '--use-modular-headers',
                 '--allow-warnings',
               ],
-              mockPackagesDir.path),
+              packagesDir.path),
         ]),
       );
 

--- a/script/tool/test/lint_podspecs_command_test.dart
+++ b/script/tool/test/lint_podspecs_command_test.dart
@@ -50,7 +50,7 @@ void main() {
     });
 
     test('only runs on macOS', () async {
-      createFakePlugin('plugin1', withExtraFiles: <List<String>>[
+      createFakePlugin('plugin1', packagesDir, withExtraFiles: <List<String>>[
         <String>['plugin1.podspec'],
       ]);
 
@@ -64,11 +64,11 @@ void main() {
     });
 
     test('runs pod lib lint on a podspec', () async {
-      final Directory plugin1Dir =
-          createFakePlugin('plugin1', withExtraFiles: <List<String>>[
-        <String>['ios', 'plugin1.podspec'],
-        <String>['bogus.dart'], // Ignore non-podspecs.
-      ]);
+      final Directory plugin1Dir = createFakePlugin('plugin1', packagesDir,
+          withExtraFiles: <List<String>>[
+            <String>['ios', 'plugin1.podspec'],
+            <String>['bogus.dart'], // Ignore non-podspecs.
+          ]);
 
       processRunner.resultStdout = 'Foo';
       processRunner.resultStderr = 'Bar';
@@ -111,10 +111,10 @@ void main() {
     });
 
     test('skips podspecs with known issues', () async {
-      createFakePlugin('plugin1', withExtraFiles: <List<String>>[
+      createFakePlugin('plugin1', packagesDir, withExtraFiles: <List<String>>[
         <String>['plugin1.podspec']
       ]);
-      createFakePlugin('plugin2', withExtraFiles: <List<String>>[
+      createFakePlugin('plugin2', packagesDir, withExtraFiles: <List<String>>[
         <String>['plugin2.podspec']
       ]);
 
@@ -130,10 +130,10 @@ void main() {
     });
 
     test('allow warnings for podspecs with known warnings', () async {
-      final Directory plugin1Dir =
-          createFakePlugin('plugin1', withExtraFiles: <List<String>>[
-        <String>['plugin1.podspec'],
-      ]);
+      final Directory plugin1Dir = createFakePlugin('plugin1', packagesDir,
+          withExtraFiles: <List<String>>[
+            <String>['plugin1.podspec'],
+          ]);
 
       await runner.run(<String>['podspecs', '--ignore-warnings=plugin1']);
 

--- a/script/tool/test/lint_podspecs_command_test.dart
+++ b/script/tool/test/lint_podspecs_command_test.dart
@@ -27,8 +27,7 @@ void main() {
 
     setUp(() {
       fileSystem = MemoryFileSystem();
-      packagesDir =
-          initializeFakePackages(parentDir: fileSystem.currentDirectory);
+      packagesDir = createPackagesDirectory(fileSystem: fileSystem);
 
       printedMessages = <String>[];
       mockPlatform = MockPlatform();

--- a/script/tool/test/list_command_test.dart
+++ b/script/tool/test/list_command_test.dart
@@ -13,12 +13,14 @@ import 'util.dart';
 void main() {
   group('$ListCommand', () {
     late FileSystem fileSystem;
+    late Directory packagesDir;
     late CommandRunner<void> runner;
 
     setUp(() {
       fileSystem = MemoryFileSystem();
-      initializeFakePackages(parentDir: fileSystem.currentDirectory);
-      final ListCommand command = ListCommand(mockPackagesDir);
+      packagesDir =
+          initializeFakePackages(parentDir: fileSystem.currentDirectory);
+      final ListCommand command = ListCommand(packagesDir);
 
       runner = CommandRunner<void>('list_test', 'Test for $ListCommand');
       runner.addCommand(command);
@@ -108,8 +110,8 @@ void main() {
 
       // Create a federated plugin by creating a directory under the packages
       // directory with several packages underneath.
-      final Directory federatedPlugin =
-          mockPackagesDir.childDirectory('my_plugin')..createSync();
+      final Directory federatedPlugin = packagesDir.childDirectory('my_plugin')
+        ..createSync();
       final Directory clientLibrary =
           federatedPlugin.childDirectory('my_plugin')..createSync();
       createFakePubspec(clientLibrary);
@@ -140,8 +142,8 @@ void main() {
 
       // Create a federated plugin by creating a directory under the packages
       // directory with several packages underneath.
-      final Directory federatedPlugin =
-          mockPackagesDir.childDirectory('my_plugin')..createSync();
+      final Directory federatedPlugin = packagesDir.childDirectory('my_plugin')
+        ..createSync();
       final Directory clientLibrary =
           federatedPlugin.childDirectory('my_plugin')..createSync();
       createFakePubspec(clientLibrary);

--- a/script/tool/test/list_command_test.dart
+++ b/script/tool/test/list_command_test.dart
@@ -27,8 +27,8 @@ void main() {
     });
 
     test('lists plugins', () async {
-      createFakePlugin('plugin1');
-      createFakePlugin('plugin2');
+      createFakePlugin('plugin1', packagesDir);
+      createFakePlugin('plugin2', packagesDir);
 
       final List<String> plugins =
           await runCapturingPrint(runner, <String>['list', '--type=plugin']);
@@ -43,10 +43,10 @@ void main() {
     });
 
     test('lists examples', () async {
-      createFakePlugin('plugin1', withSingleExample: true);
-      createFakePlugin('plugin2',
+      createFakePlugin('plugin1', packagesDir, withSingleExample: true);
+      createFakePlugin('plugin2', packagesDir,
           withExamples: <String>['example1', 'example2']);
-      createFakePlugin('plugin3');
+      createFakePlugin('plugin3', packagesDir);
 
       final List<String> examples =
           await runCapturingPrint(runner, <String>['list', '--type=example']);
@@ -62,10 +62,10 @@ void main() {
     });
 
     test('lists packages', () async {
-      createFakePlugin('plugin1', withSingleExample: true);
-      createFakePlugin('plugin2',
+      createFakePlugin('plugin1', packagesDir, withSingleExample: true);
+      createFakePlugin('plugin2', packagesDir,
           withExamples: <String>['example1', 'example2']);
-      createFakePlugin('plugin3');
+      createFakePlugin('plugin3', packagesDir);
 
       final List<String> packages =
           await runCapturingPrint(runner, <String>['list', '--type=package']);
@@ -84,10 +84,10 @@ void main() {
     });
 
     test('lists files', () async {
-      createFakePlugin('plugin1', withSingleExample: true);
-      createFakePlugin('plugin2',
+      createFakePlugin('plugin1', packagesDir, withSingleExample: true);
+      createFakePlugin('plugin2', packagesDir,
           withExamples: <String>['example1', 'example2']);
-      createFakePlugin('plugin3');
+      createFakePlugin('plugin3', packagesDir);
 
       final List<String> examples =
           await runCapturingPrint(runner, <String>['list', '--type=file']);
@@ -106,7 +106,7 @@ void main() {
     });
 
     test('lists plugins using federated plugin layout', () async {
-      createFakePlugin('plugin1');
+      createFakePlugin('plugin1', packagesDir);
 
       // Create a federated plugin by creating a directory under the packages
       // directory with several packages underneath.
@@ -138,7 +138,7 @@ void main() {
     });
 
     test('can filter plugins with the --plugins argument', () async {
-      createFakePlugin('plugin1');
+      createFakePlugin('plugin1', packagesDir);
 
       // Create a federated plugin by creating a directory under the packages
       // directory with several packages underneath.

--- a/script/tool/test/list_command_test.dart
+++ b/script/tool/test/list_command_test.dart
@@ -18,8 +18,7 @@ void main() {
 
     setUp(() {
       fileSystem = MemoryFileSystem();
-      packagesDir =
-          initializeFakePackages(parentDir: fileSystem.currentDirectory);
+      packagesDir = createPackagesDirectory(fileSystem: fileSystem);
       final ListCommand command = ListCommand(packagesDir);
 
       runner = CommandRunner<void>('list_test', 'Test for $ListCommand');

--- a/script/tool/test/list_command_test.dart
+++ b/script/tool/test/list_command_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
+import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/list_command.dart';
 import 'package:test/test.dart';
 
@@ -11,10 +12,12 @@ import 'util.dart';
 
 void main() {
   group('$ListCommand', () {
+    late FileSystem fileSystem;
     late CommandRunner<void> runner;
 
     setUp(() {
-      initializeFakePackages();
+      fileSystem = MemoryFileSystem();
+      initializeFakePackages(parentDir: fileSystem.currentDirectory);
       final ListCommand command = ListCommand(mockPackagesDir);
 
       runner = CommandRunner<void>('list_test', 'Test for $ListCommand');
@@ -35,8 +38,6 @@ void main() {
           '/packages/plugin2',
         ]),
       );
-
-      cleanupPackages();
     });
 
     test('lists examples', () async {
@@ -56,8 +57,6 @@ void main() {
           '/packages/plugin2/example/example2',
         ]),
       );
-
-      cleanupPackages();
     });
 
     test('lists packages', () async {
@@ -80,8 +79,6 @@ void main() {
           '/packages/plugin3',
         ]),
       );
-
-      cleanupPackages();
     });
 
     test('lists files', () async {
@@ -104,8 +101,6 @@ void main() {
           '/packages/plugin3/pubspec.yaml',
         ]),
       );
-
-      cleanupPackages();
     });
 
     test('lists plugins using federated plugin layout', () async {
@@ -138,8 +133,6 @@ void main() {
           '/packages/my_plugin/my_plugin_macos',
         ]),
       );
-
-      cleanupPackages();
     });
 
     test('can filter plugins with the --plugins argument', () async {

--- a/script/tool/test/publish_check_command_test.dart
+++ b/script/tool/test/publish_check_command_test.dart
@@ -43,8 +43,8 @@ void main() {
     });
 
     test('publish check all packages', () async {
-      final Directory plugin1Dir = createFakePlugin('a');
-      final Directory plugin2Dir = createFakePlugin('b');
+      final Directory plugin1Dir = createFakePlugin('a', packagesDir);
+      final Directory plugin2Dir = createFakePlugin('b', packagesDir);
 
       processRunner.processesToReturn.add(
         MockProcess()..exitCodeCompleter.complete(0),
@@ -69,7 +69,7 @@ void main() {
     });
 
     test('fail on negative test', () async {
-      createFakePlugin('a');
+      createFakePlugin('a', packagesDir);
 
       final MockProcess process = MockProcess();
       process.stdoutController.close(); // ignore: unawaited_futures
@@ -85,7 +85,7 @@ void main() {
     });
 
     test('fail on bad pubspec', () async {
-      final Directory dir = createFakePlugin('c');
+      final Directory dir = createFakePlugin('c', packagesDir);
       await dir.childFile('pubspec.yaml').writeAsString('bad-yaml');
 
       final MockProcess process = MockProcess();
@@ -96,7 +96,7 @@ void main() {
     });
 
     test('pass on prerelease if --allow-pre-release flag is on', () async {
-      createFakePlugin('d');
+      createFakePlugin('d', packagesDir);
 
       const String preReleaseOutput = 'Package has 1 warning.'
           'Packages with an SDK constraint on a pre-release of the Dart SDK should themselves be published as a pre-release version.';
@@ -115,7 +115,7 @@ void main() {
     });
 
     test('fail on prerelease if --allow-pre-release flag is off', () async {
-      createFakePlugin('d');
+      createFakePlugin('d', packagesDir);
 
       const String preReleaseOutput = 'Package has 1 warning.'
           'Packages with an SDK constraint on a pre-release of the Dart SDK should themselves be published as a pre-release version.';
@@ -133,7 +133,7 @@ void main() {
     });
 
     test('Success message on stderr is not printed as an error', () async {
-      createFakePlugin('d');
+      createFakePlugin('d', packagesDir);
 
       const String publishOutput = 'Package has 0 warnings.';
 
@@ -190,9 +190,9 @@ void main() {
       runner.addCommand(command);
 
       final Directory plugin1Dir =
-          createFakePlugin('no_publish_a', includeVersion: true);
+          createFakePlugin('no_publish_a', packagesDir, includeVersion: true);
       final Directory plugin2Dir =
-          createFakePlugin('no_publish_b', includeVersion: true);
+          createFakePlugin('no_publish_b', packagesDir, includeVersion: true);
 
       createFakePubspec(plugin1Dir,
           name: 'no_publish_a', includeVersion: true, version: '0.1.0');
@@ -256,9 +256,9 @@ void main() {
       runner.addCommand(command);
 
       final Directory plugin1Dir =
-          createFakePlugin('no_publish_a', includeVersion: true);
+          createFakePlugin('no_publish_a', packagesDir, includeVersion: true);
       final Directory plugin2Dir =
-          createFakePlugin('no_publish_b', includeVersion: true);
+          createFakePlugin('no_publish_b', packagesDir, includeVersion: true);
 
       createFakePubspec(plugin1Dir,
           name: 'no_publish_a', includeVersion: true, version: '0.1.0');
@@ -325,9 +325,9 @@ void main() {
       runner.addCommand(command);
 
       final Directory plugin1Dir =
-          createFakePlugin('no_publish_a', includeVersion: true);
+          createFakePlugin('no_publish_a', packagesDir, includeVersion: true);
       final Directory plugin2Dir =
-          createFakePlugin('no_publish_b', includeVersion: true);
+          createFakePlugin('no_publish_b', packagesDir, includeVersion: true);
 
       createFakePubspec(plugin1Dir,
           name: 'no_publish_a', includeVersion: true, version: '0.1.0');

--- a/script/tool/test/publish_check_command_test.dart
+++ b/script/tool/test/publish_check_command_test.dart
@@ -10,6 +10,7 @@ import 'dart:io' as io;
 
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
+import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common.dart';
 import 'package:flutter_plugin_tools/src/publish_check_command.dart';
 import 'package:http/http.dart' as http;
@@ -21,11 +22,13 @@ import 'util.dart';
 
 void main() {
   group('$PublishCheckProcessRunner tests', () {
+    FileSystem fileSystem;
     PublishCheckProcessRunner processRunner;
     CommandRunner<void> runner;
 
     setUp(() {
-      initializeFakePackages();
+      fileSystem = MemoryFileSystem();
+      initializeFakePackages(parentDir: fileSystem.currentDirectory);
       processRunner = PublishCheckProcessRunner();
       final PublishCheckCommand publishCheckCommand =
           PublishCheckCommand(mockPackagesDir, processRunner: processRunner);

--- a/script/tool/test/publish_check_command_test.dart
+++ b/script/tool/test/publish_check_command_test.dart
@@ -23,25 +23,23 @@ import 'util.dart';
 void main() {
   group('$PublishCheckProcessRunner tests', () {
     FileSystem fileSystem;
+    Directory packagesDir;
     PublishCheckProcessRunner processRunner;
     CommandRunner<void> runner;
 
     setUp(() {
       fileSystem = MemoryFileSystem();
-      initializeFakePackages(parentDir: fileSystem.currentDirectory);
+      packagesDir =
+          initializeFakePackages(parentDir: fileSystem.currentDirectory);
       processRunner = PublishCheckProcessRunner();
       final PublishCheckCommand publishCheckCommand =
-          PublishCheckCommand(mockPackagesDir, processRunner: processRunner);
+          PublishCheckCommand(packagesDir, processRunner: processRunner);
 
       runner = CommandRunner<void>(
         'publish_check_command',
         'Test for publish-check command.',
       );
       runner.addCommand(publishCheckCommand);
-    });
-
-    tearDown(() {
-      mockPackagesDir.deleteSync(recursive: true);
     });
 
     test('publish check all packages', () async {
@@ -182,7 +180,7 @@ void main() {
         }
         return null;
       });
-      final PublishCheckCommand command = PublishCheckCommand(mockPackagesDir,
+      final PublishCheckCommand command = PublishCheckCommand(packagesDir,
           processRunner: processRunner, httpClient: mockClient);
 
       runner = CommandRunner<void>(
@@ -248,7 +246,7 @@ void main() {
         }
         return null;
       });
-      final PublishCheckCommand command = PublishCheckCommand(mockPackagesDir,
+      final PublishCheckCommand command = PublishCheckCommand(packagesDir,
           processRunner: processRunner, httpClient: mockClient);
 
       runner = CommandRunner<void>(
@@ -317,7 +315,7 @@ void main() {
         }
         return null;
       });
-      final PublishCheckCommand command = PublishCheckCommand(mockPackagesDir,
+      final PublishCheckCommand command = PublishCheckCommand(packagesDir,
           processRunner: processRunner, httpClient: mockClient);
 
       runner = CommandRunner<void>(

--- a/script/tool/test/publish_check_command_test.dart
+++ b/script/tool/test/publish_check_command_test.dart
@@ -29,8 +29,7 @@ void main() {
 
     setUp(() {
       fileSystem = MemoryFileSystem();
-      packagesDir =
-          initializeFakePackages(parentDir: fileSystem.currentDirectory);
+      packagesDir = createPackagesDirectory(fileSystem: fileSystem);
       processRunner = PublishCheckProcessRunner();
       final PublishCheckCommand publishCheckCommand =
           PublishCheckCommand(packagesDir, processRunner: processRunner);

--- a/script/tool/test/publish_plugin_command_test.dart
+++ b/script/tool/test/publish_plugin_command_test.dart
@@ -50,8 +50,8 @@ void main() {
     // use a fully resolved version to avoid potential path comparison issues.
     testRoot = fileSystem.directory(testRoot.resolveSymbolicLinksSync());
     packagesDir = initializeFakePackages(parentDir: testRoot);
-    pluginDir = createFakePlugin(testPluginName,
-        withSingleExample: false, packagesDirectory: packagesDir);
+    pluginDir =
+        createFakePlugin(testPluginName, packagesDir, withSingleExample: false);
     assert(pluginDir != null && pluginDir.existsSync());
     createFakePubspec(pluginDir, includeVersion: true);
     io.Process.runSync('git', <String>['init'],
@@ -425,13 +425,11 @@ void main() {
 
     test('can release newly created plugins', () async {
       // Non-federated
-      final Directory pluginDir1 = createFakePlugin('plugin1',
-          withSingleExample: true, packagesDirectory: packagesDir);
+      final Directory pluginDir1 =
+          createFakePlugin('plugin1', packagesDir, withSingleExample: true);
       // federated
-      final Directory pluginDir2 = createFakePlugin('plugin2',
-          withSingleExample: true,
-          parentDirectoryName: 'plugin2',
-          packagesDirectory: packagesDir);
+      final Directory pluginDir2 = createFakePlugin('plugin2', packagesDir,
+          withSingleExample: true, parentDirectoryName: 'plugin2');
       createFakePubspec(pluginDir1,
           name: 'plugin1',
           includeVersion: true,
@@ -472,8 +470,8 @@ void main() {
     test('can release newly created plugins, while there are existing plugins',
         () async {
       // Prepare an exiting plugin and tag it
-      final Directory pluginDir0 = createFakePlugin('plugin0',
-          withSingleExample: true, packagesDirectory: packagesDir);
+      final Directory pluginDir0 =
+          createFakePlugin('plugin0', packagesDir, withSingleExample: true);
       createFakePubspec(pluginDir0,
           name: 'plugin0',
           includeVersion: true,
@@ -489,13 +487,11 @@ void main() {
       processRunner.pushTagsArgs.clear();
 
       // Non-federated
-      final Directory pluginDir1 = createFakePlugin('plugin1',
-          withSingleExample: true, packagesDirectory: packagesDir);
+      final Directory pluginDir1 =
+          createFakePlugin('plugin1', packagesDir, withSingleExample: true);
       // federated
-      final Directory pluginDir2 = createFakePlugin('plugin2',
-          withSingleExample: true,
-          parentDirectoryName: 'plugin2',
-          packagesDirectory: packagesDir);
+      final Directory pluginDir2 = createFakePlugin('plugin2', packagesDir,
+          withSingleExample: true, parentDirectoryName: 'plugin2');
       createFakePubspec(pluginDir1,
           name: 'plugin1',
           includeVersion: true,
@@ -533,13 +529,11 @@ void main() {
 
     test('can release newly created plugins, dry run', () async {
       // Non-federated
-      final Directory pluginDir1 = createFakePlugin('plugin1',
-          withSingleExample: true, packagesDirectory: packagesDir);
+      final Directory pluginDir1 =
+          createFakePlugin('plugin1', packagesDir, withSingleExample: true);
       // federated
-      final Directory pluginDir2 = createFakePlugin('plugin2',
-          withSingleExample: true,
-          parentDirectoryName: 'plugin2',
-          packagesDirectory: packagesDir);
+      final Directory pluginDir2 = createFakePlugin('plugin2', packagesDir,
+          withSingleExample: true, parentDirectoryName: 'plugin2');
       createFakePubspec(pluginDir1,
           name: 'plugin1',
           includeVersion: true,
@@ -582,13 +576,11 @@ void main() {
 
     test('version change triggers releases.', () async {
       // Non-federated
-      final Directory pluginDir1 = createFakePlugin('plugin1',
-          withSingleExample: true, packagesDirectory: packagesDir);
+      final Directory pluginDir1 =
+          createFakePlugin('plugin1', packagesDir, withSingleExample: true);
       // federated
-      final Directory pluginDir2 = createFakePlugin('plugin2',
-          withSingleExample: true,
-          parentDirectoryName: 'plugin2',
-          packagesDirectory: packagesDir);
+      final Directory pluginDir2 = createFakePlugin('plugin2', packagesDir,
+          withSingleExample: true, parentDirectoryName: 'plugin2');
       createFakePubspec(pluginDir1,
           name: 'plugin1',
           includeVersion: true,
@@ -673,13 +665,11 @@ void main() {
         'delete package will not trigger publish but exit the command successfully.',
         () async {
       // Non-federated
-      final Directory pluginDir1 = createFakePlugin('plugin1',
-          withSingleExample: true, packagesDirectory: packagesDir);
+      final Directory pluginDir1 =
+          createFakePlugin('plugin1', packagesDir, withSingleExample: true);
       // federated
-      final Directory pluginDir2 = createFakePlugin('plugin2',
-          withSingleExample: true,
-          parentDirectoryName: 'plugin2',
-          packagesDirectory: packagesDir);
+      final Directory pluginDir2 = createFakePlugin('plugin2', packagesDir,
+          withSingleExample: true, parentDirectoryName: 'plugin2');
       createFakePubspec(pluginDir1,
           name: 'plugin1',
           includeVersion: true,
@@ -761,13 +751,11 @@ void main() {
         'versions revert do not trigger releases. Also prints out warning message.',
         () async {
       // Non-federated
-      final Directory pluginDir1 = createFakePlugin('plugin1',
-          withSingleExample: true, packagesDirectory: packagesDir);
+      final Directory pluginDir1 =
+          createFakePlugin('plugin1', packagesDir, withSingleExample: true);
       // federated
-      final Directory pluginDir2 = createFakePlugin('plugin2',
-          withSingleExample: true,
-          parentDirectoryName: 'plugin2',
-          packagesDirectory: packagesDir);
+      final Directory pluginDir2 = createFakePlugin('plugin2', packagesDir,
+          withSingleExample: true, parentDirectoryName: 'plugin2');
       createFakePubspec(pluginDir1,
           name: 'plugin1',
           includeVersion: true,
@@ -843,13 +831,11 @@ void main() {
 
     test('No version change does not release any plugins', () async {
       // Non-federated
-      final Directory pluginDir1 = createFakePlugin('plugin1',
-          withSingleExample: true, packagesDirectory: packagesDir);
+      final Directory pluginDir1 =
+          createFakePlugin('plugin1', packagesDir, withSingleExample: true);
       // federated
-      final Directory pluginDir2 = createFakePlugin('plugin2',
-          withSingleExample: true,
-          parentDirectoryName: 'plugin2',
-          packagesDirectory: packagesDir);
+      final Directory pluginDir2 = createFakePlugin('plugin2', packagesDir,
+          withSingleExample: true, parentDirectoryName: 'plugin2');
       createFakePubspec(pluginDir1,
           name: 'plugin1',
           includeVersion: true,

--- a/script/tool/test/publish_plugin_command_test.dart
+++ b/script/tool/test/publish_plugin_command_test.dart
@@ -70,6 +70,10 @@ void main() {
           gitDir: gitDir));
   });
 
+  tearDown(() {
+    testRoot.deleteSync(recursive: true);
+  });
+
   group('Initial validation', () {
     test('requires a package flag', () async {
       await expectLater(() => commandRunner.run(<String>['publish-plugin']),

--- a/script/tool/test/publish_plugin_command_test.dart
+++ b/script/tool/test/publish_plugin_command_test.dart
@@ -49,7 +49,7 @@ void main() {
     // The temp directory can have symbolic links, which won't match git output;
     // use a fully resolved version to avoid potential path comparison issues.
     testRoot = fileSystem.directory(testRoot.resolveSymbolicLinksSync());
-    packagesDir = initializeFakePackages(parentDir: testRoot);
+    packagesDir = createPackagesDirectory(parentDir: testRoot);
     pluginDir =
         createFakePlugin(testPluginName, packagesDir, withSingleExample: false);
     assert(pluginDir != null && pluginDir.existsSync());

--- a/script/tool/test/publish_plugin_command_test.dart
+++ b/script/tool/test/publish_plugin_command_test.dart
@@ -70,10 +70,6 @@ void main() {
           gitDir: gitDir));
   });
 
-  tearDown(() {
-    testRoot.deleteSync(recursive: true);
-  });
-
   group('Initial validation', () {
     test('requires a package flag', () async {
       await expectLater(() => commandRunner.run(<String>['publish-plugin']),

--- a/script/tool/test/pubspec_check_command_test.dart
+++ b/script/tool/test/pubspec_check_command_test.dart
@@ -88,8 +88,8 @@ dev_dependencies:
     }
 
     test('passes for a plugin following conventions', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
-          withSingleExample: true, packagesDirectory: packagesDir);
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, withSingleExample: true);
 
       pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
 ${headerSection('plugin', isPlugin: true)}
@@ -114,8 +114,8 @@ ${devDependenciesSection()}
     });
 
     test('passes for a Flutter package following conventions', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
-          withSingleExample: true, packagesDirectory: packagesDir);
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, withSingleExample: true);
 
       pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
 ${headerSection('plugin')}
@@ -163,8 +163,8 @@ ${dependenciesSection()}
     });
 
     test('fails when homepage is included', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
-          withSingleExample: true, packagesDirectory: packagesDir);
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, withSingleExample: true);
 
       pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
 ${headerSection('plugin', isPlugin: true, includeHomepage: true)}
@@ -184,8 +184,8 @@ ${devDependenciesSection()}
     });
 
     test('fails when repository is missing', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
-          withSingleExample: true, packagesDirectory: packagesDir);
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, withSingleExample: true);
 
       pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
 ${headerSection('plugin', isPlugin: true, includeRepository: false)}
@@ -205,8 +205,8 @@ ${devDependenciesSection()}
     });
 
     test('fails when homepage is given instead of repository', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
-          withSingleExample: true, packagesDirectory: packagesDir);
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, withSingleExample: true);
 
       pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
 ${headerSection('plugin', isPlugin: true, includeHomepage: true, includeRepository: false)}
@@ -226,8 +226,8 @@ ${devDependenciesSection()}
     });
 
     test('fails when issue tracker is missing', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
-          withSingleExample: true, packagesDirectory: packagesDir);
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, withSingleExample: true);
 
       pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
 ${headerSection('plugin', isPlugin: true, includeIssueTracker: false)}
@@ -247,8 +247,8 @@ ${devDependenciesSection()}
     });
 
     test('fails when environment section is out of order', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
-          withSingleExample: true, packagesDirectory: packagesDir);
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, withSingleExample: true);
 
       pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
 ${headerSection('plugin', isPlugin: true)}
@@ -268,8 +268,8 @@ ${environmentSection()}
     });
 
     test('fails when flutter section is out of order', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
-          withSingleExample: true, packagesDirectory: packagesDir);
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, withSingleExample: true);
 
       pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
 ${headerSection('plugin', isPlugin: true)}
@@ -289,8 +289,8 @@ ${devDependenciesSection()}
     });
 
     test('fails when dependencies section is out of order', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
-          withSingleExample: true, packagesDirectory: packagesDir);
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, withSingleExample: true);
 
       pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
 ${headerSection('plugin', isPlugin: true)}
@@ -310,8 +310,8 @@ ${dependenciesSection()}
     });
 
     test('fails when devDependencies section is out of order', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
-          withSingleExample: true, packagesDirectory: packagesDir);
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, withSingleExample: true);
 
       pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
 ${headerSection('plugin', isPlugin: true)}

--- a/script/tool/test/pubspec_check_command_test.dart
+++ b/script/tool/test/pubspec_check_command_test.dart
@@ -21,7 +21,7 @@ void main() {
     setUp(() {
       fileSystem = MemoryFileSystem();
       packagesDir = fileSystem.currentDirectory.childDirectory('packages');
-      initializeFakePackages(parentDir: packagesDir.parent);
+      createPackagesDirectory(parentDir: packagesDir.parent);
       processRunner = RecordingProcessRunner();
       final PubspecCheckCommand command =
           PubspecCheckCommand(packagesDir, processRunner: processRunner);

--- a/script/tool/test/test_command_test.dart
+++ b/script/tool/test/test_command_test.dart
@@ -13,12 +13,13 @@ import 'util.dart';
 void main() {
   group('$TestCommand', () {
     late FileSystem fileSystem;
+    late Directory packagesDir;
     late CommandRunner<void> runner;
     late RecordingProcessRunner processRunner;
 
     setUp(() {
       fileSystem = MemoryFileSystem();
-      final Directory packagesDir =
+      packagesDir =
           initializeFakePackages(parentDir: fileSystem.currentDirectory);
       processRunner = RecordingProcessRunner();
       final TestCommand command =
@@ -29,14 +30,14 @@ void main() {
     });
 
     test('runs flutter test on each plugin', () async {
-      final Directory plugin1Dir =
-          createFakePlugin('plugin1', withExtraFiles: <List<String>>[
-        <String>['test', 'empty_test.dart'],
-      ]);
-      final Directory plugin2Dir =
-          createFakePlugin('plugin2', withExtraFiles: <List<String>>[
-        <String>['test', 'empty_test.dart'],
-      ]);
+      final Directory plugin1Dir = createFakePlugin('plugin1', packagesDir,
+          withExtraFiles: <List<String>>[
+            <String>['test', 'empty_test.dart'],
+          ]);
+      final Directory plugin2Dir = createFakePlugin('plugin2', packagesDir,
+          withExtraFiles: <List<String>>[
+            <String>['test', 'empty_test.dart'],
+          ]);
 
       await runner.run(<String>['test']);
 
@@ -52,11 +53,11 @@ void main() {
     });
 
     test('skips testing plugins without test directory', () async {
-      createFakePlugin('plugin1');
-      final Directory plugin2Dir =
-          createFakePlugin('plugin2', withExtraFiles: <List<String>>[
-        <String>['test', 'empty_test.dart'],
-      ]);
+      createFakePlugin('plugin1', packagesDir);
+      final Directory plugin2Dir = createFakePlugin('plugin2', packagesDir,
+          withExtraFiles: <List<String>>[
+            <String>['test', 'empty_test.dart'],
+          ]);
 
       await runner.run(<String>['test']);
 
@@ -70,12 +71,12 @@ void main() {
     });
 
     test('runs pub run test on non-Flutter packages', () async {
-      final Directory plugin1Dir = createFakePlugin('plugin1',
+      final Directory plugin1Dir = createFakePlugin('plugin1', packagesDir,
           isFlutter: true,
           withExtraFiles: <List<String>>[
             <String>['test', 'empty_test.dart'],
           ]);
-      final Directory plugin2Dir = createFakePlugin('plugin2',
+      final Directory plugin2Dir = createFakePlugin('plugin2', packagesDir,
           isFlutter: false,
           withExtraFiles: <List<String>>[
             <String>['test', 'empty_test.dart'],
@@ -102,6 +103,7 @@ void main() {
     test('runs on Chrome for web plugins', () async {
       final Directory pluginDir = createFakePlugin(
         'plugin',
+        packagesDir,
         withExtraFiles: <List<String>>[
           <String>['test', 'empty_test.dart'],
         ],
@@ -123,12 +125,12 @@ void main() {
     });
 
     test('enable-experiment flag', () async {
-      final Directory plugin1Dir = createFakePlugin('plugin1',
+      final Directory plugin1Dir = createFakePlugin('plugin1', packagesDir,
           isFlutter: true,
           withExtraFiles: <List<String>>[
             <String>['test', 'empty_test.dart'],
           ]);
-      final Directory plugin2Dir = createFakePlugin('plugin2',
+      final Directory plugin2Dir = createFakePlugin('plugin2', packagesDir,
           isFlutter: false,
           withExtraFiles: <List<String>>[
             <String>['test', 'empty_test.dart'],

--- a/script/tool/test/test_command_test.dart
+++ b/script/tool/test/test_command_test.dart
@@ -18,9 +18,10 @@ void main() {
 
     setUp(() {
       fileSystem = MemoryFileSystem();
-      initializeFakePackages(parentDir: fileSystem.currentDirectory);
+      final Directory packagesDir =
+          initializeFakePackages(parentDir: fileSystem.currentDirectory);
       final TestCommand command =
-          TestCommand(mockPackagesDir, processRunner: processRunner);
+          TestCommand(packagesDir, processRunner: processRunner);
 
       runner = CommandRunner<void>('test_test', 'Test for $TestCommand');
       runner.addCommand(command);

--- a/script/tool/test/test_command_test.dart
+++ b/script/tool/test/test_command_test.dart
@@ -14,21 +14,18 @@ void main() {
   group('$TestCommand', () {
     late FileSystem fileSystem;
     late CommandRunner<void> runner;
-    final RecordingProcessRunner processRunner = RecordingProcessRunner();
+    late RecordingProcessRunner processRunner;
 
     setUp(() {
       fileSystem = MemoryFileSystem();
       final Directory packagesDir =
           initializeFakePackages(parentDir: fileSystem.currentDirectory);
+      processRunner = RecordingProcessRunner();
       final TestCommand command =
           TestCommand(packagesDir, processRunner: processRunner);
 
       runner = CommandRunner<void>('test_test', 'Test for $TestCommand');
       runner.addCommand(command);
-    });
-
-    tearDown(() {
-      processRunner.recordedCalls.clear();
     });
 
     test('runs flutter test on each plugin', () async {

--- a/script/tool/test/test_command_test.dart
+++ b/script/tool/test/test_command_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
+import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/test_command.dart';
 import 'package:test/test.dart';
 
@@ -11,11 +12,13 @@ import 'util.dart';
 
 void main() {
   group('$TestCommand', () {
+    late FileSystem fileSystem;
     late CommandRunner<void> runner;
     final RecordingProcessRunner processRunner = RecordingProcessRunner();
 
     setUp(() {
-      initializeFakePackages();
+      fileSystem = MemoryFileSystem();
+      initializeFakePackages(parentDir: fileSystem.currentDirectory);
       final TestCommand command =
           TestCommand(mockPackagesDir, processRunner: processRunner);
 
@@ -24,7 +27,6 @@ void main() {
     });
 
     tearDown(() {
-      cleanupPackages();
       processRunner.recordedCalls.clear();
     });
 
@@ -49,8 +51,6 @@ void main() {
               'flutter', const <String>['test', '--color'], plugin2Dir.path),
         ]),
       );
-
-      cleanupPackages();
     });
 
     test('skips testing plugins without test directory', () async {
@@ -69,8 +69,6 @@ void main() {
               'flutter', const <String>['test', '--color'], plugin2Dir.path),
         ]),
       );
-
-      cleanupPackages();
     });
 
     test('runs pub run test on non-Flutter packages', () async {
@@ -101,8 +99,6 @@ void main() {
               plugin2Dir.path),
         ]),
       );
-
-      cleanupPackages();
     });
 
     test('runs on Chrome for web plugins', () async {
@@ -156,8 +152,6 @@ void main() {
               plugin2Dir.path),
         ]),
       );
-
-      cleanupPackages();
     });
   });
 }

--- a/script/tool/test/test_command_test.dart
+++ b/script/tool/test/test_command_test.dart
@@ -19,8 +19,7 @@ void main() {
 
     setUp(() {
       fileSystem = MemoryFileSystem();
-      packagesDir =
-          initializeFakePackages(parentDir: fileSystem.currentDirectory);
+      packagesDir = createPackagesDirectory(fileSystem: fileSystem);
       processRunner = RecordingProcessRunner();
       final TestCommand command =
           TestCommand(packagesDir, processRunner: processRunner);

--- a/script/tool/test/util.dart
+++ b/script/tool/test/util.dart
@@ -13,9 +13,6 @@ import 'package:flutter_plugin_tools/src/common.dart';
 import 'package:meta/meta.dart';
 import 'package:quiver/collection.dart';
 
-// TODO(stuartmorgan): Eliminate this in favor of a local variable in each test.
-late Directory mockPackagesDir;
-
 /// Creates a mock packages directory in the mock file system.
 ///
 /// If [parentDir] is set the mock packages dir will be creates as a child of
@@ -24,10 +21,10 @@ late Directory mockPackagesDir;
 Directory initializeFakePackages(
     {Directory? parentDir, MemoryFileSystem? fileSystem}) {
   assert(parentDir != null || fileSystem != null);
-  mockPackagesDir =
+  final Directory packagesDir =
       (parentDir ?? fileSystem!.currentDirectory).childDirectory('packages');
-  mockPackagesDir.createSync();
-  return mockPackagesDir;
+  packagesDir.createSync();
+  return packagesDir;
 }
 
 /// Creates a plugin package with the given [name] in [packagesDirectory].

--- a/script/tool/test/util.dart
+++ b/script/tool/test/util.dart
@@ -11,26 +11,23 @@ import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common.dart';
 import 'package:meta/meta.dart';
-import 'package:platform/platform.dart';
 import 'package:quiver/collection.dart';
 
-// TODO(stuartmorgan): Eliminate this in favor of setting up a clean filesystem
-// for each test, to eliminate the chance of files from one test interfering
-// with another test.
-FileSystem mockFileSystem = MemoryFileSystem(
-    style: const LocalPlatform().isWindows
-        ? FileSystemStyle.windows
-        : FileSystemStyle.posix);
+// TODO(stuartmorgan): Eliminate this in favor of a local variable in each test.
 late Directory mockPackagesDir;
 
 /// Creates a mock packages directory in the mock file system.
 ///
 /// If [parentDir] is set the mock packages dir will be creates as a child of
-/// it. If not [mockFileSystem] will be used instead.
-void initializeFakePackages({Directory? parentDir}) {
+/// it. If not [fileSystem] will be used instead.
+/// TODO(stuartmorgan): Remove fileSystem argument and make parentDir required.
+Directory initializeFakePackages(
+    {Directory? parentDir, MemoryFileSystem? fileSystem}) {
+  assert(parentDir != null || fileSystem != null);
   mockPackagesDir =
-      (parentDir ?? mockFileSystem.currentDirectory).childDirectory('packages');
+      (parentDir ?? fileSystem!.currentDirectory).childDirectory('packages');
   mockPackagesDir.createSync();
+  return mockPackagesDir;
 }
 
 /// Creates a plugin package with the given [name] in [packagesDirectory],
@@ -196,13 +193,6 @@ publish_to: $publishTo # Hardcoded safeguard to prevent this from somehow being 
 ''';
   }
   parent.childFile('pubspec.yaml').writeAsStringSync(yaml);
-}
-
-/// Cleans up the mock packages directory, making it an empty directory again.
-void cleanupPackages() {
-  mockPackagesDir.listSync().forEach((FileSystemEntity entity) {
-    entity.deleteSync(recursive: true);
-  });
 }
 
 typedef _ErrorHandler = void Function(Error error);

--- a/script/tool/test/util.dart
+++ b/script/tool/test/util.dart
@@ -13,14 +13,17 @@ import 'package:flutter_plugin_tools/src/common.dart';
 import 'package:meta/meta.dart';
 import 'package:quiver/collection.dart';
 
-/// Creates a mock packages directory in the mock file system.
+/// Creates a packages directory in the given location.
 ///
-/// If [parentDir] is set the mock packages dir will be creates as a child of
-/// it. If not [fileSystem] will be used instead.
-/// TODO(stuartmorgan): Remove fileSystem argument and make parentDir required.
-Directory initializeFakePackages(
-    {Directory? parentDir, MemoryFileSystem? fileSystem}) {
-  assert(parentDir != null || fileSystem != null);
+/// If [parentDir] is set the packages directory will be created there,
+/// otherwise [fileSystem] must be provided and it will be created an arbitrary
+/// location in that filesystem.
+Directory createPackagesDirectory(
+    {Directory? parentDir, FileSystem? fileSystem}) {
+  assert(parentDir != null || fileSystem != null,
+      'One of parentDir or fileSystem must be provided');
+  assert(fileSystem == null || fileSystem is MemoryFileSystem,
+      'If using a real filesystem, parentDir must be provided');
   final Directory packagesDir =
       (parentDir ?? fileSystem!.currentDirectory).childDirectory('packages');
   packagesDir.createSync();

--- a/script/tool/test/util.dart
+++ b/script/tool/test/util.dart
@@ -30,10 +30,10 @@ Directory initializeFakePackages(
   return mockPackagesDir;
 }
 
-/// Creates a plugin package with the given [name] in [packagesDirectory],
-/// defaulting to [mockPackagesDir].
+/// Creates a plugin package with the given [name] in [packagesDirectory].
 Directory createFakePlugin(
-  String name, {
+  String name,
+  Directory packagesDirectory, {
   bool withSingleExample = false,
   List<String> withExamples = const <String>[],
   List<List<String>> withExtraFiles = const <List<String>>[],
@@ -48,12 +48,11 @@ Directory createFakePlugin(
   bool includeVersion = false,
   String version = '0.0.1',
   String parentDirectoryName = '',
-  Directory? packagesDirectory,
 }) {
   assert(!(withSingleExample && withExamples.isNotEmpty),
       'cannot pass withSingleExample and withExamples simultaneously');
 
-  Directory parentDirectory = packagesDirectory ?? mockPackagesDir;
+  Directory parentDirectory = packagesDirectory;
   if (parentDirectoryName != '') {
     parentDirectory = parentDirectory.childDirectory(parentDirectoryName);
   }

--- a/script/tool/test/version_check_test.dart
+++ b/script/tool/test/version_check_test.dart
@@ -93,7 +93,7 @@ void main() {
         return Future<io.ProcessResult>.value(mockProcessResult);
       });
       processRunner = RecordingProcessRunner();
-      final VersionCheckCommand command = VersionCheckCommand(mockPackagesDir,
+      final VersionCheckCommand command = VersionCheckCommand(packagesDir,
           processRunner: processRunner, gitDir: gitDir);
 
       runner = CommandRunner<void>(
@@ -327,10 +327,8 @@ void main() {
 
     test('Allow empty lines in front of the first version in CHANGELOG',
         () async {
-      createFakePlugin('plugin', includeChangeLog: true, includeVersion: true);
-
-      final Directory pluginDirectory =
-          mockPackagesDir.childDirectory('plugin');
+      final Directory pluginDirectory = createFakePlugin('plugin',
+          includeChangeLog: true, includeVersion: true);
 
       createFakePubspec(pluginDirectory,
           isFlutter: true, includeVersion: true, version: '1.0.1');
@@ -356,10 +354,8 @@ void main() {
     });
 
     test('Throws if versions in changelog and pubspec do not match', () async {
-      createFakePlugin('plugin', includeChangeLog: true, includeVersion: true);
-
-      final Directory pluginDirectory =
-          mockPackagesDir.childDirectory('plugin');
+      final Directory pluginDirectory = createFakePlugin('plugin',
+          includeChangeLog: true, includeVersion: true);
 
       createFakePubspec(pluginDirectory,
           isFlutter: true, includeVersion: true, version: '1.0.1');
@@ -393,10 +389,8 @@ The first version listed in CHANGELOG.md is 1.0.2.
     });
 
     test('Success if CHANGELOG and pubspec versions match', () async {
-      createFakePlugin('plugin', includeChangeLog: true, includeVersion: true);
-
-      final Directory pluginDirectory =
-          mockPackagesDir.childDirectory('plugin');
+      final Directory pluginDirectory = createFakePlugin('plugin',
+          includeChangeLog: true, includeVersion: true);
 
       createFakePubspec(pluginDirectory,
           isFlutter: true, includeVersion: true, version: '1.0.1');
@@ -421,10 +415,8 @@ The first version listed in CHANGELOG.md is 1.0.2.
     test(
         'Fail if pubspec version only matches an older version listed in CHANGELOG',
         () async {
-      createFakePlugin('plugin', includeChangeLog: true, includeVersion: true);
-
-      final Directory pluginDirectory =
-          mockPackagesDir.childDirectory('plugin');
+      final Directory pluginDirectory = createFakePlugin('plugin',
+          includeChangeLog: true, includeVersion: true);
 
       createFakePubspec(pluginDirectory,
           isFlutter: true, includeVersion: true, version: '1.0.0');
@@ -465,10 +457,8 @@ The first version listed in CHANGELOG.md is 1.0.1.
 
     test('Allow NEXT as a placeholder for gathering CHANGELOG entries',
         () async {
-      createFakePlugin('plugin', includeChangeLog: true, includeVersion: true);
-
-      final Directory pluginDirectory =
-          mockPackagesDir.childDirectory('plugin');
+      final Directory pluginDirectory = createFakePlugin('plugin',
+          includeChangeLog: true, includeVersion: true);
 
       createFakePubspec(pluginDirectory,
           isFlutter: true, includeVersion: true, version: '1.0.0');
@@ -496,10 +486,8 @@ The first version listed in CHANGELOG.md is 1.0.1.
 
     test('Fail if NEXT is left in the CHANGELOG when adding a version bump',
         () async {
-      createFakePlugin('plugin', includeChangeLog: true, includeVersion: true);
-
-      final Directory pluginDirectory =
-          mockPackagesDir.childDirectory('plugin');
+      final Directory pluginDirectory = createFakePlugin('plugin',
+          includeChangeLog: true, includeVersion: true);
 
       createFakePubspec(pluginDirectory,
           isFlutter: true, includeVersion: true, version: '1.0.1');
@@ -542,10 +530,8 @@ into the new version's release notes.
     });
 
     test('Fail if the version changes without replacing NEXT', () async {
-      createFakePlugin('plugin', includeChangeLog: true, includeVersion: true);
-
-      final Directory pluginDirectory =
-          mockPackagesDir.childDirectory('plugin');
+      final Directory pluginDirectory = createFakePlugin('plugin',
+          includeChangeLog: true, includeVersion: true);
 
       createFakePubspec(pluginDirectory,
           isFlutter: true, includeVersion: true, version: '1.0.1');
@@ -597,7 +583,7 @@ The first version listed in CHANGELOG.md is 1.0.0.
       final MockClient mockClient = MockClient((http.Request request) async {
         return http.Response(json.encode(httpResponse), 200);
       });
-      final VersionCheckCommand command = VersionCheckCommand(mockPackagesDir,
+      final VersionCheckCommand command = VersionCheckCommand(packagesDir,
           processRunner: processRunner, gitDir: gitDir, httpClient: mockClient);
 
       runner = CommandRunner<void>(
@@ -633,7 +619,7 @@ The first version listed in CHANGELOG.md is 1.0.0.
       final MockClient mockClient = MockClient((http.Request request) async {
         return http.Response(json.encode(httpResponse), 200);
       });
-      final VersionCheckCommand command = VersionCheckCommand(mockPackagesDir,
+      final VersionCheckCommand command = VersionCheckCommand(packagesDir,
           processRunner: processRunner, gitDir: gitDir, httpClient: mockClient);
 
       runner = CommandRunner<void>(
@@ -677,7 +663,7 @@ ${indentation}Allowed versions: {1.0.0: NextVersionType.BREAKING_MAJOR, 0.1.0: N
       final MockClient mockClient = MockClient((http.Request request) async {
         return http.Response('xx', 400);
       });
-      final VersionCheckCommand command = VersionCheckCommand(mockPackagesDir,
+      final VersionCheckCommand command = VersionCheckCommand(packagesDir,
           processRunner: processRunner, gitDir: gitDir, httpClient: mockClient);
 
       runner = CommandRunner<void>(
@@ -720,7 +706,7 @@ ${indentation}HTTP response: xx
       final MockClient mockClient = MockClient((http.Request request) async {
         return http.Response('xx', 404);
       });
-      final VersionCheckCommand command = VersionCheckCommand(mockPackagesDir,
+      final VersionCheckCommand command = VersionCheckCommand(packagesDir,
           processRunner: processRunner, gitDir: gitDir, httpClient: mockClient);
 
       runner = CommandRunner<void>(

--- a/script/tool/test/version_check_test.dart
+++ b/script/tool/test/version_check_test.dart
@@ -67,8 +67,7 @@ void main() {
 
     setUp(() {
       fileSystem = MemoryFileSystem();
-      packagesDir =
-          initializeFakePackages(parentDir: fileSystem.currentDirectory);
+      packagesDir = createPackagesDirectory(fileSystem: fileSystem);
       gitDirCommands = <List<String>>[];
       gitDiffResponse = '';
       gitShowResponses = <String, String>{};

--- a/script/tool/test/version_check_test.dart
+++ b/script/tool/test/version_check_test.dart
@@ -10,6 +10,7 @@ import 'dart:io' as io;
 
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
+import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common.dart';
 import 'package:flutter_plugin_tools/src/version_check_command.dart';
 import 'package:git/git.dart';
@@ -55,6 +56,8 @@ String _redColorString(String string) {
 void main() {
   const String indentation = '  ';
   group('$VersionCheckCommand', () {
+    FileSystem fileSystem;
+    Directory packagesDir;
     CommandRunner<void> runner;
     RecordingProcessRunner processRunner;
     List<List<String>> gitDirCommands;
@@ -63,6 +66,9 @@ void main() {
     MockGitDir gitDir;
 
     setUp(() {
+      fileSystem = MemoryFileSystem();
+      packagesDir =
+          initializeFakePackages(parentDir: fileSystem.currentDirectory);
       gitDirCommands = <List<String>>[];
       gitDiffResponse = '';
       gitShowResponses = <String, String>{};
@@ -86,7 +92,6 @@ void main() {
         }
         return Future<io.ProcessResult>.value(mockProcessResult);
       });
-      initializeFakePackages();
       processRunner = RecordingProcessRunner();
       final VersionCheckCommand command = VersionCheckCommand(mockPackagesDir,
           processRunner: processRunner, gitDir: gitDir);
@@ -94,10 +99,6 @@ void main() {
       runner = CommandRunner<void>(
           'version_check_command', 'Test for $VersionCheckCommand');
       runner.addCommand(command);
-    });
-
-    tearDown(() {
-      cleanupPackages();
     });
 
     test('allows valid version', () async {

--- a/script/tool/test/version_check_test.dart
+++ b/script/tool/test/version_check_test.dart
@@ -102,7 +102,8 @@ void main() {
     });
 
     test('allows valid version', () async {
-      createFakePlugin('plugin', includeChangeLog: true, includeVersion: true);
+      createFakePlugin('plugin', packagesDir,
+          includeChangeLog: true, includeVersion: true);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'master:packages/plugin/pubspec.yaml': 'version: 1.0.0',
@@ -128,7 +129,8 @@ void main() {
     });
 
     test('denies invalid version', () async {
-      createFakePlugin('plugin', includeChangeLog: true, includeVersion: true);
+      createFakePlugin('plugin', packagesDir,
+          includeChangeLog: true, includeVersion: true);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'master:packages/plugin/pubspec.yaml': 'version: 0.0.1',
@@ -152,7 +154,8 @@ void main() {
     });
 
     test('allows valid version without explicit base-sha', () async {
-      createFakePlugin('plugin', includeChangeLog: true, includeVersion: true);
+      createFakePlugin('plugin', packagesDir,
+          includeChangeLog: true, includeVersion: true);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'abc123:packages/plugin/pubspec.yaml': 'version: 1.0.0',
@@ -170,7 +173,8 @@ void main() {
     });
 
     test('allows valid version for new package.', () async {
-      createFakePlugin('plugin', includeChangeLog: true, includeVersion: true);
+      createFakePlugin('plugin', packagesDir,
+          includeChangeLog: true, includeVersion: true);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'HEAD:packages/plugin/pubspec.yaml': 'version: 1.0.0',
@@ -188,7 +192,8 @@ void main() {
     });
 
     test('allows likely reverts.', () async {
-      createFakePlugin('plugin', includeChangeLog: true, includeVersion: true);
+      createFakePlugin('plugin', packagesDir,
+          includeChangeLog: true, includeVersion: true);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'abc123:packages/plugin/pubspec.yaml': 'version: 0.6.2',
@@ -206,7 +211,8 @@ void main() {
     });
 
     test('denies lower version that could not be a simple revert', () async {
-      createFakePlugin('plugin', includeChangeLog: true, includeVersion: true);
+      createFakePlugin('plugin', packagesDir,
+          includeChangeLog: true, includeVersion: true);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'abc123:packages/plugin/pubspec.yaml': 'version: 0.6.2',
@@ -222,7 +228,8 @@ void main() {
     });
 
     test('denies invalid version without explicit base-sha', () async {
-      createFakePlugin('plugin', includeChangeLog: true, includeVersion: true);
+      createFakePlugin('plugin', packagesDir,
+          includeChangeLog: true, includeVersion: true);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'abc123:packages/plugin/pubspec.yaml': 'version: 0.0.1',
@@ -238,7 +245,7 @@ void main() {
     });
 
     test('gracefully handles missing pubspec.yaml', () async {
-      final Directory pluginDir = createFakePlugin('plugin',
+      final Directory pluginDir = createFakePlugin('plugin', packagesDir,
           includeChangeLog: true, includeVersion: true);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       pluginDir.childFile('pubspec.yaml').deleteSync();
@@ -260,7 +267,7 @@ void main() {
     });
 
     test('allows minor changes to platform interfaces', () async {
-      createFakePlugin('plugin_platform_interface',
+      createFakePlugin('plugin_platform_interface', packagesDir,
           includeChangeLog: true, includeVersion: true);
       gitDiffResponse = 'packages/plugin_platform_interface/pubspec.yaml';
       gitShowResponses = <String, String>{
@@ -294,7 +301,7 @@ void main() {
     });
 
     test('disallows breaking changes to platform interfaces', () async {
-      createFakePlugin('plugin_platform_interface',
+      createFakePlugin('plugin_platform_interface', packagesDir,
           includeChangeLog: true, includeVersion: true);
       gitDiffResponse = 'packages/plugin_platform_interface/pubspec.yaml';
       gitShowResponses = <String, String>{
@@ -327,7 +334,7 @@ void main() {
 
     test('Allow empty lines in front of the first version in CHANGELOG',
         () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           includeChangeLog: true, includeVersion: true);
 
       createFakePubspec(pluginDirectory,
@@ -354,7 +361,7 @@ void main() {
     });
 
     test('Throws if versions in changelog and pubspec do not match', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           includeChangeLog: true, includeVersion: true);
 
       createFakePubspec(pluginDirectory,
@@ -389,7 +396,7 @@ The first version listed in CHANGELOG.md is 1.0.2.
     });
 
     test('Success if CHANGELOG and pubspec versions match', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           includeChangeLog: true, includeVersion: true);
 
       createFakePubspec(pluginDirectory,
@@ -415,7 +422,7 @@ The first version listed in CHANGELOG.md is 1.0.2.
     test(
         'Fail if pubspec version only matches an older version listed in CHANGELOG',
         () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           includeChangeLog: true, includeVersion: true);
 
       createFakePubspec(pluginDirectory,
@@ -457,7 +464,7 @@ The first version listed in CHANGELOG.md is 1.0.1.
 
     test('Allow NEXT as a placeholder for gathering CHANGELOG entries',
         () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           includeChangeLog: true, includeVersion: true);
 
       createFakePubspec(pluginDirectory,
@@ -486,7 +493,7 @@ The first version listed in CHANGELOG.md is 1.0.1.
 
     test('Fail if NEXT is left in the CHANGELOG when adding a version bump',
         () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           includeChangeLog: true, includeVersion: true);
 
       createFakePubspec(pluginDirectory,
@@ -530,7 +537,7 @@ into the new version's release notes.
     });
 
     test('Fail if the version changes without replacing NEXT', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           includeChangeLog: true, includeVersion: true);
 
       createFakePubspec(pluginDirectory,
@@ -590,7 +597,8 @@ The first version listed in CHANGELOG.md is 1.0.0.
           'version_check_command', 'Test for $VersionCheckCommand');
       runner.addCommand(command);
 
-      createFakePlugin('plugin', includeChangeLog: true, includeVersion: true);
+      createFakePlugin('plugin', packagesDir,
+          includeChangeLog: true, includeVersion: true);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'master:packages/plugin/pubspec.yaml': 'version: 1.0.0',
@@ -626,7 +634,8 @@ The first version listed in CHANGELOG.md is 1.0.0.
           'version_check_command', 'Test for $VersionCheckCommand');
       runner.addCommand(command);
 
-      createFakePlugin('plugin', includeChangeLog: true, includeVersion: true);
+      createFakePlugin('plugin', packagesDir,
+          includeChangeLog: true, includeVersion: true);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'master:packages/plugin/pubspec.yaml': 'version: 1.0.0',
@@ -670,7 +679,8 @@ ${indentation}Allowed versions: {1.0.0: NextVersionType.BREAKING_MAJOR, 0.1.0: N
           'version_check_command', 'Test for $VersionCheckCommand');
       runner.addCommand(command);
 
-      createFakePlugin('plugin', includeChangeLog: true, includeVersion: true);
+      createFakePlugin('plugin', packagesDir,
+          includeChangeLog: true, includeVersion: true);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'master:packages/plugin/pubspec.yaml': 'version: 1.0.0',
@@ -713,7 +723,8 @@ ${indentation}HTTP response: xx
           'version_check_command', 'Test for $VersionCheckCommand');
       runner.addCommand(command);
 
-      createFakePlugin('plugin', includeChangeLog: true, includeVersion: true);
+      createFakePlugin('plugin', packagesDir,
+          includeChangeLog: true, includeVersion: true);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'master:packages/plugin/pubspec.yaml': 'version: 1.0.0',

--- a/script/tool/test/xctest_command_test.dart
+++ b/script/tool/test/xctest_command_test.dart
@@ -93,8 +93,7 @@ void main() {
 
     setUp(() {
       fileSystem = MemoryFileSystem();
-      packagesDir =
-          initializeFakePackages(parentDir: fileSystem.currentDirectory);
+      packagesDir = createPackagesDirectory(fileSystem: fileSystem);
       processRunner = RecordingProcessRunner();
       final XCTestCommand command =
           XCTestCommand(packagesDir, processRunner: processRunner);

--- a/script/tool/test/xctest_command_test.dart
+++ b/script/tool/test/xctest_command_test.dart
@@ -87,12 +87,13 @@ void main() {
 
   group('test xctest_command', () {
     FileSystem fileSystem;
+    Directory packagesDir;
     CommandRunner<void> runner;
     RecordingProcessRunner processRunner;
 
     setUp(() {
       fileSystem = MemoryFileSystem();
-      final Directory packagesDir =
+      packagesDir =
           initializeFakePackages(parentDir: fileSystem.currentDirectory);
       processRunner = RecordingProcessRunner();
       final XCTestCommand command =
@@ -103,7 +104,7 @@ void main() {
     });
 
     test('skip if ios is not supported', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
@@ -122,16 +123,18 @@ void main() {
     });
 
     test('running with correct destination, skip 1 plugin', () async {
-      final Directory pluginDirectory1 = createFakePlugin('plugin1',
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test'],
-          ],
-          isIosPlugin: true);
-      final Directory pluginDirectory2 = createFakePlugin('plugin2',
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test'],
-          ],
-          isIosPlugin: true);
+      final Directory pluginDirectory1 =
+          createFakePlugin('plugin1', packagesDir,
+              withExtraFiles: <List<String>>[
+                <String>['example', 'test'],
+              ],
+              isIosPlugin: true);
+      final Directory pluginDirectory2 =
+          createFakePlugin('plugin2', packagesDir,
+              withExtraFiles: <List<String>>[
+                <String>['example', 'test'],
+              ],
+              isIosPlugin: true);
 
       final Directory pluginExampleDirectory1 =
           pluginDirectory1.childDirectory('example');
@@ -181,7 +184,7 @@ void main() {
 
     test('Not specifying --ios-destination assigns an available simulator',
         () async {
-      final Directory pluginDirectory = createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],

--- a/script/tool/test/xctest_command_test.dart
+++ b/script/tool/test/xctest_command_test.dart
@@ -8,6 +8,7 @@ import 'dart:convert';
 
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
+import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/xctest_command.dart';
 import 'package:test/test.dart';
 
@@ -85,18 +86,19 @@ void main() {
   const String _kSkip = '--skip';
 
   group('test xctest_command', () {
+    FileSystem fileSystem;
     CommandRunner<void> runner;
     RecordingProcessRunner processRunner;
 
     setUp(() {
-      initializeFakePackages();
+      fileSystem = MemoryFileSystem();
+      initializeFakePackages(parentDir: fileSystem.currentDirectory);
       processRunner = RecordingProcessRunner();
       final XCTestCommand command =
           XCTestCommand(mockPackagesDir, processRunner: processRunner);
 
       runner = CommandRunner<void>('xctest_command', 'Test for xctest_command');
       runner.addCommand(command);
-      cleanupPackages();
     });
 
     test('skip if ios is not supported', () async {
@@ -118,8 +120,6 @@ void main() {
           runner, <String>['xctest', _kDestination, 'foo_destination']);
       expect(output, contains('iOS is not supported by this plugin.'));
       expect(processRunner.recordedCalls, orderedEquals(<ProcessCall>[]));
-
-      cleanupPackages();
     });
 
     test('running with correct destination, skip 1 plugin', () async {
@@ -178,8 +178,6 @@ void main() {
                 ],
                 pluginExampleDirectory2.path),
           ]));
-
-      cleanupPackages();
     });
 
     test('Not specifying --ios-destination assigns an available simulator',
@@ -234,8 +232,6 @@ void main() {
                 ],
                 pluginExampleDirectory.path),
           ]));
-
-      cleanupPackages();
     });
   });
 }

--- a/script/tool/test/xctest_command_test.dart
+++ b/script/tool/test/xctest_command_test.dart
@@ -92,26 +92,25 @@ void main() {
 
     setUp(() {
       fileSystem = MemoryFileSystem();
-      initializeFakePackages(parentDir: fileSystem.currentDirectory);
+      final Directory packagesDir =
+          initializeFakePackages(parentDir: fileSystem.currentDirectory);
       processRunner = RecordingProcessRunner();
       final XCTestCommand command =
-          XCTestCommand(mockPackagesDir, processRunner: processRunner);
+          XCTestCommand(packagesDir, processRunner: processRunner);
 
       runner = CommandRunner<void>('xctest_command', 'Test for xctest_command');
       runner.addCommand(command);
     });
 
     test('skip if ios is not supported', () async {
-      createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin',
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
           isIosPlugin: false);
 
-      final Directory pluginExampleDirectory =
-          mockPackagesDir.childDirectory('plugin').childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
+      createFakePubspec(pluginDirectory.childDirectory('example'),
+          isFlutter: true);
 
       final MockProcess mockProcess = MockProcess();
       mockProcess.exitCodeCompleter.complete(0);
@@ -123,22 +122,22 @@ void main() {
     });
 
     test('running with correct destination, skip 1 plugin', () async {
-      createFakePlugin('plugin1',
+      final Directory pluginDirectory1 = createFakePlugin('plugin1',
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
           isIosPlugin: true);
-      createFakePlugin('plugin2',
+      final Directory pluginDirectory2 = createFakePlugin('plugin2',
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
           isIosPlugin: true);
 
       final Directory pluginExampleDirectory1 =
-          mockPackagesDir.childDirectory('plugin1').childDirectory('example');
+          pluginDirectory1.childDirectory('example');
       createFakePubspec(pluginExampleDirectory1, isFlutter: true);
       final Directory pluginExampleDirectory2 =
-          mockPackagesDir.childDirectory('plugin2').childDirectory('example');
+          pluginDirectory2.childDirectory('example');
       createFakePubspec(pluginExampleDirectory2, isFlutter: true);
 
       final MockProcess mockProcess = MockProcess();
@@ -182,14 +181,14 @@ void main() {
 
     test('Not specifying --ios-destination assigns an available simulator',
         () async {
-      createFakePlugin('plugin',
+      final Directory pluginDirectory = createFakePlugin('plugin',
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
           isIosPlugin: true);
 
       final Directory pluginExampleDirectory =
-          mockPackagesDir.childDirectory('plugin').childDirectory('example');
+          pluginDirectory.childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 


### PR DESCRIPTION
Eliminates the global test filesystem and global test packages directory, in favor of local versions. This guarantees that each test runs with a clean filesystem state, rather than relying on cleanup. It also simplifies understanding the tests, since everything is done via params and return values instead of needing to know about the magic global variables and which methods mutate them.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format])
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[plugin_tool format]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
