### PR TITLE
[in_app_purchase] Only register transactionObservers when someone is listening to purchaseUpdates

### DIFF
--- a/packages/in_app_purchase/in_app_purchase_ios/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_ios/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.0+2
+
+* Changed the iOS payment queue handler in such a way that it only adds a listener to the SKPaymentQueue when there 
+  is a listener to the Dart purchaseStream.
+
 ## 0.1.0+1
 
 * Added a "Restore purchases" button to conform to Apple's StoreKit guidelines on [restoring products](https://developer.apple.com/documentation/storekit/in-app_purchase/restoring_purchased_products?language=objc);

--- a/packages/in_app_purchase/in_app_purchase_ios/example/ios/RunnerTests/InAppPurchasePluginTests.m
+++ b/packages/in_app_purchase/in_app_purchase_ios/example/ios/RunnerTests/InAppPurchasePluginTests.m
@@ -323,7 +323,7 @@
                               }
                                    updatedDownloads:nil];
 
-  // Check if there is no observer to start with
+  // Check that there is no observer to start with.
   XCTAssertNil(queue.observer);
 
   // Start observing

--- a/packages/in_app_purchase/in_app_purchase_ios/example/ios/RunnerTests/InAppPurchasePluginTests.m
+++ b/packages/in_app_purchase/in_app_purchase_ios/example/ios/RunnerTests/InAppPurchasePluginTests.m
@@ -301,4 +301,46 @@
   XCTAssertEqualObjects(resultArray, @[ transactionMap ]);
 }
 
+- (void)testStartAndStopObservingPaymentQueue {
+  FlutterMethodCall* startCall = [FlutterMethodCall
+      methodCallWithMethodName:@"-[SKPaymentQueue startObservingTransactionQueue]"
+                     arguments:nil];
+  FlutterMethodCall* stopCall =
+      [FlutterMethodCall methodCallWithMethodName:@"-[SKPaymentQueue stopObservingTransactionQueue]"
+                                        arguments:nil];
+
+  SKPaymentQueueStub* queue = [SKPaymentQueueStub new];
+
+  self.plugin.paymentQueueHandler =
+      [[FIAPaymentQueueHandler alloc] initWithQueue:queue
+                                transactionsUpdated:nil
+                                 transactionRemoved:nil
+                           restoreTransactionFailed:nil
+               restoreCompletedTransactionsFinished:nil
+                              shouldAddStorePayment:^BOOL(SKPayment* _Nonnull payment,
+                                                          SKProduct* _Nonnull product) {
+                                return YES;
+                              }
+                                   updatedDownloads:nil];
+
+  // Check if there is no observer to start with
+  XCTAssertNil(queue.observer);
+
+  // Start observing
+  [self.plugin handleMethodCall:startCall
+                         result:^(id r){
+                         }];
+
+  // Observer should be set
+  XCTAssertNotNil(queue.observer);
+
+  // Stop observing
+  [self.plugin handleMethodCall:stopCall
+                         result:^(id r){
+                         }];
+
+  // No observer should be set
+  XCTAssertNil(queue.observer);
+}
+
 @end

--- a/packages/in_app_purchase/in_app_purchase_ios/example/ios/RunnerTests/Stubs.h
+++ b/packages/in_app_purchase/in_app_purchase_ios/example/ios/RunnerTests/Stubs.h
@@ -36,6 +36,7 @@ API_AVAILABLE(ios(11.2), macos(10.13.2))
 
 @interface SKPaymentQueueStub : SKPaymentQueue
 @property(assign, nonatomic) SKPaymentTransactionState testState;
+@property(strong, nonatomic, nullable) id<SKPaymentTransactionObserver> observer;
 @end
 
 @interface SKPaymentTransactionStub : SKPaymentTransaction

