### PR TITLE
[flutter_plugin_tools] Support format on Windows

### DIFF
--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -1,4 +1,4 @@
-## NEXT
+## 0.4.0
 
 - Modified the output format of many commands
 - **Breaking change**: `firebase-test-lab` no longer supports `*_e2e.dart`
@@ -10,6 +10,7 @@
 - Deprecated `--plugins` in favor of new `--packages`. `--plugins` continues to
   work for now, but will be removed in the future.
 - Make `drive-examples` device detection robust against Flutter tool banners.
+- `format` is now supported on Windows.
 
 ## 0.3.0
 

--- a/script/tool/pubspec.yaml
+++ b/script/tool/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_plugin_tools
 description: Productivity utils for flutter/plugins and flutter/packages
 repository: https://github.com/flutter/plugins/tree/master/script/tool
-version: 0.3.0
+version: 0.4.0
 
 dependencies:
   args: ^2.1.0

--- a/script/tool/test/format_command_test.dart
+++ b/script/tool/test/format_command_test.dart
@@ -46,10 +46,14 @@ void main() {
     runner.addCommand(analyzeCommand);
   });
 
-  List<String> _getAbsolutePaths(
+  /// Returns a modified version of a list of [relativePaths] that are relative
+  /// to [package] to instead be relative to [packagesDir].
+  List<String> _getPackagesDirRelativePaths(
       Directory package, List<String> relativePaths) {
+    final String relativeBase =
+        path.relative(package.path, from: packagesDir.path);
     return relativePaths
-        .map((String relativePath) => path.join(package.path, relativePath))
+        .map((String relativePath) => path.join(relativeBase, relativePath))
         .toList();
   }
 
@@ -72,7 +76,10 @@ void main() {
         orderedEquals(<ProcessCall>[
           ProcessCall(
               'flutter',
-              <String>['format', ..._getAbsolutePaths(pluginDir, files)],
+              <String>[
+                'format',
+                ..._getPackagesDirRelativePaths(pluginDir, files)
+              ],
               packagesDir.path),
         ]));
   });
@@ -124,7 +131,7 @@ void main() {
                 '-jar',
                 javaFormatPath,
                 '--replace',
-                ..._getAbsolutePaths(pluginDir, files)
+                ..._getPackagesDirRelativePaths(pluginDir, files)
               ],
               packagesDir.path),
         ]));
@@ -179,7 +186,7 @@ void main() {
               <String>[
                 '-i',
                 '--style=Google',
-                ..._getAbsolutePaths(pluginDir, files)
+                ..._getPackagesDirRelativePaths(pluginDir, files)
               ],
               packagesDir.path),
         ]));
@@ -246,12 +253,15 @@ void main() {
               <String>[
                 '-i',
                 '--style=Google',
-                ..._getAbsolutePaths(pluginDir, clangFiles)
+                ..._getPackagesDirRelativePaths(pluginDir, clangFiles)
               ],
               packagesDir.path),
           ProcessCall(
               'flutter',
-              <String>['format', ..._getAbsolutePaths(pluginDir, dartFiles)],
+              <String>[
+                'format',
+                ..._getPackagesDirRelativePaths(pluginDir, dartFiles)
+              ],
               packagesDir.path),
           ProcessCall(
               'java',
@@ -259,7 +269,7 @@ void main() {
                 '-jar',
                 javaFormatPath,
                 '--replace',
-                ..._getAbsolutePaths(pluginDir, javaFiles)
+                ..._getPackagesDirRelativePaths(pluginDir, javaFiles)
               ],
               packagesDir.path),
         ]));

--- a/script/tool/test/format_command_test.dart
+++ b/script/tool/test/format_command_test.dart
@@ -384,8 +384,8 @@ void main() {
     mockPlatform.isWindows = true;
 
     const String pluginName = 'a_plugin';
-    const int windowsCommandLineMax = 8191;
-    const int batchSize = windowsCommandLineMax ~/ 100;
+    // -1 since the command itself takes some length.
+    const int batchSize = (windowsCommandLineMax ~/ 100) - 1;
 
     // Make the file list one file longer than would fit in the batch.
     final List<String> batch1 =
@@ -418,8 +418,8 @@ void main() {
 
   test('Does not batch moderately long file lists on non-Windows', () async {
     const String pluginName = 'a_plugin';
-    const int windowsCommandLineMax = 8191;
-    const int batchSize = windowsCommandLineMax ~/ 100;
+    // -1 since the command itself takes some length.
+    const int batchSize = (windowsCommandLineMax ~/ 100) - 1;
 
     // Make the file list one file longer than would fit in a Windows batch.
     final List<String> batch =
@@ -439,10 +439,8 @@ void main() {
   test('Batches extremely long file lists on non-Windows', () async {
     const String pluginName = 'a_plugin';
     const int commandLineMax = 1000000;
-    // Since commandLineMax is evenly divisible, there's no remainder to
-    // absorb the length of the format command itself, so the maximum number of
-    // arguments is one less.
-    const int batchSize = (commandLineMax ~/ 100) - 1;
+    // -1 since the command itself takes some length.
+    const int batchSize = (nonWindowsCommandLineMax ~/ 100) - 1;
 
     // Make the file list one file longer than would fit in the batch.
     final List<String> batch1 =

--- a/script/tool/test/format_command_test.dart
+++ b/script/tool/test/format_command_test.dart
@@ -531,6 +531,9 @@ void main() {
         ));
   });
 
+  // Validates that the Windows limit--which is much lower than the limit on
+  // other platforms--isn't being used on all platforms, as that would make
+  // formatting slower on Linux and macOS.
   test('Does not batch moderately long file lists on non-Windows', () async {
     const String pluginName = 'a_plugin';
     // -1 since the command itself takes some length.
@@ -553,7 +556,6 @@ void main() {
 
   test('Batches extremely long file lists on non-Windows', () async {
     const String pluginName = 'a_plugin';
-    const int commandLineMax = 1000000;
     // -1 since the command itself takes some length.
     const int batchSize = (nonWindowsCommandLineMax ~/ 100) - 1;
 


### PR DESCRIPTION
Allows `format` to run successfully on Windows:
- Ensures that no calls exceed the command length limit.
- Allows specifying a `java` path to make it easier to run without a system Java (e.g., by pointing to the `java` binary in an Android Studio installation).
- Adds clear error messages when `java` or `clang-format` is missing since it's very non-obvious what's wrong otherwise.

Bumps the version, which I intended to do in the previous PR but apparently didn't push to the PR.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
