### PR TITLE
[flutter_plugin_tools] `publish-plugin` check against pub to determine if a release should happen

### DIFF
--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `xctest` now supports running macOS tests in addition to iOS
   - **Breaking change**: it now requires an `--ios` and/or `--macos` flag.
 - The tooling now runs in strong null-safe mode.
+- `publish plugins` check against pub.dev to determine if a release should happen.
 
 ## 0.2.0
 

--- a/script/tool/lib/src/publish_plugin_command.dart
+++ b/script/tool/lib/src/publish_plugin_command.dart
@@ -53,7 +53,8 @@ class PublishPluginCommand extends PluginCommand {
     GitDir? gitDir,
     http.Client? httpClient,
   })  : _pubVersionFinder =
-            PubVersionFinder(httpClient: httpClient ?? http.Client()), _print = print,
+            PubVersionFinder(httpClient: httpClient ?? http.Client()),
+        _print = print,
         _stdin = stdinput ?? io.stdin,
         super(packagesDir, processRunner: processRunner, gitDir: gitDir) {
     argParser.addOption(
@@ -293,11 +294,12 @@ Safe to ignore if the package is deleted in this commit.
     }
 
     // Check if the package named `packageName` with `version` has already published.
-    final Version version  = pubspec.version!;
+    final Version version = pubspec.version!;
     final PubVersionFinderResponse pubVersionFinderResponse =
         await _pubVersionFinder.getPackageVersion(package: pubspec.name);
     if (pubVersionFinderResponse.versions.contains(version)) {
-      _print('The version $version of ${pubspec.name} has already been published, skip.');
+      _print(
+          'The version $version of ${pubspec.name} has already been published, skip.');
       return _CheckNeedsReleaseResult.noRelease;
     }
     return _CheckNeedsReleaseResult.release;

--- a/script/tool/lib/src/publish_plugin_command.dart
+++ b/script/tool/lib/src/publish_plugin_command.dart
@@ -8,6 +8,7 @@ import 'dart:io' as io;
 
 import 'package:file/file.dart';
 import 'package:git/git.dart';
+import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
@@ -18,6 +19,7 @@ import 'common/core.dart';
 import 'common/git_version_finder.dart';
 import 'common/plugin_command.dart';
 import 'common/process_runner.dart';
+import 'common/pub_version_finder.dart';
 
 @immutable
 class _RemoteInfo {
@@ -49,7 +51,9 @@ class PublishPluginCommand extends PluginCommand {
     Print print = print,
     io.Stdin? stdinput,
     GitDir? gitDir,
-  })  : _print = print,
+    http.Client? httpClient,
+  })  : _pubVersionFinder =
+            PubVersionFinder(httpClient: httpClient ?? http.Client()), _print = print,
         _stdin = stdinput ?? io.stdin,
         super(packagesDir, processRunner: processRunner, gitDir: gitDir) {
     argParser.addOption(
@@ -131,6 +135,7 @@ class PublishPluginCommand extends PluginCommand {
   final Print _print;
   final io.Stdin _stdin;
   StreamSubscription<String>? _stdinSubscription;
+  final PubVersionFinder _pubVersionFinder;
 
   @override
   Future<void> run() async {
@@ -182,6 +187,8 @@ class PublishPluginCommand extends PluginCommand {
         remoteForTagPush: remote,
       );
     }
+
+    _pubVersionFinder.httpClient.close();
     await _finish(successful);
   }
 
@@ -196,12 +203,6 @@ class PublishPluginCommand extends PluginCommand {
       _print('No version updates in this commit.');
       return true;
     }
-    _print('Getting existing tags...');
-    final io.ProcessResult existingTagsResult =
-        await baseGitDir.runCommand(<String>['tag', '--sort=-committerdate']);
-    final List<String> existingTags = (existingTagsResult.stdout as String)
-        .split('\n')
-          ..removeWhere((String element) => element.isEmpty);
 
     final List<String> packagesReleased = <String>[];
     final List<String> packagesFailed = <String>[];
@@ -213,7 +214,6 @@ class PublishPluginCommand extends PluginCommand {
       final _CheckNeedsReleaseResult result = await _checkNeedsRelease(
         pubspecFile: pubspecFile,
         gitVersionFinder: gitVersionFinder,
-        existingTags: existingTags,
       );
       switch (result) {
         case _CheckNeedsReleaseResult.release:
@@ -272,7 +272,6 @@ class PublishPluginCommand extends PluginCommand {
   Future<_CheckNeedsReleaseResult> _checkNeedsRelease({
     required File pubspecFile,
     required GitVersionFinder gitVersionFinder,
-    required List<String> existingTags,
   }) async {
     if (!pubspecFile.existsSync()) {
       _print('''
@@ -293,21 +292,13 @@ Safe to ignore if the package is deleted in this commit.
       return _CheckNeedsReleaseResult.failure;
     }
 
-    // Get latest tagged version and compare with the current version.
-    // TODO(cyanglaz): Check latest version of the package on pub instead of git
-    // https://github.com/flutter/flutter/issues/81047
-
-    final String latestTag = existingTags.firstWhere(
-        (String tag) => tag.split('-v').first == pubspec.name,
-        orElse: () => '');
-    if (latestTag.isNotEmpty) {
-      final String latestTaggedVersion = latestTag.split('-v').last;
-      final Version latestVersion = Version.parse(latestTaggedVersion);
-      if (pubspec.version! < latestVersion) {
-        _print(
-            'The new version (${pubspec.version}) is lower than the current version ($latestVersion) for ${pubspec.name}.\nThis git commit is a revert, no release is tagged.');
-        return _CheckNeedsReleaseResult.noRelease;
-      }
+    // Check if the package named `packageName` with `version` has already published.
+    final Version version  = pubspec.version!;
+    final PubVersionFinderResponse pubVersionFinderResponse =
+        await _pubVersionFinder.getPackageVersion(package: pubspec.name);
+    if (pubVersionFinderResponse.versions.contains(version)) {
+      _print('The version $version of ${pubspec.name} has already been published, skip.');
+      return _CheckNeedsReleaseResult.noRelease;
     }
     return _CheckNeedsReleaseResult.release;
   }

--- a/script/tool/lib/src/publish_plugin_command.dart
+++ b/script/tool/lib/src/publish_plugin_command.dart
@@ -306,14 +306,15 @@ Safe to ignore if the package is deleted in this commit.
         await _pubVersionFinder.getPackageVersion(package: pubspec.name);
     if (pubVersionFinderResponse.versions.contains(version)) {
       final String tagsForPackageWithSameVersion = existingTags.firstWhere(
-          (String tag) => tag.split('-v').first == pubspec.name && tag.split('-v').last == version.toString(),
+          (String tag) =>
+              tag.split('-v').first == pubspec.name &&
+              tag.split('-v').last == version.toString(),
           orElse: () => '');
-      print(tagsForPackageWithSameVersion);
       _print(
           'The version $version of ${pubspec.name} has already been published');
       if (tagsForPackageWithSameVersion.isEmpty) {
         _print(
-          'However, the git release tag for this version (${pubspec.name}-v$version) is not found. Please manually fix the tag then run the command again.');
+            'However, the git release tag for this version (${pubspec.name}-v$version) is not found. Please manually fix the tag then run the command again.');
         return _CheckNeedsReleaseResult.failure;
       } else {
         _print('skip.');

--- a/script/tool/test/publish_plugin_command_test.dart
+++ b/script/tool/test/publish_plugin_command_test.dart
@@ -607,7 +607,8 @@ void main() {
       // Non-federated
       final Directory pluginDir1 = createFakePlugin('plugin1', packagesDir);
       // federated
-      final Directory pluginDir2 = createFakePlugin('plugin2', packagesDir.childDirectory('plugin2'));
+      final Directory pluginDir2 =
+          createFakePlugin('plugin2', packagesDir.childDirectory('plugin2'));
       await gitDir.runCommand(<String>['add', '-A']);
       await gitDir.runCommand(<String>['commit', '-m', 'Add plugins']);
       // Immediately return 1 when running `pub publish`. If dry-run does not work, test should throw.
@@ -672,7 +673,8 @@ void main() {
       // Non-federated
       final Directory pluginDir1 = createFakePlugin('plugin1', packagesDir);
       // federated
-      final Directory pluginDir2 = createFakePlugin('plugin2', packagesDir.childDirectory('plugin2'));
+      final Directory pluginDir2 =
+          createFakePlugin('plugin2', packagesDir.childDirectory('plugin2'));
       await gitDir.runCommand(<String>['add', '-A']);
       await gitDir.runCommand(<String>['commit', '-m', 'Add plugins']);
       // Immediately return 0 when running `pub publish`.
@@ -778,7 +780,8 @@ void main() {
       // Non-federated
       final Directory pluginDir1 = createFakePlugin('plugin1', packagesDir);
       // federated
-      final Directory pluginDir2 = createFakePlugin('plugin2', packagesDir.childDirectory('plugin2'));
+      final Directory pluginDir2 =
+          createFakePlugin('plugin2', packagesDir.childDirectory('plugin2'));
       await gitDir.runCommand(<String>['add', '-A']);
       await gitDir.runCommand(<String>['commit', '-m', 'Add plugins']);
       // Immediately return 0 when running `pub publish`.
@@ -880,8 +883,7 @@ void main() {
       // Non-federated
       createFakePlugin('plugin1', packagesDir, version: '0.0.2');
       // federated
-      createFakePlugin(
-          'plugin2', packagesDir.childDirectory('plugin2'),
+      createFakePlugin('plugin2', packagesDir.childDirectory('plugin2'),
           version: '0.0.2');
       await gitDir.runCommand(<String>['add', '-A']);
       await gitDir.runCommand(<String>['commit', '-m', 'Add plugins']);

--- a/script/tool/test/publish_plugin_command_test.dart
+++ b/script/tool/test/publish_plugin_command_test.dart
@@ -911,7 +911,8 @@ void main() {
       expect(processRunner.pushTagsArgs, isEmpty);
     });
 
-    test('Exiting versions do not trigger release, but fail if the tags do not exist.',
+    test(
+        'Exiting versions do not trigger release, but fail if the tags do not exist.',
         () async {
       const Map<String, dynamic> httpResponsePlugin1 = <String, dynamic>{
         'name': 'plugin1',
@@ -954,43 +955,12 @@ void main() {
       // Immediately return 0 when running `pub publish`.
       processRunner.mockPublishCompleteCode = 0;
       mockStdin.readLineOutput = 'y';
-      await commandRunner
-          .run(<String>['publish-plugin', '--all-changed', '--base-sha=HEAD~']);
-      expect(
-          printedMessages,
-          containsAllInOrder(<String>[
-            'Checking local repo...',
-            'Local repo is ready!',
-            'The version 0.0.2 of plugin1 has already been published, skip.',
-            'The version 0.0.2 of plugin2 has already been published, skip.',
-            'Done!'
-          ]));
-
-//       bool hasError = false;
-//       final List<String> output = await runCapturingPrint(runner, <String>[
-//         'version-check',
-//         '--base-sha=master',
-//         '--against-pub'
-//       ], errorHandler: (Error e) {
-//         expect(e, isA<ToolExit>());
-//         hasError = true;
-//       });
-//       expect(hasError, isTrue);
-
-//       expect(
-//         output,
-//         containsAllInOrder(<String>[
-//           _redColorString('''
-// versions for plugin in CHANGELOG.md and pubspec.yaml do not match.
-// The version in pubspec.yaml is 1.0.1.
-// The first version listed in CHANGELOG.md is 1.0.2.
-// '''),
-//         ]),
-      // );
-
+      await expectLater(
+          () => commandRunner.run(
+              <String>['publish-plugin', '--all-changed', '--base-sha=HEAD~']),
+          throwsA(const TypeMatcher<ToolExit>()));
       expect(processRunner.pushTagsArgs, isEmpty);
     });
-
 
     test('No version change does not release any plugins', () async {
       // Non-federated

--- a/script/tool/test/publish_plugin_command_test.dart
+++ b/script/tool/test/publish_plugin_command_test.dart
@@ -13,6 +13,8 @@ import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/common/process_runner.dart';
 import 'package:flutter_plugin_tools/src/publish_plugin_command.dart';
 import 'package:git/git.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
@@ -427,6 +429,37 @@ void main() {
     });
 
     test('can release newly created plugins', () async {
+      const Map<String, dynamic> httpResponsePlugin1 = <String, dynamic>{
+        'name': 'plugin1',
+        'versions': <String>[],
+      };
+
+      const Map<String, dynamic> httpResponsePlugin2 = <String, dynamic>{
+        'name': 'plugin2',
+        'versions': <String>[],
+      };
+
+      final MockClient mockClient = MockClient((http.Request request) async {
+        if (request.url.pathSegments.last == 'plugin1.json') {
+          return http.Response(json.encode(httpResponsePlugin1), 200);
+        } else if (request.url.pathSegments.last == 'plugin2.json') {
+          return http.Response(json.encode(httpResponsePlugin2), 200);
+        }
+        return http.Response('', 500);
+      });
+      final PublishPluginCommand command = PublishPluginCommand(packagesDir,
+          processRunner: processRunner,
+          print: (Object? message) => printedMessages.add(message.toString()),
+          stdinput: mockStdin,
+          httpClient: mockClient,
+          gitDir: gitDir);
+
+      commandRunner = CommandRunner<void>(
+        'publish_check_command',
+        'Test for publish-check command.',
+      );
+      commandRunner.addCommand(command);
+
       // Non-federated
       final Directory pluginDir1 =
           createFakePlugin('plugin1', packagesDir, withSingleExample: true);
@@ -449,7 +482,6 @@ void main() {
           containsAllInOrder(<String>[
             'Checking local repo...',
             'Local repo is ready!',
-            'Getting existing tags...',
             'Running `pub publish ` in ${pluginDir1.path}...\n',
             'Running `pub publish ` in ${pluginDir2.path}...\n',
             'Packages released: plugin1, plugin2',
@@ -466,6 +498,44 @@ void main() {
 
     test('can release newly created plugins, while there are existing plugins',
         () async {
+      const Map<String, dynamic> httpResponsePlugin0 = <String, dynamic>{
+        'name': 'plugin0',
+        'versions': <String>['0.0.1'],
+      };
+
+      const Map<String, dynamic> httpResponsePlugin1 = <String, dynamic>{
+        'name': 'plugin1',
+        'versions': <String>[],
+      };
+
+      const Map<String, dynamic> httpResponsePlugin2 = <String, dynamic>{
+        'name': 'plugin2',
+        'versions': <String>[],
+      };
+
+      final MockClient mockClient = MockClient((http.Request request) async {
+        if (request.url.pathSegments.last == 'plugin0.json') {
+          return http.Response(json.encode(httpResponsePlugin0), 200);
+        } else if (request.url.pathSegments.last == 'plugin1.json') {
+          return http.Response(json.encode(httpResponsePlugin1), 200);
+        } else if (request.url.pathSegments.last == 'plugin2.json') {
+          return http.Response(json.encode(httpResponsePlugin2), 200);
+        }
+        return http.Response('', 500);
+      });
+      final PublishPluginCommand command = PublishPluginCommand(packagesDir,
+          processRunner: processRunner,
+          print: (Object? message) => printedMessages.add(message.toString()),
+          stdinput: mockStdin,
+          httpClient: mockClient,
+          gitDir: gitDir);
+
+      commandRunner = CommandRunner<void>(
+        'publish_check_command',
+        'Test for publish-check command.',
+      );
+      commandRunner.addCommand(command);
+
       // Prepare an exiting plugin and tag it
       final Directory pluginDir0 =
           createFakePlugin('plugin0', packagesDir, withSingleExample: true);
@@ -500,7 +570,6 @@ void main() {
           containsAllInOrder(<String>[
             'Checking local repo...',
             'Local repo is ready!',
-            'Getting existing tags...',
             'Running `pub publish ` in ${pluginDir1.path}...\n',
             'Running `pub publish ` in ${pluginDir2.path}...\n',
             'Packages released: plugin1, plugin2',
@@ -516,6 +585,36 @@ void main() {
     });
 
     test('can release newly created plugins, dry run', () async {
+      const Map<String, dynamic> httpResponsePlugin1 = <String, dynamic>{
+        'name': 'plugin1',
+        'versions': <String>[],
+      };
+
+      const Map<String, dynamic> httpResponsePlugin2 = <String, dynamic>{
+        'name': 'plugin2',
+        'versions': <String>[],
+      };
+
+      final MockClient mockClient = MockClient((http.Request request) async {
+        if (request.url.pathSegments.last == 'plugin1.json') {
+          return http.Response(json.encode(httpResponsePlugin1), 200);
+        } else if (request.url.pathSegments.last == 'plugin2.json') {
+          return http.Response(json.encode(httpResponsePlugin2), 200);
+        }
+        return http.Response('', 500);
+      });
+      final PublishPluginCommand command = PublishPluginCommand(packagesDir,
+          processRunner: processRunner,
+          print: (Object? message) => printedMessages.add(message.toString()),
+          stdinput: mockStdin,
+          httpClient: mockClient,
+          gitDir: gitDir);
+
+      commandRunner = CommandRunner<void>(
+        'publish_check_command',
+        'Test for publish-check command.',
+      );
+      commandRunner.addCommand(command);
       // Non-federated
       final Directory pluginDir1 =
           createFakePlugin('plugin1', packagesDir, withSingleExample: true);
@@ -543,7 +642,6 @@ void main() {
             'Checking local repo...',
             'Local repo is ready!',
             '===============  DRY RUN ===============',
-            'Getting existing tags...',
             'Running `pub publish ` in ${pluginDir1.path}...\n',
             'Tagging release plugin1-v0.0.1...',
             'Pushing tag to upstream...',
@@ -557,6 +655,37 @@ void main() {
     });
 
     test('version change triggers releases.', () async {
+      const Map<String, dynamic> httpResponsePlugin1 = <String, dynamic>{
+        'name': 'plugin1',
+        'versions': <String>[],
+      };
+
+      const Map<String, dynamic> httpResponsePlugin2 = <String, dynamic>{
+        'name': 'plugin2',
+        'versions': <String>[],
+      };
+
+      final MockClient mockClient = MockClient((http.Request request) async {
+        if (request.url.pathSegments.last == 'plugin1.json') {
+          return http.Response(json.encode(httpResponsePlugin1), 200);
+        } else if (request.url.pathSegments.last == 'plugin2.json') {
+          return http.Response(json.encode(httpResponsePlugin2), 200);
+        }
+        return http.Response('', 500);
+      });
+      final PublishPluginCommand command = PublishPluginCommand(packagesDir,
+          processRunner: processRunner,
+          print: (Object? message) => printedMessages.add(message.toString()),
+          stdinput: mockStdin,
+          httpClient: mockClient,
+          gitDir: gitDir);
+
+      commandRunner = CommandRunner<void>(
+        'publish_check_command',
+        'Test for publish-check command.',
+      );
+      commandRunner.addCommand(command);
+
       // Non-federated
       final Directory pluginDir1 =
           createFakePlugin('plugin1', packagesDir, withSingleExample: true);
@@ -579,7 +708,6 @@ void main() {
           containsAllInOrder(<String>[
             'Checking local repo...',
             'Local repo is ready!',
-            'Getting existing tags...',
             'Running `pub publish ` in ${pluginDir1.path}...\n',
             'Running `pub publish ` in ${pluginDir2.path}...\n',
             'Packages released: plugin1, plugin2',
@@ -621,7 +749,6 @@ void main() {
           containsAllInOrder(<String>[
             'Checking local repo...',
             'Local repo is ready!',
-            'Getting existing tags...',
             'Running `pub publish ` in ${pluginDir1.path}...\n',
             'Running `pub publish ` in ${pluginDir2.path}...\n',
             'Packages released: plugin1, plugin2',
@@ -640,6 +767,37 @@ void main() {
     test(
         'delete package will not trigger publish but exit the command successfully.',
         () async {
+      const Map<String, dynamic> httpResponsePlugin1 = <String, dynamic>{
+        'name': 'plugin1',
+        'versions': <String>[],
+      };
+
+      const Map<String, dynamic> httpResponsePlugin2 = <String, dynamic>{
+        'name': 'plugin2',
+        'versions': <String>[],
+      };
+
+      final MockClient mockClient = MockClient((http.Request request) async {
+        if (request.url.pathSegments.last == 'plugin1.json') {
+          return http.Response(json.encode(httpResponsePlugin1), 200);
+        } else if (request.url.pathSegments.last == 'plugin2.json') {
+          return http.Response(json.encode(httpResponsePlugin2), 200);
+        }
+        return http.Response('', 500);
+      });
+      final PublishPluginCommand command = PublishPluginCommand(packagesDir,
+          processRunner: processRunner,
+          print: (Object? message) => printedMessages.add(message.toString()),
+          stdinput: mockStdin,
+          httpClient: mockClient,
+          gitDir: gitDir);
+
+      commandRunner = CommandRunner<void>(
+        'publish_check_command',
+        'Test for publish-check command.',
+      );
+      commandRunner.addCommand(command);
+
       // Non-federated
       final Directory pluginDir1 =
           createFakePlugin('plugin1', packagesDir, withSingleExample: true);
@@ -662,7 +820,6 @@ void main() {
           containsAllInOrder(<String>[
             'Checking local repo...',
             'Local repo is ready!',
-            'Getting existing tags...',
             'Running `pub publish ` in ${pluginDir1.path}...\n',
             'Running `pub publish ` in ${pluginDir2.path}...\n',
             'Packages released: plugin1, plugin2',
@@ -703,7 +860,6 @@ void main() {
           containsAllInOrder(<String>[
             'Checking local repo...',
             'Local repo is ready!',
-            'Getting existing tags...',
             'Running `pub publish ` in ${pluginDir1.path}...\n',
             'The file at The pubspec file at ${pluginDir2.childFile('pubspec.yaml').path} does not exist. Publishing will not happen for plugin2.\nSafe to ignore if the package is deleted in this commit.\n',
             'Packages released: plugin1',
@@ -717,9 +873,39 @@ void main() {
       expect(processRunner.pushTagsArgs[2], 'plugin1-v0.0.2');
     });
 
-    test(
-        'versions revert do not trigger releases. Also prints out warning message.',
+    test('Exiting versions do not trigger release, also prints out message.',
         () async {
+      const Map<String, dynamic> httpResponsePlugin1 = <String, dynamic>{
+        'name': 'plugin1',
+        'versions': <String>['0.0.1'],
+      };
+
+      const Map<String, dynamic> httpResponsePlugin2 = <String, dynamic>{
+        'name': 'plugin2',
+        'versions': <String>['0.0.1'],
+      };
+
+      final MockClient mockClient = MockClient((http.Request request) async {
+        if (request.url.pathSegments.last == 'plugin1.json') {
+          return http.Response(json.encode(httpResponsePlugin1), 200);
+        } else if (request.url.pathSegments.last == 'plugin2.json') {
+          return http.Response(json.encode(httpResponsePlugin2), 200);
+        }
+        return http.Response('', 500);
+      });
+      final PublishPluginCommand command = PublishPluginCommand(packagesDir,
+          processRunner: processRunner,
+          print: (Object? message) => printedMessages.add(message.toString()),
+          stdinput: mockStdin,
+          httpClient: mockClient,
+          gitDir: gitDir);
+
+      commandRunner = CommandRunner<void>(
+        'publish_check_command',
+        'Test for publish-check command.',
+      );
+      commandRunner.addCommand(command);
+
       // Non-federated
       final Directory pluginDir1 =
           createFakePlugin('plugin1', packagesDir, withSingleExample: true);
@@ -727,9 +913,9 @@ void main() {
       final Directory pluginDir2 = createFakePlugin('plugin2', packagesDir,
           withSingleExample: true, parentDirectoryName: 'plugin2');
       createFakePubspec(pluginDir1,
-          name: 'plugin1', isFlutter: false, version: '0.0.2');
+          name: 'plugin1', isFlutter: false, version: '0.0.1');
       createFakePubspec(pluginDir2,
-          name: 'plugin2', isFlutter: false, version: '0.0.2');
+          name: 'plugin2', isFlutter: false, version: '0.0.1');
       await gitDir.runCommand(<String>['add', '-A']);
       await gitDir.runCommand(<String>['commit', '-m', 'Add plugins']);
       // Immediately return 0 when running `pub publish`.
@@ -742,51 +928,8 @@ void main() {
           containsAllInOrder(<String>[
             'Checking local repo...',
             'Local repo is ready!',
-            'Getting existing tags...',
-            'Running `pub publish ` in ${pluginDir1.path}...\n',
-            'Running `pub publish ` in ${pluginDir2.path}...\n',
-            'Packages released: plugin1, plugin2',
-            'Done!'
-          ]));
-      expect(processRunner.pushTagsArgs, isNotEmpty);
-      expect(processRunner.pushTagsArgs[0], 'push');
-      expect(processRunner.pushTagsArgs[1], 'upstream');
-      expect(processRunner.pushTagsArgs[2], 'plugin1-v0.0.2');
-      expect(processRunner.pushTagsArgs[3], 'push');
-      expect(processRunner.pushTagsArgs[4], 'upstream');
-      expect(processRunner.pushTagsArgs[5], 'plugin2-v0.0.2');
-
-      processRunner.pushTagsArgs.clear();
-      printedMessages.clear();
-
-      final List<String> plugin1Pubspec =
-          pluginDir1.childFile('pubspec.yaml').readAsLinesSync();
-      plugin1Pubspec[plugin1Pubspec.indexWhere(
-          (String element) => element.contains('version:'))] = 'version: 0.0.1';
-      pluginDir1
-          .childFile('pubspec.yaml')
-          .writeAsStringSync(plugin1Pubspec.join('\n'));
-      final List<String> plugin2Pubspec =
-          pluginDir2.childFile('pubspec.yaml').readAsLinesSync();
-      plugin2Pubspec[plugin2Pubspec.indexWhere(
-          (String element) => element.contains('version:'))] = 'version: 0.0.1';
-      pluginDir2
-          .childFile('pubspec.yaml')
-          .writeAsStringSync(plugin2Pubspec.join('\n'));
-      await gitDir.runCommand(<String>['add', '-A']);
-      await gitDir
-          .runCommand(<String>['commit', '-m', 'Update versions to 0.0.1']);
-
-      await commandRunner
-          .run(<String>['publish-plugin', '--all-changed', '--base-sha=HEAD~']);
-      expect(
-          printedMessages,
-          containsAllInOrder(<String>[
-            'Checking local repo...',
-            'Local repo is ready!',
-            'Getting existing tags...',
-            'The new version (0.0.1) is lower than the current version (0.0.2) for plugin1.\nThis git commit is a revert, no release is tagged.',
-            'The new version (0.0.1) is lower than the current version (0.0.2) for plugin2.\nThis git commit is a revert, no release is tagged.',
+            'The version 0.0.1 of plugin1 has already been published, skip.',
+            'The version 0.0.1 of plugin2 has already been published, skip.',
             'Done!'
           ]));
 


### PR DESCRIPTION
This PR removes a TODO where we used to check if a release should happen against git tags, instead, we check against pub. 

Also, when auto-publish and the package is manually released, the CI will continue to fail without this change. 

Fixes https://github.com/flutter/flutter/issues/81047

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
