### PR TITLE
[flutter_plugin_tools] Migrate build-examples to new base command

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -218,7 +218,7 @@ task:
         - xcrun simctl list
         - xcrun simctl create Flutter-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-11 com.apple.CoreSimulator.SimRuntime.iOS-14-5 | xargs xcrun simctl boot
       build_script:
-        - ./script/tool_runner.sh build-examples --ipa
+        - ./script/tool_runner.sh build-examples --ios
       xctest_script:
         - ./script/tool_runner.sh xctest --ios --ios-destination "platform=iOS Simulator,name=iPhone 11,OS=latest"
       drive_script:
@@ -246,7 +246,7 @@ task:
         PATH: $PATH:/usr/local/bin
       build_script:
         - flutter config --enable-macos-desktop
-        - ./script/tool_runner.sh build-examples --macos --no-ipa
+        - ./script/tool_runner.sh build-examples --macos
       xctest_script:
         - ./script/tool_runner.sh xctest --macos --exclude $PLUGINS_TO_EXCLUDE_MACOS_XCTESTS
       drive_script:

--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -5,6 +5,8 @@
   compatibility.
 - `xctest` now supports running macOS tests in addition to iOS
   - **Breaking change**: it now requires an `--ios` and/or `--macos` flag.
+- **Breaking change**: `build-examples` for iOS now uses `--ios` rather than
+  `--ipa`.
 - The tooling now runs in strong null-safe mode.
 - Modified the output format of `pubspec-check` and `xctest`
 

--- a/script/tool/lib/src/build_examples_command.dart
+++ b/script/tool/lib/src/build_examples_command.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io' as io;
 
 import 'package:file/file.dart';
 import 'package:path/path.dart' as p;

--- a/script/tool/lib/src/build_examples_command.dart
+++ b/script/tool/lib/src/build_examples_command.dart
@@ -14,11 +14,8 @@ import 'common/package_looping_command.dart';
 import 'common/plugin_utils.dart';
 import 'common/process_runner.dart';
 
-/// Key for IPA.
-const String kIpa = 'ipa';
-
 /// Key for APK.
-const String kApk = 'apk';
+const String _platformFlagApk = 'apk';
 
 const int _exitNoPlatformFlags = 2;
 
