### PR TITLE
[image_picker] Fix README example

### DIFF
--- a/packages/image_picker/image_picker/CHANGELOG.md
+++ b/packages/image_picker/image_picker/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.8.3
+## 0.8.3+1
 
 * Fixed README Example.
 

--- a/packages/image_picker/image_picker/CHANGELOG.md
+++ b/packages/image_picker/image_picker/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.8.3
 
+* Fixed README Example.
+
+## 0.8.3
+
 * Move `ImagePickerFromLimitedGalleryUITests` to `RunnerUITests` target.
 * Improved handling of bad image data when applying metadata changes on iOS.
 

--- a/packages/image_picker/image_picker/README.md
+++ b/packages/image_picker/image_picker/README.md
@@ -47,9 +47,7 @@ import 'package:image_picker/image_picker.dart';
     // Capture a video
     final XFile? photo = await _picker.pickVideo(source: ImageSource.camera);
     // Pick multiple images
-    final List<XFile>? images = await _picker.pickMultiImage(source: ImageSource.gallery);
-    // Pick multiple photos
-    final List<XFile>? photos = await _picker.pickMultiImage(source: ImageSource.camera);
+    final List<XFile>? images = await _picker.pickMultiImage();
     ...
 ```
 

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for selecting images from the Android and iOS image
   library, and taking new pictures with the camera.
 repository: https://github.com/flutter/plugins/tree/master/packages/image_picker/image_picker
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 0.8.3
+version: 0.8.3+1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/87634
In the API Docs for [pickMultiImage](https://pub.dev/documentation/image_picker/latest/image_picker/ImagePicker/pickMultiImage.html) or [code sample](https://github.com/flutter/plugins/blob/60100908443fffee28df82735a9c4019cf549227/packages/image_picker/image_picker/example/lib/main.dart#L94), there is no `source` parameter in pickMultiImage

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
