### PR TITLE
reuse serverAuthCode obtained on login

### DIFF
--- a/packages/google_sign_in/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.6
+
+* Re-use server auth code obtained on login.
+
 ## 5.0.5
 
 * Add iOS unit and UI integration test targets.

--- a/packages/google_sign_in/google_sign_in/lib/google_sign_in.dart
+++ b/packages/google_sign_in/google_sign_in/lib/google_sign_in.dart
@@ -44,7 +44,8 @@ class GoogleSignInAccount implements GoogleIdentity {
         email = data.email,
         id = data.id,
         photoUrl = data.photoUrl,
-        _idToken = data.idToken {
+        _idToken = data.idToken,
+        _serverAuthCode = data.serverAuthCode {
     assert(id != null);
   }
 
@@ -69,6 +70,7 @@ class GoogleSignInAccount implements GoogleIdentity {
   final String? photoUrl;
 
   final String? _idToken;
+  final String? _serverAuthCode;
   final GoogleSignIn _googleSignIn;
 
   /// Retrieve [GoogleSignInAuthentication] for this account.
@@ -96,6 +98,10 @@ class GoogleSignInAccount implements GoogleIdentity {
     // the one we obtained on login.
     if (response.idToken == null) {
       response.idToken = _idToken;
+    }
+    //  re-use auth code obtained on login.
+    if (response.serverAuthCode == null) {
+      response.serverAuthCode = _serverAuthCode;
     }
     return GoogleSignInAuthentication._(response);
   }
@@ -132,11 +138,13 @@ class GoogleSignInAccount implements GoogleIdentity {
         email == otherAccount.email &&
         id == otherAccount.id &&
         photoUrl == otherAccount.photoUrl &&
-        _idToken == otherAccount._idToken;
+        _idToken == otherAccount._idToken &&
+        _serverAuthCode == otherAccount._serverAuthCode;
   }
 
   @override
-  int get hashCode => hashValues(displayName, email, id, photoUrl, _idToken);
+  int get hashCode =>
+      hashValues(displayName, email, id, photoUrl, _idToken, _serverAuthCode);
 
   @override
   String toString() {

--- a/packages/google_sign_in/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android and iOS.
 repository: https://github.com/flutter/plugins/tree/master/packages/google_sign_in/google_sign_in
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
-version: 5.0.5
+version: 5.0.6
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -23,7 +23,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  google_sign_in_platform_interface: ^2.0.1
+  google_sign_in_platform_interface: ^2.0.2
   google_sign_in_web: ^0.10.0
   meta: ^1.3.0
 


### PR DESCRIPTION
## Description
Reuse serverAuthCode obtained on login in flutter/plugins/pull/4179

## Related issues
flutter/flutter#57712
flutter/flutter#57741

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

## Breaking Change
Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is not a breaking change.