### PR TITLE
[camera] Fix camera preview not always rebuilding on orientation change

### DIFF
--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.1+7
+
+* Fix device orientation sometimes not affecting the camera preview orientation.
+
 ## 0.8.1+6
 
 * Remove references to the Android V1 embedding.

--- a/packages/camera/camera/lib/src/camera_preview.dart
+++ b/packages/camera/camera/lib/src/camera_preview.dart
@@ -21,17 +21,23 @@ class CameraPreview extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return controller.value.isInitialized
-        ? AspectRatio(
-            aspectRatio: _isLandscape()
-                ? controller.value.aspectRatio
-                : (1 / controller.value.aspectRatio),
-            child: Stack(
-              fit: StackFit.expand,
-              children: [
-                _wrapInRotatedBox(child: controller.buildPreview()),
-                child ?? Container(),
-              ],
-            ),
+        ? ValueListenableBuilder(
+            valueListenable: controller,
+            builder: (context, value, child) {
+              return AspectRatio(
+                aspectRatio: _isLandscape()
+                    ? controller.value.aspectRatio
+                    : (1 / controller.value.aspectRatio),
+                child: Stack(
+                  fit: StackFit.expand,
+                  children: [
+                    _wrapInRotatedBox(child: controller.buildPreview()),
+                    child ?? Container(),
+                  ],
+                ),
+              );
+            },
+            child: child,
           )
         : Container();
   }

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -4,7 +4,7 @@ description: A Flutter plugin for getting information about and controlling the
   and streaming image buffers to dart.
 repository: https://github.com/flutter/plugins/tree/master/packages/camera/camera
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.8.1+6
+version: 0.8.1+7
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
Currently, the preview widget does not always rebuild when a device orientation change occurs. This PR fixes this by having the widget rebuild when the `CameraValue`, which contains the device orientation, is updated.

Relevant issue: 
- flutter/flutter#87108

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
  - No new public members
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
  - If this is something that has to be tested let me know. It's a small change that does not affect any current tests and I don't feel like it warrants writing a new one. 
- [x] All existing and new tests are passing.
