### PR TITLE
[path_provider] Error handle for WidgetsFlutterBinding added

### DIFF
--- a/packages/path_provider/path_provider/CHANGELOG.md
+++ b/packages/path_provider/path_provider/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
 * Add iOS unit test target.
+* Add error handler for WidgetsBinding init.
 
 ## 2.0.2
 

--- a/packages/path_provider/path_provider/lib/path_provider.dart
+++ b/packages/path_provider/path_provider/lib/path_provider.dart
@@ -42,6 +42,7 @@ class MissingPlatformDirectoryException implements Exception {
   }
 }
 
+// * the error handler for missing flutter widgets
 // ignore: public_member_api_docs
 class MissingFlutterWidgetInitialized implements Exception {
   // ignore: public_member_api_docs
@@ -150,6 +151,7 @@ Future<Directory> getLibraryDirectory() async {
 /// Throws a `MissingPlatformDirectoryException` if the system is unable to
 /// provide the directory.
 Future<Directory> getApplicationDocumentsDirectory() async {
+  // ? check if the widgetsbinding is intialze or not
   if (WidgetsBinding.instance == null) {
     throw MissingFlutterWidgetInitialized(
         'widget flutter binding not initialized');

--- a/packages/path_provider/path_provider/lib/path_provider.dart
+++ b/packages/path_provider/path_provider/lib/path_provider.dart
@@ -5,6 +5,7 @@
 import 'dart:io' show Directory, Platform;
 
 import 'package:flutter/foundation.dart' show kIsWeb, visibleForTesting;
+import 'package:flutter/widgets.dart';
 import 'package:path_provider_linux/path_provider_linux.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 // ignore: implementation_imports
@@ -38,6 +39,20 @@ class MissingPlatformDirectoryException implements Exception {
   String toString() {
     final String detailsAddition = details == null ? '' : ': $details';
     return 'MissingPlatformDirectoryException($message)$detailsAddition';
+  }
+}
+
+// ignore: public_member_api_docs
+class MissingFlutterWidgetInitialized implements Exception {
+  // ignore: public_member_api_docs
+  MissingFlutterWidgetInitialized(this.message);
+
+  // ignore: public_member_api_docs
+  final String message;
+
+  @override
+  String toString() {
+    return 'MissingFlutterWidgetInitializedException($message)';
   }
 }
 
@@ -135,6 +150,11 @@ Future<Directory> getLibraryDirectory() async {
 /// Throws a `MissingPlatformDirectoryException` if the system is unable to
 /// provide the directory.
 Future<Directory> getApplicationDocumentsDirectory() async {
+  if (WidgetsBinding.instance == null) {
+    throw MissingFlutterWidgetInitialized(
+        'widget flutter binding not initialized');
+  }
+
   final String? path = await _platform.getApplicationDocumentsPath();
   if (path == null) {
     throw MissingPlatformDirectoryException(


### PR DESCRIPTION

In the latest null safety path provider package for flutter, the getApplicationDocumentsDirectory() called on void main  without   WidgetsFlutterBinding.ensureInitialized() cause error as [ERROR:flutter/lib/ui/ui_dart_state.cc(199)] Unhandled Exception: Null check operator used on a null value.
The error actually occurs because of WidgetsFlutterBinding.ensureInitialized() not called .
So I added an error handler to check it. Error handler named as MissingFlutterWidgetInitialized Exception.