@@ -29,12 +26,12 @@ class BuildExamplesCommand extends PackageLoopingCommand {
     Directory packagesDir, {
     ProcessRunner processRunner = const ProcessRunner(),
   }) : super(packagesDir, processRunner: processRunner) {
-    argParser.addFlag(kPlatformLinux, defaultsTo: false);
-    argParser.addFlag(kPlatformMacos, defaultsTo: false);
-    argParser.addFlag(kPlatformWeb, defaultsTo: false);
-    argParser.addFlag(kPlatformWindows, defaultsTo: false);
-    argParser.addFlag(kIpa, defaultsTo: io.Platform.isMacOS);
-    argParser.addFlag(kApk);
+    argParser.addFlag(kPlatformLinux);
+    argParser.addFlag(kPlatformMacos);
+    argParser.addFlag(kPlatformWeb);
+    argParser.addFlag(kPlatformWindows);
+    argParser.addFlag(kPlatformIos);
+    argParser.addFlag(_platformFlagApk);
     argParser.addOption(
       kEnableExperiment,
       defaultsTo: '',
@@ -53,8 +50,8 @@ class BuildExamplesCommand extends PackageLoopingCommand {
   @override
   Future<void> initializeRun() async {
     final List<String> platformSwitches = <String>[
-      kApk,
-      kIpa,
+      _platformFlagApk,
+      kPlatformIos,
       kPlatformLinux,
       kPlatformMacos,
       kPlatformWeb,
@@ -161,7 +158,7 @@ class BuildExamplesCommand extends PackageLoopingCommand {
         }
       }
 
-      if (getBoolArg(kIpa)) {
+      if (getBoolArg(kPlatformIos)) {
         print('\nBUILDING IPA for $packageName');
         if (isIosPlugin(package)) {
           final int exitCode = await processRunner.runAndStream(
@@ -182,7 +179,7 @@ class BuildExamplesCommand extends PackageLoopingCommand {
         }
       }
 
-      if (getBoolArg(kApk)) {
+      if (getBoolArg(_platformFlagApk)) {
         print('\nBUILDING APK for $packageName');
         if (isAndroidPlugin(package)) {
           final int exitCode = await processRunner.runAndStream(

--- a/script/tool/lib/src/build_examples_command.dart
+++ b/script/tool/lib/src/build_examples_command.dart
@@ -10,7 +10,7 @@ import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
 
 import 'common/core.dart';
-import 'common/plugin_command.dart';
+import 'common/package_looping_command.dart';
 import 'common/plugin_utils.dart';
 import 'common/process_runner.dart';
 
@@ -20,8 +20,10 @@ const String kIpa = 'ipa';
 /// Key for APK.
 const String kApk = 'apk';
 
+const int _exitNoPlatformFlags = 2;
+
 /// A command to build the example applications for packages.
-class BuildExamplesCommand extends PluginCommand {
+class BuildExamplesCommand extends PackageLoopingCommand {
   /// Creates an instance of the build command.
   BuildExamplesCommand(
     Directory packagesDir, {
@@ -49,7 +51,7 @@ class BuildExamplesCommand extends PluginCommand {
       'This command requires "flutter" to be in your path.';
 
   @override
-  Future<void> run() async {
+  Future<void> initializeRun() async {
     final List<String> platformSwitches = <String>[
       kApk,
       kIpa,
@@ -59,154 +61,148 @@ class BuildExamplesCommand extends PluginCommand {
       kPlatformWindows,
     ];
     if (!platformSwitches.any((String platform) => getBoolArg(platform))) {
-      print(
+      printError(
           'None of ${platformSwitches.map((String platform) => '--$platform').join(', ')} '
-          'were specified, so not building anything.');
-      return;
+          'were specified. At least one platform must be provided.');
+      throw ToolExit(_exitNoPlatformFlags);
     }
+  }
+
+  @override
+  Future<List<String>> runForPackage(Directory package) async {
     final String flutterCommand =
         const LocalPlatform().isWindows ? 'flutter.bat' : 'flutter';
 
     final String enableExperiment = getStringArg(kEnableExperiment);
 
-    final List<String> failingPackages = <String>[];
-    await for (final Directory plugin in getPlugins()) {
-      for (final Directory example in getExamplesForPlugin(plugin)) {
-        final String packageName =
-            p.relative(example.path, from: packagesDir.path);
+    final List<String> errors = <String>[];
 
-        if (getBoolArg(kPlatformLinux)) {
-          print('\nBUILDING Linux for $packageName');
-          if (isLinuxPlugin(plugin)) {
-            final int buildExitCode = await processRunner.runAndStream(
-                flutterCommand,
-                <String>[
-                  'build',
-                  kPlatformLinux,
-                  if (enableExperiment.isNotEmpty)
-                    '--enable-experiment=$enableExperiment',
-                ],
-                workingDir: example);
-            if (buildExitCode != 0) {
-              failingPackages.add('$packageName (linux)');
-            }
-          } else {
-            print('Linux is not supported by this plugin');
+    for (final Directory example in getExamplesForPlugin(package)) {
+      final String packageName =
+          p.relative(example.path, from: packagesDir.path);
+
+      if (getBoolArg(kPlatformLinux)) {
+        print('\nBUILDING Linux for $packageName');
+        if (isLinuxPlugin(package)) {
+          final int buildExitCode = await processRunner.runAndStream(
+              flutterCommand,
+              <String>[
+                'build',
+                kPlatformLinux,
+                if (enableExperiment.isNotEmpty)
+                  '--enable-experiment=$enableExperiment',
+              ],
+              workingDir: example);
+          if (buildExitCode != 0) {
+            errors.add('$packageName (linux)');
           }
+        } else {
+          printSkip('Linux is not supported by this plugin');
         }
+      }
 
-        if (getBoolArg(kPlatformMacos)) {
-          print('\nBUILDING macOS for $packageName');
-          if (isMacOsPlugin(plugin)) {
-            final int exitCode = await processRunner.runAndStream(
-                flutterCommand,
-                <String>[
-                  'build',
-                  kPlatformMacos,
-                  if (enableExperiment.isNotEmpty)
-                    '--enable-experiment=$enableExperiment',
-                ],
-                workingDir: example);
-            if (exitCode != 0) {
-              failingPackages.add('$packageName (macos)');
-            }
-          } else {
-            print('macOS is not supported by this plugin');
+      if (getBoolArg(kPlatformMacos)) {
+        print('\nBUILDING macOS for $packageName');
+        if (isMacOsPlugin(package)) {
+          final int exitCode = await processRunner.runAndStream(
+              flutterCommand,
+              <String>[
+                'build',
+                kPlatformMacos,
+                if (enableExperiment.isNotEmpty)
+                  '--enable-experiment=$enableExperiment',
+              ],
+              workingDir: example);
+          if (exitCode != 0) {
+            errors.add('$packageName (macos)');
           }
+        } else {
+          printSkip('macOS is not supported by this plugin');
         }
+      }
 
-        if (getBoolArg(kPlatformWeb)) {
-          print('\nBUILDING web for $packageName');
-          if (isWebPlugin(plugin)) {
-            final int buildExitCode = await processRunner.runAndStream(
-                flutterCommand,
-                <String>[
-                  'build',
-                  kPlatformWeb,
-                  if (enableExperiment.isNotEmpty)
-                    '--enable-experiment=$enableExperiment',
-                ],
-                workingDir: example);
-            if (buildExitCode != 0) {
-              failingPackages.add('$packageName (web)');
-            }
-          } else {
-            print('Web is not supported by this plugin');
+      if (getBoolArg(kPlatformWeb)) {
+        print('\nBUILDING web for $packageName');
+        if (isWebPlugin(package)) {
+          final int buildExitCode = await processRunner.runAndStream(
+              flutterCommand,
+              <String>[
+                'build',
+                kPlatformWeb,
+                if (enableExperiment.isNotEmpty)
+                  '--enable-experiment=$enableExperiment',
+              ],
+              workingDir: example);
+          if (buildExitCode != 0) {
+            errors.add('$packageName (web)');
           }
+        } else {
+          printSkip('Web is not supported by this plugin');
         }
+      }
 
-        if (getBoolArg(kPlatformWindows)) {
-          print('\nBUILDING Windows for $packageName');
-          if (isWindowsPlugin(plugin)) {
-            final int buildExitCode = await processRunner.runAndStream(
-                flutterCommand,
-                <String>[
-                  'build',
-                  kPlatformWindows,
-                  if (enableExperiment.isNotEmpty)
-                    '--enable-experiment=$enableExperiment',
-                ],
-                workingDir: example);
-            if (buildExitCode != 0) {
-              failingPackages.add('$packageName (windows)');
-            }
-          } else {
-            print('Windows is not supported by this plugin');
+      if (getBoolArg(kPlatformWindows)) {
+        print('\nBUILDING Windows for $packageName');
+        if (isWindowsPlugin(package)) {
+          final int buildExitCode = await processRunner.runAndStream(
+              flutterCommand,
+              <String>[
+                'build',
+                kPlatformWindows,
+                if (enableExperiment.isNotEmpty)
+                  '--enable-experiment=$enableExperiment',
+              ],
+              workingDir: example);
+          if (buildExitCode != 0) {
+            errors.add('$packageName (windows)');
           }
+        } else {
+          printSkip('Windows is not supported by this plugin');
         }
+      }
 
-        if (getBoolArg(kIpa)) {
-          print('\nBUILDING IPA for $packageName');
-          if (isIosPlugin(plugin)) {
-            final int exitCode = await processRunner.runAndStream(
-                flutterCommand,
-                <String>[
-                  'build',
-                  'ios',
-                  '--no-codesign',
-                  if (enableExperiment.isNotEmpty)
-                    '--enable-experiment=$enableExperiment',
-                ],
-                workingDir: example);
-            if (exitCode != 0) {
-              failingPackages.add('$packageName (ipa)');
-            }
-          } else {
-            print('iOS is not supported by this plugin');
+      if (getBoolArg(kIpa)) {
+        print('\nBUILDING IPA for $packageName');
+        if (isIosPlugin(package)) {
+          final int exitCode = await processRunner.runAndStream(
+              flutterCommand,
+              <String>[
+                'build',
+                'ios',
+                '--no-codesign',
+                if (enableExperiment.isNotEmpty)
+                  '--enable-experiment=$enableExperiment',
+              ],
+              workingDir: example);
+          if (exitCode != 0) {
+            errors.add('$packageName (ipa)');
           }
+        } else {
+          printSkip('iOS is not supported by this plugin');
         }
+      }
 
-        if (getBoolArg(kApk)) {
-          print('\nBUILDING APK for $packageName');
-          if (isAndroidPlugin(plugin)) {
-            final int exitCode = await processRunner.runAndStream(
-                flutterCommand,
-                <String>[
-                  'build',
-                  'apk',
-                  if (enableExperiment.isNotEmpty)
-                    '--enable-experiment=$enableExperiment',
-                ],
-                workingDir: example);
-            if (exitCode != 0) {
-              failingPackages.add('$packageName (apk)');
-            }
-          } else {
-            print('Android is not supported by this plugin');
+      if (getBoolArg(kApk)) {
+        print('\nBUILDING APK for $packageName');
+        if (isAndroidPlugin(package)) {
+          final int exitCode = await processRunner.runAndStream(
+              flutterCommand,
+              <String>[
+                'build',
+                'apk',
+                if (enableExperiment.isNotEmpty)
+                  '--enable-experiment=$enableExperiment',
+              ],
+              workingDir: example);
+          if (exitCode != 0) {
+            errors.add('$packageName (apk)');
           }
+        } else {
+          printSkip('Android is not supported by this plugin');
         }
       }
     }
-    print('\n\n');
 
-    if (failingPackages.isNotEmpty) {
-      print('The following build are failing (see above for details):');
-      for (final String package in failingPackages) {
-        print(' * $package');
-      }
-      throw ToolExit(1);
-    }
-
-    print('All builds successful!');
+    return errors;
   }
 }

--- a/script/tool/test/build_examples_command_test.dart
+++ b/script/tool/test/build_examples_command_test.dart
@@ -43,8 +43,8 @@ void main() {
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
 
-      final List<String> output = await runCapturingPrint(
-          runner, <String>['build-examples', '--ipa', '--no-macos']);
+      final List<String> output =
+          await runCapturingPrint(runner, <String>['build-examples', '--ios']);
       final String packageName =
           p.relative(pluginExampleDirectory.path, from: packagesDir.path);
 
@@ -76,12 +76,8 @@ void main() {
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
 
-      final List<String> output = await runCapturingPrint(runner, <String>[
-        'build-examples',
-        '--ipa',
-        '--no-macos',
-        '--enable-experiment=exp1'
-      ]);
+      final List<String> output = await runCapturingPrint(runner,
+          <String>['build-examples', '--ios', '--enable-experiment=exp1']);
       final String packageName =
           p.relative(pluginExampleDirectory.path, from: packagesDir.path);
 
@@ -119,7 +115,7 @@ void main() {
           pluginDirectory.childDirectory('example');
 
       final List<String> output = await runCapturingPrint(
-          runner, <String>['build-examples', '--no-ipa', '--linux']);
+          runner, <String>['build-examples', '--linux']);
       final String packageName =
           p.relative(pluginExampleDirectory.path, from: packagesDir.path);
 
@@ -152,7 +148,7 @@ void main() {
           pluginDirectory.childDirectory('example');
 
       final List<String> output = await runCapturingPrint(
-          runner, <String>['build-examples', '--no-ipa', '--linux']);
+          runner, <String>['build-examples', '--linux']);
       final String packageName =
           p.relative(pluginExampleDirectory.path, from: packagesDir.path);
 
@@ -182,7 +178,7 @@ void main() {
           pluginDirectory.childDirectory('example');
 
       final List<String> output = await runCapturingPrint(
-          runner, <String>['build-examples', '--no-ipa', '--macos']);
+          runner, <String>['build-examples', '--macos']);
       final String packageName =
           p.relative(pluginExampleDirectory.path, from: packagesDir.path);
 
@@ -216,7 +212,7 @@ void main() {
           pluginDirectory.childDirectory('example');
 
       final List<String> output = await runCapturingPrint(
-          runner, <String>['build-examples', '--no-ipa', '--macos']);
+          runner, <String>['build-examples', '--macos']);
       final String packageName =
           p.relative(pluginExampleDirectory.path, from: packagesDir.path);
 
@@ -244,8 +240,8 @@ void main() {
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
 
-      final List<String> output = await runCapturingPrint(
-          runner, <String>['build-examples', '--no-ipa', '--web']);
+      final List<String> output =
+          await runCapturingPrint(runner, <String>['build-examples', '--web']);
       final String packageName =
           p.relative(pluginExampleDirectory.path, from: packagesDir.path);
 
@@ -278,8 +274,8 @@ void main() {
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
 
-      final List<String> output = await runCapturingPrint(
-          runner, <String>['build-examples', '--no-ipa', '--web']);
+      final List<String> output =
+          await runCapturingPrint(runner, <String>['build-examples', '--web']);
       final String packageName =
           p.relative(pluginExampleDirectory.path, from: packagesDir.path);
 
@@ -310,7 +306,7 @@ void main() {
           pluginDirectory.childDirectory('example');
 
       final List<String> output = await runCapturingPrint(
-          runner, <String>['build-examples', '--no-ipa', '--windows']);
+          runner, <String>['build-examples', '--windows']);
       final String packageName =
           p.relative(pluginExampleDirectory.path, from: packagesDir.path);
 
@@ -343,7 +339,7 @@ void main() {
           pluginDirectory.childDirectory('example');
 
       final List<String> output = await runCapturingPrint(
-          runner, <String>['build-examples', '--no-ipa', '--windows']);
+          runner, <String>['build-examples', '--windows']);
       final String packageName =
           p.relative(pluginExampleDirectory.path, from: packagesDir.path);
 
@@ -373,8 +369,8 @@ void main() {
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
 
-      final List<String> output = await runCapturingPrint(
-          runner, <String>['build-examples', '--apk', '--no-ipa']);
+      final List<String> output =
+          await runCapturingPrint(runner, <String>['build-examples', '--apk']);
       final String packageName =
           p.relative(pluginExampleDirectory.path, from: packagesDir.path);
 
@@ -409,8 +405,6 @@ void main() {
       final List<String> output = await runCapturingPrint(runner, <String>[
         'build-examples',
         '--apk',
-        '--no-ipa',
-        '--no-macos',
       ]);
       final String packageName =
           p.relative(pluginExampleDirectory.path, from: packagesDir.path);
@@ -445,13 +439,8 @@ void main() {
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
 
-      await runCapturingPrint(runner, <String>[
-        'build-examples',
-        '--apk',
-        '--no-ipa',
-        '--no-macos',
-        '--enable-experiment=exp1'
-      ]);
+      await runCapturingPrint(runner,
+          <String>['build-examples', '--apk', '--enable-experiment=exp1']);
 
       expect(
           processRunner.recordedCalls,
@@ -478,12 +467,8 @@ void main() {
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
 
-      await runCapturingPrint(runner, <String>[
-        'build-examples',
-        '--ipa',
-        '--no-macos',
-        '--enable-experiment=exp1'
-      ]);
+      await runCapturingPrint(runner,
+          <String>['build-examples', '--ios', '--enable-experiment=exp1']);
       expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[

--- a/script/tool/test/build_examples_command_test.dart
+++ b/script/tool/test/build_examples_command_test.dart
@@ -50,11 +50,9 @@ void main() {
 
       expect(
         output,
-        orderedEquals(<String>[
-          '\nBUILDING IPA for $packageName',
-          'iOS is not supported by this plugin',
-          '\n\n',
-          'All builds successful!',
+        containsAllInOrder(<Matcher>[
+          contains('BUILDING IPA for $packageName'),
+          contains('iOS is not supported by this plugin'),
         ]),
       );
 
@@ -89,10 +87,8 @@ void main() {
 
       expect(
         output,
-        orderedEquals(<String>[
+        containsAllInOrder(<String>[
           '\nBUILDING IPA for $packageName',
-          '\n\n',
-          'All builds successful!',
         ]),
       );
 
@@ -129,11 +125,9 @@ void main() {
 
       expect(
         output,
-        orderedEquals(<String>[
-          '\nBUILDING Linux for $packageName',
-          'Linux is not supported by this plugin',
-          '\n\n',
-          'All builds successful!',
+        containsAllInOrder(<Matcher>[
+          contains('BUILDING Linux for $packageName'),
+          contains('Linux is not supported by this plugin'),
         ]),
       );
 
@@ -164,10 +158,8 @@ void main() {
 
       expect(
         output,
-        orderedEquals(<String>[
+        containsAllInOrder(<String>[
           '\nBUILDING Linux for $packageName',
-          '\n\n',
-          'All builds successful!',
         ]),
       );
 
@@ -196,11 +188,9 @@ void main() {
 
       expect(
         output,
-        orderedEquals(<String>[
-          '\nBUILDING macOS for $packageName',
-          'macOS is not supported by this plugin',
-          '\n\n',
-          'All builds successful!',
+        containsAllInOrder(<Matcher>[
+          contains('BUILDING macOS for $packageName'),
+          contains('macOS is not supported by this plugin'),
         ]),
       );
 
@@ -232,10 +222,8 @@ void main() {
 
       expect(
         output,
-        orderedEquals(<String>[
+        containsAllInOrder(<String>[
           '\nBUILDING macOS for $packageName',
-          '\n\n',
-          'All builds successful!',
         ]),
       );
 
@@ -263,11 +251,9 @@ void main() {
 
       expect(
         output,
-        orderedEquals(<String>[
-          '\nBUILDING web for $packageName',
-          'Web is not supported by this plugin',
-          '\n\n',
-          'All builds successful!',
+        containsAllInOrder(<Matcher>[
+          contains('BUILDING web for $packageName'),
+          contains('Web is not supported by this plugin'),
         ]),
       );
 
@@ -299,10 +285,8 @@ void main() {
 
       expect(
         output,
-        orderedEquals(<String>[
+        containsAllInOrder(<String>[
           '\nBUILDING web for $packageName',
-          '\n\n',
-          'All builds successful!',
         ]),
       );
 
@@ -332,11 +316,9 @@ void main() {
 
       expect(
         output,
-        orderedEquals(<String>[
-          '\nBUILDING Windows for $packageName',
-          'Windows is not supported by this plugin',
-          '\n\n',
-          'All builds successful!',
+        containsAllInOrder(<Matcher>[
+          contains('BUILDING Windows for $packageName'),
+          contains('Windows is not supported by this plugin'),
         ]),
       );
 
@@ -367,10 +349,8 @@ void main() {
 
       expect(
         output,
-        orderedEquals(<String>[
+        containsAllInOrder(<String>[
           '\nBUILDING Windows for $packageName',
-          '\n\n',
-          'All builds successful!',
         ]),
       );
 
@@ -400,11 +380,9 @@ void main() {
 
       expect(
         output,
-        orderedEquals(<String>[
-          '\nBUILDING APK for $packageName',
-          'Android is not supported by this plugin',
-          '\n\n',
-          'All builds successful!',
+        containsAllInOrder(<Matcher>[
+          contains('\nBUILDING APK for $packageName'),
+          contains('Android is not supported by this plugin'),
         ]),
       );
 
@@ -439,10 +417,8 @@ void main() {
 
       expect(
         output,
-        orderedEquals(<String>[
+        containsAllInOrder(<String>[
           '\nBUILDING APK for $packageName',
-          '\n\n',
-          'All builds successful!',
         ]),
       );
 

--- a/script/tool/test/build_examples_command_test.dart
+++ b/script/tool/test/build_examples_command_test.dart
@@ -15,7 +15,7 @@ import 'package:test/test.dart';
 import 'util.dart';
 
 void main() {
-  group('test build_example_command', () {
+  group('build-example', () {
     late FileSystem fileSystem;
     late Directory packagesDir;
     late CommandRunner<void> runner;
@@ -33,6 +33,13 @@ void main() {
       runner = CommandRunner<void>(
           'build_examples_command', 'Test for build_example_command');
       runner.addCommand(command);
+    });
+
+    test('fails if no plaform flags are passed', () async {
+      expect(
+        () => runCapturingPrint(runner, <String>['build-examples']),
+        throwsA(isA<ToolExit>()),
+      );
     });
 
     test('building for iOS when plugin is not set up for iOS results in no-op',

--- a/script/tool/test/build_examples_command_test.dart
+++ b/script/tool/test/build_examples_command_test.dart
@@ -51,7 +51,7 @@ void main() {
       expect(
         output,
         containsAllInOrder(<Matcher>[
-          contains('BUILDING IPA for $packageName'),
+          contains('BUILDING $packageName for iOS'),
           contains('iOS is not supported by this plugin'),
         ]),
       );
@@ -84,7 +84,7 @@ void main() {
       expect(
         output,
         containsAllInOrder(<String>[
-          '\nBUILDING IPA for $packageName',
+          '\nBUILDING $packageName for iOS',
         ]),
       );
 
@@ -122,7 +122,7 @@ void main() {
       expect(
         output,
         containsAllInOrder(<Matcher>[
-          contains('BUILDING Linux for $packageName'),
+          contains('BUILDING $packageName for Linux'),
           contains('Linux is not supported by this plugin'),
         ]),
       );
@@ -155,7 +155,7 @@ void main() {
       expect(
         output,
         containsAllInOrder(<String>[
-          '\nBUILDING Linux for $packageName',
+          '\nBUILDING $packageName for Linux',
         ]),
       );
 
@@ -185,7 +185,7 @@ void main() {
       expect(
         output,
         containsAllInOrder(<Matcher>[
-          contains('BUILDING macOS for $packageName'),
+          contains('BUILDING $packageName for macOS'),
           contains('macOS is not supported by this plugin'),
         ]),
       );
@@ -219,7 +219,7 @@ void main() {
       expect(
         output,
         containsAllInOrder(<String>[
-          '\nBUILDING macOS for $packageName',
+          '\nBUILDING $packageName for macOS',
         ]),
       );
 
@@ -248,7 +248,7 @@ void main() {
       expect(
         output,
         containsAllInOrder(<Matcher>[
-          contains('BUILDING web for $packageName'),
+          contains('BUILDING $packageName for web'),
           contains('Web is not supported by this plugin'),
         ]),
       );
@@ -282,7 +282,7 @@ void main() {
       expect(
         output,
         containsAllInOrder(<String>[
-          '\nBUILDING web for $packageName',
+          '\nBUILDING $packageName for web',
         ]),
       );
 
@@ -313,7 +313,7 @@ void main() {
       expect(
         output,
         containsAllInOrder(<Matcher>[
-          contains('BUILDING Windows for $packageName'),
+          contains('BUILDING $packageName for Windows'),
           contains('Windows is not supported by this plugin'),
         ]),
       );
@@ -346,7 +346,7 @@ void main() {
       expect(
         output,
         containsAllInOrder(<String>[
-          '\nBUILDING Windows for $packageName',
+          '\nBUILDING $packageName for Windows',
         ]),
       );
 


### PR DESCRIPTION
Switches build-examples to the new base command that handles the boilerplate of looping over target packages.

While modifying the command, also does some minor cleanup:
- Extracts a helper to reduce duplicated details of calling `flutter build`
- Switches the flag for iOS to `--ios` rather than `--ipa` since `ios` is what is actually passed to the build command
- iOS no longer defaults to on, so that it behaves like all the other platform flags
- Passing no platform flags is now an error rather than a silent pass, to ensure that we never accidentally have CI doing a no-op run without noticing.
- Rewords the logging slightly for the versions where the label for what is being built is a platform, not an artifact (which is now everything but Android).


Part of flutter/flutter#83413

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
