### PR TITLE
[flutter_plugin_tools] Add a new base command for looping over packages

### DIFF
--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `xctest` now supports running macOS tests in addition to iOS
   - **Breaking change**: it now requires an `--ios` and/or `--macos` flag.
 - The tooling now runs in strong null-safe mode.
+- Modified the output format of `pubspec-check` and `xctest`
 
 ## 0.2.0
 

--- a/script/tool/lib/src/common/core.dart
+++ b/script/tool/lib/src/common/core.dart
@@ -64,6 +64,14 @@ void printError(String errorMessage) {
 }
 
 /// Error thrown when a command needs to exit with a non-zero exit code.
+///
+/// While there is no specific definition of the meaning of different non-zero
+/// exit codes for this tool, commands should follow the general convention:
+///   1: The command ran correctly, but found errors.
+///   2: The command failed to run because the arguments were invalid.
+///  >2: The command failed to run correctly for some other reason. Ideally,
+///      each such failure should have a unique exit code within the context of
+///      that command.
 class ToolExit extends Error {
   /// Creates a tool exit with the given [exitCode].
   ToolExit(this.exitCode);
@@ -71,3 +79,9 @@ class ToolExit extends Error {
   /// The code that the process should exit with.
   final int exitCode;
 }
+
+/// A exit code for [ToolExit] for a successful run that found errors.
+const kExitCommandFoundErrors = 1;
+
+/// A exit code for [ToolExit] for a failure to run due to invalid arguments.
+const kExitInvalidArguments = 2;

--- a/script/tool/lib/src/common/core.dart
+++ b/script/tool/lib/src/common/core.dart
@@ -53,10 +53,14 @@ bool isFlutterPackage(FileSystemEntity entity) {
   }
 }
 
+/// Prints `successMessage` in green.
+void printSuccess(String successMessage) {
+  print(Colorize(successMessage)..green());
+}
+
 /// Prints `errorMessage` in red.
 void printError(String errorMessage) {
-  final Colorize redError = Colorize(errorMessage)..red();
-  print(redError);
+  print(Colorize(errorMessage)..red());
 }
 
 /// Error thrown when a command needs to exit with a non-zero exit code.

--- a/script/tool/lib/src/common/core.dart
+++ b/script/tool/lib/src/common/core.dart
@@ -81,7 +81,7 @@ class ToolExit extends Error {
 }
 
 /// A exit code for [ToolExit] for a successful run that found errors.
-const kExitCommandFoundErrors = 1;
+const int exitCommandFoundErrors = 1;
 
 /// A exit code for [ToolExit] for a failure to run due to invalid arguments.
-const kExitInvalidArguments = 2;
+const int exitInvalidArguments = 2;

