### PR TITLE
[ci.yaml] Auto-generate LUCI configs

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -24,7 +24,7 @@ platform_properties:
       os: Windows
 
 targets:
-  - name: Windows Plugins
+  - name: Windows Plugins master channel
     recipe: plugins/plugins
     timeout: 30
     properties:

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -36,7 +36,6 @@ targets:
 
   - name: Windows Plugins stable channel
     recipe: plugins/plugins
-    presubmit: false
     timeout: 30
     properties:
       channel: stable

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -8,9 +8,40 @@
 enabled_branches:
   - master
 
+platform_properties:
+  windows:
+    properties:
+      caches: >-
+        [
+          {"name": "vsbuild", "path": "vsbuild"},
+          {"name": "pub_cache", "path": ".pub-cache"}
+        ]
+      dependencies: >
+        [
+          {"dependency": "certs"}
+        ]
+      device_type: none
+      os: Windows
+
 targets:
   - name: Windows Plugins
-    builder: Windows Plugins
-    postsubmit: false
+    recipe: plugins/plugins
+    timeout: 30
+    properties:
+      dependencies: >
+        [
+          {"dependency": "vs_build"}
+        ]
     scheduler: luci
 
+  - name: Windows Plugins stable channel
+    recipe: plugins/plugins
+    presubmit: false
+    timeout: 30
+    properties:
+      channel: stable
+      dependencies: >
+        [
+          {"dependency": "vs_build"}
+        ]
+    scheduler: luci


### PR DESCRIPTION
Add the information necessary to no longer require the starlark code in flutter/infra

https://github.com/flutter/flutter/issues/85803

See https://flutter-review.googlesource.com/c/infra/+/16742 for the auto-generated diff

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [X] I signed the [CLA].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [X] All existing and new tests are passing.
