### PR TITLE
[in_app_purchase] Fix app exceptions caused by missing App Store receipt

### DIFF
--- a/packages/in_app_purchase/in_app_purchase_ios/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0+3
+
+* iOS: Fix treating missing App Store receipt as an exception.
+
 ## 0.1.0+2
 
 * Changed the iOS payment queue handler in such a way that it only adds a listener to the SKPaymentQueue when there 

--- a/packages/in_app_purchase/in_app_purchase_ios/example/ios/RunnerTests/InAppPurchasePluginTests.m
+++ b/packages/in_app_purchase/in_app_purchase_ios/example/ios/RunnerTests/InAppPurchasePluginTests.m
@@ -11,6 +11,7 @@
 
 @interface InAppPurchasePluginTest : XCTestCase
 
+@property(strong, nonatomic) FIAPReceiptManagerStub* receiptManagerStub;
 @property(strong, nonatomic) InAppPurchasePlugin* plugin;
 
 @end
@@ -18,8 +19,8 @@
 @implementation InAppPurchasePluginTest
 
 - (void)setUp {
-  self.plugin =
-      [[InAppPurchasePluginStub alloc] initWithReceiptManager:[FIAPReceiptManagerStub new]];
+  self.receiptManagerStub = [FIAPReceiptManagerStub new];
+  self.plugin = [[InAppPurchasePluginStub alloc] initWithReceiptManager:self.receiptManagerStub];
 }
 
 - (void)tearDown {
@@ -219,7 +220,7 @@
   XCTAssertTrue(callbackInvoked);
 }
 
-- (void)testRetrieveReceiptData {
+- (void)testRetrieveReceiptDataSuccess {
   XCTestExpectation* expectation = [self expectationWithDescription:@"receipt data retrieved"];
   FlutterMethodCall* call = [FlutterMethodCall
       methodCallWithMethodName:@"-[InAppPurchasePlugin retrieveReceiptData:result:]"
@@ -233,6 +234,25 @@
   [self waitForExpectations:@[ expectation ] timeout:5];
   NSLog(@"%@", result);
   XCTAssertNotNil(result);
+  XCTAssert([result isKindOfClass:[NSString class]]);
+}
+
+- (void)testRetrieveReceiptDataError {
+  XCTestExpectation* expectation = [self expectationWithDescription:@"receipt data retrieved"];
+  FlutterMethodCall* call = [FlutterMethodCall
+      methodCallWithMethodName:@"-[InAppPurchasePlugin retrieveReceiptData:result:]"
+                     arguments:nil];
+  __block NSDictionary* result;
+  self.receiptManagerStub.returnError = YES;
+  [self.plugin handleMethodCall:call
+                         result:^(id r) {
+                           result = r;
+                           [expectation fulfill];
+                         }];
+  [self waitForExpectations:@[ expectation ] timeout:5];
+  NSLog(@"%@", result);
+  XCTAssertNotNil(result);
+  XCTAssert([result isKindOfClass:[FlutterError class]]);
 }
 
 - (void)testRefreshReceiptRequest {

--- a/packages/in_app_purchase/in_app_purchase_ios/example/ios/RunnerTests/InAppPurchasePluginTests.m
+++ b/packages/in_app_purchase/in_app_purchase_ios/example/ios/RunnerTests/InAppPurchasePluginTests.m
@@ -232,7 +232,6 @@
                            [expectation fulfill];
                          }];
   [self waitForExpectations:@[ expectation ] timeout:5];
-  NSLog(@"%@", result);
   XCTAssertNotNil(result);
   XCTAssert([result isKindOfClass:[NSString class]]);
 }
@@ -250,7 +249,6 @@
                            [expectation fulfill];
                          }];
   [self waitForExpectations:@[ expectation ] timeout:5];
-  NSLog(@"%@", result);
   XCTAssertNotNil(result);
   XCTAssert([result isKindOfClass:[FlutterError class]]);
 }

--- a/packages/in_app_purchase/in_app_purchase_ios/example/ios/RunnerTests/Stubs.h
+++ b/packages/in_app_purchase/in_app_purchase_ios/example/ios/RunnerTests/Stubs.h
@@ -54,6 +54,8 @@ API_AVAILABLE(ios(11.2), macos(10.13.2))
 @end
 
 @interface FIAPReceiptManagerStub : FIAPReceiptManager
