### PR TITLE
Standardize example bundle ID domain

### DIFF
--- a/packages/battery/battery/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/battery/battery/example/ios/Runner.xcodeproj/project.pbxproj
@@ -437,7 +437,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.batteryExample;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.batteryExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -458,7 +458,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.batteryExample;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.batteryExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/packages/camera/camera/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/camera/camera/example/ios/Runner.xcodeproj/project.pbxproj
@@ -421,7 +421,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = "io.flutter.plugins.cameraExample.camera-exampleTests";
+				PRODUCT_BUNDLE_IDENTIFIER = "dev.flutter.plugins.cameraExample.camera-exampleTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/Runner";
@@ -445,7 +445,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = "io.flutter.plugins.cameraExample.camera-exampleTests";
+				PRODUCT_BUNDLE_IDENTIFIER = "dev.flutter.plugins.cameraExample.camera-exampleTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/Runner";
@@ -574,7 +574,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.cameraExample;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.cameraExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -595,7 +595,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.cameraExample;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.cameraExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/packages/connectivity/connectivity/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/connectivity/connectivity/example/ios/Runner.xcodeproj/project.pbxproj
@@ -437,7 +437,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.connectivityExample;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.connectivityExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -458,7 +458,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.connectivityExample;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.connectivityExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/packages/connectivity/connectivity/example/macos/Runner/Configs/AppInfo.xcconfig
+++ b/packages/connectivity/connectivity/example/macos/Runner/Configs/AppInfo.xcconfig
@@ -8,7 +8,7 @@
 PRODUCT_NAME = connectivity_example
 
 // The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.connectivityExample
+PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.connectivityExample
 
 // The copyright displayed in application information
-PRODUCT_COPYRIGHT = Copyright © 2019 io.flutter.plugins. All rights reserved.
+PRODUCT_COPYRIGHT = Copyright © 2019 The Flutter Authors.flutter.plugins. All rights reserved.

--- a/packages/connectivity/connectivity_macos/example/macos/Runner/Configs/AppInfo.xcconfig
+++ b/packages/connectivity/connectivity_macos/example/macos/Runner/Configs/AppInfo.xcconfig
@@ -8,7 +8,7 @@
 PRODUCT_NAME = connectivity_example
 
 // The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.connectivityExample
+PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.connectivityExample
 
 // The copyright displayed in application information
-PRODUCT_COPYRIGHT = Copyright © 2019 io.flutter.plugins. All rights reserved.
+PRODUCT_COPYRIGHT = Copyright © 2019 The Flutter Authors. All rights reserved.

--- a/packages/device_info/device_info/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/device_info/device_info/example/ios/Runner.xcodeproj/project.pbxproj
@@ -437,7 +437,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.deviceInfoExample;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.deviceInfoExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -458,7 +458,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.deviceInfoExample;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.deviceInfoExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/packages/google_maps_flutter/google_maps_flutter/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/google_maps_flutter/google_maps_flutter/example/ios/Runner.xcodeproj/project.pbxproj
@@ -609,7 +609,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.googleMobileMapsExample;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.googleMobileMapsExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -630,7 +630,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.googleMobileMapsExample;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.googleMobileMapsExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -644,7 +644,7 @@
 				INFOPLIST_FILE = RunnerTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/Runner";
 			};
@@ -659,7 +659,7 @@
 				INFOPLIST_FILE = RunnerTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/Runner";
 			};
@@ -672,7 +672,7 @@
 				INFOPLIST_FILE = RunnerUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.RunnerUITests;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.RunnerUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_TARGET_NAME = Runner;
 			};
@@ -685,7 +685,7 @@
 				INFOPLIST_FILE = RunnerUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.RunnerUITests;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.RunnerUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_TARGET_NAME = Runner;
 			};

--- a/packages/google_sign_in/google_sign_in/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/google_sign_in/google_sign_in/example/ios/Runner.xcodeproj/project.pbxproj
@@ -613,7 +613,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.googleSignInExample;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.googleSignInExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -634,7 +634,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.googleSignInExample;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.googleSignInExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -647,7 +647,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = RunnerTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/Runner";
 			};
@@ -661,7 +661,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = RunnerTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/Runner";
 			};
@@ -673,7 +673,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = RunnerUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.RunnerUITests;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.RunnerUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_TARGET_NAME = Runner;
 			};
@@ -685,7 +685,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = RunnerUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.RunnerUITests;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.RunnerUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_TARGET_NAME = Runner;
 			};

