### PR TITLE
[flutter_plugin_tools] Remove xctest's --skip

### DIFF
--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -1,3 +1,7 @@
+##
+
+- Remove `xctest`'s `--skip`, which is redundant with `--ignore`.
+
 ## 0.1.4
 
 - Add a `pubspec-check` command

--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -1,4 +1,4 @@
-##
+## 0.2.0
 
 - Remove `xctest`'s `--skip`, which is redundant with `--ignore`.
 

--- a/script/tool/README.md
+++ b/script/tool/README.md
@@ -46,7 +46,7 @@ dart pub global run flutter_plugin_tools <args>
 ## Commands
 
 Run with `--help` for a full list of commands and arguments, but the
-following shows a number of common commands.
+following shows a number of common commands being run for a specific plugin.
 
 All examples assume running from source; see above for running the
 published version instead.
@@ -79,7 +79,7 @@ dart run ./script/tool/lib/src/main.dart test --plugins plugin_name
 
 ```sh
 cd <repository root>
-dart run ./script/tool/lib/src/main.dart xctest --target RunnerUITests --skip <plugins_to_skip>
+dart run ./script/tool/lib/src/main.dart xctest --plugins plugin_name
 ```
 
 ### Publish a Release

--- a/script/tool/lib/src/xctest_command.dart
+++ b/script/tool/lib/src/xctest_command.dart
@@ -14,7 +14,6 @@ import 'package:path/path.dart' as p;
 import 'common.dart';
 
 const String _kiOSDestination = 'ios-destination';
-const String _kSkip = 'skip';
 const String _kXcodeBuildCommand = 'xcodebuild';
 const String _kXCRunCommand = 'xcrun';
 const String _kFoundNoSimulatorsMessage =
@@ -36,8 +35,6 @@ class XCTestCommand extends PluginCommand {
           'this is passed to the `-destination` argument in xcodebuild command.\n'
           'See https://developer.apple.com/library/archive/technotes/tn2339/_index.html#//apple_ref/doc/uid/DTS40014588-CH1-UNIT for details on how to specify the destination.',
     );
-    argParser.addMultiOption(_kSkip,
-        help: 'Plugins to skip while running this command. \n');
   }
 
   @override
@@ -59,8 +56,6 @@ class XCTestCommand extends PluginCommand {
       destination = 'id=$simulatorId';
     }
 
-    final List<String> skipped = getStringListArg(_kSkip);
-
     final List<String> failingPackages = <String>[];
     await for (final Directory plugin in getPlugins()) {
       // Start running for package.
@@ -69,11 +64,6 @@ class XCTestCommand extends PluginCommand {
       print('Start running for $packageName ...');
       if (!isIosPlugin(plugin)) {
         print('iOS is not supported by this plugin.');
-        print('\n\n');
-        continue;
-      }
-      if (skipped.contains(packageName)) {
-        print('$packageName was skipped with the --skip flag.');
         print('\n\n');
         continue;
       }

--- a/script/tool/pubspec.yaml
+++ b/script/tool/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_plugin_tools
 description: Productivity utils for flutter/plugins and flutter/packages
 repository: https://github.com/flutter/plugins/tree/master/script/tool
-version: 0.1.4
+version: 0.2.0
 
 dependencies:
   args: ^2.1.0

--- a/script/tool/test/xctest_command_test.dart
+++ b/script/tool/test/xctest_command_test.dart
@@ -83,7 +83,6 @@ final Map<String, dynamic> _kDeviceListMap = <String, dynamic>{
 
 void main() {
   const String _kDestination = '--ios-destination';
-  const String _kSkip = '--skip';
 
   group('test xctest_command', () {
     FileSystem fileSystem;
@@ -121,7 +120,7 @@ void main() {
       expect(processRunner.recordedCalls, orderedEquals(<ProcessCall>[]));
     });
 
-    test('running with correct destination, skip 1 plugin', () async {
+    test('running with correct destination, exclude 1 plugin', () async {
       final Directory pluginDirectory1 =
           createFakePlugin('plugin1', packagesDir,
               withExtraFiles: <List<String>>[
@@ -151,11 +150,11 @@ void main() {
         'xctest',
         _kDestination,
         'foo_destination',
-        _kSkip,
+        '--exclude',
         'plugin1'
       ]);
 
-      expect(output, contains('plugin1 was skipped with the --skip flag.'));
+      expect(output, isNot(contains('Successfully ran xctest for plugin1')));
       expect(output, contains('Successfully ran xctest for plugin2'));
 
       expect(


### PR DESCRIPTION
Removes the `xctest` flag `--skip`, at it is redundant with the general `--exclude` flag.

Part of https://github.com/flutter/flutter/issues/83413

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format])
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[plugin_tool format]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
