### PR TITLE
[flutter_plugin_tools] Migrate publish and version checks to NNBD

### DIFF
--- a/script/tool/lib/src/common.dart
+++ b/script/tool/lib/src/common.dart
@@ -580,7 +580,7 @@ class ProcessRunner {
   /// passing [workingDir].
   ///
   /// Returns the started [io.Process].
-  Future<io.Process?> start(String executable, List<String> args,
+  Future<io.Process> start(String executable, List<String> args,
       {Directory? workingDirectory}) async {
     final io.Process process = await io.Process.start(executable, args,
         workingDirectory: workingDirectory?.path);
@@ -622,12 +622,12 @@ class PubVersionFinder {
 
     if (response.statusCode == 404) {
       return PubVersionFinderResponse(
-          versions: null,
+          versions: <Version>[],
           result: PubVersionFinderResult.noPackageFound,
           httpResponse: response);
     } else if (response.statusCode != 200) {
       return PubVersionFinderResponse(
-          versions: null,
+          versions: <Version>[],
           result: PubVersionFinderResult.fail,
           httpResponse: response);
     }
@@ -647,9 +647,12 @@ class PubVersionFinder {
 /// Represents a response for [PubVersionFinder].
 class PubVersionFinderResponse {
   /// Constructor.
-  PubVersionFinderResponse({this.versions, this.result, this.httpResponse}) {
-    if (versions != null && versions!.isNotEmpty) {
-      versions!.sort((Version a, Version b) {
+  PubVersionFinderResponse(
+      {required this.versions,
+      required this.result,
+      required this.httpResponse}) {
+    if (versions.isNotEmpty) {
+      versions.sort((Version a, Version b) {
         // TODO(cyanglaz): Think about how to handle pre-release version with [Version.prioritize].
         // https://github.com/flutter/flutter/issues/82222
         return b.compareTo(a);
@@ -661,13 +664,13 @@ class PubVersionFinderResponse {
   ///
   /// This is sorted by largest to smallest, so the first element in the list is the largest version.
   /// Might be `null` if the [result] is not [PubVersionFinderResult.success].
-  final List<Version>? versions;
+  final List<Version> versions;
 
   /// The result of the version finder.
-  final PubVersionFinderResult? result;
+  final PubVersionFinderResult result;
 
   /// The response object of the http request.
-  final http.Response? httpResponse;
+  final http.Response httpResponse;
 }
 
 /// An enum representing the result of [PubVersionFinder].

--- a/script/tool/lib/src/common.dart
+++ b/script/tool/lib/src/common.dart
@@ -146,11 +146,10 @@ bool isLinuxPlugin(FileSystemEntity entity) {
   return pluginSupportsPlatform(kLinux, entity);
 }
 
-/// Throws a [ToolExit] with `exitCode` and log the `errorMessage` in red.
-void printErrorAndExit({required String errorMessage, int exitCode = 1}) {
+/// Prints `errorMessage` in red.
+void printError(String errorMessage) {
   final Colorize redError = Colorize(errorMessage)..red();
   print(redError);
-  throw ToolExit(exitCode);
 }
 
 /// Error thrown when a command needs to exit with a non-zero exit code.
@@ -437,9 +436,10 @@ abstract class PluginCommand extends Command<void> {
     GitDir? baseGitDir = gitDir;
     if (baseGitDir == null) {
       if (!await GitDir.isGitDir(rootDir)) {
-        printErrorAndExit(
-            errorMessage: '$rootDir is not a valid Git repository.',
-            exitCode: 2);
+        printError(
+          '$rootDir is not a valid Git repository.',
+        );
+        throw ToolExit(2);
       }
       baseGitDir = await GitDir.fromExisting(rootDir);
     }

--- a/script/tool/lib/src/publish_plugin_command.dart
+++ b/script/tool/lib/src/publish_plugin_command.dart
@@ -507,10 +507,11 @@ Safe to ignore if the package is deleted in this commit.
     }
     final String credential = io.Platform.environment[_pubCredentialName];
     if (credential == null) {
-      printErrorAndExit(errorMessage: '''
+      printError('''
 No pub credential available. Please check if `~/.pub-cache/credentials.json` is valid.
 If running this command on CI, you can set the pub credential content in the $_pubCredentialName environment variable.
 ''');
+      throw ToolExit(1);
     }
     credentialFile.openSync(mode: FileMode.writeOnlyAppend)
       ..writeStringSync(credential)

--- a/script/tool/lib/src/version_check_command.dart
+++ b/script/tool/lib/src/version_check_command.dart
@@ -238,8 +238,8 @@ $indentation${badVersionChangePubspecs.join('\n$indentation')}
     if (mismatchedVersionPlugins.isNotEmpty) {
       passed = false;
       printError('''
-The following pubspecs failed validaton:
-$indentation${badVersionChangePubspecs.join('\n$indentation')}
+The following pubspecs have different versions in pubspec.yaml and CHANGELOG.md:
+$indentation${mismatchedVersionPlugins.join('\n$indentation')}
 ''');
     }
     if (!passed) {

--- a/script/tool/lib/src/version_check_command.dart
+++ b/script/tool/lib/src/version_check_command.dart
@@ -37,7 +37,7 @@ enum NextVersionType {
 /// those have different semver rules.
 @visibleForTesting
 Map<Version, NextVersionType> getAllowedNextVersions(
-    Version masterVersion, Version headVersion) {
+    {@required Version masterVersion, @required Version /*!*/ headVersion}) {
   final Map<Version, NextVersionType> allowedNextVersions =
       <Version, NextVersionType>{
     masterVersion.nextMajor: NextVersionType.BREAKING_MAJOR,
@@ -76,7 +76,7 @@ class VersionCheckCommand extends PluginCommand {
     Directory packagesDir, {
     ProcessRunner processRunner = const ProcessRunner(),
     GitDir gitDir,
-    this.httpClient,
+    http.Client httpClient,
   })  : _pubVersionFinder =
             PubVersionFinder(httpClient: httpClient ?? http.Client()),
         super(packagesDir, processRunner: processRunner, gitDir: gitDir) {
@@ -100,9 +100,6 @@ class VersionCheckCommand extends PluginCommand {
       'Also checks if the latest version in CHANGELOG matches the version in pubspec.\n\n'
       'This command requires "pub" and "flutter" to be in your path.';
 
-  /// The http client used to query pub server.
-  final http.Client httpClient;
-
   final PubVersionFinder _pubVersionFinder;
 
   @override
@@ -111,6 +108,8 @@ class VersionCheckCommand extends PluginCommand {
 
     final List<String> changedPubspecs =
         await gitVersionFinder.getChangedPubSpecs();
+
+    final List<String> badVersionChangePubspecs = <String>[];
 
     const String indentation = '  ';
     for (final String pubspecPath in changedPubspecs) {
@@ -129,10 +128,11 @@ class VersionCheckCommand extends PluginCommand {
       final Version headVersion =
           await gitVersionFinder.getPackageVersion(pubspecPath, gitRef: 'HEAD');
       if (headVersion == null) {
-        printErrorAndExit(
-            errorMessage: '${indentation}No version found. A package that '
-                'intentionally has no version should be marked '
-                '"publish_to: none".');
+        printError('${indentation}No version found. A package that '
+            'intentionally has no version should be marked '
+            '"publish_to: none".');
+        badVersionChangePubspecs.add(pubspecPath);
+        continue;
       }
       Version sourceVersion;
       if (getBoolArg(_againstPubFlag)) {
@@ -146,11 +146,13 @@ class VersionCheckCommand extends PluginCommand {
                 '$indentation$packageName: Current largest version on pub: $sourceVersion');
             break;
           case PubVersionFinderResult.fail:
-            printErrorAndExit(errorMessage: '''
+            printError('''
 ${indentation}Error fetching version on pub for $packageName.
 ${indentation}HTTP Status ${pubVersionFinderResponse.httpResponse.statusCode}
 ${indentation}HTTP response: ${pubVersionFinderResponse.httpResponse.body}
 ''');
+            badVersionChangePubspecs.add(pubspecPath);
+            continue;
             break;
           case PubVersionFinderResult.noPackageFound:
             sourceVersion = null;
@@ -180,7 +182,8 @@ ${indentation}HTTP response: ${pubVersionFinderResponse.httpResponse.body}
       // Check for reverts when doing local validation.
       if (!getBoolArg(_againstPubFlag) && headVersion < sourceVersion) {
         final Map<Version, NextVersionType> possibleVersionsFromNewVersion =
-            getAllowedNextVersions(headVersion, sourceVersion);
+            getAllowedNextVersions(
+                masterVersion: headVersion, headVersion: sourceVersion);
         // Since this skips validation, try to ensure that it really is likely
         // to be a revert rather than a typo by checking that the transition
         // from the lower version to the new version would have been valid.
@@ -192,14 +195,16 @@ ${indentation}HTTP response: ${pubVersionFinderResponse.httpResponse.body}
       }
 
       final Map<Version, NextVersionType> allowedNextVersions =
-          getAllowedNextVersions(sourceVersion, headVersion);
+          getAllowedNextVersions(
+              masterVersion: sourceVersion, headVersion: headVersion);
 
       if (!allowedNextVersions.containsKey(headVersion)) {
         final String source = (getBoolArg(_againstPubFlag)) ? 'pub' : 'master';
-        final String error = '${indentation}Incorrectly updated version.\n'
+        printError('${indentation}Incorrectly updated version.\n'
             '${indentation}HEAD: $headVersion, $source: $sourceVersion.\n'
-            '${indentation}Allowed versions: $allowedNextVersions';
-        printErrorAndExit(errorMessage: error);
+            '${indentation}Allowed versions: $allowedNextVersions');
+        badVersionChangePubspecs.add(pubspecPath);
+        continue;
       } else {
         print('$indentation$headVersion -> $sourceVersion');
       }
@@ -208,21 +213,48 @@ ${indentation}HTTP response: ${pubVersionFinderResponse.httpResponse.body}
           pubspec.name.endsWith('_platform_interface');
       if (isPlatformInterface &&
           allowedNextVersions[headVersion] == NextVersionType.BREAKING_MAJOR) {
-        final String error = '$pubspecPath breaking change detected.\n'
-            'Breaking changes to platform interfaces are strongly discouraged.\n';
-        printErrorAndExit(errorMessage: error);
+        printError('$pubspecPath breaking change detected.\n'
+            'Breaking changes to platform interfaces are strongly discouraged.\n');
+        badVersionChangePubspecs.add(pubspecPath);
+        continue;
+      }
+    }
+    _pubVersionFinder.httpClient.close();
+
+    // TODO(stuartmorgan): Unify the way iteration works for these checks; the
+    // two checks shouldn't be operating independently on different lists.
+    final List<String> mismatchedVersionPlugins = <String>[];
+    await for (final Directory plugin in getPlugins()) {
+      if (!(await _checkVersionsMatch(plugin))) {
+        mismatchedVersionPlugins.add(plugin.basename);
       }
     }
 
-    await for (final Directory plugin in getPlugins()) {
-      await _checkVersionsMatch(plugin);
+    bool passed = true;
+    if (badVersionChangePubspecs.isNotEmpty) {
+      passed = false;
+      printError('''
+The following pubspecs failed validaton:
+$indentation${badVersionChangePubspecs.join('\n$indentation')}
+''');
     }
-    _pubVersionFinder.httpClient.close();
+    if (mismatchedVersionPlugins.isNotEmpty) {
+      passed = false;
+      printError('''
+The following pubspecs failed validaton:
+$indentation${badVersionChangePubspecs.join('\n$indentation')}
+''');
+    }
+    if (!passed) {
+      throw ToolExit(1);
+    }
 
     print('No version check errors found!');
   }
 
-  Future<void> _checkVersionsMatch(Directory plugin) async {
+  /// Returns whether or not the pubspec version and CHANGELOG version for
+  /// [plugin] match.
+  Future<bool> _checkVersionsMatch(Directory plugin) async {
     // get version from pubspec
     final String packageName = plugin.basename;
     print('-----------------------------------------');
@@ -231,8 +263,8 @@ ${indentation}HTTP response: ${pubVersionFinderResponse.httpResponse.body}
 
     final Pubspec pubspec = _tryParsePubspec(plugin);
     if (pubspec == null) {
-      const String error = 'Cannot parse version from pubspec.yaml';
-      printErrorAndExit(errorMessage: error);
+      printError('Cannot parse version from pubspec.yaml');
+      return false;
     }
     final Version fromPubspec = pubspec.version;
 
@@ -268,32 +300,34 @@ ${indentation}HTTP response: ${pubVersionFinderResponse.httpResponse.body}
 
     final Version fromChangeLog = Version.parse(versionString);
     if (fromChangeLog == null) {
-      final String error =
-          'Cannot find version on the first line of ${plugin.path}/CHANGELOG.md';
-      printErrorAndExit(errorMessage: error);
+      printError(
+          'Cannot find version on the first line of ${plugin.path}/CHANGELOG.md');
+      return false;
     }
 
     if (fromPubspec != fromChangeLog) {
-      final String error = '''
+      printError('''
 versions for $packageName in CHANGELOG.md and pubspec.yaml do not match.
 The version in pubspec.yaml is $fromPubspec.
 The first version listed in CHANGELOG.md is $fromChangeLog.
-''';
-      printErrorAndExit(errorMessage: error);
+''');
+      return false;
     }
 
     // If NEXT wasn't the first section, it should not exist at all.
     if (!hasNextSection) {
       final RegExp nextRegex = RegExp(r'^#+\s*NEXT\s*$');
       if (lines.any((String line) => nextRegex.hasMatch(line))) {
-        printErrorAndExit(errorMessage: '''
+        printError('''
 When bumping the version for release, the NEXT section should be incorporated
 into the new version's release notes.
 ''');
+        return false;
       }
     }
 
     print('$packageName passed version check');
+    return true;
   }
 
   Pubspec _tryParsePubspec(Directory package) {
@@ -301,16 +335,10 @@ into the new version's release notes.
 
     try {
       final Pubspec pubspec = Pubspec.parse(pubspecFile.readAsStringSync());
-      if (pubspec == null) {
-        final String error =
-            'Failed to parse `pubspec.yaml` at ${pubspecFile.path}';
-        printErrorAndExit(errorMessage: error);
-      }
       return pubspec;
     } on Exception catch (exception) {
-      final String error =
-          'Failed to parse `pubspec.yaml` at ${pubspecFile.path}: $exception}';
-      printErrorAndExit(errorMessage: error);
+      printError(
+          'Failed to parse `pubspec.yaml` at ${pubspecFile.path}: $exception}');
     }
     return null;
   }

--- a/script/tool/test/common_test.dart
+++ b/script/tool/test/common_test.dart
@@ -414,10 +414,10 @@ file2/file2.cc
       final PubVersionFinderResponse response =
           await finder.getPackageVersion(package: 'some_package');
 
-      expect(response.versions, isNull);
+      expect(response.versions, isEmpty);
       expect(response.result, PubVersionFinderResult.noPackageFound);
-      expect(response.httpResponse!.statusCode, 404);
-      expect(response.httpResponse!.body, '');
+      expect(response.httpResponse.statusCode, 404);
+      expect(response.httpResponse.body, '');
     });
 
     test('HTTP error when getting versions from pub', () async {
@@ -428,10 +428,10 @@ file2/file2.cc
       final PubVersionFinderResponse response =
           await finder.getPackageVersion(package: 'some_package');
 
-      expect(response.versions, isNull);
+      expect(response.versions, isEmpty);
       expect(response.result, PubVersionFinderResult.fail);
-      expect(response.httpResponse!.statusCode, 400);
-      expect(response.httpResponse!.body, '');
+      expect(response.httpResponse.statusCode, 400);
+      expect(response.httpResponse.body, '');
     });
 
     test('Get a correct list of versions when http response is OK.', () async {
@@ -474,8 +474,8 @@ file2/file2.cc
         Version.parse('0.0.1'),
       ]);
       expect(response.result, PubVersionFinderResult.success);
-      expect(response.httpResponse!.statusCode, 200);
-      expect(response.httpResponse!.body, json.encode(httpResponse));
+      expect(response.httpResponse.statusCode, 200);
+      expect(response.httpResponse.body, json.encode(httpResponse));
     });
   });
 }

--- a/script/tool/test/publish_check_command_test.dart
+++ b/script/tool/test/publish_check_command_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 import 'dart:collection';
 import 'dart:convert';
 import 'dart:io' as io;
@@ -23,9 +21,9 @@ import 'util.dart';
 void main() {
   group('$PublishCheckProcessRunner tests', () {
     FileSystem fileSystem;
-    Directory packagesDir;
-    PublishCheckProcessRunner processRunner;
-    CommandRunner<void> runner;
+    late Directory packagesDir;
+    late PublishCheckProcessRunner processRunner;
+    late CommandRunner<void> runner;
 
     setUp(() {
       fileSystem = MemoryFileSystem();
@@ -177,7 +175,7 @@ void main() {
         } else if (request.url.pathSegments.last == 'no_publish_b.json') {
           return http.Response(json.encode(httpResponseB), 200);
         }
-        return null;
+        return http.Response('', 500);
       });
       final PublishCheckCommand command = PublishCheckCommand(packagesDir,
           processRunner: processRunner, httpClient: mockClient);
@@ -243,7 +241,7 @@ void main() {
         } else if (request.url.pathSegments.last == 'no_publish_b.json') {
           return http.Response(json.encode(httpResponseB), 200);
         }
-        return null;
+        return http.Response('', 500);
       });
       final PublishCheckCommand command = PublishCheckCommand(packagesDir,
           processRunner: processRunner, httpClient: mockClient);
@@ -312,7 +310,7 @@ void main() {
         } else if (request.url.pathSegments.last == 'no_publish_b.json') {
           return http.Response(json.encode(httpResponseB), 200);
         }
-        return null;
+        return http.Response('', 500);
       });
       final PublishCheckCommand command = PublishCheckCommand(packagesDir,
           processRunner: processRunner, httpClient: mockClient);

--- a/script/tool/test/version_check_test.dart
+++ b/script/tool/test/version_check_test.dart
@@ -30,7 +30,7 @@ void testAllowedVersion(
   final Version master = Version.parse(masterVersion);
   final Version head = Version.parse(headVersion);
   final Map<Version, NextVersionType> allowedVersions =
-      getAllowedNextVersions(master, head);
+      getAllowedNextVersions(masterVersion: master, headVersion: head);
   if (allowed) {
     expect(allowedVersions, contains(head));
     if (nextVersionType != null) {

--- a/script/tool/test/version_check_test.dart
+++ b/script/tool/test/version_check_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io' as io;
@@ -13,19 +11,20 @@ import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common.dart';
 import 'package:flutter_plugin_tools/src/version_check_command.dart';
-import 'package:git/git.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:mockito/mockito.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
+
+import 'common_test.mocks.dart';
 import 'util.dart';
 
 void testAllowedVersion(
   String masterVersion,
   String headVersion, {
   bool allowed = true,
-  NextVersionType nextVersionType,
+  NextVersionType? nextVersionType,
 }) {
   final Version master = Version.parse(masterVersion);
   final Version head = Version.parse(headVersion);
@@ -41,8 +40,6 @@ void testAllowedVersion(
   }
 }
 
-class MockGitDir extends Mock implements GitDir {}
-
 class MockProcessResult extends Mock implements io.ProcessResult {}
 
 const String _redColorMessagePrefix = '\x1B[31m';
@@ -57,13 +54,13 @@ void main() {
   const String indentation = '  ';
   group('$VersionCheckCommand', () {
     FileSystem fileSystem;
-    Directory packagesDir;
-    CommandRunner<void> runner;
-    RecordingProcessRunner processRunner;
-    List<List<String>> gitDirCommands;
+    late Directory packagesDir;
+    late CommandRunner<void> runner;
+    late RecordingProcessRunner processRunner;
+    late List<List<String>> gitDirCommands;
     String gitDiffResponse;
     Map<String, String> gitShowResponses;
-    MockGitDir gitDir;
+    late MockGitDir gitDir;
 
     setUp(() {
       fileSystem = MemoryFileSystem();
@@ -77,17 +74,19 @@ void main() {
         gitDirCommands.add(invocation.positionalArguments[0] as List<String>);
         final MockProcessResult mockProcessResult = MockProcessResult();
         if (invocation.positionalArguments[0][0] == 'diff') {
-          when<String>(mockProcessResult.stdout as String)
+          when<String?>(mockProcessResult.stdout as String?)
               .thenReturn(gitDiffResponse);
         } else if (invocation.positionalArguments[0][0] == 'show') {
-          final String response =
+          final String? response =
               gitShowResponses[invocation.positionalArguments[0][1]];
           if (response == null) {
             throw const io.ProcessException('git', <String>['show']);
           }
-          when<String>(mockProcessResult.stdout as String).thenReturn(response);
+          when<String?>(mockProcessResult.stdout as String?)
+              .thenReturn(response);
         } else if (invocation.positionalArguments[0][0] == 'merge-base') {
-          when<String>(mockProcessResult.stdout as String).thenReturn('abc123');
+          when<String?>(mockProcessResult.stdout as String?)
+              .thenReturn('abc123');
         }
         return Future<io.ProcessResult>.value(mockProcessResult);
       });


### PR DESCRIPTION
Migrates publish-check and version-check commands to NNBD.

Reworks the version-check flow so that it's more consistent with the other commands: instead of immediately exiting on failure, it checks all plugins, gathers failures, and summarizes all failures at the end. This ensures that we don't have failures in one package temporarily masked by failures in another, so PRs don't need to go through as many check cycles.

Part of https://github.com/flutter/flutter/issues/81912

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format])
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[plugin_tool format]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
