### PR TITLE
[flutter_plugin_tools] Restructure version-check

### DIFF
--- a/script/tool/lib/src/common/core.dart
+++ b/script/tool/lib/src/common/core.dart
@@ -58,6 +58,16 @@ void printSuccess(String successMessage) {
   print(Colorize(successMessage)..green());
 }
 
+/// Prints `warningMessage` in yellow.
+///
+/// Warnings are not surfaced in CI summaries, so this is only useful for
+/// highlighting something when someone is already looking though the log
+/// messages. DO NOT RELY on someone noticing a warning; instead, use it for
+/// things that might be useful to someone debugging an unexpected result.
+void printWarning(String warningMessage) {
+  print(Colorize(warningMessage)..yellow());
+}
+
 /// Prints `errorMessage` in red.
 void printError(String errorMessage) {
   print(Colorize(errorMessage)..red());

--- a/script/tool/lib/src/common/package_looping_command.dart
+++ b/script/tool/lib/src/common/package_looping_command.dart
@@ -99,6 +99,9 @@ abstract class PackageLoopingCommand extends PluginCommand {
     return packageName;
   }
 
+  /// The suggested indentation for printed output.
+  String get indentation => hasLongOutput ? '' : '  ';
+
   // ----------------------------------------
 
   @override

--- a/script/tool/lib/src/common/package_looping_command.dart
+++ b/script/tool/lib/src/common/package_looping_command.dart
@@ -35,6 +35,10 @@ abstract class PackageLoopingCommand extends PluginCommand {
   /// in the final summary. An empty list indicates success.
   Future<List<String>> runForPackage(Directory package);
 
+  /// Called during [run] after all calls to [runForPackage]. This provides an
+  /// opportunity to do any cleanup of run-level state.
+  Future<void> completeRun() async {}
+
   /// Whether or not the output (if any) of [runForPackage] is long, or short.
   ///
   /// This changes the logging that happens at the start of each package's
@@ -117,6 +121,8 @@ abstract class PackageLoopingCommand extends PluginCommand {
       _printPackageHeading(package);
       results[package] = await runForPackage(package);
     }
+
+    completeRun();
 
     // If there were any errors reported, summarize them and exit.
     if (results.values.any((List<String> failures) => failures.isNotEmpty)) {

--- a/script/tool/lib/src/common/plugin_command.dart
+++ b/script/tool/lib/src/common/plugin_command.dart
@@ -76,8 +76,8 @@ abstract class PluginCommand extends Command<void> {
   /// This can be overridden for testing.
   final ProcessRunner processRunner;
 
-  /// The git directory to use. If unset, [getGitDir] uses the packages
-  /// directory's enclosing repository.
+  /// The git directory to use. If unset, [gitDir] populates it from the
+  /// packages directory's enclosing repository.
   ///
   /// This can be mocked for testing.
   GitDir? _gitDir;
@@ -102,7 +102,7 @@ abstract class PluginCommand extends Command<void> {
   }
 
   /// Returns the [GitDir] containing [packagesDir].
-  Future<GitDir> getGitDir() async {
+  Future<GitDir> get gitDir async {
     GitDir? gitDir = _gitDir;
     if (gitDir != null) {
       return gitDir;
@@ -309,7 +309,7 @@ abstract class PluginCommand extends Command<void> {
     final String baseSha = getStringArg(_kBaseSha);
 
     final GitVersionFinder gitVersionFinder =
-        GitVersionFinder(await getGitDir(), baseSha);
+        GitVersionFinder(await gitDir, baseSha);
     return gitVersionFinder;
   }
 

--- a/script/tool/lib/src/common/plugin_command.dart
+++ b/script/tool/lib/src/common/plugin_command.dart
@@ -20,8 +20,8 @@ abstract class PluginCommand extends Command<void> {
   PluginCommand(
     this.packagesDir, {
     this.processRunner = const ProcessRunner(),
-    this.gitDir,
-  }) {
+    GitDir? gitDir,
+  }) : _gitDir = gitDir {
     argParser.addMultiOption(
       _pluginsArg,
       splitCommas: true,
@@ -76,10 +76,11 @@ abstract class PluginCommand extends Command<void> {
   /// This can be overridden for testing.
   final ProcessRunner processRunner;
 
-  /// The git directory to use. By default it uses the parent directory.
+  /// The git directory to use. If unset, [getGitDir] uses the packages
+  /// directory's enclosing repository.
   ///
   /// This can be mocked for testing.
-  final GitDir? gitDir;
+  GitDir? _gitDir;
 
   int? _shardIndex;
   int? _shardCount;
@@ -98,6 +99,26 @@ abstract class PluginCommand extends Command<void> {
       _checkSharding();
     }
     return _shardCount!;
+  }
+
+  /// Returns the [GitDir] containing [packagesDir].
+  Future<GitDir> getGitDir() async {
+    GitDir? gitDir = _gitDir;
+    if (gitDir != null) {
+      return gitDir;
+    }
+
+    // Ensure there are no symlinks in the path, as it can break
+    // GitDir's allowSubdirectory:true.
+    final String packagesPath = packagesDir.resolveSymbolicLinksSync();
+    if (!await GitDir.isGitDir(packagesPath)) {
+      printError('$packagesPath is not a valid Git repository.');
+      throw ToolExit(2);
+    }
+    gitDir =
+        await GitDir.fromExisting(packagesDir.path, allowSubdirectory: true);
+    _gitDir = gitDir;
+    return gitDir;
   }
 
   /// Convenience accessor for boolean arguments.
@@ -285,22 +306,10 @@ abstract class PluginCommand extends Command<void> {
   ///
   /// Throws tool exit if [gitDir] nor root directory is a git directory.
   Future<GitVersionFinder> retrieveVersionFinder() async {
-    final String rootDir = packagesDir.parent.absolute.path;
     final String baseSha = getStringArg(_kBaseSha);
 
-    GitDir? baseGitDir = gitDir;
-    if (baseGitDir == null) {
-      if (!await GitDir.isGitDir(rootDir)) {
-        printError(
-          '$rootDir is not a valid Git repository.',
-        );
-        throw ToolExit(2);
-      }
-      baseGitDir = await GitDir.fromExisting(rootDir);
-    }
-
     final GitVersionFinder gitVersionFinder =
-        GitVersionFinder(baseGitDir, baseSha);
+        GitVersionFinder(await getGitDir(), baseSha);
     return gitVersionFinder;
   }
 

--- a/script/tool/lib/src/publish_plugin_command.dart
+++ b/script/tool/lib/src/publish_plugin_command.dart
@@ -149,7 +149,7 @@ class PublishPluginCommand extends PluginCommand {
     }
 
     _print('Checking local repo...');
-    final GitDir gitDir = await getGitDir();
+    final GitDir repository = await gitDir;
 
     final bool shouldPushTag = getBoolArg(_pushTagsOption);
     _RemoteInfo? remote;
@@ -171,7 +171,7 @@ class PublishPluginCommand extends PluginCommand {
     bool successful;
     if (publishAllChanged) {
       successful = await _publishAllChangedPackages(
-        baseGitDir: gitDir,
+        baseGitDir: repository,
         remoteForTagPush: remote,
       );
     } else {

--- a/script/tool/lib/src/publish_plugin_command.dart
+++ b/script/tool/lib/src/publish_plugin_command.dart
@@ -149,15 +149,7 @@ class PublishPluginCommand extends PluginCommand {
     }
 
     _print('Checking local repo...');
-    // Ensure there are no symlinks in the path, as it can break
-    // GitDir's allowSubdirectory:true.
-    final String packagesPath = packagesDir.resolveSymbolicLinksSync();
-    if (!await GitDir.isGitDir(packagesPath)) {
-      _print('$packagesPath is not a valid Git repository.');
-      throw ToolExit(1);
-    }
-    final GitDir baseGitDir = gitDir ??
-        await GitDir.fromExisting(packagesPath, allowSubdirectory: true);
+    final GitDir gitDir = await getGitDir();
 
     final bool shouldPushTag = getBoolArg(_pushTagsOption);
     _RemoteInfo? remote;
@@ -179,7 +171,7 @@ class PublishPluginCommand extends PluginCommand {
     bool successful;
     if (publishAllChanged) {
       successful = await _publishAllChangedPackages(
-        baseGitDir: baseGitDir,
+        baseGitDir: gitDir,
         remoteForTagPush: remote,
       );
     } else {

--- a/script/tool/lib/src/pubspec_check_command.dart
+++ b/script/tool/lib/src/pubspec_check_command.dart
@@ -70,7 +70,6 @@ class PubspecCheckCommand extends PackageLoopingCommand {
     File pubspecFile, {
     required String packageName,
   }) async {
-    const String indentation = '  ';
     final String contents = pubspecFile.readAsStringSync();
     final Pubspec? pubspec = _tryParsePubspec(contents);
     if (pubspec == null) {

--- a/script/tool/test/version_check_command_test.dart
+++ b/script/tool/test/version_check_command_test.dart
@@ -69,6 +69,7 @@ void main() {
       gitDiffResponse = '';
       gitShowResponses = <String, String>{};
       gitDir = MockGitDir();
+      when(gitDir.path).thenReturn(packagesDir.parent.path);
       when(gitDir.runCommand(any, throwOnError: anyNamed('throwOnError')))
           .thenAnswer((Invocation invocation) {
         gitDirCommands.add(invocation.positionalArguments[0] as List<String>);
@@ -183,7 +184,7 @@ void main() {
       expect(
         output,
         containsAllInOrder(<String>[
-          '${indentation}Unable to find pubspec in master. Safe to ignore if the project is new.',
+          '${indentation}Unable to find previous version at git base.',
           'No version check errors found!',
         ]),
       );
@@ -704,7 +705,7 @@ ${indentation}HTTP response: xx
       expect(
         result,
         containsAllInOrder(<String>[
-          '${indentation}Unable to find package on pub server. Safe to ignore if the project is new.',
+          '${indentation}Unable to find previous version on pub server.',
           'No version check errors found!',
         ]),
       );

--- a/script/tool/test/version_check_command_test.dart
+++ b/script/tool/test/version_check_command_test.dart
@@ -42,14 +42,6 @@ void testAllowedVersion(
 
 class MockProcessResult extends Mock implements io.ProcessResult {}
 
-const String _redColorMessagePrefix = '\x1B[31m';
-const String _redColorMessagePostfix = '\x1B[0m';
-
-// Some error message was printed in a "Colorized" red message. So `\x1B[31m` and `\x1B[0m` needs to be included.
-String _redColorString(String string) {
-  return '$_redColorMessagePrefix$string$_redColorMessagePostfix';
-}
-
 void main() {
   const String indentation = '  ';
   group('$VersionCheckCommand', () {
@@ -105,8 +97,9 @@ void main() {
 
       expect(
         output,
-        containsAllInOrder(<String>[
-          'No version check errors found!',
+        containsAllInOrder(<Matcher>[
+          contains('Running for plugin'),
+          contains('1.0.0 -> 2.0.0'),
         ]),
       );
       expect(gitDirCommands.length, equals(1));
@@ -147,8 +140,9 @@ void main() {
 
       expect(
         output,
-        containsAllInOrder(<String>[
-          'No version check errors found!',
+        containsAllInOrder(<Matcher>[
+          contains('Running for plugin'),
+          contains('1.0.0 -> 2.0.0'),
         ]),
       );
     });
@@ -160,9 +154,9 @@ void main() {
 
       expect(
         output,
-        containsAllInOrder(<String>[
-          '${indentation}Unable to find previous version at git base.',
-          'No version check errors found!',
+        containsAllInOrder(<Matcher>[
+          contains('Running for plugin'),
+          contains('Unable to find previous version at git base.'),
         ]),
       );
     });
@@ -177,8 +171,9 @@ void main() {
 
       expect(
         output,
-        containsAllInOrder(<String>[
-          '${indentation}New version is lower than previous version. This is assumed to be a revert.',
+        containsAllInOrder(<Matcher>[
+          contains('New version is lower than previous version. '
+              'This is assumed to be a revert.'),
         ]),
       );
     });
@@ -222,8 +217,9 @@ void main() {
           runner, <String>['version-check', '--base-sha=master']);
       expect(
         output,
-        containsAllInOrder(<String>[
-          'No version check errors found!',
+        containsAllInOrder(<Matcher>[
+          contains('Running for plugin'),
+          contains('1.0.0 -> 1.1.0'),
         ]),
       );
       expect(gitDirCommands.length, equals(1));
@@ -276,10 +272,8 @@ void main() {
           runner, <String>['version-check', '--base-sha=master']);
       expect(
         output,
-        containsAllInOrder(<String>[
-          'Checking the first version listed in CHANGELOG.md matches the version in pubspec.yaml for plugin.',
-          'plugin passed version check',
-          'No version check errors found!'
+        containsAllInOrder(<Matcher>[
+          contains('Running for plugin'),
         ]),
       );
     });
@@ -305,12 +299,8 @@ void main() {
 
       expect(
         output,
-        containsAllInOrder(<String>[
-          _redColorString('''
-versions for plugin in CHANGELOG.md and pubspec.yaml do not match.
-The version in pubspec.yaml is 1.0.1.
-The first version listed in CHANGELOG.md is 1.0.2.
-'''),
+        containsAllInOrder(<Matcher>[
+          contains('Versions in CHANGELOG.md and pubspec.yaml do not match.'),
         ]),
       );
     });
@@ -329,10 +319,8 @@ The first version listed in CHANGELOG.md is 1.0.2.
           runner, <String>['version-check', '--base-sha=master']);
       expect(
         output,
-        containsAllInOrder(<String>[
-          'Checking the first version listed in CHANGELOG.md matches the version in pubspec.yaml for plugin.',
-          'plugin passed version check',
-          'No version check errors found!'
+        containsAllInOrder(<Matcher>[
+          contains('Running for plugin'),
         ]),
       );
     });
@@ -363,14 +351,8 @@ The first version listed in CHANGELOG.md is 1.0.2.
 
       expect(
         output,
-        containsAllInOrder(<String>[
-          _redColorString(
-            '''
-versions for plugin in CHANGELOG.md and pubspec.yaml do not match.
-The version in pubspec.yaml is 1.0.0.
-The first version listed in CHANGELOG.md is 1.0.1.
-''',
-          )
+        containsAllInOrder(<Matcher>[
+          contains('Versions in CHANGELOG.md and pubspec.yaml do not match.'),
         ]),
       );
     });
@@ -392,10 +374,9 @@ The first version listed in CHANGELOG.md is 1.0.1.
           runner, <String>['version-check', '--base-sha=master']);
       await expectLater(
         output,
-        containsAllInOrder(<String>[
-          'Found NEXT; validating next version in the CHANGELOG.',
-          'plugin passed version check',
-          'No version check errors found!',
+        containsAllInOrder(<Matcher>[
+          contains('Running for plugin'),
+          contains('Found NEXT; validating next version in the CHANGELOG.'),
         ]),
       );
     });
@@ -428,13 +409,9 @@ The first version listed in CHANGELOG.md is 1.0.1.
 
       expect(
         output,
-        containsAllInOrder(<String>[
-          _redColorString(
-            '''
-When bumping the version for release, the NEXT section should be incorporated
-into the new version's release notes.
-''',
-          )
+        containsAllInOrder(<Matcher>[
+          contains('When bumping the version for release, the NEXT section '
+              'should be incorporated into the new version\'s release notes.')
         ]),
       );
     });
@@ -463,15 +440,9 @@ into the new version's release notes.
 
       expect(
         output,
-        containsAllInOrder(<String>[
-          'Found NEXT; validating next version in the CHANGELOG.',
-          _redColorString(
-            '''
-versions for plugin in CHANGELOG.md and pubspec.yaml do not match.
-The version in pubspec.yaml is 1.0.1.
-The first version listed in CHANGELOG.md is 1.0.0.
-''',
-          )
+        containsAllInOrder(<Matcher>[
+          contains('Found NEXT; validating next version in the CHANGELOG.'),
+          contains('Versions in CHANGELOG.md and pubspec.yaml do not match.'),
         ]),
       );
     });
@@ -504,9 +475,8 @@ The first version listed in CHANGELOG.md is 1.0.0.
 
       expect(
         output,
-        containsAllInOrder(<String>[
-          '${indentation}plugin: Current largest version on pub: 1.0.0',
-          'No version check errors found!',
+        containsAllInOrder(<Matcher>[
+          contains('plugin: Current largest version on pub: 1.0.0'),
         ]),
       );
     });
@@ -547,13 +517,11 @@ The first version listed in CHANGELOG.md is 1.0.0.
 
       expect(
         result,
-        containsAllInOrder(<String>[
-          _redColorString(
-            '''
+        containsAllInOrder(<Matcher>[
+          contains('''
 ${indentation}Incorrectly updated version.
 ${indentation}HEAD: 2.0.0, pub: 0.0.2.
-${indentation}Allowed versions: {1.0.0: NextVersionType.BREAKING_MAJOR, 0.1.0: NextVersionType.MINOR, 0.0.3: NextVersionType.PATCH}''',
-          )
+${indentation}Allowed versions: {1.0.0: NextVersionType.BREAKING_MAJOR, 0.1.0: NextVersionType.MINOR, 0.0.3: NextVersionType.PATCH}''')
         ]),
       );
     });
@@ -588,14 +556,12 @@ ${indentation}Allowed versions: {1.0.0: NextVersionType.BREAKING_MAJOR, 0.1.0: N
 
       expect(
         result,
-        containsAllInOrder(<String>[
-          _redColorString(
-            '''
+        containsAllInOrder(<Matcher>[
+          contains('''
 ${indentation}Error fetching version on pub for plugin.
 ${indentation}HTTP Status 400
 ${indentation}HTTP response: xx
-''',
-          )
+''')
         ]),
       );
     });
@@ -621,9 +587,8 @@ ${indentation}HTTP response: xx
 
       expect(
         result,
-        containsAllInOrder(<String>[
-          '${indentation}Unable to find previous version on pub server.',
-          'No version check errors found!',
+        containsAllInOrder(<Matcher>[
+          contains('Unable to find previous version on pub server.'),
         ]),
       );
     });


### PR DESCRIPTION
Combines the two different aspects of version-checking into a single looping structure based on plugins, using the new base command, rather than one operating on plugins as controlled by the usual flags and the other operating on a git list of changed files.

Also simplifies the determination of the new version by simply checking the file, rather than querying git for the HEAD state of the file. Tests setup is simplified since we no longer need to set up nearly as much fake `git` output.

Minor changes to base commands:
- Move indentation up to PackageLoopingCommand so that it is consistent across commands
- Add a new post-loop command for any cleanup, which is needed by version-check
- Change the way the GitDir instance is managed by the base PluginCommand, so that it's always cached even when not overridden, to reduce duplicate work and code.

Part of https://github.com/flutter/flutter/issues/83413

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
