### PR TITLE
[flutter_plugin_tools] Complete migration to NNBD

### DIFF
--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -5,6 +5,7 @@
   compatibility.
 - `xctest` now supports running macOS tests in addition to iOS
   - **Breaking change**: it now requires an `--ios` and/or `--macos` flag.
+- The tooling now runs in strong null-safe mode.
 
 ## 0.2.0
 

--- a/script/tool/bin/flutter_plugin_tools.dart
+++ b/script/tool/bin/flutter_plugin_tools.dart
@@ -2,6 +2,4 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 export 'package:flutter_plugin_tools/src/main.dart';

--- a/script/tool/lib/src/main.dart
+++ b/script/tool/lib/src/main.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 import 'dart:io' as io;
 
 import 'package:args/command_runner.dart';

--- a/script/tool/lib/src/publish_plugin_command.dart
+++ b/script/tool/lib/src/publish_plugin_command.dart
@@ -495,7 +495,7 @@ Safe to ignore if the package is deleted in this commit.
 
   void _ensureValidPubCredential() {
     final String credentialsPath = _credentialsPath;
-    final File credentialFile = packagesDir.fileSystem.file(_credentialsPath);
+    final File credentialFile = packagesDir.fileSystem.file(credentialsPath);
     if (credentialFile.existsSync() &&
         credentialFile.readAsStringSync().isNotEmpty) {
       return;

--- a/script/tool/test/publish_plugin_command_test.dart
+++ b/script/tool/test/publish_plugin_command_test.dart
@@ -35,7 +35,7 @@ void main() {
   const FileSystem fileSystem = LocalFileSystem();
 
   void _createMockCredentialFile() {
-    final String? credentialPath = PublishPluginCommand.getCredentialPath();
+    final String credentialPath = PublishPluginCommand.getCredentialPath();
     fileSystem.file(credentialPath)
       ..createSync(recursive: true)
       ..writeAsStringSync('some credential');

--- a/script/tool/test/publish_plugin_command_test.dart
+++ b/script/tool/test/publish_plugin_command_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io' as io;
@@ -22,22 +20,22 @@ import 'util.dart';
 
 void main() {
   const String testPluginName = 'foo';
-  List<String> printedMessages;
+  late List<String> printedMessages;
 
-  Directory testRoot;
-  Directory packagesDir;
-  Directory pluginDir;
-  GitDir gitDir;
-  TestProcessRunner processRunner;
-  CommandRunner<void> commandRunner;
-  MockStdin mockStdin;
+  late Directory testRoot;
+  late Directory packagesDir;
+  late Directory pluginDir;
+  late GitDir gitDir;
+  late TestProcessRunner processRunner;
+  late CommandRunner<void> commandRunner;
+  late MockStdin mockStdin;
   // This test uses a local file system instead of an in memory one throughout
   // so that git actually works. In setup we initialize a mono repo of plugins
   // with one package and commit everything to Git.
   const FileSystem fileSystem = LocalFileSystem();
 
   void _createMockCredentialFile() {
-    final String credentialPath = PublishPluginCommand.getCredentialPath();
+    final String? credentialPath = PublishPluginCommand.getCredentialPath();
     fileSystem.file(credentialPath)
       ..createSync(recursive: true)
       ..writeAsStringSync('some credential');
@@ -65,7 +63,7 @@ void main() {
     commandRunner = CommandRunner<void>('tester', '')
       ..addCommand(PublishPluginCommand(packagesDir,
           processRunner: processRunner,
-          print: (Object message) => printedMessages.add(message.toString()),
+          print: (Object? message) => printedMessages.add(message.toString()),
           stdinput: mockStdin,
           gitDir: gitDir));
   });
@@ -285,9 +283,9 @@ void main() {
         '--no-push-tags',
       ]);
 
-      final String tag =
+      final String? tag =
           (await gitDir.runCommand(<String>['show-ref', 'fake_package-v0.0.1']))
-              .stdout as String;
+              .stdout as String?;
       expect(tag, isNotEmpty);
     });
 
@@ -303,10 +301,10 @@ void main() {
           throwsA(const TypeMatcher<ToolExit>()));
 
       expect(printedMessages, contains('Publish foo failed.'));
-      final String tag = (await gitDir.runCommand(
+      final String? tag = (await gitDir.runCommand(
               <String>['show-ref', 'fake_package-v0.0.1'],
               throwOnError: false))
-          .stdout as String;
+          .stdout as String?;
       expect(tag, isEmpty);
     });
   });
