### PR TITLE
[flutter_plugin_tools] Use -version with java

### DIFF
--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -1,6 +1,8 @@
-## NEXT
+## 0.4.1
 
 - Improved `license-check` output.
+- Use `java -version` rather than `java --version`, for compatibility with more
+  versions of Java.
 
 ## 0.4.0
 

--- a/script/tool/lib/src/format_command.dart
+++ b/script/tool/lib/src/format_command.dart
@@ -244,9 +244,12 @@ class FormatCommand extends PluginCommand {
 
   /// Returns true if [command] can be run successfully.
   Future<bool> _hasDependency(String command) async {
+    // Some versions of Java accept both -version and --version, but some only
+    // accept -version.
+    final String versionFlag = command == 'java' ? '-version' : '--version';
     try {
       final io.ProcessResult result =
-          await processRunner.run(command, <String>['--version']);
+          await processRunner.run(command, <String>[versionFlag]);
       if (result.exitCode != 0) {
         return false;
       }

--- a/script/tool/pubspec.yaml
+++ b/script/tool/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_plugin_tools
 description: Productivity utils for flutter/plugins and flutter/packages
 repository: https://github.com/flutter/plugins/tree/master/script/tool
-version: 0.4.0
+version: 0.4.1
 
 dependencies:
   args: ^2.1.0

--- a/script/tool/test/format_command_test.dart
+++ b/script/tool/test/format_command_test.dart
@@ -146,7 +146,7 @@ void main() {
     expect(
         processRunner.recordedCalls,
         orderedEquals(<ProcessCall>[
-          const ProcessCall('java', <String>['--version'], null),
+          const ProcessCall('java', <String>['-version'], null),
           ProcessCall(
               'java',
               <String>[


### PR DESCRIPTION
Some versions of Java, incuding the one currently installed on Cirrus
macOS machines, don't accept `--version`.

Fixes https://github.com/flutter/flutter/issues/86675

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
