### PR TITLE
[flutter_plugin_tools] Migrate podspec to new base command

### DIFF
--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -7,7 +7,8 @@
   - **Breaking change**: it now requires an `--ios` and/or `--macos` flag.
 - The tooling now runs in strong null-safe mode.
 - `publish plugins` check against pub.dev to determine if a release should happen.
-- Modified the output format of `pubspec-check` and `xctest`
+- Modified the output format of many commands
+- Removed `podspec`'s `--skip` in favor of `--ignore` using the new structure.
 
 ## 0.2.0
 

--- a/script/tool/lib/src/common/plugin_command.dart
+++ b/script/tool/lib/src/common/plugin_command.dart
@@ -250,10 +250,16 @@ abstract class PluginCommand extends Command<void> {
   /// Returns the files contained, recursively, within the plugins
   /// involved in this command execution.
   Stream<File> getFiles() {
-    return getPlugins().asyncExpand<File>((Directory folder) => folder
+    return getPlugins()
+        .asyncExpand<File>((Directory folder) => getFilesForPackage(folder));
+  }
+
+  /// Returns the files contained, recursively, within [package].
+  Stream<File> getFilesForPackage(Directory package) {
+    return package
         .list(recursive: true, followLinks: false)
         .where((FileSystemEntity entity) => entity is File)
-        .cast<File>());
+        .cast<File>();
   }
 
   /// Returns whether the specified entity is a directory containing a


### PR DESCRIPTION
Switches `podspec` to the new base command that handles the boilerplate of looping over target packages.

Includes test improvements:
- Adds failure tests; previously no failure cases were covered.
- Captures output using the standard mechanism instead of using a custom
  `_print`, simplifying the command code.

Also removes `--skip`, which is redundant with `--exclude`.

Part of flutter/flutter#83413

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
