### PR TITLE
[flutter_plugin_tools] Make unit tests pass on Windows

### DIFF
--- a/script/tool/lib/src/analyze_command.dart
+++ b/script/tool/lib/src/analyze_command.dart
@@ -90,7 +90,7 @@ class AnalyzeCommand extends PackageLoopingCommand {
     });
     for (final Directory package in packageDirectories) {
       final int exitCode = await processRunner.runAndStream(
-          'flutter', <String>['packages', 'get'],
+          flutterCommand, <String>['packages', 'get'],
           workingDir: package);
       if (exitCode != 0) {
         return false;

--- a/script/tool/lib/src/analyze_command.dart
+++ b/script/tool/lib/src/analyze_command.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 
 import 'package:file/file.dart';
-import 'package:path/path.dart' as p;
+import 'package:platform/platform.dart';
 
 import 'common/core.dart';
 import 'common/package_looping_command.dart';
@@ -19,7 +19,8 @@ class AnalyzeCommand extends PackageLoopingCommand {
   AnalyzeCommand(
     Directory packagesDir, {
     ProcessRunner processRunner = const ProcessRunner(),
-  }) : super(packagesDir, processRunner: processRunner) {
+    Platform platform = const LocalPlatform(),
+  }) : super(packagesDir, processRunner: processRunner, platform: platform) {
     argParser.addMultiOption(_customAnalysisFlag,
         help:
             'Directories (comma separated) that are allowed to have their own analysis options.',
@@ -57,9 +58,8 @@ class AnalyzeCommand extends PackageLoopingCommand {
 
       final bool allowed = (getStringListArg(_customAnalysisFlag)).any(
           (String directory) =>
-              directory != null &&
               directory.isNotEmpty &&
-              p.isWithin(
+              path.isWithin(
                   packagesDir.childDirectory(directory).path, file.path));
       if (allowed) {
         continue;
@@ -109,7 +109,8 @@ class AnalyzeCommand extends PackageLoopingCommand {
 
     // Use the Dart SDK override if one was passed in.
     final String? dartSdk = argResults![_analysisSdk] as String?;
-    _dartBinaryPath = dartSdk == null ? 'dart' : p.join(dartSdk, 'bin', 'dart');
+    _dartBinaryPath =
+        dartSdk == null ? 'dart' : path.join(dartSdk, 'bin', 'dart');
   }
 
   @override

--- a/script/tool/lib/src/build_examples_command.dart
+++ b/script/tool/lib/src/build_examples_command.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:file/file.dart';
 import 'package:path/path.dart' as p;
+import 'package:platform/platform.dart';
 
 import 'common/core.dart';
 import 'common/package_looping_command.dart';
@@ -23,7 +24,8 @@ class BuildExamplesCommand extends PackageLoopingCommand {
   BuildExamplesCommand(
     Directory packagesDir, {
     ProcessRunner processRunner = const ProcessRunner(),
-  }) : super(packagesDir, processRunner: processRunner) {
+    Platform platform = const LocalPlatform(),
+  }) : super(packagesDir, processRunner: processRunner, platform: platform) {
     argParser.addFlag(kPlatformLinux);
     argParser.addFlag(kPlatformMacos);
     argParser.addFlag(kPlatformWeb);
@@ -126,8 +128,9 @@ class BuildExamplesCommand extends PackageLoopingCommand {
     print('');
 
     for (final Directory example in getExamplesForPlugin(package)) {
+      final p.Context posixContext = p.Context(style: p.Style.posix);
       final String packageName =
-          p.relative(example.path, from: packagesDir.path);
+          posixContext.relative(example.path, from: packagesDir.path);
 
       for (final _PlatformDetails platform in buildPlatforms) {
         String buildPlatform = platform.label;

--- a/script/tool/lib/src/build_examples_command.dart
+++ b/script/tool/lib/src/build_examples_command.dart
@@ -128,9 +128,8 @@ class BuildExamplesCommand extends PackageLoopingCommand {
     print('');
 
     for (final Directory example in getExamplesForPlugin(package)) {
-      final p.Context posixContext = p.Context(style: p.Style.posix);
       final String packageName =
-          posixContext.relative(example.path, from: packagesDir.path);
+          p.posix.relative(example.path, from: packagesDir.path);
 
       for (final _PlatformDetails platform in buildPlatforms) {
         String buildPlatform = platform.label;

--- a/script/tool/lib/src/build_examples_command.dart
+++ b/script/tool/lib/src/build_examples_command.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 
 import 'package:file/file.dart';
-import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
 
 import 'common/core.dart';

--- a/script/tool/lib/src/build_examples_command.dart
+++ b/script/tool/lib/src/build_examples_command.dart
@@ -128,8 +128,7 @@ class BuildExamplesCommand extends PackageLoopingCommand {
     print('');
 
     for (final Directory example in getExamplesForPlugin(package)) {
-      final String packageName =
-          p.posix.relative(example.path, from: packagesDir.path);
+      final String packageName = getRelativePosixPath(example, from: package);
 
       for (final _PlatformDetails platform in buildPlatforms) {
         String buildPlatform = platform.label;

--- a/script/tool/lib/src/build_examples_command.dart
+++ b/script/tool/lib/src/build_examples_command.dart
@@ -127,7 +127,8 @@ class BuildExamplesCommand extends PackageLoopingCommand {
     print('');
 
     for (final Directory example in getExamplesForPlugin(package)) {
-      final String packageName = getRelativePosixPath(example, from: package);
+      final String packageName =
+          getRelativePosixPath(example, from: packagesDir);
 
       for (final _PlatformDetails platform in buildPlatforms) {
         String buildPlatform = platform.label;

--- a/script/tool/lib/src/common/package_looping_command.dart
+++ b/script/tool/lib/src/common/package_looping_command.dart
@@ -8,6 +8,7 @@ import 'package:colorize/colorize.dart';
 import 'package:file/file.dart';
 import 'package:git/git.dart';
 import 'package:path/path.dart' as p;
+import 'package:platform/platform.dart';
 
 import 'core.dart';
 import 'plugin_command.dart';
@@ -63,8 +64,10 @@ abstract class PackageLoopingCommand extends PluginCommand {
   PackageLoopingCommand(
     Directory packagesDir, {
     ProcessRunner processRunner = const ProcessRunner(),
+    Platform platform = const LocalPlatform(),
     GitDir? gitDir,
-  }) : super(packagesDir, processRunner: processRunner, gitDir: gitDir);
+  }) : super(packagesDir,
+            processRunner: processRunner, platform: platform, gitDir: gitDir);
 
   /// Packages that had at least one [logWarning] call.
   final Set<Directory> _packagesWithWarnings = <Directory>{};

--- a/script/tool/lib/src/common/package_looping_command.dart
+++ b/script/tool/lib/src/common/package_looping_command.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:colorize/colorize.dart';
 import 'package:file/file.dart';
 import 'package:git/git.dart';
+import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
 
 import 'core.dart';
@@ -160,15 +161,16 @@ abstract class PackageLoopingCommand extends PluginCommand {
   /// an exact format (e.g., published name, or basename) is required, that
   /// should be used instead.
   String getPackageDescription(Directory package) {
-    String packageName = path.relative(package.path, from: packagesDir.path);
+    final String packageName =
+        path.relative(package.path, from: packagesDir.path);
     final List<String> components = path.split(packageName);
     // For the common federated plugin pattern of `foo/foo_subpackage`, drop
     // the first part since it's not useful.
     if (components.length == 2 &&
         components[1].startsWith('${components[0]}_')) {
-      packageName = components[1];
+      components.removeAt(0);
     }
-    return packageName;
+    return p.posix.joinAll(components);
   }
 
   /// The suggested indentation for printed output.

--- a/script/tool/lib/src/common/package_looping_command.dart
+++ b/script/tool/lib/src/common/package_looping_command.dart
@@ -161,17 +161,26 @@ abstract class PackageLoopingCommand extends PluginCommand {
   /// an exact format (e.g., published name, or basename) is required, that
   /// should be used instead.
   String getPackageDescription(Directory package) {
-    final String packageName =
-        path.relative(package.path, from: packagesDir.path);
-    final List<String> components = path.split(packageName);
+    String packageName = getRelativePosixPath(package, from: packagesDir);
+    final List<String> components = p.posix.split(packageName);
     // For the common federated plugin pattern of `foo/foo_subpackage`, drop
     // the first part since it's not useful.
     if (components.length == 2 &&
         components[1].startsWith('${components[0]}_')) {
-      components.removeAt(0);
+      packageName = components[1];
     }
-    return p.posix.joinAll(components);
+    return packageName;
   }
+
+  /// Returns the relative path from [from] to [entity] in Posix style.
+  ///
+  /// This should be used when, for example, printing package-relative paths in
+  /// status or error messages.
+  String getRelativePosixPath(
+    FileSystemEntity entity, {
+    required Directory from,
+  }) =>
+      p.posix.joinAll(path.split(path.relative(entity.path, from: from.path)));
 
   /// The suggested indentation for printed output.
   String get indentation => hasLongOutput ? '' : '  ';

--- a/script/tool/lib/src/common/package_looping_command.dart
+++ b/script/tool/lib/src/common/package_looping_command.dart
@@ -7,7 +7,6 @@ import 'dart:async';
 import 'package:colorize/colorize.dart';
 import 'package:file/file.dart';
 import 'package:git/git.dart';
-import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
 
 import 'core.dart';
@@ -161,8 +160,8 @@ abstract class PackageLoopingCommand extends PluginCommand {
   /// an exact format (e.g., published name, or basename) is required, that
   /// should be used instead.
   String getPackageDescription(Directory package) {
-    String packageName = p.relative(package.path, from: packagesDir.path);
-    final List<String> components = p.split(packageName);
+    String packageName = path.relative(package.path, from: packagesDir.path);
+    final List<String> components = path.split(packageName);
     // For the common federated plugin pattern of `foo/foo_subpackage`, drop
     // the first part since it's not useful.
     if (components.length == 2 &&

--- a/script/tool/lib/src/common/plugin_command.dart
+++ b/script/tool/lib/src/common/plugin_command.dart
@@ -21,6 +21,7 @@ abstract class PluginCommand extends Command<void> {
   PluginCommand(
     this.packagesDir, {
     this.processRunner = const ProcessRunner(),
+    this.platform = const LocalPlatform(),
     GitDir? gitDir,
   }) : _gitDir = gitDir {
     argParser.addMultiOption(
@@ -79,6 +80,11 @@ abstract class PluginCommand extends Command<void> {
   /// This can be overridden for testing.
   final ProcessRunner processRunner;
 
+  /// The current platform.
+  ///
+  /// This can be overridden for testing.
+  final Platform platform;
+
   /// The git directory to use. If unset, [gitDir] populates it from the
   /// packages directory's enclosing repository.
   ///
@@ -89,8 +95,7 @@ abstract class PluginCommand extends Command<void> {
   int? _shardCount;
 
   /// The command to use when running `flutter`.
-  String get flutterCommand =>
-      const LocalPlatform().isWindows ? 'flutter.bat' : 'flutter';
+  String get flutterCommand => platform.isWindows ? 'flutter.bat' : 'flutter';
 
   /// The shard of the overall command execution that this instance should run.
   int get shardIndex {

--- a/script/tool/lib/src/common/plugin_command.dart
+++ b/script/tool/lib/src/common/plugin_command.dart
@@ -94,6 +94,9 @@ abstract class PluginCommand extends Command<void> {
   int? _shardIndex;
   int? _shardCount;
 
+  /// A context that matches the default for [platform].
+  p.Context get path => platform.isWindows ? p.windows : p.posix;
+
   /// The command to use when running `flutter`.
   String get flutterCommand => platform.isWindows ? 'flutter.bat' : 'flutter';
 
@@ -245,9 +248,9 @@ abstract class PluginCommand extends Command<void> {
               // plugins under 'my_plugin'. Also match if the exact plugin is
               // passed.
               final String relativePath =
-                  p.relative(subdir.path, from: dir.path);
-              final String packageName = p.basename(subdir.path);
-              final String basenamePath = p.basename(entity.path);
+                  path.relative(subdir.path, from: dir.path);
+              final String packageName = path.basename(subdir.path);
+              final String basenamePath = path.basename(entity.path);
               if (!excludedPlugins.contains(basenamePath) &&
                   !excludedPlugins.contains(packageName) &&
                   !excludedPlugins.contains(relativePath) &&

--- a/script/tool/lib/src/create_all_plugins_app_command.dart
+++ b/script/tool/lib/src/create_all_plugins_app_command.dart
@@ -51,7 +51,7 @@ class CreateAllPluginsAppCommand extends PluginCommand {
 
   Future<int> _createApp() async {
     final io.ProcessResult result = io.Process.runSync(
-      'flutter',
+      flutterCommand,
       <String>[
         'create',
         '--template=app',

--- a/script/tool/lib/src/create_all_plugins_app_command.dart
+++ b/script/tool/lib/src/create_all_plugins_app_command.dart
@@ -5,6 +5,7 @@
 import 'dart:io' as io;
 
 import 'package:file/file.dart';
+import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
 
@@ -156,7 +157,7 @@ class CreateAllPluginsAppCommand extends PluginCommand {
         <String, PathDependency>{};
 
     await for (final Directory package in getPlugins()) {
-      final String pluginName = package.path.split('/').last;
+      final String pluginName = package.basename;
       final File pubspecFile = package.childFile('pubspec.yaml');
       final Pubspec pubspec = Pubspec.parse(pubspecFile.readAsStringSync());
 
@@ -172,6 +173,7 @@ class CreateAllPluginsAppCommand extends PluginCommand {
 ### Generated file. Do not edit. Run `pub global run flutter_plugin_tools gen-pubspec` to update.
 name: ${pubspec.name}
 description: ${pubspec.description}
+publish_to: none
 
 version: ${pubspec.version}
 
@@ -197,7 +199,21 @@ dev_dependencies:${_pubspecMapString(pubspec.devDependencies)}
         buffer.write('  ${entry.key}: \n    sdk: ${dep.sdk}');
       } else if (entry.value is PathDependency) {
         final PathDependency dep = entry.value as PathDependency;
-        buffer.write('  ${entry.key}: \n    path: ${dep.path}');
+        String depPath = dep.path;
+        if (path.style == p.Style.windows) {
+          // Posix-style path separators are preferred in pubspec.yaml (and
+          // using a consistent format makes unit testing simpler), so convert.
+          final List<String> components = path.split(depPath);
+          final String firstComponent = components.first;
+          // path.split leaves a \ on drive components that isn't necessary,
+          // and confuses pub, so remove it.
+          if (firstComponent.endsWith(r':\')) {
+            components[0] =
+                firstComponent.substring(0, firstComponent.length - 1);
+          }
+          depPath = p.posix.joinAll(components);
+        }
+        buffer.write('  ${entry.key}: \n    path: $depPath');
       } else {
         throw UnimplementedError(
           'Not available for type: ${entry.value.runtimeType}',

--- a/script/tool/lib/src/drive_examples_command.dart
+++ b/script/tool/lib/src/drive_examples_command.dart
@@ -6,6 +6,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:file/file.dart';
+import 'package:platform/platform.dart';
 
 import 'common/core.dart';
 import 'common/package_looping_command.dart';
@@ -21,7 +22,8 @@ class DriveExamplesCommand extends PackageLoopingCommand {
   DriveExamplesCommand(
     Directory packagesDir, {
     ProcessRunner processRunner = const ProcessRunner(),
-  }) : super(packagesDir, processRunner: processRunner) {
+    Platform platform = const LocalPlatform(),
+  }) : super(packagesDir, processRunner: processRunner, platform: platform) {
     argParser.addFlag(kPlatformAndroid,
         help: 'Runs the Android implementation of the examples');
     argParser.addFlag(kPlatformIos,

--- a/script/tool/lib/src/drive_examples_command.dart
+++ b/script/tool/lib/src/drive_examples_command.dart
@@ -147,8 +147,7 @@ class DriveExamplesCommand extends PackageLoopingCommand {
     final List<String> errors = <String>[];
     for (final Directory example in getExamplesForPlugin(package)) {
       ++examplesFound;
-      final String exampleName =
-          path.relative(example.path, from: packagesDir.path);
+      final String exampleName = getRelativePosixPath(example, from: package);
 
       final List<File> drivers = await _getDrivers(example);
       if (drivers.isEmpty) {
@@ -172,11 +171,10 @@ class DriveExamplesCommand extends PackageLoopingCommand {
 
         if (testTargets.isEmpty) {
           final String driverRelativePath =
-              path.relative(driver.path, from: package.path);
+              getRelativePosixPath(driver, from: package);
           printError(
               'Found $driverRelativePath, but no integration_test/*_test.dart files.');
-          errors.add(
-              'No test files for ${p.relative(driver.path, from: package.path)}');
+          errors.add('No test files for $driverRelativePath');
           continue;
         }
 
@@ -185,7 +183,7 @@ class DriveExamplesCommand extends PackageLoopingCommand {
             example, driver, testTargets,
             deviceFlags: deviceFlags);
         for (final File failingTarget in failingTargets) {
-          errors.add(p.relative(failingTarget.path, from: package.path));
+          errors.add(getRelativePosixPath(failingTarget, from: package));
         }
       }
     }
@@ -296,9 +294,9 @@ class DriveExamplesCommand extends PackageLoopingCommand {
             if (enableExperiment.isNotEmpty)
               '--enable-experiment=$enableExperiment',
             '--driver',
-            path.relative(driver.path, from: example.path),
+            getRelativePosixPath(driver, from: example),
             '--target',
-            path.relative(target.path, from: example.path),
+            getRelativePosixPath(target, from: example),
           ],
           workingDir: example);
       if (exitCode != 0) {

--- a/script/tool/lib/src/drive_examples_command.dart
+++ b/script/tool/lib/src/drive_examples_command.dart
@@ -6,7 +6,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:file/file.dart';
-import 'package:path/path.dart' as p;
 
 import 'common/core.dart';
 import 'common/package_looping_command.dart';
@@ -147,7 +146,8 @@ class DriveExamplesCommand extends PackageLoopingCommand {
     final List<String> errors = <String>[];
     for (final Directory example in getExamplesForPlugin(package)) {
       ++examplesFound;
-      final String exampleName = getRelativePosixPath(example, from: package);
+      final String exampleName =
+          getRelativePosixPath(example, from: packagesDir);
 
       final List<File> drivers = await _getDrivers(example);
       if (drivers.isEmpty) {

--- a/script/tool/lib/src/drive_examples_command.dart
+++ b/script/tool/lib/src/drive_examples_command.dart
@@ -148,7 +148,7 @@ class DriveExamplesCommand extends PackageLoopingCommand {
     for (final Directory example in getExamplesForPlugin(package)) {
       ++examplesFound;
       final String exampleName =
-          p.relative(example.path, from: packagesDir.path);
+          path.relative(example.path, from: packagesDir.path);
 
       final List<File> drivers = await _getDrivers(example);
       if (drivers.isEmpty) {
@@ -172,7 +172,7 @@ class DriveExamplesCommand extends PackageLoopingCommand {
 
         if (testTargets.isEmpty) {
           final String driverRelativePath =
-              p.relative(driver.path, from: package.path);
+              path.relative(driver.path, from: package.path);
           printError(
               'Found $driverRelativePath, but no integration_test/*_test.dart files.');
           errors.add(
@@ -296,9 +296,9 @@ class DriveExamplesCommand extends PackageLoopingCommand {
             if (enableExperiment.isNotEmpty)
               '--enable-experiment=$enableExperiment',
             '--driver',
-            p.relative(driver.path, from: example.path),
+            path.relative(driver.path, from: example.path),
             '--target',
-            p.relative(target.path, from: example.path),
+            path.relative(target.path, from: example.path),
           ],
           workingDir: example);
       if (exitCode != 0) {

--- a/script/tool/lib/src/firebase_test_lab_command.dart
+++ b/script/tool/lib/src/firebase_test_lab_command.dart
@@ -203,7 +203,7 @@ class FirebaseTestLabCommand extends PackageLoopingCommand {
       print('Running flutter build apk...');
       final String experiment = getStringArg(kEnableExperiment);
       final int exitCode = await processRunner.runAndStream(
-          'flutter',
+          flutterCommand,
           <String>[
             'build',
             'apk',

--- a/script/tool/lib/src/firebase_test_lab_command.dart
+++ b/script/tool/lib/src/firebase_test_lab_command.dart
@@ -150,7 +150,7 @@ class FirebaseTestLabCommand extends PackageLoopingCommand {
     // test file's run.
     int resultsCounter = 0;
     for (final File test in _findIntegrationTestFiles(package)) {
-      final String testName = path.relative(test.path, from: package.path);
+      final String testName = getRelativePosixPath(test, from: package);
       print('Testing $testName...');
       if (!await _runGradle(androidDirectory, 'app:assembleDebug',
           testFile: test)) {

--- a/script/tool/lib/src/firebase_test_lab_command.dart
+++ b/script/tool/lib/src/firebase_test_lab_command.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:io' as io;
 
 import 'package:file/file.dart';
+import 'package:platform/platform.dart';
 import 'package:uuid/uuid.dart';
 
 import 'common/core.dart';
@@ -20,7 +21,8 @@ class FirebaseTestLabCommand extends PackageLoopingCommand {
   FirebaseTestLabCommand(
     Directory packagesDir, {
     ProcessRunner processRunner = const ProcessRunner(),
-  }) : super(packagesDir, processRunner: processRunner) {
+    Platform platform = const LocalPlatform(),
+  }) : super(packagesDir, processRunner: processRunner, platform: platform) {
     argParser.addOption(
       'project',
       defaultsTo: 'flutter-infra',

--- a/script/tool/lib/src/firebase_test_lab_command.dart
+++ b/script/tool/lib/src/firebase_test_lab_command.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 import 'dart:io' as io;
 
 import 'package:file/file.dart';
-import 'package:path/path.dart' as p;
 import 'package:uuid/uuid.dart';
 
 import 'common/core.dart';
@@ -29,8 +28,9 @@ class FirebaseTestLabCommand extends PackageLoopingCommand {
     );
     final String? homeDir = io.Platform.environment['HOME'];
     argParser.addOption('service-key',
-        defaultsTo:
-            homeDir == null ? null : p.join(homeDir, 'gcloud-service-key.json'),
+        defaultsTo: homeDir == null
+            ? null
+            : path.join(homeDir, 'gcloud-service-key.json'),
         help: 'The path to the service key for gcloud authentication.\n'
             r'If not provided, \$HOME/gcloud-service-key.json will be '
             r'assumed if $HOME is set.');
@@ -150,7 +150,7 @@ class FirebaseTestLabCommand extends PackageLoopingCommand {
     // test file's run.
     int resultsCounter = 0;
     for (final File test in _findIntegrationTestFiles(package)) {
-      final String testName = p.relative(test.path, from: package.path);
+      final String testName = path.relative(test.path, from: package.path);
       print('Testing $testName...');
       if (!await _runGradle(androidDirectory, 'app:assembleDebug',
           testFile: test)) {

--- a/script/tool/lib/src/format_command.dart
+++ b/script/tool/lib/src/format_command.dart
@@ -156,7 +156,7 @@ class FormatCommand extends PluginCommand {
       // `flutter format` doesn't require the project to actually be a Flutter
       // project.
       final int exitCode = await processRunner.runAndStream(
-          'flutter', <String>['format', ...dartFiles],
+          flutterCommand, <String>['format', ...dartFiles],
           workingDir: packagesDir);
       if (exitCode != 0) {
         printError('Failed to format Dart files: exit code $exitCode.');

--- a/script/tool/lib/src/format_command.dart
+++ b/script/tool/lib/src/format_command.dart
@@ -168,7 +168,7 @@ class FormatCommand extends PluginCommand {
   Future<Iterable<String>> _getFilteredFilePaths(Stream<File> files) async {
     // Returns a pattern to check for [directories] as a subset of a file path.
     RegExp pathFragmentForDirectories(List<String> directories) {
-      final String s = p.separator;
+      final String s = path.separator;
       return RegExp('(?:^|$s)${p.joinAll(directories)}$s');
     }
 
@@ -192,8 +192,8 @@ class FormatCommand extends PluginCommand {
   }
 
   Future<String> _getGoogleFormatterPath() async {
-    final String javaFormatterPath = p.join(
-        p.dirname(p.fromUri(io.Platform.script)),
+    final String javaFormatterPath = path.join(
+        path.dirname(p.fromUri(io.Platform.script)),
         'google-java-format-1.3-all-deps.jar');
     final File javaFormatterFile =
         packagesDir.fileSystem.file(javaFormatterPath);

--- a/script/tool/lib/src/format_command.dart
+++ b/script/tool/lib/src/format_command.dart
@@ -7,7 +7,7 @@ import 'dart:io' as io;
 
 import 'package:file/file.dart';
 import 'package:http/http.dart' as http;
-import 'package:path/path.dart' as p;
+import 'package:platform/platform.dart';
 import 'package:quiver/iterables.dart';
 
 import 'common/core.dart';
@@ -28,7 +28,8 @@ class FormatCommand extends PluginCommand {
   FormatCommand(
     Directory packagesDir, {
     ProcessRunner processRunner = const ProcessRunner(),
-  }) : super(packagesDir, processRunner: processRunner) {
+    Platform platform = const LocalPlatform(),
+  }) : super(packagesDir, processRunner: processRunner, platform: platform) {
     argParser.addFlag('fail-on-change', hide: true);
     argParser.addOption('clang-format',
         defaultsTo: 'clang-format',
@@ -168,8 +169,12 @@ class FormatCommand extends PluginCommand {
   Future<Iterable<String>> _getFilteredFilePaths(Stream<File> files) async {
     // Returns a pattern to check for [directories] as a subset of a file path.
     RegExp pathFragmentForDirectories(List<String> directories) {
-      final String s = path.separator;
-      return RegExp('(?:^|$s)${p.joinAll(directories)}$s');
+      String s = path.separator;
+      // Escape the separator for use in the regex.
+      if (s == r'\') {
+        s = r'\\';
+      }
+      return RegExp('(?:^|$s)${path.joinAll(directories)}$s');
     }
 
     return files
@@ -188,12 +193,13 @@ class FormatCommand extends PluginCommand {
 
   Iterable<String> _getPathsWithExtensions(
       Iterable<String> files, Set<String> extensions) {
-    return files.where((String path) => extensions.contains(p.extension(path)));
+    return files.where(
+        (String filePath) => extensions.contains(path.extension(filePath)));
   }
 
   Future<String> _getGoogleFormatterPath() async {
     final String javaFormatterPath = path.join(
-        path.dirname(p.fromUri(io.Platform.script)),
+        path.dirname(path.fromUri(platform.script)),
         'google-java-format-1.3-all-deps.jar');
     final File javaFormatterFile =
         packagesDir.fileSystem.file(javaFormatterPath);

--- a/script/tool/lib/src/java_test_command.dart
+++ b/script/tool/lib/src/java_test_command.dart
@@ -16,7 +16,7 @@ class JavaTestCommand extends PackageLoopingCommand {
     Directory packagesDir, {
     ProcessRunner processRunner = const ProcessRunner(),
     Platform platform = const LocalPlatform(),
-  }) : super(packagesDir, processRunner: processRunner);
+  }) : super(packagesDir, processRunner: processRunner, platform: platform);
 
   static const String _gradleWrapper = 'gradlew';
 

--- a/script/tool/lib/src/java_test_command.dart
+++ b/script/tool/lib/src/java_test_command.dart
@@ -49,8 +49,7 @@ class JavaTestCommand extends PackageLoopingCommand {
 
     final List<String> errors = <String>[];
     for (final Directory example in examplesWithTests) {
-      final String exampleName =
-          path.relative(example.path, from: package.path);
+      final String exampleName = getRelativePosixPath(example, from: package);
       print('\nRUNNING JAVA TESTS for $exampleName');
 
       final Directory androidDirectory = example.childDirectory('android');

--- a/script/tool/lib/src/java_test_command.dart
+++ b/script/tool/lib/src/java_test_command.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:file/file.dart';
-import 'package:path/path.dart' as p;
 
 import 'common/core.dart';
 import 'common/package_looping_command.dart';
@@ -50,7 +49,8 @@ class JavaTestCommand extends PackageLoopingCommand {
 
     final List<String> errors = <String>[];
     for (final Directory example in examplesWithTests) {
-      final String exampleName = p.relative(example.path, from: package.path);
+      final String exampleName =
+          path.relative(example.path, from: package.path);
       print('\nRUNNING JAVA TESTS for $exampleName');
 
       final Directory androidDirectory = example.childDirectory('android');

--- a/script/tool/lib/src/java_test_command.dart
+++ b/script/tool/lib/src/java_test_command.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:file/file.dart';
+import 'package:platform/platform.dart';
 
 import 'common/core.dart';
 import 'common/package_looping_command.dart';
@@ -14,6 +15,7 @@ class JavaTestCommand extends PackageLoopingCommand {
   JavaTestCommand(
     Directory packagesDir, {
     ProcessRunner processRunner = const ProcessRunner(),
+    Platform platform = const LocalPlatform(),
   }) : super(packagesDir, processRunner: processRunner);
 
   static const String _gradleWrapper = 'gradlew';

--- a/script/tool/lib/src/license_check_command.dart
+++ b/script/tool/lib/src/license_check_command.dart
@@ -112,7 +112,7 @@ class LicenseCheckCommand extends PluginCommand {
         !_shouldIgnoreFile(file));
     final Iterable<File> firstPartyLicenseFiles = (await _getAllFiles()).where(
         (File file) =>
-            p.basename(file.basename) == 'LICENSE' && !_isThirdParty(file));
+            path.basename(file.basename) == 'LICENSE' && !_isThirdParty(file));
 
     final bool copyrightCheckSucceeded = await _checkCodeLicenses(codeFiles);
     print('\n=======================================\n');
@@ -246,7 +246,7 @@ class LicenseCheckCommand extends PluginCommand {
   }
 
   bool _isThirdParty(File file) {
-    return p.split(file.path).contains('third_party');
+    return path.split(file.path).contains('third_party');
   }
 
   Future<List<File>> _getAllFiles() => packagesDir.parent

--- a/script/tool/lib/src/lint_podspecs_command.dart
+++ b/script/tool/lib/src/lint_podspecs_command.dart
@@ -25,8 +25,7 @@ class LintPodspecsCommand extends PackageLoopingCommand {
     Directory packagesDir, {
     ProcessRunner processRunner = const ProcessRunner(),
     Platform platform = const LocalPlatform(),
-  })  : _platform = platform,
-        super(packagesDir, processRunner: processRunner) {
+  }) : super(packagesDir, processRunner: processRunner, platform: platform) {
     argParser.addMultiOption('ignore-warnings',
         help:
             'Do not pass --allow-warnings flag to "pod lib lint" for podspecs '
@@ -45,11 +44,9 @@ class LintPodspecsCommand extends PackageLoopingCommand {
       'Runs "pod lib lint" on all iOS and macOS plugin podspecs.\n\n'
       'This command requires "pod" and "flutter" to be in your path. Runs on macOS only.';
 
-  final Platform _platform;
-
   @override
   Future<void> initializeRun() async {
-    if (!_platform.isMacOS) {
+    if (!platform.isMacOS) {
       printError('This command is only supported on macOS');
       throw ToolExit(_exitUnsupportedPlatform);
     }

--- a/script/tool/lib/src/lint_podspecs_command.dart
+++ b/script/tool/lib/src/lint_podspecs_command.dart
@@ -86,11 +86,10 @@ class LintPodspecsCommand extends PackageLoopingCommand {
     final List<File> podspecs =
         await getFilesForPackage(package).where((File entity) {
       final String filePath = entity.path;
-      return p.extension(filePath) == '.podspec';
+      return path.extension(filePath) == '.podspec';
     }).toList();
 
-    podspecs.sort(
-        (File a, File b) => p.basename(a.path).compareTo(p.basename(b.path)));
+    podspecs.sort((File a, File b) => a.basename.compareTo(b.basename));
     return podspecs;
   }
 

--- a/script/tool/lib/src/list_command.dart
+++ b/script/tool/lib/src/list_command.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:file/file.dart';
+import 'package:platform/platform.dart';
 
 import 'common/plugin_command.dart';
 
@@ -10,7 +11,10 @@ import 'common/plugin_command.dart';
 class ListCommand extends PluginCommand {
   /// Creates an instance of the list command, whose behavior depends on the
   /// 'type' argument it provides.
-  ListCommand(Directory packagesDir) : super(packagesDir) {
+  ListCommand(
+    Directory packagesDir, {
+    Platform platform = const LocalPlatform(),
+  }) : super(packagesDir, platform: platform) {
     argParser.addOption(
       _type,
       defaultsTo: _plugin,

--- a/script/tool/lib/src/publish_check_command.dart
+++ b/script/tool/lib/src/publish_check_command.dart
@@ -128,7 +128,7 @@ class PublishCheckCommand extends PackageLoopingCommand {
   Future<bool> _hasValidPublishCheckRun(Directory package) async {
     print('Running pub publish --dry-run:');
     final io.Process process = await processRunner.start(
-      'flutter',
+      flutterCommand,
       <String>['pub', 'publish', '--', '--dry-run'],
       workingDirectory: package,
     );

--- a/script/tool/lib/src/publish_check_command.dart
+++ b/script/tool/lib/src/publish_check_command.dart
@@ -8,6 +8,7 @@ import 'dart:io' as io;
 
 import 'package:file/file.dart';
 import 'package:http/http.dart' as http;
+import 'package:platform/platform.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
 
@@ -22,10 +23,11 @@ class PublishCheckCommand extends PackageLoopingCommand {
   PublishCheckCommand(
     Directory packagesDir, {
     ProcessRunner processRunner = const ProcessRunner(),
+    Platform platform = const LocalPlatform(),
     http.Client? httpClient,
   })  : _pubVersionFinder =
             PubVersionFinder(httpClient: httpClient ?? http.Client()),
-        super(packagesDir, processRunner: processRunner) {
+        super(packagesDir, processRunner: processRunner, platform: platform) {
     argParser.addFlag(
       _allowPrereleaseFlag,
       help: 'Allows the pre-release SDK warning to pass.\n'

--- a/script/tool/lib/src/publish_plugin_command.dart
+++ b/script/tool/lib/src/publish_plugin_command.dart
@@ -445,7 +445,7 @@ Safe to ignore if the package is deleted in this commit.
     }
 
     final io.Process publish = await processRunner.start(
-        'flutter', <String>['pub', 'publish'] + publishFlags,
+        flutterCommand, <String>['pub', 'publish'] + publishFlags,
         workingDirectory: packageDir);
     publish.stdout
         .transform(utf8.decoder)

--- a/script/tool/lib/src/publish_plugin_command.dart
+++ b/script/tool/lib/src/publish_plugin_command.dart
@@ -208,9 +208,13 @@ class PublishPluginCommand extends PluginCommand {
     final List<String> packagesFailed = <String>[];
 
     for (final String pubspecPath in changedPubspecs) {
+      // Convert git's Posix-style paths to a path that matches the current
+      // filesystem.
+      final String localStylePubspecPath =
+          path.joinAll(p.posix.split(pubspecPath));
       final File pubspecFile = packagesDir.fileSystem
           .directory(baseGitDir.path)
-          .childFile(pubspecPath);
+          .childFile(localStylePubspecPath);
       final _CheckNeedsReleaseResult result = await _checkNeedsRelease(
         pubspecFile: pubspecFile,
         existingTags: existingTags,

--- a/script/tool/lib/src/pubspec_check_command.dart
+++ b/script/tool/lib/src/pubspec_check_command.dart
@@ -4,6 +4,7 @@
 
 import 'package:file/file.dart';
 import 'package:git/git.dart';
+import 'package:platform/platform.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
 
 import 'common/package_looping_command.dart';
@@ -19,8 +20,14 @@ class PubspecCheckCommand extends PackageLoopingCommand {
   PubspecCheckCommand(
     Directory packagesDir, {
     ProcessRunner processRunner = const ProcessRunner(),
+    Platform platform = const LocalPlatform(),
     GitDir? gitDir,
-  }) : super(packagesDir, processRunner: processRunner, gitDir: gitDir);
+  }) : super(
+          packagesDir,
+          processRunner: processRunner,
+          platform: platform,
+          gitDir: gitDir,
+        );
 
   // Section order for plugins. Because the 'flutter' section is critical
   // information for plugins, and usually small, it goes near the top unlike in

--- a/script/tool/lib/src/test_command.dart
+++ b/script/tool/lib/src/test_command.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:file/file.dart';
+import 'package:platform/platform.dart';
 
 import 'common/core.dart';
 import 'common/package_looping_command.dart';
@@ -15,7 +16,8 @@ class TestCommand extends PackageLoopingCommand {
   TestCommand(
     Directory packagesDir, {
     ProcessRunner processRunner = const ProcessRunner(),
-  }) : super(packagesDir, processRunner: processRunner) {
+    Platform platform = const LocalPlatform(),
+  }) : super(packagesDir, processRunner: processRunner, platform: platform) {
     argParser.addOption(
       kEnableExperiment,
       defaultsTo: '',

--- a/script/tool/lib/src/version_check_command.dart
+++ b/script/tool/lib/src/version_check_command.dart
@@ -6,6 +6,7 @@ import 'package:file/file.dart';
 import 'package:git/git.dart';
 import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
+import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
 
@@ -178,8 +179,13 @@ ${indentation}HTTP response: ${pubVersionFinderResponse.httpResponse.body}
     required GitVersionFinder gitVersionFinder,
   }) async {
     final File pubspecFile = package.childFile('pubspec.yaml');
-    return await gitVersionFinder.getPackageVersion(
-        path.relative(pubspecFile.absolute.path, from: (await gitDir).path));
+    final String relativePath =
+        path.relative(pubspecFile.absolute.path, from: (await gitDir).path);
+    // Use Posix-style paths for git.
+    final String gitPath = path.style == p.Style.windows
+        ? p.posix.joinAll(path.split(relativePath))
+        : relativePath;
+    return await gitVersionFinder.getPackageVersion(gitPath);
   }
 
   /// Returns true if the version of [package] is either unchanged relative to

--- a/script/tool/lib/src/version_check_command.dart
+++ b/script/tool/lib/src/version_check_command.dart
@@ -6,7 +6,6 @@ import 'package:file/file.dart';
 import 'package:git/git.dart';
 import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
-import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
 
@@ -180,7 +179,7 @@ ${indentation}HTTP response: ${pubVersionFinderResponse.httpResponse.body}
   }) async {
     final File pubspecFile = package.childFile('pubspec.yaml');
     return await gitVersionFinder.getPackageVersion(
-        p.relative(pubspecFile.absolute.path, from: (await gitDir).path));
+        path.relative(pubspecFile.absolute.path, from: (await gitDir).path));
   }
 
   /// Returns true if the version of [package] is either unchanged relative to

--- a/script/tool/lib/src/version_check_command.dart
+++ b/script/tool/lib/src/version_check_command.dart
@@ -7,6 +7,7 @@ import 'package:git/git.dart';
 import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
+import 'package:platform/platform.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
 
@@ -77,11 +78,17 @@ class VersionCheckCommand extends PackageLoopingCommand {
   VersionCheckCommand(
     Directory packagesDir, {
     ProcessRunner processRunner = const ProcessRunner(),
+    Platform platform = const LocalPlatform(),
     GitDir? gitDir,
     http.Client? httpClient,
   })  : _pubVersionFinder =
             PubVersionFinder(httpClient: httpClient ?? http.Client()),
-        super(packagesDir, processRunner: processRunner, gitDir: gitDir) {
+        super(
+          packagesDir,
+          processRunner: processRunner,
+          platform: platform,
+          gitDir: gitDir,
+        ) {
     argParser.addFlag(
       _againstPubFlag,
       help: 'Whether the version check should run against the version on pub.\n'

--- a/script/tool/lib/src/xctest_command.dart
+++ b/script/tool/lib/src/xctest_command.dart
@@ -6,6 +6,7 @@ import 'dart:convert';
 import 'dart:io' as io;
 
 import 'package:file/file.dart';
+import 'package:platform/platform.dart';
 
 import 'common/core.dart';
 import 'common/package_looping_command.dart';
@@ -31,7 +32,8 @@ class XCTestCommand extends PackageLoopingCommand {
   XCTestCommand(
     Directory packagesDir, {
     ProcessRunner processRunner = const ProcessRunner(),
-  }) : super(packagesDir, processRunner: processRunner) {
+    Platform platform = const LocalPlatform(),
+  }) : super(packagesDir, processRunner: processRunner, platform: platform) {
     argParser.addOption(
       _kiOSDestination,
       help:

--- a/script/tool/lib/src/xctest_command.dart
+++ b/script/tool/lib/src/xctest_command.dart
@@ -143,7 +143,7 @@ class XCTestCommand extends PackageLoopingCommand {
     for (final Directory example in getExamplesForPlugin(plugin)) {
       // Running tests and static analyzer.
       final String examplePath =
-          path.relative(example.path, from: plugin.parent.path);
+          getRelativePosixPath(example, from: plugin.parent);
       print('Running $platform tests and analyzer for $examplePath...');
       int exitCode =
           await _runTests(true, example, platform, extraFlags: extraXcrunFlags);

--- a/script/tool/lib/src/xctest_command.dart
+++ b/script/tool/lib/src/xctest_command.dart
@@ -6,7 +6,6 @@ import 'dart:convert';
 import 'dart:io' as io;
 
 import 'package:file/file.dart';
-import 'package:path/path.dart' as p;
 
 import 'common/core.dart';
 import 'common/package_looping_command.dart';
@@ -142,7 +141,7 @@ class XCTestCommand extends PackageLoopingCommand {
     for (final Directory example in getExamplesForPlugin(plugin)) {
       // Running tests and static analyzer.
       final String examplePath =
-          p.relative(example.path, from: plugin.parent.path);
+          path.relative(example.path, from: plugin.parent.path);
       print('Running $platform tests and analyzer for $examplePath...');
       int exitCode =
           await _runTests(true, example, platform, extraFlags: extraXcrunFlags);

--- a/script/tool/test/analyze_command_test.dart
+++ b/script/tool/test/analyze_command_test.dart
@@ -16,16 +16,21 @@ import 'util.dart';
 
 void main() {
   late FileSystem fileSystem;
+  late MockPlatform mockPlatform;
   late Directory packagesDir;
   late RecordingProcessRunner processRunner;
   late CommandRunner<void> runner;
 
   setUp(() {
     fileSystem = MemoryFileSystem();
+    mockPlatform = MockPlatform();
     packagesDir = createPackagesDirectory(fileSystem: fileSystem);
     processRunner = RecordingProcessRunner();
-    final AnalyzeCommand analyzeCommand =
-        AnalyzeCommand(packagesDir, processRunner: processRunner);
+    final AnalyzeCommand analyzeCommand = AnalyzeCommand(
+      packagesDir,
+      processRunner: processRunner,
+      platform: mockPlatform,
+    );
 
     runner = CommandRunner<void>('analyze_command', 'Test for analyze_command');
     runner.addCommand(analyzeCommand);

--- a/script/tool/test/common/plugin_command_test.dart
+++ b/script/tool/test/common/plugin_command_test.dart
@@ -12,8 +12,10 @@ import 'package:flutter_plugin_tools/src/common/process_runner.dart';
 import 'package:git/git.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
+import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
+import '../mocks.dart';
 import '../util.dart';
 import 'plugin_command_test.mocks.dart';
 
@@ -22,6 +24,7 @@ void main() {
   late RecordingProcessRunner processRunner;
   late CommandRunner<void> runner;
   late FileSystem fileSystem;
+  late MockPlatform mockPlatform;
   late Directory packagesDir;
   late Directory thirdPartyPackagesDir;
   late List<String> plugins;
@@ -30,6 +33,7 @@ void main() {
 
   setUp(() {
     fileSystem = MemoryFileSystem();
+    mockPlatform = MockPlatform();
     packagesDir = createPackagesDirectory(fileSystem: fileSystem);
     thirdPartyPackagesDir = packagesDir.parent
         .childDirectory('third_party')
@@ -54,6 +58,7 @@ void main() {
       plugins,
       packagesDir,
       processRunner: processRunner,
+      platform: mockPlatform,
       gitDir: gitDir,
     );
     runner =
@@ -414,8 +419,10 @@ class SamplePluginCommand extends PluginCommand {
     this._plugins,
     Directory packagesDir, {
     ProcessRunner processRunner = const ProcessRunner(),
+    Platform platform = const LocalPlatform(),
     GitDir? gitDir,
-  }) : super(packagesDir, processRunner: processRunner, gitDir: gitDir);
+  }) : super(packagesDir,
+            processRunner: processRunner, platform: platform, gitDir: gitDir);
 
   final List<String> _plugins;
 

--- a/script/tool/test/drive_examples_command_test.dart
+++ b/script/tool/test/drive_examples_command_test.dart
@@ -10,7 +10,6 @@ import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/common/plugin_utils.dart';
 import 'package:flutter_plugin_tools/src/drive_examples_command.dart';
-import 'package:path/path.dart' as p;
 import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
@@ -63,7 +62,7 @@ void main() {
 
       final MockProcess mockDevicesProcess = MockProcess.succeeding();
       mockDevicesProcess.stdoutController.close(); // ignore: unawaited_futures
-      processRunner.mockProcessesForExecutable['flutter'] = <io.Process>[
+      processRunner.mockProcessesForExecutable[flutterCommand] = <io.Process>[
         mockDevicesProcess
       ];
       processRunner.resultStdout = output;
@@ -150,7 +149,7 @@ void main() {
 
     test('fails for iOS if getting devices fails', () async {
       // Simulate failure from `flutter devices`.
-      processRunner.mockProcessesForExecutable['flutter'] = <io.Process>[
+      processRunner.mockProcessesForExecutable[flutterCommand] = <io.Process>[
         MockProcess.failing()
       ];
 
@@ -216,8 +215,6 @@ void main() {
         ]),
       );
 
-      final String deviceTestPath = p.join('test_driver', 'plugin.dart');
-      final String driverTestPath = p.join('test_driver', 'plugin_test.dart');
       expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
@@ -225,14 +222,14 @@ void main() {
                 flutterCommand, const <String>['devices', '--machine'], null),
             ProcessCall(
                 flutterCommand,
-                <String>[
+                const <String>[
                   'drive',
                   '-d',
                   _fakeIosDevice,
                   '--driver',
-                  driverTestPath,
+                  'test_driver/plugin_test.dart',
                   '--target',
-                  deviceTestPath
+                  'test_driver/plugin.dart'
                 ],
                 pluginExampleDirectory.path),
           ]));
@@ -337,8 +334,6 @@ void main() {
         ]),
       );
 
-      final String driverTestPath =
-          p.join('test_driver', 'integration_test.dart');
       expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
@@ -346,26 +341,26 @@ void main() {
                 flutterCommand, const <String>['devices', '--machine'], null),
             ProcessCall(
                 flutterCommand,
-                <String>[
+                const <String>[
                   'drive',
                   '-d',
                   _fakeIosDevice,
                   '--driver',
-                  driverTestPath,
+                  'test_driver/integration_test.dart',
                   '--target',
-                  p.join('integration_test', 'bar_test.dart'),
+                  'integration_test/bar_test.dart',
                 ],
                 pluginExampleDirectory.path),
             ProcessCall(
                 flutterCommand,
-                <String>[
+                const <String>[
                   'drive',
                   '-d',
                   _fakeIosDevice,
                   '--driver',
-                  driverTestPath,
+                  'test_driver/integration_test.dart',
                   '--target',
-                  p.join('integration_test', 'foo_test.dart'),
+                  'integration_test/foo_test.dart',
                 ],
                 pluginExampleDirectory.path),
           ]));
@@ -425,21 +420,19 @@ void main() {
         ]),
       );
 
-      final String deviceTestPath = p.join('test_driver', 'plugin.dart');
-      final String driverTestPath = p.join('test_driver', 'plugin_test.dart');
       expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
             ProcessCall(
                 flutterCommand,
-                <String>[
+                const <String>[
                   'drive',
                   '-d',
                   'linux',
                   '--driver',
-                  driverTestPath,
+                  'test_driver/plugin_test.dart',
                   '--target',
-                  deviceTestPath
+                  'test_driver/plugin.dart'
                 ],
                 pluginExampleDirectory.path),
           ]));
@@ -500,21 +493,19 @@ void main() {
         ]),
       );
 
-      final String deviceTestPath = p.join('test_driver', 'plugin.dart');
-      final String driverTestPath = p.join('test_driver', 'plugin_test.dart');
       expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
             ProcessCall(
                 flutterCommand,
-                <String>[
+                const <String>[
                   'drive',
                   '-d',
                   'macos',
                   '--driver',
-                  driverTestPath,
+                  'test_driver/plugin_test.dart',
                   '--target',
-                  deviceTestPath
+                  'test_driver/plugin.dart'
                 ],
                 pluginExampleDirectory.path),
           ]));
@@ -573,23 +564,21 @@ void main() {
         ]),
       );
 
-      final String deviceTestPath = p.join('test_driver', 'plugin.dart');
-      final String driverTestPath = p.join('test_driver', 'plugin_test.dart');
       expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
             ProcessCall(
                 flutterCommand,
-                <String>[
+                const <String>[
                   'drive',
                   '-d',
                   'web-server',
                   '--web-port=7357',
                   '--browser-name=chrome',
                   '--driver',
-                  driverTestPath,
+                  'test_driver/plugin_test.dart',
                   '--target',
-                  deviceTestPath
+                  'test_driver/plugin.dart'
                 ],
                 pluginExampleDirectory.path),
           ]));
@@ -649,21 +638,19 @@ void main() {
         ]),
       );
 
-      final String deviceTestPath = p.join('test_driver', 'plugin.dart');
-      final String driverTestPath = p.join('test_driver', 'plugin_test.dart');
       expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
             ProcessCall(
                 flutterCommand,
-                <String>[
+                const <String>[
                   'drive',
                   '-d',
                   'windows',
                   '--driver',
-                  driverTestPath,
+                  'test_driver/plugin_test.dart',
                   '--target',
-                  deviceTestPath
+                  'test_driver/plugin.dart'
                 ],
                 pluginExampleDirectory.path),
           ]));
@@ -699,8 +686,6 @@ void main() {
         ]),
       );
 
-      final String deviceTestPath = p.join('test_driver', 'plugin.dart');
-      final String driverTestPath = p.join('test_driver', 'plugin_test.dart');
       expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
@@ -708,14 +693,14 @@ void main() {
                 flutterCommand, const <String>['devices', '--machine'], null),
             ProcessCall(
                 flutterCommand,
-                <String>[
+                const <String>[
                   'drive',
                   '-d',
                   _fakeAndroidDevice,
                   '--driver',
-                  driverTestPath,
+                  'test_driver/plugin_test.dart',
                   '--target',
-                  deviceTestPath
+                  'test_driver/plugin.dart'
                 ],
                 pluginExampleDirectory.path),
           ]));
@@ -833,8 +818,6 @@ void main() {
         '--enable-experiment=exp1',
       ]);
 
-      final String deviceTestPath = p.join('test_driver', 'plugin.dart');
-      final String driverTestPath = p.join('test_driver', 'plugin_test.dart');
       expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
@@ -842,15 +825,15 @@ void main() {
                 flutterCommand, const <String>['devices', '--machine'], null),
             ProcessCall(
                 flutterCommand,
-                <String>[
+                const <String>[
                   'drive',
                   '-d',
                   _fakeIosDevice,
                   '--enable-experiment=exp1',
                   '--driver',
-                  driverTestPath,
+                  'test_driver/plugin_test.dart',
                   '--target',
-                  deviceTestPath
+                  'test_driver/plugin.dart'
                 ],
                 pluginExampleDirectory.path),
           ]));
@@ -967,7 +950,7 @@ void main() {
       );
 
       // Simulate failure from `flutter drive`.
-      processRunner.mockProcessesForExecutable['flutter'] = <io.Process>[
+      processRunner.mockProcessesForExecutable[flutterCommand] = <io.Process>[
         // No mock for 'devices', since it's running for macOS.
         MockProcess.failing(), // 'drive' #1
         MockProcess.failing(), // 'drive' #2
@@ -994,33 +977,31 @@ void main() {
 
       final Directory pluginExampleDirectory =
           pluginDirectory.childDirectory('example');
-      final String driverTestPath =
-          p.join('test_driver', 'integration_test.dart');
       expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
             ProcessCall(
                 flutterCommand,
-                <String>[
+                const <String>[
                   'drive',
                   '-d',
                   'macos',
                   '--driver',
-                  driverTestPath,
+                  'test_driver/integration_test.dart',
                   '--target',
-                  p.join('integration_test', 'bar_test.dart'),
+                  'integration_test/bar_test.dart',
                 ],
                 pluginExampleDirectory.path),
             ProcessCall(
                 flutterCommand,
-                <String>[
+                const <String>[
                   'drive',
                   '-d',
                   'macos',
                   '--driver',
-                  driverTestPath,
+                  'test_driver/integration_test.dart',
                   '--target',
-                  p.join('integration_test', 'foo_test.dart'),
+                  'integration_test/foo_test.dart',
                 ],
                 pluginExampleDirectory.path),
           ]));

--- a/script/tool/test/drive_examples_command_test.dart
+++ b/script/tool/test/drive_examples_command_test.dart
@@ -22,18 +22,18 @@ const String _fakeAndroidDevice = 'emulator-1234';
 void main() {
   group('test drive_example_command', () {
     late FileSystem fileSystem;
+    late Platform mockPlatform;
     late Directory packagesDir;
     late CommandRunner<void> runner;
     late RecordingProcessRunner processRunner;
-    final String flutterCommand =
-        const LocalPlatform().isWindows ? 'flutter.bat' : 'flutter';
 
     setUp(() {
       fileSystem = MemoryFileSystem();
+      mockPlatform = MockPlatform();
       packagesDir = createPackagesDirectory(fileSystem: fileSystem);
       processRunner = RecordingProcessRunner();
-      final DriveExamplesCommand command =
-          DriveExamplesCommand(packagesDir, processRunner: processRunner);
+      final DriveExamplesCommand command = DriveExamplesCommand(packagesDir,
+          processRunner: processRunner, platform: mockPlatform);
 
       runner = CommandRunner<void>(
           'drive_examples_command', 'Test for drive_example_command');
@@ -62,9 +62,9 @@ void main() {
 
       final MockProcess mockDevicesProcess = MockProcess.succeeding();
       mockDevicesProcess.stdoutController.close(); // ignore: unawaited_futures
-      processRunner.mockProcessesForExecutable[flutterCommand] = <io.Process>[
-        mockDevicesProcess
-      ];
+      processRunner
+              .mockProcessesForExecutable[getFlutterCommand(mockPlatform)] =
+          <io.Process>[mockDevicesProcess];
       processRunner.resultStdout = output;
     }
 
@@ -149,9 +149,9 @@ void main() {
 
     test('fails for iOS if getting devices fails', () async {
       // Simulate failure from `flutter devices`.
-      processRunner.mockProcessesForExecutable[flutterCommand] = <io.Process>[
-        MockProcess.failing()
-      ];
+      processRunner
+              .mockProcessesForExecutable[getFlutterCommand(mockPlatform)] =
+          <io.Process>[MockProcess.failing()];
 
       Error? commandError;
       final List<String> output = await runCapturingPrint(
@@ -218,10 +218,10 @@ void main() {
       expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
+            ProcessCall(getFlutterCommand(mockPlatform),
+                const <String>['devices', '--machine'], null),
             ProcessCall(
-                flutterCommand, const <String>['devices', '--machine'], null),
-            ProcessCall(
-                flutterCommand,
+                getFlutterCommand(mockPlatform),
                 const <String>[
                   'drive',
                   '-d',
@@ -337,10 +337,10 @@ void main() {
       expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
+            ProcessCall(getFlutterCommand(mockPlatform),
+                const <String>['devices', '--machine'], null),
             ProcessCall(
-                flutterCommand, const <String>['devices', '--machine'], null),
-            ProcessCall(
-                flutterCommand,
+                getFlutterCommand(mockPlatform),
                 const <String>[
                   'drive',
                   '-d',
@@ -352,7 +352,7 @@ void main() {
                 ],
                 pluginExampleDirectory.path),
             ProcessCall(
-                flutterCommand,
+                getFlutterCommand(mockPlatform),
                 const <String>[
                   'drive',
                   '-d',
@@ -424,7 +424,7 @@ void main() {
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
             ProcessCall(
-                flutterCommand,
+                getFlutterCommand(mockPlatform),
                 const <String>[
                   'drive',
                   '-d',
@@ -497,7 +497,7 @@ void main() {
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
             ProcessCall(
-                flutterCommand,
+                getFlutterCommand(mockPlatform),
                 const <String>[
                   'drive',
                   '-d',
@@ -568,7 +568,7 @@ void main() {
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
             ProcessCall(
-                flutterCommand,
+                getFlutterCommand(mockPlatform),
                 const <String>[
                   'drive',
                   '-d',
@@ -642,7 +642,7 @@ void main() {
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
             ProcessCall(
-                flutterCommand,
+                getFlutterCommand(mockPlatform),
                 const <String>[
                   'drive',
                   '-d',
@@ -689,10 +689,10 @@ void main() {
       expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
+            ProcessCall(getFlutterCommand(mockPlatform),
+                const <String>['devices', '--machine'], null),
             ProcessCall(
-                flutterCommand, const <String>['devices', '--machine'], null),
-            ProcessCall(
-                flutterCommand,
+                getFlutterCommand(mockPlatform),
                 const <String>[
                   'drive',
                   '-d',
@@ -734,8 +734,8 @@ void main() {
 
       // Output should be empty other than the device query.
       expect(processRunner.recordedCalls, <ProcessCall>[
-        ProcessCall(
-            flutterCommand, const <String>['devices', '--machine'], null),
+        ProcessCall(getFlutterCommand(mockPlatform),
+            const <String>['devices', '--machine'], null),
       ]);
     });
 
@@ -767,8 +767,8 @@ void main() {
 
       // Output should be empty other than the device query.
       expect(processRunner.recordedCalls, <ProcessCall>[
-        ProcessCall(
-            flutterCommand, const <String>['devices', '--machine'], null),
+        ProcessCall(getFlutterCommand(mockPlatform),
+            const <String>['devices', '--machine'], null),
       ]);
     });
 
@@ -821,10 +821,10 @@ void main() {
       expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
+            ProcessCall(getFlutterCommand(mockPlatform),
+                const <String>['devices', '--machine'], null),
             ProcessCall(
-                flutterCommand, const <String>['devices', '--machine'], null),
-            ProcessCall(
-                flutterCommand,
+                getFlutterCommand(mockPlatform),
                 const <String>[
                   'drive',
                   '-d',
@@ -950,7 +950,9 @@ void main() {
       );
 
       // Simulate failure from `flutter drive`.
-      processRunner.mockProcessesForExecutable[flutterCommand] = <io.Process>[
+      processRunner
+              .mockProcessesForExecutable[getFlutterCommand(mockPlatform)] =
+          <io.Process>[
         // No mock for 'devices', since it's running for macOS.
         MockProcess.failing(), // 'drive' #1
         MockProcess.failing(), // 'drive' #2
@@ -981,7 +983,7 @@ void main() {
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
             ProcessCall(
-                flutterCommand,
+                getFlutterCommand(mockPlatform),
                 const <String>[
                   'drive',
                   '-d',
@@ -993,7 +995,7 @@ void main() {
                 ],
                 pluginExampleDirectory.path),
             ProcessCall(
-                flutterCommand,
+                getFlutterCommand(mockPlatform),
                 const <String>[
                   'drive',
                   '-d',

--- a/script/tool/test/firebase_test_lab_command_test.dart
+++ b/script/tool/test/firebase_test_lab_command_test.dart
@@ -9,6 +9,7 @@ import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/firebase_test_lab_command.dart';
+import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
 import 'mocks.dart';
@@ -17,16 +18,21 @@ import 'util.dart';
 void main() {
   group('$FirebaseTestLabCommand', () {
     FileSystem fileSystem;
+    late MockPlatform mockPlatform;
     late Directory packagesDir;
     late CommandRunner<void> runner;
     late RecordingProcessRunner processRunner;
 
     setUp(() {
       fileSystem = MemoryFileSystem();
+      mockPlatform = MockPlatform();
       packagesDir = createPackagesDirectory(fileSystem: fileSystem);
       processRunner = RecordingProcessRunner();
-      final FirebaseTestLabCommand command =
-          FirebaseTestLabCommand(packagesDir, processRunner: processRunner);
+      final FirebaseTestLabCommand command = FirebaseTestLabCommand(
+        packagesDir,
+        processRunner: processRunner,
+        platform: mockPlatform,
+      );
 
       runner = CommandRunner<void>(
           'firebase_test_lab_command', 'Test for $FirebaseTestLabCommand');

--- a/script/tool/test/firebase_test_lab_command_test.dart
+++ b/script/tool/test/firebase_test_lab_command_test.dart
@@ -9,7 +9,6 @@ import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/firebase_test_lab_command.dart';
-import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
 import 'mocks.dart';

--- a/script/tool/test/format_command_test.dart
+++ b/script/tool/test/format_command_test.dart
@@ -17,21 +17,28 @@ import 'util.dart';
 
 void main() {
   late FileSystem fileSystem;
+  late MockPlatform mockPlatform;
   late Directory packagesDir;
+  late p.Context path;
   late RecordingProcessRunner processRunner;
   late CommandRunner<void> runner;
   late String javaFormatPath;
 
   setUp(() {
     fileSystem = MemoryFileSystem();
+    mockPlatform = MockPlatform();
     packagesDir = createPackagesDirectory(fileSystem: fileSystem);
     processRunner = RecordingProcessRunner();
-    final FormatCommand analyzeCommand =
-        FormatCommand(packagesDir, processRunner: processRunner);
+    final FormatCommand analyzeCommand = FormatCommand(
+      packagesDir,
+      processRunner: processRunner,
+      platform: mockPlatform,
+    );
 
     // Create the java formatter file that the command checks for, to avoid
     // a download.
-    javaFormatPath = p.join(p.dirname(p.fromUri(io.Platform.script)),
+    path = analyzeCommand.path;
+    javaFormatPath = path.join(path.dirname(path.fromUri(mockPlatform.script)),
         'google-java-format-1.3-all-deps.jar');
     fileSystem.file(javaFormatPath).createSync(recursive: true);
 
@@ -42,7 +49,7 @@ void main() {
   List<String> _getAbsolutePaths(
       Directory package, List<String> relativePaths) {
     return relativePaths
-        .map((String path) => p.join(package.path, path))
+        .map((String relativePath) => path.join(package.path, relativePath))
         .toList();
   }
 

--- a/script/tool/test/java_test_command_test.dart
+++ b/script/tool/test/java_test_command_test.dart
@@ -10,8 +10,6 @@ import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/common/plugin_utils.dart';
 import 'package:flutter_plugin_tools/src/java_test_command.dart';
-import 'package:mockito/mockito.dart';
-import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 import 'mocks.dart';

--- a/script/tool/test/java_test_command_test.dart
+++ b/script/tool/test/java_test_command_test.dart
@@ -10,6 +10,7 @@ import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/common/plugin_utils.dart';
 import 'package:flutter_plugin_tools/src/java_test_command.dart';
+import 'package:mockito/mockito.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
@@ -19,16 +20,21 @@ import 'util.dart';
 void main() {
   group('$JavaTestCommand', () {
     late FileSystem fileSystem;
+    late MockPlatform mockPlatform;
     late Directory packagesDir;
     late CommandRunner<void> runner;
     late RecordingProcessRunner processRunner;
 
     setUp(() {
       fileSystem = MemoryFileSystem();
+      mockPlatform = MockPlatform();
       packagesDir = createPackagesDirectory(fileSystem: fileSystem);
       processRunner = RecordingProcessRunner();
-      final JavaTestCommand command =
-          JavaTestCommand(packagesDir, processRunner: processRunner);
+      final JavaTestCommand command = JavaTestCommand(
+        packagesDir,
+        processRunner: processRunner,
+        platform: mockPlatform,
+      );
 
       runner =
           CommandRunner<void>('java_test_test', 'Test for $JavaTestCommand');
@@ -50,13 +56,16 @@ void main() {
 
       await runCapturingPrint(runner, <String>['java-test']);
 
+      final Directory androidFolder =
+          plugin.childDirectory('example').childDirectory('android');
+
       expect(
         processRunner.recordedCalls,
         orderedEquals(<ProcessCall>[
           ProcessCall(
-            p.join(plugin.path, 'example/android/gradlew'),
+            androidFolder.childFile('gradlew').path,
             const <String>['testDebugUnitTest', '--info'],
-            p.join(plugin.path, 'example/android'),
+            androidFolder.path,
           ),
         ]),
       );
@@ -77,13 +86,16 @@ void main() {
 
       await runCapturingPrint(runner, <String>['java-test']);
 
+      final Directory androidFolder =
+          plugin.childDirectory('example').childDirectory('android');
+
       expect(
         processRunner.recordedCalls,
         orderedEquals(<ProcessCall>[
           ProcessCall(
-            p.join(plugin.path, 'example/android/gradlew'),
+            androidFolder.childFile('gradlew').path,
             const <String>['testDebugUnitTest', '--info'],
-            p.join(plugin.path, 'example/android'),
+            androidFolder.path,
           ),
         ]),
       );

--- a/script/tool/test/lint_podspecs_command_test.dart
+++ b/script/tool/test/lint_podspecs_command_test.dart
@@ -9,7 +9,6 @@ import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/lint_podspecs_command.dart';
-import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 import 'mocks.dart';

--- a/script/tool/test/lint_podspecs_command_test.dart
+++ b/script/tool/test/lint_podspecs_command_test.dart
@@ -23,7 +23,7 @@ void main() {
     late RecordingProcessRunner processRunner;
 
     setUp(() {
-      fileSystem = MemoryFileSystem();
+      fileSystem = MemoryFileSystem(style: FileSystemStyle.posix);
       packagesDir = createPackagesDirectory(fileSystem: fileSystem);
 
       mockPlatform = MockPlatform(isMacOS: true);

--- a/script/tool/test/lint_podspecs_command_test.dart
+++ b/script/tool/test/lint_podspecs_command_test.dart
@@ -94,7 +94,10 @@ void main() {
               <String>[
                 'lib',
                 'lint',
-                p.join(plugin1Dir.path, 'ios', 'plugin1.podspec'),
+                plugin1Dir
+                    .childDirectory('ios')
+                    .childFile('plugin1.podspec')
+                    .path,
                 '--configuration=Debug',
                 '--skip-tests',
                 '--use-modular-headers',
@@ -106,7 +109,10 @@ void main() {
               <String>[
                 'lib',
                 'lint',
-                p.join(plugin1Dir.path, 'ios', 'plugin1.podspec'),
+                plugin1Dir
+                    .childDirectory('ios')
+                    .childFile('plugin1.podspec')
+                    .path,
                 '--configuration=Debug',
                 '--skip-tests',
                 '--use-modular-headers',
@@ -136,7 +142,7 @@ void main() {
               <String>[
                 'lib',
                 'lint',
-                p.join(plugin1Dir.path, 'plugin1.podspec'),
+                plugin1Dir.childFile('plugin1.podspec').path,
                 '--configuration=Debug',
                 '--skip-tests',
                 '--use-modular-headers',
@@ -149,7 +155,7 @@ void main() {
               <String>[
                 'lib',
                 'lint',
-                p.join(plugin1Dir.path, 'plugin1.podspec'),
+                plugin1Dir.childFile('plugin1.podspec').path,
                 '--configuration=Debug',
                 '--skip-tests',
                 '--use-modular-headers',

--- a/script/tool/test/list_command_test.dart
+++ b/script/tool/test/list_command_test.dart
@@ -8,18 +8,22 @@ import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/list_command.dart';
 import 'package:test/test.dart';
 
+import 'mocks.dart';
 import 'util.dart';
 
 void main() {
   group('$ListCommand', () {
     late FileSystem fileSystem;
+    late MockPlatform mockPlatform;
     late Directory packagesDir;
     late CommandRunner<void> runner;
 
     setUp(() {
       fileSystem = MemoryFileSystem();
+      mockPlatform = MockPlatform();
       packagesDir = createPackagesDirectory(fileSystem: fileSystem);
-      final ListCommand command = ListCommand(packagesDir);
+      final ListCommand command =
+          ListCommand(packagesDir, platform: mockPlatform);
 
       runner = CommandRunner<void>('list_test', 'Test for $ListCommand');
       runner.addCommand(command);

--- a/script/tool/test/mocks.dart
+++ b/script/tool/test/mocks.dart
@@ -10,10 +10,20 @@ import 'package:mockito/mockito.dart';
 import 'package:platform/platform.dart';
 
 class MockPlatform extends Mock implements Platform {
-  MockPlatform({this.isMacOS = false});
+  MockPlatform({
+    this.isLinux = false,
+    this.isMacOS = false,
+    this.isWindows = false,
+  });
+
+  @override
+  bool isLinux;
 
   @override
   bool isMacOS;
+
+  @override
+  bool isWindows;
 }
 
 class MockProcess extends Mock implements io.Process {

--- a/script/tool/test/mocks.dart
+++ b/script/tool/test/mocks.dart
@@ -24,6 +24,11 @@ class MockPlatform extends Mock implements Platform {
 
   @override
   bool isWindows;
+
+  @override
+  Uri get script => isWindows
+      ? Uri.file(r'C:\foo\bar', windows: true)
+      : Uri.file('/foo/bar', windows: false);
 }
 
 class MockProcess extends Mock implements io.Process {

--- a/script/tool/test/publish_plugin_command_test.dart
+++ b/script/tool/test/publish_plugin_command_test.dart
@@ -16,6 +16,7 @@ import 'package:git/git.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:mockito/mockito.dart';
+import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
 import 'mocks.dart';
@@ -1091,7 +1092,7 @@ class TestProcessRunner extends ProcessRunner {
       {Directory? workingDirectory}) async {
     /// Never actually publish anything. Start is always and only used for this
     /// since it returns something we can route stdin through.
-    assert(executable == 'flutter' &&
+    assert(executable == getFlutterCommand(const LocalPlatform()) &&
         args.isNotEmpty &&
         args[0] == 'pub' &&
         args[1] == 'publish');

--- a/script/tool/test/pubspec_check_command_test.dart
+++ b/script/tool/test/pubspec_check_command_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/pubspec_check_command.dart';
 import 'package:test/test.dart';
 
+import 'mocks.dart';
 import 'util.dart';
 
 void main() {
@@ -16,15 +17,20 @@ void main() {
     late CommandRunner<void> runner;
     late RecordingProcessRunner processRunner;
     late FileSystem fileSystem;
+    late MockPlatform mockPlatform;
     late Directory packagesDir;
 
     setUp(() {
       fileSystem = MemoryFileSystem();
+      mockPlatform = MockPlatform();
       packagesDir = fileSystem.currentDirectory.childDirectory('packages');
       createPackagesDirectory(parentDir: packagesDir.parent);
       processRunner = RecordingProcessRunner();
-      final PubspecCheckCommand command =
-          PubspecCheckCommand(packagesDir, processRunner: processRunner);
+      final PubspecCheckCommand command = PubspecCheckCommand(
+        packagesDir,
+        processRunner: processRunner,
+        platform: mockPlatform,
+      );
 
       runner = CommandRunner<void>(
           'pubspec_check_command', 'Test for pubspec_check_command');

--- a/script/tool/test/util.dart
+++ b/script/tool/test/util.dart
@@ -14,7 +14,13 @@ import 'package:flutter_plugin_tools/src/common/plugin_utils.dart';
 import 'package:flutter_plugin_tools/src/common/process_runner.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
+import 'package:platform/platform.dart';
 import 'package:quiver/collection.dart';
+
+/// Returns the exe name that command will use when running Flutter on
+/// [platform].
+String getFlutterCommand(Platform platform) =>
+    platform.isWindows ? 'flutter.bat' : 'flutter';
 
 /// Creates a packages directory in the given location.
 ///

--- a/script/tool/test/version_check_command_test.dart
+++ b/script/tool/test/version_check_command_test.dart
@@ -18,6 +18,7 @@ import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 
 import 'common/plugin_command_test.mocks.dart';
+import 'mocks.dart';
 import 'util.dart';
 
 void testAllowedVersion(
@@ -46,6 +47,7 @@ void main() {
   const String indentation = '  ';
   group('$VersionCheckCommand', () {
     FileSystem fileSystem;
+    late MockPlatform mockPlatform;
     late Directory packagesDir;
     late CommandRunner<void> runner;
     late RecordingProcessRunner processRunner;
@@ -55,6 +57,7 @@ void main() {
 
     setUp(() {
       fileSystem = MemoryFileSystem();
+      mockPlatform = MockPlatform();
       packagesDir = createPackagesDirectory(fileSystem: fileSystem);
       gitDirCommands = <List<String>>[];
       gitShowResponses = <String, String>{};
@@ -80,7 +83,7 @@ void main() {
       });
       processRunner = RecordingProcessRunner();
       final VersionCheckCommand command = VersionCheckCommand(packagesDir,
-          processRunner: processRunner, gitDir: gitDir);
+          processRunner: processRunner, platform: mockPlatform, gitDir: gitDir);
 
       runner = CommandRunner<void>(
           'version_check_command', 'Test for $VersionCheckCommand');

--- a/script/tool/test/xctest_command_test.dart
+++ b/script/tool/test/xctest_command_test.dart
@@ -90,16 +90,18 @@ void main() {
 
   group('test xctest_command', () {
     late FileSystem fileSystem;
+    late MockPlatform mockPlatform;
     late Directory packagesDir;
     late CommandRunner<void> runner;
     late RecordingProcessRunner processRunner;
 
     setUp(() {
       fileSystem = MemoryFileSystem();
+      mockPlatform = MockPlatform(isMacOS: true);
       packagesDir = createPackagesDirectory(fileSystem: fileSystem);
       processRunner = RecordingProcessRunner();
-      final XCTestCommand command =
-          XCTestCommand(packagesDir, processRunner: processRunner);
+      final XCTestCommand command = XCTestCommand(packagesDir,
+          processRunner: processRunner, platform: mockPlatform);
 
       runner = CommandRunner<void>('xctest_command', 'Test for xctest_command');
       runner.addCommand(command);


### PR DESCRIPTION
The purpose of this PR is to make running all unit tests on Windows pass (vs failing a large portion of the tests as currently happens). This does not mean that the commands actually work when run on Windows, or that Windows support is tested, only that it's possible to actually run the tests themselves. This is prep for actually supporting parts of the tool on Windows in future PRs.

Major changes:
- Make the tests significantly more hermetic:
  - Make almost all tools take a `Platform` constructor argument that can be used to inject a mock platform to control what OS the command acts like it is running on under test.
  - Add a path `Context` object to the base command, whose style matches the `Platform`, and use that almost everywhere instead of the top-level `path` functions.
  - In cases where Posix behavior is always required (such as parsing `git` output), explicitly use the `posix` context object for `path` functions.
- Start laying the groundwork for actual Windows support:
  - Replace all uses of `flutter` as a command with a getter that returns `flutter` or `flutter.bat` as appropriate.
  - For user messages that include relative paths, use a helper that always uses Posix-style relative paths for consistent output.

This bumps the version since quite a few changes have built up, and having a cut point before starting to make more changes to the commands to support Windows seems like a good idea.

Part of https://github.com/flutter/flutter/issues/86113

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