--- a/packages/image_picker/image_picker/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/image_picker/image_picker/example/ios/Runner.xcodeproj/project.pbxproj
@@ -624,7 +624,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = RunnerTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/Runner";
 			};
@@ -638,7 +638,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = RunnerTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/Runner";
 			};
@@ -816,7 +816,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.imagePickerExample;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.imagePickerExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -838,7 +838,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.imagePickerExample;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.imagePickerExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/packages/in_app_purchase/in_app_purchase/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/in_app_purchase/in_app_purchase/example/ios/Runner.xcodeproj/project.pbxproj
@@ -427,7 +427,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.inAppPurchaseExample;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.inAppPurchaseExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
@@ -451,7 +451,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.inAppPurchaseExample;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.inAppPurchaseExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				VERSIONING_SYSTEM = "apple-generic";
 			};

--- a/packages/in_app_purchase/in_app_purchase_ios/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/in_app_purchase/in_app_purchase_ios/example/ios/Runner.xcodeproj/project.pbxproj
@@ -561,7 +561,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.inAppPurchaseExample;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.inAppPurchaseExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
@@ -585,7 +585,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.inAppPurchaseExample;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.inAppPurchaseExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
@@ -608,7 +608,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/Runner";
 			};
@@ -630,7 +630,7 @@
 				INFOPLIST_FILE = RunnerTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/Runner";
 			};

--- a/packages/ios_platform_images/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/ios_platform_images/example/ios/Runner.xcodeproj/project.pbxproj
@@ -660,7 +660,7 @@
 				DEVELOPMENT_TEAM = S8QB4VV633;
 				INFOPLIST_FILE = RunnerTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/Runner";
 			};
@@ -675,7 +675,7 @@
 				DEVELOPMENT_TEAM = S8QB4VV633;
 				INFOPLIST_FILE = RunnerTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/Runner";
 			};
@@ -690,7 +690,7 @@
 				DEVELOPMENT_TEAM = S8QB4VV633;
 				INFOPLIST_FILE = RunnerTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/Runner";
 			};

--- a/packages/local_auth/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/local_auth/example/ios/Runner.xcodeproj/project.pbxproj
@@ -568,7 +568,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.localAuthExample;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.localAuthExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -589,7 +589,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.localAuthExample;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.localAuthExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/packages/package_info/example/integration_test/package_info_test.dart
+++ b/packages/package_info/example/integration_test/package_info_test.dart
@@ -24,12 +24,12 @@ void main() {
     } else if (Platform.isIOS) {
       expect(info.appName, 'Package Info Example');
       expect(info.buildNumber, '1');
-      expect(info.packageName, 'io.flutter.plugins.packageInfoExample');
+      expect(info.packageName, 'dev.flutter.plugins.packageInfoExample');
       expect(info.version, '1.0');
     } else if (Platform.isMacOS) {
       expect(info.appName, 'Package Info Example');
       expect(info.buildNumber, '1');
-      expect(info.packageName, 'io.flutter.plugins.packageInfoExample');
+      expect(info.packageName, 'dev.flutter.plugins.packageInfoExample');
       expect(info.version, '1.0.0');
     } else {
       throw (UnsupportedError('platform not supported'));
@@ -49,13 +49,13 @@ void main() {
       expect(find.text('Package Info Example'), findsOneWidget);
       expect(find.text('1'), findsOneWidget);
       expect(
-          find.text('io.flutter.plugins.packageInfoExample'), findsOneWidget);
+          find.text('dev.flutter.plugins.packageInfoExample'), findsOneWidget);
       expect(find.text('1.0'), findsOneWidget);
     } else if (Platform.isMacOS) {
       expect(find.text('Package Info Example'), findsOneWidget);
       expect(find.text('1'), findsOneWidget);
       expect(
-          find.text('io.flutter.plugins.packageInfoExample'), findsOneWidget);
+          find.text('dev.flutter.plugins.packageInfoExample'), findsOneWidget);
       expect(find.text('1.0.0'), findsOneWidget);
     } else {
       throw (UnsupportedError('platform not supported'));

--- a/packages/package_info/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/package_info/example/ios/Runner.xcodeproj/project.pbxproj
@@ -437,7 +437,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.packageInfoExample;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.packageInfoExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -458,7 +458,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.packageInfoExample;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.packageInfoExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/packages/package_info/example/macos/Runner/Configs/AppInfo.xcconfig
+++ b/packages/package_info/example/macos/Runner/Configs/AppInfo.xcconfig
@@ -8,7 +8,7 @@
 PRODUCT_NAME = Package Info Example
 
 // The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.packageInfoExample
+PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.packageInfoExample
 
 // The copyright displayed in application information
-PRODUCT_COPYRIGHT = Copyright © 2020 io.flutter.plugins. All rights reserved.
+PRODUCT_COPYRIGHT = Copyright © 2020 The Flutter Authors. All rights reserved.

--- a/packages/path_provider/path_provider/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/path_provider/path_provider/example/ios/Runner.xcodeproj/project.pbxproj
@@ -517,7 +517,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.pathProviderExample;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.pathProviderExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -538,7 +538,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.pathProviderExample;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.pathProviderExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -551,7 +551,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = RunnerTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/Runner";
 			};
