### PR TITLE
[in_app_purchase] Initialize SKError with correct data type

### DIFF
--- a/packages/in_app_purchase/in_app_purchase_ios/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_ios/CHANGELOG.md
@@ -1,10 +1,14 @@
+## 0.1.1+1
+
+* Fix wrong data type when cancelling user credentials dialog.
+
 ## 0.1.1
 
 * Added support to register a `SKPaymentQueueDelegateWrapper` and handle changes to active subscriptions accordingly (see also Store Kit's [SKPaymentQueueDelegate](https://developer.apple.com/documentation/storekit/skpaymentqueuedelegate?language=objc)).
 
 ## 0.1.0+2
 
-* Changed the iOS payment queue handler in such a way that it only adds a listener to the `SKPaymentQueue` when there 
+* Changed the iOS payment queue handler in such a way that it only adds a listener to the `SKPaymentQueue` when there
   is a listener to the Dart `purchaseStream`.
 
 ## 0.1.0+1

--- a/packages/in_app_purchase/in_app_purchase_ios/lib/src/store_kit_wrappers/sk_payment_queue_wrapper.dart
+++ b/packages/in_app_purchase/in_app_purchase_ios/lib/src/store_kit_wrappers/sk_payment_queue_wrapper.dart
@@ -232,7 +232,7 @@ class SKPaymentQueueWrapper {
         }
       case 'restoreCompletedTransactionsFailed':
         {
-          SKError error = SKError.fromJson(call.arguments);
+          SKError error = SKError.fromJson(new Map<String, dynamic>.from(call.arguments));
           return Future<void>(() {
             observer.restoreCompletedTransactionsFailed(error: error);
           });

--- a/packages/in_app_purchase/in_app_purchase_ios/lib/src/store_kit_wrappers/sk_payment_queue_wrapper.dart
+++ b/packages/in_app_purchase/in_app_purchase_ios/lib/src/store_kit_wrappers/sk_payment_queue_wrapper.dart
@@ -66,7 +66,7 @@ class SKPaymentQueueWrapper {
   /// addTransactionObserver:]`](https://developer.apple.com/documentation/storekit/skpaymentqueue/1506042-addtransactionobserver?language=objc).
   void setTransactionObserver(SKTransactionObserverWrapper observer) {
     _observer = observer;
-    channel.setMethodCallHandler(_handleObserverCallbacks);
+    channel.setMethodCallHandler(handleObserverCallbacks);
   }
 
   /// Instructs the iOS implementation to register a transaction observer and
@@ -208,8 +208,12 @@ class SKPaymentQueueWrapper {
         .invokeMethod<void>('-[SKPaymentQueue showPriceConsentIfNeeded]');
   }
 
-  // Triage a method channel call from the platform and triggers the correct observer method.
-  Future<dynamic> _handleObserverCallbacks(MethodCall call) async {
+  /// Triage a method channel call from the platform and triggers the correct observer method.
+  ///
+  /// This method is public for testing purposes only and should not be used
+  /// outside this class.
+  @visibleForTesting
+  Future<dynamic> handleObserverCallbacks(MethodCall call) async {
     assert(_observer != null,
         '[in_app_purchase]: (Fatal)The observer has not been set but we received a purchase transaction notification. Please ensure the observer has been set using `setTransactionObserver`. Make sure the observer is added right at the App Launch.');
     final SKTransactionObserverWrapper observer = _observer!;

--- a/packages/in_app_purchase/in_app_purchase_ios/lib/src/store_kit_wrappers/sk_payment_queue_wrapper.dart
+++ b/packages/in_app_purchase/in_app_purchase_ios/lib/src/store_kit_wrappers/sk_payment_queue_wrapper.dart
@@ -232,7 +232,7 @@ class SKPaymentQueueWrapper {
         }
       case 'restoreCompletedTransactionsFailed':
         {
-          SKError error = SKError.fromJson(new Map<String, dynamic>.from(call.arguments));
+          SKError error = SKError.fromJson(Map<String, dynamic>.from(call.arguments));
           return Future<void>(() {
             observer.restoreCompletedTransactionsFailed(error: error);
           });

--- a/packages/in_app_purchase/in_app_purchase_ios/lib/src/store_kit_wrappers/sk_payment_queue_wrapper.dart
+++ b/packages/in_app_purchase/in_app_purchase_ios/lib/src/store_kit_wrappers/sk_payment_queue_wrapper.dart
@@ -230,13 +230,13 @@ class SKPaymentQueueWrapper {
             observer.removedTransactions(transactions: transactions);
           });
         }
-        case 'restoreCompletedTransactionsFailed':
-          {
-            SKError error =
-                SKError.fromJson(new Map<String, dynamic>.from(call.arguments));
-            return Future<void>(() {
-              observer.restoreCompletedTransactionsFailed(error: error);
-            });
+      case 'restoreCompletedTransactionsFailed':
+        {
+          SKError error =
+              SKError.fromJson(Map<String, dynamic>.from(call.arguments));
+          return Future<void>(() {
+            observer.restoreCompletedTransactionsFailed(error: error);
+          });
         }
       case 'paymentQueueRestoreCompletedTransactionsFinished':
         {

--- a/packages/in_app_purchase/in_app_purchase_ios/lib/src/store_kit_wrappers/sk_payment_queue_wrapper.dart
+++ b/packages/in_app_purchase/in_app_purchase_ios/lib/src/store_kit_wrappers/sk_payment_queue_wrapper.dart
@@ -230,12 +230,13 @@ class SKPaymentQueueWrapper {
             observer.removedTransactions(transactions: transactions);
           });
         }
-      case 'restoreCompletedTransactionsFailed':
-        {
-          SKError error = SKError.fromJson(Map<String, dynamic>.from(call.arguments));
-          return Future<void>(() {
-            observer.restoreCompletedTransactionsFailed(error: error);
-          });
+        case 'restoreCompletedTransactionsFailed':
+          {
+            SKError error =
+                SKError.fromJson(new Map<String, dynamic>.from(call.arguments));
+            return Future<void>(() {
+              observer.restoreCompletedTransactionsFailed(error: error);
+            });
         }
       case 'paymentQueueRestoreCompletedTransactionsFinished':
         {

--- a/packages/in_app_purchase/in_app_purchase_ios/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase_ios
 description: An implementation for the iOS platform of the Flutter `in_app_purchase` plugin. This uses the iOS StoreKit Framework.
 repository: https://github.com/flutter/plugins/tree/master/packages/in_app_purchase/in_app_purchase_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 0.1.1
+version: 0.1.2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/in_app_purchase/in_app_purchase_ios/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase_ios
 description: An implementation for the iOS platform of the Flutter `in_app_purchase` plugin. This uses the iOS StoreKit Framework.
 repository: https://github.com/flutter/plugins/tree/master/packages/in_app_purchase/in_app_purchase_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 0.1.2
+version: 0.1.1+1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/in_app_purchase/in_app_purchase_ios/test/store_kit_wrappers/sk_payment_queue_delegate_api_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_ios/test/store_kit_wrappers/sk_payment_queue_delegate_api_test.dart
@@ -70,7 +70,7 @@ void main() {
   });
 
   test(
-      '_handleObserverCallbacks should call SKTransactionObserverWrapper.restoreCompletedTransactionsFailed',
+      'handleObserverCallbacks should call SKTransactionObserverWrapper.restoreCompletedTransactionsFailed',
       () async {
     SKPaymentQueueWrapper queue = SKPaymentQueueWrapper();
     TestTransactionObserverWrapper testObserver =

--- a/packages/in_app_purchase/in_app_purchase_ios/test/store_kit_wrappers/sk_payment_queue_delegate_api_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_ios/test/store_kit_wrappers/sk_payment_queue_delegate_api_test.dart
@@ -68,6 +68,65 @@ void main() {
       },
     );
   });
+
+  test(
+      '_handleObserverCallbacks should call SKTransactionObserverWrapper.restoreCompletedTransactionsFailed',
+      () async {
+    SKPaymentQueueWrapper queue = SKPaymentQueueWrapper();
+    TestTransactionObserverWrapper testObserver =
+        TestTransactionObserverWrapper();
+    queue.setTransactionObserver(testObserver);
+
+    final arguments = <dynamic, dynamic>{
+      'code': 100,
+      'domain': 'domain',
+      'userInfo': <String, dynamic>{'error': 'underlying_error'},
+    };
+
+    await queue.handleObserverCallbacks(
+      MethodCall('restoreCompletedTransactionsFailed', arguments),
+    );
+
+    expect(
+      testObserver.log,
+      <Matcher>{
+        equals('restoreCompletedTransactionsFailed'),
+      },
+    );
+  });
+}
+
+class TestTransactionObserverWrapper extends SKTransactionObserverWrapper {
+  final List<String> log = <String>[];
+
+  @override
+  void updatedTransactions(
+      {required List<SKPaymentTransactionWrapper> transactions}) {
+    log.add('updatedTransactions');
+  }
+
+  @override
+  void removedTransactions(
+      {required List<SKPaymentTransactionWrapper> transactions}) {
+    log.add('removedTransactions');
+  }
+
+  @override
+  void restoreCompletedTransactionsFailed({required SKError error}) {
+    log.add('restoreCompletedTransactionsFailed');
+  }
+
+  @override
+  void paymentQueueRestoreCompletedTransactionsFinished() {
+    log.add('paymentQueueRestoreCompletedTransactionsFinished');
+  }
+
+  @override
+  bool shouldAddStorePayment(
+      {required SKPaymentWrapper payment, required SKProductWrapper product}) {
+    log.add('shouldAddStorePayment');
+    return false;
+  }
 }
 
 class TestPaymentQueueDelegate extends SKPaymentQueueDelegateWrapper {


### PR DESCRIPTION
Makes sure that `SKError.fromJson()` gets the correct data type as argument.

*List which issues are fixed by this PR. You must list at least one issue.* 
https://github.com/flutter/flutter/issues/85534

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.