### PR TITLE
[camera_web] Add support for device orientation

### DIFF
--- a/packages/camera/camera_web/example/integration_test/camera_settings_test.dart
+++ b/packages/camera/camera_web/example/integration_test/camera_settings_test.dart
@@ -607,6 +607,120 @@ void main() {
         );
       });
     });
+
+    group('mapDeviceOrientationToOrientationType', () {
+      testWidgets(
+          'returns portraitPrimary '
+          'when the device orientation is portraitUp', (tester) async {
+        expect(
+          settings.mapDeviceOrientationToOrientationType(
+            DeviceOrientation.portraitUp,
+          ),
+          equals(OrientationType.portraitPrimary),
+        );
+      });
+
+      testWidgets(
+          'returns landscapePrimary '
+          'when the device orientation is landscapeLeft', (tester) async {
+        expect(
+          settings.mapDeviceOrientationToOrientationType(
+            DeviceOrientation.landscapeLeft,
+          ),
+          equals(OrientationType.landscapePrimary),
+        );
+      });
+
+      testWidgets(
+          'returns portraitSecondary '
+          'when the device orientation is portraitDown', (tester) async {
+        expect(
+          settings.mapDeviceOrientationToOrientationType(
+            DeviceOrientation.portraitDown,
+          ),
+          equals(OrientationType.portraitSecondary),
+        );
+      });
+
+      testWidgets(
+          'returns landscapeSecondary '
+          'when the device orientation is landscapeRight', (tester) async {
+        expect(
+          settings.mapDeviceOrientationToOrientationType(
+            DeviceOrientation.landscapeRight,
+          ),
+          equals(OrientationType.landscapeSecondary),
+        );
+      });
+    });
+
+    group('mapOrientationTypeToDeviceOrientation', () {
+      testWidgets(
+          'returns portraitUp '
+          'when the orientation type is portraitPrimary', (tester) async {
+        expect(
+          settings.mapOrientationTypeToDeviceOrientation(
+            OrientationType.portraitPrimary,
+          ),
+          equals(DeviceOrientation.portraitUp),
+        );
+      });
+
+      testWidgets(
+          'returns landscapeLeft '
+          'when the orientation type is landscapePrimary', (tester) async {
+        expect(
+          settings.mapOrientationTypeToDeviceOrientation(
+            OrientationType.landscapePrimary,
+          ),
+          equals(DeviceOrientation.landscapeLeft),
+        );
+      });
+
+      testWidgets(
+          'returns portraitDown '
+          'when the orientation type is portraitSecondary', (tester) async {
+        expect(
+          settings.mapOrientationTypeToDeviceOrientation(
+            OrientationType.portraitSecondary,
+          ),
+          equals(DeviceOrientation.portraitDown),
+        );
+      });
+
+      testWidgets(
+          'returns portraitDown '
+          'when the orientation type is portraitSecondary', (tester) async {
+        expect(
+          settings.mapOrientationTypeToDeviceOrientation(
+            OrientationType.portraitSecondary,
+          ),
+          equals(DeviceOrientation.portraitDown),
+        );
+      });
+
+      testWidgets(
+          'returns landscapeRight '
+          'when the orientation type is landscapeSecondary', (tester) async {
+        expect(
+          settings.mapOrientationTypeToDeviceOrientation(
+            OrientationType.landscapeSecondary,
+          ),
+          equals(DeviceOrientation.landscapeRight),
+        );
+      });
+
+      testWidgets(
+          'returns portraitUp '
+          'for an unknown orientation type', (tester) async {
+        expect(
+          settings.mapOrientationTypeToDeviceOrientation(
+            'unknown',
+          ),
+          equals(DeviceOrientation.portraitUp),
+        );
+      });
+    });
   });
 }
 

