### PR TITLE
 [path_provider] Error handle for WidgetsFlutterBinding added

### DIFF
--- a/packages/path_provider/path_provider/CHANGELOG.md
+++ b/packages/path_provider/path_provider/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## NEXT
 
+## 2.0.3
+
 * Add iOS unit test target.
 * Add error handler for WidgetsBinding init.
 

--- a/packages/path_provider/path_provider/CHANGELOG.md
+++ b/packages/path_provider/path_provider/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
 * Add iOS unit test target.
+* Add error handler for WidgetsBinding init.
 
 ## 2.0.2
 

--- a/packages/path_provider/path_provider/lib/path_provider.dart
+++ b/packages/path_provider/path_provider/lib/path_provider.dart
@@ -42,6 +42,7 @@ class MissingPlatformDirectoryException implements Exception {
   }
 }
 
+// * the error handler for missing flutter widgets
 // ignore: public_member_api_docs
 class MissingFlutterWidgetInitialized implements Exception {
   // ignore: public_member_api_docs
@@ -150,6 +151,7 @@ Future<Directory> getLibraryDirectory() async {
 /// Throws a `MissingPlatformDirectoryException` if the system is unable to
 /// provide the directory.
 Future<Directory> getApplicationDocumentsDirectory() async {
+  // ? check if the widgetsbinding is intialze or not
   if (WidgetsBinding.instance == null) {
     throw MissingFlutterWidgetInitialized(
         'widget flutter binding not initialized');

--- a/packages/path_provider/path_provider/lib/path_provider.dart
+++ b/packages/path_provider/path_provider/lib/path_provider.dart
@@ -5,6 +5,7 @@
 import 'dart:io' show Directory, Platform;
 
 import 'package:flutter/foundation.dart' show kIsWeb, visibleForTesting;
+import 'package:flutter/widgets.dart';
 import 'package:path_provider_linux/path_provider_linux.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 // ignore: implementation_imports
@@ -38,6 +39,20 @@ class MissingPlatformDirectoryException implements Exception {
   String toString() {
     final String detailsAddition = details == null ? '' : ': $details';
     return 'MissingPlatformDirectoryException($message)$detailsAddition';
+  }
+}
+
+// ignore: public_member_api_docs
+class MissingFlutterWidgetInitialized implements Exception {
+  // ignore: public_member_api_docs
+  MissingFlutterWidgetInitialized(this.message);
+
+  // ignore: public_member_api_docs
+  final String message;
+
+  @override
+  String toString() {
+    return 'MissingFlutterWidgetInitializedException($message)';
   }
 }
 
@@ -135,6 +150,11 @@ Future<Directory> getLibraryDirectory() async {
 /// Throws a `MissingPlatformDirectoryException` if the system is unable to
 /// provide the directory.
 Future<Directory> getApplicationDocumentsDirectory() async {
+  if (WidgetsBinding.instance == null) {
+    throw MissingFlutterWidgetInitialized(
+        'widget flutter binding not initialized');
+  }
+
   final String? path = await _platform.getApplicationDocumentsPath();
   if (path == null) {
     throw MissingPlatformDirectoryException(

--- a/packages/path_provider/path_provider/pubspec.yaml
+++ b/packages/path_provider/path_provider/pubspec.yaml
@@ -2,7 +2,7 @@ name: path_provider
 description: Flutter plugin for getting commonly used locations on host platform file systems, such as the temp and app data directories.
 repository: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+path_provider%22
-version: 2.0.2
+version: 2.0.3
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
In the latest null safety path provider package for flutter, the getApplicationDocumentsDirectory() called on void main  without   WidgetsFlutterBinding.ensureInitialized() cause error as [ERROR:flutter/lib/ui/ui_dart_state.cc(199)] Unhandled Exception: Null check operator used on a null value.
The error actually occurs because of WidgetsFlutterBinding.ensureInitialized() not called .
So I added an error handler to check it. Error handler named as MissingFlutterWidgetInitialized Exception.

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format])
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[plugin_tool format]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
