### PR TITLE
[url_launcher] Fix test button check for iOS 15

### DIFF
--- a/packages/url_launcher/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Fix test button check for iOS 15.
+
 ## 6.0.7
 
 * Update the README to describe a workaround to the `Uri` query

--- a/packages/url_launcher/url_launcher/example/ios/RunnerUITests/URLLauncherUITests.m
+++ b/packages/url_launcher/url_launcher/example/ios/RunnerUITests/URLLauncherUITests.m
@@ -27,19 +27,13 @@
   ];
   for (NSString* buttonName in buttonNames) {
     XCUIElement* button = app.buttons[buttonName];
-    if (![button waitForExistenceWithTimeout:30.0]) {
-      os_log_error(OS_LOG_DEFAULT, "%@", app.debugDescription);
-      XCTFail(@"Failed due to not able to find %@ button", buttonName);
-    }
+    XCTAssertTrue([button waitForExistenceWithTimeout:30.0]);
     XCTAssertEqual(app.webViews.count, 0);
     [button tap];
     XCUIElement* webView = app.webViews.firstMatch;
-    if (![webView waitForExistenceWithTimeout:30.0]) {
-      os_log_error(OS_LOG_DEFAULT, "%@", app.debugDescription);
-      XCTFail(@"Failed due to not able to find webview");
-    }
-    XCTAssertTrue(app.buttons[@"ForwardButton"].exists);
-    XCTAssertTrue(app.buttons[@"ShareButton"].exists);
+    XCTAssertTrue([webView waitForExistenceWithTimeout:30.0]);
+    XCTAssertTrue([app.buttons[@"ForwardButton"] waitForExistenceWithTimeout:30.0]);
+    XCTAssertTrue(app.buttons[@"Share"].exists);
     XCTAssertTrue(app.buttons[@"OpenInSafariButton"].exists);
     [app.buttons[@"Done"] tap];
   }


### PR DESCRIPTION
On iOS 15 the `ShareButton` button identifier has been renamed to `MoreOptionsButton`. Switch the check to the common `Share` label that works on both versions.

Fixes https://github.com/flutter/flutter/issues/85161

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.