### PR TITLE
[webview_flutter] Refactored creation of Android WebView for testability.

### DIFF
--- a/packages/webview_flutter/webview_flutter/android/build.gradle
+++ b/packages/webview_flutter/webview_flutter/android/build.gradle
@@ -37,5 +37,7 @@ android {
         implementation 'androidx.annotation:annotation:1.0.0'
         implementation 'androidx.webkit:webkit:1.0.0'
         testImplementation 'junit:junit:4.12'
+        testImplementation 'org.mockito:mockito-inline:3.11.1'
+        testImplementation 'androidx.test:core:1.3.0'
     }
 }

--- a/packages/webview_flutter/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -18,7 +18,6 @@ import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
-import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;

--- a/packages/webview_flutter/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -86,8 +86,7 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
   @SuppressWarnings("unchecked")
   FlutterWebView(
       final Context context,
-      BinaryMessenger messenger,
-      int id,
+      MethodChannel methodChannel,
       Map<String, Object> params,
       View containerView) {
 
@@ -104,7 +103,8 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
 
     platformThreadHandler = new Handler(context.getMainLooper());
 
-    methodChannel = createMethodChannel(messenger, id, this);
+    this.methodChannel = methodChannel;
+    this.methodChannel.setMethodCallHandler(this);
 
     flutterWebViewClient = new FlutterWebViewClient(methodChannel);
     Map<String, Object> settings = (Map<String, Object>) params.get("settings");
@@ -158,7 +158,7 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
   @VisibleForTesting
   static WebView createWebView(
       WebViewBuilder webViewBuilder, Map<String, Object> params, WebChromeClient webChromeClient) {
-    Boolean usesHybridComposition = (Boolean) params.get("usesHybridComposition");
+    boolean usesHybridComposition = Boolean.TRUE.equals(params.get("usesHybridComposition"));
     webViewBuilder
         .setUsesHybridComposition(usesHybridComposition)
         .setDomStorageEnabled(true) // Always enable DOM storage API.
@@ -169,30 +169,6 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
             webChromeClient); // Always use {@link FlutterWebChromeClient} as web Chrome client.
 
     return webViewBuilder.build();
-  }
-
-  /**
-   * Creates a {@link MethodChannel} used to handle communication with the Flutter application about
-   * the {@link FlutterWebView} instance.
-   *
-   * <p><strong>Important:</strong> This method is visible for testing purposes only and should
-   * never be called from outside this class.
-   *
-   * @param messenger a {@link BinaryMessenger} to facilitate communication with Flutter.
-   * @param id an identifier used to create a unique channel name and identify communication with a
-   *     particular {@link FlutterWebView} instance.
-   * @param handler a {@link MethodCallHandler} responsible for handling messages that arrive from
-   *     the Flutter application.
-   * @return The {@link MethodChannel} configured using the supplied {@link BinaryMessenger} and
-   *     {@link MethodCallHandler}.
-   */
-  @VisibleForTesting
-  static MethodChannel createMethodChannel(
-      BinaryMessenger messenger, int id, MethodCallHandler handler) {
-    MethodChannel methodChannel = new MethodChannel(messenger, "plugins.flutter.io/webview_" + id);
-    methodChannel.setMethodCallHandler(handler);
-
-    return methodChannel;
   }
 
   @Override

--- a/packages/webview_flutter/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewFactory.java
+++ b/packages/webview_flutter/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewFactory.java
@@ -7,6 +7,7 @@ package io.flutter.plugins.webviewflutter;
 import android.content.Context;
 import android.view.View;
 import io.flutter.plugin.common.BinaryMessenger;
+import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.StandardMessageCodec;
 import io.flutter.plugin.platform.PlatformView;
 import io.flutter.plugin.platform.PlatformViewFactory;
@@ -26,6 +27,7 @@ public final class FlutterWebViewFactory extends PlatformViewFactory {
   @Override
   public PlatformView create(Context context, int id, Object args) {
     Map<String, Object> params = (Map<String, Object>) args;
-    return new FlutterWebView(context, messenger, id, params, containerView);
+    MethodChannel methodChannel = new MethodChannel(messenger, "plugins.flutter.io/webview_" + id);
+    return new FlutterWebView(context, methodChannel, params, containerView);
   }
 }

