### PR TITLE
[camera_web] Add `onCameraResolutionChanged` implementation

### DIFF
--- a/packages/camera/camera_web/example/integration_test/camera_web_test.dart
+++ b/packages/camera/camera_web/example/integration_test/camera_web_test.dart
@@ -1068,11 +1068,11 @@ void main() {
         await streamQueue.cancel();
       });
 
-      testWidgets('onCameraResolutionChanged throws UnimplementedError',
+      testWidgets('onCameraResolutionChanged emits an empty stream',
           (tester) async {
         expect(
-          () => CameraPlatform.instance.onCameraResolutionChanged(cameraId),
-          throwsUnimplementedError,
+          CameraPlatform.instance.onCameraResolutionChanged(cameraId),
+          emits(isEmpty),
         );
       });
 

--- a/packages/camera/camera_web/lib/src/camera_web.dart
+++ b/packages/camera/camera_web/lib/src/camera_web.dart
@@ -302,9 +302,14 @@ class CameraPlugin extends CameraPlatform {
     return _cameraEvents(cameraId).whereType<CameraInitializedEvent>();
   }
 
+  /// Emits an empty stream as there is no event corresponding to a change
+  /// in the camera resolution on the web.
+  ///
+  /// In order to change the camera resolution a new camera with appropriate
+  /// [CameraOptions.video] constraints has to be created and initialized.
   @override
   Stream<CameraResolutionChangedEvent> onCameraResolutionChanged(int cameraId) {
-    throw UnimplementedError('onCameraResolutionChanged() is not implemented.');
+    return const Stream.empty();
   }
 
   @override


### PR DESCRIPTION
Adds `onCameraResolutionChanged` implementation to the web camera platform.

- Emits an empty stream as there is no event corresponding to a change in the camera resolution on the web.

Part of https://github.com/flutter/flutter/issues/45297.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
