### PR TITLE
[flutter_plugin_tools] Migrate 'test' to new base command

### DIFF
--- a/script/tool/lib/src/test_command.dart
+++ b/script/tool/lib/src/test_command.dart
@@ -20,7 +20,9 @@ class TestCommand extends PackageLoopingCommand {
       kEnableExperiment,
       defaultsTo: '',
       help:
-          'Runs Dart unit tests in Dart VM with the given experiments enabled.',
+          'Runs Dart unit tests in Dart VM with the given experiments enabled. '
+          'See https://github.com/dart-lang/sdk/blob/master/docs/process/experimental-flags.md '
+          'for details.',
     );
   }
 
@@ -56,6 +58,7 @@ class TestCommand extends PackageLoopingCommand {
         'test',
         '--color',
         if (experiment.isNotEmpty) '--enable-experiment=$experiment',
+        // TODO(ditman): Remove this once all plugins are migrated to 'drive'.
         if (isWebPlugin(package)) '--platform=chrome',
       ],
       workingDir: package,

--- a/script/tool/test/test_command_test.dart
+++ b/script/tool/test/test_command_test.dart
@@ -73,8 +73,8 @@ void main() {
       expect(
           output,
           containsAllInOrder(<Matcher>[
-            contains('Tests for the following packages are failing'),
-            contains(' * plugin1'),
+            contains('The following packages had errors:'),
+            contains('  plugin1'),
           ]));
     });
 
@@ -137,7 +137,9 @@ void main() {
       expect(
           output,
           containsAllInOrder(<Matcher>[
-            contains('Tests for the following packages are failing'),
+            contains('Unable to fetch dependencies'),
+            contains('The following packages had errors:'),
+            contains('  a_package'),
           ]));
     });
 
@@ -160,7 +162,8 @@ void main() {
       expect(
           output,
           containsAllInOrder(<Matcher>[
-            contains('Tests for the following packages are failing'),
+            contains('The following packages had errors:'),
+            contains('  a_package'),
           ]));
     });
 


### PR DESCRIPTION
Migrates `test` to the new package looping base command.

Refactors the bulk of the logic to helpers for easier understanding of the flow.

Part of flutter/flutter#83413

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