--- a/packages/webview_flutter/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewFactory.java
+++ b/packages/webview_flutter/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewFactory.java
@@ -12,11 +12,11 @@ import io.flutter.plugin.platform.PlatformView;
 import io.flutter.plugin.platform.PlatformViewFactory;
 import java.util.Map;
 
-public final class WebViewFactory extends PlatformViewFactory {
+public final class FlutterWebViewFactory extends PlatformViewFactory {
   private final BinaryMessenger messenger;
   private final View containerView;
 
-  WebViewFactory(BinaryMessenger messenger, View containerView) {
+  FlutterWebViewFactory(BinaryMessenger messenger, View containerView) {
     super(StandardMessageCodec.INSTANCE);
     this.messenger = messenger;
     this.containerView = containerView;

--- a/packages/webview_flutter/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/WebViewBuilder.java
+++ b/packages/webview_flutter/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/WebViewBuilder.java
@@ -11,30 +11,24 @@ import android.webkit.WebSettings;
 import android.webkit.WebView;
 import androidx.annotation.NonNull;
 
-/**
- * Builder used to create {@link android.webkit.WebView} objects.
- */
+/** Builder used to create {@link android.webkit.WebView} objects. */
 public class WebViewBuilder {
 
-  /**
-   * Factory used to create a new {@link android.webkit.WebView} instance.
-   */
+  /** Factory used to create a new {@link android.webkit.WebView} instance. */
   static class WebViewFactory {
 
     /**
      * Creates a new {@link android.webkit.WebView} instance.
      *
-     * @param context               an Activity Context to access application assets. This value
-     *                              cannot be null.
+     * @param context an Activity Context to access application assets. This value cannot be null.
      * @param usesHybridComposition If {@code false} a {@link InputAwareWebView} instance is
-     *                              returned.
-     * @param containerView         must be supplied when the {@code useHybridComposition} parameter
-     *                              is set to {@code false}. Used to create an InputConnection on
-     *                              the WebView's dedicated input, or IME, thread (see also {@link
-     *                              InputAwareWebView})
+     *     returned.
+     * @param containerView must be supplied when the {@code useHybridComposition} parameter is set
+     *     to {@code false}. Used to create an InputConnection on the WebView's dedicated input, or
+     *     IME, thread (see also {@link InputAwareWebView})
      * @return A new instance of the {@link android.webkit.WebView} object.
      */
-    WebView create(Context context, boolean usesHybridComposition, View containerView) {
+    static WebView create(Context context, boolean usesHybridComposition, View containerView) {
       return usesHybridComposition
           ? new WebView(context)
           : new InputAwareWebView(context, containerView);
@@ -43,55 +37,25 @@ public class WebViewBuilder {
 
   private final Context context;
   private final View containerView;
-  private final boolean usesHybridComposition;
-  private final WebViewFactory webViewFactory;
 
   private boolean enableDomStorage;
   private boolean javaScriptCanOpenWindowsAutomatically;
   private boolean supportMultipleWindows;
+  private boolean usesHybridComposition;
   private WebChromeClient webChromeClient;
-
-  /**
-   * Constructs a new {@link WebViewBuilder} object.
-   *
-   * @param context               an Activity Context to access application assets. This value
-   *                              cannot be null.
-   * @param usesHybridComposition if {@code false} a {@link InputAwareWebView} instance is returned.
-   * @param containerView         must be supplied when the {@code useHybridComposition} parameter
-   *                              is set to {@code false}. Used to create an InputConnection on the
-   *                              WebView's dedicated input, or IME, thread (see also {@link
-   *                              InputAwareWebView})
-   */
-  public WebViewBuilder(
-      @NonNull final Context context,
-      boolean usesHybridComposition,
-      View containerView) {
-    this(context, usesHybridComposition, containerView, new WebViewFactory());
-  }
 
   /**
    * Constructs a new {@link WebViewBuilder} object with a custom implementation of the {@link
    * WebViewFactory} object.
    *
-   * @param context               an Activity Context to access application assets. This value
-   *                              cannot be null.
-   * @param usesHybridComposition if {@code false} a {@link InputAwareWebView} instance is returned.
-   * @param containerView         must be supplied when the {@code useHybridComposition} parameter
-   *                              is set to {@code false}. Used to create an InputConnection on the
-   *                              WebView's dedicated input, or IME, thread (see also {@link
-   *                              InputAwareWebView})
-   * @param webViewFactory        custom implementation of the {@link WebViewFactory} object.
+   * @param context an Activity Context to access application assets. This value cannot be null.
+   * @param containerView must be supplied when the {@code useHybridComposition} parameter is set to
+   *     {@code false}. Used to create an InputConnection on the WebView's dedicated input, or IME,
+   *     thread (see also {@link InputAwareWebView})
    */
-  WebViewBuilder(
-      @NonNull final Context context,
-      boolean usesHybridComposition,
-      View containerView,
-      WebViewFactory webViewFactory
-  ) {
+  WebViewBuilder(@NonNull final Context context, View containerView) {
     this.context = context;
-    this.usesHybridComposition = usesHybridComposition;
     this.containerView = containerView;
-    this.webViewFactory = webViewFactory;
   }
 
   /**
@@ -118,7 +82,7 @@ public class WebViewBuilder {
   }
 
   /**
-   * Set whether the WebView supports multiple windows. If set to {@code true}, {@link
+   * Sets whether the {@link WebView} supports multiple windows. If set to {@code true}, {@link
    * WebChromeClient#onCreateWindow} must be implemented by the host application. The default is
    * {@code false}.
    *
@@ -127,6 +91,21 @@ public class WebViewBuilder {
    */
   public WebViewBuilder setSupportMultipleWindows(boolean flag) {
     this.supportMultipleWindows = flag;
+    return this;
+  }
+
+  /**
+   * Sets whether the hybrid composition should be used.
+   *
+   * <p>If set to {@code true} a standard {@link WebView} is created. If set to {@code false} the
+   * {@link WebViewBuilder} will create a {@link InputAwareWebView} to workaround issues using the
+   * {@link WebView} on Android versions below N.
+   *
+   * @param flag {@code true} if uses hybrid composition. The default is {@code false}.
+   * @return This builder. This value cannot be {@code null}
+   */
+  public WebViewBuilder setUsesHybridComposition(boolean flag) {
+    this.usesHybridComposition = flag;
     return this;
   }
 
@@ -148,7 +127,7 @@ public class WebViewBuilder {
    * @return The {@link android.webkit.WebView} using the current settings.
    */
   public WebView build() {
-    WebView webView = webViewFactory.create(context, usesHybridComposition, containerView);
+    WebView webView = WebViewFactory.create(context, usesHybridComposition, containerView);
 
     WebSettings webSettings = webView.getSettings();
     webSettings.setDomStorageEnabled(enableDomStorage);

--- a/packages/webview_flutter/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/WebViewBuilder.java
+++ b/packages/webview_flutter/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/WebViewBuilder.java
@@ -10,6 +10,7 @@ import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /** Builder used to create {@link android.webkit.WebView} objects. */
 public class WebViewBuilder {
@@ -116,7 +117,7 @@ public class WebViewBuilder {
    * @param webChromeClient an implementation of WebChromeClient This value may be null.
    * @return This builder. This value cannot be {@code null}.
    */
-  public WebViewBuilder setWebChromeClient(WebChromeClient webChromeClient) {
+  public WebViewBuilder setWebChromeClient(@Nullable WebChromeClient webChromeClient) {
     this.webChromeClient = webChromeClient;
     return this;
   }

--- a/packages/webview_flutter/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/WebViewBuilder.java
+++ b/packages/webview_flutter/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/WebViewBuilder.java
@@ -1,0 +1,161 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.plugins.webviewflutter;
+
+import android.content.Context;
+import android.view.View;
+import android.webkit.WebChromeClient;
+import android.webkit.WebSettings;
+import android.webkit.WebView;
+import androidx.annotation.NonNull;
+
+/**
+ * Builder used to create {@link android.webkit.WebView} objects.
+ */
+public class WebViewBuilder {
+
+  /**
+   * Factory used to create a new {@link android.webkit.WebView} instance.
+   */
+  static class WebViewFactory {
+
+    /**
+     * Creates a new {@link android.webkit.WebView} instance.
+     *
+     * @param context               an Activity Context to access application assets. This value
+     *                              cannot be null.
+     * @param usesHybridComposition If {@code false} a {@link InputAwareWebView} instance is
+     *                              returned.
+     * @param containerView         must be supplied when the {@code useHybridComposition} parameter
+     *                              is set to {@code false}. Used to create an InputConnection on
+     *                              the WebView's dedicated input, or IME, thread (see also {@link
+     *                              InputAwareWebView})
+     * @return A new instance of the {@link android.webkit.WebView} object.
+     */
+    WebView create(Context context, boolean usesHybridComposition, View containerView) {
+      return usesHybridComposition
+          ? new WebView(context)
+          : new InputAwareWebView(context, containerView);
+    }
+  }
+
+  private final Context context;
+  private final View containerView;
+  private final boolean usesHybridComposition;
+  private final WebViewFactory webViewFactory;
+
+  private boolean enableDomStorage;
+  private boolean javaScriptCanOpenWindowsAutomatically;
+  private boolean supportMultipleWindows;
+  private WebChromeClient webChromeClient;
+
+  /**
+   * Constructs a new {@link WebViewBuilder} object.
+   *
+   * @param context               an Activity Context to access application assets. This value
+   *                              cannot be null.
+   * @param usesHybridComposition if {@code false} a {@link InputAwareWebView} instance is returned.
+   * @param containerView         must be supplied when the {@code useHybridComposition} parameter
+   *                              is set to {@code false}. Used to create an InputConnection on the
+   *                              WebView's dedicated input, or IME, thread (see also {@link
+   *                              InputAwareWebView})
+   */
+  public WebViewBuilder(
+      @NonNull final Context context,
+      boolean usesHybridComposition,
+      View containerView) {
+    this(context, usesHybridComposition, containerView, new WebViewFactory());
+  }
+
+  /**
+   * Constructs a new {@link WebViewBuilder} object with a custom implementation of the {@link
+   * WebViewFactory} object.
+   *
+   * @param context               an Activity Context to access application assets. This value
+   *                              cannot be null.
+   * @param usesHybridComposition if {@code false} a {@link InputAwareWebView} instance is returned.
+   * @param containerView         must be supplied when the {@code useHybridComposition} parameter
+   *                              is set to {@code false}. Used to create an InputConnection on the
+   *                              WebView's dedicated input, or IME, thread (see also {@link
+   *                              InputAwareWebView})
+   * @param webViewFactory        custom implementation of the {@link WebViewFactory} object.
+   */
+  WebViewBuilder(
+      @NonNull final Context context,
+      boolean usesHybridComposition,
+      View containerView,
+      WebViewFactory webViewFactory
+  ) {
+    this.context = context;
+    this.usesHybridComposition = usesHybridComposition;
+    this.containerView = containerView;
+    this.webViewFactory = webViewFactory;
+  }
+
+  /**
+   * Sets whether the DOM storage API is enabled. The default value is {@code false}.
+   *
+   * @param flag {@code true} is {@link android.webkit.WebView} should use the DOM storage API.
+   * @return This builder. This value cannot be {@code null}.
+   */
+  public WebViewBuilder setDomStorageEnabled(boolean flag) {
+    this.enableDomStorage = flag;
+    return this;
+  }
+
+  /**
+   * Sets whether JavaScript is allowed to open windows automatically. This applies to the
+   * JavaScript function {@code window.open()}. The default value is {@code false}.
+   *
+   * @param flag {@code true} if JavaScript is allowed to open windows automatically.
+   * @return This builder. This value cannot be {@code null}.
+   */
+  public WebViewBuilder setJavaScriptCanOpenWindowsAutomatically(boolean flag) {
+    this.javaScriptCanOpenWindowsAutomatically = flag;
+    return this;
+  }
+
+  /**
+   * Set whether the WebView supports multiple windows. If set to {@code true}, {@link
+   * WebChromeClient#onCreateWindow} must be implemented by the host application. The default is
+   * {@code false}.
+   *
+   * @param flag {@code true} if multiple windows are supported.
+   * @return This builder. This value cannot be {@code null}.
+   */
+  public WebViewBuilder setSupportMultipleWindows(boolean flag) {
+    this.supportMultipleWindows = flag;
+    return this;
+  }
+
+  /**
+   * Sets the chrome handler. This is an implementation of WebChromeClient for use in handling
+   * JavaScript dialogs, favicons, titles, and the progress. This will replace the current handler.
+   *
+   * @param webChromeClient an implementation of WebChromeClient This value may be null.
+   * @return This builder. This value cannot be {@code null}.
+   */
+  public WebViewBuilder setWebChromeClient(WebChromeClient webChromeClient) {
+    this.webChromeClient = webChromeClient;
+    return this;
+  }
+
+  /**
+   * Build the {@link android.webkit.WebView} using the current settings.
+   *
+   * @return The {@link android.webkit.WebView} using the current settings.
+   */
+  public WebView build() {
+    WebView webView = webViewFactory.create(context, usesHybridComposition, containerView);
+
+    WebSettings webSettings = webView.getSettings();
+    webSettings.setDomStorageEnabled(enableDomStorage);
+    webSettings.setJavaScriptCanOpenWindowsAutomatically(javaScriptCanOpenWindowsAutomatically);
+    webSettings.setSupportMultipleWindows(supportMultipleWindows);
+    webView.setWebChromeClient(webChromeClient);
+
+    return webView;
+  }
+}

--- a/packages/webview_flutter/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/WebViewFlutterPlugin.java
+++ b/packages/webview_flutter/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/WebViewFlutterPlugin.java
@@ -46,7 +46,7 @@ public class WebViewFlutterPlugin implements FlutterPlugin {
         .platformViewRegistry()
         .registerViewFactory(
             "plugins.flutter.io/webview",
-            new WebViewFactory(registrar.messenger(), registrar.view()));
+            new FlutterWebViewFactory(registrar.messenger(), registrar.view()));
     new FlutterCookieManager(registrar.messenger());
   }
 
@@ -56,7 +56,7 @@ public class WebViewFlutterPlugin implements FlutterPlugin {
     binding
         .getPlatformViewRegistry()
         .registerViewFactory(
-            "plugins.flutter.io/webview", new WebViewFactory(messenger, /*containerView=*/ null));
+            "plugins.flutter.io/webview", new FlutterWebViewFactory(messenger, /*containerView=*/ null));
     flutterCookieManager = new FlutterCookieManager(messenger);
   }
 

--- a/packages/webview_flutter/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/WebViewFlutterPlugin.java
+++ b/packages/webview_flutter/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/WebViewFlutterPlugin.java
@@ -56,7 +56,8 @@ public class WebViewFlutterPlugin implements FlutterPlugin {
     binding
         .getPlatformViewRegistry()
         .registerViewFactory(
-            "plugins.flutter.io/webview", new FlutterWebViewFactory(messenger, /*containerView=*/ null));
+            "plugins.flutter.io/webview",
+            new FlutterWebViewFactory(messenger, /*containerView=*/ null));
     flutterCookieManager = new FlutterCookieManager(messenger);
   }
 

--- a/packages/webview_flutter/webview_flutter/android/src/test/java/io/flutter/plugins/webviewflutter/FlutterWebViewTest.java
+++ b/packages/webview_flutter/webview_flutter/android/src/test/java/io/flutter/plugins/webviewflutter/FlutterWebViewTest.java
@@ -1,0 +1,55 @@
+package io.flutter.plugins.webviewflutter;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.webkit.WebChromeClient;
+import android.webkit.WebView;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+
+public class FlutterWebViewTest {
+  private WebChromeClient mockWebChromeClient;
+  private WebViewBuilder mockWebViewBuilder;
+  private WebView mockWebView;
+
+  @Before
+  public void before() {
+    mockWebChromeClient = mock(WebChromeClient.class);
+    mockWebViewBuilder = mock(WebViewBuilder.class);
+    mockWebView = mock(WebView.class);
+
+    when(mockWebViewBuilder.setDomStorageEnabled(anyBoolean())).thenReturn(mockWebViewBuilder);
+    when(mockWebViewBuilder.setJavaScriptCanOpenWindowsAutomatically(anyBoolean())).thenReturn(mockWebViewBuilder);
+    when(mockWebViewBuilder.setSupportMultipleWindows(anyBoolean())).thenReturn(mockWebViewBuilder);
+    when(mockWebViewBuilder.setUsesHybridComposition(anyBoolean())).thenReturn(mockWebViewBuilder);
+    when(mockWebViewBuilder.setWebChromeClient(any(WebChromeClient.class))).thenReturn(mockWebViewBuilder);
+
+    when(mockWebViewBuilder.build()).thenReturn(mockWebView);
+  }
+
+  @Test
+  public void createWebView_should_create_webview_with_default_configuration() {
+    FlutterWebView.createWebView(
+        mockWebViewBuilder, createParameterMap(false), mockWebChromeClient);
+
+    verify(mockWebViewBuilder, times(1)).setDomStorageEnabled(true);
+    verify(mockWebViewBuilder, times(1)).setJavaScriptCanOpenWindowsAutomatically(true);
+    verify(mockWebViewBuilder, times(1)).setSupportMultipleWindows(true);
+    verify(mockWebViewBuilder, times(1)).setUsesHybridComposition(false);
+    verify(mockWebViewBuilder, times(1)).setWebChromeClient(mockWebChromeClient);
+  }
+
+  private Map<String, Object> createParameterMap(boolean usesHybridComposition) {
+    Map<String, Object> params = new HashMap<>();
+    params.put("usesHybridComposition", usesHybridComposition);
+
+    return params;
+  }
+}

--- a/packages/webview_flutter/webview_flutter/android/src/test/java/io/flutter/plugins/webviewflutter/FlutterWebViewTest.java
+++ b/packages/webview_flutter/webview_flutter/android/src/test/java/io/flutter/plugins/webviewflutter/FlutterWebViewTest.java
@@ -26,10 +26,12 @@ public class FlutterWebViewTest {
     mockWebView = mock(WebView.class);
 
     when(mockWebViewBuilder.setDomStorageEnabled(anyBoolean())).thenReturn(mockWebViewBuilder);
-    when(mockWebViewBuilder.setJavaScriptCanOpenWindowsAutomatically(anyBoolean())).thenReturn(mockWebViewBuilder);
+    when(mockWebViewBuilder.setJavaScriptCanOpenWindowsAutomatically(anyBoolean()))
+        .thenReturn(mockWebViewBuilder);
     when(mockWebViewBuilder.setSupportMultipleWindows(anyBoolean())).thenReturn(mockWebViewBuilder);
     when(mockWebViewBuilder.setUsesHybridComposition(anyBoolean())).thenReturn(mockWebViewBuilder);
-    when(mockWebViewBuilder.setWebChromeClient(any(WebChromeClient.class))).thenReturn(mockWebViewBuilder);
+    when(mockWebViewBuilder.setWebChromeClient(any(WebChromeClient.class)))
+        .thenReturn(mockWebViewBuilder);
 
     when(mockWebViewBuilder.build()).thenReturn(mockWebView);
   }

--- a/packages/webview_flutter/webview_flutter/android/src/test/java/io/flutter/plugins/webviewflutter/FlutterWebViewTest.java
+++ b/packages/webview_flutter/webview_flutter/android/src/test/java/io/flutter/plugins/webviewflutter/FlutterWebViewTest.java
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package io.flutter.plugins.webviewflutter;
 
 import static org.mockito.ArgumentMatchers.any;

--- a/packages/webview_flutter/webview_flutter/android/src/test/java/io/flutter/plugins/webviewflutter/WebViewBuilderTest.java
+++ b/packages/webview_flutter/webview_flutter/android/src/test/java/io/flutter/plugins/webviewflutter/WebViewBuilderTest.java
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package io.flutter.plugins.webviewflutter;
 
 import static org.junit.Assert.assertNotNull;

--- a/packages/webview_flutter/webview_flutter/android/src/test/java/io/flutter/plugins/webviewflutter/WebViewBuilderTest.java
+++ b/packages/webview_flutter/webview_flutter/android/src/test/java/io/flutter/plugins/webviewflutter/WebViewBuilderTest.java
@@ -86,8 +86,7 @@ public class WebViewBuilderTest {
 
     when(mockWebView.getSettings()).thenReturn(mockWebSettings);
 
-    WebViewBuilder builder =
-        new WebViewBuilder(mockContext, mockContainerView);
+    WebViewBuilder builder = new WebViewBuilder(mockContext, mockContainerView);
 
     WebView webView = builder.build();
 

--- a/packages/webview_flutter/webview_flutter/android/src/test/java/io/flutter/plugins/webviewflutter/WebViewBuilderTest.java
+++ b/packages/webview_flutter/webview_flutter/android/src/test/java/io/flutter/plugins/webviewflutter/WebViewBuilderTest.java
@@ -78,4 +78,23 @@ public class WebViewBuilderTest {
     verify(mockWebSettings).setSupportMultipleWindows(true);
     verify(mockWebView).setWebChromeClient(mockWebChromeClient);
   }
+
+  @Test
+  public void build_should_use_default_values() throws IOException {
+    WebSettings mockWebSettings = mock(WebSettings.class);
+    WebChromeClient mockWebChromeClient = mock(WebChromeClient.class);
+
+    when(mockWebView.getSettings()).thenReturn(mockWebSettings);
+
+    WebViewBuilder builder =
+        new WebViewBuilder(mockContext, mockContainerView);
+
+    WebView webView = builder.build();
+
+    assertNotNull(webView);
+    verify(mockWebSettings).setDomStorageEnabled(false);
+    verify(mockWebSettings).setJavaScriptCanOpenWindowsAutomatically(false);
+    verify(mockWebSettings).setSupportMultipleWindows(false);
+    verify(mockWebView).setWebChromeClient(null);
+  }
 }

--- a/packages/webview_flutter/webview_flutter/android/src/test/java/io/flutter/plugins/webviewflutter/WebViewBuilderTest.java
+++ b/packages/webview_flutter/webview_flutter/android/src/test/java/io/flutter/plugins/webviewflutter/WebViewBuilderTest.java
@@ -1,6 +1,5 @@
 package io.flutter.plugins.webviewflutter;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.*;
 
@@ -9,46 +8,60 @@ import android.view.View;
 import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
+import io.flutter.plugins.webviewflutter.WebViewBuilder.WebViewFactory;
 import java.io.IOException;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.MockedStatic.Verification;
 
 public class WebViewBuilderTest {
   private Context mockContext;
   private View mockContainerView;
+  private WebView mockWebView;
+  private MockedStatic<WebViewFactory> mockedStaticWebViewFactory;
 
   @Before
   public void before() {
     mockContext = mock(Context.class);
     mockContainerView = mock(View.class);
+    mockWebView = mock(WebView.class);
+    mockedStaticWebViewFactory = mockStatic(WebViewFactory.class);
+
+    mockedStaticWebViewFactory.when(new Verification() {
+      @Override
+      public void apply() {
+        WebViewFactory.create(mockContext, false, mockContainerView);
+      }
+    }).thenReturn(mockWebView);
+  }
+
+  @After
+  public void after() {
+    mockedStaticWebViewFactory.close();
   }
 
   @Test
   public void ctor_test() {
-    WebViewBuilder builder =
-        new WebViewBuilder(mockContext, false, mockContainerView);
+    WebViewBuilder builder = new WebViewBuilder(mockContext, mockContainerView);
 
     assertNotNull(builder);
   }
 
   @Test
-  public void build_Should_set_values() throws IOException {
-    WebViewBuilder.WebViewFactory mockFactory =
-        mock(WebViewBuilder.WebViewFactory.class);
-    WebView mockWebView = mock(WebView.class);
+  public void build_should_set_values() throws IOException {
     WebSettings mockWebSettings = mock(WebSettings.class);
     WebChromeClient mockWebChromeClient = mock(WebChromeClient.class);
 
     when(mockWebView.getSettings()).thenReturn(mockWebSettings);
 
     WebViewBuilder builder =
-        new WebViewBuilder(mockContext, false, mockContainerView, mockFactory)
+        new WebViewBuilder(mockContext, mockContainerView)
             .setDomStorageEnabled(true)
             .setJavaScriptCanOpenWindowsAutomatically(true)
             .setSupportMultipleWindows(true)
             .setWebChromeClient(mockWebChromeClient);
-
-    when(mockFactory.create(mockContext, false, mockContainerView)).thenReturn(mockWebView);
 
     WebView webView = builder.build();
 

--- a/packages/webview_flutter/webview_flutter/android/src/test/java/io/flutter/plugins/webviewflutter/WebViewBuilderTest.java
+++ b/packages/webview_flutter/webview_flutter/android/src/test/java/io/flutter/plugins/webviewflutter/WebViewBuilderTest.java
@@ -1,0 +1,61 @@
+package io.flutter.plugins.webviewflutter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.*;
+
+import android.content.Context;
+import android.view.View;
+import android.webkit.WebChromeClient;
+import android.webkit.WebSettings;
+import android.webkit.WebView;
+import java.io.IOException;
+import org.junit.Before;
+import org.junit.Test;
+
+public class WebViewBuilderTest {
+  private Context mockContext;
+  private View mockContainerView;
+
+  @Before
+  public void before() {
+    mockContext = mock(Context.class);
+    mockContainerView = mock(View.class);
+  }
+
+  @Test
+  public void ctor_test() {
+    WebViewBuilder builder =
+        new WebViewBuilder(mockContext, false, mockContainerView);
+
+    assertNotNull(builder);
+  }
+
+  @Test
+  public void build_Should_set_values() throws IOException {
+    WebViewBuilder.WebViewFactory mockFactory =
+        mock(WebViewBuilder.WebViewFactory.class);
+    WebView mockWebView = mock(WebView.class);
+    WebSettings mockWebSettings = mock(WebSettings.class);
+    WebChromeClient mockWebChromeClient = mock(WebChromeClient.class);
+
+    when(mockWebView.getSettings()).thenReturn(mockWebSettings);
+
+    WebViewBuilder builder =
+        new WebViewBuilder(mockContext, false, mockContainerView, mockFactory)
+            .setDomStorageEnabled(true)
+            .setJavaScriptCanOpenWindowsAutomatically(true)
+            .setSupportMultipleWindows(true)
+            .setWebChromeClient(mockWebChromeClient);
+
+    when(mockFactory.create(mockContext, false, mockContainerView)).thenReturn(mockWebView);
+
+    WebView webView = builder.build();
+
+    assertNotNull(webView);
+    verify(mockWebSettings).setDomStorageEnabled(true);
+    verify(mockWebSettings).setJavaScriptCanOpenWindowsAutomatically(true);
+    verify(mockWebSettings).setSupportMultipleWindows(true);
+    verify(mockWebView).setWebChromeClient(mockWebChromeClient);
+  }
+}

--- a/packages/webview_flutter/webview_flutter/android/src/test/java/io/flutter/plugins/webviewflutter/WebViewBuilderTest.java
+++ b/packages/webview_flutter/webview_flutter/android/src/test/java/io/flutter/plugins/webviewflutter/WebViewBuilderTest.java
@@ -29,12 +29,15 @@ public class WebViewBuilderTest {
     mockWebView = mock(WebView.class);
     mockedStaticWebViewFactory = mockStatic(WebViewFactory.class);
 
-    mockedStaticWebViewFactory.when(new Verification() {
-      @Override
-      public void apply() {
-        WebViewFactory.create(mockContext, false, mockContainerView);
-      }
-    }).thenReturn(mockWebView);
+    mockedStaticWebViewFactory
+        .when(
+            new Verification() {
+              @Override
+              public void apply() {
+                WebViewFactory.create(mockContext, false, mockContainerView);
+              }
+            })
+        .thenReturn(mockWebView);
   }
 
   @After


### PR DESCRIPTION
Currently the constructor of the Java `FlutterWebView` is populated with several lines of code that initialise and configure the Android WebView control. This has two major drawback:

1. The code becomes difficult to understand;
2. The code is extremely hard to test as there is no good way to mock the WebView control.

This PR solves this problem by introducing a `WebViewBuilder` which is responsible for correctly creating the right Android WebView control and applying the necessary configuration. 

The following PRs will directly benefit from this change:
- #4169 
- #4165

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
  - No release needed as nothing changed in the behaviour of the plugin. Simply a refactor of code structure to make the code easier to test for later features (see PRs who will benefit).
- [ ] I updated CHANGELOG.md to add a description of the change.
  - No release needed as nothing changed in the behaviour of the plugin. Simply a refactor of code structure to make the code easier to test for later features (see PRs who will benefit).
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
