### PR TITLE
[flutter_plugin_tools] Simplify extraFiles in test utils

### DIFF
--- a/script/tool/test/analyze_command_test.dart
+++ b/script/tool/test/analyze_command_test.dart
@@ -120,28 +120,24 @@ void main() {
 
   group('verifies analysis settings', () {
     test('fails analysis_options.yaml', () async {
-      createFakePlugin('foo', packagesDir, extraFiles: <List<String>>[
-        <String>['analysis_options.yaml']
-      ]);
+      createFakePlugin('foo', packagesDir,
+          extraFiles: <String>['analysis_options.yaml']);
 
       await expectLater(() => runner.run(<String>['analyze']),
           throwsA(const TypeMatcher<ToolExit>()));
     });
 
     test('fails .analysis_options', () async {
-      createFakePlugin('foo', packagesDir, extraFiles: <List<String>>[
-        <String>['.analysis_options']
-      ]);
+      createFakePlugin('foo', packagesDir,
+          extraFiles: <String>['.analysis_options']);
 
       await expectLater(() => runner.run(<String>['analyze']),
           throwsA(const TypeMatcher<ToolExit>()));
     });
 
     test('takes an allow list', () async {
-      final Directory pluginDir =
-          createFakePlugin('foo', packagesDir, extraFiles: <List<String>>[
-        <String>['analysis_options.yaml']
-      ]);
+      final Directory pluginDir = createFakePlugin('foo', packagesDir,
+          extraFiles: <String>['analysis_options.yaml']);
 
       final MockProcess mockProcess = MockProcess();
       mockProcess.exitCodeCompleter.complete(0);
@@ -160,9 +156,8 @@ void main() {
 
     // See: https://github.com/flutter/flutter/issues/78994
     test('takes an empty allow list', () async {
-      createFakePlugin('foo', packagesDir, extraFiles: <List<String>>[
-        <String>['analysis_options.yaml']
-      ]);
+      createFakePlugin('foo', packagesDir,
+          extraFiles: <String>['analysis_options.yaml']);
 
       final MockProcess mockProcess = MockProcess();
       mockProcess.exitCodeCompleter.complete(0);

--- a/script/tool/test/build_examples_command_test.dart
+++ b/script/tool/test/build_examples_command_test.dart
@@ -37,10 +37,8 @@ void main() {
 
     test('building for iOS when plugin is not set up for iOS results in no-op',
         () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
-        <String>['example', 'test'],
-      ]);
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+          extraFiles: <String>['example/test']);
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -66,12 +64,16 @@ void main() {
     });
 
     test('building for ios', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
-        <String>['example', 'test'],
-      ], platformSupport: <String, PlatformSupport>{
-        kPlatformIos: PlatformSupport.inline
-      });
+      final Directory pluginDirectory = createFakePlugin(
+        'plugin',
+        packagesDir,
+        extraFiles: <String>[
+          'example/test',
+        ],
+        platformSupport: <String, PlatformSupport>{
+          kPlatformIos: PlatformSupport.inline
+        },
+      );
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -113,8 +115,8 @@ void main() {
         'building for Linux when plugin is not set up for Linux results in no-op',
         () async {
       final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
-        <String>['example', 'test'],
+          createFakePlugin('plugin', packagesDir, extraFiles: <String>[
+        'example/test',
       ]);
 
       final Directory pluginExampleDirectory =
@@ -141,12 +143,16 @@ void main() {
     });
 
     test('building for Linux', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
-        <String>['example', 'test'],
-      ], platformSupport: <String, PlatformSupport>{
-        kPlatformLinux: PlatformSupport.inline,
-      });
+      final Directory pluginDirectory = createFakePlugin(
+        'plugin',
+        packagesDir,
+        extraFiles: <String>[
+          'example/test',
+        ],
+        platformSupport: <String, PlatformSupport>{
+          kPlatformLinux: PlatformSupport.inline,
+        },
+      );
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -176,8 +182,8 @@ void main() {
     test('building for macos with no implementation results in no-op',
         () async {
       final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
-        <String>['example', 'test'],
+          createFakePlugin('plugin', packagesDir, extraFiles: <String>[
+        'example/test',
       ]);
 
       final Directory pluginExampleDirectory =
@@ -204,13 +210,17 @@ void main() {
     });
 
     test('building for macos', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
-        <String>['example', 'test'],
-        <String>['example', 'macos', 'macos.swift'],
-      ], platformSupport: <String, PlatformSupport>{
-        kPlatformMacos: PlatformSupport.inline,
-      });
+      final Directory pluginDirectory = createFakePlugin(
+        'plugin',
+        packagesDir,
+        extraFiles: <String>[
+          'example/test',
+          'example/macos/macos.swift',
+        ],
+        platformSupport: <String, PlatformSupport>{
+          kPlatformMacos: PlatformSupport.inline,
+        },
+      );
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -239,8 +249,8 @@ void main() {
 
     test('building for web with no implementation results in no-op', () async {
       final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
-        <String>['example', 'test'],
+          createFakePlugin('plugin', packagesDir, extraFiles: <String>[
+        'example/test',
       ]);
 
       final Directory pluginExampleDirectory =
@@ -267,13 +277,17 @@ void main() {
     });
 
     test('building for web', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
-        <String>['example', 'test'],
-        <String>['example', 'web', 'index.html'],
-      ], platformSupport: <String, PlatformSupport>{
-        kPlatformWeb: PlatformSupport.inline,
-      });
+      final Directory pluginDirectory = createFakePlugin(
+        'plugin',
+        packagesDir,
+        extraFiles: <String>[
+          'example/test',
+          'example/web/index.html',
+        ],
+        platformSupport: <String, PlatformSupport>{
+          kPlatformWeb: PlatformSupport.inline,
+        },
+      );
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -304,8 +318,8 @@ void main() {
         'building for Windows when plugin is not set up for Windows results in no-op',
         () async {
       final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
-        <String>['example', 'test'],
+          createFakePlugin('plugin', packagesDir, extraFiles: <String>[
+        'example/test',
       ]);
 
       final Directory pluginExampleDirectory =
@@ -332,12 +346,16 @@ void main() {
     });
 
     test('building for windows', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
-        <String>['example', 'test'],
-      ], platformSupport: <String, PlatformSupport>{
-        kPlatformWindows: PlatformSupport.inline
-      });
+      final Directory pluginDirectory = createFakePlugin(
+        'plugin',
+        packagesDir,
+        extraFiles: <String>[
+          'example/test',
+        ],
+        platformSupport: <String, PlatformSupport>{
+          kPlatformWindows: PlatformSupport.inline
+        },
+      );
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -368,8 +386,8 @@ void main() {
         'building for Android when plugin is not set up for Android results in no-op',
         () async {
       final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
-        <String>['example', 'test'],
+          createFakePlugin('plugin', packagesDir, extraFiles: <String>[
+        'example/test',
       ]);
 
       final Directory pluginExampleDirectory =
@@ -396,12 +414,16 @@ void main() {
     });
 
     test('building for android', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
-        <String>['example', 'test'],
-      ], platformSupport: <String, PlatformSupport>{
-        kPlatformAndroid: PlatformSupport.inline
-      });
+      final Directory pluginDirectory = createFakePlugin(
+        'plugin',
+        packagesDir,
+        extraFiles: <String>[
+          'example/test',
+        ],
+        platformSupport: <String, PlatformSupport>{
+          kPlatformAndroid: PlatformSupport.inline
+        },
+      );
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -433,12 +455,16 @@ void main() {
     });
 
     test('enable-experiment flag for Android', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
-        <String>['example', 'test'],
-      ], platformSupport: <String, PlatformSupport>{
-        kPlatformAndroid: PlatformSupport.inline
-      });
+      final Directory pluginDirectory = createFakePlugin(
+        'plugin',
+        packagesDir,
+        extraFiles: <String>[
+          'example/test',
+        ],
+        platformSupport: <String, PlatformSupport>{
+          kPlatformAndroid: PlatformSupport.inline
+        },
+      );
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -462,12 +488,16 @@ void main() {
     });
 
     test('enable-experiment flag for ios', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
-        <String>['example', 'test'],
-      ], platformSupport: <String, PlatformSupport>{
-        kPlatformIos: PlatformSupport.inline
-      });
+      final Directory pluginDirectory = createFakePlugin(
+        'plugin',
+        packagesDir,
+        extraFiles: <String>[
+          'example/test',
+        ],
+        platformSupport: <String, PlatformSupport>{
+          kPlatformIos: PlatformSupport.inline
+        },
+      );
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');

--- a/script/tool/test/drive_examples_command_test.dart
+++ b/script/tool/test/drive_examples_command_test.dart
@@ -36,14 +36,18 @@ void main() {
     });
 
     test('driving under folder "test"', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
-        <String>['example', 'test_driver', 'plugin_test.dart'],
-        <String>['example', 'test', 'plugin.dart'],
-      ], platformSupport: <String, PlatformSupport>{
-        kPlatformAndroid: PlatformSupport.inline,
-        kPlatformIos: PlatformSupport.inline,
-      });
+      final Directory pluginDirectory = createFakePlugin(
+        'plugin',
+        packagesDir,
+        extraFiles: <String>[
+          'example/test_driver/plugin_test.dart',
+          'example/test/plugin.dart',
+        ],
+        platformSupport: <String, PlatformSupport>{
+          kPlatformAndroid: PlatformSupport.inline,
+          kPlatformIos: PlatformSupport.inline,
+        },
+      );
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -80,14 +84,18 @@ void main() {
     });
 
     test('driving under folder "test_driver"', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
-        <String>['example', 'test_driver', 'plugin_test.dart'],
-        <String>['example', 'test_driver', 'plugin.dart'],
-      ], platformSupport: <String, PlatformSupport>{
-        kPlatformAndroid: PlatformSupport.inline,
-        kPlatformIos: PlatformSupport.inline,
-      });
+      final Directory pluginDirectory = createFakePlugin(
+        'plugin',
+        packagesDir,
+        extraFiles: <String>[
+          'example/test_driver/plugin_test.dart',
+          'example/test_driver/plugin.dart',
+        ],
+        platformSupport: <String, PlatformSupport>{
+          kPlatformAndroid: PlatformSupport.inline,
+          kPlatformIos: PlatformSupport.inline,
+        },
+      );
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -125,12 +133,17 @@ void main() {
 
     test('driving under folder "test_driver" when test files are missing"',
         () async {
-      createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
-        <String>['example', 'test_driver', 'plugin_test.dart'],
-      ], platformSupport: <String, PlatformSupport>{
-        kPlatformAndroid: PlatformSupport.inline,
-        kPlatformIos: PlatformSupport.inline,
-      });
+      createFakePlugin(
+        'plugin',
+        packagesDir,
+        extraFiles: <String>[
+          'example/test_driver/plugin_test.dart',
+        ],
+        platformSupport: <String, PlatformSupport>{
+          kPlatformAndroid: PlatformSupport.inline,
+          kPlatformIos: PlatformSupport.inline,
+        },
+      );
 
       await expectLater(
           () => runCapturingPrint(runner, <String>['drive-examples']),
@@ -139,12 +152,17 @@ void main() {
 
     test('a plugin without any integration test files is reported as an error',
         () async {
-      createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
-        <String>['example', 'lib', 'main.dart'],
-      ], platformSupport: <String, PlatformSupport>{
-        kPlatformAndroid: PlatformSupport.inline,
-        kPlatformIos: PlatformSupport.inline,
-      });
+      createFakePlugin(
+        'plugin',
+        packagesDir,
+        extraFiles: <String>[
+          'example/lib/main.dart',
+        ],
+        platformSupport: <String, PlatformSupport>{
+          kPlatformAndroid: PlatformSupport.inline,
+          kPlatformIos: PlatformSupport.inline,
+        },
+      );
 
       await expectLater(
           () => runCapturingPrint(runner, <String>['drive-examples']),
@@ -154,16 +172,20 @@ void main() {
     test(
         'driving under folder "test_driver" when targets are under "integration_test"',
         () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
-        <String>['example', 'test_driver', 'integration_test.dart'],
-        <String>['example', 'integration_test', 'bar_test.dart'],
-        <String>['example', 'integration_test', 'foo_test.dart'],
-        <String>['example', 'integration_test', 'ignore_me.dart'],
-      ], platformSupport: <String, PlatformSupport>{
-        kPlatformAndroid: PlatformSupport.inline,
-        kPlatformIos: PlatformSupport.inline,
-      });
+      final Directory pluginDirectory = createFakePlugin(
+        'plugin',
+        packagesDir,
+        extraFiles: <String>[
+          'example/test_driver/integration_test.dart',
+          'example/integration_test/bar_test.dart',
+          'example/integration_test/foo_test.dart',
+          'example/integration_test/ignore_me.dart',
+        ],
+        platformSupport: <String, PlatformSupport>{
+          kPlatformAndroid: PlatformSupport.inline,
+          kPlatformIos: PlatformSupport.inline,
+        },
+      );
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -210,9 +232,9 @@ void main() {
     });
 
     test('driving when plugin does not support Linux is a no-op', () async {
-      createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
-        <String>['example', 'test_driver', 'plugin_test.dart'],
-        <String>['example', 'test_driver', 'plugin.dart'],
+      createFakePlugin('plugin', packagesDir, extraFiles: <String>[
+        'example/test_driver/plugin_test.dart',
+        'example/test_driver/plugin.dart',
       ]);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
@@ -236,13 +258,17 @@ void main() {
     });
 
     test('driving on a Linux plugin', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
-        <String>['example', 'test_driver', 'plugin_test.dart'],
-        <String>['example', 'test_driver', 'plugin.dart'],
-      ], platformSupport: <String, PlatformSupport>{
-        kPlatformLinux: PlatformSupport.inline,
-      });
+      final Directory pluginDirectory = createFakePlugin(
+        'plugin',
+        packagesDir,
+        extraFiles: <String>[
+          'example/test_driver/plugin_test.dart',
+          'example/test_driver/plugin.dart',
+        ],
+        platformSupport: <String, PlatformSupport>{
+          kPlatformLinux: PlatformSupport.inline,
+        },
+      );
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -282,9 +308,9 @@ void main() {
     });
 
     test('driving when plugin does not suppport macOS is a no-op', () async {
-      createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
-        <String>['example', 'test_driver', 'plugin_test.dart'],
-        <String>['example', 'test_driver', 'plugin.dart'],
+      createFakePlugin('plugin', packagesDir, extraFiles: <String>[
+        'example/test_driver/plugin_test.dart',
+        'example/test_driver/plugin.dart',
       ]);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
@@ -307,14 +333,18 @@ void main() {
       expect(processRunner.recordedCalls, <ProcessCall>[]);
     });
     test('driving on a macOS plugin', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
-        <String>['example', 'test_driver', 'plugin_test.dart'],
-        <String>['example', 'test_driver', 'plugin.dart'],
-        <String>['example', 'macos', 'macos.swift'],
-      ], platformSupport: <String, PlatformSupport>{
-        kPlatformMacos: PlatformSupport.inline,
-      });
+      final Directory pluginDirectory = createFakePlugin(
+        'plugin',
+        packagesDir,
+        extraFiles: <String>[
+          'example/test_driver/plugin_test.dart',
+          'example/test_driver/plugin.dart',
+          'example/macos/macos.swift',
+        ],
+        platformSupport: <String, PlatformSupport>{
+          kPlatformMacos: PlatformSupport.inline,
+        },
+      );
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -354,9 +384,9 @@ void main() {
     });
 
     test('driving when plugin does not suppport web is a no-op', () async {
-      createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
-        <String>['example', 'test_driver', 'plugin_test.dart'],
-        <String>['example', 'test_driver', 'plugin.dart'],
+      createFakePlugin('plugin', packagesDir, extraFiles: <String>[
+        'example/test_driver/plugin_test.dart',
+        'example/test_driver/plugin.dart',
       ]);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
@@ -380,13 +410,17 @@ void main() {
     });
 
     test('driving a web plugin', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
-        <String>['example', 'test_driver', 'plugin_test.dart'],
-        <String>['example', 'test_driver', 'plugin.dart'],
-      ], platformSupport: <String, PlatformSupport>{
-        kPlatformWeb: PlatformSupport.inline,
-      });
+      final Directory pluginDirectory = createFakePlugin(
+        'plugin',
+        packagesDir,
+        extraFiles: <String>[
+          'example/test_driver/plugin_test.dart',
+          'example/test_driver/plugin.dart',
+        ],
+        platformSupport: <String, PlatformSupport>{
+          kPlatformWeb: PlatformSupport.inline,
+        },
+      );
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -428,9 +462,9 @@ void main() {
     });
 
     test('driving when plugin does not suppport Windows is a no-op', () async {
-      createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
-        <String>['example', 'test_driver', 'plugin_test.dart'],
-        <String>['example', 'test_driver', 'plugin.dart'],
+      createFakePlugin('plugin', packagesDir, extraFiles: <String>[
+        'example/test_driver/plugin_test.dart',
+        'example/test_driver/plugin.dart',
       ]);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
@@ -454,13 +488,17 @@ void main() {
     });
 
     test('driving on a Windows plugin', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
-        <String>['example', 'test_driver', 'plugin_test.dart'],
-        <String>['example', 'test_driver', 'plugin.dart'],
-      ], platformSupport: <String, PlatformSupport>{
-        kPlatformWindows: PlatformSupport.inline
-      });
+      final Directory pluginDirectory = createFakePlugin(
+        'plugin',
+        packagesDir,
+        extraFiles: <String>[
+          'example/test_driver/plugin_test.dart',
+          'example/test_driver/plugin.dart',
+        ],
+        platformSupport: <String, PlatformSupport>{
+          kPlatformWindows: PlatformSupport.inline
+        },
+      );
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
@@ -500,12 +538,17 @@ void main() {
     });
 
     test('driving when plugin does not support mobile is no-op', () async {
-      createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
-        <String>['example', 'test_driver', 'plugin_test.dart'],
-        <String>['example', 'test_driver', 'plugin.dart'],
-      ], platformSupport: <String, PlatformSupport>{
-        kPlatformMacos: PlatformSupport.inline,
-      });
+      createFakePlugin(
+        'plugin',
+        packagesDir,
+        extraFiles: <String>[
+          'example/test_driver/plugin_test.dart',
+          'example/test_driver/plugin.dart',
+        ],
+        platformSupport: <String, PlatformSupport>{
+          kPlatformMacos: PlatformSupport.inline,
+        },
+      );
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'drive-examples',
@@ -548,14 +591,18 @@ void main() {
     });
 
     test('enable-experiment flag', () async {
-      final Directory pluginDirectory =
-          createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
-        <String>['example', 'test_driver', 'plugin_test.dart'],
-        <String>['example', 'test', 'plugin.dart'],
-      ], platformSupport: <String, PlatformSupport>{
-        kPlatformAndroid: PlatformSupport.inline,
-        kPlatformIos: PlatformSupport.inline,
-      });
+      final Directory pluginDirectory = createFakePlugin(
+        'plugin',
+        packagesDir,
+        extraFiles: <String>[
+          'example/test_driver/plugin_test.dart',
+          'example/test/plugin.dart',
+        ],
+        platformSupport: <String, PlatformSupport>{
+          kPlatformAndroid: PlatformSupport.inline,
+          kPlatformIos: PlatformSupport.inline,
+        },
+      );
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');

