### PR TITLE
[camera_web] Add support for a flash mode

### DIFF
--- a/packages/camera/camera_web/example/integration_test/camera_test.dart
+++ b/packages/camera/camera_web/example/integration_test/camera_test.dart
@@ -263,6 +263,10 @@ void main() {
 
           when(() => videoTracks.first.applyConstraints(any()))
               .thenAnswer((_) async => {});
+
+          when(videoTracks.first.getCapabilities).thenReturn({
+            'torch': true,
+          });
         });
 
         testWidgets('if the flash mode is auto', (tester) async {
@@ -390,10 +394,16 @@ void main() {
 
         when(() => videoTracks.first.applyConstraints(any()))
             .thenAnswer((_) async => {});
+
+        when(videoTracks.first.getCapabilities).thenReturn({});
       });
 
       testWidgets('sets the camera flash mode', (tester) async {
         when(mediaDevices.getSupportedConstraints).thenReturn({
+          'torch': true,
+        });
+
+        when(videoTracks.first.getCapabilities).thenReturn({
           'torch': true,
         });
 
@@ -421,6 +431,10 @@ void main() {
           'torch': true,
         });
 
+        when(videoTracks.first.getCapabilities).thenReturn({
+          'torch': true,
+        });
+
         final camera = Camera(
           textureId: textureId,
           cameraSettings: cameraSettings,
@@ -445,6 +459,10 @@ void main() {
           'disables the torch mode '
           'if the flash mode is not torch', (tester) async {
         when(mediaDevices.getSupportedConstraints).thenReturn({
+          'torch': true,
+        });
+
+        when(videoTracks.first.getCapabilities).thenReturn({
           'torch': true,
         });
 
@@ -501,8 +519,50 @@ void main() {
 
         testWidgets(
             'with torchModeNotSupported error '
-            'when the torch mode is not supported', (tester) async {
+            'when the torch mode is not supported '
+            'in the browser', (tester) async {
           when(mediaDevices.getSupportedConstraints).thenReturn({
+            'torch': false,
+          });
+
+          when(videoTracks.first.getCapabilities).thenReturn({
+            'torch': true,
+          });
+
+          final camera = Camera(
+            textureId: textureId,
+            cameraSettings: cameraSettings,
+          )
+            ..window = window
+            ..stream = videoStream;
+
+          expect(
+            () => camera.setFlashMode(FlashMode.always),
+            throwsA(
+              isA<CameraWebException>()
+                  .having(
+                    (e) => e.cameraId,
+                    'cameraId',
+                    textureId,
+                  )
+                  .having(
+                    (e) => e.code,
+                    'code',
+                    CameraErrorCode.torchModeNotSupported,
+                  ),
+            ),
+          );
+        });
+
+        testWidgets(
+            'with torchModeNotSupported error '
+            'when the torch mode is not supported '
+            'by the camera', (tester) async {
+          when(mediaDevices.getSupportedConstraints).thenReturn({
+            'torch': true,
+          });
+
+          when(videoTracks.first.getCapabilities).thenReturn({
             'torch': false,
           });
 
@@ -535,6 +595,10 @@ void main() {
             'with notStarted error '
             'when the camera stream has not been initialized', (tester) async {
           when(mediaDevices.getSupportedConstraints).thenReturn({
+            'torch': true,
+          });
+
+          when(videoTracks.first.getCapabilities).thenReturn({
             'torch': true,
           });
 

--- a/packages/camera/camera_web/example/integration_test/camera_test.dart
+++ b/packages/camera/camera_web/example/integration_test/camera_test.dart
@@ -5,9 +5,11 @@
 import 'dart:html';
 import 'dart:ui';
 
+import 'package:camera_platform_interface/camera_platform_interface.dart';
 import 'package:camera_web/src/camera.dart';
 import 'package:camera_web/src/camera_settings.dart';
 import 'package:camera_web/src/types/types.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -18,10 +20,23 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   group('Camera', () {
+    const textureId = 1;
+
+    late Window window;
+    late Navigator navigator;
+    late MediaDevices mediaDevices;
+
     late MediaStream mediaStream;
     late CameraSettings cameraSettings;
 
     setUp(() {
+      window = MockWindow();
+      navigator = MockNavigator();
+      mediaDevices = MockMediaDevices();
+
+      when(() => window.navigator).thenReturn(navigator);
+      when(() => navigator.mediaDevices).thenReturn(mediaDevices);
+
       cameraSettings = MockCameraSettings();
 
       final videoElement = getVideoElementWithBlankStream(Size(10, 10));
@@ -51,7 +66,7 @@ void main() {
         );
 
         final camera = Camera(
-          textureId: 1,
+          textureId: textureId,
           options: options,
           cameraSettings: cameraSettings,
         );
@@ -61,7 +76,7 @@ void main() {
         verify(
           () => cameraSettings.getMediaStreamForOptions(
             options,
-            cameraId: 1,
+            cameraId: textureId,
           ),
         ).called(1);
       });
@@ -72,7 +87,7 @@ void main() {
         const audioConstraints = AudioConstraints(enabled: true);
 
         final camera = Camera(
-          textureId: 1,
+          textureId: textureId,
           options: CameraOptions(
             audio: audioConstraints,
           ),
@@ -100,7 +115,7 @@ void main() {
           'creates a wrapping div element '
           'with correct properties', (tester) async {
         final camera = Camera(
-          textureId: 1,
+          textureId: textureId,
           cameraSettings: cameraSettings,
         );
 
@@ -109,6 +124,17 @@ void main() {
         expect(camera.divElement, isNotNull);
         expect(camera.divElement.style.objectFit, equals('cover'));
         expect(camera.divElement.children, contains(camera.videoElement));
+      });
+
+      testWidgets('initializes the camera stream', (tester) async {
+        final camera = Camera(
+          textureId: textureId,
+          cameraSettings: cameraSettings,
+        );
+
+        await camera.initialize();
+
+        expect(camera.stream, mediaStream);
       });
 
       testWidgets(
@@ -121,7 +147,7 @@ void main() {
             cameraId: any(named: 'cameraId'))).thenThrow(exception);
 
         final camera = Camera(
-          textureId: 1,
+          textureId: textureId,
           cameraSettings: cameraSettings,
         );
 
@@ -137,7 +163,7 @@ void main() {
         var startedPlaying = false;
 
         final camera = Camera(
-          textureId: 1,
+          textureId: textureId,
           cameraSettings: cameraSettings,
         );
 
@@ -154,9 +180,8 @@ void main() {
       });
 
       testWidgets(
-          'assigns a media stream '
+          'initializes the camera stream '
           'from CameraSettings.getMediaStreamForOptions '
-          'to the video element\'s source '
           'if it does not exist', (tester) async {
         final options = CameraOptions(
           video: VideoConstraints(
@@ -165,7 +190,7 @@ void main() {
         );
 
         final camera = Camera(
-          textureId: 1,
+          textureId: textureId,
           options: options,
           cameraSettings: cameraSettings,
         );
@@ -182,18 +207,19 @@ void main() {
         verify(
           () => cameraSettings.getMediaStreamForOptions(
             options,
-            cameraId: 1,
+            cameraId: textureId,
           ),
         ).called(2);
 
         expect(camera.videoElement.srcObject, mediaStream);
+        expect(camera.stream, mediaStream);
       });
     });
 
     group('stop', () {
-      testWidgets('resets the video element\'s source', (tester) async {
+      testWidgets('resets the camera stream', (tester) async {
         final camera = Camera(
-          textureId: 1,
+          textureId: textureId,
           cameraSettings: cameraSettings,
         );
 
@@ -203,13 +229,14 @@ void main() {
         camera.stop();
 
         expect(camera.videoElement.srcObject, isNull);
+        expect(camera.stream, isNull);
       });
     });
 
     group('takePicture', () {
       testWidgets('returns a captured picture', (tester) async {
         final camera = Camera(
-          textureId: 1,
+          textureId: textureId,
           cameraSettings: cameraSettings,
         );
 
@@ -219,6 +246,95 @@ void main() {
         final pictureFile = await camera.takePicture();
 
         expect(pictureFile, isNotNull);
+      });
+
+      group(
+          'enables the torch mode '
+          'when taking a picture', () {
+        late List<MediaStreamTrack> videoTracks;
+        late MediaStream videoStream;
+        late VideoElement videoElement;
+
+        setUp(() {
+          videoTracks = [MockMediaStreamTrack(), MockMediaStreamTrack()];
+          videoStream = FakeMediaStream(videoTracks);
+
+          videoElement = getVideoElementWithBlankStream(Size(100, 100))
+            ..muted = true;
+
+          when(() => videoTracks.first.applyConstraints(any()))
+              .thenAnswer((_) async => {});
+        });
+
+        testWidgets('if the flash mode is auto', (tester) async {
+          final camera = Camera(
+            textureId: textureId,
+            cameraSettings: cameraSettings,
+          )
+            ..window = window
+            ..stream = videoStream
+            ..videoElement = videoElement
+            ..flashMode = FlashMode.auto;
+
+          await camera.play();
+
+          final _ = await camera.takePicture();
+
+          verify(
+            () => videoTracks.first.applyConstraints({
+              "advanced": [
+                {
+                  "torch": true,
+                }
+              ]
+            }),
+          ).called(1);
+
+          verify(
+            () => videoTracks.first.applyConstraints({
+              "advanced": [
+                {
+                  "torch": false,
+                }
+              ]
+            }),
+          ).called(1);
+        });
+
+        testWidgets('if the flash mode is always', (tester) async {
+          final camera = Camera(
+            textureId: textureId,
+            cameraSettings: cameraSettings,
+          )
+            ..window = window
+            ..stream = videoStream
+            ..videoElement = videoElement
+            ..flashMode = FlashMode.always;
+
+          await camera.play();
+
+          final _ = await camera.takePicture();
+
+          verify(
+            () => videoTracks.first.applyConstraints({
+              "advanced": [
+                {
+                  "torch": true,
+                }
+              ]
+            }),
+          ).called(1);
+
+          verify(
+            () => videoTracks.first.applyConstraints({
+              "advanced": [
+                {
+                  "torch": false,
+                }
+              ]
+            }),
+          ).called(1);
+        });
       });
     });
 
@@ -232,7 +348,7 @@ void main() {
         mediaStream = videoElement.captureStream();
 
         final camera = Camera(
-          textureId: 1,
+          textureId: textureId,
           cameraSettings: cameraSettings,
         );
 
@@ -252,7 +368,7 @@ void main() {
         mediaStream = videoElement.captureStream();
 
         final camera = Camera(
-          textureId: 1,
+          textureId: textureId,
           cameraSettings: cameraSettings,
         );
 
@@ -265,10 +381,191 @@ void main() {
       });
     });
 
+    group('setFlashMode', () {
+      late List<MediaStreamTrack> videoTracks;
+      late MediaStream videoStream;
+
+      setUp(() {
+        videoTracks = [MockMediaStreamTrack(), MockMediaStreamTrack()];
+        videoStream = FakeMediaStream(videoTracks);
+
+        when(() => videoTracks.first.applyConstraints(any()))
+            .thenAnswer((_) async => {});
+      });
+
+      testWidgets('sets the camera flash mode', (tester) async {
+        when(mediaDevices.getSupportedConstraints).thenReturn({
+          'torch': true,
+        });
+
+        final camera = Camera(
+          textureId: textureId,
+          cameraSettings: cameraSettings,
+        )
+          ..window = window
+          ..stream = videoStream;
+
+        const flashMode = FlashMode.always;
+
+        camera.setFlashMode(flashMode);
+
+        expect(
+          camera.flashMode,
+          equals(flashMode),
+        );
+      });
+
+      testWidgets(
+          'enables the torch mode '
+          'if the flash mode is torch', (tester) async {
+        when(mediaDevices.getSupportedConstraints).thenReturn({
+          'torch': true,
+        });
+
+        final camera = Camera(
+          textureId: textureId,
+          cameraSettings: cameraSettings,
+        )
+          ..window = window
+          ..stream = videoStream;
+
+        camera.setFlashMode(FlashMode.torch);
+
+        verify(
+          () => videoTracks.first.applyConstraints({
+            "advanced": [
+              {
+                "torch": true,
+              }
+            ]
+          }),
+        ).called(1);
+      });
+
+      testWidgets(
+          'disables the torch mode '
+          'if the flash mode is not torch', (tester) async {
+        when(mediaDevices.getSupportedConstraints).thenReturn({
+          'torch': true,
+        });
+
+        final camera = Camera(
+          textureId: textureId,
+          cameraSettings: cameraSettings,
+        )
+          ..window = window
+          ..stream = videoStream;
+
+        camera.setFlashMode(FlashMode.auto);
+
+        verify(
+          () => videoTracks.first.applyConstraints({
+            "advanced": [
+              {
+                "torch": false,
+              }
+            ]
+          }),
+        ).called(1);
+      });
+
+      group('throws CameraWebException', () {
+        testWidgets(
+            'with torchModeNotSupported error '
+            'when there are no media devices', (tester) async {
+          when(() => navigator.mediaDevices).thenReturn(null);
+
+          final camera = Camera(
+            textureId: textureId,
+            cameraSettings: cameraSettings,
+          )
+            ..window = window
+            ..stream = videoStream;
+
+          expect(
+            () => camera.setFlashMode(FlashMode.always),
+            throwsA(
+              isA<CameraWebException>()
+                  .having(
+                    (e) => e.cameraId,
+                    'cameraId',
+                    textureId,
+                  )
+                  .having(
+                    (e) => e.code,
+                    'code',
+                    CameraErrorCode.torchModeNotSupported,
+                  ),
+            ),
+          );
+        });
+
+        testWidgets(
+            'with torchModeNotSupported error '
+            'when the torch mode is not supported', (tester) async {
+          when(mediaDevices.getSupportedConstraints).thenReturn({
+            'torch': false,
+          });
+
+          final camera = Camera(
+            textureId: textureId,
+            cameraSettings: cameraSettings,
+          )
+            ..window = window
+            ..stream = videoStream;
+
+          expect(
+            () => camera.setFlashMode(FlashMode.always),
+            throwsA(
+              isA<CameraWebException>()
+                  .having(
+                    (e) => e.cameraId,
+                    'cameraId',
+                    textureId,
+                  )
+                  .having(
+                    (e) => e.code,
+                    'code',
+                    CameraErrorCode.torchModeNotSupported,
+                  ),
+            ),
+          );
+        });
+
+        testWidgets(
+            'with notStarted error '
+            'when the camera stream has not been initialized', (tester) async {
+          when(mediaDevices.getSupportedConstraints).thenReturn({
+            'torch': true,
+          });
+
+          final camera = Camera(
+            textureId: textureId,
+            cameraSettings: cameraSettings,
+          )..window = window;
+
+          expect(
+            () => camera.setFlashMode(FlashMode.always),
+            throwsA(
+              isA<CameraWebException>()
+                  .having(
+                    (e) => e.cameraId,
+                    'cameraId',
+                    textureId,
+                  )
+                  .having(
+                    (e) => e.code,
+                    'code',
+                    CameraErrorCode.notStarted,
+                  ),
+            ),
+          );
+        });
+      });
+    });
+
     group('getViewType', () {
       testWidgets('returns a correct view type', (tester) async {
-        const textureId = 1;
-
         final camera = Camera(
           textureId: textureId,
           cameraSettings: cameraSettings,
@@ -286,7 +583,7 @@ void main() {
     group('dispose', () {
       testWidgets('resets the video element\'s source', (tester) async {
         final camera = Camera(
-          textureId: 1,
+          textureId: textureId,
           cameraSettings: cameraSettings,
         );
 

--- a/packages/camera/camera_web/example/integration_test/camera_test.dart
+++ b/packages/camera/camera_web/example/integration_test/camera_test.dart
@@ -9,7 +9,6 @@ import 'package:camera_platform_interface/camera_platform_interface.dart';
 import 'package:camera_web/src/camera.dart';
 import 'package:camera_web/src/camera_settings.dart';
 import 'package:camera_web/src/types/types.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:mocktail/mocktail.dart';

--- a/packages/camera/camera_web/lib/src/camera.dart
+++ b/packages/camera/camera_web/lib/src/camera.dart
@@ -8,6 +8,7 @@ import 'dart:ui';
 import 'package:camera_platform_interface/camera_platform_interface.dart';
 import 'package:camera_web/src/camera_settings.dart';
 import 'package:camera_web/src/types/types.dart';
+import 'package:flutter/foundation.dart';
 
 import 'shims/dart_ui.dart' as ui;
 
@@ -39,6 +40,10 @@ class Camera {
     this.options = const CameraOptions(),
   }) : _cameraSettings = cameraSettings;
 
+  // A torch mode constraint name.
+  // See: https://w3c.github.io/mediacapture-image/#dom-mediatracksupportedconstraints-torch
+  static const _torchModeKey = "torch";
+
   /// The texture id used to register the camera view.
   final int textureId;
 
@@ -47,20 +52,32 @@ class Camera {
 
   /// The video element that displays the camera stream.
   /// Initialized in [initialize].
-  late html.VideoElement videoElement;
+  late final html.VideoElement videoElement;
 
   /// The wrapping element for the [videoElement] to avoid overriding
   /// the custom styles applied in [_applyDefaultVideoStyles].
   /// Initialized in [initialize].
-  late html.DivElement divElement;
+  late final html.DivElement divElement;
+
+  /// The camera stream displayed in the [videoElement].
+  /// Initialized in [initialize] and [play], reset in [stop].
+  html.MediaStream? stream;
+
+  /// The camera flash mode.
+  @visibleForTesting
+  FlashMode? flashMode;
 
   /// The camera settings used to get the media stream for the camera.
   final CameraSettings _cameraSettings;
 
+  /// The current browser window used to access media devices.
+  @visibleForTesting
+  html.Window? window = html.window;
+
   /// Initializes the camera stream displayed in the [videoElement].
   /// Registers the camera view with [textureId] under [_getViewType] type.
   Future<void> initialize() async {
-    final stream = await _cameraSettings.getMediaStreamForOptions(
+    stream = await _cameraSettings.getMediaStreamForOptions(
       options,
       cameraId: textureId,
     );
@@ -89,7 +106,7 @@ class Camera {
   /// Initializes the camera source if the camera was previously stopped.
   Future<void> play() async {
     if (videoElement.srcObject == null) {
-      final stream = await _cameraSettings.getMediaStreamForOptions(
+      stream = await _cameraSettings.getMediaStreamForOptions(
         options,
         cameraId: textureId,
       );
@@ -107,18 +124,36 @@ class Camera {
       }
     }
     videoElement.srcObject = null;
+    stream = null;
   }
 
   /// Captures a picture and returns the saved file in a JPEG format.
+  ///
+  /// Enables the device flash when taking a picture if the flash mode
+  /// is either [FlashMode.auto] or [FlashMode.always].
   Future<XFile> takePicture() async {
+    final shouldEnableTorchMode =
+        flashMode == FlashMode.auto || flashMode == FlashMode.always;
+
+    if (shouldEnableTorchMode) {
+      _setTorchMode(enabled: true);
+    }
+
     final videoWidth = videoElement.videoWidth;
     final videoHeight = videoElement.videoHeight;
     final canvas = html.CanvasElement(width: videoWidth, height: videoHeight);
+
     canvas.context2D
       ..translate(videoWidth, 0)
       ..scale(-1, 1)
       ..drawImageScaled(videoElement, 0, 0, videoWidth, videoHeight);
+
     final blob = await canvas.toBlob('image/jpeg');
+
+    if (shouldEnableTorchMode) {
+      _setTorchMode(enabled: false);
+    }
+
     return XFile(html.Url.createObjectUrl(blob));
   }
 
@@ -143,6 +178,50 @@ class Camera {
       return Size(width, height);
     } else {
       return Size.zero;
+    }
+  }
+
+  /// Sets the camera flash mode to [mode].
+  void setFlashMode(FlashMode mode) {
+    final mediaDevices = window?.navigator.mediaDevices;
+    final supportedConstraints = mediaDevices?.getSupportedConstraints();
+    final torchModeSupported = supportedConstraints?[_torchModeKey] ?? false;
+
+    if (!torchModeSupported) {
+      throw CameraWebException(
+        textureId,
+        CameraErrorCode.torchModeNotSupported,
+        'Torch mode is not supported in the current browser.',
+      );
+    }
+
+    // Save the updated flash mode to be used later when taking a picture.
+    flashMode = mode;
+
+    // Enable the torch mode only if the flash mode is torch.
+    _setTorchMode(enabled: mode == FlashMode.torch);
+  }
+
+  /// Sets the camera torch mode constraint to [enabled].
+  void _setTorchMode({required bool enabled}) {
+    final videoTracks = stream?.getVideoTracks() ?? [];
+
+    if (videoTracks.isNotEmpty) {
+      final defaultVideoTrack = videoTracks.first;
+
+      defaultVideoTrack.applyConstraints({
+        "advanced": [
+          {
+            _torchModeKey: enabled,
+          }
+        ]
+      });
+    } else {
+      throw CameraWebException(
+        textureId,
+        CameraErrorCode.notStarted,
+        'The camera has not been initialized or started.',
+      );
     }
   }
 

--- a/packages/camera/camera_web/lib/src/camera.dart
+++ b/packages/camera/camera_web/lib/src/camera.dart
@@ -191,7 +191,7 @@ class Camera {
       throw CameraWebException(
         textureId,
         CameraErrorCode.torchModeNotSupported,
-        'Torch mode is not supported in the current browser.',
+        'The torch mode is not supported in the current browser.',
       );
     }
 
@@ -209,13 +209,24 @@ class Camera {
     if (videoTracks.isNotEmpty) {
       final defaultVideoTrack = videoTracks.first;
 
-      defaultVideoTrack.applyConstraints({
-        "advanced": [
-          {
-            _torchModeKey: enabled,
-          }
-        ]
-      });
+      final bool canEnableTorchMode =
+          defaultVideoTrack.getCapabilities()[_torchModeKey] ?? false;
+
+      if (canEnableTorchMode) {
+        defaultVideoTrack.applyConstraints({
+          "advanced": [
+            {
+              _torchModeKey: enabled,
+            }
+          ]
+        });
+      } else {
+        throw CameraWebException(
+          textureId,
+          CameraErrorCode.torchModeNotSupported,
+          'The torch mode is not supported by the current camera.',
+        );
+      }
     } else {
       throw CameraWebException(
         textureId,

--- a/packages/camera/camera_web/lib/src/camera_web.dart
+++ b/packages/camera/camera_web/lib/src/camera_web.dart
@@ -429,8 +429,15 @@ class CameraPlugin extends CameraPlatform {
   }
 
   @override
-  Future<void> setFlashMode(int cameraId, FlashMode mode) {
-    throw UnimplementedError('setFlashMode() is not implemented.');
+  Future<void> setFlashMode(int cameraId, FlashMode mode) async {
+    try {
+      getCamera(cameraId).setFlashMode(mode);
+    } on html.DomException catch (e) {
+      throw PlatformException(code: e.name, message: e.message);
+    } on CameraWebException catch (e) {
+      _addCameraErrorEvent(e);
+      throw PlatformException(code: e.code.toString(), message: e.description);
+    }
   }
 
   @override

--- a/packages/camera/camera_web/lib/src/types/camera_error_code.dart
+++ b/packages/camera/camera_web/lib/src/types/camera_error_code.dart
@@ -52,6 +52,14 @@ class CameraErrorCode {
   static const CameraErrorCode orientationNotSupported =
       CameraErrorCode._('orientationNotSupported');
 
+  /// The camera torch mode is not supported.
+  static const CameraErrorCode torchModeNotSupported =
+      CameraErrorCode._('torchModeNotSupported');
+
+  /// The camera has not been initialized or started.
+  static const CameraErrorCode notStarted =
+      CameraErrorCode._('cameraNotStarted');
+
   /// An unknown camera error.
   static const CameraErrorCode unknown = CameraErrorCode._('cameraUnknown');
 

--- a/packages/camera/camera_web/test/types/camera_error_code_test.dart
+++ b/packages/camera/camera_web/test/types/camera_error_code_test.dart
@@ -82,6 +82,20 @@ void main() {
         );
       });
 
+      test('torchModeNotSupported', () {
+        expect(
+          CameraErrorCode.torchModeNotSupported.toString(),
+          equals('torchModeNotSupported'),
+        );
+      });
+
+      test('notStarted', () {
+        expect(
+          CameraErrorCode.notStarted.toString(),
+          equals('notStarted'),
+        );
+      });
+
       test('unknown', () {
         expect(
           CameraErrorCode.unknown.toString(),

--- a/packages/camera/camera_web/test/types/camera_error_code_test.dart
+++ b/packages/camera/camera_web/test/types/camera_error_code_test.dart
@@ -92,7 +92,7 @@ void main() {
       test('notStarted', () {
         expect(
           CameraErrorCode.notStarted.toString(),
-          equals('notStarted'),
+          equals('cameraNotStarted'),
         );
       });
 


### PR DESCRIPTION
Adds support for a flash mode to the web camera platform.

- Added `setFlashMode` to `Camera`.
  - Saves the flash mode in the camera.
  - Enables the torch mode video constraint if the flash mode is `torch` (otherwise disables).
  - Throws a `CameraWebException` if the torch mode is not supported in the current browser or the camera has not been initialized or started.
- The camera stream can now be accessed through the `Camera.stream` property.
- Updated `takePicture` in `Camera`.
  - Enables the torch mode video constraint when taking a picture if the flash mode is either `auto` or `always`.
- Added `setFlashMode` implementation to the camera plugin.
  - Calls `setFlashMode` on the camera with the given id.

Part of https://github.com/flutter/flutter/issues/45297.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code