--- a/script/tool/lib/src/common/package_looping_command.dart
+++ b/script/tool/lib/src/common/package_looping_command.dart
@@ -24,14 +24,14 @@ abstract class PackageLoopingCommand extends PluginCommand {
 
   /// Called during [run] before any calls to [runForPackage]. This provides an
   /// opportunity to fail early if the command can't be run (e.g., because the
-  /// arguments are invalid).
-  void validate() {}
+  /// arguments are invalid), and to set up any run-level state.
+  Future<void> initializeRun() async {}
 
   /// Runs the command for [package], returning a list of errors.
   ///
   /// Errors may either be an empty string if there is no context that should
   /// be included in the final error summary (e.g., a command that only has a
-  /// single failure mode), or strings that should be listed for that plugin
+  /// single failure mode), or strings that should be listed for that package
   /// in the final summary. An empty list indicates success.
   Future<List<String>> runForPackage(Directory package);
 
@@ -67,6 +67,12 @@ abstract class PackageLoopingCommand extends PluginCommand {
   /// context that's more self-documenting than the value.
   static const List<String> kFailure = <String>[];
 
+  /// Prints a message using a standard format indicating that the package was
+  /// skipped, with an explanation of why.
+  void printSkip(String reason) {
+    print(Colorize('SKIPPING: $reason')..darkGray());
+  }
+
   /// Returns the identifying name to use for [package].
   ///
   /// Implementations should not expect a specific format for this string, since
@@ -89,6 +95,8 @@ abstract class PackageLoopingCommand extends PluginCommand {
 
   @override
   Future<void> run() async {
+    await initializeRun();
+
     final List<Directory> packages = await getPackages().toList();
 
     final Map<Directory, List<String>> results = <Directory, List<String>>{};
@@ -134,7 +142,9 @@ abstract class PackageLoopingCommand extends PluginCommand {
 || $heading
 ============================================================
 ''';
+    } else {
+      heading = '$heading...';
     }
-    print(Colorize('$heading...')..cyan());
+    print(Colorize(heading)..cyan());
   }
 }

--- a/script/tool/lib/src/common/package_looping_command.dart
+++ b/script/tool/lib/src/common/package_looping_command.dart
@@ -38,7 +38,11 @@ abstract class PackageLoopingCommand extends PluginCommand {
   /// Whether or not the output (if any) of [runForPackage] is long, or short.
   ///
   /// This changes the logging that happens at the start of each package's
-  /// run.
+  /// run; long output gets a banner-style message to make it easier to find,
+  /// while short output gets a single-line entry.
+  ///
+  /// When this is false, runForPackage output should be indented if possible,
+  /// to make the output structure easier to follow.
   bool get hasLongOutput => true;
 
   /// The text to output at the start when reporting one or more failures.
@@ -79,7 +83,7 @@ abstract class PackageLoopingCommand extends PluginCommand {
   /// it uses heuristics to try to be precise without being overly verbose. If
   /// an exact format (e.g., published name, or basename) is required, that
   /// should be used instead.
-  String packageDescription(Directory package) {
+  String getPackageDescription(Directory package) {
     String packageName = p.relative(package.path, from: packagesDir.path);
     final List<String> components = p.split(packageName);
     // For the common federated plugin pattern of `foo/foo_subpackage`, drop
@@ -117,11 +121,12 @@ abstract class PackageLoopingCommand extends PluginCommand {
           if (errorDetails.isNotEmpty) {
             errorDetails = ':\n$errorIndentation$errorDetails';
           }
-          printError('$indentation${packageDescription(package)}$errorDetails');
+          printError(
+              '$indentation${getPackageDescription(package)}$errorDetails');
         }
       }
       printError(failureListFooter);
-      throw ToolExit(kExitCommandFoundErrors);
+      throw ToolExit(exitCommandFoundErrors);
     }
 
     printSuccess('\n\nNo issues found!');
@@ -134,7 +139,7 @@ abstract class PackageLoopingCommand extends PluginCommand {
   /// a command running for a package and producing no output, and a command
   /// not having been run for a package.
   void _printPackageHeading(Directory package) {
-    String heading = 'Running for ${packageDescription(package)}';
+    String heading = 'Running for ${getPackageDescription(package)}';
     if (hasLongOutput) {
       heading = '''
 

--- a/script/tool/lib/src/common/package_looping_command.dart
+++ b/script/tool/lib/src/common/package_looping_command.dart
@@ -45,6 +45,10 @@ abstract class PackageLoopingCommand extends PluginCommand {
   /// to make the output structure easier to follow.
   bool get hasLongOutput => true;
 
+  /// Whether to loop over all packages (e.g., including example/), rather than
+  /// only top-level packages.
+  bool get includeSubpackages => false;
+
   /// The text to output at the start when reporting one or more failures.
   /// This will be followed by a list of packages that reported errors, with
   /// the per-package details if any.
@@ -65,11 +69,11 @@ abstract class PackageLoopingCommand extends PluginCommand {
 
   /// A convenience constant for [runForPackage] success that's more
   /// self-documenting than the value.
-  static const List<String> kSuccess = <String>[];
+  static const List<String> success = <String>[];
 
   /// A convenience constant for [runForPackage] failure without additional
   /// context that's more self-documenting than the value.
-  static const List<String> kFailure = <String>[''];
+  static const List<String> failure = <String>[''];
 
   /// Prints a message using a standard format indicating that the package was
   /// skipped, with an explanation of why.
@@ -101,7 +105,9 @@ abstract class PackageLoopingCommand extends PluginCommand {
   Future<void> run() async {
     await initializeRun();
 
-    final List<Directory> packages = await getPackages().toList();
+    final List<Directory> packages = includeSubpackages
+        ? await getPackages().toList()
+        : await getPlugins().toList();
 
     final Map<Directory, List<String>> results = <Directory, List<String>>{};
     for (final Directory package in packages) {

--- a/script/tool/lib/src/common/package_looping_command.dart
+++ b/script/tool/lib/src/common/package_looping_command.dart
@@ -22,6 +22,11 @@ abstract class PackageLoopingCommand extends PluginCommand {
     GitDir? gitDir,
   }) : super(packagesDir, processRunner: processRunner, gitDir: gitDir);
 
+  /// Called during [run] before any calls to [runForPackage]. This provides an
+  /// opportunity to fail early if the command can't be run (e.g., because the
+  /// arguments are invalid).
+  void validate() {}
+
   /// Runs the command for [package], returning a list of errors.
   ///
   /// Errors may either be an empty string if there is no context that should
@@ -108,7 +113,7 @@ abstract class PackageLoopingCommand extends PluginCommand {
         }
       }
       printError(failureListFooter);
-      throw ToolExit(1);
+      throw ToolExit(kExitCommandFoundErrors);
     }
 
     printSuccess('\n\nNo issues found!');

--- a/script/tool/lib/src/common/package_looping_command.dart
+++ b/script/tool/lib/src/common/package_looping_command.dart
@@ -65,7 +65,7 @@ abstract class PackageLoopingCommand extends PluginCommand {
 
   /// A convenience constant for [runForPackage] failure without additional
   /// context that's more self-documenting than the value.
-  static const List<String> kFailure = <String>[];
+  static const List<String> kFailure = <String>[''];
 
   /// Prints a message using a standard format indicating that the package was
   /// skipped, with an explanation of why.

--- a/script/tool/lib/src/common/package_looping_command.dart
+++ b/script/tool/lib/src/common/package_looping_command.dart
@@ -1,0 +1,135 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:colorize/colorize.dart';
+import 'package:file/file.dart';
+import 'package:git/git.dart';
+import 'package:path/path.dart' as p;
+
+import 'core.dart';
+import 'plugin_command.dart';
+import 'process_runner.dart';
+
+/// An abstract base class for a command that iterates over a set of packages
+/// controlled by a standard set of flags, running some actions on each package,
+/// and collecting and reporting the success/failure of those actions.
+abstract class PackageLoopingCommand extends PluginCommand {
+  /// Creates a command to operate on [packagesDir] with the given environment.
+  PackageLoopingCommand(
+    Directory packagesDir, {
+    ProcessRunner processRunner = const ProcessRunner(),
+    GitDir? gitDir,
+  }) : super(packagesDir, processRunner: processRunner, gitDir: gitDir);
+
+  /// Runs the command for [package], returning a list of errors.
+  ///
+  /// Errors may either be an empty string if there is no context that should
+  /// be included in the final error summary (e.g., a command that only has a
+  /// single failure mode), or strings that should be listed for that plugin
+  /// in the final summary. An empty list indicates success.
+  Future<List<String>> runForPackage(Directory package);
+
+  /// Whether or not the output (if any) of [runForPackage] is long, or short.
+  ///
+  /// This changes the logging that happens at the start of each package's
+  /// run.
+  bool get hasLongOutput => true;
+
+  /// The text to output at the start when reporting one or more failures.
+  /// This will be followed by a list of packages that reported errors, with
+  /// the per-package details if any.
+  ///
+  /// This only needs to be overridden if the summary should provide extra
+  /// context.
+  String get failureListHeader => 'The following packages had errors:';
+
+  /// The text to output at the end when reporting one or more failures. This
+  /// will be printed immediately after the a list of packages that reported
+  /// errors.
+  ///
+  /// This only needs to be overridden if the summary should provide extra
+  /// context.
+  String get failureListFooter => 'See above for full details.';
+
+  // ----------------------------------------
+
+  /// A convenience constant for [runForPackage] success that's more
+  /// self-documenting than the value.
+  static const List<String> kSuccess = <String>[];
+
+  /// A convenience constant for [runForPackage] failure without additional
+  /// context that's more self-documenting than the value.
+  static const List<String> kFailure = <String>[];
+
+  /// Returns the identifying name to use for [package].
+  ///
+  /// Implementations should not expect a specific format for this string, since
+  /// it uses heuristics to try to be precise without being overly verbose. If
+  /// an exact format (e.g., published name, or basename) is required, that
+  /// should be used instead.
+  String packageDescription(Directory package) {
+    String packageName = p.relative(package.path, from: packagesDir.path);
+    final List<String> components = p.split(packageName);
+    // For the common federated plugin pattern of `foo/foo_subpackage`, drop
+    // the first part since it's not useful.
+    if (components.length == 2 &&
+        components[1].startsWith('${components[0]}_')) {
+      packageName = components[1];
+    }
+    return packageName;
+  }
+
+  // ----------------------------------------
+
+  @override
+  Future<void> run() async {
+    final List<Directory> packages = await getPackages().toList();
+
+    final Map<Directory, List<String>> results = <Directory, List<String>>{};
+    for (final Directory package in packages) {
+      _printPackageHeading(package);
+      results[package] = await runForPackage(package);
+    }
+
+    // If there were any errors reported, summarize them and exit.
+    if (results.values.any((List<String> failures) => failures.isNotEmpty)) {
+      const String indentation = '  ';
+      printError(failureListHeader);
+      for (final Directory package in packages) {
+        final List<String> errors = results[package]!;
+        if (errors.isNotEmpty) {
+          final String errorIndentation = indentation * 2;
+          String errorDetails = errors.join('\n$errorIndentation');
+          if (errorDetails.isNotEmpty) {
+            errorDetails = ':\n$errorIndentation$errorDetails';
+          }
+          printError('$indentation${packageDescription(package)}$errorDetails');
+        }
+      }
+      printError(failureListFooter);
+      throw ToolExit(1);
+    }
+
+    printSuccess('\n\nNo issues found!');
+  }
+
+  /// Prints the status message indicating that the command is being run for
+  /// [package].
+  ///
+  /// Something is always printed to make it easier to distinguish between
+  /// a command running for a package and producing no output, and a command
+  /// not having been run for a package.
+  void _printPackageHeading(Directory package) {
+    String heading = 'Running for ${packageDescription(package)}';
+    if (hasLongOutput) {
+      heading = '''
+
+============================================================
+|| $heading
+============================================================
+''';
+    }
+    print(Colorize('$heading...')..cyan());
+  }
+}

--- a/script/tool/lib/src/common/plugin_command.dart
+++ b/script/tool/lib/src/common/plugin_command.dart
@@ -14,6 +14,7 @@ import 'git_version_finder.dart';
 import 'process_runner.dart';
 
 /// Interface definition for all commands in this tool.
+// TODO(stuartmorgan): Move most of this logic to PackageLoopingCommand.
 abstract class PluginCommand extends Command<void> {
   /// Creates a command to operate on [packagesDir] with the given environment.
   PluginCommand(
@@ -136,6 +137,8 @@ abstract class PluginCommand extends Command<void> {
 
   /// Returns the root Dart package folders of the plugins involved in this
   /// command execution.
+  // TODO(stuartmorgan): Rename/restructure this, _getAllPlugins, and
+  // getPackages, as the current naming is very confusing.
   Stream<Directory> getPlugins() async* {
     // To avoid assuming consistency of `Directory.list` across command
     // invocations, we collect and sort the plugin folders before sharding.

--- a/script/tool/lib/src/pubspec_check_command.dart
+++ b/script/tool/lib/src/pubspec_check_command.dart
@@ -8,7 +8,7 @@ import 'package:path/path.dart' as p;
 import 'package:pubspec_parse/pubspec_parse.dart';
 
 import 'common/core.dart';
-import 'common/plugin_command.dart';
+import 'common/package_looping_command.dart';
 import 'common/process_runner.dart';
 
 /// A command to enforce pubspec conventions across the repository.
@@ -16,7 +16,7 @@ import 'common/process_runner.dart';
 /// This both ensures that repo best practices for which optional fields are
 /// used are followed, and that the structure is consistent to make edits
 /// across multiple pubspec files easier.
-class PubspecCheckCommand extends PluginCommand {
+class PubspecCheckCommand extends PackageLoopingCommand {
   /// Creates an instance of the version check command.
   PubspecCheckCommand(
     Directory packagesDir, {
@@ -52,29 +52,17 @@ class PubspecCheckCommand extends PluginCommand {
       'Checks that pubspecs follow repository conventions.';
 
   @override
-  Future<void> run() async {
-    final List<String> failingPackages = <String>[];
-    await for (final Directory package in getPackages()) {
-      final String relativePackagePath =
-          p.relative(package.path, from: packagesDir.path);
-      print('Checking $relativePackagePath...');
-      final File pubspec = package.childFile('pubspec.yaml');
-      final bool passesCheck = !pubspec.existsSync() ||
-          await _checkPubspec(pubspec, packageName: package.basename);
-      if (!passesCheck) {
-        failingPackages.add(relativePackagePath);
-      }
-    }
+  bool get hasLongOutput => false;
 
-    if (failingPackages.isNotEmpty) {
-      print('The following packages have pubspec issues:');
-      for (final String package in failingPackages) {
-        print('  $package');
-      }
-      throw ToolExit(1);
+  @override
+  Future<List<String>> runForPackage(Directory package) async {
+    final File pubspec = package.childFile('pubspec.yaml');
+    final bool passesCheck = !pubspec.existsSync() ||
+        await _checkPubspec(pubspec, packageName: package.basename);
+    if (!passesCheck) {
+      return PackageLoopingCommand.kFailure;
     }
-
-    print('\nNo pubspec issues found!');
+    return PackageLoopingCommand.kSuccess;
   }
 
   Future<bool> _checkPubspec(

--- a/script/tool/lib/src/pubspec_check_command.dart
+++ b/script/tool/lib/src/pubspec_check_command.dart
@@ -4,10 +4,8 @@
 
 import 'package:file/file.dart';
 import 'package:git/git.dart';
-import 'package:path/path.dart' as p;
 import 'package:pubspec_parse/pubspec_parse.dart';
 
-import 'common/core.dart';
 import 'common/package_looping_command.dart';
 import 'common/process_runner.dart';
 

--- a/script/tool/lib/src/pubspec_check_command.dart
+++ b/script/tool/lib/src/pubspec_check_command.dart
@@ -53,14 +53,17 @@ class PubspecCheckCommand extends PackageLoopingCommand {
   bool get hasLongOutput => false;
 
   @override
+  bool get includeSubpackages => true;
+
+  @override
   Future<List<String>> runForPackage(Directory package) async {
     final File pubspec = package.childFile('pubspec.yaml');
     final bool passesCheck = !pubspec.existsSync() ||
         await _checkPubspec(pubspec, packageName: package.basename);
     if (!passesCheck) {
-      return PackageLoopingCommand.kFailure;
+      return PackageLoopingCommand.failure;
     }
-    return PackageLoopingCommand.kSuccess;
+    return PackageLoopingCommand.success;
   }
 
   Future<bool> _checkPubspec(

--- a/script/tool/lib/src/xctest_command.dart
+++ b/script/tool/lib/src/xctest_command.dart
@@ -9,7 +9,7 @@ import 'package:file/file.dart';
 import 'package:path/path.dart' as p;
 
 import 'common/core.dart';
-import 'common/plugin_command.dart';
+import 'common/package_looping_command.dart';
 import 'common/plugin_utils.dart';
 import 'common/process_runner.dart';
 
@@ -24,7 +24,7 @@ const String _kFoundNoSimulatorsMessage =
 /// usually at "example/{ios,macos}/Runner.xcworkspace".
 ///
 /// The static analyzer is also run.
-class XCTestCommand extends PluginCommand {
+class XCTestCommand extends PackageLoopingCommand {
   /// Creates an instance of the test command.
   XCTestCommand(
     Directory packagesDir, {
@@ -41,6 +41,9 @@ class XCTestCommand extends PluginCommand {
     argParser.addFlag(kPlatformFlagMacos, help: 'Runs the macOS tests');
   }
 
+  // The device destination flags for iOS tests.
+  List<String> _iosDestinationFlags = <String>[];
+
   @override
   final String name = 'xctest';
 
@@ -50,62 +53,53 @@ class XCTestCommand extends PluginCommand {
       'This command requires "flutter" and "xcrun" to be in your path.';
 
   @override
-  Future<void> run() async {
+  String get failureListHeader => 'The following packages are failing XCTests:';
+
+  @override
+  Future<void> initializeRun() async {
     final bool testIos = getBoolArg(kPlatformFlagIos);
     final bool testMacos = getBoolArg(kPlatformFlagMacos);
 
     if (!(testIos || testMacos)) {
       print('At least one platform flag must be provided.');
-      throw ToolExit(2);
+      throw ToolExit(kExitInvalidArguments);
     }
 
-    List<String> iosDestinationFlags = <String>[];
     if (testIos) {
       String destination = getStringArg(_kiOSDestination);
       if (destination.isEmpty) {
         final String? simulatorId = await _findAvailableIphoneSimulator();
         if (simulatorId == null) {
           print(_kFoundNoSimulatorsMessage);
-          throw ToolExit(1);
+          throw ToolExit(3);
         }
         destination = 'id=$simulatorId';
       }
-      iosDestinationFlags = <String>[
+      _iosDestinationFlags = <String>[
         '-destination',
         destination,
       ];
     }
+  }
 
-    final List<String> failingPackages = <String>[];
-    await for (final Directory plugin in getPlugins()) {
-      final String packageName =
-          p.relative(plugin.path, from: packagesDir.path);
-      print('============================================================');
-      print('Start running for $packageName...');
-      bool passed = true;
-      if (testIos) {
-        passed &= await _testPlugin(plugin, 'iOS',
-            extraXcrunFlags: iosDestinationFlags);
-      }
-      if (testMacos) {
-        passed &= await _testPlugin(plugin, 'macOS');
-      }
-      if (!passed) {
-        failingPackages.add(packageName);
-      }
-    }
+  @override
+  Future<List<String>> runForPackage(Directory package) async {
+    final List<String> failures = <String>[];
+    final bool testIos = getBoolArg(kPlatformFlagIos);
+    final bool testMacos = getBoolArg(kPlatformFlagMacos);
+    // Only provide the failing platform(s) in the summary if testing multiple
+    // platforms, otherwise it's just noise.
+    final bool provideErrorDetails = testIos && testMacos;
 
-    // Command end, print reports.
-    if (failingPackages.isEmpty) {
-      print('All XCTests have passed!');
-    } else {
-      print(
-          'The following packages are failing XCTests (see above for details):');
-      for (final String package in failingPackages) {
-        print(' * $package');
-      }
-      throw ToolExit(1);
+    if (testIos &&
+        !await _testPlugin(package, 'iOS',
+            extraXcrunFlags: _iosDestinationFlags)) {
+      failures.add(provideErrorDetails ? 'iOS' : '');
     }
+    if (testMacos && !await _testPlugin(package, 'macOS')) {
+      failures.add(provideErrorDetails ? 'macOS' : '');
+    }
+    return failures;
   }
 
   /// Runs all applicable tests for [plugin], printing status and returning
@@ -117,8 +111,7 @@ class XCTestCommand extends PluginCommand {
   }) async {
     if (!pluginSupportsPlatform(platform.toLowerCase(), plugin,
         requiredMode: PlatformSupport.inline)) {
-      print('$platform is not implemented by this plugin package.');
-      print('\n');
+      printSkip('$platform is not implemented by this plugin package.\n');
       return true;
     }
     bool passing = true;
@@ -186,7 +179,7 @@ class XCTestCommand extends PluginCommand {
     if (findSimulatorsResult.exitCode != 0) {
       print('Error occurred while running "$findSimulatorCompleteCommand":\n'
           '${findSimulatorsResult.stderr}');
-      throw ToolExit(1);
+      throw ToolExit(4);
     }
     final Map<String, dynamic> simulatorListJson =
         jsonDecode(findSimulatorsResult.stdout as String)

--- a/script/tool/lib/src/xctest_command.dart
+++ b/script/tool/lib/src/xctest_command.dart
@@ -61,7 +61,7 @@ class XCTestCommand extends PackageLoopingCommand {
     final bool testMacos = getBoolArg(kPlatformFlagMacos);
 
     if (!(testIos || testMacos)) {
-      print('At least one platform flag must be provided.');
+      printError('At least one platform flag must be provided.');
       throw ToolExit(kExitInvalidArguments);
     }
 
@@ -70,7 +70,7 @@ class XCTestCommand extends PackageLoopingCommand {
       if (destination.isEmpty) {
         final String? simulatorId = await _findAvailableIphoneSimulator();
         if (simulatorId == null) {
-          print(_kFoundNoSimulatorsMessage);
+          printError(_kFoundNoSimulatorsMessage);
           throw ToolExit(3);
         }
         destination = 'id=$simulatorId';
@@ -129,7 +129,7 @@ class XCTestCommand extends PackageLoopingCommand {
             extraFlags: extraXcrunFlags);
       }
       if (exitCode == 0) {
-        print('Successfully ran $platform xctest for $examplePath');
+        printSuccess('Successfully ran $platform xctest for $examplePath');
       } else {
         passing = false;
       }
@@ -177,7 +177,8 @@ class XCTestCommand extends PackageLoopingCommand {
     final io.ProcessResult findSimulatorsResult =
         await processRunner.run(_kXCRunCommand, findSimulatorsArguments);
     if (findSimulatorsResult.exitCode != 0) {
-      print('Error occurred while running "$findSimulatorCompleteCommand":\n'
+      printError(
+          'Error occurred while running "$findSimulatorCompleteCommand":\n'
           '${findSimulatorsResult.stderr}');
       throw ToolExit(4);
     }

--- a/script/tool/test/common/package_looping_command_test.dart
+++ b/script/tool/test/common/package_looping_command_test.dart
@@ -1,0 +1,433 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+import 'package:file/file.dart';
+import 'package:file/memory.dart';
+import 'package:flutter_plugin_tools/src/common/core.dart';
+import 'package:flutter_plugin_tools/src/common/package_looping_command.dart';
+import 'package:flutter_plugin_tools/src/common/process_runner.dart';
+import 'package:git/git.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+import '../util.dart';
+import 'plugin_command_test.mocks.dart';
+
+// Constants for colorized output start and end.
+const String _startHeadingColor = '\x1B[36m';
+const String _startSkipColor = '\x1B[90m';
+const String _startSuccessColor = '\x1B[32m';
+const String _startErrorColor = '\x1B[31m';
+const String _endColor = '\x1B[0m';
+
+// The filename within a package containing errors to return from runForPackage.
+const String _errorFile = 'errors';
+
+void main() {
+  late FileSystem fileSystem;
+  late Directory packagesDir;
+  late Directory thirdPartyPackagesDir;
+
+  setUp(() {
+    fileSystem = MemoryFileSystem();
+    packagesDir = createPackagesDirectory(fileSystem: fileSystem);
+    thirdPartyPackagesDir = packagesDir.parent
+        .childDirectory('third_party')
+        .childDirectory('packages');
+  });
+
+  /// Creates a TestPackageLoopingCommand instance that uses [gitDiffResponse]
+  /// for git diffs, and logs output to [printOutput].
+  TestPackageLoopingCommand createTestCommand({
+    String gitDiffResponse = '',
+    bool hasLongOutput = true,
+    bool includeSubpackages = false,
+    bool failsDuringInit = false,
+    String? customFailureListHeader,
+    String? customFailureListFooter,
+  }) {
+    // Set up the git diff response.
+    final MockGitDir gitDir = MockGitDir();
+    when(gitDir.runCommand(any, throwOnError: anyNamed('throwOnError')))
+        .thenAnswer((Invocation invocation) {
+      final MockProcessResult mockProcessResult = MockProcessResult();
+      if (invocation.positionalArguments[0][0] == 'diff') {
+        when<String?>(mockProcessResult.stdout as String?)
+            .thenReturn(gitDiffResponse);
+      }
+      return Future<ProcessResult>.value(mockProcessResult);
+    });
+
+    return TestPackageLoopingCommand(
+      packagesDir,
+      hasLongOutput: hasLongOutput,
+      includeSubpackages: includeSubpackages,
+      failsDuringInit: failsDuringInit,
+      customFailureListHeader: customFailureListHeader,
+      customFailureListFooter: customFailureListFooter,
+      gitDir: gitDir,
+    );
+  }
+
+  /// Runs [command] with the given [arguments], and returns its output.
+  Future<List<String>> runCommand(
+    TestPackageLoopingCommand command, {
+    List<String> arguments = const <String>[],
+    void Function(Error error)? errorHandler,
+  }) async {
+    late CommandRunner<void> runner;
+    runner = CommandRunner<void>('test_package_looping_command',
+        'Test for base package looping functionality');
+    runner.addCommand(command);
+    return await runCapturingPrint(
+      runner,
+      <String>[command.name, ...arguments],
+      errorHandler: errorHandler,
+    );
+  }
+
+  group('tool exit', () {
+    test('is handled during initializeRun', () async {
+      final TestPackageLoopingCommand command =
+          createTestCommand(failsDuringInit: true);
+
+      expect(() => runCommand(command), throwsA(isA<ToolExit>()));
+    });
+
+    test('does not stop looping', () async {
+      createFakePackage('package_a', packagesDir);
+      final Directory failingPackage =
+          createFakePlugin('package_b', packagesDir);
+      createFakePackage('package_c', packagesDir);
+      failingPackage.childFile(_errorFile).createSync();
+
+      final TestPackageLoopingCommand command =
+          createTestCommand(hasLongOutput: false);
+      Error? commandError;
+      final List<String> output =
+          await runCommand(command, errorHandler: (Error e) {
+        commandError = e;
+      });
+
+      expect(commandError, isA<ToolExit>());
+      expect(
+          output,
+          containsAllInOrder(<String>[
+            '${_startHeadingColor}Running for package_a...$_endColor',
+            '${_startHeadingColor}Running for package_b...$_endColor',
+            '${_startHeadingColor}Running for package_c...$_endColor',
+          ]));
+    });
+  });
+
+  group('package iteration', () {
+    test('includes plugins and packages', () async {
+      final Directory plugin = createFakePlugin('a_plugin', packagesDir);
+      final Directory package = createFakePackage('a_package', packagesDir);
+
+      final TestPackageLoopingCommand command = createTestCommand();
+      await runCommand(command);
+
+      expect(command.checkedPackages,
+          unorderedEquals(<String>[plugin.path, package.path]));
+    });
+
+    test('includes third_party/packages', () async {
+      final Directory package1 = createFakePackage('a_package', packagesDir);
+      final Directory package2 =
+          createFakePackage('another_package', thirdPartyPackagesDir);
+
+      final TestPackageLoopingCommand command = createTestCommand();
+      await runCommand(command);
+
+      expect(command.checkedPackages,
+          unorderedEquals(<String>[package1.path, package2.path]));
+    });
+
+    test('includes subpackages when requested', () async {
+      final Directory plugin = createFakePlugin('a_plugin', packagesDir,
+          examples: <String>['example1', 'example2']);
+      final Directory package = createFakePackage('a_package', packagesDir);
+
+      final TestPackageLoopingCommand command =
+          createTestCommand(includeSubpackages: true);
+      await runCommand(command);
+
+      expect(
+          command.checkedPackages,
+          unorderedEquals(<String>[
+            plugin.path,
+            plugin.childDirectory('example').childDirectory('example1').path,
+            plugin.childDirectory('example').childDirectory('example2').path,
+            package.path,
+            package.childDirectory('example').path,
+          ]));
+    });
+  });
+
+  group('output', () {
+    test('has the expected package headers for long-form output', () async {
+      createFakePlugin('package_a', packagesDir);
+      createFakePackage('package_b', packagesDir);
+
+      final TestPackageLoopingCommand command =
+          createTestCommand(hasLongOutput: true);
+      final List<String> output = await runCommand(command);
+
+      const String separator =
+          '============================================================';
+      expect(
+          output,
+          containsAllInOrder(<String>[
+            '$_startHeadingColor\n$separator\n|| Running for package_a\n$separator\n$_endColor',
+            '$_startHeadingColor\n$separator\n|| Running for package_b\n$separator\n$_endColor',
+          ]));
+    });
+
+    test('has the expected package headers for short-form output', () async {
+      createFakePlugin('package_a', packagesDir);
+      createFakePackage('package_b', packagesDir);
+
+      final TestPackageLoopingCommand command =
+          createTestCommand(hasLongOutput: false);
+      final List<String> output = await runCommand(command);
+
+      expect(
+          output,
+          containsAllInOrder(<String>[
+            '${_startHeadingColor}Running for package_a...$_endColor',
+            '${_startHeadingColor}Running for package_b...$_endColor',
+          ]));
+    });
+
+    test('shows the success message when nothing fails', () async {
+      createFakePackage('package_a', packagesDir);
+      createFakePackage('package_b', packagesDir);
+
+      final TestPackageLoopingCommand command =
+          createTestCommand(hasLongOutput: false);
+      final List<String> output = await runCommand(command);
+
+      expect(
+          output,
+          containsAllInOrder(<String>[
+            '$_startSuccessColor\n\nNo issues found!$_endColor',
+          ]));
+    });
+
+    test('shows failure summaries when something fails without extra details',
+        () async {
+      createFakePackage('package_a', packagesDir);
+      final Directory failingPackage1 =
+          createFakePlugin('package_b', packagesDir);
+      createFakePackage('package_c', packagesDir);
+      final Directory failingPackage2 =
+          createFakePlugin('package_d', packagesDir);
+      failingPackage1.childFile(_errorFile).createSync();
+      failingPackage2.childFile(_errorFile).createSync();
+
+      final TestPackageLoopingCommand command =
+          createTestCommand(hasLongOutput: false);
+      Error? commandError;
+      final List<String> output =
+          await runCommand(command, errorHandler: (Error e) {
+        commandError = e;
+      });
+
+      expect(commandError, isA<ToolExit>());
+      expect(
+          output,
+          containsAllInOrder(<String>[
+            '${_startErrorColor}The following packages had errors:$_endColor',
+            '$_startErrorColor  package_b$_endColor',
+            '$_startErrorColor  package_d$_endColor',
+            '${_startErrorColor}See above for full details.$_endColor',
+          ]));
+    });
+
+    test('uses custom summary header and footer if provided', () async {
+      createFakePackage('package_a', packagesDir);
+      final Directory failingPackage1 =
+          createFakePlugin('package_b', packagesDir);
+      createFakePackage('package_c', packagesDir);
+      final Directory failingPackage2 =
+          createFakePlugin('package_d', packagesDir);
+      failingPackage1.childFile(_errorFile).createSync();
+      failingPackage2.childFile(_errorFile).createSync();
+
+      final TestPackageLoopingCommand command = createTestCommand(
+          hasLongOutput: false,
+          customFailureListHeader: 'This is a custom header',
+          customFailureListFooter: 'And a custom footer!');
+      Error? commandError;
+      final List<String> output =
+          await runCommand(command, errorHandler: (Error e) {
+        commandError = e;
+      });
+
+      expect(commandError, isA<ToolExit>());
+      expect(
+          output,
+          containsAllInOrder(<String>[
+            '${_startErrorColor}This is a custom header$_endColor',
+            '$_startErrorColor  package_b$_endColor',
+            '$_startErrorColor  package_d$_endColor',
+            '${_startErrorColor}And a custom footer!$_endColor',
+          ]));
+    });
+
+    test('shows failure summaries when something fails with extra details',
+        () async {
+      createFakePackage('package_a', packagesDir);
+      final Directory failingPackage1 =
+          createFakePlugin('package_b', packagesDir);
+      createFakePackage('package_c', packagesDir);
+      final Directory failingPackage2 =
+          createFakePlugin('package_d', packagesDir);
+      final File errorFile1 = failingPackage1.childFile(_errorFile);
+      errorFile1.createSync();
+      errorFile1.writeAsStringSync('just one detail');
+      final File errorFile2 = failingPackage2.childFile(_errorFile);
+      errorFile2.createSync();
+      errorFile2.writeAsStringSync('first detail\nsecond detail');
+
+      final TestPackageLoopingCommand command =
+          createTestCommand(hasLongOutput: false);
+      Error? commandError;
+      final List<String> output =
+          await runCommand(command, errorHandler: (Error e) {
+        commandError = e;
+      });
+
+      expect(commandError, isA<ToolExit>());
+      expect(
+          output,
+          containsAllInOrder(<String>[
+            '${_startErrorColor}The following packages had errors:$_endColor',
+            '$_startErrorColor  package_b:\n    just one detail$_endColor',
+            '$_startErrorColor  package_d:\n    first detail\n    second detail$_endColor',
+            '${_startErrorColor}See above for full details.$_endColor',
+          ]));
+    });
+  });
+
+  group('utility', () {
+    test('printSkip has expected output', () async {
+      final TestPackageLoopingCommand command =
+          TestPackageLoopingCommand(packagesDir);
+
+      final List<String> printBuffer = <String>[];
+      Zone.current.fork(specification: ZoneSpecification(
+        print: (_, __, ___, String message) {
+          printBuffer.add(message);
+        },
+      )).run<void>(() => command.printSkip('For a reason'));
+
+      expect(printBuffer.first,
+          '${_startSkipColor}SKIPPING: For a reason$_endColor');
+    });
+
+    test('getPackageDescription prints packageDir-relative paths by default',
+        () async {
+      final TestPackageLoopingCommand command =
+          TestPackageLoopingCommand(packagesDir);
+
+      expect(
+        command.getPackageDescription(packagesDir.childDirectory('foo')),
+        'foo',
+      );
+      expect(
+        command.getPackageDescription(packagesDir
+            .childDirectory('foo')
+            .childDirectory('bar')
+            .childDirectory('baz')),
+        'foo/bar/baz',
+      );
+    });
+
+    test(
+        'getPackageDescription elides group name in grouped federated plugin structure',
+        () async {
+      final TestPackageLoopingCommand command =
+          TestPackageLoopingCommand(packagesDir);
+
+      expect(
+        command.getPackageDescription(packagesDir
+            .childDirectory('a_plugin')
+            .childDirectory('a_plugin_platform_interface')),
+        'a_plugin_platform_interface',
+      );
+      expect(
+        command.getPackageDescription(packagesDir
+            .childDirectory('a_plugin')
+            .childDirectory('a_plugin_web')),
+        'a_plugin_web',
+      );
+    });
+  });
+}
+
+class TestPackageLoopingCommand extends PackageLoopingCommand {
+  TestPackageLoopingCommand(
+    Directory packagesDir, {
+    this.hasLongOutput = true,
+    this.includeSubpackages = false,
+    this.customFailureListHeader,
+    this.customFailureListFooter,
+    this.failsDuringInit = false,
+    ProcessRunner processRunner = const ProcessRunner(),
+    GitDir? gitDir,
+  }) : super(packagesDir, processRunner: processRunner, gitDir: gitDir);
+
+  final List<String> checkedPackages = <String>[];
+
+  final String? customFailureListHeader;
+  final String? customFailureListFooter;
+
+  final bool failsDuringInit;
+
+  @override
+  bool hasLongOutput;
+
+  @override
+  bool includeSubpackages;
+
+  @override
+  String get failureListHeader =>
+      customFailureListHeader ?? super.failureListHeader;
+
+  @override
+  String get failureListFooter =>
+      customFailureListFooter ?? super.failureListFooter;
+
+  @override
+  final String name = 'loop-test';
+
+  @override
+  final String description = 'sample package looping command';
+
+  @override
+  Future<void> initializeRun() async {
+    if (failsDuringInit) {
+      throw ToolExit(2);
+    }
+  }
+
+  @override
+  Future<List<String>> runForPackage(Directory package) async {
+    checkedPackages.add(package.path);
+    final File errorFile = package.childFile(_errorFile);
+    if (errorFile.existsSync()) {
+      final List<String> errors = errorFile.readAsLinesSync();
+      return errors.isNotEmpty ? errors : PackageLoopingCommand.failure;
+    }
+    return PackageLoopingCommand.success;
+  }
+}
+
+class MockProcessResult extends Mock implements ProcessResult {}

--- a/script/tool/test/pubspec_check_command_test.dart
+++ b/script/tool/test/pubspec_check_command_test.dart
@@ -105,10 +105,10 @@ ${devDependenciesSection()}
 
       expect(
         output,
-        containsAllInOrder(<String>[
-          'Checking plugin...',
-          'Checking plugin/example...',
-          '\nNo pubspec issues found!',
+        containsAllInOrder(<Matcher>[
+          contains('Running for plugin...'),
+          contains('Running for plugin/example...'),
+          contains('No issues found!'),
         ]),
       );
     });
@@ -131,10 +131,10 @@ ${flutterSection()}
 
       expect(
         output,
-        containsAllInOrder(<String>[
-          'Checking plugin...',
-          'Checking plugin/example...',
-          '\nNo pubspec issues found!',
+        containsAllInOrder(<Matcher>[
+          contains('Running for plugin...'),
+          contains('Running for plugin/example...'),
+          contains('No issues found!'),
         ]),
       );
     });
@@ -155,9 +155,9 @@ ${dependenciesSection()}
 
       expect(
         output,
-        containsAllInOrder(<String>[
-          'Checking package...',
-          '\nNo pubspec issues found!',
+        containsAllInOrder(<Matcher>[
+          contains('Running for package...'),
+          contains('No issues found!'),
         ]),
       );
     });

--- a/script/tool/test/xctest_command_test.dart
+++ b/script/tool/test/xctest_command_test.dart
@@ -130,7 +130,9 @@ void main() {
         final List<String> output = await runCapturingPrint(runner,
             <String>['xctest', '--ios', _kDestination, 'foo_destination']);
         expect(
-            output, contains('iOS is not implemented by this plugin package.'));
+            output,
+            contains(
+                contains('iOS is not implemented by this plugin package.')));
         expect(processRunner.recordedCalls, orderedEquals(<ProcessCall>[]));
       });
 
@@ -153,7 +155,9 @@ void main() {
         final List<String> output = await runCapturingPrint(runner,
             <String>['xctest', '--ios', _kDestination, 'foo_destination']);
         expect(
-            output, contains('iOS is not implemented by this plugin package.'));
+            output,
+            contains(
+                contains('iOS is not implemented by this plugin package.')));
         expect(processRunner.recordedCalls, orderedEquals(<ProcessCall>[]));
       });
 
@@ -192,10 +196,12 @@ void main() {
           'plugin1'
         ]);
 
-        expect(output, isNot(contains('Start running for plugin1...')));
-        expect(output, contains('Start running for plugin2...'));
-        expect(output,
-            contains('Successfully ran iOS xctest for plugin2/example'));
+        expect(output, isNot(contains(contains('Running for plugin1'))));
+        expect(output, contains(contains('Running for plugin2')));
+        expect(
+            output,
+            contains(
+                contains('Successfully ran iOS xctest for plugin2/example')));
 
         expect(
             processRunner.recordedCalls,
@@ -292,8 +298,10 @@ void main() {
         processRunner.processToReturn = mockProcess;
         final List<String> output = await runCapturingPrint(runner,
             <String>['xctest', '--macos', _kDestination, 'foo_destination']);
-        expect(output,
-            contains('macOS is not implemented by this plugin package.'));
+        expect(
+            output,
+            contains(
+                contains('macOS is not implemented by this plugin package.')));
         expect(processRunner.recordedCalls, orderedEquals(<ProcessCall>[]));
       });
 
@@ -315,8 +323,10 @@ void main() {
         processRunner.processToReturn = mockProcess;
         final List<String> output = await runCapturingPrint(runner,
             <String>['xctest', '--macos', _kDestination, 'foo_destination']);
-        expect(output,
-            contains('macOS is not implemented by this plugin package.'));
+        expect(
+            output,
+            contains(
+                contains('macOS is not implemented by this plugin package.')));
         expect(processRunner.recordedCalls, orderedEquals(<ProcessCall>[]));
       });
 
@@ -342,8 +352,10 @@ void main() {
           '--macos',
         ]);
 
-        expect(output,
-            contains('Successfully ran macOS xctest for plugin/example'));
+        expect(
+            output,
+            contains(
+                contains('Successfully ran macOS xctest for plugin/example')));
 
         expect(
             processRunner.recordedCalls,


### PR DESCRIPTION
Most of our commands are generally of the form:
```
  for (each plugin as defined by the tool flags)
    check some things for success or failure
  print a summary all of the failing things
  exit non-zero if anything failed
```

Currently all that logic not consistent, having been at various points copied and pasted around, modified, in some cases rewritten. There's unnecessary boilerplate in each new command, and there's unnecessary variation that makes it harder both to maintain the tool, and to consume the test output:
- There's no standard format for separating each plugin's run to search within a log
- There's no standard format for the summary at the end
- In some cases commands have been written to ToolExit on failure, which means we don't actually get the rest of the runs

This makes a new base class for commands that follow this structure to use, with shared code for all the common bits. This makes it harder to accidentally write new commands incorrectly, easier to maintain the code, and lets us standardize output so that searching within large logs will be easier.

This ports two commands over as a proof of concept to demonstrate that it works; more will be converted in follow-ups.

Related to https://github.com/flutter/flutter/issues/83413

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