+// Indicates whether getReceiptData of this stub is going to return an error.
+// Setting this to true will let getReceiptData give a basic NSError and return nil.
 @property(assign, nonatomic) BOOL returnError;
 @end
 

--- a/packages/in_app_purchase/in_app_purchase_ios/example/ios/RunnerTests/Stubs.h
+++ b/packages/in_app_purchase/in_app_purchase_ios/example/ios/RunnerTests/Stubs.h
@@ -54,6 +54,7 @@ API_AVAILABLE(ios(11.2), macos(10.13.2))
 @end
 
 @interface FIAPReceiptManagerStub : FIAPReceiptManager
+@property(assign, nonatomic) BOOL returnError;
 @end
 
 @interface SKReceiptRefreshRequestStub : SKReceiptRefreshRequest

--- a/packages/in_app_purchase/in_app_purchase_ios/example/ios/RunnerTests/Stubs.m
+++ b/packages/in_app_purchase/in_app_purchase_ios/example/ios/RunnerTests/Stubs.m
@@ -260,6 +260,9 @@
 @implementation FIAPReceiptManagerStub : FIAPReceiptManager
 
 - (NSData *)getReceiptData:(NSURL *)url error:(NSError **)error {
+  if (self.returnError) {
+    *error = [[NSError alloc] init];
+  }
   NSString *originalString = [NSString stringWithFormat:@"test"];
   return [[NSData alloc] initWithBase64EncodedString:originalString options:kNilOptions];
 }