@@ -838,20 +836,20 @@ void main() {
 class TestProcessRunner extends ProcessRunner {
   final List<io.ProcessResult> results = <io.ProcessResult>[];
   // Most recent returned publish process.
-  MockProcess mockPublishProcess;
+  late MockProcess mockPublishProcess;
   final List<String> mockPublishArgs = <String>[];
   final MockProcessResult mockPushTagsResult = MockProcessResult();
   final List<String> pushTagsArgs = <String>[];
 
-  String mockPublishStdout;
-  String mockPublishStderr;
-  int mockPublishCompleteCode;
+  String? mockPublishStdout;
+  String? mockPublishStderr;
+  int? mockPublishCompleteCode;
 
   @override
   Future<io.ProcessResult> run(
     String executable,
     List<String> args, {
-    Directory workingDir,
+    Directory? workingDir,
     bool exitOnError = false,
     bool logOnError = false,
     Encoding stdoutEncoding = io.systemEncoding,
@@ -874,7 +872,7 @@ class TestProcessRunner extends ProcessRunner {
 
   @override
   Future<io.Process> start(String executable, List<String> args,
-      {Directory workingDirectory}) async {
+      {Directory? workingDirectory}) async {
     /// Never actually publish anything. Start is always and only used for this
     /// since it returns something we can route stdin through.
     assert(executable == 'flutter' &&
@@ -884,10 +882,10 @@ class TestProcessRunner extends ProcessRunner {
     mockPublishArgs.addAll(args);
     mockPublishProcess = MockProcess();
     if (mockPublishStdout != null) {
-      mockPublishProcess.stdoutController.add(utf8.encode(mockPublishStdout));
+      mockPublishProcess.stdoutController.add(utf8.encode(mockPublishStdout!));
     }
     if (mockPublishStderr != null) {
-      mockPublishProcess.stderrController.add(utf8.encode(mockPublishStderr));
+      mockPublishProcess.stderrController.add(utf8.encode(mockPublishStderr!));
     }
     if (mockPublishCompleteCode != null) {
       mockPublishProcess.exitCodeCompleter.complete(mockPublishCompleteCode);
@@ -899,8 +897,8 @@ class TestProcessRunner extends ProcessRunner {
 
 class MockStdin extends Mock implements io.Stdin {
   List<List<int>> mockUserInputs = <List<int>>[];
-  StreamController<List<int>> _controller;
-  String readLineOutput;
+  late StreamController<List<int>> _controller;
+  String? readLineOutput;
 
   @override
   Stream<S> transform<S>(StreamTransformer<List<int>, S> streamTransformer) {
@@ -915,14 +913,14 @@ class MockStdin extends Mock implements io.Stdin {
   }
 
   @override
-  StreamSubscription<List<int>> listen(void onData(List<int> event),
-      {Function onError, void onDone(), bool cancelOnError}) {
+  StreamSubscription<List<int>> listen(void onData(List<int> event)?,
+      {Function? onError, void onDone()?, bool? cancelOnError}) {
     return _controller.stream.listen(onData,
         onError: onError, onDone: onDone, cancelOnError: cancelOnError);
   }
 
   @override
-  String readLineSync(
+  String? readLineSync(
           {Encoding encoding = io.systemEncoding,
           bool retainNewlines = false}) =>
       readLineOutput;


### PR DESCRIPTION
Migrates the publish command to NNBD.

This is the last command, so the top-level files are migrated as well, allowing the tool to run in strong mode.

Fixes https://github.com/flutter/flutter/issues/81912

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
