### PR TITLE
wake lock permission

### DIFF
--- a/packages/webview_flutter/webview_flutter/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/webview_flutter/webview_flutter/example/android/app/src/main/AndroidManifest.xml
@@ -34,4 +34,9 @@
        to allow setting breakpoints, to provide hot reload, etc.
   -->
   <uses-permission android:name="android.permission.INTERNET"/>
+
+  <!-- When tests are ran on Firebase Test Lab, a wake lock
+       permission failure prevents tests from running.
+  -->
+  <uses-permission android:name="android.permission.WAKE_LOCK" />
 </manifest>


### PR DESCRIPTION
According to the logs from Firebase Test Lab, the tests have this error on timeouts:

```
07-26 23:28:25.498: I/flutter(19917): (The following exception is now available via WidgetTester.takeException:)
07-26 23:28:25.547: I/flutter(19917): â•â•â•¡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK â•žâ•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•
07-26 23:28:25.547: I/flutter(19917): The following PlatformException was thrown running a test:
07-26 23:28:25.547: I/flutter(19917): PlatformException(error, Neither user 10223 nor current process has android.permission.WAKE_LOCK.,
07-26 23:28:25.547: I/flutter(19917): null, java.lang.SecurityException: Neither user 10223 nor current process has
07-26 23:28:25.547: I/flutter(19917): android.permission.WAKE_LOCK.
07-26 23:28:25.547: I/flutter(19917): 	at android.os.Parcel.createException(Parcel.java:2071)
07-26 23:28:25.547: I/flutter(19917): 	at android.os.Parcel.readException(Parcel.java:2039)
07-26 23:28:25.547: I/flutter(19917): 	at android.os.Parcel.readException(Parcel.java:1987)
07-26 23:28:25.547: I/flutter(19917): 	at android.view.IWindowSession$Stub$Proxy.addToDisplay(IWindowSession.java:1242)
07-26 23:28:25.547: I/flutter(19917): 	at android.view.ViewRootImpl.setView(ViewRootImpl.java:888)
07-26 23:28:25.547: I/flutter(19917): 	at android.view.WindowManagerGlobal.addView(WindowManagerGlobal.java:387)
07-26 23:28:25.547: I/flutter(19917): 	at android.view.WindowManagerImpl.addView(WindowManagerImpl.java:95)
07-26 23:28:25.547: I/flutter(19917): 	at android.app.Dialog.show(Dialog.java:342)
07-26 23:28:25.547: I/flutter(19917): 	at android.app.Presentation.show(Presentation.java:257)
07-26 23:28:25.547: I/flutter(19917): 	at io.flutter.plugin.platform.VirtualDisplayController.resize(VirtualDisplayController.java:161)
07-26 23:28:25.547: I/flutter(19917): 	at
07-26 23:28:25.547: I/flutter(19917): io.flutter.plugin.platform.PlatformViewsController$1.resizePlatformView(PlatformViewsController.java:285)
07-26 23:28:25.547: I/flutter(19917): 	at
07-26 23:28:25.547: I/flutter(19917): io.flutter.embedding.engine.systemchannels.PlatformViewsChannel$1.resize(PlatformViewsChannel.java:138)
07-26 23:28:25.547: I/flutter(19917): 	at
07-26 23:28:25.547: I/flutter(19917): io.flutter.embedding.engine.systemchannels.PlatformViewsChannel$1.onMethodCall(PlatformViewsChannel.java:65)
07-26 23:28:25.547: I/flutter(19917): 	at
07-26 23:28:25.547: I/flutter(19917): io.flutter.plugin.common.MethodChannel$IncomingMethodCallHandler.onMessage(MethodChannel.java:233)
07-26 23:28:25.547: I/flutter(19917): 	at io.flutter.embedding.engine.dart.DartMessenger.handleMessageFromDart(DartMessenger.java:85)
07-26 23:28:25.547: I/flutter(19917): 	at io.flutter.embedding.engine.FlutterJNI.handlePlatformMessage(FlutterJNI.java:818)
07-26 23:28:25.547: I/flutter(19917): 	at android.os.MessageQueue.nativePollOnce(Native Method)
07-26 23:28:25.547: I/flutter(19917): 	at android.os.MessageQueue.next(MessageQueue.java:336)
07-26 23:28:25.547: I/flutter(19917): 	at android.os.Looper.loop(Looper.java:174)
07-26 23:28:25.547: I/flutter(19917): 	at android.app.ActivityThread.main(ActivityThread.java:7356)
07-26 23:28:25.547: I/flutter(19917): 	at java.lang.reflect.Method.invoke(Native Method)
07-26 23:28:25.547: I/flutter(19917): 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
07-26 23:28:25.547: I/flutter(19917): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:930)
07-26 23:28:25.547: I/flutter(19917): Caused by: android.os.RemoteException: Remote stack trace:
07-26 23:28:25.547: I/flutter(19917): 	at android.app.ContextImpl.enforce(ContextImpl.java:1896)
07-26 23:28:25.547: I/flutter(19917): 	at android.app.ContextImpl.enforceCallingOrSelfPermission(ContextImpl.java:1924)
07-26 23:28:25.547: I/flutter(19917): 	at
07-26 23:28:25.547: I/flutter(19917): com.android.server.power.PowerManagerService$BinderService.acquireWakeLock(PowerManagerService.java:4309)
07-26 23:28:25.547: I/flutter(19917): 	at android.os.PowerManager$WakeLock.acquireLocked(PowerManager.java:2127)
07-26 23:28:25.547: I/flutter(19917): 	at android.os.PowerManager$WakeLock.acquire(PowerManager.java:2093)
07-26 23:28:25.547: I/flutter(19917): )
07-26 23:28:25.547: I/flutter(19917): When the exception was thrown, this was the stack:
07-26 23:28:25.547: I/flutter(19917): #0      StandardMethodCodec.decodeEnvelope (package:flutter/src/services/message_codecs.dart:597:7)
07-26 23:28:25.547: I/flutter(19917): #1      MethodChannel._invokeMethod (package:flutter/src/services/platform_channel.dart:158:18)
07-26 23:28:25.547: I/flutter(19917): <asynchronous suspension>
07-26 23:28:25.547: I/flutter(19917): <asynchronous suspension>
07-26 23:28:25.547: I/flutter(19917): (elided one frame from package:stack_trace)
07-26 23:28:25.547: I/flutter(19917): The test description was:
07-26 23:28:25.547: I/flutter(19917):   resize webview
07-26 23:28:25.547: I/flutter(19917): 
```

I haven't seen this locally, so it may be something with Firebase Test Lab?