--- a/packages/in_app_purchase/in_app_purchase_ios/example/ios/RunnerTests/Stubs.m
+++ b/packages/in_app_purchase/in_app_purchase_ios/example/ios/RunnerTests/Stubs.m
@@ -262,6 +262,7 @@
 - (NSData *)getReceiptData:(NSURL *)url error:(NSError **)error {
   if (self.returnError) {
     *error = [[NSError alloc] init];
+    return nil;
   }
   NSString *originalString = [NSString stringWithFormat:@"test"];
   return [[NSData alloc] initWithBase64EncodedString:originalString options:kNilOptions];

--- a/packages/in_app_purchase/in_app_purchase_ios/example/ios/RunnerTests/Stubs.m
+++ b/packages/in_app_purchase/in_app_purchase_ios/example/ios/RunnerTests/Stubs.m
@@ -259,7 +259,7 @@
 
 @implementation FIAPReceiptManagerStub : FIAPReceiptManager
 
-- (NSData *)getReceiptData:(NSURL *)url {
+- (NSData *)getReceiptData:(NSURL *)url error:(NSError **)error {
   NSString *originalString = [NSString stringWithFormat:@"test"];
   return [[NSData alloc] initWithBase64EncodedString:originalString options:kNilOptions];
 }

--- a/packages/in_app_purchase/in_app_purchase_ios/ios/Classes/FIAPReceiptManager.m
+++ b/packages/in_app_purchase/in_app_purchase_ios/ios/Classes/FIAPReceiptManager.m
@@ -18,7 +18,7 @@
   NSError *receiptError;
   NSData *receipt = [self getReceiptData:receiptURL error:&receiptError];
   if (receiptError) {
-    if (flutterError != nil) {
+    if (flutterError) {
       *flutterError = [FlutterError
           errorWithCode:[[NSString alloc] initWithFormat:@"%li", (long)receiptError.code]
                 message:receiptError.domain
@@ -27,7 +27,7 @@
     return nil;
   }
   if (!receipt) {
-    if (flutterError != nil) {
+    if (flutterError) {
       *flutterError = [FlutterError errorWithCode:@"0"
                                           message:@"dataWithContentsOfURL returned nil without an "
                                                   @"error in retrieveReceiptWithError"

--- a/packages/in_app_purchase/in_app_purchase_ios/ios/Classes/FIAPReceiptManager.m
+++ b/packages/in_app_purchase/in_app_purchase_ios/ios/Classes/FIAPReceiptManager.m
@@ -9,18 +9,22 @@
 
 - (NSString *)retrieveReceiptWithError:(FlutterError **)error {
   NSURL *receiptURL = [[NSBundle mainBundle] appStoreReceiptURL];
-  NSData *receipt = [self getReceiptData:receiptURL];
+  NSError *err;
+  NSData *receipt = [self getReceiptData:receiptURL error:&err];
+  if (err) {
+    *error = [FlutterError errorWithCode:[[NSString alloc] initWithFormat:@"%li", (long)err.code]
+                                 message:err.domain
+                                 details:err.userInfo];
+    return nil;
+  }
   if (!receipt) {
-    *error = [FlutterError errorWithCode:@"storekit_no_receipt"
-                                 message:@"Cannot find receipt for the current main bundle."
-                                 details:nil];
     return nil;
   }
   return [receipt base64EncodedStringWithOptions:kNilOptions];
 }
 
-- (NSData *)getReceiptData:(NSURL *)url {
-  return [NSData dataWithContentsOfURL:url];
+- (NSData *)getReceiptData:(NSURL *)url error:(NSError **)error {
+  return [NSData dataWithContentsOfURL:url options:NSDataReadingMappedIfSafe error:error];
 }
 
 @end

--- a/packages/in_app_purchase/in_app_purchase_ios/ios/Classes/FIAPReceiptManager.m
+++ b/packages/in_app_purchase/in_app_purchase_ios/ios/Classes/FIAPReceiptManager.m
@@ -5,19 +5,34 @@
 #import "FIAPReceiptManager.h"
 #import <Flutter/Flutter.h>
 
+@interface FIAPReceiptManager ()
+
+- (NSData *)getReceiptData:(NSURL *)url error:(NSError **)error;
+
+@end
+
 @implementation FIAPReceiptManager
 
-- (NSString *)retrieveReceiptWithError:(FlutterError **)error {
+- (NSString *)retrieveReceiptWithError:(FlutterError **)flutterError {
   NSURL *receiptURL = [[NSBundle mainBundle] appStoreReceiptURL];
-  NSError *err;
-  NSData *receipt = [self getReceiptData:receiptURL error:&err];
-  if (err) {
-    *error = [FlutterError errorWithCode:[[NSString alloc] initWithFormat:@"%li", (long)err.code]
-                                 message:err.domain
-                                 details:err.userInfo];
+  NSError *receiptError;
+  NSData *receipt = [self getReceiptData:receiptURL error:&receiptError];
+  if (receiptError) {
+    if (flutterError != nil) {
+      *flutterError = [FlutterError
+          errorWithCode:[[NSString alloc] initWithFormat:@"%li", (long)receiptError.code]
+                message:receiptError.domain
+                details:receiptError.userInfo];
+    }
     return nil;
   }
   if (!receipt) {
+    if (flutterError != nil) {
+      *flutterError = [FlutterError errorWithCode:@"0"
+                                          message:@"dataWithContentsOfURL returned nil without an "
+                                                  @"error in retrieveReceiptWithError"
+                                          details:nil];
+    }
     return nil;
   }
   return [receipt base64EncodedStringWithOptions:kNilOptions];

--- a/packages/in_app_purchase/in_app_purchase_ios/ios/Classes/FIAPReceiptManager.m
+++ b/packages/in_app_purchase/in_app_purchase_ios/ios/Classes/FIAPReceiptManager.m
@@ -6,7 +6,8 @@
 #import <Flutter/Flutter.h>
 
 @interface FIAPReceiptManager ()
-
+// Gets the receipt file data from the location of the url. Can be nil if
+// there is an error. This interface is defined so it can be stubbed for testing.
 - (NSData *)getReceiptData:(NSURL *)url error:(NSError **)error;
 
 @end
@@ -17,21 +18,12 @@
   NSURL *receiptURL = [[NSBundle mainBundle] appStoreReceiptURL];
   NSError *receiptError;
   NSData *receipt = [self getReceiptData:receiptURL error:&receiptError];
-  if (receiptError) {
+  if (!receipt || receiptError) {
     if (flutterError) {
       *flutterError = [FlutterError
           errorWithCode:[[NSString alloc] initWithFormat:@"%li", (long)receiptError.code]
                 message:receiptError.domain
                 details:receiptError.userInfo];
-    }
-    return nil;
-  }
-  if (!receipt) {
-    if (flutterError) {
-      *flutterError = [FlutterError errorWithCode:@"0"
-                                          message:@"dataWithContentsOfURL returned nil without an "
-                                                  @"error in retrieveReceiptWithError"
-                                          details:nil];
     }
     return nil;
   }

--- a/packages/in_app_purchase/in_app_purchase_ios/lib/src/in_app_purchase_ios_platform_addition.dart
+++ b/packages/in_app_purchase/in_app_purchase_ios/lib/src/in_app_purchase_ios_platform_addition.dart
@@ -21,13 +21,17 @@ class InAppPurchaseIosPlatformAddition extends InAppPurchasePlatformAddition {
   /// If no results, a `null` value is returned.
   Future<PurchaseVerificationData?> refreshPurchaseVerificationData() async {
     await SKRequestMaker().startRefreshReceiptRequest();
-    final String? receipt = await SKReceiptManager.retrieveReceiptData();
-    if (receipt == null) {
+    try {
+      String receipt = await SKReceiptManager.retrieveReceiptData();
+      return PurchaseVerificationData(
+          localVerificationData: receipt,
+          serverVerificationData: receipt,
+          source: kIAPSource);
+    } catch (e) {
+      print(
+          'Something is wrong while fetching the receipt, this normally happens when the app is '
+          'running on a simulator: $e');
       return null;
     }
-    return PurchaseVerificationData(
-        localVerificationData: receipt,
-        serverVerificationData: receipt,
-        source: kIAPSource);
   }
 }

--- a/packages/in_app_purchase/in_app_purchase_ios/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase_ios
 description: An implementation for the iOS platform of the Flutter `in_app_purchase` plugin. This uses the iOS StoreKit Framework.
 repository: https://github.com/flutter/plugins/tree/master/packages/in_app_purchase/in_app_purchase_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 0.1.0+2
+version: 0.1.0+3
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/in_app_purchase/in_app_purchase_ios/test/store_kit_wrappers/sk_methodchannel_apis_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_ios/test/store_kit_wrappers/sk_methodchannel_apis_test.dart
@@ -23,6 +23,7 @@ void main() {
   tearDown(() {
     fakeIOSPlatform.testReturnNull = false;
     fakeIOSPlatform.queueIsActive = null;
+    fakeIOSPlatform.getReceiptFailTest = false;
   });
 
   group('sk_request_maker', () {

--- a/packages/in_app_purchase/in_app_purchase_ios/test/store_kit_wrappers/sk_methodchannel_apis_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_ios/test/store_kit_wrappers/sk_methodchannel_apis_test.dart
@@ -74,6 +74,12 @@ void main() {
       expect(fakeIOSPlatform.refreshReceiptParam,
           <String, dynamic>{"isExpired": true});
     });
+
+    test('should get null receipt if any exceptions are raised', () async {
+      fakeIOSPlatform.getReceiptFailTest = true;
+      expect(() async => SKReceiptManager.retrieveReceiptData(),
+          throwsA(TypeMatcher<PlatformException>()));
+    });
   });
 
   group('sk_receipt_manager', () {
@@ -166,6 +172,9 @@ class FakeIOSPlatform {
   bool getProductRequestFailTest = false;
   bool testReturnNull = false;
 
+  // get receipt request
+  bool getReceiptFailTest = false;
+
   // refresh receipt request
   int refreshReceipt = 0;
   late Map<String, dynamic> refreshReceiptParam;
@@ -201,6 +210,9 @@ class FakeIOSPlatform {
         return Future<void>.sync(() {});
       // receipt manager
       case '-[InAppPurchasePlugin retrieveReceiptData:result:]':
+        if (getReceiptFailTest) {
+          throw ("some arbitrary error");
+        }
         return Future<String>.value('receipt data');
       // payment queue
       case '-[SKPaymentQueue canMakePayments:]':


### PR DESCRIPTION
## Description

Missing App Store receipt can happen for different scenarios, thus shouldn't trigger an exception.
Reboot of PR #2862

## Related Issues

https://github.com/flutter/flutter/issues/43957

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ x ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ x ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ x ] All existing and new tests are passing.
- [ x ] I updated/added relevant documentation (doc comments with `///`).
- [ x ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [ x ] I read and followed the [Flutter Style Guide].
- [ x ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [ x ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ x ] I updated CHANGELOG.md to add a description of the change.
- [ x ] I signed the [CLA].
- [ x ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ x ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
