### PR TITLE
[image_picker] Check for failure in iOS metadata updates

### DIFF
--- a/packages/image_picker/image_picker/CHANGELOG.md
+++ b/packages/image_picker/image_picker/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 0.8.3
 
 * Move `ImagePickerFromLimitedGalleryUITests` to `RunnerUITests` target.
+* Improved handling of bad image data when applying metadata changes on iOS.
 
 ## 0.8.2
 
@@ -53,8 +54,8 @@ see: [#84634](https://github.com/flutter/flutter/issues/84634).
 ## 0.8.0
 
 * BREAKING CHANGE: Changed storage location for captured images and videos to internal cache on Android,
-to comply with new Google Play storage requirements. This means developers are responsible for moving 
-the image or video to a different location in case more permanent storage is required. Other applications 
+to comply with new Google Play storage requirements. This means developers are responsible for moving
+the image or video to a different location in case more permanent storage is required. Other applications
 will no longer be able to access images or videos captured unless they are moved to a publicly accessible location.
 * Updated Mockito to fix Android tests.
 

--- a/packages/image_picker/image_picker/example/ios/RunnerTests/MetaDataUtilTests.m
+++ b/packages/image_picker/image_picker/example/ios/RunnerTests/MetaDataUtilTests.m
@@ -60,7 +60,7 @@
   NSString *tmpFile = [NSString stringWithFormat:@"image_picker_test.jpg"];
   NSString *tmpDirectory = NSTemporaryDirectory();
   NSString *tmpPath = [tmpDirectory stringByAppendingPathComponent:tmpFile];
-  NSData *newData = [FLTImagePickerMetaDataUtil updateMetaData:metaData toImage:dataJPG];
+  NSData *newData = [FLTImagePickerMetaDataUtil imageFromImage:dataJPG withMetaData:metaData];
   if ([[NSFileManager defaultManager] createFileAtPath:tmpPath contents:newData attributes:nil]) {
     NSData *savedTmpImageData = [NSData dataWithContentsOfFile:tmpPath];
     NSDictionary *tmpMetaData =
@@ -69,6 +69,14 @@
   } else {
     XCTAssert(NO);
   }
+}
+
+- (void)testUpdateMetaDataBadData {
+  NSData *imageData = [NSData data];
+
+  NSDictionary *metaData = [FLTImagePickerMetaDataUtil getMetaDataFromImageData:imageData];
+  NSData *newData = [FLTImagePickerMetaDataUtil imageFromImage:imageData withMetaData:metaData];
+  XCTAssertNil(newData);
 }
 
 - (void)testConvertImageToData {

--- a/packages/image_picker/image_picker/ios/Classes/FLTImagePickerMetaDataUtil.h
+++ b/packages/image_picker/image_picker/ios/Classes/FLTImagePickerMetaDataUtil.h
@@ -27,7 +27,11 @@ extern const FLTImagePickerMIMEType kFLTImagePickerMIMETypeDefault;
 
 + (NSDictionary *)getMetaDataFromImageData:(NSData *)imageData;
 
-+ (NSData *)updateMetaData:(NSDictionary *)metaData toImage:(NSData *)imageData;
+// Creates and returns data for a new image based on imageData, but with the
+// given metadata.
+//
+// If creating a new image fails, returns nil.
++ (nullable NSData *)imageFromImage:(NSData *)imageData withMetaData:(NSDictionary *)metadata;
 
 // Converting UIImage to a NSData with the type proveide.
 //

--- a/packages/image_picker/image_picker/ios/Classes/FLTImagePickerMetaDataUtil.m
+++ b/packages/image_picker/image_picker/ios/Classes/FLTImagePickerMetaDataUtil.m
@@ -49,16 +49,27 @@ const FLTImagePickerMIMEType kFLTImagePickerMIMETypeDefault = FLTImagePickerMIME
   return metadata;
 }
 
-+ (NSData *)updateMetaData:(NSDictionary *)metaData toImage:(NSData *)imageData {
-  NSMutableData *mutableData = [NSMutableData data];
-  CGImageSourceRef cgImage = CGImageSourceCreateWithData((__bridge CFDataRef)imageData, NULL);
-  CGImageDestinationRef destination = CGImageDestinationCreateWithData(
-      (__bridge CFMutableDataRef)mutableData, CGImageSourceGetType(cgImage), 1, nil);
-  CGImageDestinationAddImageFromSource(destination, cgImage, 0, (__bridge CFDictionaryRef)metaData);
++ (NSData *)imageFromImage:(NSData *)imageData withMetaData:(NSDictionary *)metadata {
+  NSMutableData *targetData = [NSMutableData data];
+  CGImageSourceRef source = CGImageSourceCreateWithData((__bridge CFDataRef)imageData, NULL);
+  if (source == NULL) {
+    return nil;
+  }
+  CGImageDestinationRef destination = NULL;
+  CFStringRef sourceType = CGImageSourceGetType(source);
+  if (sourceType != NULL) {
+    destination =
+        CGImageDestinationCreateWithData((__bridge CFMutableDataRef)targetData, sourceType, 1, nil);
+  }
+  if (destination == NULL) {
+    CFRelease(source);
+    return nil;
+  }
+  CGImageDestinationAddImageFromSource(destination, source, 0, (__bridge CFDictionaryRef)metadata);
   CGImageDestinationFinalize(destination);
-  CFRelease(cgImage);
+  CFRelease(source);
   CFRelease(destination);
-  return mutableData;
+  return targetData;
 }
 
 + (NSData *)convertImage:(UIImage *)image

--- a/packages/image_picker/image_picker/ios/Classes/FLTImagePickerPhotoAssetUtil.m
+++ b/packages/image_picker/image_picker/ios/Classes/FLTImagePickerPhotoAssetUtil.m
@@ -86,7 +86,11 @@
                                                 usingType:type
                                                   quality:imageQuality];
   if (metaData) {
-    data = [FLTImagePickerMetaDataUtil updateMetaData:metaData toImage:data];
+    NSData *updatedData = [FLTImagePickerMetaDataUtil imageFromImage:data withMetaData:metaData];
+    // If updating the metadata fails, just save the original.
+    if (updatedData) {
+      data = updatedData;
+    }
   }
 
   return [self createFile:data suffix:suffix];

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for selecting images from the Android and iOS image
   library, and taking new pictures with the camera.
 repository: https://github.com/flutter/plugins/tree/master/packages/image_picker/image_picker
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 0.8.2
+version: 0.8.3
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
Reworks the logic in updateMetaData:toImage: to correctly handle the
possibility of null return values from intermediate steps. Also renames
it to have a more idiomatic ObjC name.

Speculative fix for https://github.com/flutter/flutter/issues/80429
Since the case this would likely fix is bad image data, this may simply
move problems to another part of the plugin, but this is definitely a
correctness improvement here, and if it does move the issue elsewhere we
can tackle that once we have more information.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