--- a/packages/in_app_purchase/in_app_purchase_ios/example/ios/RunnerTests/Stubs.m
+++ b/packages/in_app_purchase/in_app_purchase_ios/example/ios/RunnerTests/Stubs.m
@@ -151,14 +151,16 @@
 
 @interface SKPaymentQueueStub ()
 
-@property(strong, nonatomic) id<SKPaymentTransactionObserver> observer;
-
 @end
 
 @implementation SKPaymentQueueStub
 
 - (void)addTransactionObserver:(id<SKPaymentTransactionObserver>)observer {
   self.observer = observer;
+}
+
+- (void)removeTransactionObserver:(id<SKPaymentTransactionObserver>)observer {
+  self.observer = nil;
 }
 
 - (void)addPayment:(SKPayment *)payment {

--- a/packages/in_app_purchase/in_app_purchase_ios/ios/Classes/FIAPaymentQueueHandler.h
+++ b/packages/in_app_purchase/in_app_purchase_ios/ios/Classes/FIAPaymentQueueHandler.h
@@ -34,6 +34,8 @@ typedef void (^UpdatedDownloads)(NSArray<SKDownload *> *downloads);
 
 // This method needs to be called before any other methods.
 - (void)startObservingPaymentQueue;
+// Call this method when the Flutter app is no longer listening
+- (void)stopObservingPaymentQueue;
 
 // Appends a payment to the SKPaymentQueue.
 //

--- a/packages/in_app_purchase/in_app_purchase_ios/ios/Classes/FIAPaymentQueueHandler.m
+++ b/packages/in_app_purchase/in_app_purchase_ios/ios/Classes/FIAPaymentQueueHandler.m
@@ -44,6 +44,10 @@
   [_queue addTransactionObserver:self];
 }
 