@@ -565,7 +565,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = RunnerTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/Runner";
 			};

--- a/packages/path_provider/path_provider/example/linux/CMakeLists.txt
+++ b/packages/path_provider/path_provider/example/linux/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.10)
 project(runner LANGUAGES CXX)
 
 set(BINARY_NAME "example")
-set(APPLICATION_ID "io.flutter.plugins.example")
+set(APPLICATION_ID "dev.flutter.plugins.path_provider_example")
 
 cmake_policy(SET CMP0063 NEW)
 

--- a/packages/path_provider/path_provider/example/macos/Runner/Configs/AppInfo.xcconfig
+++ b/packages/path_provider/path_provider/example/macos/Runner/Configs/AppInfo.xcconfig
@@ -8,7 +8,7 @@
 PRODUCT_NAME = path_provider_example
 
 // The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.pathProviderExample
+PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.pathProviderExample
 
 // The copyright displayed in application information
-PRODUCT_COPYRIGHT = Copyright © 2019 io.flutter.plugins. All rights reserved.
+PRODUCT_COPYRIGHT = Copyright © 2019 The Flutter Authors. All rights reserved.

--- a/packages/path_provider/path_provider/example/windows/runner/Runner.rc
+++ b/packages/path_provider/path_provider/example/windows/runner/Runner.rc
@@ -89,11 +89,11 @@ BEGIN
     BEGIN
         BLOCK "040904e4"
         BEGIN
-            VALUE "CompanyName", "io.flutter.plugins" "\0"
+            VALUE "CompanyName", "Flutter Dev" "\0"
             VALUE "FileDescription", "A new Flutter project." "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
             VALUE "InternalName", "example" "\0"
-            VALUE "LegalCopyright", "Copyright (C) 2020 io.flutter.plugins. All rights reserved." "\0"
+            VALUE "LegalCopyright", "Copyright (C) 2020 The Flutter Authors. All rights reserved." "\0"
             VALUE "OriginalFilename", "example.exe" "\0"
             VALUE "ProductName", "example" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"

--- a/packages/path_provider/path_provider_linux/example/linux/CMakeLists.txt
+++ b/packages/path_provider/path_provider_linux/example/linux/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.10)
 project(runner LANGUAGES CXX)
 
 set(BINARY_NAME "example")
-set(APPLICATION_ID "com.example.example")
+set(APPLICATION_ID "dev.flutter.plugins.path_provider_linux_example")
 
 cmake_policy(SET CMP0063 NEW)
 

--- a/packages/path_provider/path_provider_macos/example/macos/Runner/Configs/AppInfo.xcconfig
+++ b/packages/path_provider/path_provider_macos/example/macos/Runner/Configs/AppInfo.xcconfig
@@ -8,7 +8,7 @@
 PRODUCT_NAME = path_provider_example
 
 // The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.pathProviderExample
+PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.pathProviderExample
 
 // The copyright displayed in application information
-PRODUCT_COPYRIGHT = Copyright © 2019 io.flutter.plugins. All rights reserved.
+PRODUCT_COPYRIGHT = Copyright © 2019 The Flutter Authors. All rights reserved.

--- a/packages/quick_actions/quick_actions/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/quick_actions/quick_actions/example/ios/Runner.xcodeproj/project.pbxproj
@@ -531,7 +531,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.quickActionsExample;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.quickActionsExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -552,7 +552,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.quickActionsExample;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.quickActionsExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/packages/sensors/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/sensors/example/ios/Runner.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.sensorsExample;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.sensorsExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -460,7 +460,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.sensorsExample;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.sensorsExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/packages/share/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/share/example/ios/Runner.xcodeproj/project.pbxproj
@@ -531,7 +531,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.shareExample;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.shareExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -552,7 +552,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.shareExample;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.shareExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/packages/shared_preferences/shared_preferences/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/shared_preferences/shared_preferences/example/ios/Runner.xcodeproj/project.pbxproj
@@ -517,7 +517,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.sharedPreferencesExample;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.sharedPreferencesExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -538,7 +538,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.sharedPreferencesExample;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.sharedPreferencesExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -551,7 +551,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = RunnerTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/Runner";
 			};
