### PR TITLE
[camera] Fix coordinate rotation for setting focus- and exposure points on iOS

### DIFF
--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.1+5
+
+* Fixed setFocusPoint and setExposurePoint coordinates only being correct in a single orientation on iOS.
+
 ## 0.8.1+4
 
 * Silenced warnings that may occur during build when using a very

--- a/packages/camera/camera/example/ios/RunnerTests/CameraExposureTests.m
+++ b/packages/camera/camera/example/ios/RunnerTests/CameraExposureTests.m
@@ -1,0 +1,57 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@import camera;
+@import XCTest;
+@import AVFoundation;
+#import <OCMock/OCMock.h>
+
+@interface FLTCam : NSObject <FlutterTexture,
+                              AVCaptureVideoDataOutputSampleBufferDelegate,
+                              AVCaptureAudioDataOutputSampleBufferDelegate>
+
+- (void)setExposurePointWithResult:(FlutterResult)result x:(double)x y:(double)y;
+@end
+
+@interface CameraExposureTests : XCTestCase
+@property(readonly, nonatomic) FLTCam *camera;
+@property(readonly, nonatomic) id mockDevice;
+@property(readonly, nonatomic) id mockUIDevice;
+@end
+
+@implementation CameraExposureTests
+
+- (void)setUp {
+  _camera = [[FLTCam alloc] init];
+  _mockDevice = OCMClassMock([AVCaptureDevice class]);
+  _mockUIDevice = OCMPartialMock([UIDevice currentDevice]);
+}
+
+- (void)tearDown {
+  // Put teardown code here. This method is called after the invocation of each test method in the
+  // class.
+  [_mockDevice stopMocking];
+  [_mockUIDevice stopMocking];
+}
+
+- (void)testSetExpsourePointWithResult_SetsExposurePointOfInterest {
+  // UI is currently in landscape left orientation
+  OCMStub([(UIDevice *)_mockUIDevice orientation]).andReturn(UIDeviceOrientationLandscapeLeft);
+  // Exposure point of interest is supported
+  OCMStub([_mockDevice isExposurePointOfInterestSupported]).andReturn(true);
+  // Set mock device as the current capture device
+  [_camera setValue:_mockDevice forKey:@"captureDevice"];
+
+  // Run test
+  [_camera
+      setExposurePointWithResult:^void(id _Nullable result) {
+      }
+                               x:1
+                               y:1];
+
+  // Verify the focus point of interest has been set
+  OCMVerify([_mockDevice setExposurePointOfInterest:CGPointMake(1, 1)]);
+}
+
+@end

--- a/packages/camera/camera/example/ios/RunnerTests/CameraExposureTests.m
+++ b/packages/camera/camera/example/ios/RunnerTests/CameraExposureTests.m
@@ -29,8 +29,6 @@
 }
 
 - (void)tearDown {
-  // Put teardown code here. This method is called after the invocation of each test method in the
-  // class.
   [_mockDevice stopMocking];
   [_mockUIDevice stopMocking];
 }

