### PR TITLE
Re-use server auth code obtained on login.

### DIFF
--- a/packages/google_sign_in/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.6
+
+* Re-use server auth code obtained on login.
+
 ## 5.0.5
 
 * Add iOS unit and UI integration test targets.

--- a/packages/google_sign_in/google_sign_in/lib/google_sign_in.dart
+++ b/packages/google_sign_in/google_sign_in/lib/google_sign_in.dart
@@ -44,6 +44,7 @@ class GoogleSignInAccount implements GoogleIdentity {
         email = data.email,
         id = data.id,
         photoUrl = data.photoUrl,
+        _serverAuthCode = data.serverAuthCode,
         _idToken = data.idToken {
     assert(id != null);
   }
@@ -67,6 +68,8 @@ class GoogleSignInAccount implements GoogleIdentity {
 
   @override
   final String? photoUrl;
+
+  final String? _serverAuthCode;
 
   final String? _idToken;
   final GoogleSignIn _googleSignIn;
@@ -97,6 +100,10 @@ class GoogleSignInAccount implements GoogleIdentity {
     if (response.idToken == null) {
       response.idToken = _idToken;
     }
+
+    //  re-use auth code obtained on login.
+    response.serverAuthCode = _serverAuthCode;
+
     return GoogleSignInAuthentication._(response);
   }
 
@@ -132,11 +139,13 @@ class GoogleSignInAccount implements GoogleIdentity {
         email == otherAccount.email &&
         id == otherAccount.id &&
         photoUrl == otherAccount.photoUrl &&
+        _serverAuthCode == otherAccount._serverAuthCode &&
         _idToken == otherAccount._idToken;
   }
 
   @override
-  int get hashCode => hashValues(displayName, email, id, photoUrl, _idToken);
+  int get hashCode =>
+      hashValues(displayName, email, id, photoUrl, _serverAuthCode, _idToken);
 
   @override
   String toString() {

--- a/packages/google_sign_in/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android and iOS.
 repository: https://github.com/flutter/plugins/tree/master/packages/google_sign_in/google_sign_in
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
-version: 5.0.5
+version: 5.0.6
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -23,8 +23,8 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  google_sign_in_platform_interface: ^2.0.1
-  google_sign_in_web: ^0.10.0
+  google_sign_in_platform_interface: ^2.0.2
+  google_sign_in_web: ^0.10.1
   meta: ^1.3.0
 
 dev_dependencies:

--- a/packages/google_sign_in/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   flutter:
     sdk: flutter
   google_sign_in_platform_interface: ^2.0.2
-  google_sign_in_web: ^0.10.1
+  google_sign_in_web: ^0.10.0
   meta: ^1.3.0
 
 dev_dependencies:

--- a/packages/google_sign_in/google_sign_in_platform_interface/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.2
+
+* Re-use server auth code obtained on login.
+
 ## 2.0.1
 
 * Updates `init` function in `MethodChannelGoogleSignIn` to parametrize `clientId` property.

--- a/packages/google_sign_in/google_sign_in_platform_interface/lib/src/types.dart
+++ b/packages/google_sign_in/google_sign_in_platform_interface/lib/src/types.dart
@@ -25,13 +25,13 @@ enum SignInOption {
 /// Holds information about the signed in user.
 class GoogleSignInUserData {
   /// Uses the given data to construct an instance.
-  GoogleSignInUserData({
-    required this.email,
-    required this.id,
-    this.displayName,
-    this.photoUrl,
-    this.idToken,
-  });
+  GoogleSignInUserData(
+      {required this.email,
+      required this.id,
+      this.displayName,
+      this.photoUrl,
+      this.idToken,
+      this.serverAuthCode});
 
   /// The display name of the signed in user.
   ///
@@ -66,9 +66,12 @@ class GoogleSignInUserData {
   /// data.
   String? idToken;
 
+  /// Server auth code used to access Google Login
+  String? serverAuthCode;
+
   @override
-  int get hashCode =>
-      hashObjects(<String?>[displayName, email, id, photoUrl, idToken]);
+  int get hashCode => hashObjects(
+      <String?>[displayName, email, id, photoUrl, idToken, serverAuthCode]);
 
   @override
   bool operator ==(dynamic other) {
@@ -79,7 +82,8 @@ class GoogleSignInUserData {
         otherUserData.email == email &&
         otherUserData.id == id &&
         otherUserData.photoUrl == photoUrl &&
-        otherUserData.idToken == idToken;
+        otherUserData.idToken == idToken &&
+        otherUserData.serverAuthCode == serverAuthCode;
   }
 }
 

--- a/packages/google_sign_in/google_sign_in_platform_interface/lib/src/utils.dart
+++ b/packages/google_sign_in/google_sign_in_platform_interface/lib/src/utils.dart
@@ -14,7 +14,8 @@ GoogleSignInUserData? getUserDataFromMap(Map<String, dynamic>? data) {
       id: data['id']!,
       displayName: data['displayName'],
       photoUrl: data['photoUrl'],
-      idToken: data['idToken']);
+      idToken: data['idToken'],
+      serverAuthCode: data['serverAuthCode']);
 }
 
 /// Converts token data coming from native code into the proper platform interface type.

--- a/packages/google_sign_in/google_sign_in_platform_interface/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/master/packages/google_sign_
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.0.1
+version: 2.0.2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/google_sign_in/google_sign_in_web/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_web/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android, iOS and Web.
 repository: https://github.com/flutter/plugins/tree/master/packages/google_sign_in/google_sign_in_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
-version: 0.10.0
+version: 0.10.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -21,7 +21,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  google_sign_in_platform_interface: ^2.0.0
+  google_sign_in_platform_interface: ^2.0.2
   js: ^0.6.3
   meta: ^1.3.0
 

--- a/packages/google_sign_in/google_sign_in_web/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_web/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android, iOS and Web.
 repository: https://github.com/flutter/plugins/tree/master/packages/google_sign_in/google_sign_in_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
-version: 0.10.1
+version: 0.10.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -21,7 +21,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  google_sign_in_platform_interface: ^2.0.2
+  google_sign_in_platform_interface: ^2.0.0
   js: ^0.6.3
   meta: ^1.3.0
 


### PR DESCRIPTION
## Description
Re-use serverAuthCode obtained on login to fix serverAuthCode=null issues for android/ios.

## Related issues
flutter/flutter#57712
flutter/flutter#57741

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

## Breaking Change
Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is not a breaking change.