@@ -565,7 +565,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = RunnerTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/Runner";
 			};

--- a/packages/shared_preferences/shared_preferences/example/linux/CMakeLists.txt
+++ b/packages/shared_preferences/shared_preferences/example/linux/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.10)
 project(runner LANGUAGES CXX)
 
 set(BINARY_NAME "example")
-set(APPLICATION_ID "io.flutter.plugins.example")
+set(APPLICATION_ID "dev.flutter.plugins.shared_preferences_example")
 
 cmake_policy(SET CMP0063 NEW)
 

--- a/packages/shared_preferences/shared_preferences/example/macos/Runner/Configs/AppInfo.xcconfig
+++ b/packages/shared_preferences/shared_preferences/example/macos/Runner/Configs/AppInfo.xcconfig
@@ -8,7 +8,7 @@
 PRODUCT_NAME = example
 
 // The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.example
+PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.example
 
 // The copyright displayed in application information
-PRODUCT_COPYRIGHT = Copyright © 2021 io.flutter.plugins. All rights reserved.
+PRODUCT_COPYRIGHT = Copyright © 2021 The Flutter Authors. All rights reserved.

--- a/packages/shared_preferences/shared_preferences/example/windows/runner/Runner.rc
+++ b/packages/shared_preferences/shared_preferences/example/windows/runner/Runner.rc
@@ -89,11 +89,11 @@ BEGIN
     BEGIN
         BLOCK "040904e4"
         BEGIN
-            VALUE "CompanyName", "io.flutter.plugins" "\0"
+            VALUE "CompanyName", "Flutter Dev" "\0"
             VALUE "FileDescription", "A new Flutter project." "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
             VALUE "InternalName", "example" "\0"
-            VALUE "LegalCopyright", "Copyright (C) 2020 io.flutter.plugins. All rights reserved." "\0"
+            VALUE "LegalCopyright", "Copyright (C) 2020 The Flutter Authors. All rights reserved." "\0"
             VALUE "OriginalFilename", "example.exe" "\0"
             VALUE "ProductName", "example" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"

--- a/packages/shared_preferences/shared_preferences_macos/example/macos/Runner/Configs/AppInfo.xcconfig
+++ b/packages/shared_preferences/shared_preferences_macos/example/macos/Runner/Configs/AppInfo.xcconfig
@@ -8,7 +8,7 @@
 PRODUCT_NAME = url_launcher_example_example
 
 // The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.urlLauncherExample
+PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.urlLauncherExample
 
 // The copyright displayed in application information
-PRODUCT_COPYRIGHT = Copyright © 2019 io.flutter.plugins. All rights reserved.
+PRODUCT_COPYRIGHT = Copyright © 2019 The Flutter Authors. All rights reserved.

--- a/packages/url_launcher/url_launcher/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/url_launcher/url_launcher/example/ios/Runner.xcodeproj/project.pbxproj
@@ -591,7 +591,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.urlLauncher;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.urlLauncher;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -612,7 +612,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.urlLauncher;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.urlLauncher;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -626,7 +626,7 @@
 				INFOPLIST_FILE = RunnerTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/Runner";
 			};
@@ -641,7 +641,7 @@
 				INFOPLIST_FILE = RunnerTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/Runner";
 			};
@@ -654,7 +654,7 @@
 				INFOPLIST_FILE = RunnerUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.RunnerUITests;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.RunnerUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_TARGET_NAME = Runner;
 			};
@@ -667,7 +667,7 @@
 				INFOPLIST_FILE = RunnerUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.RunnerUITests;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.RunnerUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_TARGET_NAME = Runner;
 			};

--- a/packages/url_launcher/url_launcher/example/macos/Runner/Configs/AppInfo.xcconfig
+++ b/packages/url_launcher/url_launcher/example/macos/Runner/Configs/AppInfo.xcconfig
@@ -8,7 +8,7 @@
 PRODUCT_NAME = url_launcher_example_example
 
 // The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.urlLauncherExample
+PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.urlLauncherExample
 
 // The copyright displayed in application information
