### PR TITLE
[flutter_plugin_tools] Migrate xctest command to NNBD

### DIFF
--- a/script/tool/lib/src/xctest_command.dart
+++ b/script/tool/lib/src/xctest_command.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io' as io;
@@ -51,7 +49,7 @@ class XCTestCommand extends PluginCommand {
   Future<void> run() async {
     String destination = getStringArg(_kiOSDestination);
     if (destination.isEmpty) {
-      final String simulatorId = await _findAvailableIphoneSimulator();
+      final String? simulatorId = await _findAvailableIphoneSimulator();
       if (simulatorId == null) {
         print(_kFoundNoSimulatorsMessage);
         throw ToolExit(1);
@@ -129,7 +127,7 @@ class XCTestCommand extends PluginCommand {
         workingDir: example, exitOnError: false);
   }
 
-  Future<String> _findAvailableIphoneSimulator() async {
+  Future<String?> _findAvailableIphoneSimulator() async {
     // Find the first available destination if not specified.
     final List<String> findSimulatorsArguments = <String>[
       'simctl',
@@ -153,30 +151,40 @@ class XCTestCommand extends PluginCommand {
     final List<Map<String, dynamic>> runtimes =
         (simulatorListJson['runtimes'] as List<dynamic>)
             .cast<Map<String, dynamic>>();
-    final Map<String, dynamic> devices =
-        simulatorListJson['devices'] as Map<String, dynamic>;
+    final Map<String, Object> devices =
+        (simulatorListJson['devices'] as Map<String, dynamic>)
+            .cast<String, Object>();
     if (runtimes.isEmpty || devices.isEmpty) {
       return null;
     }
-    String id;
+    String? id;
     // Looking for runtimes, trying to find one with highest OS version.
-    for (final Map<String, dynamic> runtimeMap in runtimes.reversed) {
-      if (!(runtimeMap['name'] as String).contains('iOS')) {
+    for (final Map<String, dynamic> rawRuntimeMap in runtimes.reversed) {
+      final Map<String, Object> runtimeMap =
+          rawRuntimeMap.cast<String, Object>();
+      if ((runtimeMap['name'] as String?)?.contains('iOS') != true) {
         continue;
       }
-      final String runtimeID = runtimeMap['identifier'] as String;
-      final List<Map<String, dynamic>> devicesForRuntime =
-          (devices[runtimeID] as List<dynamic>).cast<Map<String, dynamic>>();
-      if (devicesForRuntime.isEmpty) {
+      final String? runtimeID = runtimeMap['identifier'] as String?;
+      if (runtimeID == null) {
+        continue;
+      }
+      final List<Map<String, dynamic>>? devicesForRuntime =
+          (devices[runtimeID] as List<dynamic>?)?.cast<Map<String, dynamic>>();
+      if (devicesForRuntime == null || devicesForRuntime.isEmpty) {
         continue;
       }
       // Looking for runtimes, trying to find latest version of device.
-      for (final Map<String, dynamic> device in devicesForRuntime.reversed) {
+      for (final Map<String, dynamic> rawDevice in devicesForRuntime.reversed) {
+        final Map<String, Object> device = rawDevice.cast<String, Object>();
         if (device['availabilityError'] != null ||
-            (device['isAvailable'] as bool == false)) {
+            (device['isAvailable'] as bool?) == false) {
           continue;
         }
-        id = device['udid'] as String;
+        id = device['udid'] as String?;
+        if (id == null) {
+          continue;
+        }
         print('device selected: $device');
         return id;
       }

--- a/script/tool/test/mocks.dart
+++ b/script/tool/test/mocks.dart
@@ -17,6 +17,9 @@ class MockProcess extends Mock implements io.Process {
   final MockIOSink stdinMock = MockIOSink();
 
   @override
+  int get pid => 99;
+
+  @override
   Future<int> get exitCode => exitCodeCompleter.future;
 
   @override

--- a/script/tool/test/xctest_command_test.dart
+++ b/script/tool/test/xctest_command_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 import 'dart:convert';
 
 import 'package:args/command_runner.dart';
@@ -15,6 +13,9 @@ import 'package:test/test.dart';
 import 'mocks.dart';
 import 'util.dart';
 
+// Note: This uses `dynamic` deliberately, and should not be updated to Object,
+// in order to ensure that the code correctly handles this return type from
+// JSON decoding.
 final Map<String, dynamic> _kDeviceListMap = <String, dynamic>{
   'runtimes': <Map<String, dynamic>>[
     <String, dynamic>{
@@ -86,10 +87,10 @@ void main() {
   const String _kSkip = '--skip';
 
   group('test xctest_command', () {
-    FileSystem fileSystem;
-    Directory packagesDir;
-    CommandRunner<void> runner;
-    RecordingProcessRunner processRunner;
+    late FileSystem fileSystem;
+    late Directory packagesDir;
+    late CommandRunner<void> runner;
+    late RecordingProcessRunner processRunner;
 
     setUp(() {
       fileSystem = MemoryFileSystem();


### PR DESCRIPTION
Migrates the `xctest` command and its test. Includes tightening down the
use of `dynamic` when extracting data from JSON, since `dynamic`
eliminates much of the safety of NNBD.

Part of https://github.com/flutter/flutter/issues/81912

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format])
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[plugin_tool format]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