+- (void)stopObservingPaymentQueue {
+  [_queue removeTransactionObserver:self];
+}
+
 - (BOOL)addPayment:(SKPayment *)payment {
   for (SKPaymentTransaction *transaction in self.queue.transactions) {
     if ([transaction.payment.productIdentifier isEqualToString:payment.productIdentifier]) {

--- a/packages/in_app_purchase/in_app_purchase_ios/ios/Classes/InAppPurchasePlugin.m
+++ b/packages/in_app_purchase/in_app_purchase_ios/ios/Classes/InAppPurchasePlugin.m
@@ -73,7 +73,6 @@
       updatedDownloads:^void(NSArray<SKDownload *> *_Nonnull downloads) {
         [weakSelf updatedDownloads:downloads];
       }];
-  [_paymentQueueHandler startObservingPaymentQueue];
   _callbackChannel =
       [FlutterMethodChannel methodChannelWithName:@"plugins.flutter.io/in_app_purchase"
                                   binaryMessenger:[registrar messenger]];
@@ -100,6 +99,10 @@
     [self retrieveReceiptData:call result:result];
   } else if ([@"-[InAppPurchasePlugin refreshReceipt:result:]" isEqualToString:call.method]) {
     [self refreshReceipt:call result:result];
+  } else if ([@"-[SKPaymentQueue startObservingTransactionQueue]" isEqualToString:call.method]) {
+    [_paymentQueueHandler startObservingPaymentQueue];
+  } else if ([@"-[SKPaymentQueue stopObservingTransactionQueue]" isEqualToString:call.method]) {
+    [_paymentQueueHandler stopObservingPaymentQueue];
   } else {
     result(FlutterMethodNotImplemented);
   }

--- a/packages/in_app_purchase/in_app_purchase_ios/lib/src/in_app_purchase_ios_platform.dart
+++ b/packages/in_app_purchase/in_app_purchase_ios/lib/src/in_app_purchase_ios_platform.dart
@@ -51,7 +51,15 @@ class InAppPurchaseIosPlatform extends InAppPurchasePlatform {
     InAppPurchasePlatform.instance = InAppPurchaseIosPlatform();
 
     _skPaymentQueueWrapper = SKPaymentQueueWrapper();
-    _observer = _TransactionObserver(StreamController.broadcast());
+
+    // Create a purchaseUpdatedController and notify the native side when to
+    // start of stop sending updates.
+    StreamController<List<PurchaseDetails>> updateController =
+        StreamController.broadcast(
+      onListen: () => _skPaymentQueueWrapper.startObservingTransactionQueue(),
+      onCancel: () => _skPaymentQueueWrapper.stopObservingTransactionQueue(),
+    );
+    _observer = _TransactionObserver(updateController);
     _skPaymentQueueWrapper.setTransactionObserver(observer);
   }
 

--- a/packages/in_app_purchase/in_app_purchase_ios/lib/src/store_kit_wrappers/sk_payment_queue_wrapper.dart
+++ b/packages/in_app_purchase/in_app_purchase_ios/lib/src/store_kit_wrappers/sk_payment_queue_wrapper.dart
@@ -67,7 +67,7 @@ class SKPaymentQueueWrapper {
 
   /// Instructs the iOS implementation to register a transaction observer and
   /// start listening to it.
-  /// 
+  ///
   /// Call this method when the first listener is subscribed to the
   /// [InAppPurchaseIosPlatform.purchaseStream].
   Future startObservingTransactionQueue() async =>

--- a/packages/in_app_purchase/in_app_purchase_ios/lib/src/store_kit_wrappers/sk_payment_queue_wrapper.dart
+++ b/packages/in_app_purchase/in_app_purchase_ios/lib/src/store_kit_wrappers/sk_payment_queue_wrapper.dart
@@ -11,6 +11,7 @@ import 'package:json_annotation/json_annotation.dart';
 import 'package:meta/meta.dart';
 
 import '../channel.dart';
+import '../in_app_purchase_ios_platform.dart';
 import 'sk_payment_transaction_wrappers.dart';
 import 'sk_product_wrapper.dart';
 
@@ -63,6 +64,18 @@ class SKPaymentQueueWrapper {
     _observer = observer;
     channel.setMethodCallHandler(_handleObserverCallbacks);
   }
+
+  /// Call this when the first listener is subscribed to the
+  /// [InAppPurchaseIosPlatform.purchaseStream].
+  Future startObservingTransactionQueue() async =>
+      await channel.invokeListMethod<void>(
+          '-[SKPaymentQueue startObservingTransactionQueue]');
+
+  /// Call this when there are no longer any listeners subscribed to the
+  /// [InAppPurchaseIosPlatform.purchaseStream].
+  Future stopObservingTransactionQueue() async =>
+      await channel.invokeListMethod<void>(
+          '-[SKPaymentQueue stopObservingTransactionQueue]');
 
   /// Posts a payment to the queue.
   ///

--- a/packages/in_app_purchase/in_app_purchase_ios/lib/src/store_kit_wrappers/sk_payment_queue_wrapper.dart
+++ b/packages/in_app_purchase/in_app_purchase_ios/lib/src/store_kit_wrappers/sk_payment_queue_wrapper.dart
@@ -65,7 +65,10 @@ class SKPaymentQueueWrapper {
     channel.setMethodCallHandler(_handleObserverCallbacks);
   }
 
-  /// Call this when the first listener is subscribed to the
+  /// Instructs the iOS implementation to register a transaction observer and
+  /// start listening to it.
+  /// 
+  /// Call this method when the first listener is subscribed to the
   /// [InAppPurchaseIosPlatform.purchaseStream].
   Future startObservingTransactionQueue() async =>
       await channel.invokeListMethod<void>(

--- a/packages/in_app_purchase/in_app_purchase_ios/lib/src/store_kit_wrappers/sk_payment_queue_wrapper.dart
+++ b/packages/in_app_purchase/in_app_purchase_ios/lib/src/store_kit_wrappers/sk_payment_queue_wrapper.dart
@@ -74,6 +74,9 @@ class SKPaymentQueueWrapper {
       await channel.invokeListMethod<void>(
           '-[SKPaymentQueue startObservingTransactionQueue]');
 
+  /// Instructs the iOS implementation to remove the transaction observer and
+  /// stop listening to it.
+  ///
   /// Call this when there are no longer any listeners subscribed to the
   /// [InAppPurchaseIosPlatform.purchaseStream].
   Future stopObservingTransactionQueue() async =>

--- a/packages/in_app_purchase/in_app_purchase_ios/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase_ios
 description: An implementation for the iOS platform of the Flutter `in_app_purchase` plugin. This uses the iOS StoreKit Framework.
 repository: https://github.com/flutter/plugins/tree/master/packages/in_app_purchase/in_app_purchase_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 0.1.0+1
+version: 0.1.0+2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/in_app_purchase/in_app_purchase_ios/test/fakes/fake_ios_platform.dart
+++ b/packages/in_app_purchase/in_app_purchase_ios/test/fakes/fake_ios_platform.dart
@@ -29,6 +29,7 @@ class FakeIOSPlatform {
   PlatformException? queryProductException;
   PlatformException? restoreException;
   SKError? testRestoredError;
+  bool queueIsActive = false;
 
   void reset() {
     transactions = [];
@@ -175,6 +176,12 @@ class FakeIOSPlatform {
         finishedTransactions.add(createPurchasedTransaction(
             call.arguments["productIdentifier"],
             call.arguments["transactionIdentifier"]));
+        break;
+      case '-[SKPaymentQueue startObservingTransactionQueue]':
+        queueIsActive = true;
+        break;
+      case '-[SKPaymentQueue stopObservingTransactionQueue]':
+        queueIsActive = false;
         break;
     }
     return Future<void>.sync(() {});

--- a/packages/in_app_purchase/in_app_purchase_ios/test/fakes/fake_ios_platform.dart
+++ b/packages/in_app_purchase/in_app_purchase_ios/test/fakes/fake_ios_platform.dart
@@ -67,6 +67,7 @@ class FakeIOSPlatform {
     queryProductException = null;
     restoreException = null;
     testRestoredError = null;
+    queueIsActive = false;
   }
 
   SKPaymentTransactionWrapper createPendingTransaction(String id) {

--- a/packages/in_app_purchase/in_app_purchase_ios/test/in_app_purchase_ios_platform_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_ios/test/in_app_purchase_ios_platform_test.dart
@@ -302,4 +302,19 @@ void main() {
       expect(fakeIOSPlatform.finishedTransactions.length, 1);
     });
   });
+
+  group('purchase stream', () {
+    test('Should only have active queue when purchaseStream has listeners', () {
+      Stream<List<PurchaseDetails>> stream = iapIosPlatform.purchaseStream;
+      expect(fakeIOSPlatform.queueIsActive, false);
+      StreamSubscription subscription1 = stream.listen((event) {});
+      expect(fakeIOSPlatform.queueIsActive, true);
+      StreamSubscription subscription2 = stream.listen((event) {});
+      expect(fakeIOSPlatform.queueIsActive, true);
+      subscription1.cancel();
+      expect(fakeIOSPlatform.queueIsActive, true);
+      subscription2.cancel();
+      expect(fakeIOSPlatform.queueIsActive, false);
+    });
+  });
 }

--- a/packages/in_app_purchase/in_app_purchase_ios/test/store_kit_wrappers/sk_methodchannel_apis_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_ios/test/store_kit_wrappers/sk_methodchannel_apis_test.dart
@@ -22,6 +22,7 @@ void main() {
 
   tearDown(() {
     fakeIOSPlatform.testReturnNull = false;
+    fakeIOSPlatform.queueIsActive = null;
   });
 
   group('sk_request_maker', () {
@@ -137,14 +138,12 @@ void main() {
       expect(fakeIOSPlatform.queueIsActive, isNot(true));
       await SKPaymentQueueWrapper().startObservingTransactionQueue();
       expect(fakeIOSPlatform.queueIsActive, true);
-      fakeIOSPlatform.queueIsActive = null;
     });
 
     test('stopObservingTransactionQueue should call methodChannel', () async {
       expect(fakeIOSPlatform.queueIsActive, isNot(false));
       await SKPaymentQueueWrapper().stopObservingTransactionQueue();
       expect(fakeIOSPlatform.queueIsActive, false);
-      fakeIOSPlatform.queueIsActive = null;
     });
   });
 

--- a/packages/in_app_purchase/in_app_purchase_ios/test/store_kit_wrappers/sk_methodchannel_apis_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_ios/test/store_kit_wrappers/sk_methodchannel_apis_test.dart
@@ -132,6 +132,20 @@ void main() {
       await queue.restoreTransactions(applicationUserName: 'aUserID');
       expect(fakeIOSPlatform.applicationNameHasTransactionRestored, 'aUserID');
     });
+
+    test('startObservingTransactionQueue should call methodChannel', () async {
+      expect(fakeIOSPlatform.queueIsActive, isNot(true));
+      await SKPaymentQueueWrapper().startObservingTransactionQueue();
+      expect(fakeIOSPlatform.queueIsActive, true);
+      fakeIOSPlatform.queueIsActive = null;
+    });
+
+    test('stopObservingTransactionQueue should call methodChannel', () async {
+      expect(fakeIOSPlatform.queueIsActive, isNot(false));
+      await SKPaymentQueueWrapper().stopObservingTransactionQueue();
+      expect(fakeIOSPlatform.queueIsActive, false);
+      fakeIOSPlatform.queueIsActive = null;
+    });
   });
 
   group('Code Redemption Sheet', () {
@@ -164,6 +178,9 @@ class FakeIOSPlatform {
 
   // present Code Redemption
   bool presentCodeRedemption = false;
+
+  // Listen to purchase updates
+  bool? queueIsActive;
 
   Future<dynamic> onMethodCall(MethodCall call) {
     switch (call.method) {
@@ -208,8 +225,14 @@ class FakeIOSPlatform {
       case '-[InAppPurchasePlugin presentCodeRedemptionSheet:result:]':
         presentCodeRedemption = true;
         return Future<void>.sync(() {});
+      case '-[SKPaymentQueue startObservingTransactionQueue]':
+        queueIsActive = true;
+        return Future<void>.sync(() {});
+      case '-[SKPaymentQueue stopObservingTransactionQueue]':
+        queueIsActive = false;
+        return Future<void>.sync(() {});
     }
-    return Future<void>.sync(() {});
+    return Future.error('method not mocked');
   }
 }
 


### PR DESCRIPTION
At the moment `[_paymentQueueHandler startObservingPaymentQueue];` is called during the initialisation of the plugin. This means potentially iOS can directly start sending transaction updates. On the Dart side the _TransactionObserver is made with a broadcast stream, which means that any transaction received before anyone is listening will be lost.

I removed `[_paymentQueueHandler startObservingPaymentQueue];` from the plugin initialisation and added 2 method channel methods: `startObservingTransactionQueue` and `stopObservingTransactionQueue`. `startObservingTransactionQueue` is called when the first listener subscribes to the `purchaseStream` and `stopObservingTransactionQueue` when there are no longer any listeners subscribed.

This PR fixes flutter/flutter#83018 and the solution is largely inspired by the well written issue.

It should not be a breaking change, but I guess this might break apps that tried to do transactions without having any listeners to the `purchaseStream` as the [Apple Documentation](https://developer.apple.com/documentation/storekit/skpaymentqueue) says "To process a payment, first add at least one observer object to the queue.", but I guess that's a good thing.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format])
- [X] I signed the [CLA].
- [X] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [X] I listed at least one issue that this PR fixes in the description above.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[plugin_tool format]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
