### PR TITLE
[image_picker] Fix rotation when camera is a source

### DIFF
--- a/packages/image_picker/image_picker/CHANGELOG.md
+++ b/packages/image_picker/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.0+2
+
+* Fix a rotation problem where when camera is chosen as a source and additional parameters are added.
+
 ## 0.8.0+1
 
 * Removed redundant request for camera permissions.

--- a/packages/image_picker/image_picker/example/ios/RunnerTests/ImageUtilTests.m
+++ b/packages/image_picker/image_picker/example/ios/RunnerTests/ImageUtilTests.m
@@ -34,6 +34,16 @@
   XCTAssertEqual(newImage.size.height, 2);
 }
 
+- (void)testScaledImage_ShouldBeCorrectRotation {
+  UIImage *image = [UIImage imageWithData:ImagePickerTestImages.JPGTestData];
+  UIImage *newImage = [FLTImagePickerImageUtil scaledImage:image
+                                                  maxWidth:@3
+                                                 maxHeight:@2
+                                       isMetadataAvailable:YES];
+
+  XCTAssertEqual(newImage.imageOrientation, UIImageOrientationUp);
+}
+
 - (void)testScaledGIFImage_ShouldBeScaled {
   // gif image that frame size is 3 and the duration is 1 second.
   GIFInfo *info = [FLTImagePickerImageUtil scaledGIFImage:ImagePickerTestImages.GIFTestData

--- a/packages/image_picker/image_picker/ios/Classes/FLTImagePickerPlugin.m
+++ b/packages/image_picker/image_picker/ios/Classes/FLTImagePickerPlugin.m
@@ -460,7 +460,7 @@ typedef NS_ENUM(NSInteger, ImagePickerClassType) { UIImagePickerClassType, PHPic
       image = [FLTImagePickerImageUtil scaledImage:image
                                           maxWidth:maxWidth
                                          maxHeight:maxHeight
-                               isMetadataAvailable:originalAsset != nil];
+                               isMetadataAvailable:YES];
     }
 
     if (!originalAsset) {

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for selecting images from the Android and iOS image
   library, and taking new pictures with the camera.
 repository: https://github.com/flutter/plugins/tree/master/packages/image_picker/image_picker
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 0.8.0+1
+version: 0.8.0+2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
This PR fixes a rotation problem where when the camera is chosen as a source and additional parameters are added. This change is related to [#3873](https://github.com/flutter/plugins/pull/3873). `isMetadataAvailable` parameter is used to handle the rotation problem for limited access to the photo library and it should be `YES` for all other occasions.

Related issues:

- Fixes [flutter/flutter#74014](https://github.com/flutter/flutter/issues/74014)

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format])
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[plugin_tool format]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
