### PR TITLE
[camera_platform_interface] Expand camera platform interface to support pausing the camera preview.

### DIFF
--- a/packages/camera/camera_platform_interface/CHANGELOG.md
+++ b/packages/camera/camera_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0
+
+* Introduces interface methods for pausing and resuming the camera preview.
+
 ## 2.0.1
 
 * Update platform_plugin_interface version requirement.

--- a/packages/camera/camera_platform_interface/lib/src/method_channel/method_channel_camera.dart
+++ b/packages/camera/camera_platform_interface/lib/src/method_channel/method_channel_camera.dart
@@ -400,6 +400,22 @@ class MethodChannelCamera extends CameraPlatform {
   }
 
   @override
+  Future<void> pausePreview(int cameraId) async {
+    await _channel.invokeMethod<double>(
+      'pausePreview',
+      <String, dynamic>{'cameraId': cameraId},
+    );
+  }
+
+  @override
+  Future<void> resumePreview(int cameraId) async {
+    await _channel.invokeMethod<double>(
+      'resumePreview',
+      <String, dynamic>{'cameraId': cameraId},
+    );
+  }
+
+  @override
   Widget buildPreview(int cameraId) {
     return Texture(textureId: cameraId);
   }

--- a/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
+++ b/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
@@ -235,6 +235,16 @@ abstract class CameraPlatform extends PlatformInterface {
     throw UnimplementedError('setZoomLevel() is not implemented.');
   }
 
+  /// Pause the active preview on the current frame for the selected camera.
+  Future<void> pausePreview(int cameraId) {
+    throw UnimplementedError('pausePreview() is not implemented.');
+  }
+
+  /// Resume the paused preview for the selected camera.
+  Future<void> resumePreview(int cameraId) {
+    throw UnimplementedError('pausePreview() is not implemented.');
+  }
+
   /// Returns a widget showing a live camera preview.
   Widget buildPreview(int cameraId) {
     throw UnimplementedError('buildView() has not been implemented.');

--- a/packages/camera/camera_platform_interface/pubspec.yaml
+++ b/packages/camera/camera_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/master/packages/camera/camer
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.0.1
+version: 2.1.0
 
 environment:
   sdk: '>=2.12.0 <3.0.0'

--- a/packages/camera/camera_platform_interface/test/camera_platform_interface_test.dart
+++ b/packages/camera/camera_platform_interface/test/camera_platform_interface_test.dart
@@ -408,6 +408,32 @@ void main() {
         throwsUnimplementedError,
       );
     });
+
+    test(
+        'Default implementation of pausePreview() should throw unimplemented error',
+        () {
+      // Arrange
+      final cameraPlatform = ExtendsCameraPlatform();
+
+      // Act & Assert
+      expect(
+        () => cameraPlatform.pausePreview(1),
+        throwsUnimplementedError,
+      );
+    });
+
+    test(
+        'Default implementation of resumePreview() should throw unimplemented error',
+        () {
+      // Arrange
+      final cameraPlatform = ExtendsCameraPlatform();
+
+      // Act & Assert
+      expect(
+        () => cameraPlatform.resumePreview(1),
+        throwsUnimplementedError,
+      );
+    });
   });
 }
 

--- a/packages/camera/camera_platform_interface/test/method_channel/method_channel_camera_test.dart
+++ b/packages/camera/camera_platform_interface/test/method_channel/method_channel_camera_test.dart
@@ -923,6 +923,38 @@ void main() {
               arguments: {'cameraId': cameraId}),
         ]);
       });
+
+      test('Should pause the camera preview', () async {
+        // Arrange
+        MethodChannelMock channel = MethodChannelMock(
+          channelName: 'plugins.flutter.io/camera',
+          methods: {'pausePreview': null},
+        );
+
+        // Act
+        await camera.pausePreview(cameraId);
+
+        // Assert
+        expect(channel.log, <Matcher>[
+          isMethodCall('pausePreview', arguments: {'cameraId': cameraId}),
+        ]);
+      });
+
+      test('Should resume the camera preview', () async {
+        // Arrange
+        MethodChannelMock channel = MethodChannelMock(
+          channelName: 'plugins.flutter.io/camera',
+          methods: {'resumePreview': null},
+        );
+
+        // Act
+        await camera.resumePreview(cameraId);
+
+        // Assert
+        expect(channel.log, <Matcher>[
+          isMethodCall('resumePreview', arguments: {'cameraId': cameraId}),
+        ]);
+      });
     });
   });
 }


### PR DESCRIPTION
This PR adds `pausePreview` and `resumePreview` methods to the camera plugin's platform interface, to support the (un)pausing of the camera preview.

Android & iOS implementations for these methods can be found in #4192.

Related issues:
- flutter/flutter#34997
- flutter/flutter#27079

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.
