### PR TITLE
[flutter_plugin_tools] Remove most exitOnError:true usage

### DIFF
--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Modified the output format of many commands
 - **Breaking change**: `firebase-test-lab` no longer supports `*_e2e.dart`
   files, only `integration_test/*_test.dart`.
+- Fixed some cases where a failure in a command for a single package would
+  immidiately abort the test.
 
 ## 0.3.0
 

--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Add a summary to the end of successful command runs for commands using the
   new output format.
 - Fixed some cases where a failure in a command for a single package would
-  immidiately abort the test.
+  immediately abort the test.
 
 ## 0.3.0
 

--- a/script/tool/lib/src/drive_examples_command.dart
+++ b/script/tool/lib/src/drive_examples_command.dart
@@ -203,7 +203,7 @@ class DriveExamplesCommand extends PackageLoopingCommand {
 
     final ProcessResult result = await processRunner.run(
         flutterCommand, <String>['devices', '--machine'],
-        stdoutEncoding: utf8, exitOnError: true);
+        stdoutEncoding: utf8);
     if (result.exitCode != 0) {
       return deviceIds;
     }
@@ -295,8 +295,7 @@ class DriveExamplesCommand extends PackageLoopingCommand {
             '--target',
             p.relative(target.path, from: example.path),
           ],
-          workingDir: example,
-          exitOnError: true);
+          workingDir: example);
       if (exitCode != 0) {
         failures.add(target);
       }

--- a/script/tool/lib/src/firebase_test_lab_command.dart
+++ b/script/tool/lib/src/firebase_test_lab_command.dart
@@ -13,6 +13,8 @@ import 'common/core.dart';
 import 'common/package_looping_command.dart';
 import 'common/process_runner.dart';
 
