### PR TITLE
[flutter_plugin_tools] Add a command to lint Android code

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -100,7 +100,7 @@ task:
       script:
         - flutter config --enable-linux-desktop
         - ./script/build_all_plugins_app.sh linux
-    - name: build-linux+drive-examples
+    - name: linux-build+platform-tests
       env:
         matrix:
           CHANNEL: "master"
@@ -127,7 +127,7 @@ task:
     memory: 12G
   matrix:
     ### Android tasks ###
-    - name: build-apks+android-unit+firebase-test-lab
+    - name: android-build+platform-tests
       env:
         matrix:
           PLUGIN_SHARDING: "--shardIndex 0 --shardCount 4"
@@ -175,7 +175,7 @@ task:
         -   echo "This user does not have permission to run Firebase Test Lab tests."
         - fi
     ### Web tasks ###
-    - name: build-web+drive-examples
+    - name: web-build+platform-tests
       env:
         matrix:
           CHANNEL: "master"
@@ -208,7 +208,7 @@ task:
           CHANNEL: "stable"
       script:
         - ./script/build_all_plugins_app.sh ios --no-codesign
-    - name: build-ipas+drive-examples
+    - name: ios-build+platform-tests
       env:
         PATH: $PATH:/usr/local/bin
         matrix:
@@ -243,7 +243,7 @@ task:
       script:
         - flutter config --enable-macos-desktop
         - ./script/build_all_plugins_app.sh macos
-    - name: build-macos+drive-examples
+    - name: macos-build+platform-tests
       env:
         matrix:
           CHANNEL: "master"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -146,6 +146,13 @@ task:
         - export CIRRUS_CHANGE_MESSAGE=""
         - export CIRRUS_COMMIT_MESSAGE=""
         - ./script/tool_runner.sh build-examples --apk
+      lint_script:
+        # Unsetting CIRRUS_CHANGE_MESSAGE and CIRRUS_COMMIT_MESSAGE as they
+        # might include non-ASCII characters which makes Gradle crash.
+        # TODO(stuartmorgan): See https://github.com/flutter/flutter/issues/24935
+        - export CIRRUS_CHANGE_MESSAGE=""
+        - export CIRRUS_COMMIT_MESSAGE=""
+        - ./script/tool_runner.sh lint-android # must come after build-examples
       native_unit_test_script:
         # Unsetting CIRRUS_CHANGE_MESSAGE and CIRRUS_COMMIT_MESSAGE as they
         # might include non-ASCII characters which makes Gradle crash.

--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -21,6 +21,7 @@
     `--no-integration`.
 - **Breaking change**: Replaced `java-test` with Android unit test support for
   the new `native-test` command.
+- Added a new `android-lint` command to lint Android plugin native code.
 
 ## 0.4.1
 

--- a/script/tool/lib/src/lint_android_command.dart
+++ b/script/tool/lib/src/lint_android_command.dart
@@ -1,0 +1,56 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file/file.dart';
+import 'package:flutter_plugin_tools/src/common/plugin_utils.dart';
+import 'package:platform/platform.dart';
+
+import 'common/package_looping_command.dart';
+import 'common/process_runner.dart';
+
+const String _gradleWrapper = 'gradlew';
+
+/// Lint the CocoaPod podspecs and run unit tests.
+///
+/// See https://guides.cocoapods.org/terminal/commands.html#pod_lib_lint.
+class LintAndroidCommand extends PackageLoopingCommand {
+  /// Creates an instance of the linter command.
+  LintAndroidCommand(
+    Directory packagesDir, {
+    ProcessRunner processRunner = const ProcessRunner(),
+    Platform platform = const LocalPlatform(),
+  }) : super(packagesDir, processRunner: processRunner, platform: platform);
+
+  @override
+  final String name = 'lint-android';
+
+  @override
+  final String description = 'Runs "gradlew lint" on Android plugins.\n\n'
+      'Requires the example to have been build at least once before running.';
+
+  @override
+  Future<PackageResult> runForPackage(Directory package) async {
+    if (!isAndroidPlugin(package)) {
+      return PackageResult.skip('Plugin does not support Android.');
+    }
+
+    final Directory androidDirectory =
+        package.childDirectory('example').childDirectory('android');
+    if (!androidDirectory.childFile(_gradleWrapper).existsSync()) {
+      return PackageResult.fail(<String>['Build example before linting']);
+    }
+
+    // TODO(stuartmorgan): Consider adding an XML parser to read and summarize
+    // all results. Currently, only the first three errors will be shown, and
+    // the rest are only in an XML file that won't be accessible for CI runs.
+    final int exitCode = await processRunner.runAndStream(
+        androidDirectory.childFile(_gradleWrapper).path,
+        <String>[
+          'lintDebug', // Only lint one build mode to avoid extra work.
+        ],
+        workingDir: androidDirectory);
+
+    return exitCode == 0 ? PackageResult.success() : PackageResult.fail();
+  }
+}

--- a/script/tool/lib/src/main.dart
+++ b/script/tool/lib/src/main.dart
@@ -16,6 +16,7 @@ import 'drive_examples_command.dart';
 import 'firebase_test_lab_command.dart';
 import 'format_command.dart';
 import 'license_check_command.dart';