--- a/packages/camera/camera_web/example/integration_test/camera_web_test.dart
+++ b/packages/camera/camera_web/example/integration_test/camera_web_test.dart
@@ -30,6 +30,11 @@ void main() {
     late Navigator navigator;
     late MediaDevices mediaDevices;
     late VideoElement videoElement;
+    late Screen screen;
+    late ScreenOrientation screenOrientation;
+    late Document document;
+    late Element documentElement;
+
     late CameraSettings cameraSettings;
 
     setUp(() async {
@@ -39,10 +44,22 @@ void main() {
 
       videoElement = getVideoElementWithBlankStream(Size(10, 10));
 
-      cameraSettings = MockCameraSettings();
-
       when(() => window.navigator).thenReturn(navigator);
       when(() => navigator.mediaDevices).thenReturn(mediaDevices);
+
+      screen = MockScreen();
+      screenOrientation = MockScreenOrientation();
+
+      when(() => screen.orientation).thenReturn(screenOrientation);
+      when(() => window.screen).thenReturn(screen);
+
+      document = MockDocument();
+      documentElement = MockElement();
+
+      when(() => document.documentElement).thenReturn(documentElement);
+      when(() => window.document).thenReturn(document);
+
+      cameraSettings = MockCameraSettings();
 
       when(
         () => cameraSettings.getMediaStreamForOptions(
@@ -636,23 +653,236 @@ void main() {
       });
     });
 
-    testWidgets('lockCaptureOrientation throws UnimplementedError',
-        (tester) async {
-      expect(
-        () => CameraPlatform.instance.lockCaptureOrientation(
+    group('lockCaptureOrientation', () {
+      setUp(() {
+        when(
+          () => cameraSettings.mapDeviceOrientationToOrientationType(any()),
+        ).thenReturn(OrientationType.portraitPrimary);
+      });
+
+      testWidgets(
+          'requests full-screen mode '
+          'on documentElement', (tester) async {
+        await CameraPlatform.instance.lockCaptureOrientation(
           cameraId,
-          DeviceOrientation.landscapeLeft,
-        ),
-        throwsUnimplementedError,
-      );
+          DeviceOrientation.portraitUp,
+        );
+
+        verify(documentElement.requestFullscreen).called(1);
+      });
+
+      testWidgets(
+          'locks the capture orientation '
+          'based on the given device orientation', (tester) async {
+        when(
+          () => cameraSettings.mapDeviceOrientationToOrientationType(
+            DeviceOrientation.landscapeRight,
+          ),
+        ).thenReturn(OrientationType.landscapeSecondary);
+
+        await CameraPlatform.instance.lockCaptureOrientation(
+          cameraId,
+          DeviceOrientation.landscapeRight,
+        );
+
+        verify(
+          () => cameraSettings.mapDeviceOrientationToOrientationType(
+            DeviceOrientation.landscapeRight,
+          ),
+        ).called(1);
+
+        verify(
+          () => screenOrientation.lock(
+            OrientationType.landscapeSecondary,
+          ),
+        ).called(1);
+      });
+
+      group('throws PlatformException', () {
+        testWidgets(
+            'with orientationNotSupported error '
+            'when screen is not supported', (tester) async {
+          when(() => window.screen).thenReturn(null);
+
+          expect(
+            () => CameraPlatform.instance.lockCaptureOrientation(
+              cameraId,
+              DeviceOrientation.portraitUp,
+            ),
+            throwsA(
+              isA<PlatformException>().having(
+                (e) => e.code,
+                'code',
+                CameraErrorCode.orientationNotSupported.toString(),
+              ),
+            ),
+          );
+        });
+
+        testWidgets(
+            'with orientationNotSupported error '
+            'when screen orientation is not supported', (tester) async {
+          when(() => screen.orientation).thenReturn(null);
+
+          expect(
+            () => CameraPlatform.instance.lockCaptureOrientation(
+              cameraId,
+              DeviceOrientation.portraitUp,
+            ),
+            throwsA(
+              isA<PlatformException>().having(
+                (e) => e.code,
+                'code',
+                CameraErrorCode.orientationNotSupported.toString(),
+              ),
+            ),
+          );
+        });
+
+        testWidgets(
+            'with orientationNotSupported error '
+            'when documentElement is not available', (tester) async {
+          when(() => document.documentElement).thenReturn(null);
+
+          expect(
+            () => CameraPlatform.instance.lockCaptureOrientation(
+              cameraId,
+              DeviceOrientation.portraitUp,
+            ),
+            throwsA(
+              isA<PlatformException>().having(
+                (e) => e.code,
+                'code',
+                CameraErrorCode.orientationNotSupported.toString(),
+              ),
+            ),
+          );
+        });
+
+        testWidgets('when lock throws DomException', (tester) async {
+          final exception = FakeDomException(DomException.NOT_ALLOWED);
+
+          when(() => screenOrientation.lock(any())).thenThrow(exception);
+
+          expect(
+            () => CameraPlatform.instance.lockCaptureOrientation(
+              cameraId,
+              DeviceOrientation.portraitDown,
+            ),
+            throwsA(
+              isA<PlatformException>().having(
+                (e) => e.code,
+                'code',
+                exception.name,
+              ),
+            ),
+          );
+        });
+      });
     });
 
-    testWidgets('unlockCaptureOrientation throws UnimplementedError',
-        (tester) async {
-      expect(
-        () => CameraPlatform.instance.unlockCaptureOrientation(cameraId),
-        throwsUnimplementedError,
-      );
+    group('unlockCaptureOrientation', () {
+      setUp(() {
+        when(
+          () => cameraSettings.mapDeviceOrientationToOrientationType(any()),
+        ).thenReturn(OrientationType.portraitPrimary);
+      });
+
+      testWidgets(
+          'requests full-screen mode '
+          'on documentElement', (tester) async {
+        await CameraPlatform.instance.unlockCaptureOrientation(
+          cameraId,
+        );
+
+        verify(documentElement.requestFullscreen).called(1);
+      });
+
+      testWidgets('unlocks the capture orientation', (tester) async {
+        await CameraPlatform.instance.unlockCaptureOrientation(
+          cameraId,
+        );
+
+        verify(screenOrientation.unlock).called(1);
+      });
+
+      group('throws PlatformException', () {
+        testWidgets(
+            'with orientationNotSupported error '
+            'when screen is not supported', (tester) async {
+          when(() => window.screen).thenReturn(null);
+
+          expect(
+            () => CameraPlatform.instance.unlockCaptureOrientation(
+              cameraId,
+            ),
+            throwsA(
+              isA<PlatformException>().having(
+                (e) => e.code,
+                'code',
+                CameraErrorCode.orientationNotSupported.toString(),
+              ),
+            ),
+          );
+        });
+
+        testWidgets(
+            'with orientationNotSupported error '
+            'when screen orientation is not supported', (tester) async {
+          when(() => screen.orientation).thenReturn(null);
+
+          expect(
+            () => CameraPlatform.instance.unlockCaptureOrientation(
+              cameraId,
+            ),
+            throwsA(
+              isA<PlatformException>().having(
+                (e) => e.code,
+                'code',
+                CameraErrorCode.orientationNotSupported.toString(),
+              ),
+            ),
+          );
+        });
+
+        testWidgets(
+            'with orientationNotSupported error '
+            'when documentElement is not available', (tester) async {
+          when(() => document.documentElement).thenReturn(null);
+
+          expect(
+            () => CameraPlatform.instance.unlockCaptureOrientation(
+              cameraId,
+            ),
+            throwsA(
+              isA<PlatformException>().having(
+                (e) => e.code,
+                'code',
+                CameraErrorCode.orientationNotSupported.toString(),
+              ),
+            ),
+          );
+        });
+
+        testWidgets('when unlock throws DomException', (tester) async {
+          final exception = FakeDomException(DomException.NOT_ALLOWED);
+
+          when(screenOrientation.unlock).thenThrow(exception);
+
+          expect(
+            () => CameraPlatform.instance.unlockCaptureOrientation(
+              cameraId,
+            ),
+            throwsA(
+              isA<PlatformException>().having(
+                (e) => e.code,
+                'code',
+                exception.name,
+              ),
+            ),
+          );
+        });
+      });
     });
 
     group('takePicture', () {

--- a/packages/camera/camera_web/example/integration_test/helpers/mocks.dart
+++ b/packages/camera/camera_web/example/integration_test/helpers/mocks.dart
@@ -14,6 +14,14 @@ import 'package:mocktail/mocktail.dart';
 
 class MockWindow extends Mock implements Window {}
 
+class MockScreen extends Mock implements Screen {}
+
+class MockScreenOrientation extends Mock implements ScreenOrientation {}
+
+class MockDocument extends Mock implements Document {}
+
+class MockElement extends Mock implements Element {}
+
 class MockNavigator extends Mock implements Navigator {}
 
 class MockMediaDevices extends Mock implements MediaDevices {}

--- a/packages/camera/camera_web/lib/src/camera_settings.dart
+++ b/packages/camera/camera_web/lib/src/camera_settings.dart
@@ -230,4 +230,38 @@ class CameraSettings {
         return Size(320, 240);
     }
   }
+
+  /// Maps the given [deviceOrientation] to [OrientationType].
+  String mapDeviceOrientationToOrientationType(
+    DeviceOrientation deviceOrientation,
+  ) {
+    switch (deviceOrientation) {
+      case DeviceOrientation.portraitUp:
+        return OrientationType.portraitPrimary;
+      case DeviceOrientation.landscapeLeft:
+        return OrientationType.landscapePrimary;
+      case DeviceOrientation.portraitDown:
+        return OrientationType.portraitSecondary;
+      case DeviceOrientation.landscapeRight:
+        return OrientationType.landscapeSecondary;
+    }
+  }
+
+  /// Maps the given [orientationType] to [DeviceOrientation].
+  DeviceOrientation mapOrientationTypeToDeviceOrientation(
+    String orientationType,
+  ) {
+    switch (orientationType) {
+      case OrientationType.portraitPrimary:
+        return DeviceOrientation.portraitUp;
+      case OrientationType.landscapePrimary:
+        return DeviceOrientation.landscapeLeft;
+      case OrientationType.portraitSecondary:
+        return DeviceOrientation.portraitDown;
+      case OrientationType.landscapeSecondary:
+        return DeviceOrientation.landscapeRight;
+      default:
+        return DeviceOrientation.portraitUp;
+    }
+  }
 }

--- a/packages/camera/camera_web/lib/src/camera_web.dart
+++ b/packages/camera/camera_web/lib/src/camera_web.dart
@@ -332,9 +332,28 @@ class CameraPlugin extends CameraPlatform {
   @override
   Future<void> lockCaptureOrientation(
     int cameraId,
-    DeviceOrientation orientation,
-  ) {
-    throw UnimplementedError('lockCaptureOrientation() is not implemented.');
+    DeviceOrientation deviceOrientation,
+  ) async {
+    try {
+      final orientation = window?.screen?.orientation;
+      final documentElement = window?.document.documentElement;
+
+      if (orientation != null && documentElement != null) {
+        final orientationType = _cameraSettings
+            .mapDeviceOrientationToOrientationType(deviceOrientation);
+
+        // Full-screen mode is required to modify the device orientation.
+        documentElement.requestFullscreen();
+        await orientation.lock(orientationType.toString());
+      } else {
+        throw PlatformException(
+          code: CameraErrorCode.orientationNotSupported.toString(),
+          message: 'Orientation is not supported in the current browser.',
+        );
+      }
+    } on html.DomException catch (e) {
+      throw PlatformException(code: e.name, message: e.message);
+    }
   }
 
   @override

--- a/packages/camera/camera_web/lib/src/camera_web.dart
+++ b/packages/camera/camera_web/lib/src/camera_web.dart
@@ -357,8 +357,24 @@ class CameraPlugin extends CameraPlatform {
   }
 
   @override
-  Future<void> unlockCaptureOrientation(int cameraId) {
-    throw UnimplementedError('unlockCaptureOrientation() is not implemented.');
+  Future<void> unlockCaptureOrientation(int cameraId) async {
+    try {
+      final orientation = window?.screen?.orientation;
+      final documentElement = window?.document.documentElement;
+
+      if (orientation != null && documentElement != null) {
+        // Full-screen mode is required to modify the device orientation.
+        documentElement.requestFullscreen();
+        orientation.unlock();
+      } else {
+        throw PlatformException(
+          code: CameraErrorCode.orientationNotSupported.toString(),
+          message: 'Orientation is not supported in the current browser.',
+        );
+      }
+    } on html.DomException catch (e) {
+      throw PlatformException(code: e.name, message: e.message);
+    }
   }
 
   @override

--- a/packages/camera/camera_web/lib/src/camera_web.dart
+++ b/packages/camera/camera_web/lib/src/camera_web.dart
@@ -324,9 +324,19 @@ class CameraPlugin extends CameraPlatform {
 
   @override
   Stream<DeviceOrientationChangedEvent> onDeviceOrientationChanged() {
-    throw UnimplementedError(
-      'onDeviceOrientationChanged() is not implemented.',
-    );
+    final orientation = window?.screen?.orientation;
+
+    if (orientation != null) {
+      return orientation.onChange.map(
+        (html.Event _) {
+          final deviceOrientation = _cameraSettings
+              .mapOrientationTypeToDeviceOrientation(orientation.type!);
+          return DeviceOrientationChangedEvent(deviceOrientation);
+        },
+      );
+    } else {
+      return const Stream.empty();
+    }
   }
 
   @override

--- a/packages/camera/camera_web/lib/src/camera_web.dart
+++ b/packages/camera/camera_web/lib/src/camera_web.dart
@@ -352,7 +352,8 @@ class CameraPlugin extends CameraPlatform {
         final orientationType = _cameraSettings
             .mapDeviceOrientationToOrientationType(deviceOrientation);
 
-        // Full-screen mode is required to modify the device orientation.
+        // Full-screen mode may be required to modify the device orientation.
+        // See: https://w3c.github.io/screen-orientation/#interaction-with-fullscreen-api
         documentElement.requestFullscreen();
         await orientation.lock(orientationType.toString());
       } else {
@@ -373,7 +374,8 @@ class CameraPlugin extends CameraPlatform {
       final documentElement = window?.document.documentElement;
 
       if (orientation != null && documentElement != null) {
-        // Full-screen mode is required to modify the device orientation.
+        // Full-screen mode may be required to modify the device orientation.
+        // See: https://w3c.github.io/screen-orientation/#interaction-with-fullscreen-api
         documentElement.requestFullscreen();
         orientation.unlock();
       } else {

--- a/packages/camera/camera_web/lib/src/types/camera_error_code.dart
+++ b/packages/camera/camera_web/lib/src/types/camera_error_code.dart
@@ -48,6 +48,10 @@ class CameraErrorCode {
   static const CameraErrorCode missingMetadata =
       CameraErrorCode._('cameraMissingMetadata');
 
+  /// The camera orientation is not supported.
+  static const CameraErrorCode orientationNotSupported =
+      CameraErrorCode._('orientationNotSupported');
+
   /// An unknown camera error.
   static const CameraErrorCode unknown = CameraErrorCode._('cameraUnknown');
 

--- a/packages/camera/camera_web/lib/src/types/orientation_type.dart
+++ b/packages/camera/camera_web/lib/src/types/orientation_type.dart
@@ -1,0 +1,26 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/services.dart';
+
+/// A screen orientation type.
+///
+/// See: https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation/type
+abstract class OrientationType {
+  /// The primary portrait mode orientation.
+  /// Corresponds to [DeviceOrientation.portraitUp].
+  static const String portraitPrimary = 'portrait-primary';
+
+  /// The secondary portrait mode orientation.
+  /// Corresponds to [DeviceOrientation.portraitSecondary].
+  static const String portraitSecondary = 'portrait-secondary';
+
+  /// The primary landscape mode orientation.
+  /// Corresponds to [DeviceOrientation.landscapeLeft].
+  static const String landscapePrimary = 'landscape-primary';
+
+  /// The secondary landscape mode orientation.
+  /// Corresponds to [DeviceOrientation.landscapeRight].
+  static const String landscapeSecondary = 'landscape-secondary';
+}

--- a/packages/camera/camera_web/lib/src/types/types.dart
+++ b/packages/camera/camera_web/lib/src/types/types.dart
@@ -1,9 +1,9 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-
 export 'camera_error_code.dart';
 export 'camera_metadata.dart';
 export 'camera_options.dart';
 export 'camera_web_exception.dart';
 export 'media_device_kind.dart';
+export 'orientation_type.dart';

--- a/packages/camera/camera_web/test/types/camera_error_code_test.dart
+++ b/packages/camera/camera_web/test/types/camera_error_code_test.dart
@@ -75,6 +75,13 @@ void main() {
         );
       });
 
+      test('orientationNotSupported', () {
+        expect(
+          CameraErrorCode.orientationNotSupported.toString(),
+          equals('orientationNotSupported'),
+        );
+      });
+
       test('unknown', () {
         expect(
           CameraErrorCode.unknown.toString(),


### PR DESCRIPTION
Adds support for device orientation to the web camera platform.

- Added `OrientationType` representing a screen orientation type of the browser ([`ScreenOrientation.type`](https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation/type)).
- Added `lockCaptureOrientation` implementation.
  - Requests the full-screen mode as it may be required to modify the device orientation ([Interaction with Fullscreen API](https://w3c.github.io/screen-orientation/#interaction-with-fullscreen-api)).
  - Locks the orientation to the given device orientation with [`ScreenOrientation.lock`](https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation/lock).
  - Throws a `PlatformException` when the screen orientation API is not supported.
- Added `unlockCaptureOrientation` implementation.
  - Requests the full-screen mode as it may be required to modify the device orientation ([Interaction with Fullscreen API](https://w3c.github.io/screen-orientation/#interaction-with-fullscreen-api)).
  - Unlocks the orientation with [`ScreenOrientation.unlock`](https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation/unlock).
  - Throws a `PlatformException` when the screen orientation API is not supported.
- Added `onDeviceOrientationChanged` implementation.
  - Emits an event on [`ScreenOrientation.onchange`](https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation/onchange).
  - Emits an empty stream if the screen orientation API is not supported.

Part of https://github.com/flutter/flutter/issues/45297.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code