### PR TITLE
[google_sign_in] Adds support for serverAuthCode. 

### DIFF
--- a/packages/google_sign_in/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 5.0.5
 
 * Add iOS unit and UI integration test targets.
+* Adds support for serverAuthCode and server side authentication.
 
 ## 5.0.4
 

--- a/packages/google_sign_in/google_sign_in/ios/Classes/FLTGoogleSignInPlugin.m
+++ b/packages/google_sign_in/google_sign_in/ios/Classes/FLTGoogleSignInPlugin.m
@@ -124,6 +124,7 @@ static FlutterError *getFlutterError(NSError *error) {
       result(error != nil ? getFlutterError(error) : @{
         @"idToken" : authentication.idToken,
         @"accessToken" : authentication.accessToken,
+        @"serverAuthCode" : currentUser.serverAuthCode,
       });
     }];
   } else if ([call.method isEqualToString:@"signOut"]) {
@@ -235,8 +236,7 @@ static FlutterError *getFlutterError(NSError *error) {
         @"displayName" : user.profile.name ?: [NSNull null],
         @"email" : user.profile.email ?: [NSNull null],
         @"id" : user.userID ?: [NSNull null],
-        @"photoUrl" : [photoUrl absoluteString] ?: [NSNull null],
-        @"serverAuthCode" : user.serverAuthCode ?: [NSNull null]
+        @"photoUrl" : [photoUrl absoluteString] ?: [NSNull null]
       }
                          error:nil];
     }

--- a/packages/google_sign_in/google_sign_in/lib/google_sign_in.dart
+++ b/packages/google_sign_in/google_sign_in/lib/google_sign_in.dart
@@ -44,7 +44,8 @@ class GoogleSignInAccount implements GoogleIdentity {
         email = data.email,
         id = data.id,
         photoUrl = data.photoUrl,
-        _idToken = data.idToken {
+        _idToken = data.idToken,
+        _serverAuthCode = data.serverAuthCode {
     assert(id != null);
   }
 
@@ -69,6 +70,7 @@ class GoogleSignInAccount implements GoogleIdentity {
   final String? photoUrl;
 
   final String? _idToken;
+  final String? _serverAuthCode;
   final GoogleSignIn _googleSignIn;
 
   /// Retrieve [GoogleSignInAuthentication] for this account.
@@ -97,6 +99,11 @@ class GoogleSignInAccount implements GoogleIdentity {
     if (response.idToken == null) {
       response.idToken = _idToken;
     }
+    
+    if (response.serverAuthCode == null) {
+      response.serverAuthCode = _serverAuthCode;
+    }
+    
     return GoogleSignInAuthentication._(response);
   }
 
@@ -132,11 +139,12 @@ class GoogleSignInAccount implements GoogleIdentity {
         email == otherAccount.email &&
         id == otherAccount.id &&
         photoUrl == otherAccount.photoUrl &&
-        _idToken == otherAccount._idToken;
+        _idToken == otherAccount._idToken &&
+        _serverAuthCode == otherAccount._serverAuthCode;
   }
 
   @override
-  int get hashCode => hashValues(displayName, email, id, photoUrl, _idToken);
+  int get hashCode => hashValues(displayName, email, id, photoUrl, _idToken, _serverAuthCode);
 
   @override
   String toString() {

--- a/packages/google_sign_in/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android and iOS.
 repository: https://github.com/flutter/plugins/tree/master/packages/google_sign_in/google_sign_in
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
-version: 5.0.4
+version: 5.0.5
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -23,7 +23,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  google_sign_in_platform_interface: ^2.0.1
+  google_sign_in_platform_interface: ^2.0.2
   google_sign_in_web: ^0.10.0
   meta: ^1.3.0
 

--- a/packages/google_sign_in/google_sign_in_platform_interface/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.2
+
+* Adds support for serverAuthCode and server side authentication.
+
 ## 2.0.1
 
 * Updates `init` function in `MethodChannelGoogleSignIn` to parametrize `clientId` property.

--- a/packages/google_sign_in/google_sign_in_platform_interface/lib/src/types.dart
+++ b/packages/google_sign_in/google_sign_in_platform_interface/lib/src/types.dart
@@ -31,6 +31,7 @@ class GoogleSignInUserData {
     this.displayName,
     this.photoUrl,
     this.idToken,
+    this.serverAuthCode,
   });
 
   /// The display name of the signed in user.
@@ -66,9 +67,12 @@ class GoogleSignInUserData {
   /// data.
   String? idToken;
 
+  /// Authorization code required to make Google API calls from your server.
+  String? serverAuthCode;
+
   @override
   int get hashCode =>
-      hashObjects(<String?>[displayName, email, id, photoUrl, idToken]);
+      hashObjects(<String?>[displayName, email, id, photoUrl, idToken, serverAuthCode]);
 
   @override
   bool operator ==(dynamic other) {
@@ -79,7 +83,8 @@ class GoogleSignInUserData {
         otherUserData.email == email &&
         otherUserData.id == id &&
         otherUserData.photoUrl == photoUrl &&
-        otherUserData.idToken == idToken;
+        otherUserData.idToken == idToken  &&
+        otherUserData.serverAuthCode == serverAuthCode;
   }
 }
 

--- a/packages/google_sign_in/google_sign_in_platform_interface/lib/src/utils.dart
+++ b/packages/google_sign_in/google_sign_in_platform_interface/lib/src/utils.dart
@@ -14,7 +14,8 @@ GoogleSignInUserData? getUserDataFromMap(Map<String, dynamic>? data) {
       id: data['id']!,
       displayName: data['displayName'],
       photoUrl: data['photoUrl'],
-      idToken: data['idToken']);
+      idToken: data['idToken'],
+      serverAuthCode: data['serverAuthCode'],);
 }
 
 /// Converts token data coming from native code into the proper platform interface type.

--- a/packages/google_sign_in/google_sign_in_platform_interface/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/master/packages/google_sign_
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.0.1
+version: 2.0.2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/google_sign_in/google_sign_in_web/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.1
+
+* Updates dependencies.
+
 ## 0.10.0
 
 * Migrate to null-safety.

--- a/packages/google_sign_in/google_sign_in_web/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_web/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android, iOS and Web.
 repository: https://github.com/flutter/plugins/tree/master/packages/google_sign_in/google_sign_in_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
-version: 0.10.0
+version: 0.10.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -21,7 +21,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  google_sign_in_platform_interface: ^2.0.0
+  google_sign_in_platform_interface: ^2.0.2
   js: ^0.6.3
   meta: ^1.3.0
 


### PR DESCRIPTION
Adds missing support for `serverAuthCode` in google_sign_in packages. Without this fix, it's not possible to do server-side authentification with Google sign-in.

This module has very limited tests. It's also very hard to test this fix automatically as it would include talking with Google's API:s, having access to API keys, and doing non-Flutter actions such as signing in through native code.

Fixes:
https://github.com/flutter/flutter/issues/57712

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.
