### PR TITLE
[flutter_plugin_tools] Move license-check tests to runCapturingPrint

### DIFF
--- a/script/tool/lib/src/license_check_command.dart
+++ b/script/tool/lib/src/license_check_command.dart
@@ -96,13 +96,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /// Validates that code files have copyright and license blocks.
 class LicenseCheckCommand extends PluginCommand {
   /// Creates a new license check command for [packagesDir].
-  LicenseCheckCommand(
-    Directory packagesDir, {
-    Print print = print,
-  })  : _print = print,
-        super(packagesDir);
-
-  final Print _print;
+  LicenseCheckCommand(Directory packagesDir) : super(packagesDir);
 
   @override
   final String name = 'license-check';
@@ -121,7 +115,7 @@ class LicenseCheckCommand extends PluginCommand {
             p.basename(file.basename) == 'LICENSE' && !_isThirdParty(file));
 
     final bool copyrightCheckSucceeded = await _checkCodeLicenses(codeFiles);
-    _print('\n=======================================\n');
+    print('\n=======================================\n');
     final bool licenseCheckSucceeded =
         await _checkLicenseFiles(firstPartyLicenseFiles);
 
@@ -157,7 +151,7 @@ class LicenseCheckCommand extends PluginCommand {
     };
 
     for (final File file in codeFiles) {
-      _print('Checking ${file.path}');
+      print('Checking ${file.path}');
       final String content = await file.readAsString();
 
       final String firstParyLicense =
@@ -177,7 +171,7 @@ class LicenseCheckCommand extends PluginCommand {
         }
       }
     }
-    _print('\n');
+    print('\n');
 
     // Sort by path for more usable output.
     final int Function(File, File) pathCompare =
@@ -186,22 +180,22 @@ class LicenseCheckCommand extends PluginCommand {
     unrecognizedThirdPartyFiles.sort(pathCompare);
 
     if (incorrectFirstPartyFiles.isNotEmpty) {
-      _print('The license block for these files is missing or incorrect:');
+      print('The license block for these files is missing or incorrect:');
       for (final File file in incorrectFirstPartyFiles) {
-        _print('  ${file.path}');
+        print('  ${file.path}');
       }
-      _print('If this third-party code, move it to a "third_party/" directory, '
+      print('If this third-party code, move it to a "third_party/" directory, '
           'otherwise ensure that you are using the exact copyright and license '
           'text used by all first-party files in this repository.\n');
     }
 
     if (unrecognizedThirdPartyFiles.isNotEmpty) {
-      _print(
+      print(
           'No recognized license was found for the following third-party files:');
       for (final File file in unrecognizedThirdPartyFiles) {
-        _print('  ${file.path}');
+        print('  ${file.path}');
       }
-      _print('Please check that they have a license at the top of the file. '
+      print('Please check that they have a license at the top of the file. '
           'If they do, the license check needs to be updated to recognize '
           'the new third-party license block.\n');
     }
@@ -209,7 +203,7 @@ class LicenseCheckCommand extends PluginCommand {
     final bool succeeded =
         incorrectFirstPartyFiles.isEmpty && unrecognizedThirdPartyFiles.isEmpty;
     if (succeeded) {
-      _print('All source files passed validation!');
+      print('All source files passed validation!');
     }
     return succeeded;
   }
@@ -220,25 +214,25 @@ class LicenseCheckCommand extends PluginCommand {
     final List<File> incorrectLicenseFiles = <File>[];
 
     for (final File file in files) {
-      _print('Checking ${file.path}');
+      print('Checking ${file.path}');
       if (!file.readAsStringSync().contains(_fullBsdLicenseText)) {
         incorrectLicenseFiles.add(file);
       }
     }
-    _print('\n');
+    print('\n');
 
     if (incorrectLicenseFiles.isNotEmpty) {
-      _print('The following LICENSE files do not follow the expected format:');
+      print('The following LICENSE files do not follow the expected format:');
       for (final File file in incorrectLicenseFiles) {
-        _print('  ${file.path}');
+        print('  ${file.path}');
       }
-      _print(
+      print(
           'Please ensure that they use the exact format used in this repository".\n');
     }
 
     final bool succeeded = incorrectLicenseFiles.isEmpty;
     if (succeeded) {
-      _print('All LICENSE files passed validation!');
+      print('All LICENSE files passed validation!');
     }
     return succeeded;
   }


### PR DESCRIPTION
Eliminates the custom printer in the command, and updates the tests to use the repo-standard `runCapturingPrint`.

This avoids unnecessary divergence of test styles, and simplifies the command itself. It was only written the other way in the first place because I wasn't aware of `runCapturingPrint`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
