### PR TITLE
[flutter_plugin_tools] Only check target packages in analyze

### DIFF
--- a/script/tool/test/analyze_command_test.dart
+++ b/script/tool/test/analyze_command_test.dart
@@ -126,6 +126,8 @@ void main() {
         containsAllInOrder(<Matcher>[
           contains(
               'Found an extra analysis_options.yaml at /packages/foo/analysis_options.yaml'),
+          contains('  foo:\n'
+              '    Unexpected local analysis options'),
         ]),
       );
     });
@@ -146,6 +148,8 @@ void main() {
         containsAllInOrder(<Matcher>[
           contains(
               'Found an extra analysis_options.yaml at /packages/foo/.analysis_options'),
+          contains('  foo:\n'
+              '    Unexpected local analysis options'),
         ]),
       );
     });


### PR DESCRIPTION
Makes validating that there are no unexpected analysis_options.yaml
files part of the per-package loop, rather than a pre-check, so that it
only runs against the target packages. This makes it easier to run
locally on specific packages, since it's not necessary to pass the allow
list for every package when targeting just one package.

This also means that the command will run all the way to the end even
if one package fails that check, rather than exiting immediately and
not analyzing other packages.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
