### PR TITLE
[image_picker] Fixed IOException when cache directory is removed

### DIFF
--- a/packages/image_picker/image_picker/CHANGELOG.md
+++ b/packages/image_picker/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.1+3
+
+* Fix image picker causing a crash when the cache directory is deleted.
+
 ## 0.8.1+2
 
 * Update the example app to support the multi-image feature.

--- a/packages/image_picker/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
+++ b/packages/image_picker/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
@@ -401,6 +401,7 @@ public class ImagePickerDelegate
     File image;
 
     try {
+      externalFilesDirectory.mkdirs();
       image = File.createTempFile(filename, suffix, externalFilesDirectory);
     } catch (IOException e) {
       throw new RuntimeException(e);

--- a/packages/image_picker/image_picker/example/android/app/src/test/java/io/flutter/plugins/imagepicker/ImagePickerDelegateTest.java
+++ b/packages/image_picker/image_picker/example/android/app/src/test/java/io/flutter/plugins/imagepicker/ImagePickerDelegateTest.java
@@ -23,6 +23,7 @@ import android.net.Uri;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import java.io.File;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -47,6 +48,7 @@ public class ImagePickerDelegateTest {
   @Mock ImagePickerCache cache;
 
   ImagePickerDelegate.FileUriResolver mockFileUriResolver;
+  MockedStatic<File> mockStaticFile;
 
   private static class MockFileUriResolver implements ImagePickerDelegate.FileUriResolver {
     @Override
@@ -63,6 +65,11 @@ public class ImagePickerDelegateTest {
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
+
+    mockStaticFile = Mockito.mockStatic(File.class);
+    mockStaticFile
+        .when(() -> File.createTempFile(any(), any(), any()))
+        .thenReturn(new File("/tmpfile"));
 
     when(mockActivity.getPackageName()).thenReturn("com.example.test");
     when(mockActivity.getPackageManager()).thenReturn(mock(PackageManager.class));
@@ -85,6 +92,11 @@ public class ImagePickerDelegateTest {
 
     Uri mockUri = mock(Uri.class);
     when(mockIntent.getData()).thenReturn(mockUri);
+  }
+
+  @After
+  public void tearDown() {
+    mockStaticFile.close();
   }
 
   @Test
@@ -155,18 +167,11 @@ public class ImagePickerDelegateTest {
     when(mockIntentResolver.resolveActivity(any(Intent.class))).thenReturn(true);
 
     ImagePickerDelegate delegate = createDelegate();
+    delegate.takeImageWithCamera(mockMethodCall, mockResult);
 
-    try (MockedStatic<File> mockStaticFile = Mockito.mockStatic(File.class)) {
-      mockStaticFile
-          .when(() -> File.createTempFile(any(), any(), any()))
-          .thenReturn(new File("/tmpfile"));
-
-      delegate.takeImageWithCamera(mockMethodCall, mockResult);
-
-      verify(mockActivity)
-          .startActivityForResult(
-              any(Intent.class), eq(ImagePickerDelegate.REQUEST_CODE_TAKE_IMAGE_WITH_CAMERA));
-    }
+    verify(mockActivity)
+        .startActivityForResult(
+            any(Intent.class), eq(ImagePickerDelegate.REQUEST_CODE_TAKE_IMAGE_WITH_CAMERA));
   }
 
   @Test
@@ -176,18 +181,11 @@ public class ImagePickerDelegateTest {
     when(mockIntentResolver.resolveActivity(any(Intent.class))).thenReturn(true);
 
     ImagePickerDelegate delegate = createDelegate();
+    delegate.takeImageWithCamera(mockMethodCall, mockResult);
 
-    try (MockedStatic<File> mockStaticFile = Mockito.mockStatic(File.class)) {
-      mockStaticFile
-          .when(() -> File.createTempFile(any(), any(), any()))
-          .thenReturn(new File("/tmpfile"));
-
-      delegate.takeImageWithCamera(mockMethodCall, mockResult);
-
-      verify(mockActivity)
-          .startActivityForResult(
-              any(Intent.class), eq(ImagePickerDelegate.REQUEST_CODE_TAKE_IMAGE_WITH_CAMERA));
-    }
+    verify(mockActivity)
+        .startActivityForResult(
+            any(Intent.class), eq(ImagePickerDelegate.REQUEST_CODE_TAKE_IMAGE_WITH_CAMERA));
   }
 
   @Test
@@ -209,18 +207,12 @@ public class ImagePickerDelegateTest {
     when(mockPermissionManager.isPermissionGranted(Manifest.permission.CAMERA)).thenReturn(true);
     when(mockIntentResolver.resolveActivity(any(Intent.class))).thenReturn(true);
 
-    try (MockedStatic<File> mockStaticFile = Mockito.mockStatic(File.class)) {
-      mockStaticFile
-          .when(() -> File.createTempFile(any(), any(), any()))
-          .thenReturn(new File("/tmpfile"));
+    ImagePickerDelegate delegate = createDelegate();
+    delegate.takeImageWithCamera(mockMethodCall, mockResult);
 
-      ImagePickerDelegate delegate = createDelegate();
-      delegate.takeImageWithCamera(mockMethodCall, mockResult);
-
-      mockStaticFile.verify(
-          () -> File.createTempFile(any(), eq(".jpg"), eq(new File("/image_picker_cache"))),
-          times(1));
-    }
+    mockStaticFile.verify(
+        () -> File.createTempFile(any(), eq(".jpg"), eq(new File("/image_picker_cache"))),
+        times(1));
   }
 
   @Test
@@ -240,44 +232,32 @@ public class ImagePickerDelegateTest {
   public void
       onRequestTakeVideoPermissionsResult_WhenCameraPermissionGranted_LaunchesTakeVideoWithCameraIntent() {
     when(mockIntentResolver.resolveActivity(any(Intent.class))).thenReturn(true);
+
     ImagePickerDelegate delegate = createDelegateWithPendingResultAndMethodCall();
+    delegate.onRequestPermissionsResult(
+        ImagePickerDelegate.REQUEST_CAMERA_VIDEO_PERMISSION,
+        new String[] {Manifest.permission.CAMERA},
+        new int[] {PackageManager.PERMISSION_GRANTED});
 
-    try (MockedStatic<File> mockStaticFile = Mockito.mockStatic(File.class)) {
-      mockStaticFile
-          .when(() -> File.createTempFile(any(), any(), any()))
-          .thenReturn(new File("/tmpfile"));
-
-      delegate.onRequestPermissionsResult(
-          ImagePickerDelegate.REQUEST_CAMERA_VIDEO_PERMISSION,
-          new String[] {Manifest.permission.CAMERA},
-          new int[] {PackageManager.PERMISSION_GRANTED});
-
-      verify(mockActivity)
-          .startActivityForResult(
-              any(Intent.class), eq(ImagePickerDelegate.REQUEST_CODE_TAKE_VIDEO_WITH_CAMERA));
-    }
+    verify(mockActivity)
+        .startActivityForResult(
+            any(Intent.class), eq(ImagePickerDelegate.REQUEST_CODE_TAKE_VIDEO_WITH_CAMERA));
   }
 
   @Test
   public void
       onRequestTakeImagePermissionsResult_WhenCameraPermissionGranted_LaunchesTakeWithCameraIntent() {
     when(mockIntentResolver.resolveActivity(any(Intent.class))).thenReturn(true);
+
     ImagePickerDelegate delegate = createDelegateWithPendingResultAndMethodCall();
+    delegate.onRequestPermissionsResult(
+        ImagePickerDelegate.REQUEST_CAMERA_IMAGE_PERMISSION,
+        new String[] {Manifest.permission.CAMERA},
+        new int[] {PackageManager.PERMISSION_GRANTED});
 
-    try (MockedStatic<File> mockStaticFile = Mockito.mockStatic(File.class)) {
-      mockStaticFile
-          .when(() -> File.createTempFile(any(), any(), any()))
-          .thenReturn(new File("/tmpfile"));
-
-      delegate.onRequestPermissionsResult(
-          ImagePickerDelegate.REQUEST_CAMERA_IMAGE_PERMISSION,
-          new String[] {Manifest.permission.CAMERA},
-          new int[] {PackageManager.PERMISSION_GRANTED});
-
-      verify(mockActivity)
-          .startActivityForResult(
-              any(Intent.class), eq(ImagePickerDelegate.REQUEST_CODE_TAKE_IMAGE_WITH_CAMERA));
-    }
+    verify(mockActivity)
+        .startActivityForResult(
+            any(Intent.class), eq(ImagePickerDelegate.REQUEST_CODE_TAKE_IMAGE_WITH_CAMERA));
   }
 
   @Test

--- a/packages/image_picker/image_picker/example/android/app/src/test/java/io/flutter/plugins/imagepicker/ImagePickerDelegateTest.java
+++ b/packages/image_picker/image_picker/example/android/app/src/test/java/io/flutter/plugins/imagepicker/ImagePickerDelegateTest.java
@@ -155,11 +155,18 @@ public class ImagePickerDelegateTest {
     when(mockIntentResolver.resolveActivity(any(Intent.class))).thenReturn(true);
 
     ImagePickerDelegate delegate = createDelegate();
-    delegate.takeImageWithCamera(mockMethodCall, mockResult);
 
-    verify(mockActivity)
-        .startActivityForResult(
-            any(Intent.class), eq(ImagePickerDelegate.REQUEST_CODE_TAKE_IMAGE_WITH_CAMERA));
+    try (MockedStatic<File> mockStaticFile = Mockito.mockStatic(File.class)) {
+      mockStaticFile
+          .when(() -> File.createTempFile(any(), any(), any()))
+          .thenReturn(new File("/tmpfile"));
+
+      delegate.takeImageWithCamera(mockMethodCall, mockResult);
+
+      verify(mockActivity)
+          .startActivityForResult(
+              any(Intent.class), eq(ImagePickerDelegate.REQUEST_CODE_TAKE_IMAGE_WITH_CAMERA));
+    }
   }
 
   @Test
@@ -169,11 +176,18 @@ public class ImagePickerDelegateTest {
     when(mockIntentResolver.resolveActivity(any(Intent.class))).thenReturn(true);
 
     ImagePickerDelegate delegate = createDelegate();
-    delegate.takeImageWithCamera(mockMethodCall, mockResult);
 
-    verify(mockActivity)
-        .startActivityForResult(
-            any(Intent.class), eq(ImagePickerDelegate.REQUEST_CODE_TAKE_IMAGE_WITH_CAMERA));
+    try (MockedStatic<File> mockStaticFile = Mockito.mockStatic(File.class)) {
+      mockStaticFile
+          .when(() -> File.createTempFile(any(), any(), any()))
+          .thenReturn(new File("/tmpfile"));
+
+      delegate.takeImageWithCamera(mockMethodCall, mockResult);
+
+      verify(mockActivity)
+          .startActivityForResult(
+              any(Intent.class), eq(ImagePickerDelegate.REQUEST_CODE_TAKE_IMAGE_WITH_CAMERA));
+    }
   }
 
   @Test
@@ -195,17 +209,18 @@ public class ImagePickerDelegateTest {
     when(mockPermissionManager.isPermissionGranted(Manifest.permission.CAMERA)).thenReturn(true);
     when(mockIntentResolver.resolveActivity(any(Intent.class))).thenReturn(true);
 
-    MockedStatic<File> mockStaticFile = Mockito.mockStatic(File.class);
-    mockStaticFile
-        .when(() -> File.createTempFile(any(), any(), any()))
-        .thenReturn(new File("/tmpfile"));
+    try (MockedStatic<File> mockStaticFile = Mockito.mockStatic(File.class)) {
+      mockStaticFile
+          .when(() -> File.createTempFile(any(), any(), any()))
+          .thenReturn(new File("/tmpfile"));
 
-    ImagePickerDelegate delegate = createDelegate();
-    delegate.takeImageWithCamera(mockMethodCall, mockResult);
+      ImagePickerDelegate delegate = createDelegate();
+      delegate.takeImageWithCamera(mockMethodCall, mockResult);
 
-    mockStaticFile.verify(
-        () -> File.createTempFile(any(), eq(".jpg"), eq(new File("/image_picker_cache"))),
-        times(1));
+      mockStaticFile.verify(
+          () -> File.createTempFile(any(), eq(".jpg"), eq(new File("/image_picker_cache"))),
+          times(1));
+    }
   }
 
   @Test
@@ -225,32 +240,44 @@ public class ImagePickerDelegateTest {
   public void
       onRequestTakeVideoPermissionsResult_WhenCameraPermissionGranted_LaunchesTakeVideoWithCameraIntent() {
     when(mockIntentResolver.resolveActivity(any(Intent.class))).thenReturn(true);
-
     ImagePickerDelegate delegate = createDelegateWithPendingResultAndMethodCall();
-    delegate.onRequestPermissionsResult(
-        ImagePickerDelegate.REQUEST_CAMERA_VIDEO_PERMISSION,
-        new String[] {Manifest.permission.CAMERA},
-        new int[] {PackageManager.PERMISSION_GRANTED});
 
-    verify(mockActivity)
-        .startActivityForResult(
-            any(Intent.class), eq(ImagePickerDelegate.REQUEST_CODE_TAKE_VIDEO_WITH_CAMERA));
+    try (MockedStatic<File> mockStaticFile = Mockito.mockStatic(File.class)) {
+      mockStaticFile
+          .when(() -> File.createTempFile(any(), any(), any()))
+          .thenReturn(new File("/tmpfile"));
+
+      delegate.onRequestPermissionsResult(
+          ImagePickerDelegate.REQUEST_CAMERA_VIDEO_PERMISSION,
+          new String[] {Manifest.permission.CAMERA},
+          new int[] {PackageManager.PERMISSION_GRANTED});
+
+      verify(mockActivity)
+          .startActivityForResult(
+              any(Intent.class), eq(ImagePickerDelegate.REQUEST_CODE_TAKE_VIDEO_WITH_CAMERA));
+    }
   }
 
   @Test
   public void
       onRequestTakeImagePermissionsResult_WhenCameraPermissionGranted_LaunchesTakeWithCameraIntent() {
     when(mockIntentResolver.resolveActivity(any(Intent.class))).thenReturn(true);
-
     ImagePickerDelegate delegate = createDelegateWithPendingResultAndMethodCall();
-    delegate.onRequestPermissionsResult(
-        ImagePickerDelegate.REQUEST_CAMERA_IMAGE_PERMISSION,
-        new String[] {Manifest.permission.CAMERA},
-        new int[] {PackageManager.PERMISSION_GRANTED});
 
-    verify(mockActivity)
-        .startActivityForResult(
-            any(Intent.class), eq(ImagePickerDelegate.REQUEST_CODE_TAKE_IMAGE_WITH_CAMERA));
+    try (MockedStatic<File> mockStaticFile = Mockito.mockStatic(File.class)) {
+      mockStaticFile
+          .when(() -> File.createTempFile(any(), any(), any()))
+          .thenReturn(new File("/tmpfile"));
+
+      delegate.onRequestPermissionsResult(
+          ImagePickerDelegate.REQUEST_CAMERA_IMAGE_PERMISSION,
+          new String[] {Manifest.permission.CAMERA},
+          new int[] {PackageManager.PERMISSION_GRANTED});
+
+      verify(mockActivity)
+          .startActivityForResult(
+              any(Intent.class), eq(ImagePickerDelegate.REQUEST_CODE_TAKE_IMAGE_WITH_CAMERA));
+    }
   }
 
   @Test
@@ -380,7 +407,7 @@ public class ImagePickerDelegateTest {
   private ImagePickerDelegate createDelegateWithPendingResultAndMethodCall() {
     return new ImagePickerDelegate(
         mockActivity,
-        null,
+        new File("/image_picker_cache"),
         mockImageResizer,
         mockResult,
         mockMethodCall,

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for selecting images from the Android and iOS image
   library, and taking new pictures with the camera.
 repository: https://github.com/flutter/plugins/tree/master/packages/image_picker/image_picker
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 0.8.1+2
+version: 0.8.1+3
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
Currently, the image picker plugin throws an IOException when trying to pick an image, if the cache directory does not exist. 
This PR makes it so the cache directory is created in case it does not exist.

Relevant issue:
- flutter/flutter#84251

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.