--- a/script/tool/test/firebase_test_lab_test.dart
+++ b/script/tool/test/firebase_test_lab_test.dart
@@ -40,20 +40,13 @@ void main() {
       final MockProcess mockProcess = MockProcess();
       mockProcess.exitCodeCompleter.complete(1);
       processRunner.processToReturn = mockProcess;
-      createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
-        <String>['lib/test/should_not_run_e2e.dart'],
-        <String>['example', 'test_driver', 'plugin_e2e.dart'],
-        <String>['example', 'test_driver', 'plugin_e2e_test.dart'],
-        <String>['example', 'android', 'gradlew'],
-        <String>['example', 'should_not_run_e2e.dart'],
-        <String>[
-          'example',
-          'android',
-          'app',
-          'src',
-          'androidTest',
-          'MainActivityTest.java'
-        ],
+      createFakePlugin('plugin', packagesDir, extraFiles: <String>[
+        'lib/test/should_not_run_e2e.dart',
+        'example/test_driver/plugin_e2e.dart',
+        'example/test_driver/plugin_e2e_test.dart',
+        'example/android/gradlew',
+        'example/should_not_run_e2e.dart',
+        'example/android/app/src/androidTest/MainActivityTest.java',
       ]);
       await expectLater(
           () => runCapturingPrint(runner, <String>['firebase-test-lab']),
@@ -65,26 +58,19 @@ void main() {
     });
 
     test('runs e2e tests', () async {
-      createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
-        <String>['test', 'plugin_test.dart'],
-        <String>['test', 'plugin_e2e.dart'],
-        <String>['should_not_run_e2e.dart'],
-        <String>['lib/test/should_not_run_e2e.dart'],
-        <String>['example', 'test', 'plugin_e2e.dart'],
-        <String>['example', 'test_driver', 'plugin_e2e.dart'],
-        <String>['example', 'test_driver', 'plugin_e2e_test.dart'],
-        <String>['example', 'integration_test', 'foo_test.dart'],
-        <String>['example', 'integration_test', 'should_not_run.dart'],
-        <String>['example', 'android', 'gradlew'],
-        <String>['example', 'should_not_run_e2e.dart'],
-        <String>[
-          'example',
-          'android',
-          'app',
-          'src',
-          'androidTest',
-          'MainActivityTest.java'
-        ],
+      createFakePlugin('plugin', packagesDir, extraFiles: <String>[
+        'test/plugin_test.dart',
+        'test/plugin_e2e.dart',
+        'should_not_run_e2e.dart',
+        'lib/test/should_not_run_e2e.dart',
+        'example/test/plugin_e2e.dart',
+        'example/test_driver/plugin_e2e.dart',
+        'example/test_driver/plugin_e2e_test.dart',
+        'example/integration_test/foo_test.dart',
+        'example/integration_test/should_not_run.dart',
+        'example/android/gradlew',
+        'example/should_not_run_e2e.dart',
+        'example/android/app/src/androidTest/MainActivityTest.java',
       ]);
 
       await runCapturingPrint(runner, <String>[
@@ -168,26 +154,19 @@ void main() {
     });
 
     test('experimental flag', () async {
-      createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
-        <String>['test', 'plugin_test.dart'],
-        <String>['test', 'plugin_e2e.dart'],
-        <String>['should_not_run_e2e.dart'],
-        <String>['lib/test/should_not_run_e2e.dart'],
-        <String>['example', 'test', 'plugin_e2e.dart'],
-        <String>['example', 'test_driver', 'plugin_e2e.dart'],
-        <String>['example', 'test_driver', 'plugin_e2e_test.dart'],
-        <String>['example', 'integration_test', 'foo_test.dart'],
-        <String>['example', 'integration_test', 'should_not_run.dart'],
-        <String>['example', 'android', 'gradlew'],
-        <String>['example', 'should_not_run_e2e.dart'],
-        <String>[
-          'example',
-          'android',
-          'app',
-          'src',
-          'androidTest',
-          'MainActivityTest.java'
-        ],
+      createFakePlugin('plugin', packagesDir, extraFiles: <String>[
+        'test/plugin_test.dart',
+        'test/plugin_e2e.dart',
+        'should_not_run_e2e.dart',
+        'lib/test/should_not_run_e2e.dart',
+        'example/test/plugin_e2e.dart',
+        'example/test_driver/plugin_e2e.dart',
+        'example/test_driver/plugin_e2e_test.dart',
+        'example/integration_test/foo_test.dart',
+        'example/integration_test/should_not_run.dart',
+        'example/android/gradlew',
+        'example/should_not_run_e2e.dart',
+        'example/android/app/src/androidTest/MainActivityTest.java',
       ]);
 
       await runCapturingPrint(runner, <String>[

--- a/script/tool/test/java_test_command_test.dart
+++ b/script/tool/test/java_test_command_test.dart
@@ -39,9 +39,9 @@ void main() {
         platformSupport: <String, PlatformSupport>{
           kPlatformAndroid: PlatformSupport.inline
         },
-        extraFiles: <List<String>>[
-          <String>['example/android', 'gradlew'],
-          <String>['android/src/test', 'example_test.java'],
+        extraFiles: <String>[
+          'example/android/gradlew',
+          'android/src/test/example_test.java',
         ],
       );
 
@@ -66,9 +66,9 @@ void main() {
         platformSupport: <String, PlatformSupport>{
           kPlatformAndroid: PlatformSupport.inline
         },
-        extraFiles: <List<String>>[
-          <String>['example/android', 'gradlew'],
-          <String>['example/android/app/src/test', 'example_test.java'],
+        extraFiles: <String>[
+          'example/android/gradlew',
+          'example/android/app/src/test/example_test.java',
         ],
       );
 

--- a/script/tool/test/lint_podspecs_command_test.dart
+++ b/script/tool/test/lint_podspecs_command_test.dart
@@ -45,9 +45,8 @@ void main() {
     });
 
     test('only runs on macOS', () async {
-      createFakePlugin('plugin1', packagesDir, extraFiles: <List<String>>[
-        <String>['plugin1.podspec'],
-      ]);
+      createFakePlugin('plugin1', packagesDir,
+          extraFiles: <String>['plugin1.podspec']);
 
       mockPlatform.isMacOS = false;
       await runner.run(<String>['podspecs']);
@@ -59,11 +58,14 @@ void main() {
     });
 
     test('runs pod lib lint on a podspec', () async {
-      final Directory plugin1Dir =
-          createFakePlugin('plugin1', packagesDir, extraFiles: <List<String>>[
-        <String>['ios', 'plugin1.podspec'],
-        <String>['bogus.dart'], // Ignore non-podspecs.
-      ]);
+      final Directory plugin1Dir = createFakePlugin(
+        'plugin1',
+        packagesDir,
+        extraFiles: <String>[
+          'ios/plugin1.podspec',
+          'bogus.dart', // Ignore non-podspecs.
+        ],
+      );
 
       processRunner.resultStdout = 'Foo';
       processRunner.resultStderr = 'Bar';
@@ -106,12 +108,10 @@ void main() {
     });
 
     test('skips podspecs with known issues', () async {
-      createFakePlugin('plugin1', packagesDir, extraFiles: <List<String>>[
-        <String>['plugin1.podspec']
-      ]);
-      createFakePlugin('plugin2', packagesDir, extraFiles: <List<String>>[
-        <String>['plugin2.podspec']
-      ]);
+      createFakePlugin('plugin1', packagesDir,
+          extraFiles: <String>['plugin1.podspec']);
+      createFakePlugin('plugin2', packagesDir,
+          extraFiles: <String>['plugin2.podspec']);
 
       await runner
           .run(<String>['podspecs', '--skip=plugin1', '--skip=plugin2']);
@@ -125,10 +125,8 @@ void main() {
     });
 
     test('allow warnings for podspecs with known warnings', () async {
-      final Directory plugin1Dir =
-          createFakePlugin('plugin1', packagesDir, extraFiles: <List<String>>[
-        <String>['plugin1.podspec'],
-      ]);
+      final Directory plugin1Dir = createFakePlugin('plugin1', packagesDir,
+          extraFiles: <String>['plugin1.podspec']);
 
       await runner.run(<String>['podspecs', '--ignore-warnings=plugin1']);
 

--- a/script/tool/test/test_command_test.dart
+++ b/script/tool/test/test_command_test.dart
@@ -31,14 +31,10 @@ void main() {
     });
 
     test('runs flutter test on each plugin', () async {
-      final Directory plugin1Dir =
-          createFakePlugin('plugin1', packagesDir, extraFiles: <List<String>>[
-        <String>['test', 'empty_test.dart'],
-      ]);
-      final Directory plugin2Dir =
-          createFakePlugin('plugin2', packagesDir, extraFiles: <List<String>>[
-        <String>['test', 'empty_test.dart'],
-      ]);
+      final Directory plugin1Dir = createFakePlugin('plugin1', packagesDir,
+          extraFiles: <String>['test/empty_test.dart']);
+      final Directory plugin2Dir = createFakePlugin('plugin2', packagesDir,
+          extraFiles: <String>['test/empty_test.dart']);
 
       await runner.run(<String>['test']);
 
@@ -55,10 +51,8 @@ void main() {
 
     test('skips testing plugins without test directory', () async {
       createFakePlugin('plugin1', packagesDir);
-      final Directory plugin2Dir =
-          createFakePlugin('plugin2', packagesDir, extraFiles: <List<String>>[
-        <String>['test', 'empty_test.dart'],
-      ]);
+      final Directory plugin2Dir = createFakePlugin('plugin2', packagesDir,
+          extraFiles: <String>['test/empty_test.dart']);
 
       await runner.run(<String>['test']);
 
@@ -72,14 +66,10 @@ void main() {
     });
 
     test('runs pub run test on non-Flutter packages', () async {
-      final Directory pluginDir =
-          createFakePlugin('a', packagesDir, extraFiles: <List<String>>[
-        <String>['test', 'empty_test.dart'],
-      ]);
-      final Directory packageDir =
-          createFakePackage('b', packagesDir, extraFiles: <List<String>>[
-        <String>['test', 'empty_test.dart'],
-      ]);
+      final Directory pluginDir = createFakePlugin('a', packagesDir,
+          extraFiles: <String>['test/empty_test.dart']);
+      final Directory packageDir = createFakePackage('b', packagesDir,
+          extraFiles: <String>['test/empty_test.dart']);
 
       await runner.run(<String>['test', '--enable-experiment=exp1']);
 
@@ -103,9 +93,7 @@ void main() {
       final Directory pluginDir = createFakePlugin(
         'plugin',
         packagesDir,
-        extraFiles: <List<String>>[
-          <String>['test', 'empty_test.dart'],
-        ],
+        extraFiles: <String>['test/empty_test.dart'],
         platformSupport: <String, PlatformSupport>{
           kPlatformWeb: PlatformSupport.inline,
         },
@@ -125,14 +113,10 @@ void main() {
     });
 
     test('enable-experiment flag', () async {
-      final Directory pluginDir =
-          createFakePlugin('a', packagesDir, extraFiles: <List<String>>[
-        <String>['test', 'empty_test.dart'],
-      ]);
-      final Directory packageDir =
-          createFakePackage('b', packagesDir, extraFiles: <List<String>>[
-        <String>['test', 'empty_test.dart'],
-      ]);
+      final Directory pluginDir = createFakePlugin('a', packagesDir,
+          extraFiles: <String>['test/empty_test.dart']);
+      final Directory packageDir = createFakePackage('b', packagesDir,
+          extraFiles: <String>['test/empty_test.dart']);
 
       await runner.run(<String>['test', '--enable-experiment=exp1']);
 

--- a/script/tool/test/util.dart
+++ b/script/tool/test/util.dart
@@ -13,6 +13,7 @@ import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/common/plugin_utils.dart';
 import 'package:flutter_plugin_tools/src/common/process_runner.dart';
 import 'package:meta/meta.dart';
+import 'package:path/path.dart' as p;
 import 'package:quiver/collection.dart';
 
 /// Creates a packages directory in the given location.
@@ -36,11 +37,14 @@ Directory createPackagesDirectory(
 ///
 /// [platformSupport] is a map of platform string to the support details for
 /// that platform.
+///
+/// [extraFiles] is an optional list of plugin-relative paths, using unix-style
+/// separators, of extra files to create in the plugin.
 Directory createFakePlugin(
   String name,
   Directory parentDirectory, {
   List<String> examples = const <String>['example'],
-  List<List<String>> extraFiles = const <List<String>>[],
+  List<String> extraFiles = const <String>[],
   Map<String, PlatformSupport> platformSupport =
       const <String, PlatformSupport>{},
   String? version = '0.0.1',
@@ -60,22 +64,18 @@ Directory createFakePlugin(
     version: version,
   );
 
-  final FileSystem fileSystem = pluginDirectory.fileSystem;
-  for (final List<String> file in extraFiles) {
-    final List<String> newFilePath = <String>[pluginDirectory.path, ...file];
-    final File newFile = fileSystem.file(fileSystem.path.joinAll(newFilePath));
-    newFile.createSync(recursive: true);
-  }
-
   return pluginDirectory;
 }
 
 /// Creates a plugin package with the given [name] in [packagesDirectory].
+///
+/// [extraFiles] is an optional list of package-relative paths, using unix-style
+/// separators, of extra files to create in the package.
 Directory createFakePackage(
   String name,
   Directory parentDirectory, {
   List<String> examples = const <String>['example'],
-  List<List<String>> extraFiles = const <List<String>>[],
+  List<String> extraFiles = const <String>[],
   bool isFlutter = false,
   String? version = '0.0.1',
 }) {
@@ -105,8 +105,11 @@ Directory createFakePackage(
   }
 
   final FileSystem fileSystem = packageDirectory.fileSystem;
-  for (final List<String> file in extraFiles) {
-    final List<String> newFilePath = <String>[packageDirectory.path, ...file];
+  for (final String file in extraFiles) {
+    final List<String> newFilePath = <String>[
+      packageDirectory.path,
+      ...p.split(file)
+    ];
     final File newFile = fileSystem.file(fileSystem.path.joinAll(newFilePath));
     newFile.createSync(recursive: true);
   }

--- a/script/tool/test/util.dart
+++ b/script/tool/test/util.dart
@@ -38,7 +38,7 @@ Directory createPackagesDirectory(
 /// [platformSupport] is a map of platform string to the support details for
 /// that platform.
 ///
-/// [extraFiles] is an optional list of plugin-relative paths, using unix-style
+/// [extraFiles] is an optional list of plugin-relative paths, using Posix
 /// separators, of extra files to create in the plugin.
 Directory createFakePlugin(
   String name,
@@ -105,10 +105,11 @@ Directory createFakePackage(
   }
 
   final FileSystem fileSystem = packageDirectory.fileSystem;
+  final p.Context posixContext = p.posix;
   for (final String file in extraFiles) {
     final List<String> newFilePath = <String>[
       packageDirectory.path,
-      ...p.split(file)
+      ...posixContext.split(file)
     ];
     final File newFile = fileSystem.file(fileSystem.path.joinAll(newFilePath));
     newFile.createSync(recursive: true);

--- a/script/tool/test/xctest_command_test.dart
+++ b/script/tool/test/xctest_command_test.dart
@@ -113,8 +113,8 @@ void main() {
 
     group('iOS', () {
       test('skip if iOS is not supported', () async {
-        createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
-          <String>['example', 'test'],
+        createFakePlugin('plugin', packagesDir, extraFiles: <String>[
+          'example/test',
         ], platformSupport: <String, PlatformSupport>{
           kPlatformMacos: PlatformSupport.inline,
         });
@@ -130,8 +130,8 @@ void main() {
       });
 
       test('skip if iOS is implemented in a federated package', () async {
-        createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
-          <String>['example', 'test'],
+        createFakePlugin('plugin', packagesDir, extraFiles: <String>[
+          'example/test',
         ], platformSupport: <String, PlatformSupport>{
           kPlatformIos: PlatformSupport.federated
         });
@@ -147,14 +147,14 @@ void main() {
       });
 
       test('running with correct destination, exclude 1 plugin', () async {
-        createFakePlugin('plugin1', packagesDir, extraFiles: <List<String>>[
-          <String>['example', 'test'],
+        createFakePlugin('plugin1', packagesDir, extraFiles: <String>[
+          'example/test',
         ], platformSupport: <String, PlatformSupport>{
           kPlatformIos: PlatformSupport.inline
         });
         final Directory pluginDirectory2 =
-            createFakePlugin('plugin2', packagesDir, extraFiles: <List<String>>[
-          <String>['example', 'test'],
+            createFakePlugin('plugin2', packagesDir, extraFiles: <String>[
+          'example/test',
         ], platformSupport: <String, PlatformSupport>{
           kPlatformIos: PlatformSupport.inline
         });
@@ -207,8 +207,8 @@ void main() {
       test('Not specifying --ios-destination assigns an available simulator',
           () async {
         final Directory pluginDirectory =
-            createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
-          <String>['example', 'test'],
+            createFakePlugin('plugin', packagesDir, extraFiles: <String>[
+          'example/test',
         ], platformSupport: <String, PlatformSupport>{
           kPlatformIos: PlatformSupport.inline
         });
@@ -261,8 +261,8 @@ void main() {
         createFakePlugin(
           'plugin',
           packagesDir,
-          extraFiles: <List<String>>[
-            <String>['example', 'test'],
+          extraFiles: <String>[
+            'example/test',
           ],
         );
 
@@ -277,8 +277,8 @@ void main() {
       });
 
       test('skip if macOS is implemented in a federated package', () async {
-        createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
-          <String>['example', 'test'],
+        createFakePlugin('plugin', packagesDir, extraFiles: <String>[
+          'example/test',
         ], platformSupport: <String, PlatformSupport>{
           kPlatformMacos: PlatformSupport.federated,
         });
@@ -295,8 +295,8 @@ void main() {
 
       test('runs for macOS plugin', () async {
         final Directory pluginDirectory1 =
-            createFakePlugin('plugin', packagesDir, extraFiles: <List<String>>[
-          <String>['example', 'test'],
+            createFakePlugin('plugin', packagesDir, extraFiles: <String>[
+          'example/test',
         ], platformSupport: <String, PlatformSupport>{
           kPlatformMacos: PlatformSupport.inline,
         });


### PR DESCRIPTION
Rather than taking a list of list of path elements, just accept a list
of Posix-style paths. In practice, the API was already being partially
used that way.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
