### PR TITLE
[flutter_plugin_tool] Add support for building UWP plugins

### DIFF
--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -5,6 +5,7 @@
   compatibility.
 - `xctest` now supports running macOS tests in addition to iOS
   - **Breaking change**: it now requires an `--ios` and/or `--macos` flag.
+- `build-examples` now supports UWP plugins via a `--winuwp` flag.
 
 ## 0.2.0
 

--- a/script/tool/lib/src/build_examples_command.dart
+++ b/script/tool/lib/src/build_examples_command.dart
@@ -135,8 +135,8 @@ class BuildExamplesCommand extends PluginCommand {
         }
 
         if (getBoolArg(kPlatformWindows)) {
-          print('\nBUILDING Windows for $packageName');
-          if (isWindowsPlugin(plugin)) {
+          print('\nBUILDING Windows (Win32) for $packageName');
+          if (isWindowsPlugin(plugin, variant: kPlatformVariantWin32)) {
             final int buildExitCode = await processRunner.runAndStream(
                 flutterCommand,
                 <String>[
@@ -150,13 +150,13 @@ class BuildExamplesCommand extends PluginCommand {
               failingPackages.add('$packageName (windows)');
             }
           } else {
-            print('Windows is not supported by this plugin');
+            print('Win32 is not supported by this plugin');
           }
         }
 
         if (getBoolArg(kPlatformWinUwp)) {
           print('\nBUILDING UWP for $packageName');
-          if (isWindowsPlugin(plugin)) {
+          if (isWindowsPlugin(plugin, variant: kPlatformVariantWinUwp)) {
             // The UWP template is not yet stable, so the UWP directory
             // needs to be created on the fly with 'flutter create .'
             final Directory uwpFolder = example.childDirectory('uwp');

--- a/script/tool/lib/src/build_examples_command.dart
+++ b/script/tool/lib/src/build_examples_command.dart
@@ -164,7 +164,7 @@ class BuildExamplesCommand extends PluginCommand {
             if (!uwpFolder.existsSync()) {
               print('Creating temporary winuwp folder');
               final int exampleCreateCode = await processRunner.runAndStream(
-                  flutterCommand, <String>['create', '.', '--platforms=winuwp'],
+                  flutterCommand, <String>['create', '--platforms=winuwp', '.'],
                   workingDir: example);
               if (exampleCreateCode == 0) {
                 exampleCreated = true;

--- a/script/tool/lib/src/build_examples_command.dart
+++ b/script/tool/lib/src/build_examples_command.dart
@@ -24,11 +24,11 @@ class BuildExamplesCommand extends PluginCommand {
     Directory packagesDir, {
     ProcessRunner processRunner = const ProcessRunner(),
   }) : super(packagesDir, processRunner: processRunner) {
-    argParser.addFlag(kPlatformFlagLinux, defaultsTo: false);
-    argParser.addFlag(kPlatformFlagMacos, defaultsTo: false);
-    argParser.addFlag(kPlatformFlagWeb, defaultsTo: false);
-    argParser.addFlag(kPlatformFlagWindows, defaultsTo: false);
-    argParser.addFlag(kPlatformFlagWinUwp, defaultsTo: false);
+    argParser.addFlag(kPlatformLinux, defaultsTo: false);
+    argParser.addFlag(kPlatformMacos, defaultsTo: false);
+    argParser.addFlag(kPlatformWeb, defaultsTo: false);
+    argParser.addFlag(kPlatformWindows, defaultsTo: false);
+    argParser.addFlag(kPlatformWinUwp, defaultsTo: false);
     argParser.addFlag(kIpa, defaultsTo: io.Platform.isMacOS);
     argParser.addFlag(kApk);
     argParser.addOption(
@@ -51,11 +51,11 @@ class BuildExamplesCommand extends PluginCommand {
     final List<String> platformSwitches = <String>[
       kApk,
       kIpa,
-      kPlatformFlagLinux,
-      kPlatformFlagMacos,
-      kPlatformFlagWeb,
-      kPlatformFlagWindows,
-      kPlatformFlagWinUwp,
+      kPlatformLinux,
+      kPlatformMacos,
+      kPlatformWeb,
+      kPlatformWindows,
+      kPlatformWinUwp,
     ];
     if (!platformSwitches.any((String platform) => getBoolArg(platform))) {
       print(
@@ -74,14 +74,14 @@ class BuildExamplesCommand extends PluginCommand {
         final String packageName =
             p.relative(example.path, from: packagesDir.path);
 
-        if (getBoolArg(kPlatformFlagLinux)) {
+        if (getBoolArg(kPlatformLinux)) {
           print('\nBUILDING Linux for $packageName');
           if (isLinuxPlugin(plugin)) {
             final int buildExitCode = await processRunner.runAndStream(
                 flutterCommand,
                 <String>[
                   'build',
-                  kPlatformFlagLinux,
+                  kPlatformLinux,
                   if (enableExperiment.isNotEmpty)
                     '--enable-experiment=$enableExperiment',
                 ],
@@ -94,14 +94,14 @@ class BuildExamplesCommand extends PluginCommand {
           }
         }
 
-        if (getBoolArg(kPlatformFlagMacos)) {
+        if (getBoolArg(kPlatformMacos)) {
           print('\nBUILDING macOS for $packageName');
           if (isMacOsPlugin(plugin)) {
             final int exitCode = await processRunner.runAndStream(
                 flutterCommand,
                 <String>[
                   'build',
-                  kPlatformFlagMacos,
+                  kPlatformMacos,
                   if (enableExperiment.isNotEmpty)
                     '--enable-experiment=$enableExperiment',
                 ],
@@ -114,14 +114,14 @@ class BuildExamplesCommand extends PluginCommand {
           }
         }
 
-        if (getBoolArg(kPlatformFlagWeb)) {
+        if (getBoolArg(kPlatformWeb)) {
           print('\nBUILDING web for $packageName');
           if (isWebPlugin(plugin)) {
             final int buildExitCode = await processRunner.runAndStream(
                 flutterCommand,
                 <String>[
                   'build',
-                  kPlatformFlagWeb,
+                  kPlatformWeb,
                   if (enableExperiment.isNotEmpty)
                     '--enable-experiment=$enableExperiment',
                 ],
@@ -134,14 +134,14 @@ class BuildExamplesCommand extends PluginCommand {
           }
         }
 
-        if (getBoolArg(kPlatformFlagWindows)) {
+        if (getBoolArg(kPlatformWindows)) {
           print('\nBUILDING Windows for $packageName');
           if (isWindowsPlugin(plugin)) {
             final int buildExitCode = await processRunner.runAndStream(
                 flutterCommand,
                 <String>[
                   'build',
-                  kPlatformFlagWindows,
+                  kPlatformWindows,
                   if (enableExperiment.isNotEmpty)
                     '--enable-experiment=$enableExperiment',
                 ],
@@ -154,7 +154,7 @@ class BuildExamplesCommand extends PluginCommand {
           }
         }
 
-        if (getBoolArg(kPlatformFlagWinUwp)) {
+        if (getBoolArg(kPlatformWinUwp)) {
           print('\nBUILDING UWP for $packageName');
           if (isWindowsPlugin(plugin)) {
             // The UWP template is not yet stable, so the UWP directory
@@ -174,7 +174,7 @@ class BuildExamplesCommand extends PluginCommand {
                 flutterCommand,
                 <String>[
                   'build',
-                  kPlatformFlagWinUwp,
+                  kPlatformWinUwp,
                   if (enableExperiment.isNotEmpty)
                     '--enable-experiment=$enableExperiment',
                 ],

--- a/script/tool/lib/src/common.dart
+++ b/script/tool/lib/src/common.dart
@@ -20,23 +20,26 @@ import 'package:yaml/yaml.dart';
 /// print destination.
 typedef Print = void Function(Object? object);
 
-/// Key for windows platform.
-const String kPlatformFlagWindows = 'windows';
-
-/// Key for macos platform.
-const String kPlatformFlagMacos = 'macos';
-
-/// Key for linux platform.
-const String kPlatformFlagLinux = 'linux';
+/// Key for APK (Android) platform.
+const String kPlatformFlagAndroid = 'android';
 
 /// Key for IPA (iOS) platform.
 const String kPlatformFlagIos = 'ios';
 
-/// Key for APK (Android) platform.
-const String kPlatformFlagAndroid = 'android';
+/// Key for linux platform.
+const String kPlatformFlagLinux = 'linux';
+
+/// Key for macos platform.
+const String kPlatformFlagMacos = 'macos';
 
 /// Key for Web platform.
 const String kPlatformFlagWeb = 'web';
+
+/// Key for windows platform.
+const String kPlatformFlagWindows = 'windows';
+
+/// Key for windows platform.
+const String kPlatformFlagWinUwp = 'winuwp';
 
 /// Key for enable experiment.
 const String kEnableExperiment = 'enable-experiment';

--- a/script/tool/lib/src/common.dart
+++ b/script/tool/lib/src/common.dart
@@ -195,9 +195,10 @@ bool isWebPlugin(FileSystemEntity entity) {
   return pluginSupportsPlatform(kPlatformWeb, entity);
 }
 
-/// Returns whether the given directory contains a Flutter Windows plugin.
-bool isWindowsPlugin(FileSystemEntity entity) {
-  return pluginSupportsPlatform(kPlatformWindows, entity);
+/// Returns whether the given directory contains a Flutter Windows plugin
+/// supporting the given variant.
+bool isWindowsPlugin(FileSystemEntity entity, {required String variant}) {
+  return pluginSupportsPlatform(kPlatformWindows, entity, variant: variant);
 }
 
 /// Returns whether the given directory contains a Flutter macOS plugin.

--- a/script/tool/lib/src/drive_examples_command.dart
+++ b/script/tool/lib/src/drive_examples_command.dart
@@ -15,17 +15,17 @@ class DriveExamplesCommand extends PluginCommand {
     Directory packagesDir, {
     ProcessRunner processRunner = const ProcessRunner(),
   }) : super(packagesDir, processRunner: processRunner) {
-    argParser.addFlag(kPlatformFlagAndroid,
+    argParser.addFlag(kPlatformAndroid,
         help: 'Runs the Android implementation of the examples');
-    argParser.addFlag(kPlatformFlagIos,
+    argParser.addFlag(kPlatformIos,
         help: 'Runs the iOS implementation of the examples');
-    argParser.addFlag(kPlatformFlagLinux,
+    argParser.addFlag(kPlatformLinux,
         help: 'Runs the Linux implementation of the examples');
-    argParser.addFlag(kPlatformFlagMacos,
+    argParser.addFlag(kPlatformMacos,
         help: 'Runs the macOS implementation of the examples');
-    argParser.addFlag(kPlatformFlagWeb,
+    argParser.addFlag(kPlatformWeb,
         help: 'Runs the web implementation of the examples');
-    argParser.addFlag(kPlatformFlagWindows,
+    argParser.addFlag(kPlatformWindows,
         help: 'Runs the Windows implementation of the examples');
     argParser.addOption(
       kEnableExperiment,
@@ -52,10 +52,10 @@ class DriveExamplesCommand extends PluginCommand {
   Future<void> run() async {
     final List<String> failingTests = <String>[];
     final List<String> pluginsWithoutTests = <String>[];
-    final bool isLinux = getBoolArg(kPlatformFlagLinux);
-    final bool isMacos = getBoolArg(kPlatformFlagMacos);
-    final bool isWeb = getBoolArg(kPlatformFlagWeb);
-    final bool isWindows = getBoolArg(kPlatformFlagWindows);
+    final bool isLinux = getBoolArg(kPlatformLinux);
+    final bool isMacos = getBoolArg(kPlatformMacos);
+    final bool isWeb = getBoolArg(kPlatformWeb);
+    final bool isWindows = getBoolArg(kPlatformWindows);
     await for (final Directory plugin in getPlugins()) {
       final String pluginName = plugin.basename;
       if (pluginName.endsWith('_platform_interface') &&
@@ -219,12 +219,12 @@ Tried searching for the following:
 
   Future<bool> _pluginSupportedOnCurrentPlatform(
       FileSystemEntity plugin) async {
-    final bool isAndroid = getBoolArg(kPlatformFlagAndroid);
-    final bool isIOS = getBoolArg(kPlatformFlagIos);
-    final bool isLinux = getBoolArg(kPlatformFlagLinux);
-    final bool isMacos = getBoolArg(kPlatformFlagMacos);
-    final bool isWeb = getBoolArg(kPlatformFlagWeb);
-    final bool isWindows = getBoolArg(kPlatformFlagWindows);
+    final bool isAndroid = getBoolArg(kPlatformAndroid);
+    final bool isIOS = getBoolArg(kPlatformIos);
+    final bool isLinux = getBoolArg(kPlatformLinux);
+    final bool isMacos = getBoolArg(kPlatformMacos);
+    final bool isWeb = getBoolArg(kPlatformWeb);
+    final bool isWindows = getBoolArg(kPlatformWindows);
     if (isAndroid) {
       return isAndroidPlugin(plugin);
     }

--- a/script/tool/lib/src/drive_examples_command.dart
+++ b/script/tool/lib/src/drive_examples_command.dart
@@ -66,7 +66,7 @@ class DriveExamplesCommand extends PluginCommand {
         continue;
       }
       print('\n==========\nChecking $pluginName...');
-      if (!(await _pluginSupportedOnCurrentPlatform(plugin))) {
+      if (!(await _pluginSupportedOnTargetPlatform(plugin))) {
         print('Not supported for the target platform; skipping.');
         continue;
       }
@@ -163,7 +163,8 @@ Tried searching for the following:
               '--browser-name=chrome',
             ]);
           }
-          if (isWindows && isWindowsPlugin(plugin)) {
+          if (isWindows &&
+              isWindowsPlugin(plugin, variant: kPlatformVariantWin32)) {
             driveArgs.addAll(<String>[
               '-d',
               'windows',
@@ -217,8 +218,7 @@ Tried searching for the following:
     print('All driver tests successful!');
   }
 
-  Future<bool> _pluginSupportedOnCurrentPlatform(
-      FileSystemEntity plugin) async {
+  Future<bool> _pluginSupportedOnTargetPlatform(FileSystemEntity plugin) async {
     final bool isAndroid = getBoolArg(kPlatformAndroid);
     final bool isIOS = getBoolArg(kPlatformIos);
     final bool isLinux = getBoolArg(kPlatformLinux);
@@ -241,7 +241,7 @@ Tried searching for the following:
       return isWebPlugin(plugin);
     }
     if (isWindows) {
-      return isWindowsPlugin(plugin);
+      return isWindowsPlugin(plugin, variant: kPlatformVariantWin32);
     }
     // When we are here, no flags are specified. Only return true if the plugin
     // supports Android for legacy command support.

--- a/script/tool/lib/src/xctest_command.dart
+++ b/script/tool/lib/src/xctest_command.dart
@@ -35,8 +35,8 @@ class XCTestCommand extends PluginCommand {
           'this is passed to the `-destination` argument in xcodebuild command.\n'
           'See https://developer.apple.com/library/archive/technotes/tn2339/_index.html#//apple_ref/doc/uid/DTS40014588-CH1-UNIT for details on how to specify the destination.',
     );
-    argParser.addFlag(kPlatformFlagIos, help: 'Runs the iOS tests');
-    argParser.addFlag(kPlatformFlagMacos, help: 'Runs the macOS tests');
+    argParser.addFlag(kPlatformIos, help: 'Runs the iOS tests');
+    argParser.addFlag(kPlatformMacos, help: 'Runs the macOS tests');
   }
 
   @override
@@ -49,8 +49,8 @@ class XCTestCommand extends PluginCommand {
 
   @override
   Future<void> run() async {
-    final bool testIos = getBoolArg(kPlatformFlagIos);
-    final bool testMacos = getBoolArg(kPlatformFlagMacos);
+    final bool testIos = getBoolArg(kPlatformIos);
+    final bool testMacos = getBoolArg(kPlatformMacos);
 
     if (!(testIos || testMacos)) {
       print('At least one platform flag must be provided.');

--- a/script/tool/test/analyze_command_test.dart
+++ b/script/tool/test/analyze_command_test.dart
@@ -53,8 +53,7 @@ void main() {
   });
 
   test('skips flutter pub get for examples', () async {
-    final Directory plugin1Dir =
-        createFakePlugin('a', packagesDir, withSingleExample: true);
+    final Directory plugin1Dir = createFakePlugin('a', packagesDir);
 
     final MockProcess mockProcess = MockProcess();
     mockProcess.exitCodeCompleter.complete(0);
@@ -121,7 +120,7 @@ void main() {
 
   group('verifies analysis settings', () {
     test('fails analysis_options.yaml', () async {
-      createFakePlugin('foo', packagesDir, withExtraFiles: <List<String>>[
+      createFakePlugin('foo', packagesDir, extraFiles: <List<String>>[
         <String>['analysis_options.yaml']
       ]);
 
@@ -130,7 +129,7 @@ void main() {
     });
 
     test('fails .analysis_options', () async {
-      createFakePlugin('foo', packagesDir, withExtraFiles: <List<String>>[
+      createFakePlugin('foo', packagesDir, extraFiles: <List<String>>[
         <String>['.analysis_options']
       ]);
 
@@ -140,7 +139,7 @@ void main() {
 
     test('takes an allow list', () async {
       final Directory pluginDir =
-          createFakePlugin('foo', packagesDir, withExtraFiles: <List<String>>[
+          createFakePlugin('foo', packagesDir, extraFiles: <List<String>>[
         <String>['analysis_options.yaml']
       ]);
 
@@ -161,7 +160,7 @@ void main() {
 
     // See: https://github.com/flutter/flutter/issues/78994
     test('takes an empty allow list', () async {
-      createFakePlugin('foo', packagesDir, withExtraFiles: <List<String>>[
+      createFakePlugin('foo', packagesDir, extraFiles: <List<String>>[
         <String>['analysis_options.yaml']
       ]);
 

--- a/script/tool/test/build_examples_command_test.dart
+++ b/script/tool/test/build_examples_command_test.dart
@@ -6,6 +6,7 @@ import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
 import 'package:file/local.dart';
 import 'package:flutter_plugin_tools/src/build_examples_command.dart';
+import 'package:flutter_plugin_tools/src/common.dart';
 import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
 import 'package:test/test.dart';
@@ -325,7 +326,7 @@ void main() {
     });
 
     test(
-        'building for Windows when plugin is not set up for Windows results in no-op',
+        'building for win32 when plugin is not set up for Windows results in no-op',
         () async {
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           withExtraFiles: <List<String>>[
@@ -346,8 +347,8 @@ void main() {
       expect(
         output,
         orderedEquals(<String>[
-          '\nBUILDING Windows for $packageName',
-          'Windows is not supported by this plugin',
+          '\nBUILDING Windows (Win32) for $packageName',
+          'Win32 is not supported by this plugin',
           '\n\n',
           'All builds successful!',
         ]),
@@ -358,7 +359,7 @@ void main() {
       expect(processRunner.recordedCalls, orderedEquals(<ProcessCall>[]));
     });
 
-    test('building for windows', () async {
+    test('building for win32', () async {
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
@@ -378,7 +379,7 @@ void main() {
       expect(
         output,
         orderedEquals(<String>[
-          '\nBUILDING Windows for $packageName',
+          '\nBUILDING Windows (Win32) for $packageName',
           '\n\n',
           'All builds successful!',
         ]),
@@ -392,17 +393,16 @@ void main() {
           ]));
     });
 
-    test(
-        'building for UWP when plugin is not set up for Windows results in no-op',
+    test('building for UWP when plugin does not support UWP is a no-op',
         () async {
-      createFakePlugin('plugin', packagesDir,
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
           isWindowsPlugin: false);
 
       final Directory pluginExampleDirectory =
-          packagesDir.childDirectory('plugin').childDirectory('example');
+          pluginDirectory.childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -415,7 +415,7 @@ void main() {
         output,
         orderedEquals(<String>[
           '\nBUILDING UWP for $packageName',
-          'Windows is not supported by this plugin',
+          'UWP is not supported by this plugin',
           '\n\n',
           'All builds successful!',
         ]),
@@ -428,14 +428,25 @@ void main() {
     });
 
     test('building for UWP', () async {
-      createFakePlugin('plugin', packagesDir,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test'],
-          ],
-          isWindowsPlugin: true);
+      const String pluginName = 'plugin';
+      final Directory pluginDirectory =
+          createFakePlugin(pluginName, packagesDir,
+              withExtraFiles: <List<String>>[
+                <String>['example', 'test'],
+              ],
+              isWindowsPlugin: true);
+      // Declare UWP support.
+      createFakePubspec(
+        pluginDirectory,
+        name: pluginName,
+        platformSupport: <String, PlatformDetails>{
+          kPlatformWindows: const PlatformDetails(PlatformSupport.federated,
+              variants: <String>[kPlatformVariantWinUwp]),
+        },
+      );
 
       final Directory pluginExampleDirectory =
-          packagesDir.childDirectory('plugin').childDirectory('example');
+          pluginDirectory.childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
@@ -464,14 +475,24 @@ void main() {
     });
 
     test('building for UWP creates a folder if necessary', () async {
-      createFakePlugin('plugin', packagesDir,
+      const String pluginName = 'plugin';
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
           isWindowsPlugin: true);
+      // Declare UWP support.
+      createFakePubspec(
+        pluginDirectory,
+        name: pluginName,
+        platformSupport: <String, PlatformDetails>{
+          kPlatformWindows: const PlatformDetails(PlatformSupport.federated,
+              variants: <String>[kPlatformVariantWinUwp]),
+        },
+      );
 
       final Directory pluginExampleDirectory =
-          packagesDir.childDirectory('plugin').childDirectory('example');
+          pluginDirectory.childDirectory('example');
 
       createFakePubspec(pluginExampleDirectory, isFlutter: true);
 

--- a/script/tool/test/build_examples_command_test.dart
+++ b/script/tool/test/build_examples_command_test.dart
@@ -49,15 +49,13 @@ void main() {
     test('building for iOS when plugin is not set up for iOS results in no-op',
         () async {
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+          withSingleExample: true,
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
-          ],
-          isLinuxPlugin: false);
+          ]);
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(
           runner, <String>['build-examples', '--ipa', '--no-macos']);
@@ -81,15 +79,16 @@ void main() {
 
     test('building for ios', () async {
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+          withSingleExample: true,
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
-          isIosPlugin: true);
+          platformSupport: <String, PlatformDetails>{
+            kPlatformIos: const PlatformDetails(PlatformSupport.inline),
+          });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'build-examples',
@@ -128,15 +127,13 @@ void main() {
         'building for Linux when plugin is not set up for Linux results in no-op',
         () async {
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+          withSingleExample: true,
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
-          ],
-          isLinuxPlugin: false);
+          ]);
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(
           runner, <String>['build-examples', '--no-ipa', '--linux']);
@@ -160,15 +157,16 @@ void main() {
 
     test('building for Linux', () async {
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+          withSingleExample: true,
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
-          isLinuxPlugin: true);
+          platformSupport: <String, PlatformDetails>{
+            kPlatformLinux: const PlatformDetails(PlatformSupport.inline),
+          });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(
           runner, <String>['build-examples', '--no-ipa', '--linux']);
@@ -195,14 +193,13 @@ void main() {
     test('building for macos with no implementation results in no-op',
         () async {
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+          withSingleExample: true,
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ]);
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(
           runner, <String>['build-examples', '--no-ipa', '--macos']);
@@ -226,16 +223,17 @@ void main() {
 
     test('building for macos', () async {
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+          withSingleExample: true,
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
             <String>['example', 'macos', 'macos.swift'],
           ],
-          isMacOsPlugin: true);
+          platformSupport: <String, PlatformDetails>{
+            kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
+          });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(
           runner, <String>['build-examples', '--no-ipa', '--macos']);
@@ -261,14 +259,13 @@ void main() {
 
     test('building for web with no implementation results in no-op', () async {
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+          withSingleExample: true,
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ]);
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(
           runner, <String>['build-examples', '--no-ipa', '--web']);
@@ -292,16 +289,17 @@ void main() {
 
     test('building for web', () async {
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+          withSingleExample: true,
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
             <String>['example', 'web', 'index.html'],
           ],
-          isWebPlugin: true);
+          platformSupport: <String, PlatformDetails>{
+            kPlatformWeb: const PlatformDetails(PlatformSupport.inline),
+          });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(
           runner, <String>['build-examples', '--no-ipa', '--web']);
@@ -329,15 +327,13 @@ void main() {
         'building for win32 when plugin is not set up for Windows results in no-op',
         () async {
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+          withSingleExample: true,
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
-          ],
-          isWindowsPlugin: false);
+          ]);
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(
           runner, <String>['build-examples', '--no-ipa', '--windows']);
@@ -361,15 +357,16 @@ void main() {
 
     test('building for win32', () async {
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+          withSingleExample: true,
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
-          isWindowsPlugin: true);
+          platformSupport: <String, PlatformDetails>{
+            kPlatformWindows: const PlatformDetails(PlatformSupport.inline),
+          });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(
           runner, <String>['build-examples', '--no-ipa', '--windows']);
@@ -396,15 +393,13 @@ void main() {
     test('building for UWP when plugin does not support UWP is a no-op',
         () async {
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+          withSingleExample: true,
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
-          ],
-          isWindowsPlugin: false);
+          ]);
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(
           runner, <String>['build-examples', '--no-ipa', '--winuwp']);
@@ -428,27 +423,18 @@ void main() {
     });
 
     test('building for UWP', () async {
-      const String pluginName = 'plugin';
-      final Directory pluginDirectory =
-          createFakePlugin(pluginName, packagesDir,
-              withExtraFiles: <List<String>>[
-                <String>['example', 'test'],
-              ],
-              isWindowsPlugin: true);
-      // Declare UWP support.
-      createFakePubspec(
-        pluginDirectory,
-        name: pluginName,
-        platformSupport: <String, PlatformDetails>{
-          kPlatformWindows: const PlatformDetails(PlatformSupport.federated,
-              variants: <String>[kPlatformVariantWinUwp]),
-        },
-      );
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+          withSingleExample: true,
+          withExtraFiles: <List<String>>[
+            <String>['example', 'test'],
+          ],
+          platformSupport: <String, PlatformDetails>{
+            kPlatformWindows: const PlatformDetails(PlatformSupport.federated,
+                variants: <String>[kPlatformVariantWinUwp]),
+          });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(
           runner, <String>['build-examples', '--no-ipa', '--winuwp']);
@@ -475,26 +461,18 @@ void main() {
     });
 
     test('building for UWP creates a folder if necessary', () async {
-      const String pluginName = 'plugin';
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+          withSingleExample: true,
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
-          isWindowsPlugin: true);
-      // Declare UWP support.
-      createFakePubspec(
-        pluginDirectory,
-        name: pluginName,
-        platformSupport: <String, PlatformDetails>{
-          kPlatformWindows: const PlatformDetails(PlatformSupport.federated,
-              variants: <String>[kPlatformVariantWinUwp]),
-        },
-      );
+          platformSupport: <String, PlatformDetails>{
+            kPlatformWindows: const PlatformDetails(PlatformSupport.federated,
+                variants: <String>[kPlatformVariantWinUwp]),
+          });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(
           runner, <String>['build-examples', '--no-ipa', '--winuwp']);
@@ -521,15 +499,13 @@ void main() {
         'building for Android when plugin is not set up for Android results in no-op',
         () async {
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+          withSingleExample: true,
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
-          ],
-          isLinuxPlugin: false);
+          ]);
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(
           runner, <String>['build-examples', '--apk', '--no-ipa']);
@@ -553,15 +529,16 @@ void main() {
 
     test('building for android', () async {
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+          withSingleExample: true,
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
-          isAndroidPlugin: true);
+          platformSupport: <String, PlatformDetails>{
+            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
+          });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'build-examples',
@@ -591,15 +568,16 @@ void main() {
 
     test('enable-experiment flag for Android', () async {
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+          withSingleExample: true,
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
-          isAndroidPlugin: true);
+          platformSupport: <String, PlatformDetails>{
+            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
+          });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       await runCapturingPrint(runner, <String>[
         'build-examples',
@@ -621,15 +599,16 @@ void main() {
 
     test('enable-experiment flag for ios', () async {
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+          withSingleExample: true,
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
-          isIosPlugin: true);
+          platformSupport: <String, PlatformDetails>{
+            kPlatformIos: const PlatformDetails(PlatformSupport.inline),
+          });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       await runCapturingPrint(runner, <String>[
         'build-examples',

--- a/script/tool/test/build_examples_command_test.dart
+++ b/script/tool/test/build_examples_command_test.dart
@@ -489,7 +489,7 @@ void main() {
           orderedEquals(<ProcessCall>[
             ProcessCall(
                 flutterCommand,
-                const <String>['create', '.', '--platforms=winuwp'],
+                const <String>['create', '--platforms=winuwp', '.'],
                 pluginExampleDirectory.path),
             ProcessCall(flutterCommand, const <String>['build', 'winuwp'],
                 pluginExampleDirectory.path),

--- a/script/tool/test/build_examples_command_test.dart
+++ b/script/tool/test/build_examples_command_test.dart
@@ -48,11 +48,10 @@ void main() {
 
     test('building for iOS when plugin is not set up for iOS results in no-op',
         () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withSingleExample: true,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test'],
-          ]);
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test'],
+      ]);
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -78,14 +77,12 @@ void main() {
     });
 
     test('building for ios', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withSingleExample: true,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test'],
-          ],
-          platformSupport: <String, PlatformDetails>{
-            kPlatformIos: const PlatformDetails(PlatformSupport.inline),
-          });
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test'],
+      ], platformSupport: <String, PlatformDetails>{
+        kPlatformIos: const PlatformDetails(PlatformSupport.inline),
+      });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -126,11 +123,10 @@ void main() {
     test(
         'building for Linux when plugin is not set up for Linux results in no-op',
         () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withSingleExample: true,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test'],
-          ]);
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test'],
+      ]);
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -156,14 +152,12 @@ void main() {
     });
 
     test('building for Linux', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withSingleExample: true,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test'],
-          ],
-          platformSupport: <String, PlatformDetails>{
-            kPlatformLinux: const PlatformDetails(PlatformSupport.inline),
-          });
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test'],
+      ], platformSupport: <String, PlatformDetails>{
+        kPlatformLinux: const PlatformDetails(PlatformSupport.inline),
+      });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -192,11 +186,10 @@ void main() {
 
     test('building for macos with no implementation results in no-op',
         () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withSingleExample: true,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test'],
-          ]);
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test'],
+      ]);
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -222,15 +215,13 @@ void main() {
     });
 
     test('building for macos', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withSingleExample: true,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test'],
-            <String>['example', 'macos', 'macos.swift'],
-          ],
-          platformSupport: <String, PlatformDetails>{
-            kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
-          });
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test'],
+        <String>['example', 'macos', 'macos.swift'],
+      ], platformSupport: <String, PlatformDetails>{
+        kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
+      });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -258,11 +249,10 @@ void main() {
     });
 
     test('building for web with no implementation results in no-op', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withSingleExample: true,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test'],
-          ]);
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test'],
+      ]);
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -288,15 +278,13 @@ void main() {
     });
 
     test('building for web', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withSingleExample: true,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test'],
-            <String>['example', 'web', 'index.html'],
-          ],
-          platformSupport: <String, PlatformDetails>{
-            kPlatformWeb: const PlatformDetails(PlatformSupport.inline),
-          });
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test'],
+        <String>['example', 'web', 'index.html'],
+      ], platformSupport: <String, PlatformDetails>{
+        kPlatformWeb: const PlatformDetails(PlatformSupport.inline),
+      });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -326,11 +314,10 @@ void main() {
     test(
         'building for win32 when plugin is not set up for Windows results in no-op',
         () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withSingleExample: true,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test'],
-          ]);
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test'],
+      ]);
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -356,14 +343,12 @@ void main() {
     });
 
     test('building for win32', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withSingleExample: true,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test'],
-          ],
-          platformSupport: <String, PlatformDetails>{
-            kPlatformWindows: const PlatformDetails(PlatformSupport.inline),
-          });
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test'],
+      ], platformSupport: <String, PlatformDetails>{
+        kPlatformWindows: const PlatformDetails(PlatformSupport.inline),
+      });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -392,11 +377,10 @@ void main() {
 
     test('building for UWP when plugin does not support UWP is a no-op',
         () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withSingleExample: true,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test'],
-          ]);
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test'],
+      ]);
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -423,15 +407,13 @@ void main() {
     });
 
     test('building for UWP', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withSingleExample: true,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test'],
-          ],
-          platformSupport: <String, PlatformDetails>{
-            kPlatformWindows: const PlatformDetails(PlatformSupport.federated,
-                variants: <String>[kPlatformVariantWinUwp]),
-          });
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test'],
+      ], platformSupport: <String, PlatformDetails>{
+        kPlatformWindows: const PlatformDetails(PlatformSupport.federated,
+            variants: <String>[kPlatformVariantWinUwp]),
+      });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -461,15 +443,13 @@ void main() {
     });
 
     test('building for UWP creates a folder if necessary', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withSingleExample: true,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test'],
-          ],
-          platformSupport: <String, PlatformDetails>{
-            kPlatformWindows: const PlatformDetails(PlatformSupport.federated,
-                variants: <String>[kPlatformVariantWinUwp]),
-          });
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test'],
+      ], platformSupport: <String, PlatformDetails>{
+        kPlatformWindows: const PlatformDetails(PlatformSupport.federated,
+            variants: <String>[kPlatformVariantWinUwp]),
+      });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -498,11 +478,10 @@ void main() {
     test(
         'building for Android when plugin is not set up for Android results in no-op',
         () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withSingleExample: true,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test'],
-          ]);
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test'],
+      ]);
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -528,14 +507,12 @@ void main() {
     });
 
     test('building for android', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withSingleExample: true,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test'],
-          ],
-          platformSupport: <String, PlatformDetails>{
-            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
-          });
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test'],
+      ], platformSupport: <String, PlatformDetails>{
+        kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
+      });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -567,14 +544,12 @@ void main() {
     });
 
     test('enable-experiment flag for Android', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withSingleExample: true,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test'],
-          ],
-          platformSupport: <String, PlatformDetails>{
-            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
-          });
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test'],
+      ], platformSupport: <String, PlatformDetails>{
+        kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
+      });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -598,14 +573,12 @@ void main() {
     });
 
     test('enable-experiment flag for ios', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withSingleExample: true,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test'],
-          ],
-          platformSupport: <String, PlatformDetails>{
-            kPlatformIos: const PlatformDetails(PlatformSupport.inline),
-          });
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test'],
+      ], platformSupport: <String, PlatformDetails>{
+        kPlatformIos: const PlatformDetails(PlatformSupport.inline),
+      });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');

--- a/script/tool/test/common_test.dart
+++ b/script/tool/test/common_test.dart
@@ -535,16 +535,15 @@ file2/file2.cc
     });
 
     test('all platforms', () async {
-      final Directory plugin = createFakePlugin(
-        'plugin',
-        packagesDir,
-        isAndroidPlugin: true,
-        isIosPlugin: true,
-        isLinuxPlugin: true,
-        isMacOsPlugin: true,
-        isWebPlugin: true,
-        isWindowsPlugin: true,
-      );
+      final Directory plugin = createFakePlugin('plugin', packagesDir,
+          platformSupport: <String, PlatformDetails>{
+            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
+            kPlatformIos: const PlatformDetails(PlatformSupport.inline),
+            kPlatformLinux: const PlatformDetails(PlatformSupport.inline),
+            kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
+            kPlatformWeb: const PlatformDetails(PlatformSupport.inline),
+            kPlatformWindows: const PlatformDetails(PlatformSupport.inline),
+          });
 
       expect(pluginSupportsPlatform(kPlatformAndroid, plugin), isTrue);
       expect(pluginSupportsPlatform(kPlatformIos, plugin), isTrue);
@@ -555,16 +554,12 @@ file2/file2.cc
     });
 
     test('some platforms', () async {
-      final Directory plugin = createFakePlugin(
-        'plugin',
-        packagesDir,
-        isAndroidPlugin: true,
-        isIosPlugin: false,
-        isLinuxPlugin: true,
-        isMacOsPlugin: false,
-        isWebPlugin: true,
-        isWindowsPlugin: false,
-      );
+      final Directory plugin = createFakePlugin('plugin', packagesDir,
+          platformSupport: <String, PlatformDetails>{
+            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
+            kPlatformLinux: const PlatformDetails(PlatformSupport.inline),
+            kPlatformWeb: const PlatformDetails(PlatformSupport.inline),
+          });
 
       expect(pluginSupportsPlatform(kPlatformAndroid, plugin), isTrue);
       expect(pluginSupportsPlatform(kPlatformIos, plugin), isFalse);
@@ -575,17 +570,15 @@ file2/file2.cc
     });
 
     test('inline plugins are only detected as inline', () async {
-      // createFakePlugin makes non-federated pubspec entries.
-      final Directory plugin = createFakePlugin(
-        'plugin',
-        packagesDir,
-        isAndroidPlugin: true,
-        isIosPlugin: true,
-        isLinuxPlugin: true,
-        isMacOsPlugin: true,
-        isWebPlugin: true,
-        isWindowsPlugin: true,
-      );
+      final Directory plugin = createFakePlugin('plugin', packagesDir,
+          platformSupport: <String, PlatformDetails>{
+            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
+            kPlatformIos: const PlatformDetails(PlatformSupport.inline),
+            kPlatformLinux: const PlatformDetails(PlatformSupport.inline),
+            kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
+            kPlatformWeb: const PlatformDetails(PlatformSupport.inline),
+            kPlatformWindows: const PlatformDetails(PlatformSupport.inline),
+          });
 
       expect(
           pluginSupportsPlatform(kPlatformAndroid, plugin,
@@ -638,30 +631,15 @@ file2/file2.cc
     });
 
     test('federated plugins are only detected as federated', () async {
-      const String pluginName = 'plugin';
-      final Directory plugin = createFakePlugin(
-        pluginName,
-        packagesDir,
-        isAndroidPlugin: true,
-        isIosPlugin: true,
-        isLinuxPlugin: true,
-        isMacOsPlugin: true,
-        isWebPlugin: true,
-        isWindowsPlugin: true,
-      );
-
-      createFakePubspec(
-        plugin,
-        name: pluginName,
-        platformSupport: <String, PlatformDetails>{
-          kPlatformAndroid: const PlatformDetails(PlatformSupport.federated),
-          kPlatformIos: const PlatformDetails(PlatformSupport.federated),
-          kPlatformLinux: const PlatformDetails(PlatformSupport.federated),
-          kPlatformMacos: const PlatformDetails(PlatformSupport.federated),
-          kPlatformWeb: const PlatformDetails(PlatformSupport.federated),
-          kPlatformWindows: const PlatformDetails(PlatformSupport.federated),
-        },
-      );
+      final Directory plugin = createFakePlugin('plugin', packagesDir,
+          platformSupport: <String, PlatformDetails>{
+            kPlatformAndroid: const PlatformDetails(PlatformSupport.federated),
+            kPlatformIos: const PlatformDetails(PlatformSupport.federated),
+            kPlatformLinux: const PlatformDetails(PlatformSupport.federated),
+            kPlatformMacos: const PlatformDetails(PlatformSupport.federated),
+            kPlatformWeb: const PlatformDetails(PlatformSupport.federated),
+            kPlatformWindows: const PlatformDetails(PlatformSupport.federated),
+          });
 
       expect(
           pluginSupportsPlatform(kPlatformAndroid, plugin,
@@ -717,7 +695,9 @@ file2/file2.cc
       final Directory plugin = createFakePlugin(
         'plugin',
         packagesDir,
-        isWindowsPlugin: true,
+        platformSupport: <String, PlatformDetails>{
+          kPlatformWindows: const PlatformDetails(PlatformSupport.inline),
+        },
       );
 
       expect(
@@ -731,23 +711,13 @@ file2/file2.cc
     });
 
     test('windows with both variants matches win32 and winuwp', () async {
-      const String pluginName = 'plugin';
-      final Directory plugin = createFakePlugin(
-        pluginName,
-        packagesDir,
-        isWindowsPlugin: true,
-      );
-
-      createFakePubspec(
-        plugin,
-        name: pluginName,
-        platformSupport: <String, PlatformDetails>{
-          kPlatformWindows: const PlatformDetails(
-            PlatformSupport.federated,
-            variants: <String>[kPlatformVariantWin32, kPlatformVariantWinUwp],
-          ),
-        },
-      );
+      final Directory plugin = createFakePlugin('plugin', packagesDir,
+          platformSupport: <String, PlatformDetails>{
+            kPlatformWindows: const PlatformDetails(
+              PlatformSupport.federated,
+              variants: <String>[kPlatformVariantWin32, kPlatformVariantWinUwp],
+            ),
+          });
 
       expect(
           pluginSupportsPlatform(kPlatformWindows, plugin,
@@ -760,23 +730,13 @@ file2/file2.cc
     });
 
     test('win32 plugin is only win32', () async {
-      const String pluginName = 'plugin';
-      final Directory plugin = createFakePlugin(
-        pluginName,
-        packagesDir,
-        isWindowsPlugin: true,
-      );
-
-      createFakePubspec(
-        plugin,
-        name: pluginName,
-        platformSupport: <String, PlatformDetails>{
-          kPlatformWindows: const PlatformDetails(
-            PlatformSupport.federated,
-            variants: <String>[kPlatformVariantWin32],
-          ),
-        },
-      );
+      final Directory plugin = createFakePlugin('plugin', packagesDir,
+          platformSupport: <String, PlatformDetails>{
+            kPlatformWindows: const PlatformDetails(
+              PlatformSupport.federated,
+              variants: <String>[kPlatformVariantWin32],
+            ),
+          });
 
       expect(
           pluginSupportsPlatform(kPlatformWindows, plugin,
@@ -789,16 +749,9 @@ file2/file2.cc
     });
 
     test('winup plugin is only winuwp', () async {
-      const String pluginName = 'plugin';
       final Directory plugin = createFakePlugin(
-        pluginName,
+        'plugin',
         packagesDir,
-        isWindowsPlugin: true,
-      );
-
-      createFakePubspec(
-        plugin,
-        name: pluginName,
         platformSupport: <String, PlatformDetails>{
           kPlatformWindows: const PlatformDetails(PlatformSupport.federated,
               variants: <String>[kPlatformVariantWinUwp]),

--- a/script/tool/test/common_test.dart
+++ b/script/tool/test/common_test.dart
@@ -526,12 +526,12 @@ file2/file2.cc
     test('no platforms', () async {
       final Directory plugin = createFakePlugin('plugin', packagesDir);
 
-      expect(pluginSupportsPlatform('android', plugin), isFalse);
-      expect(pluginSupportsPlatform('ios', plugin), isFalse);
-      expect(pluginSupportsPlatform('linux', plugin), isFalse);
-      expect(pluginSupportsPlatform('macos', plugin), isFalse);
-      expect(pluginSupportsPlatform('web', plugin), isFalse);
-      expect(pluginSupportsPlatform('windows', plugin), isFalse);
+      expect(pluginSupportsPlatform(kPlatformAndroid, plugin), isFalse);
+      expect(pluginSupportsPlatform(kPlatformIos, plugin), isFalse);
+      expect(pluginSupportsPlatform(kPlatformLinux, plugin), isFalse);
+      expect(pluginSupportsPlatform(kPlatformMacos, plugin), isFalse);
+      expect(pluginSupportsPlatform(kPlatformWeb, plugin), isFalse);
+      expect(pluginSupportsPlatform(kPlatformWindows, plugin), isFalse);
     });
 
     test('all platforms', () async {
@@ -546,12 +546,12 @@ file2/file2.cc
         isWindowsPlugin: true,
       );
 
-      expect(pluginSupportsPlatform('android', plugin), isTrue);
-      expect(pluginSupportsPlatform('ios', plugin), isTrue);
-      expect(pluginSupportsPlatform('linux', plugin), isTrue);
-      expect(pluginSupportsPlatform('macos', plugin), isTrue);
-      expect(pluginSupportsPlatform('web', plugin), isTrue);
-      expect(pluginSupportsPlatform('windows', plugin), isTrue);
+      expect(pluginSupportsPlatform(kPlatformAndroid, plugin), isTrue);
+      expect(pluginSupportsPlatform(kPlatformIos, plugin), isTrue);
+      expect(pluginSupportsPlatform(kPlatformLinux, plugin), isTrue);
+      expect(pluginSupportsPlatform(kPlatformMacos, plugin), isTrue);
+      expect(pluginSupportsPlatform(kPlatformWeb, plugin), isTrue);
+      expect(pluginSupportsPlatform(kPlatformWindows, plugin), isTrue);
     });
 
     test('some platforms', () async {
@@ -566,12 +566,12 @@ file2/file2.cc
         isWindowsPlugin: false,
       );
 
-      expect(pluginSupportsPlatform('android', plugin), isTrue);
-      expect(pluginSupportsPlatform('ios', plugin), isFalse);
-      expect(pluginSupportsPlatform('linux', plugin), isTrue);
-      expect(pluginSupportsPlatform('macos', plugin), isFalse);
-      expect(pluginSupportsPlatform('web', plugin), isTrue);
-      expect(pluginSupportsPlatform('windows', plugin), isFalse);
+      expect(pluginSupportsPlatform(kPlatformAndroid, plugin), isTrue);
+      expect(pluginSupportsPlatform(kPlatformIos, plugin), isFalse);
+      expect(pluginSupportsPlatform(kPlatformLinux, plugin), isTrue);
+      expect(pluginSupportsPlatform(kPlatformMacos, plugin), isFalse);
+      expect(pluginSupportsPlatform(kPlatformWeb, plugin), isTrue);
+      expect(pluginSupportsPlatform(kPlatformWindows, plugin), isFalse);
     });
 
     test('inline plugins are only detected as inline', () async {
@@ -588,51 +588,51 @@ file2/file2.cc
       );
 
       expect(
-          pluginSupportsPlatform('android', plugin,
+          pluginSupportsPlatform(kPlatformAndroid, plugin,
               requiredMode: PlatformSupport.inline),
           isTrue);
       expect(
-          pluginSupportsPlatform('android', plugin,
+          pluginSupportsPlatform(kPlatformAndroid, plugin,
               requiredMode: PlatformSupport.federated),
           isFalse);
       expect(
-          pluginSupportsPlatform('ios', plugin,
+          pluginSupportsPlatform(kPlatformIos, plugin,
               requiredMode: PlatformSupport.inline),
           isTrue);
       expect(
-          pluginSupportsPlatform('ios', plugin,
+          pluginSupportsPlatform(kPlatformIos, plugin,
               requiredMode: PlatformSupport.federated),
           isFalse);
       expect(
-          pluginSupportsPlatform('linux', plugin,
+          pluginSupportsPlatform(kPlatformLinux, plugin,
               requiredMode: PlatformSupport.inline),
           isTrue);
       expect(
-          pluginSupportsPlatform('linux', plugin,
+          pluginSupportsPlatform(kPlatformLinux, plugin,
               requiredMode: PlatformSupport.federated),
           isFalse);
       expect(
-          pluginSupportsPlatform('macos', plugin,
+          pluginSupportsPlatform(kPlatformMacos, plugin,
               requiredMode: PlatformSupport.inline),
           isTrue);
       expect(
-          pluginSupportsPlatform('macos', plugin,
+          pluginSupportsPlatform(kPlatformMacos, plugin,
               requiredMode: PlatformSupport.federated),
           isFalse);
       expect(
-          pluginSupportsPlatform('web', plugin,
+          pluginSupportsPlatform(kPlatformWeb, plugin,
               requiredMode: PlatformSupport.inline),
           isTrue);
       expect(
-          pluginSupportsPlatform('web', plugin,
+          pluginSupportsPlatform(kPlatformWeb, plugin,
               requiredMode: PlatformSupport.federated),
           isFalse);
       expect(
-          pluginSupportsPlatform('windows', plugin,
+          pluginSupportsPlatform(kPlatformWindows, plugin,
               requiredMode: PlatformSupport.inline),
           isTrue);
       expect(
-          pluginSupportsPlatform('windows', plugin,
+          pluginSupportsPlatform(kPlatformWindows, plugin,
               requiredMode: PlatformSupport.federated),
           isFalse);
     });
@@ -653,62 +653,165 @@ file2/file2.cc
       createFakePubspec(
         plugin,
         name: pluginName,
-        androidSupport: PlatformSupport.federated,
-        iosSupport: PlatformSupport.federated,
-        linuxSupport: PlatformSupport.federated,
-        macosSupport: PlatformSupport.federated,
-        webSupport: PlatformSupport.federated,
-        windowsSupport: PlatformSupport.federated,
+        platformSupport: <String, PlatformDetails>{
+          kPlatformAndroid: const PlatformDetails(PlatformSupport.federated),
+          kPlatformIos: const PlatformDetails(PlatformSupport.federated),
+          kPlatformLinux: const PlatformDetails(PlatformSupport.federated),
+          kPlatformMacos: const PlatformDetails(PlatformSupport.federated),
+          kPlatformWeb: const PlatformDetails(PlatformSupport.federated),
+          kPlatformWindows: const PlatformDetails(PlatformSupport.federated),
+        },
       );
 
       expect(
-          pluginSupportsPlatform('android', plugin,
+          pluginSupportsPlatform(kPlatformAndroid, plugin,
               requiredMode: PlatformSupport.federated),
           isTrue);
       expect(
-          pluginSupportsPlatform('android', plugin,
+          pluginSupportsPlatform(kPlatformAndroid, plugin,
               requiredMode: PlatformSupport.inline),
           isFalse);
       expect(
-          pluginSupportsPlatform('ios', plugin,
+          pluginSupportsPlatform(kPlatformIos, plugin,
               requiredMode: PlatformSupport.federated),
           isTrue);
       expect(
-          pluginSupportsPlatform('ios', plugin,
+          pluginSupportsPlatform(kPlatformIos, plugin,
               requiredMode: PlatformSupport.inline),
           isFalse);
       expect(
-          pluginSupportsPlatform('linux', plugin,
+          pluginSupportsPlatform(kPlatformLinux, plugin,
               requiredMode: PlatformSupport.federated),
           isTrue);
       expect(
-          pluginSupportsPlatform('linux', plugin,
+          pluginSupportsPlatform(kPlatformLinux, plugin,
               requiredMode: PlatformSupport.inline),
           isFalse);
       expect(
-          pluginSupportsPlatform('macos', plugin,
+          pluginSupportsPlatform(kPlatformMacos, plugin,
               requiredMode: PlatformSupport.federated),
           isTrue);
       expect(
-          pluginSupportsPlatform('macos', plugin,
+          pluginSupportsPlatform(kPlatformMacos, plugin,
               requiredMode: PlatformSupport.inline),
           isFalse);
       expect(
-          pluginSupportsPlatform('web', plugin,
+          pluginSupportsPlatform(kPlatformWeb, plugin,
               requiredMode: PlatformSupport.federated),
           isTrue);
       expect(
-          pluginSupportsPlatform('web', plugin,
+          pluginSupportsPlatform(kPlatformWeb, plugin,
               requiredMode: PlatformSupport.inline),
           isFalse);
       expect(
-          pluginSupportsPlatform('windows', plugin,
+          pluginSupportsPlatform(kPlatformWindows, plugin,
               requiredMode: PlatformSupport.federated),
           isTrue);
       expect(
-          pluginSupportsPlatform('windows', plugin,
+          pluginSupportsPlatform(kPlatformWindows, plugin,
               requiredMode: PlatformSupport.inline),
           isFalse);
+    });
+
+    test('windows without variants is only win32', () async {
+      final Directory plugin = createFakePlugin(
+        'plugin',
+        packagesDir,
+        isWindowsPlugin: true,
+      );
+
+      expect(
+          pluginSupportsPlatform(kPlatformWindows, plugin,
+              variant: kPlatformVariantWin32),
+          isTrue);
+      expect(
+          pluginSupportsPlatform(kPlatformWindows, plugin,
+              variant: kPlatformVariantWinUwp),
+          isFalse);
+    });
+
+    test('windows with both variants matches win32 and winuwp', () async {
+      const String pluginName = 'plugin';
+      final Directory plugin = createFakePlugin(
+        pluginName,
+        packagesDir,
+        isWindowsPlugin: true,
+      );
+
+      createFakePubspec(
+        plugin,
+        name: pluginName,
+        platformSupport: <String, PlatformDetails>{
+          kPlatformWindows: const PlatformDetails(PlatformSupport.federated,
+              variants: <String>[
+                kPlatformVariantWin32,
+                kPlatformVariantWinUwp
+              ]),
+        },
+      );
+
+      expect(
+          pluginSupportsPlatform(kPlatformWindows, plugin,
+              variant: kPlatformVariantWin32),
+          isTrue);
+      expect(
+          pluginSupportsPlatform(kPlatformWindows, plugin,
+              variant: kPlatformVariantWinUwp),
+          isTrue);
+    });
+
+    test('win32 plugin is only win32', () async {
+      const String pluginName = 'plugin';
+      final Directory plugin = createFakePlugin(
+        pluginName,
+        packagesDir,
+        isWindowsPlugin: true,
+      );
+
+      createFakePubspec(
+        plugin,
+        name: pluginName,
+        platformSupport: <String, PlatformDetails>{
+          kPlatformWindows: const PlatformDetails(PlatformSupport.federated,
+              variants: <String>[kPlatformVariantWin32]),
+        },
+      );
+
+      expect(
+          pluginSupportsPlatform(kPlatformWindows, plugin,
+              variant: kPlatformVariantWin32),
+          isTrue);
+      expect(
+          pluginSupportsPlatform(kPlatformWindows, plugin,
+              variant: kPlatformVariantWinUwp),
+          isFalse);
+    });
+
+    test('winup plugin is only winuwp', () async {
+      const String pluginName = 'plugin';
+      final Directory plugin = createFakePlugin(
+        pluginName,
+        packagesDir,
+        isWindowsPlugin: true,
+      );
+
+      createFakePubspec(
+        plugin,
+        name: pluginName,
+        platformSupport: <String, PlatformDetails>{
+          kPlatformWindows: const PlatformDetails(PlatformSupport.federated,
+              variants: <String>[kPlatformVariantWinUwp]),
+        },
+      );
+
+      expect(
+          pluginSupportsPlatform(kPlatformWindows, plugin,
+              variant: kPlatformVariantWin32),
+          isFalse);
+      expect(
+          pluginSupportsPlatform(kPlatformWindows, plugin,
+              variant: kPlatformVariantWinUwp),
+          isTrue);
     });
   });
 }

--- a/script/tool/test/common_test.dart
+++ b/script/tool/test/common_test.dart
@@ -742,11 +742,10 @@ file2/file2.cc
         plugin,
         name: pluginName,
         platformSupport: <String, PlatformDetails>{
-          kPlatformWindows: const PlatformDetails(PlatformSupport.federated,
-              variants: <String>[
-                kPlatformVariantWin32,
-                kPlatformVariantWinUwp
-              ]),
+          kPlatformWindows: const PlatformDetails(
+            PlatformSupport.federated,
+            variants: <String>[kPlatformVariantWin32, kPlatformVariantWinUwp],
+          ),
         },
       );
 
@@ -772,8 +771,10 @@ file2/file2.cc
         plugin,
         name: pluginName,
         platformSupport: <String, PlatformDetails>{
-          kPlatformWindows: const PlatformDetails(PlatformSupport.federated,
-              variants: <String>[kPlatformVariantWin32]),
+          kPlatformWindows: const PlatformDetails(
+            PlatformSupport.federated,
+            variants: <String>[kPlatformVariantWin32],
+          ),
         },
       );
 

--- a/script/tool/test/create_all_plugins_app_command_test.dart
+++ b/script/tool/test/create_all_plugins_app_command_test.dart
@@ -21,7 +21,7 @@ void main() {
     setUp(() {
       // Since the core of this command is a call to 'flutter create', the test
       // has to use the real filesystem. Put everything possible in a unique
-      // temporary to minimize affect on the host system.
+      // temporary to minimize effect on the host system.
       fileSystem = const LocalFileSystem();
       testRoot = fileSystem.systemTempDirectory.createTempSync();
       packagesDir = testRoot.childDirectory('packages');

--- a/script/tool/test/drive_examples_command_test.dart
+++ b/script/tool/test/drive_examples_command_test.dart
@@ -35,16 +35,14 @@ void main() {
     });
 
     test('driving under folder "test"', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withSingleExample: true,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test_driver', 'plugin_test.dart'],
-            <String>['example', 'test', 'plugin.dart'],
-          ],
-          platformSupport: <String, PlatformDetails>{
-            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
-            kPlatformIos: const PlatformDetails(PlatformSupport.inline),
-          });
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test_driver', 'plugin_test.dart'],
+        <String>['example', 'test', 'plugin.dart'],
+      ], platformSupport: <String, PlatformDetails>{
+        kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
+        kPlatformIos: const PlatformDetails(PlatformSupport.inline),
+      });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -81,16 +79,14 @@ void main() {
     });
 
     test('driving under folder "test_driver"', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withSingleExample: true,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test_driver', 'plugin_test.dart'],
-            <String>['example', 'test_driver', 'plugin.dart'],
-          ],
-          platformSupport: <String, PlatformDetails>{
-            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
-            kPlatformIos: const PlatformDetails(PlatformSupport.inline),
-          });
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test_driver', 'plugin_test.dart'],
+        <String>['example', 'test_driver', 'plugin.dart'],
+      ], platformSupport: <String, PlatformDetails>{
+        kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
+        kPlatformIos: const PlatformDetails(PlatformSupport.inline),
+      });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -128,15 +124,12 @@ void main() {
 
     test('driving under folder "test_driver" when test files are missing"',
         () async {
-      createFakePlugin('plugin', packagesDir,
-          withSingleExample: true,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test_driver', 'plugin_test.dart'],
-          ],
-          platformSupport: <String, PlatformDetails>{
-            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
-            kPlatformIos: const PlatformDetails(PlatformSupport.inline),
-          });
+      createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test_driver', 'plugin_test.dart'],
+      ], platformSupport: <String, PlatformDetails>{
+        kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
+        kPlatformIos: const PlatformDetails(PlatformSupport.inline),
+      });
 
       await expectLater(
           () => runCapturingPrint(runner, <String>['drive-examples']),
@@ -145,15 +138,12 @@ void main() {
 
     test('a plugin without any integration test files is reported as an error',
         () async {
-      createFakePlugin('plugin', packagesDir,
-          withSingleExample: true,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'lib', 'main.dart'],
-          ],
-          platformSupport: <String, PlatformDetails>{
-            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
-            kPlatformIos: const PlatformDetails(PlatformSupport.inline),
-          });
+      createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'lib', 'main.dart'],
+      ], platformSupport: <String, PlatformDetails>{
+        kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
+        kPlatformIos: const PlatformDetails(PlatformSupport.inline),
+      });
 
       await expectLater(
           () => runCapturingPrint(runner, <String>['drive-examples']),
@@ -163,18 +153,16 @@ void main() {
     test(
         'driving under folder "test_driver" when targets are under "integration_test"',
         () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withSingleExample: true,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test_driver', 'integration_test.dart'],
-            <String>['example', 'integration_test', 'bar_test.dart'],
-            <String>['example', 'integration_test', 'foo_test.dart'],
-            <String>['example', 'integration_test', 'ignore_me.dart'],
-          ],
-          platformSupport: <String, PlatformDetails>{
-            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
-            kPlatformIos: const PlatformDetails(PlatformSupport.inline),
-          });
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test_driver', 'integration_test.dart'],
+        <String>['example', 'integration_test', 'bar_test.dart'],
+        <String>['example', 'integration_test', 'foo_test.dart'],
+        <String>['example', 'integration_test', 'ignore_me.dart'],
+      ], platformSupport: <String, PlatformDetails>{
+        kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
+        kPlatformIos: const PlatformDetails(PlatformSupport.inline),
+      });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -221,12 +209,10 @@ void main() {
     });
 
     test('driving when plugin does not support Linux is a no-op', () async {
-      createFakePlugin('plugin', packagesDir,
-          withSingleExample: true,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test_driver', 'plugin_test.dart'],
-            <String>['example', 'test_driver', 'plugin.dart'],
-          ]);
+      createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test_driver', 'plugin_test.dart'],
+        <String>['example', 'test_driver', 'plugin.dart'],
+      ]);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'drive-examples',
@@ -249,15 +235,13 @@ void main() {
     });
 
     test('driving on a Linux plugin', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withSingleExample: true,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test_driver', 'plugin_test.dart'],
-            <String>['example', 'test_driver', 'plugin.dart'],
-          ],
-          platformSupport: <String, PlatformDetails>{
-            kPlatformLinux: const PlatformDetails(PlatformSupport.inline),
-          });
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test_driver', 'plugin_test.dart'],
+        <String>['example', 'test_driver', 'plugin.dart'],
+      ], platformSupport: <String, PlatformDetails>{
+        kPlatformLinux: const PlatformDetails(PlatformSupport.inline),
+      });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -297,12 +281,10 @@ void main() {
     });
 
     test('driving when plugin does not suppport macOS is a no-op', () async {
-      createFakePlugin('plugin', packagesDir,
-          withSingleExample: true,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test_driver', 'plugin_test.dart'],
-            <String>['example', 'test_driver', 'plugin.dart'],
-          ]);
+      createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test_driver', 'plugin_test.dart'],
+        <String>['example', 'test_driver', 'plugin.dart'],
+      ]);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'drive-examples',
@@ -324,16 +306,14 @@ void main() {
       expect(processRunner.recordedCalls, <ProcessCall>[]);
     });
     test('driving on a macOS plugin', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withSingleExample: true,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test_driver', 'plugin_test.dart'],
-            <String>['example', 'test_driver', 'plugin.dart'],
-            <String>['example', 'macos', 'macos.swift'],
-          ],
-          platformSupport: <String, PlatformDetails>{
-            kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
-          });
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test_driver', 'plugin_test.dart'],
+        <String>['example', 'test_driver', 'plugin.dart'],
+        <String>['example', 'macos', 'macos.swift'],
+      ], platformSupport: <String, PlatformDetails>{
+        kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
+      });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -373,12 +353,10 @@ void main() {
     });
 
     test('driving when plugin does not suppport web is a no-op', () async {
-      createFakePlugin('plugin', packagesDir,
-          withSingleExample: true,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test_driver', 'plugin_test.dart'],
-            <String>['example', 'test_driver', 'plugin.dart'],
-          ]);
+      createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test_driver', 'plugin_test.dart'],
+        <String>['example', 'test_driver', 'plugin.dart'],
+      ]);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'drive-examples',
@@ -401,15 +379,13 @@ void main() {
     });
 
     test('driving a web plugin', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withSingleExample: true,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test_driver', 'plugin_test.dart'],
-            <String>['example', 'test_driver', 'plugin.dart'],
-          ],
-          platformSupport: <String, PlatformDetails>{
-            kPlatformWeb: const PlatformDetails(PlatformSupport.inline),
-          });
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test_driver', 'plugin_test.dart'],
+        <String>['example', 'test_driver', 'plugin.dart'],
+      ], platformSupport: <String, PlatformDetails>{
+        kPlatformWeb: const PlatformDetails(PlatformSupport.inline),
+      });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -451,12 +427,10 @@ void main() {
     });
 
     test('driving when plugin does not suppport Windows is a no-op', () async {
-      createFakePlugin('plugin', packagesDir,
-          withSingleExample: true,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test_driver', 'plugin_test.dart'],
-            <String>['example', 'test_driver', 'plugin.dart'],
-          ]);
+      createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test_driver', 'plugin_test.dart'],
+        <String>['example', 'test_driver', 'plugin.dart'],
+      ]);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'drive-examples',
@@ -479,15 +453,13 @@ void main() {
     });
 
     test('driving on a Windows plugin', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withSingleExample: true,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test_driver', 'plugin_test.dart'],
-            <String>['example', 'test_driver', 'plugin.dart'],
-          ],
-          platformSupport: <String, PlatformDetails>{
-            kPlatformWindows: const PlatformDetails(PlatformSupport.inline),
-          });
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test_driver', 'plugin_test.dart'],
+        <String>['example', 'test_driver', 'plugin.dart'],
+      ], platformSupport: <String, PlatformDetails>{
+        kPlatformWindows: const PlatformDetails(PlatformSupport.inline),
+      });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -529,15 +501,12 @@ void main() {
     test(
         'driving with no arguments when plugin does not support mobile is no-op',
         () async {
-      createFakePlugin('plugin', packagesDir,
-          withSingleExample: true,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test_driver', 'plugin_test.dart'],
-            <String>['example', 'test_driver', 'plugin.dart'],
-          ],
-          platformSupport: <String, PlatformDetails>{
-            kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
-          });
+      createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test_driver', 'plugin_test.dart'],
+        <String>['example', 'test_driver', 'plugin.dart'],
+      ], platformSupport: <String, PlatformDetails>{
+        kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
+      });
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'drive-examples',
@@ -559,7 +528,8 @@ void main() {
     });
 
     test('platform interface plugins are silently skipped', () async {
-      createFakePlugin('aplugin_platform_interface', packagesDir);
+      createFakePlugin('aplugin_platform_interface', packagesDir,
+          examples: <String>[]);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'drive-examples',
@@ -579,16 +549,14 @@ void main() {
     });
 
     test('enable-experiment flag', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withSingleExample: true,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test_driver', 'plugin_test.dart'],
-            <String>['example', 'test', 'plugin.dart'],
-          ],
-          platformSupport: <String, PlatformDetails>{
-            kPlatformIos: const PlatformDetails(PlatformSupport.inline),
-            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
-          });
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test_driver', 'plugin_test.dart'],
+        <String>['example', 'test', 'plugin.dart'],
+      ], platformSupport: <String, PlatformDetails>{
+        kPlatformIos: const PlatformDetails(PlatformSupport.inline),
+        kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
+      });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');

--- a/script/tool/test/drive_examples_command_test.dart
+++ b/script/tool/test/drive_examples_command_test.dart
@@ -36,17 +36,18 @@ void main() {
 
     test('driving under folder "test"', () async {
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+          withSingleExample: true,
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test', 'plugin.dart'],
           ],
-          isIosPlugin: true,
-          isAndroidPlugin: true);
+          platformSupport: <String, PlatformDetails>{
+            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
+            kPlatformIos: const PlatformDetails(PlatformSupport.inline),
+          });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'drive-examples',
@@ -81,17 +82,18 @@ void main() {
 
     test('driving under folder "test_driver"', () async {
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+          withSingleExample: true,
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test_driver', 'plugin.dart'],
           ],
-          isAndroidPlugin: true,
-          isIosPlugin: true);
+          platformSupport: <String, PlatformDetails>{
+            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
+            kPlatformIos: const PlatformDetails(PlatformSupport.inline),
+          });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'drive-examples',
@@ -126,17 +128,15 @@ void main() {
 
     test('driving under folder "test_driver" when test files are missing"',
         () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+      createFakePlugin('plugin', packagesDir,
+          withSingleExample: true,
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
           ],
-          isAndroidPlugin: true,
-          isIosPlugin: true);
-
-      final Directory pluginExampleDirectory =
-          pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
+          platformSupport: <String, PlatformDetails>{
+            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
+            kPlatformIos: const PlatformDetails(PlatformSupport.inline),
+          });
 
       await expectLater(
           () => runCapturingPrint(runner, <String>['drive-examples']),
@@ -145,17 +145,15 @@ void main() {
 
     test('a plugin without any integration test files is reported as an error',
         () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+      createFakePlugin('plugin', packagesDir,
+          withSingleExample: true,
           withExtraFiles: <List<String>>[
             <String>['example', 'lib', 'main.dart'],
           ],
-          isAndroidPlugin: true,
-          isIosPlugin: true);
-
-      final Directory pluginExampleDirectory =
-          pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
+          platformSupport: <String, PlatformDetails>{
+            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
+            kPlatformIos: const PlatformDetails(PlatformSupport.inline),
+          });
 
       await expectLater(
           () => runCapturingPrint(runner, <String>['drive-examples']),
@@ -166,19 +164,20 @@ void main() {
         'driving under folder "test_driver" when targets are under "integration_test"',
         () async {
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+          withSingleExample: true,
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'integration_test.dart'],
             <String>['example', 'integration_test', 'bar_test.dart'],
             <String>['example', 'integration_test', 'foo_test.dart'],
             <String>['example', 'integration_test', 'ignore_me.dart'],
           ],
-          isAndroidPlugin: true,
-          isIosPlugin: true);
+          platformSupport: <String, PlatformDetails>{
+            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
+            kPlatformIos: const PlatformDetails(PlatformSupport.inline),
+          });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'drive-examples',
@@ -222,17 +221,12 @@ void main() {
     });
 
     test('driving when plugin does not support Linux is a no-op', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+      createFakePlugin('plugin', packagesDir,
+          withSingleExample: true,
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test_driver', 'plugin.dart'],
-          ],
-          isMacOsPlugin: false);
-
-      final Directory pluginExampleDirectory =
-          pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
+          ]);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'drive-examples',
@@ -256,16 +250,17 @@ void main() {
 
     test('driving on a Linux plugin', () async {
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+          withSingleExample: true,
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test_driver', 'plugin.dart'],
           ],
-          isLinuxPlugin: true);
+          platformSupport: <String, PlatformDetails>{
+            kPlatformLinux: const PlatformDetails(PlatformSupport.inline),
+          });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'drive-examples',
@@ -302,16 +297,12 @@ void main() {
     });
 
     test('driving when plugin does not suppport macOS is a no-op', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+      createFakePlugin('plugin', packagesDir,
+          withSingleExample: true,
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test_driver', 'plugin.dart'],
           ]);
-
-      final Directory pluginExampleDirectory =
-          pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'drive-examples',
@@ -334,17 +325,18 @@ void main() {
     });
     test('driving on a macOS plugin', () async {
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+          withSingleExample: true,
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test_driver', 'plugin.dart'],
             <String>['example', 'macos', 'macos.swift'],
           ],
-          isMacOsPlugin: true);
+          platformSupport: <String, PlatformDetails>{
+            kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
+          });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'drive-examples',
@@ -381,17 +373,12 @@ void main() {
     });
 
     test('driving when plugin does not suppport web is a no-op', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+      createFakePlugin('plugin', packagesDir,
+          withSingleExample: true,
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test_driver', 'plugin.dart'],
-          ],
-          isWebPlugin: false);
-
-      final Directory pluginExampleDirectory =
-          pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
+          ]);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'drive-examples',
@@ -415,16 +402,17 @@ void main() {
 
     test('driving a web plugin', () async {
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+          withSingleExample: true,
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test_driver', 'plugin.dart'],
           ],
-          isWebPlugin: true);
+          platformSupport: <String, PlatformDetails>{
+            kPlatformWeb: const PlatformDetails(PlatformSupport.inline),
+          });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'drive-examples',
@@ -463,17 +451,12 @@ void main() {
     });
 
     test('driving when plugin does not suppport Windows is a no-op', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+      createFakePlugin('plugin', packagesDir,
+          withSingleExample: true,
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test_driver', 'plugin.dart'],
-          ],
-          isWindowsPlugin: false);
-
-      final Directory pluginExampleDirectory =
-          pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
+          ]);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'drive-examples',
@@ -497,16 +480,17 @@ void main() {
 
     test('driving on a Windows plugin', () async {
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+          withSingleExample: true,
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test_driver', 'plugin.dart'],
           ],
-          isWindowsPlugin: true);
+          platformSupport: <String, PlatformDetails>{
+            kPlatformWindows: const PlatformDetails(PlatformSupport.inline),
+          });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'drive-examples',
@@ -542,18 +526,18 @@ void main() {
           ]));
     });
 
-    test('driving when plugin does not support mobile is no-op', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+    test(
+        'driving with no arguments when plugin does not support mobile is no-op',
+        () async {
+      createFakePlugin('plugin', packagesDir,
+          withSingleExample: true,
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test_driver', 'plugin.dart'],
           ],
-          isMacOsPlugin: true);
-
-      final Directory pluginExampleDirectory =
-          pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
+          platformSupport: <String, PlatformDetails>{
+            kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
+          });
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'drive-examples',
@@ -596,17 +580,18 @@ void main() {
 
     test('enable-experiment flag', () async {
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+          withSingleExample: true,
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test', 'plugin.dart'],
           ],
-          isIosPlugin: true,
-          isAndroidPlugin: true);
+          platformSupport: <String, PlatformDetails>{
+            kPlatformIos: const PlatformDetails(PlatformSupport.inline),
+            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
+          });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       await runCapturingPrint(runner, <String>[
         'drive-examples',

--- a/script/tool/test/firebase_test_lab_test.dart
+++ b/script/tool/test/firebase_test_lab_test.dart
@@ -40,7 +40,7 @@ void main() {
       final MockProcess mockProcess = MockProcess();
       mockProcess.exitCodeCompleter.complete(1);
       processRunner.processToReturn = mockProcess;
-      createFakePlugin('plugin', packagesDir, withExtraFiles: <List<String>>[
+      createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
         <String>['lib/test/should_not_run_e2e.dart'],
         <String>['example', 'test_driver', 'plugin_e2e.dart'],
         <String>['example', 'test_driver', 'plugin_e2e_test.dart'],
@@ -65,7 +65,7 @@ void main() {
     });
 
     test('runs e2e tests', () async {
-      createFakePlugin('plugin', packagesDir, withExtraFiles: <List<String>>[
+      createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
         <String>['test', 'plugin_test.dart'],
         <String>['test', 'plugin_e2e.dart'],
         <String>['should_not_run_e2e.dart'],
@@ -168,7 +168,7 @@ void main() {
     });
 
     test('experimental flag', () async {
-      createFakePlugin('plugin', packagesDir, withExtraFiles: <List<String>>[
+      createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
         <String>['test', 'plugin_test.dart'],
         <String>['test', 'plugin_e2e.dart'],
         <String>['should_not_run_e2e.dart'],

--- a/script/tool/test/java_test_command_test.dart
+++ b/script/tool/test/java_test_command_test.dart
@@ -5,6 +5,7 @@
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
+import 'package:flutter_plugin_tools/src/common.dart';
 import 'package:flutter_plugin_tools/src/java_test_command.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
@@ -34,13 +35,14 @@ void main() {
       final Directory plugin = createFakePlugin(
         'plugin1',
         packagesDir,
-        isAndroidPlugin: true,
-        isFlutter: true,
         withSingleExample: true,
         withExtraFiles: <List<String>>[
           <String>['example/android', 'gradlew'],
           <String>['android/src/test', 'example_test.java'],
         ],
+        platformSupport: <String, PlatformDetails>{
+          kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
+        },
       );
 
       await runner.run(<String>['java-test']);
@@ -61,13 +63,14 @@ void main() {
       final Directory plugin = createFakePlugin(
         'plugin1',
         packagesDir,
-        isAndroidPlugin: true,
-        isFlutter: true,
         withSingleExample: true,
         withExtraFiles: <List<String>>[
           <String>['example/android', 'gradlew'],
           <String>['example/android/app/src/test', 'example_test.java'],
         ],
+        platformSupport: <String, PlatformDetails>{
+          kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
+        },
       );
 
       await runner.run(<String>['java-test']);

--- a/script/tool/test/java_test_command_test.dart
+++ b/script/tool/test/java_test_command_test.dart
@@ -35,8 +35,7 @@ void main() {
       final Directory plugin = createFakePlugin(
         'plugin1',
         packagesDir,
-        withSingleExample: true,
-        withExtraFiles: <List<String>>[
+        extraFiles: <List<String>>[
           <String>['example/android', 'gradlew'],
           <String>['android/src/test', 'example_test.java'],
         ],
@@ -63,8 +62,7 @@ void main() {
       final Directory plugin = createFakePlugin(
         'plugin1',
         packagesDir,
-        withSingleExample: true,
-        withExtraFiles: <List<String>>[
+        extraFiles: <List<String>>[
           <String>['example/android', 'gradlew'],
           <String>['example/android/app/src/test', 'example_test.java'],
         ],

--- a/script/tool/test/lint_podspecs_command_test.dart
+++ b/script/tool/test/lint_podspecs_command_test.dart
@@ -45,7 +45,7 @@ void main() {
     });
 
     test('only runs on macOS', () async {
-      createFakePlugin('plugin1', packagesDir, withExtraFiles: <List<String>>[
+      createFakePlugin('plugin1', packagesDir, extraFiles: <List<String>>[
         <String>['plugin1.podspec'],
       ]);
 
@@ -59,11 +59,11 @@ void main() {
     });
 
     test('runs pod lib lint on a podspec', () async {
-      final Directory plugin1Dir = createFakePlugin('plugin1', packagesDir,
-          withExtraFiles: <List<String>>[
-            <String>['ios', 'plugin1.podspec'],
-            <String>['bogus.dart'], // Ignore non-podspecs.
-          ]);
+      final Directory plugin1Dir =
+          createFakePlugin('plugin1', packagesDir, extraFiles: <List<String>>[
+        <String>['ios', 'plugin1.podspec'],
+        <String>['bogus.dart'], // Ignore non-podspecs.
+      ]);
 
       processRunner.resultStdout = 'Foo';
       processRunner.resultStderr = 'Bar';
@@ -106,10 +106,10 @@ void main() {
     });
 
     test('skips podspecs with known issues', () async {
-      createFakePlugin('plugin1', packagesDir, withExtraFiles: <List<String>>[
+      createFakePlugin('plugin1', packagesDir, extraFiles: <List<String>>[
         <String>['plugin1.podspec']
       ]);
-      createFakePlugin('plugin2', packagesDir, withExtraFiles: <List<String>>[
+      createFakePlugin('plugin2', packagesDir, extraFiles: <List<String>>[
         <String>['plugin2.podspec']
       ]);
 
@@ -125,10 +125,10 @@ void main() {
     });
 
     test('allow warnings for podspecs with known warnings', () async {
-      final Directory plugin1Dir = createFakePlugin('plugin1', packagesDir,
-          withExtraFiles: <List<String>>[
-            <String>['plugin1.podspec'],
-          ]);
+      final Directory plugin1Dir =
+          createFakePlugin('plugin1', packagesDir, extraFiles: <List<String>>[
+        <String>['plugin1.podspec'],
+      ]);
 
       await runner.run(<String>['podspecs', '--ignore-warnings=plugin1']);
 

--- a/script/tool/test/list_command_test.dart
+++ b/script/tool/test/list_command_test.dart
@@ -42,10 +42,10 @@ void main() {
     });
 
     test('lists examples', () async {
-      createFakePlugin('plugin1', packagesDir, withSingleExample: true);
+      createFakePlugin('plugin1', packagesDir);
       createFakePlugin('plugin2', packagesDir,
-          withExamples: <String>['example1', 'example2']);
-      createFakePlugin('plugin3', packagesDir);
+          examples: <String>['example1', 'example2']);
+      createFakePlugin('plugin3', packagesDir, examples: <String>[]);
 
       final List<String> examples =
           await runCapturingPrint(runner, <String>['list', '--type=example']);
@@ -61,10 +61,10 @@ void main() {
     });
 
     test('lists packages', () async {
-      createFakePlugin('plugin1', packagesDir, withSingleExample: true);
+      createFakePlugin('plugin1', packagesDir);
       createFakePlugin('plugin2', packagesDir,
-          withExamples: <String>['example1', 'example2']);
-      createFakePlugin('plugin3', packagesDir);
+          examples: <String>['example1', 'example2']);
+      createFakePlugin('plugin3', packagesDir, examples: <String>[]);
 
       final List<String> packages =
           await runCapturingPrint(runner, <String>['list', '--type=package']);
@@ -83,10 +83,10 @@ void main() {
     });
 
     test('lists files', () async {
-      createFakePlugin('plugin1', packagesDir, withSingleExample: true);
+      createFakePlugin('plugin1', packagesDir);
       createFakePlugin('plugin2', packagesDir,
-          withExamples: <String>['example1', 'example2']);
-      createFakePlugin('plugin3', packagesDir);
+          examples: <String>['example1', 'example2']);
+      createFakePlugin('plugin3', packagesDir, examples: <String>[]);
 
       final List<String> examples =
           await runCapturingPrint(runner, <String>['list', '--type=file']);
@@ -95,11 +95,14 @@ void main() {
         examples,
         unorderedEquals(<String>[
           '/packages/plugin1/pubspec.yaml',
+          '/packages/plugin1/CHANGELOG.md',
           '/packages/plugin1/example/pubspec.yaml',
           '/packages/plugin2/pubspec.yaml',
+          '/packages/plugin2/CHANGELOG.md',
           '/packages/plugin2/example/example1/pubspec.yaml',
           '/packages/plugin2/example/example2/pubspec.yaml',
           '/packages/plugin3/pubspec.yaml',
+          '/packages/plugin3/CHANGELOG.md',
         ]),
       );
     });

--- a/script/tool/test/publish_check_command_test.dart
+++ b/script/tool/test/publish_check_command_test.dart
@@ -42,8 +42,10 @@ void main() {
     });
 
     test('publish check all packages', () async {
-      final Directory plugin1Dir = createFakePlugin('a', packagesDir);
-      final Directory plugin2Dir = createFakePlugin('b', packagesDir);
+      final Directory plugin1Dir =
+          createFakePlugin('plugin_tools_test_package_a', packagesDir);
+      final Directory plugin2Dir =
+          createFakePlugin('plugin_tools_test_package_b', packagesDir);
 
       processRunner.processesToReturn.add(
         MockProcess()..exitCodeCompleter.complete(0),
@@ -68,7 +70,7 @@ void main() {
     });
 
     test('fail on negative test', () async {
-      createFakePlugin('a', packagesDir);
+      createFakePlugin('plugin_tools_test_package_a', packagesDir);
 
       final MockProcess process = MockProcess();
       process.stdoutController.close(); // ignore: unawaited_futures
@@ -188,13 +190,8 @@ void main() {
       );
       runner.addCommand(command);
 
-      final Directory plugin1Dir =
-          createFakePlugin('no_publish_a', packagesDir, includeVersion: true);
-      final Directory plugin2Dir =
-          createFakePlugin('no_publish_b', packagesDir, includeVersion: true);
-
-      createFakePubspec(plugin1Dir, name: 'no_publish_a', version: '0.1.0');
-      createFakePubspec(plugin2Dir, name: 'no_publish_b', version: '0.2.0');
+      createFakePlugin('no_publish_a', packagesDir, version: '0.1.0');
+      createFakePlugin('no_publish_b', packagesDir, version: '0.2.0');
 
       processRunner.processesToReturn.add(
         MockProcess()..exitCodeCompleter.complete(0),
@@ -252,13 +249,8 @@ void main() {
       );
       runner.addCommand(command);
 
-      final Directory plugin1Dir =
-          createFakePlugin('no_publish_a', packagesDir, includeVersion: true);
-      final Directory plugin2Dir =
-          createFakePlugin('no_publish_b', packagesDir, includeVersion: true);
-
-      createFakePubspec(plugin1Dir, name: 'no_publish_a', version: '0.1.0');
-      createFakePubspec(plugin2Dir, name: 'no_publish_b', version: '0.2.0');
+      createFakePlugin('no_publish_a', packagesDir, version: '0.1.0');
+      createFakePlugin('no_publish_b', packagesDir, version: '0.2.0');
 
       processRunner.processesToReturn.add(
         MockProcess()..exitCodeCompleter.complete(0),
@@ -320,12 +312,9 @@ void main() {
       runner.addCommand(command);
 
       final Directory plugin1Dir =
-          createFakePlugin('no_publish_a', packagesDir, includeVersion: true);
-      final Directory plugin2Dir =
-          createFakePlugin('no_publish_b', packagesDir, includeVersion: true);
+          createFakePlugin('no_publish_a', packagesDir, version: '0.1.0');
+      createFakePlugin('no_publish_b', packagesDir, version: '0.2.0');
 
-      createFakePubspec(plugin1Dir, name: 'no_publish_a', version: '0.1.0');
-      createFakePubspec(plugin2Dir, name: 'no_publish_b', version: '0.2.0');
       await plugin1Dir.childFile('pubspec.yaml').writeAsString('bad-yaml');
 
       processRunner.processesToReturn.add(

--- a/script/tool/test/publish_plugin_command_test.dart
+++ b/script/tool/test/publish_plugin_command_test.dart
@@ -50,8 +50,7 @@ void main() {
     // use a fully resolved version to avoid potential path comparison issues.
     testRoot = fileSystem.directory(testRoot.resolveSymbolicLinksSync());
     packagesDir = createPackagesDirectory(parentDir: testRoot);
-    pluginDir =
-        createFakePlugin(testPluginName, packagesDir, withSingleExample: false);
+    pluginDir = createFakePlugin(testPluginName, packagesDir);
     assert(pluginDir != null && pluginDir.existsSync());
     createFakePubspec(pluginDir, version: '0.0.1');
     io.Process.runSync('git', <String>['init'],
@@ -429,11 +428,10 @@ void main() {
 
     test('can release newly created plugins', () async {
       // Non-federated
-      final Directory pluginDir1 =
-          createFakePlugin('plugin1', packagesDir, withSingleExample: true);
+      final Directory pluginDir1 = createFakePlugin('plugin1', packagesDir);
       // federated
       final Directory pluginDir2 = createFakePlugin('plugin2', packagesDir,
-          withSingleExample: true, parentDirectoryName: 'plugin2');
+          parentDirectoryName: 'plugin2');
       createFakePubspec(pluginDir1,
           name: 'plugin1', isFlutter: false, version: '0.0.1');
       createFakePubspec(pluginDir2,
@@ -468,8 +466,7 @@ void main() {
     test('can release newly created plugins, while there are existing plugins',
         () async {
       // Prepare an exiting plugin and tag it
-      final Directory pluginDir0 =
-          createFakePlugin('plugin0', packagesDir, withSingleExample: true);
+      final Directory pluginDir0 = createFakePlugin('plugin0', packagesDir);
       createFakePubspec(pluginDir0,
           name: 'plugin0', isFlutter: false, version: '0.0.1');
       await gitDir.runCommand(<String>['add', '-A']);
@@ -482,11 +479,10 @@ void main() {
       processRunner.pushTagsArgs.clear();
 
       // Non-federated
-      final Directory pluginDir1 =
-          createFakePlugin('plugin1', packagesDir, withSingleExample: true);
+      final Directory pluginDir1 = createFakePlugin('plugin1', packagesDir);
       // federated
       final Directory pluginDir2 = createFakePlugin('plugin2', packagesDir,
-          withSingleExample: true, parentDirectoryName: 'plugin2');
+          parentDirectoryName: 'plugin2');
       createFakePubspec(pluginDir1,
           name: 'plugin1', isFlutter: false, version: '0.0.1');
       createFakePubspec(pluginDir2,
@@ -518,11 +514,10 @@ void main() {
 
     test('can release newly created plugins, dry run', () async {
       // Non-federated
-      final Directory pluginDir1 =
-          createFakePlugin('plugin1', packagesDir, withSingleExample: true);
+      final Directory pluginDir1 = createFakePlugin('plugin1', packagesDir);
       // federated
       final Directory pluginDir2 = createFakePlugin('plugin2', packagesDir,
-          withSingleExample: true, parentDirectoryName: 'plugin2');
+          parentDirectoryName: 'plugin2');
       createFakePubspec(pluginDir1,
           name: 'plugin1', isFlutter: false, version: '0.0.1');
       createFakePubspec(pluginDir2,
@@ -559,11 +554,10 @@ void main() {
 
     test('version change triggers releases.', () async {
       // Non-federated
-      final Directory pluginDir1 =
-          createFakePlugin('plugin1', packagesDir, withSingleExample: true);
+      final Directory pluginDir1 = createFakePlugin('plugin1', packagesDir);
       // federated
       final Directory pluginDir2 = createFakePlugin('plugin2', packagesDir,
-          withSingleExample: true, parentDirectoryName: 'plugin2');
+          parentDirectoryName: 'plugin2');
       createFakePubspec(pluginDir1,
           name: 'plugin1', isFlutter: false, version: '0.0.1');
       createFakePubspec(pluginDir2,
@@ -642,11 +636,10 @@ void main() {
         'delete package will not trigger publish but exit the command successfully.',
         () async {
       // Non-federated
-      final Directory pluginDir1 =
-          createFakePlugin('plugin1', packagesDir, withSingleExample: true);
+      final Directory pluginDir1 = createFakePlugin('plugin1', packagesDir);
       // federated
       final Directory pluginDir2 = createFakePlugin('plugin2', packagesDir,
-          withSingleExample: true, parentDirectoryName: 'plugin2');
+          parentDirectoryName: 'plugin2');
       createFakePubspec(pluginDir1,
           name: 'plugin1', isFlutter: false, version: '0.0.1');
       createFakePubspec(pluginDir2,
@@ -722,11 +715,10 @@ void main() {
         'versions revert do not trigger releases. Also prints out warning message.',
         () async {
       // Non-federated
-      final Directory pluginDir1 =
-          createFakePlugin('plugin1', packagesDir, withSingleExample: true);
+      final Directory pluginDir1 = createFakePlugin('plugin1', packagesDir);
       // federated
       final Directory pluginDir2 = createFakePlugin('plugin2', packagesDir,
-          withSingleExample: true, parentDirectoryName: 'plugin2');
+          parentDirectoryName: 'plugin2');
       createFakePubspec(pluginDir1,
           name: 'plugin1', isFlutter: false, version: '0.0.2');
       createFakePubspec(pluginDir2,
@@ -796,11 +788,10 @@ void main() {
 
     test('No version change does not release any plugins', () async {
       // Non-federated
-      final Directory pluginDir1 =
-          createFakePlugin('plugin1', packagesDir, withSingleExample: true);
+      final Directory pluginDir1 = createFakePlugin('plugin1', packagesDir);
       // federated
       final Directory pluginDir2 = createFakePlugin('plugin2', packagesDir,
-          withSingleExample: true, parentDirectoryName: 'plugin2');
+          parentDirectoryName: 'plugin2');
       createFakePubspec(pluginDir1,
           name: 'plugin1', isFlutter: false, version: '0.0.1');
       createFakePubspec(pluginDir2,

--- a/script/tool/test/publish_plugin_command_test.dart
+++ b/script/tool/test/publish_plugin_command_test.dart
@@ -52,7 +52,6 @@ void main() {
     packagesDir = createPackagesDirectory(parentDir: testRoot);
     pluginDir = createFakePlugin(testPluginName, packagesDir);
     assert(pluginDir != null && pluginDir.existsSync());
-    createFakePubspec(pluginDir, version: '0.0.1');
     io.Process.runSync('git', <String>['init'],
         workingDirectory: testRoot.path);
     gitDir = await GitDir.fromExisting(testRoot.path);
@@ -138,7 +137,8 @@ void main() {
     });
 
     test('can publish non-flutter package', () async {
-      createFakePubspec(pluginDir, version: '0.0.1', isFlutter: false);
+      const String packageName = 'a_package';
+      createFakePackage(packageName, packagesDir);
       io.Process.runSync('git', <String>['init'],
           workingDirectory: testRoot.path);
       gitDir = await GitDir.fromExisting(testRoot.path);
@@ -149,7 +149,7 @@ void main() {
       await commandRunner.run(<String>[
         'publish-plugin',
         '--package',
-        testPluginName,
+        packageName,
         '--no-push-tags',
         '--no-tag-release'
       ]);
@@ -284,9 +284,9 @@ void main() {
         '--no-push-tags',
       ]);
 
-      final String tag =
-          (await gitDir.runCommand(<String>['show-ref', 'fake_package-v0.0.1']))
-              .stdout as String;
+      final String tag = (await gitDir
+              .runCommand(<String>['show-ref', '$testPluginName-v0.0.1']))
+          .stdout as String;
       expect(tag, isNotEmpty);
     });
 
@@ -303,7 +303,7 @@ void main() {
 
       expect(printedMessages, contains('Publish foo failed.'));
       final String tag = (await gitDir.runCommand(
-              <String>['show-ref', 'fake_package-v0.0.1'],
+              <String>['show-ref', '$testPluginName-v0.0.1'],
               throwOnError: false))
           .stdout as String;
       expect(tag, isEmpty);
@@ -342,7 +342,7 @@ void main() {
 
       expect(processRunner.pushTagsArgs.isNotEmpty, isTrue);
       expect(processRunner.pushTagsArgs[1], 'upstream');
-      expect(processRunner.pushTagsArgs[2], 'fake_package-v0.0.1');
+      expect(processRunner.pushTagsArgs[2], '$testPluginName-v0.0.1');
       expect(printedMessages.last, 'Done!');
     });
 
@@ -360,7 +360,7 @@ void main() {
 
       expect(processRunner.pushTagsArgs.isNotEmpty, isTrue);
       expect(processRunner.pushTagsArgs[1], 'upstream');
-      expect(processRunner.pushTagsArgs[2], 'fake_package-v0.0.1');
+      expect(processRunner.pushTagsArgs[2], '$testPluginName-v0.0.1');
       expect(printedMessages.last, 'Done!');
     });
 
@@ -378,7 +378,7 @@ void main() {
           containsAllInOrder(<String>[
             '===============  DRY RUN ===============',
             'Running `pub publish ` in ${pluginDir.path}...\n',
-            'Tagging release fake_package-v0.0.1...',
+            'Tagging release $testPluginName-v0.0.1...',
             'Pushing tag to upstream...',
             'Done!'
           ]));
@@ -399,7 +399,7 @@ void main() {
 
       expect(processRunner.pushTagsArgs.isNotEmpty, isTrue);
       expect(processRunner.pushTagsArgs[1], 'origin');
-      expect(processRunner.pushTagsArgs[2], 'fake_package-v0.0.1');
+      expect(processRunner.pushTagsArgs[2], '$testPluginName-v0.0.1');
       expect(printedMessages.last, 'Done!');
     });
 
@@ -432,10 +432,6 @@ void main() {
       // federated
       final Directory pluginDir2 = createFakePlugin('plugin2', packagesDir,
           parentDirectoryName: 'plugin2');
-      createFakePubspec(pluginDir1,
-          name: 'plugin1', isFlutter: false, version: '0.0.1');
-      createFakePubspec(pluginDir2,
-          name: 'plugin2', isFlutter: false, version: '0.0.1');
       await gitDir.runCommand(<String>['add', '-A']);
       await gitDir.runCommand(<String>['commit', '-m', 'Add plugins']);
       // Immediately return 0 when running `pub publish`.
@@ -466,9 +462,7 @@ void main() {
     test('can release newly created plugins, while there are existing plugins',
         () async {
       // Prepare an exiting plugin and tag it
-      final Directory pluginDir0 = createFakePlugin('plugin0', packagesDir);
-      createFakePubspec(pluginDir0,
-          name: 'plugin0', isFlutter: false, version: '0.0.1');
+      createFakePlugin('plugin0', packagesDir);
       await gitDir.runCommand(<String>['add', '-A']);
       await gitDir.runCommand(<String>['commit', '-m', 'Add plugins']);
       // Immediately return 0 when running `pub publish`.
@@ -483,10 +477,6 @@ void main() {
       // federated
       final Directory pluginDir2 = createFakePlugin('plugin2', packagesDir,
           parentDirectoryName: 'plugin2');
-      createFakePubspec(pluginDir1,
-          name: 'plugin1', isFlutter: false, version: '0.0.1');
-      createFakePubspec(pluginDir2,
-          name: 'plugin2', isFlutter: false, version: '0.0.1');
       await gitDir.runCommand(<String>['add', '-A']);
       await gitDir.runCommand(<String>['commit', '-m', 'Add plugins']);
       // Immediately return 0 when running `pub publish`.
@@ -518,10 +508,6 @@ void main() {
       // federated
       final Directory pluginDir2 = createFakePlugin('plugin2', packagesDir,
           parentDirectoryName: 'plugin2');
-      createFakePubspec(pluginDir1,
-          name: 'plugin1', isFlutter: false, version: '0.0.1');
-      createFakePubspec(pluginDir2,
-          name: 'plugin2', isFlutter: false, version: '0.0.1');
       await gitDir.runCommand(<String>['add', '-A']);
       await gitDir.runCommand(<String>['commit', '-m', 'Add plugins']);
       // Immediately return 1 when running `pub publish`. If dry-run does not work, test should throw.
@@ -558,10 +544,6 @@ void main() {
       // federated
       final Directory pluginDir2 = createFakePlugin('plugin2', packagesDir,
           parentDirectoryName: 'plugin2');
-      createFakePubspec(pluginDir1,
-          name: 'plugin1', isFlutter: false, version: '0.0.1');
-      createFakePubspec(pluginDir2,
-          name: 'plugin2', isFlutter: false, version: '0.0.1');
       await gitDir.runCommand(<String>['add', '-A']);
       await gitDir.runCommand(<String>['commit', '-m', 'Add plugins']);
       // Immediately return 0 when running `pub publish`.
@@ -640,10 +622,6 @@ void main() {
       // federated
       final Directory pluginDir2 = createFakePlugin('plugin2', packagesDir,
           parentDirectoryName: 'plugin2');
-      createFakePubspec(pluginDir1,
-          name: 'plugin1', isFlutter: false, version: '0.0.1');
-      createFakePubspec(pluginDir2,
-          name: 'plugin2', isFlutter: false, version: '0.0.1');
       await gitDir.runCommand(<String>['add', '-A']);
       await gitDir.runCommand(<String>['commit', '-m', 'Add plugins']);
       // Immediately return 0 when running `pub publish`.
@@ -715,14 +693,18 @@ void main() {
         'versions revert do not trigger releases. Also prints out warning message.',
         () async {
       // Non-federated
-      final Directory pluginDir1 = createFakePlugin('plugin1', packagesDir);
+      final Directory pluginDir1 = createFakePlugin(
+        'plugin1',
+        packagesDir,
+        version: '0.0.2',
+      );
       // federated
-      final Directory pluginDir2 = createFakePlugin('plugin2', packagesDir,
-          parentDirectoryName: 'plugin2');
-      createFakePubspec(pluginDir1,
-          name: 'plugin1', isFlutter: false, version: '0.0.2');
-      createFakePubspec(pluginDir2,
-          name: 'plugin2', isFlutter: false, version: '0.0.2');
+      final Directory pluginDir2 = createFakePlugin(
+        'plugin2',
+        packagesDir,
+        version: '0.0.2',
+        parentDirectoryName: 'plugin2',
+      );
       await gitDir.runCommand(<String>['add', '-A']);
       await gitDir.runCommand(<String>['commit', '-m', 'Add plugins']);
       // Immediately return 0 when running `pub publish`.
@@ -792,10 +774,6 @@ void main() {
       // federated
       final Directory pluginDir2 = createFakePlugin('plugin2', packagesDir,
           parentDirectoryName: 'plugin2');
-      createFakePubspec(pluginDir1,
-          name: 'plugin1', isFlutter: false, version: '0.0.1');
-      createFakePubspec(pluginDir2,
-          name: 'plugin2', isFlutter: false, version: '0.0.1');
 
       io.Process.runSync('git', <String>['init'],
           workingDirectory: testRoot.path);

--- a/script/tool/test/pubspec_check_command_test.dart
+++ b/script/tool/test/pubspec_check_command_test.dart
@@ -88,8 +88,7 @@ dev_dependencies:
     }
 
     test('passes for a plugin following conventions', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, withSingleExample: true);
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir);
 
       pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
 ${headerSection('plugin', isPlugin: true)}
@@ -114,8 +113,7 @@ ${devDependenciesSection()}
     });
 
     test('passes for a Flutter package following conventions', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, withSingleExample: true);
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir);
 
       pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
 ${headerSection('plugin')}
@@ -163,8 +161,7 @@ ${dependenciesSection()}
     });
 
     test('fails when homepage is included', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, withSingleExample: true);
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir);
 
       pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
 ${headerSection('plugin', isPlugin: true, includeHomepage: true)}
@@ -184,8 +181,7 @@ ${devDependenciesSection()}
     });
 
     test('fails when repository is missing', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, withSingleExample: true);
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir);
 
       pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
 ${headerSection('plugin', isPlugin: true, includeRepository: false)}
@@ -205,8 +201,7 @@ ${devDependenciesSection()}
     });
 
     test('fails when homepage is given instead of repository', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, withSingleExample: true);
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir);
 
       pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
 ${headerSection('plugin', isPlugin: true, includeHomepage: true, includeRepository: false)}
@@ -226,8 +221,7 @@ ${devDependenciesSection()}
     });
 
     test('fails when issue tracker is missing', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, withSingleExample: true);
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir);
 
       pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
 ${headerSection('plugin', isPlugin: true, includeIssueTracker: false)}
@@ -247,8 +241,7 @@ ${devDependenciesSection()}
     });
 
     test('fails when environment section is out of order', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, withSingleExample: true);
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir);
 
       pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
 ${headerSection('plugin', isPlugin: true)}
@@ -268,8 +261,7 @@ ${environmentSection()}
     });
 
     test('fails when flutter section is out of order', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, withSingleExample: true);
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir);
 
       pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
 ${headerSection('plugin', isPlugin: true)}
@@ -289,8 +281,7 @@ ${devDependenciesSection()}
     });
 
     test('fails when dependencies section is out of order', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, withSingleExample: true);
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir);
 
       pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
 ${headerSection('plugin', isPlugin: true)}
@@ -310,8 +301,7 @@ ${dependenciesSection()}
     });
 
     test('fails when devDependencies section is out of order', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, withSingleExample: true);
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir);
 
       pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
 ${headerSection('plugin', isPlugin: true)}

--- a/script/tool/test/test_command_test.dart
+++ b/script/tool/test/test_command_test.dart
@@ -5,6 +5,7 @@
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
+import 'package:flutter_plugin_tools/src/common.dart';
 import 'package:flutter_plugin_tools/src/test_command.dart';
 import 'package:test/test.dart';
 
@@ -70,16 +71,14 @@ void main() {
     });
 
     test('runs pub run test on non-Flutter packages', () async {
-      final Directory plugin1Dir = createFakePlugin('plugin1', packagesDir,
-          isFlutter: true,
-          withExtraFiles: <List<String>>[
-            <String>['test', 'empty_test.dart'],
-          ]);
-      final Directory plugin2Dir = createFakePlugin('plugin2', packagesDir,
-          isFlutter: false,
-          withExtraFiles: <List<String>>[
-            <String>['test', 'empty_test.dart'],
-          ]);
+      final Directory pluginDir =
+          createFakePlugin('a', packagesDir, withExtraFiles: <List<String>>[
+        <String>['test', 'empty_test.dart'],
+      ]);
+      final Directory packageDir =
+          createFakePackage('b', packagesDir, withExtraFiles: <List<String>>[
+        <String>['test', 'empty_test.dart'],
+      ]);
 
       await runner.run(<String>['test', '--enable-experiment=exp1']);
 
@@ -89,12 +88,12 @@ void main() {
           ProcessCall(
               'flutter',
               const <String>['test', '--color', '--enable-experiment=exp1'],
-              plugin1Dir.path),
-          ProcessCall('dart', const <String>['pub', 'get'], plugin2Dir.path),
+              pluginDir.path),
+          ProcessCall('dart', const <String>['pub', 'get'], packageDir.path),
           ProcessCall(
               'dart',
               const <String>['pub', 'run', '--enable-experiment=exp1', 'test'],
-              plugin2Dir.path),
+              packageDir.path),
         ]),
       );
     });
@@ -106,8 +105,9 @@ void main() {
         withExtraFiles: <List<String>>[
           <String>['test', 'empty_test.dart'],
         ],
-        isFlutter: true,
-        isWebPlugin: true,
+        platformSupport: <String, PlatformDetails>{
+          kPlatformWeb: const PlatformDetails(PlatformSupport.inline),
+        },
       );
 
       await runner.run(<String>['test']);
@@ -124,16 +124,14 @@ void main() {
     });
 
     test('enable-experiment flag', () async {
-      final Directory plugin1Dir = createFakePlugin('plugin1', packagesDir,
-          isFlutter: true,
-          withExtraFiles: <List<String>>[
-            <String>['test', 'empty_test.dart'],
-          ]);
-      final Directory plugin2Dir = createFakePlugin('plugin2', packagesDir,
-          isFlutter: false,
-          withExtraFiles: <List<String>>[
-            <String>['test', 'empty_test.dart'],
-          ]);
+      final Directory pluginDir =
+          createFakePlugin('a', packagesDir, withExtraFiles: <List<String>>[
+        <String>['test', 'empty_test.dart'],
+      ]);
+      final Directory packageDir =
+          createFakePackage('b', packagesDir, withExtraFiles: <List<String>>[
+        <String>['test', 'empty_test.dart'],
+      ]);
 
       await runner.run(<String>['test', '--enable-experiment=exp1']);
 
@@ -143,12 +141,12 @@ void main() {
           ProcessCall(
               'flutter',
               const <String>['test', '--color', '--enable-experiment=exp1'],
-              plugin1Dir.path),
-          ProcessCall('dart', const <String>['pub', 'get'], plugin2Dir.path),
+              pluginDir.path),
+          ProcessCall('dart', const <String>['pub', 'get'], packageDir.path),
           ProcessCall(
               'dart',
               const <String>['pub', 'run', '--enable-experiment=exp1', 'test'],
-              plugin2Dir.path),
+              packageDir.path),
         ]),
       );
     });

--- a/script/tool/test/test_command_test.dart
+++ b/script/tool/test/test_command_test.dart
@@ -30,14 +30,14 @@ void main() {
     });
 
     test('runs flutter test on each plugin', () async {
-      final Directory plugin1Dir = createFakePlugin('plugin1', packagesDir,
-          withExtraFiles: <List<String>>[
-            <String>['test', 'empty_test.dart'],
-          ]);
-      final Directory plugin2Dir = createFakePlugin('plugin2', packagesDir,
-          withExtraFiles: <List<String>>[
-            <String>['test', 'empty_test.dart'],
-          ]);
+      final Directory plugin1Dir =
+          createFakePlugin('plugin1', packagesDir, extraFiles: <List<String>>[
+        <String>['test', 'empty_test.dart'],
+      ]);
+      final Directory plugin2Dir =
+          createFakePlugin('plugin2', packagesDir, extraFiles: <List<String>>[
+        <String>['test', 'empty_test.dart'],
+      ]);
 
       await runner.run(<String>['test']);
 
@@ -54,10 +54,10 @@ void main() {
 
     test('skips testing plugins without test directory', () async {
       createFakePlugin('plugin1', packagesDir);
-      final Directory plugin2Dir = createFakePlugin('plugin2', packagesDir,
-          withExtraFiles: <List<String>>[
-            <String>['test', 'empty_test.dart'],
-          ]);
+      final Directory plugin2Dir =
+          createFakePlugin('plugin2', packagesDir, extraFiles: <List<String>>[
+        <String>['test', 'empty_test.dart'],
+      ]);
 
       await runner.run(<String>['test']);
 
@@ -72,11 +72,11 @@ void main() {
 
     test('runs pub run test on non-Flutter packages', () async {
       final Directory pluginDir =
-          createFakePlugin('a', packagesDir, withExtraFiles: <List<String>>[
+          createFakePlugin('a', packagesDir, extraFiles: <List<String>>[
         <String>['test', 'empty_test.dart'],
       ]);
       final Directory packageDir =
-          createFakePackage('b', packagesDir, withExtraFiles: <List<String>>[
+          createFakePackage('b', packagesDir, extraFiles: <List<String>>[
         <String>['test', 'empty_test.dart'],
       ]);
 
@@ -102,7 +102,7 @@ void main() {
       final Directory pluginDir = createFakePlugin(
         'plugin',
         packagesDir,
-        withExtraFiles: <List<String>>[
+        extraFiles: <List<String>>[
           <String>['test', 'empty_test.dart'],
         ],
         platformSupport: <String, PlatformDetails>{
@@ -125,11 +125,11 @@ void main() {
 
     test('enable-experiment flag', () async {
       final Directory pluginDir =
-          createFakePlugin('a', packagesDir, withExtraFiles: <List<String>>[
+          createFakePlugin('a', packagesDir, extraFiles: <List<String>>[
         <String>['test', 'empty_test.dart'],
       ]);
       final Directory packageDir =
-          createFakePackage('b', packagesDir, withExtraFiles: <List<String>>[
+          createFakePackage('b', packagesDir, extraFiles: <List<String>>[
         <String>['test', 'empty_test.dart'],
       ]);
 

--- a/script/tool/test/util.dart
+++ b/script/tool/test/util.dart
@@ -52,46 +52,39 @@ class PlatformDetails {
 Directory createFakePlugin(
   String name,
   Directory packagesDirectory, {
-  bool withSingleExample = false,
-  List<String> withExamples = const <String>[],
-  List<List<String>> withExtraFiles = const <List<String>>[],
+  List<String> examples = const <String>['example'],
+  List<List<String>> extraFiles = const <List<String>>[],
   Map<String, PlatformDetails> platformSupport =
       const <String, PlatformDetails>{},
-  bool includeChangeLog = false,
   String? version = '0.0.1',
   String parentDirectoryName = '',
 }) {
-  assert(!(withSingleExample && withExamples.isNotEmpty),
-      'cannot pass withSingleExample and withExamples simultaneously');
-
   Directory parentDirectory = packagesDirectory;
   if (parentDirectoryName != '') {
     parentDirectory = parentDirectory.childDirectory(parentDirectoryName);
   }
   final Directory pluginDirectory =
-      createFakePackage(name, parentDirectory, withExtraFiles: withExtraFiles);
+      createFakePackage(name, parentDirectory, extraFiles: extraFiles);
 
   createFakePubspec(pluginDirectory,
       name: name,
       isFlutter: true,
       platformSupport: platformSupport,
       version: version);
-  if (includeChangeLog) {
-    createFakeCHANGELOG(pluginDirectory, '''
+  createFakeCHANGELOG(pluginDirectory, '''
 ## $version
   * Some changes.
   ''');
-  }
 
-  if (withSingleExample) {
-    final Directory exampleDir = pluginDirectory.childDirectory('example')
+  if (examples.length == 1) {
+    final Directory exampleDir = pluginDirectory.childDirectory(examples.first)
       ..createSync();
     createFakePubspec(exampleDir,
         name: '${name}_example', isFlutter: true, publishTo: 'none');
-  } else if (withExamples.isNotEmpty) {
+  } else if (examples.isNotEmpty) {
     final Directory exampleDir = pluginDirectory.childDirectory('example')
       ..createSync();
-    for (final String example in withExamples) {
+    for (final String example in examples) {
       final Directory currentExample = exampleDir.childDirectory(example)
         ..createSync();
       createFakePubspec(currentExample,
@@ -109,7 +102,7 @@ Directory createFakePlugin(
 Directory createFakePackage(
   String name,
   Directory parentDirectory, {
-  List<List<String>> withExtraFiles = const <List<String>>[],
+  List<List<String>> extraFiles = const <List<String>>[],
   bool isFlutter = false,
 }) {
   final Directory packageDirectory = parentDirectory.childDirectory(name);
@@ -118,7 +111,7 @@ Directory createFakePackage(
   createFakePubspec(packageDirectory, name: name, isFlutter: isFlutter);
 
   final FileSystem fileSystem = packageDirectory.fileSystem;
-  for (final List<String> file in withExtraFiles) {
+  for (final List<String> file in extraFiles) {
     final List<String> newFilePath = <String>[packageDirectory.path, ...file];
     final File newFile = fileSystem.file(fileSystem.path.joinAll(newFilePath));
     newFile.createSync(recursive: true);

--- a/script/tool/test/version_check_test.dart
+++ b/script/tool/test/version_check_test.dart
@@ -102,8 +102,7 @@ void main() {
 
     test('allows valid version', () async {
       const String newVersion = '2.0.0';
-      createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, version: newVersion);
+      createFakePlugin('plugin', packagesDir, version: newVersion);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'master:packages/plugin/pubspec.yaml': 'version: 1.0.0',
@@ -130,8 +129,7 @@ void main() {
 
     test('denies invalid version', () async {
       const String newVersion = '0.2.0';
-      createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, version: newVersion);
+      createFakePlugin('plugin', packagesDir, version: newVersion);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'master:packages/plugin/pubspec.yaml': 'version: 0.0.1',
@@ -156,8 +154,7 @@ void main() {
 
     test('allows valid version without explicit base-sha', () async {
       const String newVersion = '2.0.0';
-      createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, version: newVersion);
+      createFakePlugin('plugin', packagesDir, version: newVersion);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'abc123:packages/plugin/pubspec.yaml': 'version: 1.0.0',
@@ -176,8 +173,7 @@ void main() {
 
     test('allows valid version for new package.', () async {
       const String newVersion = '1.0.0';
-      createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, version: newVersion);
+      createFakePlugin('plugin', packagesDir, version: newVersion);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'HEAD:packages/plugin/pubspec.yaml': 'version: $newVersion',
@@ -196,8 +192,7 @@ void main() {
 
     test('allows likely reverts.', () async {
       const String newVersion = '0.6.1';
-      createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, version: newVersion);
+      createFakePlugin('plugin', packagesDir, version: newVersion);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'abc123:packages/plugin/pubspec.yaml': 'version: 0.6.2',
@@ -216,8 +211,7 @@ void main() {
 
     test('denies lower version that could not be a simple revert', () async {
       const String newVersion = '0.5.1';
-      createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, version: newVersion);
+      createFakePlugin('plugin', packagesDir, version: newVersion);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'abc123:packages/plugin/pubspec.yaml': 'version: 0.6.2',
@@ -234,8 +228,7 @@ void main() {
 
     test('denies invalid version without explicit base-sha', () async {
       const String newVersion = '0.2.0';
-      createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, version: newVersion);
+      createFakePlugin('plugin', packagesDir, version: newVersion);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'abc123:packages/plugin/pubspec.yaml': 'version: 0.0.1',
@@ -252,7 +245,7 @@ void main() {
 
     test('gracefully handles missing pubspec.yaml', () async {
       final Directory pluginDir =
-          createFakePlugin('plugin', packagesDir, includeChangeLog: true);
+          createFakePlugin('plugin', packagesDir, examples: <String>[]);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       pluginDir.childFile('pubspec.yaml').deleteSync();
       final List<String> output = await runCapturingPrint(
@@ -275,7 +268,7 @@ void main() {
     test('allows minor changes to platform interfaces', () async {
       const String newVersion = '1.1.0';
       createFakePlugin('plugin_platform_interface', packagesDir,
-          includeChangeLog: true, version: newVersion);
+          version: newVersion);
       gitDiffResponse = 'packages/plugin_platform_interface/pubspec.yaml';
       gitShowResponses = <String, String>{
         'master:packages/plugin_platform_interface/pubspec.yaml':
@@ -310,7 +303,7 @@ void main() {
     test('disallows breaking changes to platform interfaces', () async {
       const String newVersion = '2.0.0';
       createFakePlugin('plugin_platform_interface', packagesDir,
-          includeChangeLog: true, version: newVersion);
+          version: newVersion);
       gitDiffResponse = 'packages/plugin_platform_interface/pubspec.yaml';
       gitShowResponses = <String, String>{
         'master:packages/plugin_platform_interface/pubspec.yaml':
@@ -343,8 +336,8 @@ void main() {
     test('Allow empty lines in front of the first version in CHANGELOG',
         () async {
       const String version = '1.0.1';
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, version: version);
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, version: version);
       const String changelog = '''
 
 
@@ -367,8 +360,8 @@ void main() {
     });
 
     test('Throws if versions in changelog and pubspec do not match', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, version: '1.0.1');
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, version: '1.0.1');
       const String changelog = '''
 ## 1.0.2
 
@@ -400,8 +393,8 @@ The first version listed in CHANGELOG.md is 1.0.2.
 
     test('Success if CHANGELOG and pubspec versions match', () async {
       const String version = '1.0.1';
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, version: version);
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, version: version);
 
       const String changelog = '''
 ## $version
@@ -424,8 +417,8 @@ The first version listed in CHANGELOG.md is 1.0.2.
     test(
         'Fail if pubspec version only matches an older version listed in CHANGELOG',
         () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, version: '1.0.0');
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, version: '1.0.0');
 
       const String changelog = '''
 ## 1.0.1
@@ -465,8 +458,8 @@ The first version listed in CHANGELOG.md is 1.0.1.
     test('Allow NEXT as a placeholder for gathering CHANGELOG entries',
         () async {
       const String version = '1.0.0';
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, version: version);
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, version: version);
 
       const String changelog = '''
 ## NEXT
@@ -493,8 +486,8 @@ The first version listed in CHANGELOG.md is 1.0.1.
     test('Fail if NEXT is left in the CHANGELOG when adding a version bump',
         () async {
       const String version = '1.0.1';
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, version: version);
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, version: version);
 
       const String changelog = '''
 ## $version
@@ -535,8 +528,8 @@ into the new version's release notes.
     });
 
     test('Fail if the version changes without replacing NEXT', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, version: '1.0.1');
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, version: '1.0.1');
 
       const String changelog = '''
 ## NEXT
@@ -594,8 +587,7 @@ The first version listed in CHANGELOG.md is 1.0.0.
       runner.addCommand(command);
 
       const String newVersion = '2.0.0';
-      createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, version: newVersion);
+      createFakePlugin('plugin', packagesDir, version: newVersion);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'master:packages/plugin/pubspec.yaml': 'version: 1.0.0',
@@ -632,8 +624,7 @@ The first version listed in CHANGELOG.md is 1.0.0.
       runner.addCommand(command);
 
       const String newVersion = '2.0.0';
-      createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, version: newVersion);
+      createFakePlugin('plugin', packagesDir, version: newVersion);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'master:packages/plugin/pubspec.yaml': 'version: 1.0.0',
@@ -678,8 +669,7 @@ ${indentation}Allowed versions: {1.0.0: NextVersionType.BREAKING_MAJOR, 0.1.0: N
       runner.addCommand(command);
 
       const String newVersion = '2.0.0';
-      createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, version: newVersion);
+      createFakePlugin('plugin', packagesDir, version: newVersion);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'master:packages/plugin/pubspec.yaml': 'version: 1.0.0',
@@ -723,8 +713,7 @@ ${indentation}HTTP response: xx
       runner.addCommand(command);
 
       const String newVersion = '2.0.0';
-      createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, version: newVersion);
+      createFakePlugin('plugin', packagesDir, version: newVersion);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'master:packages/plugin/pubspec.yaml': 'version: 1.0.0',

--- a/script/tool/test/version_check_test.dart
+++ b/script/tool/test/version_check_test.dart
@@ -101,12 +101,13 @@ void main() {
     });
 
     test('allows valid version', () async {
+      const String newVersion = '2.0.0';
       createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, includeVersion: true);
+          includeChangeLog: true, version: newVersion);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'master:packages/plugin/pubspec.yaml': 'version: 1.0.0',
-        'HEAD:packages/plugin/pubspec.yaml': 'version: 2.0.0',
+        'HEAD:packages/plugin/pubspec.yaml': 'version: $newVersion',
       };
       final List<String> output = await runCapturingPrint(
           runner, <String>['version-check', '--base-sha=master']);
@@ -128,12 +129,13 @@ void main() {
     });
 
     test('denies invalid version', () async {
+      const String newVersion = '0.2.0';
       createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, includeVersion: true);
+          includeChangeLog: true, version: newVersion);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'master:packages/plugin/pubspec.yaml': 'version: 0.0.1',
-        'HEAD:packages/plugin/pubspec.yaml': 'version: 0.2.0',
+        'HEAD:packages/plugin/pubspec.yaml': 'version: $newVersion',
       };
       final Future<List<String>> result = runCapturingPrint(
           runner, <String>['version-check', '--base-sha=master']);
@@ -153,12 +155,13 @@ void main() {
     });
 
     test('allows valid version without explicit base-sha', () async {
+      const String newVersion = '2.0.0';
       createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, includeVersion: true);
+          includeChangeLog: true, version: newVersion);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'abc123:packages/plugin/pubspec.yaml': 'version: 1.0.0',
-        'HEAD:packages/plugin/pubspec.yaml': 'version: 2.0.0',
+        'HEAD:packages/plugin/pubspec.yaml': 'version: $newVersion',
       };
       final List<String> output =
           await runCapturingPrint(runner, <String>['version-check']);
@@ -172,11 +175,12 @@ void main() {
     });
 
     test('allows valid version for new package.', () async {
+      const String newVersion = '1.0.0';
       createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, includeVersion: true);
+          includeChangeLog: true, version: newVersion);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
-        'HEAD:packages/plugin/pubspec.yaml': 'version: 1.0.0',
+        'HEAD:packages/plugin/pubspec.yaml': 'version: $newVersion',
       };
       final List<String> output =
           await runCapturingPrint(runner, <String>['version-check']);
@@ -191,12 +195,13 @@ void main() {
     });
 
     test('allows likely reverts.', () async {
+      const String newVersion = '0.6.1';
       createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, includeVersion: true);
+          includeChangeLog: true, version: newVersion);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'abc123:packages/plugin/pubspec.yaml': 'version: 0.6.2',
-        'HEAD:packages/plugin/pubspec.yaml': 'version: 0.6.1',
+        'HEAD:packages/plugin/pubspec.yaml': 'version: $newVersion',
       };
       final List<String> output =
           await runCapturingPrint(runner, <String>['version-check']);
@@ -210,12 +215,13 @@ void main() {
     });
 
     test('denies lower version that could not be a simple revert', () async {
+      const String newVersion = '0.5.1';
       createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, includeVersion: true);
+          includeChangeLog: true, version: newVersion);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'abc123:packages/plugin/pubspec.yaml': 'version: 0.6.2',
-        'HEAD:packages/plugin/pubspec.yaml': 'version: 0.5.1',
+        'HEAD:packages/plugin/pubspec.yaml': 'version: $newVersion',
       };
       final Future<List<String>> result =
           runCapturingPrint(runner, <String>['version-check']);
@@ -227,12 +233,13 @@ void main() {
     });
 
     test('denies invalid version without explicit base-sha', () async {
+      const String newVersion = '0.2.0';
       createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, includeVersion: true);
+          includeChangeLog: true, version: newVersion);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'abc123:packages/plugin/pubspec.yaml': 'version: 0.0.1',
-        'HEAD:packages/plugin/pubspec.yaml': 'version: 0.2.0',
+        'HEAD:packages/plugin/pubspec.yaml': 'version: $newVersion',
       };
       final Future<List<String>> result =
           runCapturingPrint(runner, <String>['version-check']);
@@ -244,8 +251,8 @@ void main() {
     });
 
     test('gracefully handles missing pubspec.yaml', () async {
-      final Directory pluginDir = createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, includeVersion: true);
+      final Directory pluginDir =
+          createFakePlugin('plugin', packagesDir, includeChangeLog: true);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       pluginDir.childFile('pubspec.yaml').deleteSync();
       final List<String> output = await runCapturingPrint(
@@ -266,14 +273,15 @@ void main() {
     });
 
     test('allows minor changes to platform interfaces', () async {
+      const String newVersion = '1.1.0';
       createFakePlugin('plugin_platform_interface', packagesDir,
-          includeChangeLog: true, includeVersion: true);
+          includeChangeLog: true, version: newVersion);
       gitDiffResponse = 'packages/plugin_platform_interface/pubspec.yaml';
       gitShowResponses = <String, String>{
         'master:packages/plugin_platform_interface/pubspec.yaml':
             'version: 1.0.0',
         'HEAD:packages/plugin_platform_interface/pubspec.yaml':
-            'version: 1.1.0',
+            'version: $newVersion',
       };
       final List<String> output = await runCapturingPrint(
           runner, <String>['version-check', '--base-sha=master']);
@@ -300,14 +308,15 @@ void main() {
     });
 
     test('disallows breaking changes to platform interfaces', () async {
+      const String newVersion = '2.0.0';
       createFakePlugin('plugin_platform_interface', packagesDir,
-          includeChangeLog: true, includeVersion: true);
+          includeChangeLog: true, version: newVersion);
       gitDiffResponse = 'packages/plugin_platform_interface/pubspec.yaml';
       gitShowResponses = <String, String>{
         'master:packages/plugin_platform_interface/pubspec.yaml':
             'version: 1.0.0',
         'HEAD:packages/plugin_platform_interface/pubspec.yaml':
-            'version: 2.0.0',
+            'version: $newVersion',
       };
       final Future<List<String>> output = runCapturingPrint(
           runner, <String>['version-check', '--base-sha=master']);
@@ -333,15 +342,14 @@ void main() {
 
     test('Allow empty lines in front of the first version in CHANGELOG',
         () async {
+      const String version = '1.0.1';
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, includeVersion: true);
-
-      createFakePubspec(pluginDirectory, isFlutter: true, version: '1.0.1');
+          includeChangeLog: true, version: version);
       const String changelog = '''
 
 
 
-## 1.0.1
+## $version
 
 * Some changes.
 ''';
@@ -360,9 +368,7 @@ void main() {
 
     test('Throws if versions in changelog and pubspec do not match', () async {
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, includeVersion: true);
-
-      createFakePubspec(pluginDirectory, isFlutter: true, version: '1.0.1');
+          includeChangeLog: true, version: '1.0.1');
       const String changelog = '''
 ## 1.0.2
 
@@ -393,12 +399,12 @@ The first version listed in CHANGELOG.md is 1.0.2.
     });
 
     test('Success if CHANGELOG and pubspec versions match', () async {
+      const String version = '1.0.1';
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, includeVersion: true);
+          includeChangeLog: true, version: version);
 
-      createFakePubspec(pluginDirectory, isFlutter: true, version: '1.0.1');
       const String changelog = '''
-## 1.0.1
+## $version
 
 * Some changes.
 ''';
@@ -419,9 +425,8 @@ The first version listed in CHANGELOG.md is 1.0.2.
         'Fail if pubspec version only matches an older version listed in CHANGELOG',
         () async {
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, includeVersion: true);
+          includeChangeLog: true, version: '1.0.0');
 
-      createFakePubspec(pluginDirectory, isFlutter: true, version: '1.0.0');
       const String changelog = '''
 ## 1.0.1
 
@@ -459,16 +464,16 @@ The first version listed in CHANGELOG.md is 1.0.1.
 
     test('Allow NEXT as a placeholder for gathering CHANGELOG entries',
         () async {
+      const String version = '1.0.0';
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, includeVersion: true);
+          includeChangeLog: true, version: version);
 
-      createFakePubspec(pluginDirectory, isFlutter: true, version: '1.0.0');
       const String changelog = '''
 ## NEXT
 
 * Some changes that won't be published until the next time there's a release.
 
-## 1.0.0
+## $version
 
 * Some other changes.
 ''';
@@ -487,12 +492,12 @@ The first version listed in CHANGELOG.md is 1.0.1.
 
     test('Fail if NEXT is left in the CHANGELOG when adding a version bump',
         () async {
+      const String version = '1.0.1';
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, includeVersion: true);
+          includeChangeLog: true, version: version);
 
-      createFakePubspec(pluginDirectory, isFlutter: true, version: '1.0.1');
       const String changelog = '''
-## 1.0.1
+## $version
 
 * Some changes.
 
@@ -531,9 +536,8 @@ into the new version's release notes.
 
     test('Fail if the version changes without replacing NEXT', () async {
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, includeVersion: true);
+          includeChangeLog: true, version: '1.0.1');
 
-      createFakePubspec(pluginDirectory, isFlutter: true, version: '1.0.1');
       const String changelog = '''
 ## NEXT
 
@@ -589,12 +593,13 @@ The first version listed in CHANGELOG.md is 1.0.0.
           'version_check_command', 'Test for $VersionCheckCommand');
       runner.addCommand(command);
 
+      const String newVersion = '2.0.0';
       createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, includeVersion: true);
+          includeChangeLog: true, version: newVersion);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'master:packages/plugin/pubspec.yaml': 'version: 1.0.0',
-        'HEAD:packages/plugin/pubspec.yaml': 'version: 2.0.0',
+        'HEAD:packages/plugin/pubspec.yaml': 'version: $newVersion',
       };
       final List<String> output = await runCapturingPrint(runner,
           <String>['version-check', '--base-sha=master', '--against-pub']);
@@ -626,12 +631,13 @@ The first version listed in CHANGELOG.md is 1.0.0.
           'version_check_command', 'Test for $VersionCheckCommand');
       runner.addCommand(command);
 
+      const String newVersion = '2.0.0';
       createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, includeVersion: true);
+          includeChangeLog: true, version: newVersion);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'master:packages/plugin/pubspec.yaml': 'version: 1.0.0',
-        'HEAD:packages/plugin/pubspec.yaml': 'version: 2.0.0',
+        'HEAD:packages/plugin/pubspec.yaml': 'version: $newVersion',
       };
 
       bool hasError = false;
@@ -671,12 +677,13 @@ ${indentation}Allowed versions: {1.0.0: NextVersionType.BREAKING_MAJOR, 0.1.0: N
           'version_check_command', 'Test for $VersionCheckCommand');
       runner.addCommand(command);
 
+      const String newVersion = '2.0.0';
       createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, includeVersion: true);
+          includeChangeLog: true, version: newVersion);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'master:packages/plugin/pubspec.yaml': 'version: 1.0.0',
-        'HEAD:packages/plugin/pubspec.yaml': 'version: 2.0.0',
+        'HEAD:packages/plugin/pubspec.yaml': 'version: $newVersion',
       };
       bool hasError = false;
       final List<String> result = await runCapturingPrint(runner, <String>[
@@ -715,12 +722,13 @@ ${indentation}HTTP response: xx
           'version_check_command', 'Test for $VersionCheckCommand');
       runner.addCommand(command);
 
+      const String newVersion = '2.0.0';
       createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, includeVersion: true);
+          includeChangeLog: true, version: newVersion);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'master:packages/plugin/pubspec.yaml': 'version: 1.0.0',
-        'HEAD:packages/plugin/pubspec.yaml': 'version: 2.0.0',
+        'HEAD:packages/plugin/pubspec.yaml': 'version: $newVersion',
       };
       final List<String> result = await runCapturingPrint(runner,
           <String>['version-check', '--base-sha=master', '--against-pub']);

--- a/script/tool/test/xctest_command_test.dart
+++ b/script/tool/test/xctest_command_test.dart
@@ -112,14 +112,12 @@ void main() {
 
     group('iOS', () {
       test('skip if iOS is not supported', () async {
-        final Directory pluginDirectory = createFakePlugin(
-            'plugin', packagesDir,
-            withExtraFiles: <List<String>>[
-              <String>['example', 'test'],
-            ],
-            platformSupport: <String, PlatformDetails>{
-              kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
-            });
+        final Directory pluginDirectory =
+            createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+          <String>['example', 'test'],
+        ], platformSupport: <String, PlatformDetails>{
+          kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
+        });
 
         createFakePubspec(pluginDirectory.childDirectory('example'),
             isFlutter: true);
@@ -135,14 +133,12 @@ void main() {
       });
 
       test('skip if iOS is implemented in a federated package', () async {
-        final Directory pluginDirectory = createFakePlugin(
-            'plugin', packagesDir,
-            withExtraFiles: <List<String>>[
-              <String>['example', 'test'],
-            ],
-            platformSupport: <String, PlatformDetails>{
-              'ios': const PlatformDetails(PlatformSupport.federated)
-            });
+        final Directory pluginDirectory =
+            createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+          <String>['example', 'test'],
+        ], platformSupport: <String, PlatformDetails>{
+          'ios': const PlatformDetails(PlatformSupport.federated)
+        });
 
         createFakePubspec(pluginDirectory.childDirectory('example'),
             isFlutter: true);
@@ -158,23 +154,17 @@ void main() {
       });
 
       test('running with correct destination, exclude 1 plugin', () async {
-        createFakePlugin('plugin1', packagesDir,
-            withSingleExample: true,
-            withExtraFiles: <List<String>>[
-              <String>['example', 'test'],
-            ],
-            platformSupport: <String, PlatformDetails>{
-              kPlatformIos: const PlatformDetails(PlatformSupport.inline),
-            });
-        final Directory pluginDirectory2 = createFakePlugin(
-            'plugin2', packagesDir,
-            withSingleExample: true,
-            withExtraFiles: <List<String>>[
-              <String>['example', 'test'],
-            ],
-            platformSupport: <String, PlatformDetails>{
-              kPlatformIos: const PlatformDetails(PlatformSupport.inline),
-            });
+        createFakePlugin('plugin1', packagesDir, extraFiles: <List<String>>[
+          <String>['example', 'test'],
+        ], platformSupport: <String, PlatformDetails>{
+          kPlatformIos: const PlatformDetails(PlatformSupport.inline),
+        });
+        final Directory pluginDirectory2 =
+            createFakePlugin('plugin2', packagesDir, extraFiles: <List<String>>[
+          <String>['example', 'test'],
+        ], platformSupport: <String, PlatformDetails>{
+          kPlatformIos: const PlatformDetails(PlatformSupport.inline),
+        });
 
         final Directory pluginExampleDirectory2 =
             pluginDirectory2.childDirectory('example');
@@ -223,15 +213,12 @@ void main() {
 
       test('Not specifying --ios-destination assigns an available simulator',
           () async {
-        final Directory pluginDirectory = createFakePlugin(
-            'plugin', packagesDir,
-            withSingleExample: true,
-            withExtraFiles: <List<String>>[
-              <String>['example', 'test'],
-            ],
-            platformSupport: <String, PlatformDetails>{
-              kPlatformIos: const PlatformDetails(PlatformSupport.inline),
-            });
+        final Directory pluginDirectory =
+            createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+          <String>['example', 'test'],
+        ], platformSupport: <String, PlatformDetails>{
+          kPlatformIos: const PlatformDetails(PlatformSupport.inline),
+        });
 
         final Directory pluginExampleDirectory =
             pluginDirectory.childDirectory('example');
@@ -278,14 +265,12 @@ void main() {
 
     group('macOS', () {
       test('skip if macOS is not supported', () async {
-        final Directory pluginDirectory = createFakePlugin(
-            'plugin', packagesDir,
-            withExtraFiles: <List<String>>[
-              <String>['example', 'test'],
-            ],
-            platformSupport: <String, PlatformDetails>{
-              kPlatformIos: const PlatformDetails(PlatformSupport.inline),
-            });
+        final Directory pluginDirectory =
+            createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+          <String>['example', 'test'],
+        ], platformSupport: <String, PlatformDetails>{
+          kPlatformIos: const PlatformDetails(PlatformSupport.inline),
+        });
 
         createFakePubspec(pluginDirectory.childDirectory('example'),
             isFlutter: true);
@@ -301,14 +286,12 @@ void main() {
       });
 
       test('skip if macOS is implemented in a federated package', () async {
-        final Directory pluginDirectory = createFakePlugin(
-            'plugin', packagesDir,
-            withExtraFiles: <List<String>>[
-              <String>['example', 'test'],
-            ],
-            platformSupport: <String, PlatformDetails>{
-              kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
-            });
+        final Directory pluginDirectory =
+            createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+          <String>['example', 'test'],
+        ], platformSupport: <String, PlatformDetails>{
+          kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
+        });
         createFakePubspec(pluginDirectory,
             platformSupport: <String, PlatformDetails>{
               'macos': const PlatformDetails(PlatformSupport.federated)
@@ -328,15 +311,12 @@ void main() {
       });
 
       test('runs for macOS plugin', () async {
-        final Directory pluginDirectory1 = createFakePlugin(
-            'plugin', packagesDir,
-            withSingleExample: true,
-            withExtraFiles: <List<String>>[
-              <String>['example', 'test'],
-            ],
-            platformSupport: <String, PlatformDetails>{
-              kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
-            });
+        final Directory pluginDirectory1 =
+            createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+          <String>['example', 'test'],
+        ], platformSupport: <String, PlatformDetails>{
+          kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
+        });
 
         final Directory pluginExampleDirectory =
             pluginDirectory1.childDirectory('example');

--- a/script/tool/test/xctest_command_test.dart
+++ b/script/tool/test/xctest_command_test.dart
@@ -141,7 +141,9 @@ void main() {
                 ],
                 isIosPlugin: true);
         createFakePubspec(pluginDirectory,
-            iosSupport: PlatformSupport.federated);
+            platformSupport: <String, PlatformDetails>{
+              'ios': const PlatformDetails(PlatformSupport.federated)
+            });
 
         createFakePubspec(pluginDirectory.childDirectory('example'),
             isFlutter: true);
@@ -304,7 +306,9 @@ void main() {
                 ],
                 isMacOsPlugin: true);
         createFakePubspec(pluginDirectory,
-            macosSupport: PlatformSupport.federated);
+            platformSupport: <String, PlatformDetails>{
+              'macos': const PlatformDetails(PlatformSupport.federated)
+            });
 
         createFakePubspec(pluginDirectory.childDirectory('example'),
             isFlutter: true);

--- a/script/tool/test/xctest_command_test.dart
+++ b/script/tool/test/xctest_command_test.dart
@@ -112,15 +112,11 @@ void main() {
 
     group('iOS', () {
       test('skip if iOS is not supported', () async {
-        final Directory pluginDirectory =
-            createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
           <String>['example', 'test'],
         ], platformSupport: <String, PlatformDetails>{
           kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
         });
-
-        createFakePubspec(pluginDirectory.childDirectory('example'),
-            isFlutter: true);
 
         final MockProcess mockProcess = MockProcess();
         mockProcess.exitCodeCompleter.complete(0);
@@ -133,15 +129,11 @@ void main() {
       });
 
       test('skip if iOS is implemented in a federated package', () async {
-        final Directory pluginDirectory =
-            createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
           <String>['example', 'test'],
         ], platformSupport: <String, PlatformDetails>{
           'ios': const PlatformDetails(PlatformSupport.federated)
         });
-
-        createFakePubspec(pluginDirectory.childDirectory('example'),
-            isFlutter: true);
 
         final MockProcess mockProcess = MockProcess();
         mockProcess.exitCodeCompleter.complete(0);
@@ -265,15 +257,11 @@ void main() {
 
     group('macOS', () {
       test('skip if macOS is not supported', () async {
-        final Directory pluginDirectory =
-            createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
           <String>['example', 'test'],
         ], platformSupport: <String, PlatformDetails>{
           kPlatformIos: const PlatformDetails(PlatformSupport.inline),
         });
-
-        createFakePubspec(pluginDirectory.childDirectory('example'),
-            isFlutter: true);
 
         final MockProcess mockProcess = MockProcess();
         mockProcess.exitCodeCompleter.complete(0);
@@ -290,15 +278,8 @@ void main() {
             createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
           <String>['example', 'test'],
         ], platformSupport: <String, PlatformDetails>{
-          kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
+          kPlatformMacos: const PlatformDetails(PlatformSupport.federated),
         });
-        createFakePubspec(pluginDirectory,
-            platformSupport: <String, PlatformDetails>{
-              'macos': const PlatformDetails(PlatformSupport.federated)
-            });
-
-        createFakePubspec(pluginDirectory.childDirectory('example'),
-            isFlutter: true);
 
         final MockProcess mockProcess = MockProcess();
         mockProcess.exitCodeCompleter.complete(0);

--- a/script/tool/test/xctest_command_test.dart
+++ b/script/tool/test/xctest_command_test.dart
@@ -112,13 +112,14 @@ void main() {
 
     group('iOS', () {
       test('skip if iOS is not supported', () async {
-        final Directory pluginDirectory =
-            createFakePlugin('plugin', packagesDir,
-                withExtraFiles: <List<String>>[
-                  <String>['example', 'test'],
-                ],
-                isIosPlugin: false,
-                isMacOsPlugin: true);
+        final Directory pluginDirectory = createFakePlugin(
+            'plugin', packagesDir,
+            withExtraFiles: <List<String>>[
+              <String>['example', 'test'],
+            ],
+            platformSupport: <String, PlatformDetails>{
+              kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
+            });
 
         createFakePubspec(pluginDirectory.childDirectory('example'),
             isFlutter: true);
@@ -134,13 +135,11 @@ void main() {
       });
 
       test('skip if iOS is implemented in a federated package', () async {
-        final Directory pluginDirectory =
-            createFakePlugin('plugin', packagesDir,
-                withExtraFiles: <List<String>>[
-                  <String>['example', 'test'],
-                ],
-                isIosPlugin: true);
-        createFakePubspec(pluginDirectory,
+        final Directory pluginDirectory = createFakePlugin(
+            'plugin', packagesDir,
+            withExtraFiles: <List<String>>[
+              <String>['example', 'test'],
+            ],
             platformSupport: <String, PlatformDetails>{
               'ios': const PlatformDetails(PlatformSupport.federated)
             });
@@ -159,25 +158,26 @@ void main() {
       });
 
       test('running with correct destination, exclude 1 plugin', () async {
-        final Directory pluginDirectory1 =
-            createFakePlugin('plugin1', packagesDir,
-                withExtraFiles: <List<String>>[
-                  <String>['example', 'test'],
-                ],
-                isIosPlugin: true);
-        final Directory pluginDirectory2 =
-            createFakePlugin('plugin2', packagesDir,
-                withExtraFiles: <List<String>>[
-                  <String>['example', 'test'],
-                ],
-                isIosPlugin: true);
+        createFakePlugin('plugin1', packagesDir,
+            withSingleExample: true,
+            withExtraFiles: <List<String>>[
+              <String>['example', 'test'],
+            ],
+            platformSupport: <String, PlatformDetails>{
+              kPlatformIos: const PlatformDetails(PlatformSupport.inline),
+            });
+        final Directory pluginDirectory2 = createFakePlugin(
+            'plugin2', packagesDir,
+            withSingleExample: true,
+            withExtraFiles: <List<String>>[
+              <String>['example', 'test'],
+            ],
+            platformSupport: <String, PlatformDetails>{
+              kPlatformIos: const PlatformDetails(PlatformSupport.inline),
+            });
 
-        final Directory pluginExampleDirectory1 =
-            pluginDirectory1.childDirectory('example');
-        createFakePubspec(pluginExampleDirectory1, isFlutter: true);
         final Directory pluginExampleDirectory2 =
             pluginDirectory2.childDirectory('example');
-        createFakePubspec(pluginExampleDirectory2, isFlutter: true);
 
         final MockProcess mockProcess = MockProcess();
         mockProcess.exitCodeCompleter.complete(0);
@@ -223,17 +223,18 @@ void main() {
 
       test('Not specifying --ios-destination assigns an available simulator',
           () async {
-        final Directory pluginDirectory =
-            createFakePlugin('plugin', packagesDir,
-                withExtraFiles: <List<String>>[
-                  <String>['example', 'test'],
-                ],
-                isIosPlugin: true);
+        final Directory pluginDirectory = createFakePlugin(
+            'plugin', packagesDir,
+            withSingleExample: true,
+            withExtraFiles: <List<String>>[
+              <String>['example', 'test'],
+            ],
+            platformSupport: <String, PlatformDetails>{
+              kPlatformIos: const PlatformDetails(PlatformSupport.inline),
+            });
 
         final Directory pluginExampleDirectory =
             pluginDirectory.childDirectory('example');
-
-        createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
         final MockProcess mockProcess = MockProcess();
         mockProcess.exitCodeCompleter.complete(0);
@@ -277,13 +278,14 @@ void main() {
 
     group('macOS', () {
       test('skip if macOS is not supported', () async {
-        final Directory pluginDirectory =
-            createFakePlugin('plugin', packagesDir,
-                withExtraFiles: <List<String>>[
-                  <String>['example', 'test'],
-                ],
-                isIosPlugin: true,
-                isMacOsPlugin: false);
+        final Directory pluginDirectory = createFakePlugin(
+            'plugin', packagesDir,
+            withExtraFiles: <List<String>>[
+              <String>['example', 'test'],
+            ],
+            platformSupport: <String, PlatformDetails>{
+              kPlatformIos: const PlatformDetails(PlatformSupport.inline),
+            });
 
         createFakePubspec(pluginDirectory.childDirectory('example'),
             isFlutter: true);
@@ -299,12 +301,14 @@ void main() {
       });
 
       test('skip if macOS is implemented in a federated package', () async {
-        final Directory pluginDirectory =
-            createFakePlugin('plugin', packagesDir,
-                withExtraFiles: <List<String>>[
-                  <String>['example', 'test'],
-                ],
-                isMacOsPlugin: true);
+        final Directory pluginDirectory = createFakePlugin(
+            'plugin', packagesDir,
+            withExtraFiles: <List<String>>[
+              <String>['example', 'test'],
+            ],
+            platformSupport: <String, PlatformDetails>{
+              kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
+            });
         createFakePubspec(pluginDirectory,
             platformSupport: <String, PlatformDetails>{
               'macos': const PlatformDetails(PlatformSupport.federated)
@@ -324,16 +328,18 @@ void main() {
       });
 
       test('runs for macOS plugin', () async {
-        final Directory pluginDirectory1 =
-            createFakePlugin('plugin', packagesDir,
-                withExtraFiles: <List<String>>[
-                  <String>['example', 'test'],
-                ],
-                isMacOsPlugin: true);
+        final Directory pluginDirectory1 = createFakePlugin(
+            'plugin', packagesDir,
+            withSingleExample: true,
+            withExtraFiles: <List<String>>[
+              <String>['example', 'test'],
+            ],
+            platformSupport: <String, PlatformDetails>{
+              kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
+            });
 
         final Directory pluginExampleDirectory =
             pluginDirectory1.childDirectory('example');
-        createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
         final MockProcess mockProcess = MockProcess();
         mockProcess.exitCodeCompleter.complete(0);


### PR DESCRIPTION
This allows building UWP plugin examples with `build-examples --winuwp`. As with previous pre-stable-template desktop support, this avoids the issue of unstable app templates by running `flutter create` on the fly before trying to build, so a template that will bitrot doesn't need to be checked in.

This required some supporting tool changes:
- Adds the ability to check for the new platform variants in a pubspec
- Adds the ability to write test pubspecs that include variants, for testing

The PR also includes a number of cleanups that stemmed from the changes above:
- To avoid adding even more cases where `createFakePlugin` required tests to then overwrite the pubspec immediately due to the limited API of that method, it reworks the way platform support is given to that method.
- Since it was already making that major change to the API, cleans up a number of other oddities:
  - It had two incompatible ways of creating example folders
  - It had two flags for controlling versions instead of one
  - It was being used in a handful of places to make packages, so had an `isFlutter` parameter that could be set to false, which makes no sense for a plugin
  - It defaulted many standard files to off, rather than on, meaning that by default tests ran against something that looked very little like a plugin; this is reversed so that tests that specifically need unusual changes must explicitly change that.
These changes cause some churn across many tests, mostly code removal/reduction.

Part of https://github.com/flutter/flutter/issues/82817

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