+const int _exitGcloudAuthFailed = 2;
+
 /// A command to run tests via Firebase test lab.
 class FirebaseTestLabCommand extends PackageLoopingCommand {
   /// Creates an instance of the test runner command.
@@ -84,7 +86,7 @@ class FirebaseTestLabCommand extends PackageLoopingCommand {
     if (serviceKey.isEmpty) {
       print('No --service-key provided; skipping gcloud authorization');
     } else {
-      await processRunner.run(
+      final io.ProcessResult result = await processRunner.run(
         'gcloud',
         <String>[
           'auth',
@@ -93,6 +95,10 @@ class FirebaseTestLabCommand extends PackageLoopingCommand {
         ],
         logOnError: true,
       );
+      if (result.exitCode != 0) {
+        printError('Unable to activate gcloud account.');
+        throw ToolExit(_exitGcloudAuthFailed);
+      }
       final int exitCode = await processRunner.runAndStream('gcloud', <String>[
         'config',
         'set',

--- a/script/tool/lib/src/firebase_test_lab_command.dart
+++ b/script/tool/lib/src/firebase_test_lab_command.dart
@@ -91,7 +91,6 @@ class FirebaseTestLabCommand extends PackageLoopingCommand {
           'activate-service-account',
           '--key-file=$serviceKey',
         ],
-        exitOnError: true,
         logOnError: true,
       );
       final int exitCode = await processRunner.runAndStream('gcloud', <String>[

--- a/script/tool/lib/src/lint_podspecs_command.dart
+++ b/script/tool/lib/src/lint_podspecs_command.dart
@@ -14,6 +14,7 @@ import 'common/package_looping_command.dart';
 import 'common/process_runner.dart';
 
 const int _exitUnsupportedPlatform = 2;
+const int _exitPodNotInstalled = 3;
 
 /// Lint the CocoaPod podspecs and run unit tests.
 ///
@@ -53,13 +54,16 @@ class LintPodspecsCommand extends PackageLoopingCommand {
       throw ToolExit(_exitUnsupportedPlatform);
     }
 
-    await processRunner.run(
+    final ProcessResult result = await processRunner.run(
       'which',
       <String>['pod'],
       workingDir: packagesDir,
-      exitOnError: true,
       logOnError: true,
     );
+    if (result.exitCode != 0) {
+      printError('Unable to find "pod". Make sure it is in your path.');
+      throw ToolExit(_exitPodNotInstalled);
+    }
   }
 
   @override

--- a/script/tool/lib/src/publish_plugin_command.dart
+++ b/script/tool/lib/src/publish_plugin_command.dart
@@ -355,7 +355,6 @@ Safe to ignore if the package is deleted in this commit.
         'git',
         <String>['tag', tag],
         workingDir: packageDir,
-        exitOnError: false,
         logOnError: true,
       );
       if (result.exitCode != 0) {
@@ -402,7 +401,6 @@ Safe to ignore if the package is deleted in this commit.
       <String>['status', '--porcelain', '--ignored', packageDir.absolute.path],
       workingDir: packageDir,
       logOnError: true,
-      exitOnError: false,
     );
     if (statusResult.exitCode != 0) {
       return false;
@@ -498,7 +496,6 @@ Safe to ignore if the package is deleted in this commit.
         'git',
         <String>['push', remote.name, tag],
         workingDir: packagesDir,
-        exitOnError: false,
         logOnError: true,
       );
       if (result.exitCode != 0) {

--- a/script/tool/lib/src/publish_plugin_command.dart
+++ b/script/tool/lib/src/publish_plugin_command.dart
@@ -421,9 +421,11 @@ Safe to ignore if the package is deleted in this commit.
       'git',
       <String>['remote', 'get-url', remote],
       workingDir: packagesDir,
-      exitOnError: true,
       logOnError: true,
     );
+    if (getRemoteUrlResult.exitCode != 0) {
+      return null;
+    }
     return getRemoteUrlResult.stdout as String?;
   }
 

--- a/script/tool/lib/src/xctest_command.dart
+++ b/script/tool/lib/src/xctest_command.dart
@@ -163,7 +163,7 @@ class XCTestCommand extends PackageLoopingCommand {
         '$_kXCRunCommand ${xctestArgs.join(' ')}';
     print(completeTestCommand);
     return processRunner.runAndStream(_kXCRunCommand, xctestArgs,
-        workingDir: example, exitOnError: false);
+        workingDir: example);
   }
 
   Future<String?> _findAvailableIphoneSimulator() async {

--- a/script/tool/test/drive_examples_command_test.dart
+++ b/script/tool/test/drive_examples_command_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io' as io;
+
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
@@ -53,7 +55,9 @@ void main() {
       final MockProcess mockDevicesProcess = MockProcess();
       mockDevicesProcess.exitCodeCompleter.complete(0);
       mockDevicesProcess.stdoutController.close(); // ignore: unawaited_futures
-      processRunner.processToReturn = mockDevicesProcess;
+      processRunner.mockProcessesForExecutable['flutter'] = <io.Process>[
+        mockDevicesProcess
+      ];
       processRunner.resultStdout = output;
     }
 
@@ -133,7 +137,8 @@ void main() {
       );
     });
 
-    test('fails if Android if no Android devices are present', () async {
+    test('fails for Android if no Android devices are present', () async {
+      setMockFlutterDevicesOutput(hasAndroidDevice: false);
       Error? commandError;
       final List<String> output = await runCapturingPrint(
           runner, <String>['drive-examples', '--android'],

--- a/script/tool/test/drive_examples_command_test.dart
+++ b/script/tool/test/drive_examples_command_test.dart
@@ -110,6 +110,29 @@ void main() {
       );
     });
 
+    test('fails for iOS if getting devices fails', () async {
+      setMockFlutterDevicesOutput(hasIosDevice: false);
+
+      // Simulate failure from `flutter devices`.
+      final MockProcess mockProcess = MockProcess();
+      mockProcess.exitCodeCompleter.complete(1);
+      processRunner.processToReturn = mockProcess;
+
+      Error? commandError;
+      final List<String> output = await runCapturingPrint(
+          runner, <String>['drive-examples', '--ios'], errorHandler: (Error e) {
+        commandError = e;
+      });
+
+      expect(commandError, isA<ToolExit>());
+      expect(
+        output,
+        containsAllInOrder(<Matcher>[
+          contains('No iOS devices'),
+        ]),
+      );
+    });
+
     test('fails if Android if no Android devices are present', () async {
       Error? commandError;
       final List<String> output = await runCapturingPrint(

--- a/script/tool/test/firebase_test_lab_command_test.dart
+++ b/script/tool/test/firebase_test_lab_command_test.dart
@@ -36,7 +36,7 @@ void main() {
     test('retries gcloud set', () async {
       final MockProcess mockProcess = MockProcess();
       mockProcess.exitCodeCompleter.complete(1);
-      processRunner.processToReturn = mockProcess;
+      processRunner.processToReturnForExecutable['gcloud'] = mockProcess;
       createFakePlugin('plugin', packagesDir, extraFiles: <String>[
         'lib/test/should_not_run_e2e.dart',
         'example/test_driver/plugin_e2e.dart',

--- a/script/tool/test/lint_podspecs_command_test.dart
+++ b/script/tool/test/lint_podspecs_command_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io' as io;
+
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
@@ -167,7 +169,9 @@ void main() {
       // Simulate failure from `which pod`.
       final MockProcess mockWhichProcess = MockProcess();
       mockWhichProcess.exitCodeCompleter.complete(1);
-      processRunner.processToReturnForExecutable['which'] = mockWhichProcess;
+      processRunner.mockProcessesForExecutable['which'] = <io.Process>[
+        mockWhichProcess
+      ];
 
       Error? commandError;
       final List<String> output = await runCapturingPrint(
@@ -193,7 +197,9 @@ void main() {
       // Simulate failure from `pod`.
       final MockProcess mockDriveProcess = MockProcess();
       mockDriveProcess.exitCodeCompleter.complete(1);
-      processRunner.processToReturnForExecutable['pod'] = mockDriveProcess;
+      processRunner.mockProcessesForExecutable['pod'] = <io.Process>[
+        mockDriveProcess
+      ];
 
       Error? commandError;
       final List<String> output = await runCapturingPrint(

--- a/script/tool/test/util.dart
+++ b/script/tool/test/util.dart
@@ -301,7 +301,7 @@ class RecordingProcessRunner extends ProcessRunner {
 
     final io.Process? process = _getProcessToReturn(executable);
     final io.ProcessResult result = process == null
-        ? io.ProcessResult(0, 0, '', '')
+        ? io.ProcessResult(1, 0, '', '')
         : io.ProcessResult(process.pid, await process.exitCode,
             resultStdout ?? process.stdout, resultStderr ?? process.stderr);
 

--- a/script/tool/test/util.dart
+++ b/script/tool/test/util.dart
@@ -269,8 +269,12 @@ class RecordingProcessRunner extends ProcessRunner {
     bool exitOnError = false,
   }) async {
     recordedCalls.add(ProcessCall(executable, args, workingDir?.path));
-    return Future<int>.value(
-        processToReturn == null ? 0 : await processToReturn!.exitCode);
+    final int exitCode =
+        processToReturn == null ? 0 : await processToReturn!.exitCode;
+    if (exitOnError && (exitCode != 0)) {
+      throw io.ProcessException(executable, args);
+    }
+    return Future<int>.value(exitCode);
   }
 
   /// Returns [io.ProcessResult] created from [processToReturn], [resultStdout], and [resultStderr].
@@ -291,6 +295,10 @@ class RecordingProcessRunner extends ProcessRunner {
         ? io.ProcessResult(1, 1, '', '')
         : io.ProcessResult(process.pid, await process.exitCode,
             resultStdout ?? process.stdout, resultStderr ?? process.stderr);
+
+    if (exitOnError && (result.exitCode != 0)) {
+      throw io.ProcessException(executable, args);
+    }
 
     return Future<io.ProcessResult>.value(result);
   }


### PR DESCRIPTION
The intent of package-looping commands is that we always want to run them for all the targeted packages, accumulating failures, and then report them all at the end, so we don't end up with the problem of only finding errors one at a time. However, some of them were using `exitOnError: true` for the underlying commands, causing the first error to be fatal to the test.

This PR:
- Removes all use of `exitOnError: true` from the package-looping commands. (It's still used in `format`, but fixing that is a larger issue, and less important due to the way `format` is currently structured.)
- Fixes the mock process runner used in our tests to correctly simulate `exitOrError: true`; the fact that it didn't was hiding this problem in test (e.g., `drive-examples` had a test that asserted that all failures were summarized correctly, which passed because in tests it was behaving as if `exitOnError` were false)
- Adjusts the mock process runner to allow setting a list of mock result for a specific executable instead of one result for all calls to anything, in order to fix some tests that were broken by the two changes above and unfixable without this (e.g., a test of a command that had been calling one executable with `exitOnError: true` then another with ``exitOnError: false`, where the test was asserting things about the second call failing, which only worked because the first call's failure wasn't actually checked). To limit the scope of the PR, the old method of setting a single result for all calls is still supported for now as a fallback.
- Fixes the fact that the mock `run` and `runAndStream` had opposite default exit code behavior when no mock process was set (since that caused me a lot of confusion while fixing the above until I figured it out).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
