### PR TITLE
[flutter_plugin_tool] Refactor createFakePlugin

### DIFF
--- a/script/tool/lib/src/build_examples_command.dart
+++ b/script/tool/lib/src/build_examples_command.dart
@@ -27,10 +27,10 @@ class BuildExamplesCommand extends PluginCommand {
     Directory packagesDir, {
     ProcessRunner processRunner = const ProcessRunner(),
   }) : super(packagesDir, processRunner: processRunner) {
-    argParser.addFlag(kPlatformFlagLinux, defaultsTo: false);
-    argParser.addFlag(kPlatformFlagMacos, defaultsTo: false);
-    argParser.addFlag(kPlatformFlagWeb, defaultsTo: false);
-    argParser.addFlag(kPlatformFlagWindows, defaultsTo: false);
+    argParser.addFlag(kPlatformLinux, defaultsTo: false);
+    argParser.addFlag(kPlatformMacos, defaultsTo: false);
+    argParser.addFlag(kPlatformWeb, defaultsTo: false);
+    argParser.addFlag(kPlatformWindows, defaultsTo: false);
     argParser.addFlag(kIpa, defaultsTo: io.Platform.isMacOS);
     argParser.addFlag(kApk);
     argParser.addOption(
@@ -53,10 +53,10 @@ class BuildExamplesCommand extends PluginCommand {
     final List<String> platformSwitches = <String>[
       kApk,
       kIpa,
-      kPlatformFlagLinux,
-      kPlatformFlagMacos,
-      kPlatformFlagWeb,
-      kPlatformFlagWindows,
+      kPlatformLinux,
+      kPlatformMacos,
+      kPlatformWeb,
+      kPlatformWindows,
     ];
     if (!platformSwitches.any((String platform) => getBoolArg(platform))) {
       print(
@@ -75,14 +75,14 @@ class BuildExamplesCommand extends PluginCommand {
         final String packageName =
             p.relative(example.path, from: packagesDir.path);
 
-        if (getBoolArg(kPlatformFlagLinux)) {
+        if (getBoolArg(kPlatformLinux)) {
           print('\nBUILDING Linux for $packageName');
           if (isLinuxPlugin(plugin)) {
             final int buildExitCode = await processRunner.runAndStream(
                 flutterCommand,
                 <String>[
                   'build',
-                  kPlatformFlagLinux,
+                  kPlatformLinux,
                   if (enableExperiment.isNotEmpty)
                     '--enable-experiment=$enableExperiment',
                 ],
@@ -95,14 +95,14 @@ class BuildExamplesCommand extends PluginCommand {
           }
         }
 
-        if (getBoolArg(kPlatformFlagMacos)) {
+        if (getBoolArg(kPlatformMacos)) {
           print('\nBUILDING macOS for $packageName');
           if (isMacOsPlugin(plugin)) {
             final int exitCode = await processRunner.runAndStream(
                 flutterCommand,
                 <String>[
                   'build',
-                  kPlatformFlagMacos,
+                  kPlatformMacos,
                   if (enableExperiment.isNotEmpty)
                     '--enable-experiment=$enableExperiment',
                 ],
@@ -115,14 +115,14 @@ class BuildExamplesCommand extends PluginCommand {
           }
         }
 
-        if (getBoolArg(kPlatformFlagWeb)) {
+        if (getBoolArg(kPlatformWeb)) {
           print('\nBUILDING web for $packageName');
           if (isWebPlugin(plugin)) {
             final int buildExitCode = await processRunner.runAndStream(
                 flutterCommand,
                 <String>[
                   'build',
-                  kPlatformFlagWeb,
+                  kPlatformWeb,
                   if (enableExperiment.isNotEmpty)
                     '--enable-experiment=$enableExperiment',
                 ],
@@ -135,14 +135,14 @@ class BuildExamplesCommand extends PluginCommand {
           }
         }
 
-        if (getBoolArg(kPlatformFlagWindows)) {
+        if (getBoolArg(kPlatformWindows)) {
           print('\nBUILDING Windows for $packageName');
           if (isWindowsPlugin(plugin)) {
             final int buildExitCode = await processRunner.runAndStream(
                 flutterCommand,
                 <String>[
                   'build',
-                  kPlatformFlagWindows,
+                  kPlatformWindows,
                   if (enableExperiment.isNotEmpty)
                     '--enable-experiment=$enableExperiment',
                 ],

--- a/script/tool/lib/src/common/core.dart
+++ b/script/tool/lib/src/common/core.dart
@@ -11,22 +11,22 @@ import 'package:yaml/yaml.dart';
 typedef Print = void Function(Object? object);
 
 /// Key for windows platform.
-const String kPlatformFlagWindows = 'windows';
+const String kPlatformWindows = 'windows';
 
 /// Key for macos platform.
-const String kPlatformFlagMacos = 'macos';
+const String kPlatformMacos = 'macos';
 
 /// Key for linux platform.
-const String kPlatformFlagLinux = 'linux';
+const String kPlatformLinux = 'linux';
 
 /// Key for IPA (iOS) platform.
-const String kPlatformFlagIos = 'ios';
+const String kPlatformIos = 'ios';
 
 /// Key for APK (Android) platform.
-const String kPlatformFlagAndroid = 'android';
+const String kPlatformAndroid = 'android';
 
 /// Key for Web platform.
-const String kPlatformFlagWeb = 'web';
+const String kPlatformWeb = 'web';
 
 /// Key for enable experiment.
 const String kEnableExperiment = 'enable-experiment';

--- a/script/tool/lib/src/common/plugin_utils.dart
+++ b/script/tool/lib/src/common/plugin_utils.dart
@@ -29,12 +29,12 @@ enum PlatformSupport {
 /// implementation in order to return true.
 bool pluginSupportsPlatform(String platform, FileSystemEntity entity,
     {PlatformSupport? requiredMode}) {
-  assert(platform == kPlatformFlagIos ||
-      platform == kPlatformFlagAndroid ||
-      platform == kPlatformFlagWeb ||
-      platform == kPlatformFlagMacos ||
-      platform == kPlatformFlagWindows ||
-      platform == kPlatformFlagLinux);
+  assert(platform == kPlatformIos ||
+      platform == kPlatformAndroid ||
+      platform == kPlatformWeb ||
+      platform == kPlatformMacos ||
+      platform == kPlatformWindows ||
+      platform == kPlatformLinux);
   if (entity is! Directory) {
     return false;
   }
@@ -59,7 +59,7 @@ bool pluginSupportsPlatform(String platform, FileSystemEntity entity,
         return false;
       }
       if (!pluginSection.containsKey('platforms')) {
-        return platform == kPlatformFlagIos || platform == kPlatformFlagAndroid;
+        return platform == kPlatformIos || platform == kPlatformAndroid;
       }
       return false;
     }
@@ -81,30 +81,30 @@ bool pluginSupportsPlatform(String platform, FileSystemEntity entity,
 
 /// Returns whether the given directory contains a Flutter Android plugin.
 bool isAndroidPlugin(FileSystemEntity entity) {
-  return pluginSupportsPlatform(kPlatformFlagAndroid, entity);
+  return pluginSupportsPlatform(kPlatformAndroid, entity);
 }
 
 /// Returns whether the given directory contains a Flutter iOS plugin.
 bool isIosPlugin(FileSystemEntity entity) {
-  return pluginSupportsPlatform(kPlatformFlagIos, entity);
+  return pluginSupportsPlatform(kPlatformIos, entity);
 }
 
 /// Returns whether the given directory contains a Flutter web plugin.
 bool isWebPlugin(FileSystemEntity entity) {
-  return pluginSupportsPlatform(kPlatformFlagWeb, entity);
+  return pluginSupportsPlatform(kPlatformWeb, entity);
 }
 
 /// Returns whether the given directory contains a Flutter Windows plugin.
 bool isWindowsPlugin(FileSystemEntity entity) {
-  return pluginSupportsPlatform(kPlatformFlagWindows, entity);
+  return pluginSupportsPlatform(kPlatformWindows, entity);
 }
 
 /// Returns whether the given directory contains a Flutter macOS plugin.
 bool isMacOsPlugin(FileSystemEntity entity) {
-  return pluginSupportsPlatform(kPlatformFlagMacos, entity);
+  return pluginSupportsPlatform(kPlatformMacos, entity);
 }
 
 /// Returns whether the given directory contains a Flutter linux plugin.
 bool isLinuxPlugin(FileSystemEntity entity) {
-  return pluginSupportsPlatform(kPlatformFlagLinux, entity);
+  return pluginSupportsPlatform(kPlatformLinux, entity);
 }

--- a/script/tool/lib/src/drive_examples_command.dart
+++ b/script/tool/lib/src/drive_examples_command.dart
@@ -18,17 +18,17 @@ class DriveExamplesCommand extends PluginCommand {
     Directory packagesDir, {
     ProcessRunner processRunner = const ProcessRunner(),
   }) : super(packagesDir, processRunner: processRunner) {
-    argParser.addFlag(kPlatformFlagAndroid,
+    argParser.addFlag(kPlatformAndroid,
         help: 'Runs the Android implementation of the examples');
-    argParser.addFlag(kPlatformFlagIos,
+    argParser.addFlag(kPlatformIos,
         help: 'Runs the iOS implementation of the examples');
-    argParser.addFlag(kPlatformFlagLinux,
+    argParser.addFlag(kPlatformLinux,
         help: 'Runs the Linux implementation of the examples');
-    argParser.addFlag(kPlatformFlagMacos,
+    argParser.addFlag(kPlatformMacos,
         help: 'Runs the macOS implementation of the examples');
-    argParser.addFlag(kPlatformFlagWeb,
+    argParser.addFlag(kPlatformWeb,
         help: 'Runs the web implementation of the examples');
-    argParser.addFlag(kPlatformFlagWindows,
+    argParser.addFlag(kPlatformWindows,
         help: 'Runs the Windows implementation of the examples');
     argParser.addOption(
       kEnableExperiment,
@@ -55,10 +55,10 @@ class DriveExamplesCommand extends PluginCommand {
   Future<void> run() async {
     final List<String> failingTests = <String>[];
     final List<String> pluginsWithoutTests = <String>[];
-    final bool isLinux = getBoolArg(kPlatformFlagLinux);
-    final bool isMacos = getBoolArg(kPlatformFlagMacos);
-    final bool isWeb = getBoolArg(kPlatformFlagWeb);
-    final bool isWindows = getBoolArg(kPlatformFlagWindows);
+    final bool isLinux = getBoolArg(kPlatformLinux);
+    final bool isMacos = getBoolArg(kPlatformMacos);
+    final bool isWeb = getBoolArg(kPlatformWeb);
+    final bool isWindows = getBoolArg(kPlatformWindows);
     await for (final Directory plugin in getPlugins()) {
       final String pluginName = plugin.basename;
       if (pluginName.endsWith('_platform_interface') &&
@@ -222,12 +222,12 @@ Tried searching for the following:
 
   Future<bool> _pluginSupportedOnCurrentPlatform(
       FileSystemEntity plugin) async {
-    final bool isAndroid = getBoolArg(kPlatformFlagAndroid);
-    final bool isIOS = getBoolArg(kPlatformFlagIos);
-    final bool isLinux = getBoolArg(kPlatformFlagLinux);
-    final bool isMacos = getBoolArg(kPlatformFlagMacos);
-    final bool isWeb = getBoolArg(kPlatformFlagWeb);
-    final bool isWindows = getBoolArg(kPlatformFlagWindows);
+    final bool isAndroid = getBoolArg(kPlatformAndroid);
+    final bool isIOS = getBoolArg(kPlatformIos);
+    final bool isLinux = getBoolArg(kPlatformLinux);
+    final bool isMacos = getBoolArg(kPlatformMacos);
+    final bool isWeb = getBoolArg(kPlatformWeb);
+    final bool isWindows = getBoolArg(kPlatformWindows);
     if (isAndroid) {
       return isAndroidPlugin(plugin);
     }

--- a/script/tool/lib/src/xctest_command.dart
+++ b/script/tool/lib/src/xctest_command.dart
@@ -37,8 +37,8 @@ class XCTestCommand extends PluginCommand {
           'this is passed to the `-destination` argument in xcodebuild command.\n'
           'See https://developer.apple.com/library/archive/technotes/tn2339/_index.html#//apple_ref/doc/uid/DTS40014588-CH1-UNIT for details on how to specify the destination.',
     );
-    argParser.addFlag(kPlatformFlagIos, help: 'Runs the iOS tests');
-    argParser.addFlag(kPlatformFlagMacos, help: 'Runs the macOS tests');
+    argParser.addFlag(kPlatformIos, help: 'Runs the iOS tests');
+    argParser.addFlag(kPlatformMacos, help: 'Runs the macOS tests');
   }
 
   @override
@@ -51,8 +51,8 @@ class XCTestCommand extends PluginCommand {
 
   @override
   Future<void> run() async {
-    final bool testIos = getBoolArg(kPlatformFlagIos);
-    final bool testMacos = getBoolArg(kPlatformFlagMacos);
+    final bool testIos = getBoolArg(kPlatformIos);
+    final bool testMacos = getBoolArg(kPlatformMacos);
 
     if (!(testIos || testMacos)) {
       print('At least one platform flag must be provided.');

--- a/script/tool/test/analyze_command_test.dart
+++ b/script/tool/test/analyze_command_test.dart
@@ -121,7 +121,7 @@ void main() {
 
   group('verifies analysis settings', () {
     test('fails analysis_options.yaml', () async {
-      createFakePlugin('foo', packagesDir, withExtraFiles: <List<String>>[
+      createFakePlugin('foo', packagesDir, extraFiles: <List<String>>[
         <String>['analysis_options.yaml']
       ]);
 
@@ -130,7 +130,7 @@ void main() {
     });
 
     test('fails .analysis_options', () async {
-      createFakePlugin('foo', packagesDir, withExtraFiles: <List<String>>[
+      createFakePlugin('foo', packagesDir, extraFiles: <List<String>>[
         <String>['.analysis_options']
       ]);
 
@@ -140,7 +140,7 @@ void main() {
 
     test('takes an allow list', () async {
       final Directory pluginDir =
-          createFakePlugin('foo', packagesDir, withExtraFiles: <List<String>>[
+          createFakePlugin('foo', packagesDir, extraFiles: <List<String>>[
         <String>['analysis_options.yaml']
       ]);
 
@@ -161,7 +161,7 @@ void main() {
 
     // See: https://github.com/flutter/flutter/issues/78994
     test('takes an empty allow list', () async {
-      createFakePlugin('foo', packagesDir, withExtraFiles: <List<String>>[
+      createFakePlugin('foo', packagesDir, extraFiles: <List<String>>[
         <String>['analysis_options.yaml']
       ]);
 

--- a/script/tool/test/analyze_command_test.dart
+++ b/script/tool/test/analyze_command_test.dart
@@ -53,8 +53,7 @@ void main() {
   });
 
   test('skips flutter pub get for examples', () async {
-    final Directory plugin1Dir =
-        createFakePlugin('a', packagesDir, withSingleExample: true);
+    final Directory plugin1Dir = createFakePlugin('a', packagesDir);
 
     final MockProcess mockProcess = MockProcess();
     mockProcess.exitCodeCompleter.complete(0);

--- a/script/tool/test/build_examples_command_test.dart
+++ b/script/tool/test/build_examples_command_test.dart
@@ -6,6 +6,8 @@ import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/build_examples_command.dart';
+import 'package:flutter_plugin_tools/src/common/core.dart';
+import 'package:flutter_plugin_tools/src/common/plugin_utils.dart';
 import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
 import 'package:test/test.dart';
@@ -38,8 +40,7 @@ void main() {
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
-          ],
-          isLinuxPlugin: false);
+          ]);
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -71,7 +72,9 @@ void main() {
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
-          isIosPlugin: true);
+          platformSupport: <String, PlatformSupport>{
+            kPlatformIos: PlatformSupport.inline
+          });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -117,8 +120,7 @@ void main() {
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
-          ],
-          isLinuxPlugin: false);
+          ]);
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -150,7 +152,9 @@ void main() {
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
-          isLinuxPlugin: true);
+          platformSupport: <String, PlatformSupport>{
+            kPlatformLinux: PlatformSupport.inline,
+          });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -217,7 +221,9 @@ void main() {
             <String>['example', 'test'],
             <String>['example', 'macos', 'macos.swift'],
           ],
-          isMacOsPlugin: true);
+          platformSupport: <String, PlatformSupport>{
+            kPlatformMacos: PlatformSupport.inline,
+          });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -283,7 +289,9 @@ void main() {
             <String>['example', 'test'],
             <String>['example', 'web', 'index.html'],
           ],
-          isWebPlugin: true);
+          platformSupport: <String, PlatformSupport>{
+            kPlatformWeb: PlatformSupport.inline,
+          });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -318,8 +326,7 @@ void main() {
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
-          ],
-          isWindowsPlugin: false);
+          ]);
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -351,7 +358,9 @@ void main() {
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
-          isWindowsPlugin: true);
+          platformSupport: <String, PlatformSupport>{
+            kPlatformWindows: PlatformSupport.inline
+          });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -386,8 +395,7 @@ void main() {
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
-          ],
-          isLinuxPlugin: false);
+          ]);
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -419,7 +427,9 @@ void main() {
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
-          isAndroidPlugin: true);
+          platformSupport: <String, PlatformSupport>{
+            kPlatformAndroid: PlatformSupport.inline
+          });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -457,7 +467,9 @@ void main() {
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
-          isAndroidPlugin: true);
+          platformSupport: <String, PlatformSupport>{
+            kPlatformAndroid: PlatformSupport.inline
+          });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -487,7 +499,9 @@ void main() {
           withExtraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
-          isIosPlugin: true);
+          platformSupport: <String, PlatformSupport>{
+            kPlatformIos: PlatformSupport.inline
+          });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');

--- a/script/tool/test/build_examples_command_test.dart
+++ b/script/tool/test/build_examples_command_test.dart
@@ -45,8 +45,6 @@ void main() {
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
 
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
-
       final List<String> output = await runCapturingPrint(
           runner, <String>['build-examples', '--ipa', '--no-macos']);
       final String packageName =
@@ -77,8 +75,6 @@ void main() {
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'build-examples',
@@ -124,8 +120,6 @@ void main() {
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
 
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
-
       final List<String> output = await runCapturingPrint(
           runner, <String>['build-examples', '--no-ipa', '--linux']);
       final String packageName =
@@ -156,8 +150,6 @@ void main() {
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(
           runner, <String>['build-examples', '--no-ipa', '--linux']);
@@ -191,8 +183,6 @@ void main() {
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
 
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
-
       final List<String> output = await runCapturingPrint(
           runner, <String>['build-examples', '--no-ipa', '--macos']);
       final String packageName =
@@ -225,8 +215,6 @@ void main() {
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
 
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
-
       final List<String> output = await runCapturingPrint(
           runner, <String>['build-examples', '--no-ipa', '--macos']);
       final String packageName =
@@ -257,8 +245,6 @@ void main() {
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(
           runner, <String>['build-examples', '--no-ipa', '--web']);
@@ -291,8 +277,6 @@ void main() {
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(
           runner, <String>['build-examples', '--no-ipa', '--web']);
@@ -327,8 +311,6 @@ void main() {
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
 
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
-
       final List<String> output = await runCapturingPrint(
           runner, <String>['build-examples', '--no-ipa', '--windows']);
       final String packageName =
@@ -359,8 +341,6 @@ void main() {
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(
           runner, <String>['build-examples', '--no-ipa', '--windows']);
@@ -395,8 +375,6 @@ void main() {
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
 
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
-
       final List<String> output = await runCapturingPrint(
           runner, <String>['build-examples', '--apk', '--no-ipa']);
       final String packageName =
@@ -427,8 +405,6 @@ void main() {
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'build-examples',
@@ -467,8 +443,6 @@ void main() {
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
 
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
-
       await runCapturingPrint(runner, <String>[
         'build-examples',
         '--apk',
@@ -497,8 +471,6 @@ void main() {
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       await runCapturingPrint(runner, <String>[
         'build-examples',

--- a/script/tool/test/build_examples_command_test.dart
+++ b/script/tool/test/build_examples_command_test.dart
@@ -37,10 +37,10 @@ void main() {
 
     test('building for iOS when plugin is not set up for iOS results in no-op',
         () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test'],
-          ]);
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test'],
+      ]);
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -68,13 +68,12 @@ void main() {
     });
 
     test('building for ios', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test'],
-          ],
-          platformSupport: <String, PlatformSupport>{
-            kPlatformIos: PlatformSupport.inline
-          });
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test'],
+      ], platformSupport: <String, PlatformSupport>{
+        kPlatformIos: PlatformSupport.inline
+      });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -117,10 +116,10 @@ void main() {
     test(
         'building for Linux when plugin is not set up for Linux results in no-op',
         () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test'],
-          ]);
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test'],
+      ]);
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -148,13 +147,12 @@ void main() {
     });
 
     test('building for Linux', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test'],
-          ],
-          platformSupport: <String, PlatformSupport>{
-            kPlatformLinux: PlatformSupport.inline,
-          });
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test'],
+      ], platformSupport: <String, PlatformSupport>{
+        kPlatformLinux: PlatformSupport.inline,
+      });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -185,10 +183,10 @@ void main() {
 
     test('building for macos with no implementation results in no-op',
         () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test'],
-          ]);
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test'],
+      ]);
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -216,14 +214,13 @@ void main() {
     });
 
     test('building for macos', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test'],
-            <String>['example', 'macos', 'macos.swift'],
-          ],
-          platformSupport: <String, PlatformSupport>{
-            kPlatformMacos: PlatformSupport.inline,
-          });
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test'],
+        <String>['example', 'macos', 'macos.swift'],
+      ], platformSupport: <String, PlatformSupport>{
+        kPlatformMacos: PlatformSupport.inline,
+      });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -253,10 +250,10 @@ void main() {
     });
 
     test('building for web with no implementation results in no-op', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test'],
-          ]);
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test'],
+      ]);
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -284,14 +281,13 @@ void main() {
     });
 
     test('building for web', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test'],
-            <String>['example', 'web', 'index.html'],
-          ],
-          platformSupport: <String, PlatformSupport>{
-            kPlatformWeb: PlatformSupport.inline,
-          });
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test'],
+        <String>['example', 'web', 'index.html'],
+      ], platformSupport: <String, PlatformSupport>{
+        kPlatformWeb: PlatformSupport.inline,
+      });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -323,10 +319,10 @@ void main() {
     test(
         'building for Windows when plugin is not set up for Windows results in no-op',
         () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test'],
-          ]);
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test'],
+      ]);
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -354,13 +350,12 @@ void main() {
     });
 
     test('building for windows', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test'],
-          ],
-          platformSupport: <String, PlatformSupport>{
-            kPlatformWindows: PlatformSupport.inline
-          });
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test'],
+      ], platformSupport: <String, PlatformSupport>{
+        kPlatformWindows: PlatformSupport.inline
+      });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -392,10 +387,10 @@ void main() {
     test(
         'building for Android when plugin is not set up for Android results in no-op',
         () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test'],
-          ]);
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test'],
+      ]);
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -423,13 +418,12 @@ void main() {
     });
 
     test('building for android', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test'],
-          ],
-          platformSupport: <String, PlatformSupport>{
-            kPlatformAndroid: PlatformSupport.inline
-          });
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test'],
+      ], platformSupport: <String, PlatformSupport>{
+        kPlatformAndroid: PlatformSupport.inline
+      });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -463,13 +457,12 @@ void main() {
     });
 
     test('enable-experiment flag for Android', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test'],
-          ],
-          platformSupport: <String, PlatformSupport>{
-            kPlatformAndroid: PlatformSupport.inline
-          });
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test'],
+      ], platformSupport: <String, PlatformSupport>{
+        kPlatformAndroid: PlatformSupport.inline
+      });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -495,13 +488,12 @@ void main() {
     });
 
     test('enable-experiment flag for ios', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test'],
-          ],
-          platformSupport: <String, PlatformSupport>{
-            kPlatformIos: PlatformSupport.inline
-          });
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test'],
+      ], platformSupport: <String, PlatformSupport>{
+        kPlatformIos: PlatformSupport.inline
+      });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');

--- a/script/tool/test/common/plugin_command_test.dart
+++ b/script/tool/test/common/plugin_command_test.dart
@@ -95,8 +95,7 @@ void main() {
     });
 
     test('exclude federated plugins when plugins flag is specified', () async {
-      createFakePlugin('plugin1', packagesDir,
-          parentDirectoryName: 'federated');
+      createFakePlugin('plugin1', packagesDir.childDirectory('federated'));
       final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
       await runner.run(<String>[
         'sample',
@@ -108,8 +107,7 @@ void main() {
 
     test('exclude entire federated plugins when plugins flag is specified',
         () async {
-      createFakePlugin('plugin1', packagesDir,
-          parentDirectoryName: 'federated');
+      createFakePlugin('plugin1', packagesDir.childDirectory('federated'));
       final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
       await runner.run(<String>[
         'sample',
@@ -303,8 +301,8 @@ packages/plugin1/plugin1/plugin1.dart
 packages/plugin1/plugin1_platform_interface/plugin1_platform_interface.dart
 packages/plugin1/plugin1_web/plugin1_web.dart
 ''';
-        final Directory plugin1 = createFakePlugin('plugin1', packagesDir,
-            parentDirectoryName: 'plugin1');
+        final Directory plugin1 =
+            createFakePlugin('plugin1', packagesDir.childDirectory('plugin1'));
         createFakePlugin('plugin2', packagesDir);
         createFakePlugin('plugin3', packagesDir);
         await runner.run(<String>[
@@ -323,8 +321,8 @@ packages/plugin1/plugin1.dart
 packages/plugin2/ios/plugin2.m
 packages/plugin3/plugin3.dart
 ''';
-        final Directory plugin1 = createFakePlugin('plugin1', packagesDir,
-            parentDirectoryName: 'plugin1');
+        final Directory plugin1 =
+            createFakePlugin('plugin1', packagesDir.childDirectory('plugin1'));
         final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
         createFakePlugin('plugin3', packagesDir);
         await runner.run(<String>[
@@ -343,8 +341,8 @@ packages/plugin1/plugin1.dart
 packages/plugin2/ios/plugin2.m
 packages/plugin3/plugin3.dart
 ''';
-        final Directory plugin1 = createFakePlugin('plugin1', packagesDir,
-            parentDirectoryName: 'plugin1');
+        final Directory plugin1 =
+            createFakePlugin('plugin1', packagesDir.childDirectory('plugin1'));
         createFakePlugin('plugin2', packagesDir);
         createFakePlugin('plugin3', packagesDir);
         await runner.run(<String>[

--- a/script/tool/test/common/plugin_utils_test.dart
+++ b/script/tool/test/common/plugin_utils_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
+import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/common/plugin_utils.dart';
 import 'package:test/test.dart';
 
@@ -22,12 +23,12 @@ void main() {
     test('no platforms', () async {
       final Directory plugin = createFakePlugin('plugin', packagesDir);
 
-      expect(pluginSupportsPlatform('android', plugin), isFalse);
-      expect(pluginSupportsPlatform('ios', plugin), isFalse);
-      expect(pluginSupportsPlatform('linux', plugin), isFalse);
-      expect(pluginSupportsPlatform('macos', plugin), isFalse);
-      expect(pluginSupportsPlatform('web', plugin), isFalse);
-      expect(pluginSupportsPlatform('windows', plugin), isFalse);
+      expect(pluginSupportsPlatform(kPlatformAndroid, plugin), isFalse);
+      expect(pluginSupportsPlatform(kPlatformIos, plugin), isFalse);
+      expect(pluginSupportsPlatform(kPlatformLinux, plugin), isFalse);
+      expect(pluginSupportsPlatform(kPlatformMacos, plugin), isFalse);
+      expect(pluginSupportsPlatform(kPlatformWeb, plugin), isFalse);
+      expect(pluginSupportsPlatform(kPlatformWindows, plugin), isFalse);
     });
 
     test('all platforms', () async {
@@ -42,12 +43,12 @@ void main() {
         isWindowsPlugin: true,
       );
 
-      expect(pluginSupportsPlatform('android', plugin), isTrue);
-      expect(pluginSupportsPlatform('ios', plugin), isTrue);
-      expect(pluginSupportsPlatform('linux', plugin), isTrue);
-      expect(pluginSupportsPlatform('macos', plugin), isTrue);
-      expect(pluginSupportsPlatform('web', plugin), isTrue);
-      expect(pluginSupportsPlatform('windows', plugin), isTrue);
+      expect(pluginSupportsPlatform(kPlatformAndroid, plugin), isTrue);
+      expect(pluginSupportsPlatform(kPlatformIos, plugin), isTrue);
+      expect(pluginSupportsPlatform(kPlatformLinux, plugin), isTrue);
+      expect(pluginSupportsPlatform(kPlatformMacos, plugin), isTrue);
+      expect(pluginSupportsPlatform(kPlatformWeb, plugin), isTrue);
+      expect(pluginSupportsPlatform(kPlatformWindows, plugin), isTrue);
     });
 
     test('some platforms', () async {
@@ -62,12 +63,12 @@ void main() {
         isWindowsPlugin: false,
       );
 
-      expect(pluginSupportsPlatform('android', plugin), isTrue);
-      expect(pluginSupportsPlatform('ios', plugin), isFalse);
-      expect(pluginSupportsPlatform('linux', plugin), isTrue);
-      expect(pluginSupportsPlatform('macos', plugin), isFalse);
-      expect(pluginSupportsPlatform('web', plugin), isTrue);
-      expect(pluginSupportsPlatform('windows', plugin), isFalse);
+      expect(pluginSupportsPlatform(kPlatformAndroid, plugin), isTrue);
+      expect(pluginSupportsPlatform(kPlatformIos, plugin), isFalse);
+      expect(pluginSupportsPlatform(kPlatformLinux, plugin), isTrue);
+      expect(pluginSupportsPlatform(kPlatformMacos, plugin), isFalse);
+      expect(pluginSupportsPlatform(kPlatformWeb, plugin), isTrue);
+      expect(pluginSupportsPlatform(kPlatformWindows, plugin), isFalse);
     });
 
     test('inline plugins are only detected as inline', () async {
@@ -84,51 +85,51 @@ void main() {
       );
 
       expect(
-          pluginSupportsPlatform('android', plugin,
+          pluginSupportsPlatform(kPlatformAndroid, plugin,
               requiredMode: PlatformSupport.inline),
           isTrue);
       expect(
-          pluginSupportsPlatform('android', plugin,
+          pluginSupportsPlatform(kPlatformAndroid, plugin,
               requiredMode: PlatformSupport.federated),
           isFalse);
       expect(
-          pluginSupportsPlatform('ios', plugin,
+          pluginSupportsPlatform(kPlatformIos, plugin,
               requiredMode: PlatformSupport.inline),
           isTrue);
       expect(
-          pluginSupportsPlatform('ios', plugin,
+          pluginSupportsPlatform(kPlatformIos, plugin,
               requiredMode: PlatformSupport.federated),
           isFalse);
       expect(
-          pluginSupportsPlatform('linux', plugin,
+          pluginSupportsPlatform(kPlatformLinux, plugin,
               requiredMode: PlatformSupport.inline),
           isTrue);
       expect(
-          pluginSupportsPlatform('linux', plugin,
+          pluginSupportsPlatform(kPlatformLinux, plugin,
               requiredMode: PlatformSupport.federated),
           isFalse);
       expect(
-          pluginSupportsPlatform('macos', plugin,
+          pluginSupportsPlatform(kPlatformMacos, plugin,
               requiredMode: PlatformSupport.inline),
           isTrue);
       expect(
-          pluginSupportsPlatform('macos', plugin,
+          pluginSupportsPlatform(kPlatformMacos, plugin,
               requiredMode: PlatformSupport.federated),
           isFalse);
       expect(
-          pluginSupportsPlatform('web', plugin,
+          pluginSupportsPlatform(kPlatformWeb, plugin,
               requiredMode: PlatformSupport.inline),
           isTrue);
       expect(
-          pluginSupportsPlatform('web', plugin,
+          pluginSupportsPlatform(kPlatformWeb, plugin,
               requiredMode: PlatformSupport.federated),
           isFalse);
       expect(
-          pluginSupportsPlatform('windows', plugin,
+          pluginSupportsPlatform(kPlatformWindows, plugin,
               requiredMode: PlatformSupport.inline),
           isTrue);
       expect(
-          pluginSupportsPlatform('windows', plugin,
+          pluginSupportsPlatform(kPlatformWindows, plugin,
               requiredMode: PlatformSupport.federated),
           isFalse);
     });
@@ -158,51 +159,51 @@ void main() {
       );
 
       expect(
-          pluginSupportsPlatform('android', plugin,
+          pluginSupportsPlatform(kPlatformAndroid, plugin,
               requiredMode: PlatformSupport.federated),
           isTrue);
       expect(
-          pluginSupportsPlatform('android', plugin,
+          pluginSupportsPlatform(kPlatformAndroid, plugin,
               requiredMode: PlatformSupport.inline),
           isFalse);
       expect(
-          pluginSupportsPlatform('ios', plugin,
+          pluginSupportsPlatform(kPlatformIos, plugin,
               requiredMode: PlatformSupport.federated),
           isTrue);
       expect(
-          pluginSupportsPlatform('ios', plugin,
+          pluginSupportsPlatform(kPlatformIos, plugin,
               requiredMode: PlatformSupport.inline),
           isFalse);
       expect(
-          pluginSupportsPlatform('linux', plugin,
+          pluginSupportsPlatform(kPlatformLinux, plugin,
               requiredMode: PlatformSupport.federated),
           isTrue);
       expect(
-          pluginSupportsPlatform('linux', plugin,
+          pluginSupportsPlatform(kPlatformLinux, plugin,
               requiredMode: PlatformSupport.inline),
           isFalse);
       expect(
-          pluginSupportsPlatform('macos', plugin,
+          pluginSupportsPlatform(kPlatformMacos, plugin,
               requiredMode: PlatformSupport.federated),
           isTrue);
       expect(
-          pluginSupportsPlatform('macos', plugin,
+          pluginSupportsPlatform(kPlatformMacos, plugin,
               requiredMode: PlatformSupport.inline),
           isFalse);
       expect(
-          pluginSupportsPlatform('web', plugin,
+          pluginSupportsPlatform(kPlatformWeb, plugin,
               requiredMode: PlatformSupport.federated),
           isTrue);
       expect(
-          pluginSupportsPlatform('web', plugin,
+          pluginSupportsPlatform(kPlatformWeb, plugin,
               requiredMode: PlatformSupport.inline),
           isFalse);
       expect(
-          pluginSupportsPlatform('windows', plugin,
+          pluginSupportsPlatform(kPlatformWindows, plugin,
               requiredMode: PlatformSupport.federated),
           isTrue);
       expect(
-          pluginSupportsPlatform('windows', plugin,
+          pluginSupportsPlatform(kPlatformWindows, plugin,
               requiredMode: PlatformSupport.inline),
           isFalse);
     });

--- a/script/tool/test/common/plugin_utils_test.dart
+++ b/script/tool/test/common/plugin_utils_test.dart
@@ -32,16 +32,15 @@ void main() {
     });
 
     test('all platforms', () async {
-      final Directory plugin = createFakePlugin(
-        'plugin',
-        packagesDir,
-        isAndroidPlugin: true,
-        isIosPlugin: true,
-        isLinuxPlugin: true,
-        isMacOsPlugin: true,
-        isWebPlugin: true,
-        isWindowsPlugin: true,
-      );
+      final Directory plugin = createFakePlugin('plugin', packagesDir,
+          platformSupport: <String, PlatformSupport>{
+            kPlatformAndroid: PlatformSupport.inline,
+            kPlatformIos: PlatformSupport.inline,
+            kPlatformLinux: PlatformSupport.inline,
+            kPlatformMacos: PlatformSupport.inline,
+            kPlatformWeb: PlatformSupport.inline,
+            kPlatformWindows: PlatformSupport.inline,
+          });
 
       expect(pluginSupportsPlatform(kPlatformAndroid, plugin), isTrue);
       expect(pluginSupportsPlatform(kPlatformIos, plugin), isTrue);
@@ -55,12 +54,11 @@ void main() {
       final Directory plugin = createFakePlugin(
         'plugin',
         packagesDir,
-        isAndroidPlugin: true,
-        isIosPlugin: false,
-        isLinuxPlugin: true,
-        isMacOsPlugin: false,
-        isWebPlugin: true,
-        isWindowsPlugin: false,
+        platformSupport: <String, PlatformSupport>{
+          kPlatformAndroid: PlatformSupport.inline,
+          kPlatformLinux: PlatformSupport.inline,
+          kPlatformWeb: PlatformSupport.inline,
+        },
       );
 
       expect(pluginSupportsPlatform(kPlatformAndroid, plugin), isTrue);
@@ -72,16 +70,17 @@ void main() {
     });
 
     test('inline plugins are only detected as inline', () async {
-      // createFakePlugin makes non-federated pubspec entries.
       final Directory plugin = createFakePlugin(
         'plugin',
         packagesDir,
-        isAndroidPlugin: true,
-        isIosPlugin: true,
-        isLinuxPlugin: true,
-        isMacOsPlugin: true,
-        isWebPlugin: true,
-        isWindowsPlugin: true,
+        platformSupport: <String, PlatformSupport>{
+          kPlatformAndroid: PlatformSupport.inline,
+          kPlatformIos: PlatformSupport.inline,
+          kPlatformLinux: PlatformSupport.inline,
+          kPlatformMacos: PlatformSupport.inline,
+          kPlatformWeb: PlatformSupport.inline,
+          kPlatformWindows: PlatformSupport.inline,
+        },
       );
 
       expect(
@@ -139,23 +138,14 @@ void main() {
       final Directory plugin = createFakePlugin(
         pluginName,
         packagesDir,
-        isAndroidPlugin: true,
-        isIosPlugin: true,
-        isLinuxPlugin: true,
-        isMacOsPlugin: true,
-        isWebPlugin: true,
-        isWindowsPlugin: true,
-      );
-
-      createFakePubspec(
-        plugin,
-        name: pluginName,
-        androidSupport: PlatformSupport.federated,
-        iosSupport: PlatformSupport.federated,
-        linuxSupport: PlatformSupport.federated,
-        macosSupport: PlatformSupport.federated,
-        webSupport: PlatformSupport.federated,
-        windowsSupport: PlatformSupport.federated,
+        platformSupport: <String, PlatformSupport>{
+          kPlatformAndroid: PlatformSupport.federated,
+          kPlatformIos: PlatformSupport.federated,
+          kPlatformLinux: PlatformSupport.federated,
+          kPlatformMacos: PlatformSupport.federated,
+          kPlatformWeb: PlatformSupport.federated,
+          kPlatformWindows: PlatformSupport.federated,
+        },
       );
 
       expect(

--- a/script/tool/test/drive_examples_command_test.dart
+++ b/script/tool/test/drive_examples_command_test.dart
@@ -6,6 +6,7 @@ import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
+import 'package:flutter_plugin_tools/src/common/plugin_utils.dart';
 import 'package:flutter_plugin_tools/src/drive_examples_command.dart';
 import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
@@ -40,8 +41,10 @@ void main() {
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test', 'plugin.dart'],
           ],
-          isIosPlugin: true,
-          isAndroidPlugin: true);
+          platformSupport: <String, PlatformSupport>{
+            kPlatformAndroid: PlatformSupport.inline,
+            kPlatformIos: PlatformSupport.inline,
+          });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -85,8 +88,10 @@ void main() {
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test_driver', 'plugin.dart'],
           ],
-          isAndroidPlugin: true,
-          isIosPlugin: true);
+          platformSupport: <String, PlatformSupport>{
+            kPlatformAndroid: PlatformSupport.inline,
+            kPlatformIos: PlatformSupport.inline,
+          });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -130,8 +135,10 @@ void main() {
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
           ],
-          isAndroidPlugin: true,
-          isIosPlugin: true);
+          platformSupport: <String, PlatformSupport>{
+            kPlatformAndroid: PlatformSupport.inline,
+            kPlatformIos: PlatformSupport.inline,
+          });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -149,8 +156,10 @@ void main() {
           withExtraFiles: <List<String>>[
             <String>['example', 'lib', 'main.dart'],
           ],
-          isAndroidPlugin: true,
-          isIosPlugin: true);
+          platformSupport: <String, PlatformSupport>{
+            kPlatformAndroid: PlatformSupport.inline,
+            kPlatformIos: PlatformSupport.inline,
+          });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -172,8 +181,10 @@ void main() {
             <String>['example', 'integration_test', 'foo_test.dart'],
             <String>['example', 'integration_test', 'ignore_me.dart'],
           ],
-          isAndroidPlugin: true,
-          isIosPlugin: true);
+          platformSupport: <String, PlatformSupport>{
+            kPlatformAndroid: PlatformSupport.inline,
+            kPlatformIos: PlatformSupport.inline,
+          });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -226,8 +237,7 @@ void main() {
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test_driver', 'plugin.dart'],
-          ],
-          isMacOsPlugin: false);
+          ]);
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -260,7 +270,9 @@ void main() {
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test_driver', 'plugin.dart'],
           ],
-          isLinuxPlugin: true);
+          platformSupport: <String, PlatformSupport>{
+            kPlatformLinux: PlatformSupport.inline,
+          });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -339,7 +351,9 @@ void main() {
             <String>['example', 'test_driver', 'plugin.dart'],
             <String>['example', 'macos', 'macos.swift'],
           ],
-          isMacOsPlugin: true);
+          platformSupport: <String, PlatformSupport>{
+            kPlatformMacos: PlatformSupport.inline,
+          });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -385,8 +399,7 @@ void main() {
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test_driver', 'plugin.dart'],
-          ],
-          isWebPlugin: false);
+          ]);
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -419,7 +432,9 @@ void main() {
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test_driver', 'plugin.dart'],
           ],
-          isWebPlugin: true);
+          platformSupport: <String, PlatformSupport>{
+            kPlatformWeb: PlatformSupport.inline,
+          });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -467,8 +482,7 @@ void main() {
           withExtraFiles: <List<String>>[
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test_driver', 'plugin.dart'],
-          ],
-          isWindowsPlugin: false);
+          ]);
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -501,7 +515,9 @@ void main() {
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test_driver', 'plugin.dart'],
           ],
-          isWindowsPlugin: true);
+          platformSupport: <String, PlatformSupport>{
+            kPlatformWindows: PlatformSupport.inline
+          });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -548,7 +564,9 @@ void main() {
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test_driver', 'plugin.dart'],
           ],
-          isMacOsPlugin: true);
+          platformSupport: <String, PlatformSupport>{
+            kPlatformMacos: PlatformSupport.inline,
+          });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -600,8 +618,10 @@ void main() {
             <String>['example', 'test_driver', 'plugin_test.dart'],
             <String>['example', 'test', 'plugin.dart'],
           ],
-          isIosPlugin: true,
-          isAndroidPlugin: true);
+          platformSupport: <String, PlatformSupport>{
+            kPlatformAndroid: PlatformSupport.inline,
+            kPlatformIos: PlatformSupport.inline,
+          });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');

--- a/script/tool/test/drive_examples_command_test.dart
+++ b/script/tool/test/drive_examples_command_test.dart
@@ -48,8 +48,6 @@ void main() {
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
 
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
-
       final List<String> output = await runCapturingPrint(runner, <String>[
         'drive-examples',
       ]);
@@ -94,8 +92,6 @@ void main() {
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
 
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
-
       final List<String> output = await runCapturingPrint(runner, <String>[
         'drive-examples',
       ]);
@@ -129,18 +125,12 @@ void main() {
 
     test('driving under folder "test_driver" when test files are missing"',
         () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+      createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
         <String>['example', 'test_driver', 'plugin_test.dart'],
       ], platformSupport: <String, PlatformSupport>{
         kPlatformAndroid: PlatformSupport.inline,
         kPlatformIos: PlatformSupport.inline,
       });
-
-      final Directory pluginExampleDirectory =
-          pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       await expectLater(
           () => runCapturingPrint(runner, <String>['drive-examples']),
@@ -149,18 +139,12 @@ void main() {
 
     test('a plugin without any integration test files is reported as an error',
         () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+      createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
         <String>['example', 'lib', 'main.dart'],
       ], platformSupport: <String, PlatformSupport>{
         kPlatformAndroid: PlatformSupport.inline,
         kPlatformIos: PlatformSupport.inline,
       });
-
-      final Directory pluginExampleDirectory =
-          pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       await expectLater(
           () => runCapturingPrint(runner, <String>['drive-examples']),
@@ -183,8 +167,6 @@ void main() {
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'drive-examples',
@@ -228,16 +210,10 @@ void main() {
     });
 
     test('driving when plugin does not support Linux is a no-op', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+      createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
         <String>['example', 'test_driver', 'plugin_test.dart'],
         <String>['example', 'test_driver', 'plugin.dart'],
       ]);
-
-      final Directory pluginExampleDirectory =
-          pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'drive-examples',
@@ -270,8 +246,6 @@ void main() {
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'drive-examples',
@@ -308,16 +282,10 @@ void main() {
     });
 
     test('driving when plugin does not suppport macOS is a no-op', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+      createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
         <String>['example', 'test_driver', 'plugin_test.dart'],
         <String>['example', 'test_driver', 'plugin.dart'],
       ]);
-
-      final Directory pluginExampleDirectory =
-          pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'drive-examples',
@@ -350,8 +318,6 @@ void main() {
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'drive-examples',
@@ -388,16 +354,10 @@ void main() {
     });
 
     test('driving when plugin does not suppport web is a no-op', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+      createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
         <String>['example', 'test_driver', 'plugin_test.dart'],
         <String>['example', 'test_driver', 'plugin.dart'],
       ]);
-
-      final Directory pluginExampleDirectory =
-          pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'drive-examples',
@@ -430,8 +390,6 @@ void main() {
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'drive-examples',
@@ -470,16 +428,10 @@ void main() {
     });
 
     test('driving when plugin does not suppport Windows is a no-op', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+      createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
         <String>['example', 'test_driver', 'plugin_test.dart'],
         <String>['example', 'test_driver', 'plugin.dart'],
       ]);
-
-      final Directory pluginExampleDirectory =
-          pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'drive-examples',
@@ -512,8 +464,6 @@ void main() {
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'drive-examples',
@@ -550,18 +500,12 @@ void main() {
     });
 
     test('driving when plugin does not support mobile is no-op', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+      createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
         <String>['example', 'test_driver', 'plugin_test.dart'],
         <String>['example', 'test_driver', 'plugin.dart'],
       ], platformSupport: <String, PlatformSupport>{
         kPlatformMacos: PlatformSupport.inline,
       });
-
-      final Directory pluginExampleDirectory =
-          pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'drive-examples',
@@ -583,7 +527,8 @@ void main() {
     });
 
     test('platform interface plugins are silently skipped', () async {
-      createFakePlugin('aplugin_platform_interface', packagesDir);
+      createFakePlugin('aplugin_platform_interface', packagesDir,
+          examples: <String>[]);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'drive-examples',
@@ -614,8 +559,6 @@ void main() {
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
-
-      createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
       await runCapturingPrint(runner, <String>[
         'drive-examples',

--- a/script/tool/test/drive_examples_command_test.dart
+++ b/script/tool/test/drive_examples_command_test.dart
@@ -36,15 +36,14 @@ void main() {
     });
 
     test('driving under folder "test"', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test_driver', 'plugin_test.dart'],
-            <String>['example', 'test', 'plugin.dart'],
-          ],
-          platformSupport: <String, PlatformSupport>{
-            kPlatformAndroid: PlatformSupport.inline,
-            kPlatformIos: PlatformSupport.inline,
-          });
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test_driver', 'plugin_test.dart'],
+        <String>['example', 'test', 'plugin.dart'],
+      ], platformSupport: <String, PlatformSupport>{
+        kPlatformAndroid: PlatformSupport.inline,
+        kPlatformIos: PlatformSupport.inline,
+      });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -83,15 +82,14 @@ void main() {
     });
 
     test('driving under folder "test_driver"', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test_driver', 'plugin_test.dart'],
-            <String>['example', 'test_driver', 'plugin.dart'],
-          ],
-          platformSupport: <String, PlatformSupport>{
-            kPlatformAndroid: PlatformSupport.inline,
-            kPlatformIos: PlatformSupport.inline,
-          });
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test_driver', 'plugin_test.dart'],
+        <String>['example', 'test_driver', 'plugin.dart'],
+      ], platformSupport: <String, PlatformSupport>{
+        kPlatformAndroid: PlatformSupport.inline,
+        kPlatformIos: PlatformSupport.inline,
+      });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -131,14 +129,13 @@ void main() {
 
     test('driving under folder "test_driver" when test files are missing"',
         () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test_driver', 'plugin_test.dart'],
-          ],
-          platformSupport: <String, PlatformSupport>{
-            kPlatformAndroid: PlatformSupport.inline,
-            kPlatformIos: PlatformSupport.inline,
-          });
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test_driver', 'plugin_test.dart'],
+      ], platformSupport: <String, PlatformSupport>{
+        kPlatformAndroid: PlatformSupport.inline,
+        kPlatformIos: PlatformSupport.inline,
+      });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -152,14 +149,13 @@ void main() {
 
     test('a plugin without any integration test files is reported as an error',
         () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'lib', 'main.dart'],
-          ],
-          platformSupport: <String, PlatformSupport>{
-            kPlatformAndroid: PlatformSupport.inline,
-            kPlatformIos: PlatformSupport.inline,
-          });
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'lib', 'main.dart'],
+      ], platformSupport: <String, PlatformSupport>{
+        kPlatformAndroid: PlatformSupport.inline,
+        kPlatformIos: PlatformSupport.inline,
+      });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -174,17 +170,16 @@ void main() {
     test(
         'driving under folder "test_driver" when targets are under "integration_test"',
         () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test_driver', 'integration_test.dart'],
-            <String>['example', 'integration_test', 'bar_test.dart'],
-            <String>['example', 'integration_test', 'foo_test.dart'],
-            <String>['example', 'integration_test', 'ignore_me.dart'],
-          ],
-          platformSupport: <String, PlatformSupport>{
-            kPlatformAndroid: PlatformSupport.inline,
-            kPlatformIos: PlatformSupport.inline,
-          });
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test_driver', 'integration_test.dart'],
+        <String>['example', 'integration_test', 'bar_test.dart'],
+        <String>['example', 'integration_test', 'foo_test.dart'],
+        <String>['example', 'integration_test', 'ignore_me.dart'],
+      ], platformSupport: <String, PlatformSupport>{
+        kPlatformAndroid: PlatformSupport.inline,
+        kPlatformIos: PlatformSupport.inline,
+      });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -233,11 +228,11 @@ void main() {
     });
 
     test('driving when plugin does not support Linux is a no-op', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test_driver', 'plugin_test.dart'],
-            <String>['example', 'test_driver', 'plugin.dart'],
-          ]);
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test_driver', 'plugin_test.dart'],
+        <String>['example', 'test_driver', 'plugin.dart'],
+      ]);
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -265,14 +260,13 @@ void main() {
     });
 
     test('driving on a Linux plugin', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test_driver', 'plugin_test.dart'],
-            <String>['example', 'test_driver', 'plugin.dart'],
-          ],
-          platformSupport: <String, PlatformSupport>{
-            kPlatformLinux: PlatformSupport.inline,
-          });
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test_driver', 'plugin_test.dart'],
+        <String>['example', 'test_driver', 'plugin.dart'],
+      ], platformSupport: <String, PlatformSupport>{
+        kPlatformLinux: PlatformSupport.inline,
+      });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -314,11 +308,11 @@ void main() {
     });
 
     test('driving when plugin does not suppport macOS is a no-op', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test_driver', 'plugin_test.dart'],
-            <String>['example', 'test_driver', 'plugin.dart'],
-          ]);
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test_driver', 'plugin_test.dart'],
+        <String>['example', 'test_driver', 'plugin.dart'],
+      ]);
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -345,15 +339,14 @@ void main() {
       expect(processRunner.recordedCalls, <ProcessCall>[]);
     });
     test('driving on a macOS plugin', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test_driver', 'plugin_test.dart'],
-            <String>['example', 'test_driver', 'plugin.dart'],
-            <String>['example', 'macos', 'macos.swift'],
-          ],
-          platformSupport: <String, PlatformSupport>{
-            kPlatformMacos: PlatformSupport.inline,
-          });
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test_driver', 'plugin_test.dart'],
+        <String>['example', 'test_driver', 'plugin.dart'],
+        <String>['example', 'macos', 'macos.swift'],
+      ], platformSupport: <String, PlatformSupport>{
+        kPlatformMacos: PlatformSupport.inline,
+      });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -395,11 +388,11 @@ void main() {
     });
 
     test('driving when plugin does not suppport web is a no-op', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test_driver', 'plugin_test.dart'],
-            <String>['example', 'test_driver', 'plugin.dart'],
-          ]);
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test_driver', 'plugin_test.dart'],
+        <String>['example', 'test_driver', 'plugin.dart'],
+      ]);
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -427,14 +420,13 @@ void main() {
     });
 
     test('driving a web plugin', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test_driver', 'plugin_test.dart'],
-            <String>['example', 'test_driver', 'plugin.dart'],
-          ],
-          platformSupport: <String, PlatformSupport>{
-            kPlatformWeb: PlatformSupport.inline,
-          });
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test_driver', 'plugin_test.dart'],
+        <String>['example', 'test_driver', 'plugin.dart'],
+      ], platformSupport: <String, PlatformSupport>{
+        kPlatformWeb: PlatformSupport.inline,
+      });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -478,11 +470,11 @@ void main() {
     });
 
     test('driving when plugin does not suppport Windows is a no-op', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test_driver', 'plugin_test.dart'],
-            <String>['example', 'test_driver', 'plugin.dart'],
-          ]);
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test_driver', 'plugin_test.dart'],
+        <String>['example', 'test_driver', 'plugin.dart'],
+      ]);
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -510,14 +502,13 @@ void main() {
     });
 
     test('driving on a Windows plugin', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test_driver', 'plugin_test.dart'],
-            <String>['example', 'test_driver', 'plugin.dart'],
-          ],
-          platformSupport: <String, PlatformSupport>{
-            kPlatformWindows: PlatformSupport.inline
-          });
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test_driver', 'plugin_test.dart'],
+        <String>['example', 'test_driver', 'plugin.dart'],
+      ], platformSupport: <String, PlatformSupport>{
+        kPlatformWindows: PlatformSupport.inline
+      });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -559,14 +550,13 @@ void main() {
     });
 
     test('driving when plugin does not support mobile is no-op', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test_driver', 'plugin_test.dart'],
-            <String>['example', 'test_driver', 'plugin.dart'],
-          ],
-          platformSupport: <String, PlatformSupport>{
-            kPlatformMacos: PlatformSupport.inline,
-          });
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test_driver', 'plugin_test.dart'],
+        <String>['example', 'test_driver', 'plugin.dart'],
+      ], platformSupport: <String, PlatformSupport>{
+        kPlatformMacos: PlatformSupport.inline,
+      });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -613,15 +603,14 @@ void main() {
     });
 
     test('enable-experiment flag', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          withExtraFiles: <List<String>>[
-            <String>['example', 'test_driver', 'plugin_test.dart'],
-            <String>['example', 'test', 'plugin.dart'],
-          ],
-          platformSupport: <String, PlatformSupport>{
-            kPlatformAndroid: PlatformSupport.inline,
-            kPlatformIos: PlatformSupport.inline,
-          });
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        <String>['example', 'test_driver', 'plugin_test.dart'],
+        <String>['example', 'test', 'plugin.dart'],
+      ], platformSupport: <String, PlatformSupport>{
+        kPlatformAndroid: PlatformSupport.inline,
+        kPlatformIos: PlatformSupport.inline,
+      });
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');

--- a/script/tool/test/firebase_test_lab_test.dart
+++ b/script/tool/test/firebase_test_lab_test.dart
@@ -40,7 +40,7 @@ void main() {
       final MockProcess mockProcess = MockProcess();
       mockProcess.exitCodeCompleter.complete(1);
       processRunner.processToReturn = mockProcess;
-      createFakePlugin('plugin', packagesDir, withExtraFiles: <List<String>>[
+      createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
         <String>['lib/test/should_not_run_e2e.dart'],
         <String>['example', 'test_driver', 'plugin_e2e.dart'],
         <String>['example', 'test_driver', 'plugin_e2e_test.dart'],
@@ -65,7 +65,7 @@ void main() {
     });
 
     test('runs e2e tests', () async {
-      createFakePlugin('plugin', packagesDir, withExtraFiles: <List<String>>[
+      createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
         <String>['test', 'plugin_test.dart'],
         <String>['test', 'plugin_e2e.dart'],
         <String>['should_not_run_e2e.dart'],
@@ -168,7 +168,7 @@ void main() {
     });
 
     test('experimental flag', () async {
-      createFakePlugin('plugin', packagesDir, withExtraFiles: <List<String>>[
+      createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
         <String>['test', 'plugin_test.dart'],
         <String>['test', 'plugin_e2e.dart'],
         <String>['should_not_run_e2e.dart'],

--- a/script/tool/test/java_test_command_test.dart
+++ b/script/tool/test/java_test_command_test.dart
@@ -39,7 +39,6 @@ void main() {
         platformSupport: <String, PlatformSupport>{
           kPlatformAndroid: PlatformSupport.inline
         },
-        isFlutter: true,
         withSingleExample: true,
         withExtraFiles: <List<String>>[
           <String>['example/android', 'gradlew'],
@@ -68,7 +67,6 @@ void main() {
         platformSupport: <String, PlatformSupport>{
           kPlatformAndroid: PlatformSupport.inline
         },
-        isFlutter: true,
         withSingleExample: true,
         withExtraFiles: <List<String>>[
           <String>['example/android', 'gradlew'],

--- a/script/tool/test/java_test_command_test.dart
+++ b/script/tool/test/java_test_command_test.dart
@@ -39,7 +39,6 @@ void main() {
         platformSupport: <String, PlatformSupport>{
           kPlatformAndroid: PlatformSupport.inline
         },
-        withSingleExample: true,
         extraFiles: <List<String>>[
           <String>['example/android', 'gradlew'],
           <String>['android/src/test', 'example_test.java'],
@@ -67,7 +66,6 @@ void main() {
         platformSupport: <String, PlatformSupport>{
           kPlatformAndroid: PlatformSupport.inline
         },
-        withSingleExample: true,
         extraFiles: <List<String>>[
           <String>['example/android', 'gradlew'],
           <String>['example/android/app/src/test', 'example_test.java'],

--- a/script/tool/test/java_test_command_test.dart
+++ b/script/tool/test/java_test_command_test.dart
@@ -5,6 +5,8 @@
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
+import 'package:flutter_plugin_tools/src/common/core.dart';
+import 'package:flutter_plugin_tools/src/common/plugin_utils.dart';
 import 'package:flutter_plugin_tools/src/java_test_command.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
@@ -34,7 +36,9 @@ void main() {
       final Directory plugin = createFakePlugin(
         'plugin1',
         packagesDir,
-        isAndroidPlugin: true,
+        platformSupport: <String, PlatformSupport>{
+          kPlatformAndroid: PlatformSupport.inline
+        },
         isFlutter: true,
         withSingleExample: true,
         withExtraFiles: <List<String>>[
@@ -61,7 +65,9 @@ void main() {
       final Directory plugin = createFakePlugin(
         'plugin1',
         packagesDir,
-        isAndroidPlugin: true,
+        platformSupport: <String, PlatformSupport>{
+          kPlatformAndroid: PlatformSupport.inline
+        },
         isFlutter: true,
         withSingleExample: true,
         withExtraFiles: <List<String>>[

--- a/script/tool/test/java_test_command_test.dart
+++ b/script/tool/test/java_test_command_test.dart
@@ -40,7 +40,7 @@ void main() {
           kPlatformAndroid: PlatformSupport.inline
         },
         withSingleExample: true,
-        withExtraFiles: <List<String>>[
+        extraFiles: <List<String>>[
           <String>['example/android', 'gradlew'],
           <String>['android/src/test', 'example_test.java'],
         ],
@@ -68,7 +68,7 @@ void main() {
           kPlatformAndroid: PlatformSupport.inline
         },
         withSingleExample: true,
-        withExtraFiles: <List<String>>[
+        extraFiles: <List<String>>[
           <String>['example/android', 'gradlew'],
           <String>['example/android/app/src/test', 'example_test.java'],
         ],

--- a/script/tool/test/lint_podspecs_command_test.dart
+++ b/script/tool/test/lint_podspecs_command_test.dart
@@ -45,7 +45,7 @@ void main() {
     });
 
     test('only runs on macOS', () async {
-      createFakePlugin('plugin1', packagesDir, withExtraFiles: <List<String>>[
+      createFakePlugin('plugin1', packagesDir, extraFiles: <List<String>>[
         <String>['plugin1.podspec'],
       ]);
 
@@ -59,11 +59,11 @@ void main() {
     });
 
     test('runs pod lib lint on a podspec', () async {
-      final Directory plugin1Dir = createFakePlugin('plugin1', packagesDir,
-          withExtraFiles: <List<String>>[
-            <String>['ios', 'plugin1.podspec'],
-            <String>['bogus.dart'], // Ignore non-podspecs.
-          ]);
+      final Directory plugin1Dir =
+          createFakePlugin('plugin1', packagesDir, extraFiles: <List<String>>[
+        <String>['ios', 'plugin1.podspec'],
+        <String>['bogus.dart'], // Ignore non-podspecs.
+      ]);
 
       processRunner.resultStdout = 'Foo';
       processRunner.resultStderr = 'Bar';
@@ -106,10 +106,10 @@ void main() {
     });
 
     test('skips podspecs with known issues', () async {
-      createFakePlugin('plugin1', packagesDir, withExtraFiles: <List<String>>[
+      createFakePlugin('plugin1', packagesDir, extraFiles: <List<String>>[
         <String>['plugin1.podspec']
       ]);
-      createFakePlugin('plugin2', packagesDir, withExtraFiles: <List<String>>[
+      createFakePlugin('plugin2', packagesDir, extraFiles: <List<String>>[
         <String>['plugin2.podspec']
       ]);
 
@@ -125,10 +125,10 @@ void main() {
     });
 
     test('allow warnings for podspecs with known warnings', () async {
-      final Directory plugin1Dir = createFakePlugin('plugin1', packagesDir,
-          withExtraFiles: <List<String>>[
-            <String>['plugin1.podspec'],
-          ]);
+      final Directory plugin1Dir =
+          createFakePlugin('plugin1', packagesDir, extraFiles: <List<String>>[
+        <String>['plugin1.podspec'],
+      ]);
 
       await runner.run(<String>['podspecs', '--ignore-warnings=plugin1']);
 

--- a/script/tool/test/list_command_test.dart
+++ b/script/tool/test/list_command_test.dart
@@ -42,10 +42,10 @@ void main() {
     });
 
     test('lists examples', () async {
-      createFakePlugin('plugin1', packagesDir, withSingleExample: true);
+      createFakePlugin('plugin1', packagesDir);
       createFakePlugin('plugin2', packagesDir,
-          withExamples: <String>['example1', 'example2']);
-      createFakePlugin('plugin3', packagesDir);
+          examples: <String>['example1', 'example2']);
+      createFakePlugin('plugin3', packagesDir, examples: <String>[]);
 
       final List<String> examples =
           await runCapturingPrint(runner, <String>['list', '--type=example']);
@@ -61,10 +61,10 @@ void main() {
     });
 
     test('lists packages', () async {
-      createFakePlugin('plugin1', packagesDir, withSingleExample: true);
+      createFakePlugin('plugin1', packagesDir);
       createFakePlugin('plugin2', packagesDir,
-          withExamples: <String>['example1', 'example2']);
-      createFakePlugin('plugin3', packagesDir);
+          examples: <String>['example1', 'example2']);
+      createFakePlugin('plugin3', packagesDir, examples: <String>[]);
 
       final List<String> packages =
           await runCapturingPrint(runner, <String>['list', '--type=package']);
@@ -83,10 +83,10 @@ void main() {
     });
 
     test('lists files', () async {
-      createFakePlugin('plugin1', packagesDir, withSingleExample: true);
+      createFakePlugin('plugin1', packagesDir);
       createFakePlugin('plugin2', packagesDir,
-          withExamples: <String>['example1', 'example2']);
-      createFakePlugin('plugin3', packagesDir);
+          examples: <String>['example1', 'example2']);
+      createFakePlugin('plugin3', packagesDir, examples: <String>[]);
 
       final List<String> examples =
           await runCapturingPrint(runner, <String>['list', '--type=file']);

--- a/script/tool/test/list_command_test.dart
+++ b/script/tool/test/list_command_test.dart
@@ -95,11 +95,14 @@ void main() {
         examples,
         unorderedEquals(<String>[
           '/packages/plugin1/pubspec.yaml',
+          '/packages/plugin1/CHANGELOG.md',
           '/packages/plugin1/example/pubspec.yaml',
           '/packages/plugin2/pubspec.yaml',
+          '/packages/plugin2/CHANGELOG.md',
           '/packages/plugin2/example/example1/pubspec.yaml',
           '/packages/plugin2/example/example2/pubspec.yaml',
           '/packages/plugin3/pubspec.yaml',
+          '/packages/plugin3/CHANGELOG.md',
         ]),
       );
     });

--- a/script/tool/test/publish_check_command_test.dart
+++ b/script/tool/test/publish_check_command_test.dart
@@ -40,8 +40,10 @@ void main() {
     });
 
     test('publish check all packages', () async {
-      final Directory plugin1Dir = createFakePlugin('a', packagesDir);
-      final Directory plugin2Dir = createFakePlugin('b', packagesDir);
+      final Directory plugin1Dir =
+          createFakePlugin('plugin_tools_test_package_a', packagesDir);
+      final Directory plugin2Dir =
+          createFakePlugin('plugin_tools_test_package_b', packagesDir);
 
       processRunner.processesToReturn.add(
         MockProcess()..exitCodeCompleter.complete(0),
@@ -66,7 +68,7 @@ void main() {
     });
 
     test('fail on negative test', () async {
-      createFakePlugin('a', packagesDir);
+      createFakePlugin('plugin_tools_test_package_a', packagesDir);
 
       final MockProcess process = MockProcess();
       process.stdoutController.close(); // ignore: unawaited_futures
@@ -186,13 +188,8 @@ void main() {
       );
       runner.addCommand(command);
 
-      final Directory plugin1Dir =
-          createFakePlugin('no_publish_a', packagesDir, includeVersion: true);
-      final Directory plugin2Dir =
-          createFakePlugin('no_publish_b', packagesDir, includeVersion: true);
-
-      createFakePubspec(plugin1Dir, name: 'no_publish_a', version: '0.1.0');
-      createFakePubspec(plugin2Dir, name: 'no_publish_b', version: '0.2.0');
+      createFakePlugin('no_publish_a', packagesDir, version: '0.1.0');
+      createFakePlugin('no_publish_b', packagesDir, version: '0.2.0');
 
       processRunner.processesToReturn.add(
         MockProcess()..exitCodeCompleter.complete(0),
@@ -250,13 +247,8 @@ void main() {
       );
       runner.addCommand(command);
 
-      final Directory plugin1Dir =
-          createFakePlugin('no_publish_a', packagesDir, includeVersion: true);
-      final Directory plugin2Dir =
-          createFakePlugin('no_publish_b', packagesDir, includeVersion: true);
-
-      createFakePubspec(plugin1Dir, name: 'no_publish_a', version: '0.1.0');
-      createFakePubspec(plugin2Dir, name: 'no_publish_b', version: '0.2.0');
+      createFakePlugin('no_publish_a', packagesDir, version: '0.1.0');
+      createFakePlugin('no_publish_b', packagesDir, version: '0.2.0');
 
       processRunner.processesToReturn.add(
         MockProcess()..exitCodeCompleter.complete(0),
@@ -318,12 +310,9 @@ void main() {
       runner.addCommand(command);
 
       final Directory plugin1Dir =
-          createFakePlugin('no_publish_a', packagesDir, includeVersion: true);
-      final Directory plugin2Dir =
-          createFakePlugin('no_publish_b', packagesDir, includeVersion: true);
+          createFakePlugin('no_publish_a', packagesDir, version: '0.1.0');
+      createFakePlugin('no_publish_b', packagesDir, version: '0.2.0');
 
-      createFakePubspec(plugin1Dir, name: 'no_publish_a', version: '0.1.0');
-      createFakePubspec(plugin2Dir, name: 'no_publish_b', version: '0.2.0');
       await plugin1Dir.childFile('pubspec.yaml').writeAsString('bad-yaml');
 
       processRunner.processesToReturn.add(

--- a/script/tool/test/publish_plugin_command_test.dart
+++ b/script/tool/test/publish_plugin_command_test.dart
@@ -50,9 +50,8 @@ void main() {
     testRoot = fileSystem.directory(testRoot.resolveSymbolicLinksSync());
     packagesDir = createPackagesDirectory(parentDir: testRoot);
     pluginDir =
-        createFakePlugin(testPluginName, packagesDir, withSingleExample: false);
+        createFakePlugin(testPluginName, packagesDir, examples: <String>[]);
     assert(pluginDir != null && pluginDir.existsSync());
-    createFakePubspec(pluginDir, version: '0.0.1');
     io.Process.runSync('git', <String>['init'],
         workingDirectory: testRoot.path);
     gitDir = await GitDir.fromExisting(testRoot.path);
@@ -285,9 +284,9 @@ void main() {
         '--no-push-tags',
       ]);
 
-      final String? tag =
-          (await gitDir.runCommand(<String>['show-ref', 'fake_package-v0.0.1']))
-              .stdout as String?;
+      final String? tag = (await gitDir
+              .runCommand(<String>['show-ref', '$testPluginName-v0.0.1']))
+          .stdout as String?;
       expect(tag, isNotEmpty);
     });
 
@@ -304,7 +303,7 @@ void main() {
 
       expect(printedMessages, contains('Publish foo failed.'));
       final String? tag = (await gitDir.runCommand(
-              <String>['show-ref', 'fake_package-v0.0.1'],
+              <String>['show-ref', '$testPluginName-v0.0.1'],
               throwOnError: false))
           .stdout as String?;
       expect(tag, isEmpty);
@@ -343,7 +342,7 @@ void main() {
 
       expect(processRunner.pushTagsArgs.isNotEmpty, isTrue);
       expect(processRunner.pushTagsArgs[1], 'upstream');
-      expect(processRunner.pushTagsArgs[2], 'fake_package-v0.0.1');
+      expect(processRunner.pushTagsArgs[2], '$testPluginName-v0.0.1');
       expect(printedMessages.last, 'Done!');
     });
 
@@ -361,7 +360,7 @@ void main() {
 
       expect(processRunner.pushTagsArgs.isNotEmpty, isTrue);
       expect(processRunner.pushTagsArgs[1], 'upstream');
-      expect(processRunner.pushTagsArgs[2], 'fake_package-v0.0.1');
+      expect(processRunner.pushTagsArgs[2], '$testPluginName-v0.0.1');
       expect(printedMessages.last, 'Done!');
     });
 
@@ -379,7 +378,7 @@ void main() {
           containsAllInOrder(<String>[
             '===============  DRY RUN ===============',
             'Running `pub publish ` in ${pluginDir.path}...\n',
-            'Tagging release fake_package-v0.0.1...',
+            'Tagging release $testPluginName-v0.0.1...',
             'Pushing tag to upstream...',
             'Done!'
           ]));
@@ -400,7 +399,7 @@ void main() {
 
       expect(processRunner.pushTagsArgs.isNotEmpty, isTrue);
       expect(processRunner.pushTagsArgs[1], 'origin');
-      expect(processRunner.pushTagsArgs[2], 'fake_package-v0.0.1');
+      expect(processRunner.pushTagsArgs[2], '$testPluginName-v0.0.1');
       expect(printedMessages.last, 'Done!');
     });
 
@@ -429,15 +428,10 @@ void main() {
 
     test('can release newly created plugins', () async {
       // Non-federated
-      final Directory pluginDir1 =
-          createFakePlugin('plugin1', packagesDir, withSingleExample: true);
+      final Directory pluginDir1 = createFakePlugin('plugin1', packagesDir);
       // federated
       final Directory pluginDir2 = createFakePlugin('plugin2', packagesDir,
-          withSingleExample: true, parentDirectoryName: 'plugin2');
-      createFakePubspec(pluginDir1,
-          name: 'plugin1', isFlutter: false, version: '0.0.1');
-      createFakePubspec(pluginDir2,
-          name: 'plugin2', isFlutter: false, version: '0.0.1');
+          parentDirectoryName: 'plugin2');
       await gitDir.runCommand(<String>['add', '-A']);
       await gitDir.runCommand(<String>['commit', '-m', 'Add plugins']);
       // Immediately return 0 when running `pub publish`.
@@ -468,10 +462,7 @@ void main() {
     test('can release newly created plugins, while there are existing plugins',
         () async {
       // Prepare an exiting plugin and tag it
-      final Directory pluginDir0 =
-          createFakePlugin('plugin0', packagesDir, withSingleExample: true);
-      createFakePubspec(pluginDir0,
-          name: 'plugin0', isFlutter: false, version: '0.0.1');
+      createFakePlugin('plugin0', packagesDir);
       await gitDir.runCommand(<String>['add', '-A']);
       await gitDir.runCommand(<String>['commit', '-m', 'Add plugins']);
       // Immediately return 0 when running `pub publish`.
@@ -482,15 +473,10 @@ void main() {
       processRunner.pushTagsArgs.clear();
 
       // Non-federated
-      final Directory pluginDir1 =
-          createFakePlugin('plugin1', packagesDir, withSingleExample: true);
+      final Directory pluginDir1 = createFakePlugin('plugin1', packagesDir);
       // federated
       final Directory pluginDir2 = createFakePlugin('plugin2', packagesDir,
-          withSingleExample: true, parentDirectoryName: 'plugin2');
-      createFakePubspec(pluginDir1,
-          name: 'plugin1', isFlutter: false, version: '0.0.1');
-      createFakePubspec(pluginDir2,
-          name: 'plugin2', isFlutter: false, version: '0.0.1');
+          parentDirectoryName: 'plugin2');
       await gitDir.runCommand(<String>['add', '-A']);
       await gitDir.runCommand(<String>['commit', '-m', 'Add plugins']);
       // Immediately return 0 when running `pub publish`.
@@ -518,15 +504,10 @@ void main() {
 
     test('can release newly created plugins, dry run', () async {
       // Non-federated
-      final Directory pluginDir1 =
-          createFakePlugin('plugin1', packagesDir, withSingleExample: true);
+      final Directory pluginDir1 = createFakePlugin('plugin1', packagesDir);
       // federated
       final Directory pluginDir2 = createFakePlugin('plugin2', packagesDir,
-          withSingleExample: true, parentDirectoryName: 'plugin2');
-      createFakePubspec(pluginDir1,
-          name: 'plugin1', isFlutter: false, version: '0.0.1');
-      createFakePubspec(pluginDir2,
-          name: 'plugin2', isFlutter: false, version: '0.0.1');
+          parentDirectoryName: 'plugin2');
       await gitDir.runCommand(<String>['add', '-A']);
       await gitDir.runCommand(<String>['commit', '-m', 'Add plugins']);
       // Immediately return 1 when running `pub publish`. If dry-run does not work, test should throw.
@@ -559,15 +540,10 @@ void main() {
 
     test('version change triggers releases.', () async {
       // Non-federated
-      final Directory pluginDir1 =
-          createFakePlugin('plugin1', packagesDir, withSingleExample: true);
+      final Directory pluginDir1 = createFakePlugin('plugin1', packagesDir);
       // federated
       final Directory pluginDir2 = createFakePlugin('plugin2', packagesDir,
-          withSingleExample: true, parentDirectoryName: 'plugin2');
-      createFakePubspec(pluginDir1,
-          name: 'plugin1', isFlutter: false, version: '0.0.1');
-      createFakePubspec(pluginDir2,
-          name: 'plugin2', isFlutter: false, version: '0.0.1');
+          parentDirectoryName: 'plugin2');
       await gitDir.runCommand(<String>['add', '-A']);
       await gitDir.runCommand(<String>['commit', '-m', 'Add plugins']);
       // Immediately return 0 when running `pub publish`.
@@ -642,15 +618,10 @@ void main() {
         'delete package will not trigger publish but exit the command successfully.',
         () async {
       // Non-federated
-      final Directory pluginDir1 =
-          createFakePlugin('plugin1', packagesDir, withSingleExample: true);
+      final Directory pluginDir1 = createFakePlugin('plugin1', packagesDir);
       // federated
       final Directory pluginDir2 = createFakePlugin('plugin2', packagesDir,
-          withSingleExample: true, parentDirectoryName: 'plugin2');
-      createFakePubspec(pluginDir1,
-          name: 'plugin1', isFlutter: false, version: '0.0.1');
-      createFakePubspec(pluginDir2,
-          name: 'plugin2', isFlutter: false, version: '0.0.1');
+          parentDirectoryName: 'plugin2');
       await gitDir.runCommand(<String>['add', '-A']);
       await gitDir.runCommand(<String>['commit', '-m', 'Add plugins']);
       // Immediately return 0 when running `pub publish`.
@@ -723,14 +694,10 @@ void main() {
         () async {
       // Non-federated
       final Directory pluginDir1 =
-          createFakePlugin('plugin1', packagesDir, withSingleExample: true);
+          createFakePlugin('plugin1', packagesDir, version: '0.0.2');
       // federated
       final Directory pluginDir2 = createFakePlugin('plugin2', packagesDir,
-          withSingleExample: true, parentDirectoryName: 'plugin2');
-      createFakePubspec(pluginDir1,
-          name: 'plugin1', isFlutter: false, version: '0.0.2');
-      createFakePubspec(pluginDir2,
-          name: 'plugin2', isFlutter: false, version: '0.0.2');
+          parentDirectoryName: 'plugin2', version: '0.0.2');
       await gitDir.runCommand(<String>['add', '-A']);
       await gitDir.runCommand(<String>['commit', '-m', 'Add plugins']);
       // Immediately return 0 when running `pub publish`.
@@ -796,15 +763,10 @@ void main() {
 
     test('No version change does not release any plugins', () async {
       // Non-federated
-      final Directory pluginDir1 =
-          createFakePlugin('plugin1', packagesDir, withSingleExample: true);
+      final Directory pluginDir1 = createFakePlugin('plugin1', packagesDir);
       // federated
       final Directory pluginDir2 = createFakePlugin('plugin2', packagesDir,
-          withSingleExample: true, parentDirectoryName: 'plugin2');
-      createFakePubspec(pluginDir1,
-          name: 'plugin1', isFlutter: false, version: '0.0.1');
-      createFakePubspec(pluginDir2,
-          name: 'plugin2', isFlutter: false, version: '0.0.1');
+          parentDirectoryName: 'plugin2');
 
       io.Process.runSync('git', <String>['init'],
           workingDirectory: testRoot.path);

--- a/script/tool/test/publish_plugin_command_test.dart
+++ b/script/tool/test/publish_plugin_command_test.dart
@@ -138,7 +138,8 @@ void main() {
     });
 
     test('can publish non-flutter package', () async {
-      createFakePubspec(pluginDir, version: '0.0.1', isFlutter: false);
+      const String packageName = 'a_package';
+      createFakePackage(packageName, packagesDir);
       io.Process.runSync('git', <String>['init'],
           workingDirectory: testRoot.path);
       gitDir = await GitDir.fromExisting(testRoot.path);
@@ -149,7 +150,7 @@ void main() {
       await commandRunner.run(<String>[
         'publish-plugin',
         '--package',
-        testPluginName,
+        packageName,
         '--no-push-tags',
         '--no-tag-release'
       ]);

--- a/script/tool/test/publish_plugin_command_test.dart
+++ b/script/tool/test/publish_plugin_command_test.dart
@@ -430,8 +430,10 @@ void main() {
       // Non-federated
       final Directory pluginDir1 = createFakePlugin('plugin1', packagesDir);
       // federated
-      final Directory pluginDir2 = createFakePlugin('plugin2', packagesDir,
-          parentDirectoryName: 'plugin2');
+      final Directory pluginDir2 = createFakePlugin(
+        'plugin2',
+        packagesDir.childDirectory('plugin2'),
+      );
       await gitDir.runCommand(<String>['add', '-A']);
       await gitDir.runCommand(<String>['commit', '-m', 'Add plugins']);
       // Immediately return 0 when running `pub publish`.
@@ -475,8 +477,8 @@ void main() {
       // Non-federated
       final Directory pluginDir1 = createFakePlugin('plugin1', packagesDir);
       // federated
-      final Directory pluginDir2 = createFakePlugin('plugin2', packagesDir,
-          parentDirectoryName: 'plugin2');
+      final Directory pluginDir2 =
+          createFakePlugin('plugin2', packagesDir.childDirectory('plugin2'));
       await gitDir.runCommand(<String>['add', '-A']);
       await gitDir.runCommand(<String>['commit', '-m', 'Add plugins']);
       // Immediately return 0 when running `pub publish`.
@@ -506,8 +508,8 @@ void main() {
       // Non-federated
       final Directory pluginDir1 = createFakePlugin('plugin1', packagesDir);
       // federated
-      final Directory pluginDir2 = createFakePlugin('plugin2', packagesDir,
-          parentDirectoryName: 'plugin2');
+      final Directory pluginDir2 =
+          createFakePlugin('plugin2', packagesDir.childDirectory('plugin2'));
       await gitDir.runCommand(<String>['add', '-A']);
       await gitDir.runCommand(<String>['commit', '-m', 'Add plugins']);
       // Immediately return 1 when running `pub publish`. If dry-run does not work, test should throw.
@@ -542,8 +544,8 @@ void main() {
       // Non-federated
       final Directory pluginDir1 = createFakePlugin('plugin1', packagesDir);
       // federated
-      final Directory pluginDir2 = createFakePlugin('plugin2', packagesDir,
-          parentDirectoryName: 'plugin2');
+      final Directory pluginDir2 =
+          createFakePlugin('plugin2', packagesDir.childDirectory('plugin2'));
       await gitDir.runCommand(<String>['add', '-A']);
       await gitDir.runCommand(<String>['commit', '-m', 'Add plugins']);
       // Immediately return 0 when running `pub publish`.
@@ -620,8 +622,8 @@ void main() {
       // Non-federated
       final Directory pluginDir1 = createFakePlugin('plugin1', packagesDir);
       // federated
-      final Directory pluginDir2 = createFakePlugin('plugin2', packagesDir,
-          parentDirectoryName: 'plugin2');
+      final Directory pluginDir2 =
+          createFakePlugin('plugin2', packagesDir.childDirectory('plugin2'));
       await gitDir.runCommand(<String>['add', '-A']);
       await gitDir.runCommand(<String>['commit', '-m', 'Add plugins']);
       // Immediately return 0 when running `pub publish`.
@@ -696,8 +698,9 @@ void main() {
       final Directory pluginDir1 =
           createFakePlugin('plugin1', packagesDir, version: '0.0.2');
       // federated
-      final Directory pluginDir2 = createFakePlugin('plugin2', packagesDir,
-          parentDirectoryName: 'plugin2', version: '0.0.2');
+      final Directory pluginDir2 = createFakePlugin(
+          'plugin2', packagesDir.childDirectory('plugin2'),
+          version: '0.0.2');
       await gitDir.runCommand(<String>['add', '-A']);
       await gitDir.runCommand(<String>['commit', '-m', 'Add plugins']);
       // Immediately return 0 when running `pub publish`.
@@ -765,8 +768,8 @@ void main() {
       // Non-federated
       final Directory pluginDir1 = createFakePlugin('plugin1', packagesDir);
       // federated
-      final Directory pluginDir2 = createFakePlugin('plugin2', packagesDir,
-          parentDirectoryName: 'plugin2');
+      final Directory pluginDir2 =
+          createFakePlugin('plugin2', packagesDir.childDirectory('plugin2'));
 
       io.Process.runSync('git', <String>['init'],
           workingDirectory: testRoot.path);

--- a/script/tool/test/pubspec_check_command_test.dart
+++ b/script/tool/test/pubspec_check_command_test.dart
@@ -88,8 +88,7 @@ dev_dependencies:
     }
 
     test('passes for a plugin following conventions', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, withSingleExample: true);
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir);
 
       pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
 ${headerSection('plugin', isPlugin: true)}
@@ -114,8 +113,7 @@ ${devDependenciesSection()}
     });
 
     test('passes for a Flutter package following conventions', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, withSingleExample: true);
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir);
 
       pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
 ${headerSection('plugin')}
@@ -163,8 +161,7 @@ ${dependenciesSection()}
     });
 
     test('fails when homepage is included', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, withSingleExample: true);
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir);
 
       pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
 ${headerSection('plugin', isPlugin: true, includeHomepage: true)}
@@ -184,8 +181,7 @@ ${devDependenciesSection()}
     });
 
     test('fails when repository is missing', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, withSingleExample: true);
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir);
 
       pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
 ${headerSection('plugin', isPlugin: true, includeRepository: false)}
@@ -205,8 +201,7 @@ ${devDependenciesSection()}
     });
 
     test('fails when homepage is given instead of repository', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, withSingleExample: true);
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir);
 
       pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
 ${headerSection('plugin', isPlugin: true, includeHomepage: true, includeRepository: false)}
@@ -226,8 +221,7 @@ ${devDependenciesSection()}
     });
 
     test('fails when issue tracker is missing', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, withSingleExample: true);
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir);
 
       pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
 ${headerSection('plugin', isPlugin: true, includeIssueTracker: false)}
@@ -247,8 +241,7 @@ ${devDependenciesSection()}
     });
 
     test('fails when environment section is out of order', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, withSingleExample: true);
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir);
 
       pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
 ${headerSection('plugin', isPlugin: true)}
@@ -268,8 +261,7 @@ ${environmentSection()}
     });
 
     test('fails when flutter section is out of order', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, withSingleExample: true);
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir);
 
       pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
 ${headerSection('plugin', isPlugin: true)}
@@ -289,8 +281,7 @@ ${devDependenciesSection()}
     });
 
     test('fails when dependencies section is out of order', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, withSingleExample: true);
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir);
 
       pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
 ${headerSection('plugin', isPlugin: true)}
@@ -310,8 +301,7 @@ ${dependenciesSection()}
     });
 
     test('fails when devDependencies section is out of order', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, withSingleExample: true);
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir);
 
       pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
 ${headerSection('plugin', isPlugin: true)}

--- a/script/tool/test/test_command_test.dart
+++ b/script/tool/test/test_command_test.dart
@@ -72,16 +72,14 @@ void main() {
     });
 
     test('runs pub run test on non-Flutter packages', () async {
-      final Directory plugin1Dir = createFakePlugin('plugin1', packagesDir,
-          isFlutter: true,
-          withExtraFiles: <List<String>>[
-            <String>['test', 'empty_test.dart'],
-          ]);
-      final Directory plugin2Dir = createFakePlugin('plugin2', packagesDir,
-          isFlutter: false,
-          withExtraFiles: <List<String>>[
-            <String>['test', 'empty_test.dart'],
-          ]);
+      final Directory pluginDir =
+          createFakePlugin('a', packagesDir, withExtraFiles: <List<String>>[
+        <String>['test', 'empty_test.dart'],
+      ]);
+      final Directory packageDir =
+          createFakePackage('b', packagesDir, extraFiles: <List<String>>[
+        <String>['test', 'empty_test.dart'],
+      ]);
 
       await runner.run(<String>['test', '--enable-experiment=exp1']);
 
@@ -91,12 +89,12 @@ void main() {
           ProcessCall(
               'flutter',
               const <String>['test', '--color', '--enable-experiment=exp1'],
-              plugin1Dir.path),
-          ProcessCall('dart', const <String>['pub', 'get'], plugin2Dir.path),
+              pluginDir.path),
+          ProcessCall('dart', const <String>['pub', 'get'], packageDir.path),
           ProcessCall(
               'dart',
               const <String>['pub', 'run', '--enable-experiment=exp1', 'test'],
-              plugin2Dir.path),
+              packageDir.path),
         ]),
       );
     });
@@ -108,7 +106,6 @@ void main() {
         withExtraFiles: <List<String>>[
           <String>['test', 'empty_test.dart'],
         ],
-        isFlutter: true,
         platformSupport: <String, PlatformSupport>{
           kPlatformWeb: PlatformSupport.inline,
         },
@@ -128,16 +125,14 @@ void main() {
     });
 
     test('enable-experiment flag', () async {
-      final Directory plugin1Dir = createFakePlugin('plugin1', packagesDir,
-          isFlutter: true,
-          withExtraFiles: <List<String>>[
-            <String>['test', 'empty_test.dart'],
-          ]);
-      final Directory plugin2Dir = createFakePlugin('plugin2', packagesDir,
-          isFlutter: false,
-          withExtraFiles: <List<String>>[
-            <String>['test', 'empty_test.dart'],
-          ]);
+      final Directory pluginDir =
+          createFakePlugin('a', packagesDir, withExtraFiles: <List<String>>[
+        <String>['test', 'empty_test.dart'],
+      ]);
+      final Directory packageDir =
+          createFakePackage('b', packagesDir, extraFiles: <List<String>>[
+        <String>['test', 'empty_test.dart'],
+      ]);
 
       await runner.run(<String>['test', '--enable-experiment=exp1']);
 
@@ -147,12 +142,12 @@ void main() {
           ProcessCall(
               'flutter',
               const <String>['test', '--color', '--enable-experiment=exp1'],
-              plugin1Dir.path),
-          ProcessCall('dart', const <String>['pub', 'get'], plugin2Dir.path),
+              pluginDir.path),
+          ProcessCall('dart', const <String>['pub', 'get'], packageDir.path),
           ProcessCall(
               'dart',
               const <String>['pub', 'run', '--enable-experiment=exp1', 'test'],
-              plugin2Dir.path),
+              packageDir.path),
         ]),
       );
     });

--- a/script/tool/test/test_command_test.dart
+++ b/script/tool/test/test_command_test.dart
@@ -5,6 +5,8 @@
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
+import 'package:flutter_plugin_tools/src/common/core.dart';
+import 'package:flutter_plugin_tools/src/common/plugin_utils.dart';
 import 'package:flutter_plugin_tools/src/test_command.dart';
 import 'package:test/test.dart';
 
@@ -107,7 +109,9 @@ void main() {
           <String>['test', 'empty_test.dart'],
         ],
         isFlutter: true,
-        isWebPlugin: true,
+        platformSupport: <String, PlatformSupport>{
+          kPlatformWeb: PlatformSupport.inline,
+        },
       );
 
       await runner.run(<String>['test']);

--- a/script/tool/test/test_command_test.dart
+++ b/script/tool/test/test_command_test.dart
@@ -31,14 +31,14 @@ void main() {
     });
 
     test('runs flutter test on each plugin', () async {
-      final Directory plugin1Dir = createFakePlugin('plugin1', packagesDir,
-          withExtraFiles: <List<String>>[
-            <String>['test', 'empty_test.dart'],
-          ]);
-      final Directory plugin2Dir = createFakePlugin('plugin2', packagesDir,
-          withExtraFiles: <List<String>>[
-            <String>['test', 'empty_test.dart'],
-          ]);
+      final Directory plugin1Dir =
+          createFakePlugin('plugin1', packagesDir, extraFiles: <List<String>>[
+        <String>['test', 'empty_test.dart'],
+      ]);
+      final Directory plugin2Dir =
+          createFakePlugin('plugin2', packagesDir, extraFiles: <List<String>>[
+        <String>['test', 'empty_test.dart'],
+      ]);
 
       await runner.run(<String>['test']);
 
@@ -55,10 +55,10 @@ void main() {
 
     test('skips testing plugins without test directory', () async {
       createFakePlugin('plugin1', packagesDir);
-      final Directory plugin2Dir = createFakePlugin('plugin2', packagesDir,
-          withExtraFiles: <List<String>>[
-            <String>['test', 'empty_test.dart'],
-          ]);
+      final Directory plugin2Dir =
+          createFakePlugin('plugin2', packagesDir, extraFiles: <List<String>>[
+        <String>['test', 'empty_test.dart'],
+      ]);
 
       await runner.run(<String>['test']);
 
@@ -73,7 +73,7 @@ void main() {
 
     test('runs pub run test on non-Flutter packages', () async {
       final Directory pluginDir =
-          createFakePlugin('a', packagesDir, withExtraFiles: <List<String>>[
+          createFakePlugin('a', packagesDir, extraFiles: <List<String>>[
         <String>['test', 'empty_test.dart'],
       ]);
       final Directory packageDir =
@@ -103,7 +103,7 @@ void main() {
       final Directory pluginDir = createFakePlugin(
         'plugin',
         packagesDir,
-        withExtraFiles: <List<String>>[
+        extraFiles: <List<String>>[
           <String>['test', 'empty_test.dart'],
         ],
         platformSupport: <String, PlatformSupport>{
@@ -126,7 +126,7 @@ void main() {
 
     test('enable-experiment flag', () async {
       final Directory pluginDir =
-          createFakePlugin('a', packagesDir, withExtraFiles: <List<String>>[
+          createFakePlugin('a', packagesDir, extraFiles: <List<String>>[
         <String>['test', 'empty_test.dart'],
       ]);
       final Directory packageDir =

--- a/script/tool/test/util.dart
+++ b/script/tool/test/util.dart
@@ -44,8 +44,7 @@ Directory createFakePlugin(
   List<List<String>> extraFiles = const <List<String>>[],
   Map<String, PlatformSupport> platformSupport =
       const <String, PlatformSupport>{},
-  bool includeVersion = false,
-  String version = '0.0.1',
+  String? version = '0.0.1',
   String parentDirectoryName = '',
 }) {
   assert(!(withSingleExample && withExamples.isNotEmpty),
@@ -56,7 +55,7 @@ Directory createFakePlugin(
     parentDirectory = parentDirectory.childDirectory(parentDirectoryName);
   }
   final Directory pluginDirectory = createFakePackage(name, parentDirectory,
-      isFlutter: true, extraFiles: extraFiles);
+      isFlutter: true, extraFiles: extraFiles, version: version);
 
   createFakePubspec(
     pluginDirectory,
@@ -64,7 +63,7 @@ Directory createFakePlugin(
     isFlutter: true,
     isPlugin: true,
     platformSupport: platformSupport,
-    version: includeVersion ? version : null,
+    version: version,
   );
 
   if (withSingleExample) {

--- a/script/tool/test/util.dart
+++ b/script/tool/test/util.dart
@@ -38,18 +38,13 @@ Directory createPackagesDirectory(
 /// that platform.
 Directory createFakePlugin(
   String name,
-  Directory packagesDirectory, {
+  Directory parentDirectory, {
   List<String> examples = const <String>['example'],
   List<List<String>> extraFiles = const <List<String>>[],
   Map<String, PlatformSupport> platformSupport =
       const <String, PlatformSupport>{},
   String? version = '0.0.1',
-  String parentDirectoryName = '',
 }) {
-  Directory parentDirectory = packagesDirectory;
-  if (parentDirectoryName != '') {
-    parentDirectory = parentDirectory.childDirectory(parentDirectoryName);
-  }
   final Directory pluginDirectory = createFakePackage(name, parentDirectory,
       isFlutter: true,
       examples: examples,

--- a/script/tool/test/util.dart
+++ b/script/tool/test/util.dart
@@ -44,7 +44,6 @@ Directory createFakePlugin(
   List<List<String>> extraFiles = const <List<String>>[],
   Map<String, PlatformSupport> platformSupport =
       const <String, PlatformSupport>{},
-  bool includeChangeLog = false,
   bool includeVersion = false,
   String version = '0.0.1',
   String parentDirectoryName = '',
@@ -67,12 +66,6 @@ Directory createFakePlugin(
     platformSupport: platformSupport,
     version: includeVersion ? version : null,
   );
-  if (includeChangeLog) {
-    createFakeCHANGELOG(pluginDirectory, '''
-## 0.0.1
-  * Some changes.
-  ''');
-  }
 
   if (withSingleExample) {
     final Directory exampleDir = pluginDirectory.childDirectory('example')
@@ -106,11 +99,16 @@ Directory createFakePackage(
   Directory parentDirectory, {
   List<List<String>> extraFiles = const <List<String>>[],
   bool isFlutter = false,
+  String? version = '0.0.1',
 }) {
   final Directory packageDirectory = parentDirectory.childDirectory(name);
   packageDirectory.createSync(recursive: true);
 
   createFakePubspec(packageDirectory, name: name, isFlutter: isFlutter);
+  createFakeCHANGELOG(packageDirectory, '''
+## $version
+  * Some changes.
+  ''');
 
   final FileSystem fileSystem = packageDirectory.fileSystem;
   for (final List<String> file in extraFiles) {

--- a/script/tool/test/util.dart
+++ b/script/tool/test/util.dart
@@ -41,7 +41,7 @@ Directory createFakePlugin(
   Directory packagesDirectory, {
   bool withSingleExample = false,
   List<String> withExamples = const <String>[],
-  List<List<String>> withExtraFiles = const <List<String>>[],
+  List<List<String>> extraFiles = const <List<String>>[],
   Map<String, PlatformSupport> platformSupport =
       const <String, PlatformSupport>{},
   bool includeChangeLog = false,
@@ -57,7 +57,7 @@ Directory createFakePlugin(
     parentDirectory = parentDirectory.childDirectory(parentDirectoryName);
   }
   final Directory pluginDirectory = createFakePackage(name, parentDirectory,
-      isFlutter: true, extraFiles: withExtraFiles);
+      isFlutter: true, extraFiles: extraFiles);
 
   createFakePubspec(
     pluginDirectory,
@@ -91,7 +91,7 @@ Directory createFakePlugin(
   }
 
   final FileSystem fileSystem = pluginDirectory.fileSystem;
-  for (final List<String> file in withExtraFiles) {
+  for (final List<String> file in extraFiles) {
     final List<String> newFilePath = <String>[pluginDirectory.path, ...file];
     final File newFile = fileSystem.file(fileSystem.path.joinAll(newFilePath));
     newFile.createSync(recursive: true);

--- a/script/tool/test/util.dart
+++ b/script/tool/test/util.dart
@@ -39,23 +39,22 @@ Directory createPackagesDirectory(
 Directory createFakePlugin(
   String name,
   Directory packagesDirectory, {
-  bool withSingleExample = false,
-  List<String> withExamples = const <String>[],
+  List<String> examples = const <String>['example'],
   List<List<String>> extraFiles = const <List<String>>[],
   Map<String, PlatformSupport> platformSupport =
       const <String, PlatformSupport>{},
   String? version = '0.0.1',
   String parentDirectoryName = '',
 }) {
-  assert(!(withSingleExample && withExamples.isNotEmpty),
-      'cannot pass withSingleExample and withExamples simultaneously');
-
   Directory parentDirectory = packagesDirectory;
   if (parentDirectoryName != '') {
     parentDirectory = parentDirectory.childDirectory(parentDirectoryName);
   }
   final Directory pluginDirectory = createFakePackage(name, parentDirectory,
-      isFlutter: true, extraFiles: extraFiles, version: version);
+      isFlutter: true,
+      examples: examples,
+      extraFiles: extraFiles,
+      version: version);
 
   createFakePubspec(
     pluginDirectory,
@@ -65,22 +64,6 @@ Directory createFakePlugin(
     platformSupport: platformSupport,
     version: version,
   );
-
-  if (withSingleExample) {
-    final Directory exampleDir = pluginDirectory.childDirectory('example')
-      ..createSync();
-    createFakePubspec(exampleDir,
-        name: '${name}_example', isFlutter: true, publishTo: 'none');
-  } else if (withExamples.isNotEmpty) {
-    final Directory exampleDir = pluginDirectory.childDirectory('example')
-      ..createSync();
-    for (final String example in withExamples) {
-      final Directory currentExample = exampleDir.childDirectory(example)
-        ..createSync();
-      createFakePubspec(currentExample,
-          name: example, isFlutter: true, publishTo: 'none');
-    }
-  }
 
   final FileSystem fileSystem = pluginDirectory.fileSystem;
   for (final List<String> file in extraFiles) {
@@ -96,6 +79,7 @@ Directory createFakePlugin(
 Directory createFakePackage(
   String name,
   Directory parentDirectory, {
+  List<String> examples = const <String>['example'],
   List<List<String>> extraFiles = const <List<String>>[],
   bool isFlutter = false,
   String? version = '0.0.1',
@@ -108,6 +92,22 @@ Directory createFakePackage(
 ## $version
   * Some changes.
   ''');
+
+  if (examples.length == 1) {
+    final Directory exampleDir = packageDirectory.childDirectory(examples.first)
+      ..createSync();
+    createFakePubspec(exampleDir,
+        name: '${name}_example', isFlutter: isFlutter, publishTo: 'none');
+  } else if (examples.isNotEmpty) {
+    final Directory exampleDir = packageDirectory.childDirectory('example')
+      ..createSync();
+    for (final String example in examples) {
+      final Directory currentExample = exampleDir.childDirectory(example)
+        ..createSync();
+      createFakePubspec(currentExample,
+          name: example, isFlutter: isFlutter, publishTo: 'none');
+    }
+  }
 
   final FileSystem fileSystem = packageDirectory.fileSystem;
   for (final List<String> file in extraFiles) {

--- a/script/tool/test/util.dart
+++ b/script/tool/test/util.dart
@@ -42,7 +42,6 @@ Directory createFakePlugin(
   bool withSingleExample = false,
   List<String> withExamples = const <String>[],
   List<List<String>> withExtraFiles = const <List<String>>[],
-  bool isFlutter = true,
   Map<String, PlatformSupport> platformSupport =
       const <String, PlatformSupport>{},
   bool includeChangeLog = false,
@@ -57,13 +56,13 @@ Directory createFakePlugin(
   if (parentDirectoryName != '') {
     parentDirectory = parentDirectory.childDirectory(parentDirectoryName);
   }
-  final Directory pluginDirectory = parentDirectory.childDirectory(name);
-  pluginDirectory.createSync(recursive: true);
+  final Directory pluginDirectory = createFakePackage(name, parentDirectory,
+      isFlutter: true, extraFiles: withExtraFiles);
 
   createFakePubspec(
     pluginDirectory,
     name: name,
-    isFlutter: isFlutter,
+    isFlutter: true,
     isPlugin: true,
     platformSupport: platformSupport,
     version: includeVersion ? version : null,
@@ -79,7 +78,7 @@ Directory createFakePlugin(
     final Directory exampleDir = pluginDirectory.childDirectory('example')
       ..createSync();
     createFakePubspec(exampleDir,
-        name: '${name}_example', isFlutter: isFlutter, publishTo: 'none');
+        name: '${name}_example', isFlutter: true, publishTo: 'none');
   } else if (withExamples.isNotEmpty) {
     final Directory exampleDir = pluginDirectory.childDirectory('example')
       ..createSync();
@@ -87,7 +86,7 @@ Directory createFakePlugin(
       final Directory currentExample = exampleDir.childDirectory(example)
         ..createSync();
       createFakePubspec(currentExample,
-          name: example, isFlutter: isFlutter, publishTo: 'none');
+          name: example, isFlutter: true, publishTo: 'none');
     }
   }
 
@@ -99,6 +98,28 @@ Directory createFakePlugin(
   }
 
   return pluginDirectory;
+}
+
+/// Creates a plugin package with the given [name] in [packagesDirectory].
+Directory createFakePackage(
+  String name,
+  Directory parentDirectory, {
+  List<List<String>> extraFiles = const <List<String>>[],
+  bool isFlutter = false,
+}) {
+  final Directory packageDirectory = parentDirectory.childDirectory(name);
+  packageDirectory.createSync(recursive: true);
+
+  createFakePubspec(packageDirectory, name: name, isFlutter: isFlutter);
+
+  final FileSystem fileSystem = packageDirectory.fileSystem;
+  for (final List<String> file in extraFiles) {
+    final List<String> newFilePath = <String>[packageDirectory.path, ...file];
+    final File newFile = fileSystem.file(fileSystem.path.joinAll(newFilePath));
+    newFile.createSync(recursive: true);
+  }
+
+  return packageDirectory;
 }
 
 void createFakeCHANGELOG(Directory parent, String texts) {

--- a/script/tool/test/util.dart
+++ b/script/tool/test/util.dart
@@ -9,6 +9,7 @@ import 'dart:io' as io;
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
+import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/common/plugin_utils.dart';
 import 'package:flutter_plugin_tools/src/common/process_runner.dart';
 import 'package:meta/meta.dart';
@@ -177,34 +178,34 @@ String _pluginPlatformSection(
 ''';
   }
   switch (platform) {
-    case 'android':
+    case kPlatformAndroid:
       return '''
       android:
         package: io.flutter.plugins.fake
         pluginClass: FakePlugin
 ''';
-    case 'ios':
+    case kPlatformIos:
       return '''
       ios:
         pluginClass: FLTFakePlugin
 ''';
-    case 'linux':
+    case kPlatformLinux:
       return '''
       linux:
         pluginClass: FakePlugin
 ''';
-    case 'macos':
+    case kPlatformMacos:
       return '''
       macos:
         pluginClass: FakePlugin
 ''';
-    case 'web':
+    case kPlatformWeb:
       return '''
       web:
         pluginClass: FakePlugin
         fileName: ${packageName}_web.dart
 ''';
-    case 'windows':
+    case kPlatformWindows:
       return '''
       windows:
         pluginClass: FakePlugin

--- a/script/tool/test/version_check_test.dart
+++ b/script/tool/test/version_check_test.dart
@@ -243,7 +243,8 @@ void main() {
     });
 
     test('gracefully handles missing pubspec.yaml', () async {
-      final Directory pluginDir = createFakePlugin('plugin', packagesDir);
+      final Directory pluginDir =
+          createFakePlugin('plugin', packagesDir, examples: <String>[]);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       pluginDir.childFile('pubspec.yaml').deleteSync();
       final List<String> output = await runCapturingPrint(

--- a/script/tool/test/version_check_test.dart
+++ b/script/tool/test/version_check_test.dart
@@ -100,11 +100,12 @@ void main() {
     });
 
     test('allows valid version', () async {
-      createFakePlugin('plugin', packagesDir, includeVersion: true);
+      const String newVersion = '2.0.0';
+      createFakePlugin('plugin', packagesDir, version: newVersion);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'master:packages/plugin/pubspec.yaml': 'version: 1.0.0',
-        'HEAD:packages/plugin/pubspec.yaml': 'version: 2.0.0',
+        'HEAD:packages/plugin/pubspec.yaml': 'version: $newVersion',
       };
       final List<String> output = await runCapturingPrint(
           runner, <String>['version-check', '--base-sha=master']);
@@ -126,11 +127,12 @@ void main() {
     });
 
     test('denies invalid version', () async {
-      createFakePlugin('plugin', packagesDir, includeVersion: true);
+      const String newVersion = '0.2.0';
+      createFakePlugin('plugin', packagesDir, version: newVersion);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'master:packages/plugin/pubspec.yaml': 'version: 0.0.1',
-        'HEAD:packages/plugin/pubspec.yaml': 'version: 0.2.0',
+        'HEAD:packages/plugin/pubspec.yaml': 'version: $newVersion',
       };
       final Future<List<String>> result = runCapturingPrint(
           runner, <String>['version-check', '--base-sha=master']);
@@ -150,11 +152,12 @@ void main() {
     });
 
     test('allows valid version without explicit base-sha', () async {
-      createFakePlugin('plugin', packagesDir, includeVersion: true);
+      const String newVersion = '2.0.0';
+      createFakePlugin('plugin', packagesDir, version: newVersion);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'abc123:packages/plugin/pubspec.yaml': 'version: 1.0.0',
-        'HEAD:packages/plugin/pubspec.yaml': 'version: 2.0.0',
+        'HEAD:packages/plugin/pubspec.yaml': 'version: $newVersion',
       };
       final List<String> output =
           await runCapturingPrint(runner, <String>['version-check']);
@@ -168,10 +171,11 @@ void main() {
     });
 
     test('allows valid version for new package.', () async {
-      createFakePlugin('plugin', packagesDir, includeVersion: true);
+      const String newVersion = '1.0.0';
+      createFakePlugin('plugin', packagesDir, version: newVersion);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
-        'HEAD:packages/plugin/pubspec.yaml': 'version: 1.0.0',
+        'HEAD:packages/plugin/pubspec.yaml': 'version: $newVersion',
       };
       final List<String> output =
           await runCapturingPrint(runner, <String>['version-check']);
@@ -186,11 +190,12 @@ void main() {
     });
 
     test('allows likely reverts.', () async {
-      createFakePlugin('plugin', packagesDir, includeVersion: true);
+      const String newVersion = '0.6.1';
+      createFakePlugin('plugin', packagesDir, version: newVersion);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'abc123:packages/plugin/pubspec.yaml': 'version: 0.6.2',
-        'HEAD:packages/plugin/pubspec.yaml': 'version: 0.6.1',
+        'HEAD:packages/plugin/pubspec.yaml': 'version: $newVersion',
       };
       final List<String> output =
           await runCapturingPrint(runner, <String>['version-check']);
@@ -204,11 +209,12 @@ void main() {
     });
 
     test('denies lower version that could not be a simple revert', () async {
-      createFakePlugin('plugin', packagesDir, includeVersion: true);
+      const String newVersion = '0.5.1';
+      createFakePlugin('plugin', packagesDir, version: newVersion);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'abc123:packages/plugin/pubspec.yaml': 'version: 0.6.2',
-        'HEAD:packages/plugin/pubspec.yaml': 'version: 0.5.1',
+        'HEAD:packages/plugin/pubspec.yaml': 'version: $newVersion',
       };
       final Future<List<String>> result =
           runCapturingPrint(runner, <String>['version-check']);
@@ -220,11 +226,12 @@ void main() {
     });
 
     test('denies invalid version without explicit base-sha', () async {
-      createFakePlugin('plugin', packagesDir, includeVersion: true);
+      const String newVersion = '0.2.0';
+      createFakePlugin('plugin', packagesDir, version: newVersion);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'abc123:packages/plugin/pubspec.yaml': 'version: 0.0.1',
-        'HEAD:packages/plugin/pubspec.yaml': 'version: 0.2.0',
+        'HEAD:packages/plugin/pubspec.yaml': 'version: $newVersion',
       };
       final Future<List<String>> result =
           runCapturingPrint(runner, <String>['version-check']);
@@ -236,8 +243,7 @@ void main() {
     });
 
     test('gracefully handles missing pubspec.yaml', () async {
-      final Directory pluginDir =
-          createFakePlugin('plugin', packagesDir, includeVersion: true);
+      final Directory pluginDir = createFakePlugin('plugin', packagesDir);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       pluginDir.childFile('pubspec.yaml').deleteSync();
       final List<String> output = await runCapturingPrint(
@@ -258,14 +264,15 @@ void main() {
     });
 
     test('allows minor changes to platform interfaces', () async {
+      const String newVersion = '1.1.0';
       createFakePlugin('plugin_platform_interface', packagesDir,
-          includeVersion: true);
+          version: newVersion);
       gitDiffResponse = 'packages/plugin_platform_interface/pubspec.yaml';
       gitShowResponses = <String, String>{
         'master:packages/plugin_platform_interface/pubspec.yaml':
             'version: 1.0.0',
         'HEAD:packages/plugin_platform_interface/pubspec.yaml':
-            'version: 1.1.0',
+            'version: $newVersion',
       };
       final List<String> output = await runCapturingPrint(
           runner, <String>['version-check', '--base-sha=master']);
@@ -292,14 +299,15 @@ void main() {
     });
 
     test('disallows breaking changes to platform interfaces', () async {
+      const String newVersion = '2.0.0';
       createFakePlugin('plugin_platform_interface', packagesDir,
-          includeVersion: true);
+          version: newVersion);
       gitDiffResponse = 'packages/plugin_platform_interface/pubspec.yaml';
       gitShowResponses = <String, String>{
         'master:packages/plugin_platform_interface/pubspec.yaml':
             'version: 1.0.0',
         'HEAD:packages/plugin_platform_interface/pubspec.yaml':
-            'version: 2.0.0',
+            'version: $newVersion',
       };
       final Future<List<String>> output = runCapturingPrint(
           runner, <String>['version-check', '--base-sha=master']);
@@ -325,16 +333,11 @@ void main() {
 
     test('Allow empty lines in front of the first version in CHANGELOG',
         () async {
+      const String version = '1.0.1';
       final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, includeVersion: true);
-
-      createFakePubspec(pluginDirectory, isFlutter: true, version: '1.0.1');
+          createFakePlugin('plugin', packagesDir, version: version);
       const String changelog = '''
-
-
-
-## 1.0.1
-
+## $version
 * Some changes.
 ''';
       createFakeCHANGELOG(pluginDirectory, changelog);
@@ -352,12 +355,9 @@ void main() {
 
     test('Throws if versions in changelog and pubspec do not match', () async {
       final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, includeVersion: true);
-
-      createFakePubspec(pluginDirectory, isFlutter: true, version: '1.0.1');
+          createFakePlugin('plugin', packagesDir, version: '1.0.1');
       const String changelog = '''
 ## 1.0.2
-
 * Some changes.
 ''';
       createFakeCHANGELOG(pluginDirectory, changelog);
@@ -385,13 +385,12 @@ The first version listed in CHANGELOG.md is 1.0.2.
     });
 
     test('Success if CHANGELOG and pubspec versions match', () async {
+      const String version = '1.0.1';
       final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, includeVersion: true);
+          createFakePlugin('plugin', packagesDir, version: version);
 
-      createFakePubspec(pluginDirectory, isFlutter: true, version: '1.0.1');
       const String changelog = '''
-## 1.0.1
-
+## $version
 * Some changes.
 ''';
       createFakeCHANGELOG(pluginDirectory, changelog);
@@ -411,16 +410,12 @@ The first version listed in CHANGELOG.md is 1.0.2.
         'Fail if pubspec version only matches an older version listed in CHANGELOG',
         () async {
       final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, includeVersion: true);
+          createFakePlugin('plugin', packagesDir, version: '1.0.0');
 
-      createFakePubspec(pluginDirectory, isFlutter: true, version: '1.0.0');
       const String changelog = '''
 ## 1.0.1
-
 * Some changes.
-
 ## 1.0.0
-
 * Some other changes.
 ''';
       createFakeCHANGELOG(pluginDirectory, changelog);
@@ -451,17 +446,14 @@ The first version listed in CHANGELOG.md is 1.0.1.
 
     test('Allow NEXT as a placeholder for gathering CHANGELOG entries',
         () async {
+      const String version = '1.0.0';
       final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, includeVersion: true);
+          createFakePlugin('plugin', packagesDir, version: version);
 
-      createFakePubspec(pluginDirectory, isFlutter: true, version: '1.0.0');
       const String changelog = '''
 ## NEXT
-
 * Some changes that won't be published until the next time there's a release.
-
-## 1.0.0
-
+## $version
 * Some other changes.
 ''';
       createFakeCHANGELOG(pluginDirectory, changelog);
@@ -479,21 +471,16 @@ The first version listed in CHANGELOG.md is 1.0.1.
 
     test('Fail if NEXT is left in the CHANGELOG when adding a version bump',
         () async {
+      const String version = '1.0.1';
       final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, includeVersion: true);
+          createFakePlugin('plugin', packagesDir, version: version);
 
-      createFakePubspec(pluginDirectory, isFlutter: true, version: '1.0.1');
       const String changelog = '''
-## 1.0.1
-
+## $version
 * Some changes.
-
 ## NEXT
-
 * Some changes that should have been folded in 1.0.1.
-
 ## 1.0.0
-
 * Some other changes.
 ''';
       createFakeCHANGELOG(pluginDirectory, changelog);
@@ -523,16 +510,12 @@ into the new version's release notes.
 
     test('Fail if the version changes without replacing NEXT', () async {
       final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, includeVersion: true);
+          createFakePlugin('plugin', packagesDir, version: '1.0.1');
 
-      createFakePubspec(pluginDirectory, isFlutter: true, version: '1.0.1');
       const String changelog = '''
 ## NEXT
-
 * Some changes that should be listed as part of 1.0.1.
-
 ## 1.0.0
-
 * Some other changes.
 ''';
       createFakeCHANGELOG(pluginDirectory, changelog);
@@ -581,11 +564,12 @@ The first version listed in CHANGELOG.md is 1.0.0.
           'version_check_command', 'Test for $VersionCheckCommand');
       runner.addCommand(command);
 
-      createFakePlugin('plugin', packagesDir, includeVersion: true);
+      const String newVersion = '2.0.0';
+      createFakePlugin('plugin', packagesDir, version: newVersion);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'master:packages/plugin/pubspec.yaml': 'version: 1.0.0',
-        'HEAD:packages/plugin/pubspec.yaml': 'version: 2.0.0',
+        'HEAD:packages/plugin/pubspec.yaml': 'version: $newVersion',
       };
       final List<String> output = await runCapturingPrint(runner,
           <String>['version-check', '--base-sha=master', '--against-pub']);
@@ -617,11 +601,12 @@ The first version listed in CHANGELOG.md is 1.0.0.
           'version_check_command', 'Test for $VersionCheckCommand');
       runner.addCommand(command);
 
-      createFakePlugin('plugin', packagesDir, includeVersion: true);
+      const String newVersion = '2.0.0';
+      createFakePlugin('plugin', packagesDir, version: newVersion);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'master:packages/plugin/pubspec.yaml': 'version: 1.0.0',
-        'HEAD:packages/plugin/pubspec.yaml': 'version: 2.0.0',
+        'HEAD:packages/plugin/pubspec.yaml': 'version: $newVersion',
       };
 
       bool hasError = false;
@@ -661,11 +646,12 @@ ${indentation}Allowed versions: {1.0.0: NextVersionType.BREAKING_MAJOR, 0.1.0: N
           'version_check_command', 'Test for $VersionCheckCommand');
       runner.addCommand(command);
 
-      createFakePlugin('plugin', packagesDir, includeVersion: true);
+      const String newVersion = '2.0.0';
+      createFakePlugin('plugin', packagesDir, version: newVersion);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'master:packages/plugin/pubspec.yaml': 'version: 1.0.0',
-        'HEAD:packages/plugin/pubspec.yaml': 'version: 2.0.0',
+        'HEAD:packages/plugin/pubspec.yaml': 'version: $newVersion',
       };
       bool hasError = false;
       final List<String> result = await runCapturingPrint(runner, <String>[
@@ -704,11 +690,12 @@ ${indentation}HTTP response: xx
           'version_check_command', 'Test for $VersionCheckCommand');
       runner.addCommand(command);
 
-      createFakePlugin('plugin', packagesDir, includeVersion: true);
+      const String newVersion = '2.0.0';
+      createFakePlugin('plugin', packagesDir, version: newVersion);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'master:packages/plugin/pubspec.yaml': 'version: 1.0.0',
-        'HEAD:packages/plugin/pubspec.yaml': 'version: 2.0.0',
+        'HEAD:packages/plugin/pubspec.yaml': 'version: $newVersion',
       };
       final List<String> result = await runCapturingPrint(runner,
           <String>['version-check', '--base-sha=master', '--against-pub']);

--- a/script/tool/test/version_check_test.dart
+++ b/script/tool/test/version_check_test.dart
@@ -100,8 +100,7 @@ void main() {
     });
 
     test('allows valid version', () async {
-      createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, includeVersion: true);
+      createFakePlugin('plugin', packagesDir, includeVersion: true);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'master:packages/plugin/pubspec.yaml': 'version: 1.0.0',
@@ -127,8 +126,7 @@ void main() {
     });
 
     test('denies invalid version', () async {
-      createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, includeVersion: true);
+      createFakePlugin('plugin', packagesDir, includeVersion: true);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'master:packages/plugin/pubspec.yaml': 'version: 0.0.1',
@@ -152,8 +150,7 @@ void main() {
     });
 
     test('allows valid version without explicit base-sha', () async {
-      createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, includeVersion: true);
+      createFakePlugin('plugin', packagesDir, includeVersion: true);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'abc123:packages/plugin/pubspec.yaml': 'version: 1.0.0',
@@ -171,8 +168,7 @@ void main() {
     });
 
     test('allows valid version for new package.', () async {
-      createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, includeVersion: true);
+      createFakePlugin('plugin', packagesDir, includeVersion: true);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'HEAD:packages/plugin/pubspec.yaml': 'version: 1.0.0',
@@ -190,8 +186,7 @@ void main() {
     });
 
     test('allows likely reverts.', () async {
-      createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, includeVersion: true);
+      createFakePlugin('plugin', packagesDir, includeVersion: true);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'abc123:packages/plugin/pubspec.yaml': 'version: 0.6.2',
@@ -209,8 +204,7 @@ void main() {
     });
 
     test('denies lower version that could not be a simple revert', () async {
-      createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, includeVersion: true);
+      createFakePlugin('plugin', packagesDir, includeVersion: true);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'abc123:packages/plugin/pubspec.yaml': 'version: 0.6.2',
@@ -226,8 +220,7 @@ void main() {
     });
 
     test('denies invalid version without explicit base-sha', () async {
-      createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, includeVersion: true);
+      createFakePlugin('plugin', packagesDir, includeVersion: true);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'abc123:packages/plugin/pubspec.yaml': 'version: 0.0.1',
@@ -243,8 +236,8 @@ void main() {
     });
 
     test('gracefully handles missing pubspec.yaml', () async {
-      final Directory pluginDir = createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, includeVersion: true);
+      final Directory pluginDir =
+          createFakePlugin('plugin', packagesDir, includeVersion: true);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       pluginDir.childFile('pubspec.yaml').deleteSync();
       final List<String> output = await runCapturingPrint(
@@ -266,7 +259,7 @@ void main() {
 
     test('allows minor changes to platform interfaces', () async {
       createFakePlugin('plugin_platform_interface', packagesDir,
-          includeChangeLog: true, includeVersion: true);
+          includeVersion: true);
       gitDiffResponse = 'packages/plugin_platform_interface/pubspec.yaml';
       gitShowResponses = <String, String>{
         'master:packages/plugin_platform_interface/pubspec.yaml':
@@ -300,7 +293,7 @@ void main() {
 
     test('disallows breaking changes to platform interfaces', () async {
       createFakePlugin('plugin_platform_interface', packagesDir,
-          includeChangeLog: true, includeVersion: true);
+          includeVersion: true);
       gitDiffResponse = 'packages/plugin_platform_interface/pubspec.yaml';
       gitShowResponses = <String, String>{
         'master:packages/plugin_platform_interface/pubspec.yaml':
@@ -332,8 +325,8 @@ void main() {
 
     test('Allow empty lines in front of the first version in CHANGELOG',
         () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, includeVersion: true);
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, includeVersion: true);
 
       createFakePubspec(pluginDirectory, isFlutter: true, version: '1.0.1');
       const String changelog = '''
@@ -358,8 +351,8 @@ void main() {
     });
 
     test('Throws if versions in changelog and pubspec do not match', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, includeVersion: true);
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, includeVersion: true);
 
       createFakePubspec(pluginDirectory, isFlutter: true, version: '1.0.1');
       const String changelog = '''
@@ -392,8 +385,8 @@ The first version listed in CHANGELOG.md is 1.0.2.
     });
 
     test('Success if CHANGELOG and pubspec versions match', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, includeVersion: true);
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, includeVersion: true);
 
       createFakePubspec(pluginDirectory, isFlutter: true, version: '1.0.1');
       const String changelog = '''
@@ -417,8 +410,8 @@ The first version listed in CHANGELOG.md is 1.0.2.
     test(
         'Fail if pubspec version only matches an older version listed in CHANGELOG',
         () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, includeVersion: true);
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, includeVersion: true);
 
       createFakePubspec(pluginDirectory, isFlutter: true, version: '1.0.0');
       const String changelog = '''
@@ -458,8 +451,8 @@ The first version listed in CHANGELOG.md is 1.0.1.
 
     test('Allow NEXT as a placeholder for gathering CHANGELOG entries',
         () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, includeVersion: true);
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, includeVersion: true);
 
       createFakePubspec(pluginDirectory, isFlutter: true, version: '1.0.0');
       const String changelog = '''
@@ -486,8 +479,8 @@ The first version listed in CHANGELOG.md is 1.0.1.
 
     test('Fail if NEXT is left in the CHANGELOG when adding a version bump',
         () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, includeVersion: true);
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, includeVersion: true);
 
       createFakePubspec(pluginDirectory, isFlutter: true, version: '1.0.1');
       const String changelog = '''
@@ -529,8 +522,8 @@ into the new version's release notes.
     });
 
     test('Fail if the version changes without replacing NEXT', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, includeVersion: true);
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, includeVersion: true);
 
       createFakePubspec(pluginDirectory, isFlutter: true, version: '1.0.1');
       const String changelog = '''
@@ -588,8 +581,7 @@ The first version listed in CHANGELOG.md is 1.0.0.
           'version_check_command', 'Test for $VersionCheckCommand');
       runner.addCommand(command);
 
-      createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, includeVersion: true);
+      createFakePlugin('plugin', packagesDir, includeVersion: true);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'master:packages/plugin/pubspec.yaml': 'version: 1.0.0',
@@ -625,8 +617,7 @@ The first version listed in CHANGELOG.md is 1.0.0.
           'version_check_command', 'Test for $VersionCheckCommand');
       runner.addCommand(command);
 
-      createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, includeVersion: true);
+      createFakePlugin('plugin', packagesDir, includeVersion: true);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'master:packages/plugin/pubspec.yaml': 'version: 1.0.0',
@@ -670,8 +661,7 @@ ${indentation}Allowed versions: {1.0.0: NextVersionType.BREAKING_MAJOR, 0.1.0: N
           'version_check_command', 'Test for $VersionCheckCommand');
       runner.addCommand(command);
 
-      createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, includeVersion: true);
+      createFakePlugin('plugin', packagesDir, includeVersion: true);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'master:packages/plugin/pubspec.yaml': 'version: 1.0.0',
@@ -714,8 +704,7 @@ ${indentation}HTTP response: xx
           'version_check_command', 'Test for $VersionCheckCommand');
       runner.addCommand(command);
 
-      createFakePlugin('plugin', packagesDir,
-          includeChangeLog: true, includeVersion: true);
+      createFakePlugin('plugin', packagesDir, includeVersion: true);
       gitDiffResponse = 'packages/plugin/pubspec.yaml';
       gitShowResponses = <String, String>{
         'master:packages/plugin/pubspec.yaml': 'version: 1.0.0',

--- a/script/tool/test/xctest_command_test.dart
+++ b/script/tool/test/xctest_command_test.dart
@@ -113,13 +113,14 @@ void main() {
 
     group('iOS', () {
       test('skip if iOS is not supported', () async {
-        final Directory pluginDirectory =
-            createFakePlugin('plugin', packagesDir,
-                withExtraFiles: <List<String>>[
-                  <String>['example', 'test'],
-                ],
-                isIosPlugin: false,
-                isMacOsPlugin: true);
+        final Directory pluginDirectory = createFakePlugin(
+            'plugin', packagesDir,
+            withExtraFiles: <List<String>>[
+              <String>['example', 'test'],
+            ],
+            platformSupport: <String, PlatformSupport>{
+              kPlatformMacos: PlatformSupport.inline,
+            });
 
         createFakePubspec(pluginDirectory.childDirectory('example'),
             isFlutter: true);
@@ -135,14 +136,14 @@ void main() {
       });
 
       test('skip if iOS is implemented in a federated package', () async {
-        final Directory pluginDirectory =
-            createFakePlugin('plugin', packagesDir,
-                withExtraFiles: <List<String>>[
-                  <String>['example', 'test'],
-                ],
-                isIosPlugin: true);
-        createFakePubspec(pluginDirectory,
-            iosSupport: PlatformSupport.federated);
+        final Directory pluginDirectory = createFakePlugin(
+            'plugin', packagesDir,
+            withExtraFiles: <List<String>>[
+              <String>['example', 'test'],
+            ],
+            platformSupport: <String, PlatformSupport>{
+              kPlatformIos: PlatformSupport.federated
+            });
 
         createFakePubspec(pluginDirectory.childDirectory('example'),
             isFlutter: true);
@@ -158,18 +159,22 @@ void main() {
       });
 
       test('running with correct destination, exclude 1 plugin', () async {
-        final Directory pluginDirectory1 =
-            createFakePlugin('plugin1', packagesDir,
-                withExtraFiles: <List<String>>[
-                  <String>['example', 'test'],
-                ],
-                isIosPlugin: true);
-        final Directory pluginDirectory2 =
-            createFakePlugin('plugin2', packagesDir,
-                withExtraFiles: <List<String>>[
-                  <String>['example', 'test'],
-                ],
-                isIosPlugin: true);
+        final Directory pluginDirectory1 = createFakePlugin(
+            'plugin1', packagesDir,
+            withExtraFiles: <List<String>>[
+              <String>['example', 'test'],
+            ],
+            platformSupport: <String, PlatformSupport>{
+              kPlatformIos: PlatformSupport.inline
+            });
+        final Directory pluginDirectory2 = createFakePlugin(
+            'plugin2', packagesDir,
+            withExtraFiles: <List<String>>[
+              <String>['example', 'test'],
+            ],
+            platformSupport: <String, PlatformSupport>{
+              kPlatformIos: PlatformSupport.inline
+            });
 
         final Directory pluginExampleDirectory1 =
             pluginDirectory1.childDirectory('example');
@@ -222,12 +227,14 @@ void main() {
 
       test('Not specifying --ios-destination assigns an available simulator',
           () async {
-        final Directory pluginDirectory =
-            createFakePlugin('plugin', packagesDir,
-                withExtraFiles: <List<String>>[
-                  <String>['example', 'test'],
-                ],
-                isIosPlugin: true);
+        final Directory pluginDirectory = createFakePlugin(
+            'plugin', packagesDir,
+            withExtraFiles: <List<String>>[
+              <String>['example', 'test'],
+            ],
+            platformSupport: <String, PlatformSupport>{
+              kPlatformIos: PlatformSupport.inline
+            });
 
         final Directory pluginExampleDirectory =
             pluginDirectory.childDirectory('example');
@@ -276,13 +283,13 @@ void main() {
 
     group('macOS', () {
       test('skip if macOS is not supported', () async {
-        final Directory pluginDirectory =
-            createFakePlugin('plugin', packagesDir,
-                withExtraFiles: <List<String>>[
-                  <String>['example', 'test'],
-                ],
-                isIosPlugin: true,
-                isMacOsPlugin: false);
+        final Directory pluginDirectory = createFakePlugin(
+          'plugin',
+          packagesDir,
+          withExtraFiles: <List<String>>[
+            <String>['example', 'test'],
+          ],
+        );
 
         createFakePubspec(pluginDirectory.childDirectory('example'),
             isFlutter: true);
@@ -298,14 +305,14 @@ void main() {
       });
 
       test('skip if macOS is implemented in a federated package', () async {
-        final Directory pluginDirectory =
-            createFakePlugin('plugin', packagesDir,
-                withExtraFiles: <List<String>>[
-                  <String>['example', 'test'],
-                ],
-                isMacOsPlugin: true);
-        createFakePubspec(pluginDirectory,
-            macosSupport: PlatformSupport.federated);
+        final Directory pluginDirectory = createFakePlugin(
+            'plugin', packagesDir,
+            withExtraFiles: <List<String>>[
+              <String>['example', 'test'],
+            ],
+            platformSupport: <String, PlatformSupport>{
+              kPlatformMacos: PlatformSupport.federated,
+            });
 
         createFakePubspec(pluginDirectory.childDirectory('example'),
             isFlutter: true);
@@ -321,12 +328,14 @@ void main() {
       });
 
       test('runs for macOS plugin', () async {
-        final Directory pluginDirectory1 =
-            createFakePlugin('plugin', packagesDir,
-                withExtraFiles: <List<String>>[
-                  <String>['example', 'test'],
-                ],
-                isMacOsPlugin: true);
+        final Directory pluginDirectory1 = createFakePlugin(
+            'plugin', packagesDir,
+            withExtraFiles: <List<String>>[
+              <String>['example', 'test'],
+            ],
+            platformSupport: <String, PlatformSupport>{
+              kPlatformMacos: PlatformSupport.inline,
+            });
 
         final Directory pluginExampleDirectory =
             pluginDirectory1.childDirectory('example');

--- a/script/tool/test/xctest_command_test.dart
+++ b/script/tool/test/xctest_command_test.dart
@@ -113,14 +113,12 @@ void main() {
 
     group('iOS', () {
       test('skip if iOS is not supported', () async {
-        final Directory pluginDirectory = createFakePlugin(
-            'plugin', packagesDir,
-            withExtraFiles: <List<String>>[
-              <String>['example', 'test'],
-            ],
-            platformSupport: <String, PlatformSupport>{
-              kPlatformMacos: PlatformSupport.inline,
-            });
+        final Directory pluginDirectory =
+            createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+          <String>['example', 'test'],
+        ], platformSupport: <String, PlatformSupport>{
+          kPlatformMacos: PlatformSupport.inline,
+        });
 
         createFakePubspec(pluginDirectory.childDirectory('example'),
             isFlutter: true);
@@ -136,14 +134,12 @@ void main() {
       });
 
       test('skip if iOS is implemented in a federated package', () async {
-        final Directory pluginDirectory = createFakePlugin(
-            'plugin', packagesDir,
-            withExtraFiles: <List<String>>[
-              <String>['example', 'test'],
-            ],
-            platformSupport: <String, PlatformSupport>{
-              kPlatformIos: PlatformSupport.federated
-            });
+        final Directory pluginDirectory =
+            createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+          <String>['example', 'test'],
+        ], platformSupport: <String, PlatformSupport>{
+          kPlatformIos: PlatformSupport.federated
+        });
 
         createFakePubspec(pluginDirectory.childDirectory('example'),
             isFlutter: true);
@@ -159,22 +155,18 @@ void main() {
       });
 
       test('running with correct destination, exclude 1 plugin', () async {
-        final Directory pluginDirectory1 = createFakePlugin(
-            'plugin1', packagesDir,
-            withExtraFiles: <List<String>>[
-              <String>['example', 'test'],
-            ],
-            platformSupport: <String, PlatformSupport>{
-              kPlatformIos: PlatformSupport.inline
-            });
-        final Directory pluginDirectory2 = createFakePlugin(
-            'plugin2', packagesDir,
-            withExtraFiles: <List<String>>[
-              <String>['example', 'test'],
-            ],
-            platformSupport: <String, PlatformSupport>{
-              kPlatformIos: PlatformSupport.inline
-            });
+        final Directory pluginDirectory1 =
+            createFakePlugin('plugin1', packagesDir, extraFiles: <List<String>>[
+          <String>['example', 'test'],
+        ], platformSupport: <String, PlatformSupport>{
+          kPlatformIos: PlatformSupport.inline
+        });
+        final Directory pluginDirectory2 =
+            createFakePlugin('plugin2', packagesDir, extraFiles: <List<String>>[
+          <String>['example', 'test'],
+        ], platformSupport: <String, PlatformSupport>{
+          kPlatformIos: PlatformSupport.inline
+        });
 
         final Directory pluginExampleDirectory1 =
             pluginDirectory1.childDirectory('example');
@@ -227,14 +219,12 @@ void main() {
 
       test('Not specifying --ios-destination assigns an available simulator',
           () async {
-        final Directory pluginDirectory = createFakePlugin(
-            'plugin', packagesDir,
-            withExtraFiles: <List<String>>[
-              <String>['example', 'test'],
-            ],
-            platformSupport: <String, PlatformSupport>{
-              kPlatformIos: PlatformSupport.inline
-            });
+        final Directory pluginDirectory =
+            createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+          <String>['example', 'test'],
+        ], platformSupport: <String, PlatformSupport>{
+          kPlatformIos: PlatformSupport.inline
+        });
 
         final Directory pluginExampleDirectory =
             pluginDirectory.childDirectory('example');
@@ -286,7 +276,7 @@ void main() {
         final Directory pluginDirectory = createFakePlugin(
           'plugin',
           packagesDir,
-          withExtraFiles: <List<String>>[
+          extraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
         );
@@ -305,14 +295,12 @@ void main() {
       });
 
       test('skip if macOS is implemented in a federated package', () async {
-        final Directory pluginDirectory = createFakePlugin(
-            'plugin', packagesDir,
-            withExtraFiles: <List<String>>[
-              <String>['example', 'test'],
-            ],
-            platformSupport: <String, PlatformSupport>{
-              kPlatformMacos: PlatformSupport.federated,
-            });
+        final Directory pluginDirectory =
+            createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+          <String>['example', 'test'],
+        ], platformSupport: <String, PlatformSupport>{
+          kPlatformMacos: PlatformSupport.federated,
+        });
 
         createFakePubspec(pluginDirectory.childDirectory('example'),
             isFlutter: true);
@@ -328,14 +316,12 @@ void main() {
       });
 
       test('runs for macOS plugin', () async {
-        final Directory pluginDirectory1 = createFakePlugin(
-            'plugin', packagesDir,
-            withExtraFiles: <List<String>>[
-              <String>['example', 'test'],
-            ],
-            platformSupport: <String, PlatformSupport>{
-              kPlatformMacos: PlatformSupport.inline,
-            });
+        final Directory pluginDirectory1 =
+            createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+          <String>['example', 'test'],
+        ], platformSupport: <String, PlatformSupport>{
+          kPlatformMacos: PlatformSupport.inline,
+        });
 
         final Directory pluginExampleDirectory =
             pluginDirectory1.childDirectory('example');

--- a/script/tool/test/xctest_command_test.dart
+++ b/script/tool/test/xctest_command_test.dart
@@ -113,15 +113,11 @@ void main() {
 
     group('iOS', () {
       test('skip if iOS is not supported', () async {
-        final Directory pluginDirectory =
-            createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
           <String>['example', 'test'],
         ], platformSupport: <String, PlatformSupport>{
           kPlatformMacos: PlatformSupport.inline,
         });
-
-        createFakePubspec(pluginDirectory.childDirectory('example'),
-            isFlutter: true);
 
         final MockProcess mockProcess = MockProcess();
         mockProcess.exitCodeCompleter.complete(0);
@@ -134,15 +130,11 @@ void main() {
       });
 
       test('skip if iOS is implemented in a federated package', () async {
-        final Directory pluginDirectory =
-            createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
           <String>['example', 'test'],
         ], platformSupport: <String, PlatformSupport>{
           kPlatformIos: PlatformSupport.federated
         });
-
-        createFakePubspec(pluginDirectory.childDirectory('example'),
-            isFlutter: true);
 
         final MockProcess mockProcess = MockProcess();
         mockProcess.exitCodeCompleter.complete(0);
@@ -155,8 +147,7 @@ void main() {
       });
 
       test('running with correct destination, exclude 1 plugin', () async {
-        final Directory pluginDirectory1 =
-            createFakePlugin('plugin1', packagesDir, extraFiles: <List<String>>[
+        createFakePlugin('plugin1', packagesDir, extraFiles: <List<String>>[
           <String>['example', 'test'],
         ], platformSupport: <String, PlatformSupport>{
           kPlatformIos: PlatformSupport.inline
@@ -168,12 +159,8 @@ void main() {
           kPlatformIos: PlatformSupport.inline
         });
 
-        final Directory pluginExampleDirectory1 =
-            pluginDirectory1.childDirectory('example');
-        createFakePubspec(pluginExampleDirectory1, isFlutter: true);
         final Directory pluginExampleDirectory2 =
             pluginDirectory2.childDirectory('example');
-        createFakePubspec(pluginExampleDirectory2, isFlutter: true);
 
         final MockProcess mockProcess = MockProcess();
         mockProcess.exitCodeCompleter.complete(0);
@@ -229,8 +216,6 @@ void main() {
         final Directory pluginExampleDirectory =
             pluginDirectory.childDirectory('example');
 
-        createFakePubspec(pluginExampleDirectory, isFlutter: true);
-
         final MockProcess mockProcess = MockProcess();
         mockProcess.exitCodeCompleter.complete(0);
         processRunner.processToReturn = mockProcess;
@@ -273,16 +258,13 @@ void main() {
 
     group('macOS', () {
       test('skip if macOS is not supported', () async {
-        final Directory pluginDirectory = createFakePlugin(
+        createFakePlugin(
           'plugin',
           packagesDir,
           extraFiles: <List<String>>[
             <String>['example', 'test'],
           ],
         );
-
-        createFakePubspec(pluginDirectory.childDirectory('example'),
-            isFlutter: true);
 
         final MockProcess mockProcess = MockProcess();
         mockProcess.exitCodeCompleter.complete(0);
@@ -295,15 +277,11 @@ void main() {
       });
 
       test('skip if macOS is implemented in a federated package', () async {
-        final Directory pluginDirectory =
-            createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
+        createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
           <String>['example', 'test'],
         ], platformSupport: <String, PlatformSupport>{
           kPlatformMacos: PlatformSupport.federated,
         });
-
-        createFakePubspec(pluginDirectory.childDirectory('example'),
-            isFlutter: true);
 
         final MockProcess mockProcess = MockProcess();
         mockProcess.exitCodeCompleter.complete(0);
@@ -325,7 +303,6 @@ void main() {
 
         final Directory pluginExampleDirectory =
             pluginDirectory1.childDirectory('example');
-        createFakePubspec(pluginExampleDirectory, isFlutter: true);
 
         final MockProcess mockProcess = MockProcess();
         mockProcess.exitCodeCompleter.complete(0);


### PR DESCRIPTION
createFakePlugin is used extensively in tests, but has become more and more complex over time. This substantially refactors it and related test utilities:
- Extracts a createFakePackage for the cases where we want non-plugin packages (allowing the removal of isFlutter from createFakePlugin).
- Makes most things created automatically instead of being opt-in, so that tests are operating on things that look more like actual packages/plugins unless they specifically override that behavior:
  - Version is added by default.
  - An example/ directory is added by default.
  - A CHANGELOG is added (it can be deleted manually if we ever need to test for that).
- Combines the two different ways of defining the example format.
- Replaces the list of platform boolean with a map of platform name to details. This allows more control over how things are set in the pubspec (currently, federated vs inline), rather than requiring rewriting the pubspec after creation.
- Uses the platform constants in more places instead of raw strings, and renames them to reflect the more general use.
- Eliminates almost all calls to createFakePubspec, as it is almost never needed any more.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
