### PR TITLE
[in_app_purchase]Iap/platform interface add cancel status

### DIFF
--- a/packages/in_app_purchase/in_app_purchase_platform_interface/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2
+
+* Added new `PurchaseStatus` named `canceled` to distinguish between an error and user cancellation. 
+
 ## 1.0.1
 
 * Fixed `Restoring previous purchases` link.

--- a/packages/in_app_purchase/in_app_purchase_platform_interface/lib/src/types/purchase_status.dart
+++ b/packages/in_app_purchase/in_app_purchase_platform_interface/lib/src/types/purchase_status.dart
@@ -26,4 +26,9 @@ enum PurchaseStatus {
   /// the purchase by calling the `completePurchase` method. More information on
   /// verifying purchases can be found [here](https://pub.dev/packages/in_app_purchase#restoring-previous-purchases).
   restored,
+
+  /// The purchase has been canceled.
+  ///
+  /// Update your UI to indicate the purchase is canceled.
+  canceled,
 }

--- a/packages/in_app_purchase/in_app_purchase_platform_interface/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/master/packages/in_app_purch
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.0.1
+version: 1.0.2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
This PR adds a new `PurchaseStatus` named `canceled` to distinguish between an error and user cancellation. 

Related issues:

- Fixes [flutter/flutter#83730](https://github.com/flutter/flutter/issues/83730)

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
