### PR TITLE
[camera_web] Add `createCamera` implementation

### DIFF
--- a/packages/camera/camera_platform_interface/lib/src/types/resolution_preset.dart
+++ b/packages/camera/camera_platform_interface/lib/src/types/resolution_preset.dart
@@ -6,10 +6,10 @@
 ///
 /// If a preset is not available on the camera being used a preset of lower quality will be selected automatically.
 enum ResolutionPreset {
-  /// 352x288 on iOS, 240p (320x240) on Android and Web
+  /// 352x288 on iOS, 240p (320x240) on Android
   low,
 
-  /// 480p (640x480 on iOS, 720x480 on Android and Web)
+  /// 480p (640x480 on iOS, 720x480 on Android)
   medium,
 
   /// 720p (1280x720)

--- a/packages/camera/camera_platform_interface/lib/src/types/resolution_preset.dart
+++ b/packages/camera/camera_platform_interface/lib/src/types/resolution_preset.dart
@@ -6,10 +6,10 @@
 ///
 /// If a preset is not available on the camera being used a preset of lower quality will be selected automatically.
 enum ResolutionPreset {
-  /// 352x288 on iOS, 240p (320x240) on Android
+  /// 352x288 on iOS, 240p (320x240) on Android and Web
   low,
 
-  /// 480p (640x480 on iOS, 720x480 on Android)
+  /// 480p (640x480 on iOS, 720x480 on Android and Web)
   medium,
 
   /// 720p (1280x720)

--- a/packages/camera/camera_web/example/integration_test/camera_settings_test.dart
+++ b/packages/camera/camera_web/example/integration_test/camera_settings_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:html';
+import 'dart:ui';
 
 import 'package:camera_platform_interface/camera_platform_interface.dart';
 import 'package:camera_web/src/camera_settings.dart';
@@ -201,6 +202,100 @@ void main() {
         expect(
           settings.mapFacingModeToLensDirection('right'),
           equals(CameraLensDirection.external),
+        );
+      });
+    });
+
+    group('mapFacingModeToCameraType', () {
+      testWidgets(
+          'returns user '
+          'when the facing mode is user', (tester) async {
+        expect(
+          settings.mapFacingModeToCameraType('user'),
+          equals(CameraType.user),
+        );
+      });
+
+      testWidgets(
+          'returns environment '
+          'when the facing mode is environment', (tester) async {
+        expect(
+          settings.mapFacingModeToCameraType('environment'),
+          equals(CameraType.environment),
+        );
+      });
+
+      testWidgets(
+          'returns user '
+          'when the facing mode is left', (tester) async {
+        expect(
+          settings.mapFacingModeToCameraType('left'),
+          equals(CameraType.user),
+        );
+      });
+
+      testWidgets(
+          'returns user '
+          'when the facing mode is right', (tester) async {
+        expect(
+          settings.mapFacingModeToCameraType('right'),
+          equals(CameraType.user),
+        );
+      });
+    });
+
+    group('mapResolutionPresetToSize', () {
+      testWidgets(
+          'returns 3840x2160 '
+          'when the resolution preset is max', (tester) async {
+        expect(
+          settings.mapResolutionPresetToSize(ResolutionPreset.max),
+          equals(Size(3840, 2160)),
+        );
+      });
+
+      testWidgets(
+          'returns 3840x2160 '
+          'when the resolution preset is ultraHigh', (tester) async {
+        expect(
+          settings.mapResolutionPresetToSize(ResolutionPreset.ultraHigh),
+          equals(Size(3840, 2160)),
+        );
+      });
+
+      testWidgets(
+          'returns 1920x1080 '
+          'when the resolution preset is veryHigh', (tester) async {
+        expect(
+          settings.mapResolutionPresetToSize(ResolutionPreset.veryHigh),
+          equals(Size(1920, 1080)),
+        );
+      });
+
+      testWidgets(
+          'returns 1280x720 '
+          'when the resolution preset is high', (tester) async {
+        expect(
+          settings.mapResolutionPresetToSize(ResolutionPreset.high),
+          equals(Size(1280, 720)),
+        );
+      });
+
+      testWidgets(
+          'returns 720x480 '
+          'when the resolution preset is medium', (tester) async {
+        expect(
+          settings.mapResolutionPresetToSize(ResolutionPreset.medium),
+          equals(Size(720, 480)),
+        );
+      });
+
+      testWidgets(
+          'returns 320x240 '
+          'when the resolution preset is low', (tester) async {
+        expect(
+          settings.mapResolutionPresetToSize(ResolutionPreset.low),
+          equals(Size(320, 240)),
         );
       });
     });

--- a/packages/camera/camera_web/lib/src/camera_settings.dart
+++ b/packages/camera/camera_web/lib/src/camera_settings.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:html' as html;
+import 'dart:ui';
 
 import 'package:camera_platform_interface/camera_platform_interface.dart';
 import 'package:camera_web/src/types/types.dart';
@@ -103,6 +104,40 @@ class CameraSettings {
       case 'right':
       default:
         return CameraLensDirection.external;
+    }
+  }
+
+  /// Maps the given [facingMode] to [CameraType].
+  ///
+  /// See [CameraMetadata.facingMode] for more details.
+  CameraType mapFacingModeToCameraType(String facingMode) {
+    switch (facingMode) {
+      case 'user':
+        return CameraType.user;
+      case 'environment':
+        return CameraType.environment;
+      case 'left':
+      case 'right':
+      default:
+        return CameraType.user;
+    }
+  }
+
+  /// Maps the given [resolutionPreset] to [Size].
+  Size mapResolutionPresetToSize(ResolutionPreset resolutionPreset) {
+    switch (resolutionPreset) {
+      case ResolutionPreset.max:
+      case ResolutionPreset.ultraHigh:
+        return Size(3840, 2160);
+      case ResolutionPreset.veryHigh:
+        return Size(1920, 1080);
+      case ResolutionPreset.high:
+        return Size(1280, 720);
+      case ResolutionPreset.medium:
+        return Size(720, 480);
+      case ResolutionPreset.low:
+      default:
+        return Size(320, 240);
     }
   }
 }

--- a/packages/camera/camera_web/lib/src/types/camera_error_codes.dart
+++ b/packages/camera/camera_web/lib/src/types/camera_error_codes.dart
@@ -24,6 +24,9 @@ abstract class CameraErrorCodes {
   /// to access the media input from an insecure context.
   static const type = 'cameraType';
 
+  /// The camera metadata is missing.
+  static const missingMetadata = 'missingMetadata';
+
   /// An unknown camera error.
   static const unknown = 'cameraUnknown';
 }


### PR DESCRIPTION
Adds `createCamera` implementation of the camera platform interface.

- Added `mapFacingModeToCameraType` to `CameraSettings`.
  - Maps the [camera facing mode](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackSettings/facingMode) to a [camera type](https://github.com/flutter/plugins/blob/master/packages/camera/camera_web/lib/src/types/camera_options.dart#L131), used when creating a camera.
- Added `mapResolutionPresetToSize` to `CameraSettings`.
  - Maps the [resolution preset](https://github.com/flutter/plugins/blob/master/packages/camera/camera_platform_interface/lib/src/types/resolution_preset.dart#L8) to a size, used when creating a camera.
  - Uses the same sizes as on Android.
- Added `createCamera` implementation.
  - Uses camera metadata initialized in `availableCameras` to extract the camera type. 
  - Creates an uninitialized camera and constrains its audio, resolution, facing mode and device id with `CameraOptions`.
  - Returns the id of the created camera.

Part of https://github.com/flutter/flutter/issues/45297.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
