### PR TITLE
[in_app_purchase] Add iOS currency symbol to ProductDetails

### DIFF
--- a/packages/in_app_purchase/in_app_purchase_ios/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3
+
+* Add price symbol to platform interface object ProductDetail.
+
 ## 0.1.2+1
 
 * Fix wrong data type when cancelling user credentials dialog.

--- a/packages/in_app_purchase/in_app_purchase_ios/lib/src/types/app_store_product_details.dart
+++ b/packages/in_app_purchase/in_app_purchase_ios/lib/src/types/app_store_product_details.dart
@@ -19,6 +19,7 @@ class AppStoreProductDetails extends ProductDetails {
     required double rawPrice,
     required String currencyCode,
     required this.skProduct,
+    required String currencySymbol,
   }) : super(
           id: id,
           title: title,
@@ -26,6 +27,7 @@ class AppStoreProductDetails extends ProductDetails {
           price: price,
           rawPrice: rawPrice,
           currencyCode: currencyCode,
+          currencySymbol: currencySymbol,
         );
 
   /// Points back to the [SKProductWrapper] object that was used to generate
@@ -41,6 +43,9 @@ class AppStoreProductDetails extends ProductDetails {
       price: product.priceLocale.currencySymbol + product.price,
       rawPrice: double.parse(product.price),
       currencyCode: product.priceLocale.currencyCode,
+      currencySymbol: product.priceLocale.currencySymbol.isNotEmpty
+          ? product.priceLocale.currencySymbol
+          : product.priceLocale.currencyCode,
       skProduct: product,
     );
   }

--- a/packages/in_app_purchase/in_app_purchase_ios/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_ios/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   collection: ^1.15.0
   flutter:
     sdk: flutter
-  in_app_purchase_platform_interface: ^1.0.0
+  in_app_purchase_platform_interface: ^1.1.0
   json_annotation: ^4.0.1
   meta: ^1.3.0
   test: ^1.16.0

--- a/packages/in_app_purchase/in_app_purchase_ios/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase_ios
 description: An implementation for the iOS platform of the Flutter `in_app_purchase` plugin. This uses the iOS StoreKit Framework.
 repository: https://github.com/flutter/plugins/tree/master/packages/in_app_purchase/in_app_purchase_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 0.1.2+1
+version: 0.1.3
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/in_app_purchase/in_app_purchase_ios/test/fakes/fake_ios_platform.dart
+++ b/packages/in_app_purchase/in_app_purchase_ios/test/fakes/fake_ios_platform.dart
@@ -40,6 +40,9 @@ class FakeIOSPlatform {
       Map<String, dynamic> productWrapperMap =
           buildProductMap(dummyProductWrapper);
       productWrapperMap['productIdentifier'] = validID;
+      if (validID == '456') {
+        productWrapperMap['priceLocale'] = buildLocaleMap(noSymbolLocale);
+      }
       validProducts[validID] = SKProductWrapper.fromJson(productWrapperMap);
     }
 

--- a/packages/in_app_purchase/in_app_purchase_ios/test/in_app_purchase_ios_platform_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_ios/test/in_app_purchase_ios_platform_test.dart
@@ -49,6 +49,8 @@ void main() {
       expect(products[1].id, '456');
       expect(response.notFoundIDs, ['789']);
       expect(response.error, isNull);
+      expect(response.productDetails.first.currencySymbol, r'$');
+      expect(response.productDetails[1].currencySymbol, 'EUR');
     });
 
     test(

--- a/packages/in_app_purchase/in_app_purchase_ios/test/store_kit_wrappers/sk_product_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_ios/test/store_kit_wrappers/sk_product_test.dart
@@ -119,8 +119,8 @@ void main() {
 
     test('LocaleWrapper should have property values consistent with map', () {
       final SKPriceLocaleWrapper wrapper =
-          SKPriceLocaleWrapper.fromJson(buildLocaleMap(dummyLocale));
-      expect(wrapper, equals(dummyLocale));
+          SKPriceLocaleWrapper.fromJson(buildLocaleMap(dollarLocale));
+      expect(wrapper, equals(dollarLocale));
     });
   });
 

--- a/packages/in_app_purchase/in_app_purchase_ios/test/store_kit_wrappers/sk_test_stub_objects.dart
+++ b/packages/in_app_purchase/in_app_purchase_ios/test/store_kit_wrappers/sk_test_stub_objects.dart
@@ -33,10 +33,16 @@ final SKPaymentTransactionWrapper dummyTransaction =
   error: dummyError,
 );
 
-final SKPriceLocaleWrapper dummyLocale = SKPriceLocaleWrapper(
+final SKPriceLocaleWrapper dollarLocale = SKPriceLocaleWrapper(
   currencySymbol: '\$',
   currencyCode: 'USD',
   countryCode: 'US',
+);
+
+final SKPriceLocaleWrapper noSymbolLocale = SKPriceLocaleWrapper(
+  currencySymbol: '',
+  currencyCode: 'EUR',
+  countryCode: 'UK',
 );
 
 final SKProductSubscriptionPeriodWrapper dummySubscription =
@@ -47,7 +53,7 @@ final SKProductSubscriptionPeriodWrapper dummySubscription =
 
 final SKProductDiscountWrapper dummyDiscount = SKProductDiscountWrapper(
   price: '1.0',
-  priceLocale: dummyLocale,
+  priceLocale: dollarLocale,
   numberOfPeriods: 1,
   paymentMode: SKProductDiscountPaymentMode.payUpFront,
   subscriptionPeriod: dummySubscription,
@@ -57,7 +63,7 @@ final SKProductWrapper dummyProductWrapper = SKProductWrapper(
   productIdentifier: 'id',
   localizedTitle: 'title',
   localizedDescription: 'description',
-  priceLocale: dummyLocale,
+  priceLocale: dollarLocale,
   subscriptionGroupIdentifier: 'com.group',
   price: '1.0',
   subscriptionPeriod: dummySubscription,


### PR DESCRIPTION
This PR adds the existing iOS price currency symbol to the platform interface object ProductDetails.
The symbol is not expected to be empty, but if it is it has a fallback to the currency code, just like Android has.

iOS implementation of #4115
Last part of flutter/flutter#83984.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [X] I signed the [CLA].
- [X] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