--- a/packages/camera/camera/example/ios/RunnerTests/CameraFocusTests.m
+++ b/packages/camera/camera/example/ios/RunnerTests/CameraFocusTests.m
@@ -19,12 +19,13 @@ typedef enum {
 
 - (void)applyFocusMode;
 - (void)applyFocusMode:(FocusMode)focusMode onDevice:(AVCaptureDevice *)captureDevice;
+- (void)setFocusPointWithResult:(FlutterResult)result x:(double)x y:(double)y;
 @end
 
 @interface CameraFocusTests : XCTestCase
 @property(readonly, nonatomic) FLTCam *camera;
 @property(readonly, nonatomic) id mockDevice;
-
+@property(readonly, nonatomic) id mockUIDevice;
 @end
 
 @implementation CameraFocusTests
@@ -32,11 +33,14 @@ typedef enum {
 - (void)setUp {
   _camera = [[FLTCam alloc] init];
   _mockDevice = OCMClassMock([AVCaptureDevice class]);
+  _mockUIDevice = OCMPartialMock([UIDevice currentDevice]);
 }
 
 - (void)tearDown {
   // Put teardown code here. This method is called after the invocation of each test method in the
   // class.
+  [_mockDevice stopMocking];
+  [_mockUIDevice stopMocking];
 }
 
 - (void)testAutoFocusWithContinuousModeSupported_ShouldSetContinuousAutoFocus {
@@ -115,6 +119,25 @@ typedef enum {
 
   // Run test
   [_camera applyFocusMode:FocusModeLocked onDevice:_mockDevice];
+}
+
+- (void)testSetFocusPointWithResult_SetsFocusPointOfInterest {
+  // UI is currently in landscape left orientation
+  OCMStub([(UIDevice *)_mockUIDevice orientation]).andReturn(UIDeviceOrientationLandscapeLeft);
+  // Focus point of interest is supported
+  OCMStub([_mockDevice isFocusPointOfInterestSupported]).andReturn(true);
+  // Set mock device as the current capture device
+  [_camera setValue:_mockDevice forKey:@"captureDevice"];
+
+  // Run test
+  [_camera
+      setFocusPointWithResult:^void(id _Nullable result) {
+      }
+                            x:1
+                            y:1];
+
+  // Verify the focus point of interest has been set
+  OCMVerify([_mockDevice setFocusPointOfInterest:CGPointMake(1, 1)]);
 }
 
 @end

--- a/packages/camera/camera/example/ios/RunnerTests/CameraFocusTests.m
+++ b/packages/camera/camera/example/ios/RunnerTests/CameraFocusTests.m
@@ -37,8 +37,6 @@ typedef enum {
 }
 
 - (void)tearDown {
-  // Put teardown code here. This method is called after the invocation of each test method in the
-  // class.
   [_mockDevice stopMocking];
   [_mockUIDevice stopMocking];
 }

--- a/packages/camera/camera/example/ios/RunnerTests/CameraUtilTests.m
+++ b/packages/camera/camera/example/ios/RunnerTests/CameraUtilTests.m
@@ -28,11 +28,6 @@
   _camera = [[FLTCam alloc] init];
 }
 
-- (void)tearDown {
-  // Put teardown code here. This method is called after the invocation of each test method in the
-  // class.
-}
-
 - (void)testGetCGPointForCoordsWithOrientation_ShouldRotateCoords {
   CGPoint point;
   point = [_camera getCGPointForCoordsWithOrientation:UIDeviceOrientationLandscapeLeft x:1 y:1];

--- a/packages/camera/camera/example/ios/RunnerTests/CameraUtilTests.m
+++ b/packages/camera/camera/example/ios/RunnerTests/CameraUtilTests.m
@@ -1,0 +1,54 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@import camera;
+@import XCTest;
+@import AVFoundation;
+#import <OCMock/OCMock.h>
+
+@interface FLTCam : NSObject <FlutterTexture,
+                              AVCaptureVideoDataOutputSampleBufferDelegate,
+                              AVCaptureAudioDataOutputSampleBufferDelegate>
+
+- (CGPoint)getCGPointForCoordsWithOrientation:(UIDeviceOrientation)orientation
+                                            x:(double)x
+                                            y:(double)y;
+
+@end
+
+@interface CameraUtilTests : XCTestCase
+@property(readonly, nonatomic) FLTCam *camera;
+
+@end
+
+@implementation CameraUtilTests
+
+- (void)setUp {
+  _camera = [[FLTCam alloc] init];
+}
+
+- (void)tearDown {
+  // Put teardown code here. This method is called after the invocation of each test method in the
+  // class.
+}
+
+- (void)testGetCGPointForCoordsWithOrientation_ShouldRotateCoords {
+  CGPoint point;
+  point = [_camera getCGPointForCoordsWithOrientation:UIDeviceOrientationLandscapeLeft x:1 y:1];
+  XCTAssertTrue(CGPointEqualToPoint(point, CGPointMake(1, 1)),
+                @"Resulting coordinates are invalid.");
+  point = [_camera getCGPointForCoordsWithOrientation:UIDeviceOrientationPortrait x:0 y:1];
+  XCTAssertTrue(CGPointEqualToPoint(point, CGPointMake(1, 1)),
+                @"Resulting coordinates are invalid.");
+  point = [_camera getCGPointForCoordsWithOrientation:UIDeviceOrientationLandscapeRight x:0 y:0];
+  XCTAssertTrue(CGPointEqualToPoint(point, CGPointMake(1, 1)),
+                @"Resulting coordinates are invalid.");
+  point = [_camera getCGPointForCoordsWithOrientation:UIDeviceOrientationPortraitUpsideDown
+                                                    x:1
+                                                    y:0];
+  XCTAssertTrue(CGPointEqualToPoint(point, CGPointMake(1, 1)),
+                @"Resulting coordinates are invalid.");
+}
+
+@end

--- a/packages/camera/camera/ios/Classes/CameraPlugin.m
+++ b/packages/camera/camera/ios/Classes/CameraPlugin.m
@@ -1030,6 +1030,31 @@ NSString *const errorMethod = @"error";
   [captureDevice unlockForConfiguration];
 }
 
+- (CGPoint)getCGPointForCoordsWithOrientation:(UIDeviceOrientation)orientation
+                                            x:(double)x
+                                            y:(double)y {
+  double oldX = x, oldY = y;
+  switch (orientation) {
+    case UIDeviceOrientationPortrait:  // 90 ccw
+      y = 1 - oldX;
+      x = oldY;
+      break;
+    case UIDeviceOrientationPortraitUpsideDown:  // 90 cw
+      x = 1 - oldY;
+      y = oldX;
+      break;
+    case UIDeviceOrientationLandscapeRight:  // 180
+      x = 1 - x;
+      y = 1 - y;
+      break;
+    case UIDeviceOrientationLandscapeLeft:
+    default:
+      // No rotation required
+      break;
+  }
+  return CGPointMake(x, y);
+}
+
 - (void)setExposurePointWithResult:(FlutterResult)result x:(double)x y:(double)y {
   if (!_captureDevice.isExposurePointOfInterestSupported) {
     result([FlutterError errorWithCode:@"setExposurePointFailed"
@@ -1037,8 +1062,11 @@ NSString *const errorMethod = @"error";
                                details:nil]);
     return;
   }
+  UIDeviceOrientation orientation = [[UIDevice currentDevice] orientation];
   [_captureDevice lockForConfiguration:nil];
-  [_captureDevice setExposurePointOfInterest:CGPointMake(y, 1 - x)];
+  [_captureDevice setExposurePointOfInterest:[self getCGPointForCoordsWithOrientation:orientation
+                                                                                    x:x
+                                                                                    y:y]];
   [_captureDevice unlockForConfiguration];
   // Retrigger auto exposure
   [self applyExposureMode];
@@ -1052,11 +1080,16 @@ NSString *const errorMethod = @"error";
                                details:nil]);
     return;
   }
+  UIDeviceOrientation orientation = [[UIDevice currentDevice] orientation];
   [_captureDevice lockForConfiguration:nil];
-  [_captureDevice setFocusPointOfInterest:CGPointMake(y, 1 - x)];
+
+  [_captureDevice setFocusPointOfInterest:[self getCGPointForCoordsWithOrientation:orientation
+                                                                                 x:x
+                                                                                 y:y]];
   [_captureDevice unlockForConfiguration];
   // Retrigger auto focus
   [self applyFocusMode];
+
   result(nil);
 }
 

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -4,7 +4,7 @@ description: A Flutter plugin for getting information about and controlling the
   and streaming image buffers to dart.
 repository: https://github.com/flutter/plugins/tree/master/packages/camera/camera
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.8.1+4
+version: 0.8.1+5
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
As of right now, the setFocusPoint and setExposurePoint methods in the camera plugin do not correctly rotate the supplied coordinates according to the UI orientation, causing them to only show correct behaviour in one orientation.

This PR fixes this issue on iOS. 
The fix for Android has been included in the part 9 PR of the android refactor (#4059).

Relevant issue:
- flutter/flutter#86468

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
