### PR TITLE
Don't use 'flutter upgrade' on Cirrus

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -25,7 +25,7 @@ flutter_upgrade_template: &FLUTTER_UPGRADE_TEMPLATE
     # can sometimes be in a state where it has diverged from upstream (!).
     - git reset --hard @{u}
     # Run doctor to allow auditing of what version of Flutter the run is using.
-    - flutter doctor
+    - flutter doctor -v
   << : *TOOL_SETUP_TEMPLATE
 
 macos_template: &MACOS_TEMPLATE

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,8 +20,10 @@ flutter_upgrade_template: &FLUTTER_UPGRADE_TEMPLATE
     - git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
     - git fetch origin
     # Switch to the requested branch.
-    - flutter channel $CHANNEL
-    - flutter upgrade
+    - git checkout $CHANNEL
+    - git pull
+    # Run doctor to allow auditing of what version of Flutter the run is using.
+    - flutter doctor
   << : *TOOL_SETUP_TEMPLATE
 
 macos_template: &MACOS_TEMPLATE

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -21,7 +21,9 @@ flutter_upgrade_template: &FLUTTER_UPGRADE_TEMPLATE
     - git fetch origin
     # Switch to the requested branch.
     - git checkout $CHANNEL
-    - git pull
+    # Reset to upstream branch, rather than using pull, since the base image
+    # can sometimes be in a state where it has diverged from upstream (!).
+    - git reset --hard @{u}
     # Run doctor to allow auditing of what version of Flutter the run is using.
     - flutter doctor
   << : *TOOL_SETUP_TEMPLATE


### PR DESCRIPTION
This command isn't intended for CI use, and is also slower due to
downloading artifacts that will be immidately discarded.

Cirrus portion of https://github.com/flutter/flutter/issues/86037

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
