### PR TITLE
[flutter_plugin_tools] Work around banner in drive-examples

### DIFF
--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -9,6 +9,7 @@
   immediately abort the test.
 - Deprecated `--plugins` in favor of new `--packages`. `--plugins` continues to
   work for now, but will be removed in the future.
+- Make `drive-examples` device detection robust against Flutter tool banners.
 
 ## 0.3.0
 

--- a/script/tool/lib/src/drive_examples_command.dart
+++ b/script/tool/lib/src/drive_examples_command.dart
@@ -208,9 +208,14 @@ class DriveExamplesCommand extends PackageLoopingCommand {
       return deviceIds;
     }
 
+    String output = result.stdout as String;
+    // --machine doesn't currently prevent the tool from printing banners;
+    // see https://github.com/flutter/flutter/issues/86055. This workaround
+    // can be removed once that is fixed.
+    output = output.substring(output.indexOf('['));
+
     final List<Map<String, dynamic>> devices =
-        (jsonDecode(result.stdout as String) as List<dynamic>)
-            .cast<Map<String, dynamic>>();
+        (jsonDecode(output) as List<dynamic>).cast<Map<String, dynamic>>();
     for (final Map<String, dynamic> deviceInfo in devices) {
       final String targetPlatform =
           (deviceInfo['targetPlatform'] as String?) ?? '';

--- a/script/tool/test/drive_examples_command_test.dart
+++ b/script/tool/test/drive_examples_command_test.dart
@@ -44,13 +44,22 @@ void main() {
     void setMockFlutterDevicesOutput({
       bool hasIosDevice = true,
       bool hasAndroidDevice = true,
+      bool includeBanner = false,
     }) {
+      const String updateBanner = '''
+╔════════════════════════════════════════════════════════════════════════════╗
+║ A new version of Flutter is available!                                     ║
+║                                                                            ║
+║ To update to the latest version, run "flutter upgrade".                    ║
+╚════════════════════════════════════════════════════════════════════════════╝
+''';
       final List<String> devices = <String>[
         if (hasIosDevice) '{"id": "$_fakeIosDevice", "targetPlatform": "ios"}',
         if (hasAndroidDevice)
           '{"id": "$_fakeAndroidDevice", "targetPlatform": "android-x86"}',
       ];
-      final String output = '''[${devices.join(',')}]''';
+      final String output =
+          '''${includeBanner ? updateBanner : ''}[${devices.join(',')}]''';
 
       final MockProcess mockDevicesProcess = MockProcess.succeeding();
       mockDevicesProcess.stdoutController.close(); // ignore: unawaited_futures
@@ -109,6 +118,32 @@ void main() {
         output,
         containsAllInOrder(<Matcher>[
           contains('No iOS devices'),
+        ]),
+      );
+    });
+
+    test('handles flutter tool banners when checking devices', () async {
+      final Directory pluginDirectory = createFakePlugin(
+        'plugin',
+        packagesDir,
+        extraFiles: <String>[
+          'example/test_driver/integration_test.dart',
+          'example/integration_test/foo_test.dart',
+        ],
+        platformSupport: <String, PlatformSupport>{
+          kPlatformIos: PlatformSupport.inline,
+        },
+      );
+
+      setMockFlutterDevicesOutput(includeBanner: true);
+      final List<String> output =
+          await runCapturingPrint(runner, <String>['drive-examples', '--ios']);
+
+      expect(
+        output,
+        containsAllInOrder(<Matcher>[
+          contains('Running for plugin'),
+          contains('No issues found!'),
         ]),
       );
     });

--- a/script/tool/test/drive_examples_command_test.dart
+++ b/script/tool/test/drive_examples_command_test.dart
@@ -123,7 +123,7 @@ void main() {
     });
 
     test('handles flutter tool banners when checking devices', () async {
-      final Directory pluginDirectory = createFakePlugin(
+      createFakePlugin(
         'plugin',
         packagesDir,
         extraFiles: <String>[


### PR DESCRIPTION
Strip off any unexpected output before parsing `flutter devices
--machine` output. Works around a bug in the Flutter tool that can
result in banners being printed in `--machine` mode.

Fixes https://github.com/flutter/flutter/issues/86052

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