-PRODUCT_COPYRIGHT = Copyright © 2019 io.flutter.plugins. All rights reserved.
+PRODUCT_COPYRIGHT = Copyright © 2019 The Flutter Authors. All rights reserved.

--- a/packages/url_launcher/url_launcher/example/windows/runner/Runner.rc
+++ b/packages/url_launcher/url_launcher/example/windows/runner/Runner.rc
@@ -89,11 +89,11 @@ BEGIN
     BEGIN
         BLOCK "040904e4"
         BEGIN
-            VALUE "CompanyName", "io.flutter.plugins" "\0"
+            VALUE "CompanyName", "Flutter Dev" "\0"
             VALUE "FileDescription", "A new Flutter project." "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
             VALUE "InternalName", "example" "\0"
-            VALUE "LegalCopyright", "Copyright (C) 2020 io.flutter.plugins. All rights reserved." "\0"
+            VALUE "LegalCopyright", "Copyright (C) 2020 The Flutter Authors. All rights reserved." "\0"
             VALUE "OriginalFilename", "example.exe" "\0"
             VALUE "ProductName", "example" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"

--- a/packages/url_launcher/url_launcher_macos/example/macos/Runner/Configs/AppInfo.xcconfig
+++ b/packages/url_launcher/url_launcher_macos/example/macos/Runner/Configs/AppInfo.xcconfig
@@ -8,7 +8,7 @@
 PRODUCT_NAME = url_launcher_example_example
 
 // The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.urlLauncherExample
+PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.urlLauncherExample
 
 // The copyright displayed in application information
-PRODUCT_COPYRIGHT = Copyright © 2019 io.flutter.plugins. All rights reserved.
+PRODUCT_COPYRIGHT = Copyright © 2019 The Flutter Authors. All rights reserved.

--- a/packages/video_player/video_player/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/video_player/video_player/example/ios/Runner.xcodeproj/project.pbxproj
@@ -590,7 +590,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.videoPlayerExample;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.videoPlayerExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -611,7 +611,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.videoPlayerExample;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.videoPlayerExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -623,7 +623,7 @@
 				INFOPLIST_FILE = RunnerUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.RunnerUITests;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.RunnerUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_TARGET_NAME = Runner;
 			};
@@ -636,7 +636,7 @@
 				INFOPLIST_FILE = RunnerUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.RunnerUITests;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.RunnerUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_TARGET_NAME = Runner;
 			};
@@ -651,7 +651,7 @@
 				INFOPLIST_FILE = RunnerTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/Runner";
 			};
@@ -666,7 +666,7 @@
 				INFOPLIST_FILE = RunnerTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/Runner";
 			};

--- a/packages/webview_flutter/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/webview_flutter/example/ios/Runner.xcodeproj/project.pbxproj
@@ -479,7 +479,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = RunnerTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/Runner";
 			};
@@ -493,7 +493,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = RunnerTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/Runner";
 			};
@@ -622,7 +622,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.webviewFlutterExample;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.webviewFlutterExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
@@ -645,7 +645,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.webviewFlutterExample;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.webviewFlutterExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
@@ -658,7 +658,7 @@
 				INFOPLIST_FILE = RunnerUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.RunnerUITests;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.RunnerUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_TARGET_NAME = Runner;
 			};
@@ -671,7 +671,7 @@
 				INFOPLIST_FILE = RunnerUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.RunnerUITests;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.RunnerUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_TARGET_NAME = Runner;
 			};

--- a/packages/wifi_info_flutter/wifi_info_flutter/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/wifi_info_flutter/wifi_info_flutter/example/ios/Runner.xcodeproj/project.pbxproj
@@ -310,7 +310,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.wifiInfoFlutterExample;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.wifiInfoFlutterExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
@@ -438,7 +438,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.wifiInfoFlutterExample;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.wifiInfoFlutterExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
@@ -461,7 +461,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.flutter.plugins.wifiInfoFlutterExample;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.wifiInfoFlutterExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				VERSIONING_SYSTEM = "apple-generic";
 			};


### PR DESCRIPTION
Uses "dev.flutter" rather than "io.flutter" for example application IDs on most platforms. Does not change Android since that may have more wide-reaching impact.

Also updates example copyrights on those platforms to the correct authorship.

Does not update versions on CHANGELOGs since this is an irrelevant-to-clients implementation detail of the example apps.

Part of https://github.com/flutter/flutter/issues/31336

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`. See [plugin_tool format])
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[plugin_tool format]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
