### PR TITLE
[url_launcher] Fix extracting headers NPE

### DIFF
--- a/packages/url_launcher/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Fix NPE failure on Nexus5X
+
 ## 6.0.9
 
 * Silenced warnings that may occur during build when using a very

--- a/packages/url_launcher/url_launcher/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/url_launcher/url_launcher/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/packages/url_launcher/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/WebViewActivity.java
+++ b/packages/url_launcher/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/WebViewActivity.java
@@ -21,6 +21,8 @@ import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
+
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -143,6 +145,9 @@ public class WebViewActivity extends Activity {
   }
 
   private Map<String, String> extractHeaders(Bundle headersBundle) {
+    if (headersBundle == null) {
+      return Collections.emptyMap();
+    }
     final Map<String, String> headersMap = new HashMap<>();
     for (String key : headersBundle.keySet()) {
       final String value = headersBundle.getString(key);

--- a/packages/url_launcher/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/WebViewActivity.java
+++ b/packages/url_launcher/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/WebViewActivity.java
@@ -20,6 +20,7 @@ import android.webkit.WebResourceRequest;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 
 import java.util.Collections;
@@ -144,7 +145,7 @@ public class WebViewActivity extends Activity {
     registerReceiver(broadcastReceiver, closeIntentFilter);
   }
 
-  private Map<String, String> extractHeaders(Bundle headersBundle) {
+  private Map<String, String> extractHeaders(@Nullable Bundle headersBundle) {
     if (headersBundle == null) {
       return Collections.emptyMap();
     }

--- a/packages/url_launcher/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/WebViewActivity.java
+++ b/packages/url_launcher/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/WebViewActivity.java
@@ -22,7 +22,6 @@ import android.webkit.WebViewClient;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;

--- a/packages/url_launcher/url_launcher/android/src/test/java/io/flutter/plugins/urllauncher/MethodCallHandlerImplTest.java
+++ b/packages/url_launcher/url_launcher/android/src/test/java/io/flutter/plugins/urllauncher/MethodCallHandlerImplTest.java
@@ -200,6 +200,33 @@ public class MethodCallHandlerImplTest {
   }
 
   @Test
+  public void onMethodCall_launchReturnsTrueWhenHeadersAreNull() {
+    // Setup mock objects
+    urlLauncher = mock(UrlLauncher.class);
+    Result result = mock(Result.class);
+    // Setup expected values
+    String url = "foo";
+    boolean useWebView = false;
+    boolean enableJavaScript = false;
+    boolean enableDomStorage = false;
+    // Setup arguments map send on the method channel
+    Map<String, Object> args = new HashMap<>();
+    args.put("url", url);
+    args.put("useWebView", useWebView);
+    args.put("enableJavaScript", enableJavaScript);
+    args.put("enableDomStorage", enableDomStorage);
+    // Mock the launch method on the urlLauncher class
+    when(urlLauncher.launch(
+            eq(url), any(Bundle.class), eq(useWebView), eq(enableJavaScript), eq(enableDomStorage)))
+            .thenReturn(UrlLauncher.LaunchStatus.OK);
+    // Act by calling the "launch" method on the method channel
+    methodCallHandler = new MethodCallHandlerImpl(urlLauncher);
+    methodCallHandler.onMethodCall(new MethodCall("launch", args), result);
+    // Verify the results and assert
+    verify(result, times(1)).success(true);
+  }
+
+  @Test
   public void onMethodCall_closeWebView() {
     urlLauncher = mock(UrlLauncher.class);
     methodCallHandler = new MethodCallHandlerImpl(urlLauncher);


### PR DESCRIPTION
Fix NPE in `url-launcher` (https://github.com/flutter/flutter/issues/72863).

Error reproduces on the Nexus 5X devices:
```
Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'java.util.Set android.os.Bundle.keySet()' on a null object reference
       at io.flutter.plugins.urllauncher.WebViewActivity.extractHeaders(WebViewActivity.java:5)
       at io.flutter.plugins.urllauncher.WebViewActivity.onCreate(WebViewActivity.java:42) 
      ...
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
