### PR TITLE
[camera_web] Add `initializeCamera` implementation

### DIFF
--- a/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
+++ b/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
@@ -64,7 +64,6 @@ abstract class CameraPlatform extends PlatformInterface {
   /// [imageFormatGroup] is used to specify the image formatting used.
   /// On Android this defaults to ImageFormat.YUV_420_888 and applies only to the imageStream.
   /// On iOS this defaults to kCVPixelFormatType_32BGRA.
-  /// On Web this parameter is currently not supported.
   Future<void> initializeCamera(
     int cameraId, {
     ImageFormatGroup imageFormatGroup = ImageFormatGroup.unknown,

--- a/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
+++ b/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
@@ -64,6 +64,7 @@ abstract class CameraPlatform extends PlatformInterface {
   /// [imageFormatGroup] is used to specify the image formatting used.
   /// On Android this defaults to ImageFormat.YUV_420_888 and applies only to the imageStream.
   /// On iOS this defaults to kCVPixelFormatType_32BGRA.
+  /// On Web this parameter is currently not supported.
   Future<void> initializeCamera(
     int cameraId, {
     ImageFormatGroup imageFormatGroup = ImageFormatGroup.unknown,

--- a/packages/camera/camera_web/example/integration_test/camera_test.dart
+++ b/packages/camera/camera_web/example/integration_test/camera_test.dart
@@ -29,13 +29,7 @@ void main() {
       navigator = MockNavigator();
       mediaDevices = MockMediaDevices();
 
-      final videoElement = VideoElement()
-        ..src =
-            'https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4'
-        ..preload = 'true'
-        ..width = 10
-        ..height = 10;
-
+      final videoElement = getVideoElementWithBlankStream(Size(10, 10));
       mediaStream = videoElement.captureStream();
 
       when(() => window.navigator).thenReturn(navigator);

--- a/packages/camera/camera_web/example/integration_test/camera_test.dart
+++ b/packages/camera/camera_web/example/integration_test/camera_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:html';
+import 'dart:ui';
 
 import 'package:camera_platform_interface/camera_platform_interface.dart';
 import 'package:camera_web/src/camera.dart';
@@ -466,6 +467,49 @@ void main() {
         final pictureFile = await camera.takePicture();
 
         expect(pictureFile, isNotNull);
+      });
+    });
+
+    group('getVideoSize', () {
+      testWidgets(
+          'returns a size '
+          'based on the first video track settings', (tester) async {
+        const videoSize = Size(1280, 720);
+
+        final videoElement = getVideoElementWithBlankStream(videoSize);
+        mediaStream = videoElement.captureStream();
+
+        final camera = Camera(
+          textureId: 1,
+          window: window,
+        );
+
+        await camera.initialize();
+
+        expect(
+          await camera.getVideoSize(),
+          equals(videoSize),
+        );
+      });
+
+      testWidgets(
+          'returns Size.zero '
+          'if the camera is missing video tracks', (tester) async {
+        // Create a video stream with no video tracks.
+        final videoElement = VideoElement();
+        mediaStream = videoElement.captureStream();
+
+        final camera = Camera(
+          textureId: 1,
+          window: window,
+        );
+
+        await camera.initialize();
+
+        expect(
+          await camera.getVideoSize(),
+          equals(Size.zero),
+        );
       });
     });
 

--- a/packages/camera/camera_web/example/integration_test/camera_web_test.dart
+++ b/packages/camera/camera_web/example/integration_test/camera_web_test.dart
@@ -5,6 +5,7 @@
 import 'dart:html';
 import 'dart:ui';
 
+import 'package:async/async.dart';
 import 'package:camera_platform_interface/camera_platform_interface.dart';
 import 'package:camera_web/camera_web.dart';
 import 'package:camera_web/src/camera.dart';
@@ -327,21 +328,18 @@ void main() {
         const ultraHighResolutionSize = Size(3840, 2160);
         const maxResolutionSize = Size(3840, 2160);
 
-        late CameraDescription cameraDescription;
-        late CameraMetadata cameraMetadata;
+        final cameraDescription = CameraDescription(
+          name: 'name',
+          lensDirection: CameraLensDirection.front,
+          sensorOrientation: 0,
+        );
+
+        final cameraMetadata = CameraMetadata(
+          deviceId: 'deviceId',
+          facingMode: 'user',
+        );
 
         setUp(() {
-          cameraDescription = CameraDescription(
-            name: 'name',
-            lensDirection: CameraLensDirection.front,
-            sensorOrientation: 0,
-          );
-
-          cameraMetadata = CameraMetadata(
-            deviceId: 'deviceId',
-            facingMode: 'user',
-          );
-
           // Add metadata for the camera description.
           (CameraPlatform.instance as CameraPlugin)
               .camerasMetadata[cameraDescription] = cameraMetadata;
@@ -434,11 +432,38 @@ void main() {
       });
     });
 
-    testWidgets('initializeCamera throws UnimplementedError', (tester) async {
-      expect(
-        () => CameraPlatform.instance.initializeCamera(cameraId),
-        throwsUnimplementedError,
-      );
+    group('initializeCamera', () {
+      testWidgets(
+          'throws CameraException '
+          'with notFound error '
+          'if the camera does not exist', (tester) async {
+        expect(
+          () => CameraPlatform.instance.initializeCamera(cameraId),
+          throwsA(
+            isA<CameraException>().having(
+              (e) => e.code,
+              'code',
+              CameraErrorCodes.notFound,
+            ),
+          ),
+        );
+      });
+
+      testWidgets('initializes and plays the camera', (tester) async {
+        final camera = MockCamera();
+
+        when(camera.getVideoSize).thenAnswer((_) => Future.value(Size(10, 10)));
+        when(camera.initialize).thenAnswer((_) => Future.value());
+        when(camera.play).thenAnswer((_) => Future.value());
+
+        // Save the camera in the camera plugin.
+        (CameraPlatform.instance as CameraPlugin).cameras[cameraId] = camera;
+
+        await CameraPlatform.instance.initializeCamera(cameraId);
+
+        verify(camera.initialize).called(1);
+        verify(camera.play).called(1);
+      });
     });
 
     testWidgets('lockCaptureOrientation throws UnimplementedError',
@@ -628,13 +653,78 @@ void main() {
       );
     });
 
-    group('events', () {
-      testWidgets('onCameraInitialized throws UnimplementedError',
-          (tester) async {
+    group('getCamera', () {
+      testWidgets('returns the correct camera', (tester) async {
+        final camera = Camera(textureId: cameraId, window: window);
+
+        // Save the camera in the camera plugin.
+        (CameraPlatform.instance as CameraPlugin).cameras[cameraId] = camera;
+
         expect(
-          () => CameraPlatform.instance.onCameraInitialized(cameraId),
-          throwsUnimplementedError,
+          (CameraPlatform.instance as CameraPlugin).getCamera(cameraId),
+          equals(camera),
         );
+      });
+
+      testWidgets(
+          'throws CameraException '
+          'with notFound error '
+          'if the camera does not exist', (tester) async {
+        expect(
+          () => (CameraPlatform.instance as CameraPlugin).getCamera(cameraId),
+          throwsA(
+            isA<CameraException>().having(
+              (e) => e.code,
+              'code',
+              CameraErrorCodes.notFound,
+            ),
+          ),
+        );
+      });
+    });
+
+    group('events', () {
+      testWidgets(
+          'onCameraInitialized emits a CameraInitializedEvent '
+          'on initializeCamera', (tester) async {
+        // Mock the camera to use a blank video stream of size 1280x720.
+        const videoSize = Size(1280, 720);
+
+        videoElement = getVideoElementWithBlankStream(videoSize);
+
+        when(
+          () => mediaDevices.getUserMedia(any()),
+        ).thenAnswer((_) async => videoElement.captureStream());
+
+        final camera = Camera(
+          textureId: cameraId,
+          window: window,
+        );
+
+        // Save the camera in the camera plugin.
+        (CameraPlatform.instance as CameraPlugin).cameras[cameraId] = camera;
+
+        final Stream<CameraInitializedEvent> eventStream =
+            CameraPlatform.instance.onCameraInitialized(cameraId);
+
+        final streamQueue = StreamQueue(eventStream);
+
+        await CameraPlatform.instance.initializeCamera(cameraId);
+
+        expect(
+          await streamQueue.next,
+          CameraInitializedEvent(
+            cameraId,
+            videoSize.width,
+            videoSize.height,
+            ExposureMode.auto,
+            false,
+            FocusMode.auto,
+            false,
+          ),
+        );
+
+        await streamQueue.cancel();
       });
 
       testWidgets('onCameraResolutionChanged throws UnimplementedError',

--- a/packages/camera/camera_web/example/integration_test/camera_web_test.dart
+++ b/packages/camera/camera_web/example/integration_test/camera_web_test.dart
@@ -34,13 +34,8 @@ void main() {
       window = MockWindow();
       navigator = MockNavigator();
       mediaDevices = MockMediaDevices();
-      videoElement = VideoElement()
-        ..src =
-            'https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4'
-        ..preload = 'true'
-        ..width = 10
-        ..height = 10
-        ..crossOrigin = 'anonymous';
+
+      videoElement = getVideoElementWithBlankStream(Size(10, 10));
 
       cameraSettings = MockCameraSettings();
 

--- a/packages/camera/camera_web/example/integration_test/helpers/mocks.dart
+++ b/packages/camera/camera_web/example/integration_test/helpers/mocks.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:html';
+import 'dart:ui';
 
 import 'package:camera_web/src/camera.dart';
 import 'package:camera_web/src/camera_settings.dart';
@@ -56,4 +57,23 @@ class FakeDomException extends Fake implements DomException {
 
   @override
   String get name => _name;
+}
+
+/// Returns a video element with a blank stream of size [videoSize].
+///
+/// Can be used to mock a video stream:
+/// ```dart
+/// final videoElement = getVideoElementWithBlankStream(Size(100, 100));
+/// final videoStream = videoElement.captureStream();
+/// ```
+VideoElement getVideoElementWithBlankStream(Size videoSize) {
+  final canvasElement = CanvasElement(
+    width: videoSize.width.toInt(),
+    height: videoSize.height.toInt(),
+  )..context2D.fillRect(0, 0, videoSize.width, videoSize.height);
+
+  final videoElement = VideoElement()
+    ..srcObject = canvasElement.captureStream();
+
+  return videoElement;
 }

--- a/packages/camera/camera_web/example/integration_test/helpers/mocks.dart
+++ b/packages/camera/camera_web/example/integration_test/helpers/mocks.dart
@@ -4,6 +4,7 @@
 
 import 'dart:html';
 
+import 'package:camera_web/src/camera.dart';
 import 'package:camera_web/src/camera_settings.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -16,6 +17,8 @@ class MockMediaDevices extends Mock implements MediaDevices {}
 class MockCameraSettings extends Mock implements CameraSettings {}
 
 class MockMediaStreamTrack extends Mock implements MediaStreamTrack {}
+
+class MockCamera extends Mock implements Camera {}
 
 /// A fake [MediaStream] that returns the provided [_videoTracks].
 class FakeMediaStream extends Fake implements MediaStream {

--- a/packages/camera/camera_web/lib/src/camera.dart
+++ b/packages/camera/camera_web/lib/src/camera.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:html' as html;
+import 'dart:ui';
 import 'shims/dart_ui.dart' as ui;
 
 import 'package:camera_platform_interface/camera_platform_interface.dart';
@@ -169,6 +170,30 @@ class Camera {
       ..drawImageScaled(videoElement, 0, 0, videoWidth, videoHeight);
     final blob = await canvas.toBlob('image/jpeg');
     return XFile(html.Url.createObjectUrl(blob));
+  }
+
+  /// Returns a size of the camera video based on its first video track size.
+  ///
+  /// Returns [Size.zero] if the camera is missing a video track or
+  /// the video track does not include the width or height setting.
+  Future<Size> getVideoSize() async {
+    final videoTracks = videoElement.srcObject?.getVideoTracks() ?? [];
+
+    if (videoTracks.isEmpty) {
+      return Size.zero;
+    }
+
+    final defaultVideoTrack = videoTracks.first;
+    final defaultVideoTrackSettings = defaultVideoTrack.getSettings();
+
+    final width = defaultVideoTrackSettings['width'];
+    final height = defaultVideoTrackSettings['height'];
+
+    if (width != null && height != null) {
+      return Size(width, height);
+    } else {
+      return Size.zero;
+    }
   }
 
   /// Disposes the camera by stopping the camera stream


### PR DESCRIPTION
Adds `initializeCamera` implementation of the camera platform interface.

- Added `getVideoSize` to `Camera`.
  - Returns a size of the camera video based on its first video track size.
- Added `initializeCamera` and `onCameraInitialized` implementation.
  - Initializes and starts playing the camera stream.
  - Adds a `CameraInitializedEvent` to the camera events stream controller. The event is emitted on the `onCameraInitialized` stream and includes a camera id, video size, default exposure and focus modes (auto).
- Replaced an HTTP stream with a blank canvas stream in tests that use a video element. In this way, tests are not reliant on the network and the video size can be easily adjusted.

Part of https://github.com/flutter/flutter/issues/45297.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