+import 'lint_android_command.dart';
 import 'lint_podspecs_command.dart';
 import 'list_command.dart';
 import 'native_test_command.dart';
@@ -51,6 +52,7 @@ void main(List<String> args) {
     ..addCommand(FirebaseTestLabCommand(packagesDir))
     ..addCommand(FormatCommand(packagesDir))
     ..addCommand(LicenseCheckCommand(packagesDir))
+    ..addCommand(LintAndroidCommand(packagesDir))
     ..addCommand(LintPodspecsCommand(packagesDir))
     ..addCommand(ListCommand(packagesDir))
     ..addCommand(NativeTestCommand(packagesDir))

--- a/script/tool/test/lint_android_command_test.dart
+++ b/script/tool/test/lint_android_command_test.dart
@@ -1,0 +1,136 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io' as io;
+
+import 'package:args/command_runner.dart';
+import 'package:file/file.dart';
+import 'package:file/memory.dart';
+import 'package:flutter_plugin_tools/src/common/core.dart';
+import 'package:flutter_plugin_tools/src/common/plugin_utils.dart';
+import 'package:flutter_plugin_tools/src/lint_android_command.dart';
+import 'package:test/test.dart';
+
+import 'mocks.dart';
+import 'util.dart';
+
+void main() {
+  group('$LintAndroidCommand', () {
+    FileSystem fileSystem;
+    late Directory packagesDir;
+    late CommandRunner<void> runner;
+    late MockPlatform mockPlatform;
+    late RecordingProcessRunner processRunner;
+
+    setUp(() {
+      fileSystem = MemoryFileSystem(style: FileSystemStyle.posix);
+      packagesDir = createPackagesDirectory(fileSystem: fileSystem);
+      mockPlatform = MockPlatform();
+      processRunner = RecordingProcessRunner();
+      final LintAndroidCommand command = LintAndroidCommand(
+        packagesDir,
+        processRunner: processRunner,
+        platform: mockPlatform,
+      );
+
+      runner = CommandRunner<void>(
+          'lint_android_test', 'Test for $LintAndroidCommand');
+      runner.addCommand(command);
+    });
+
+    test('runs gradle lint', () async {
+      final Directory pluginDir =
+          createFakePlugin('plugin1', packagesDir, extraFiles: <String>[
+        'example/android/gradlew',
+      ], platformSupport: <String, PlatformSupport>{
+        kPlatformAndroid: PlatformSupport.inline
+      });
+
+      final Directory androidDir =
+          pluginDir.childDirectory('example').childDirectory('android');
+
+      final List<String> output =
+          await runCapturingPrint(runner, <String>['lint-android']);
+
+      expect(
+        processRunner.recordedCalls,
+        orderedEquals(<ProcessCall>[
+          ProcessCall(
+            androidDir.childFile('gradlew').path,
+            const <String>['lintDebug'],
+            androidDir.path,
+          ),
+        ]),
+      );
+
+      expect(
+          output,
+          containsAllInOrder(<Matcher>[
+            contains('Running for plugin1'),
+            contains('No issues found!'),
+          ]));
+    });
+
+    test('fails if gradlew is missing', () async {
+      createFakePlugin('plugin1', packagesDir,
+          platformSupport: <String, PlatformSupport>{
+            kPlatformAndroid: PlatformSupport.inline
+          });
+
+      Error? commandError;
+      final List<String> output = await runCapturingPrint(
+          runner, <String>['lint-android'], errorHandler: (Error e) {
+        commandError = e;
+      });
+
+      expect(commandError, isA<ToolExit>());
+      expect(
+          output,
+          containsAllInOrder(
+            <Matcher>[
+              contains('Build example before linting'),
+            ],
+          ));
+    });
+
+    test('fails if linting finds issues', () async {
+      createFakePlugin('plugin1', packagesDir,
+          platformSupport: <String, PlatformSupport>{
+            kPlatformAndroid: PlatformSupport.inline
+          });
+
+      processRunner.mockProcessesForExecutable['gradlew'] = <io.Process>[
+        MockProcess.failing(),
+      ];
+
+      Error? commandError;
+      final List<String> output = await runCapturingPrint(
+          runner, <String>['lint-android'], errorHandler: (Error e) {
+        commandError = e;
+      });
+
+      expect(commandError, isA<ToolExit>());
+      expect(
+          output,
+          containsAllInOrder(
+            <Matcher>[
+              contains('Build example before linting'),
+            ],
+          ));
+    });
+
+    test('skips non-Android plugins', () async {
+      createFakePlugin('plugin1', packagesDir);
+
+      final List<String> output =
+          await runCapturingPrint(runner, <String>['lint-android']);
+
+      expect(
+          output,
+          containsAllInOrder(
+            <Matcher>[contains('SKIPPING: Plugin does not support Android.')],
+          ));
+    });
+  });
+}


### PR DESCRIPTION
Adds a new `lint-android` command to run `gradlew lint` on Android plugins.

Also standardizes the names of the Cirrus tasks that run all the build and platform-specific (i.e., not Dart unit test) tests for each platform, as they were getting unnecessarily long and complex in some cases.

Fixes https://github.com/flutter/flutter/issues/87071

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
