### PR TITLE
[google_sign_in] Add serverAuthCode attribute to google_sign_in_platform_interface user data

### DIFF
--- a/packages/google_sign_in/google_sign_in_platform_interface/lib/src/types.dart
+++ b/packages/google_sign_in/google_sign_in_platform_interface/lib/src/types.dart
@@ -31,6 +31,7 @@ class GoogleSignInUserData {
     this.displayName,
     this.photoUrl,
     this.idToken,
+    this.serverAuthCode,
   });
 
   /// The display name of the signed in user.
@@ -66,9 +67,12 @@ class GoogleSignInUserData {
   /// data.
   String? idToken;
 
+  /// Server auth code used to access Google Login
+  String? serverAuthCode;
+
   @override
-  int get hashCode =>
-      hashObjects(<String?>[displayName, email, id, photoUrl, idToken]);
+  int get hashCode => hashObjects(
+      <String?>[displayName, email, id, photoUrl, idToken, serverAuthCode]);
 
   @override
   bool operator ==(dynamic other) {
@@ -79,7 +83,8 @@ class GoogleSignInUserData {
         otherUserData.email == email &&
         otherUserData.id == id &&
         otherUserData.photoUrl == photoUrl &&
-        otherUserData.idToken == idToken;
+        otherUserData.idToken == idToken &&
+        otherUserData.serverAuthCode == serverAuthCode;
   }
 }
 

--- a/packages/google_sign_in/google_sign_in_platform_interface/lib/src/utils.dart
+++ b/packages/google_sign_in/google_sign_in_platform_interface/lib/src/utils.dart
@@ -14,7 +14,8 @@ GoogleSignInUserData? getUserDataFromMap(Map<String, dynamic>? data) {
       id: data['id']!,
       displayName: data['displayName'],
       photoUrl: data['photoUrl'],
-      idToken: data['idToken']);
+      idToken: data['idToken'],
+      serverAuthCode: data['serverAuthCode']);
 }
 
 /// Converts token data coming from native code into the proper platform interface type.

--- a/packages/google_sign_in/google_sign_in_platform_interface/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/master/packages/google_sign_
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.0.1
+version: 2.0.2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
## Description
Obtain serverAuthCode on login. This value can be reused then by google_sign_in plugin in the same way as idToken

## Related issues
flutter/flutter#57712
flutter/flutter#57741

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

## Breaking Change
Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is not a breaking change.