### PR TITLE
[camera_web] Add support for a zoom level

### DIFF
--- a/packages/camera/camera_web/example/integration_test/camera_test.dart
+++ b/packages/camera/camera_web/example/integration_test/camera_test.dart
@@ -627,6 +627,180 @@ void main() {
       });
     });
 
+    group('zoomLevel', () {
+      group('getMaxZoomLevel', () {
+        testWidgets(
+            'returns maximum '
+            'from CameraSettings.getZoomLevelCapabilityForCamera',
+            (tester) async {
+          final camera = Camera(
+            textureId: textureId,
+            cameraSettings: cameraSettings,
+          );
+
+          final zoomLevelCapability = ZoomLevelCapability(
+            minimum: 50.0,
+            maximum: 100.0,
+            videoTrack: MockMediaStreamTrack(),
+          );
+
+          when(() => cameraSettings.getZoomLevelCapabilityForCamera(camera))
+              .thenReturn(zoomLevelCapability);
+
+          final maximumZoomLevel = camera.getMaxZoomLevel();
+
+          verify(() => cameraSettings.getZoomLevelCapabilityForCamera(camera))
+              .called(1);
+
+          expect(
+            maximumZoomLevel,
+            equals(zoomLevelCapability.maximum),
+          );
+        });
+      });
+
+      group('getMinZoomLevel', () {
+        testWidgets(
+            'returns minimum '
+            'from CameraSettings.getZoomLevelCapabilityForCamera',
+            (tester) async {
+          final camera = Camera(
+            textureId: textureId,
+            cameraSettings: cameraSettings,
+          );
+
+          final zoomLevelCapability = ZoomLevelCapability(
+            minimum: 50.0,
+            maximum: 100.0,
+            videoTrack: MockMediaStreamTrack(),
+          );
+
+          when(() => cameraSettings.getZoomLevelCapabilityForCamera(camera))
+              .thenReturn(zoomLevelCapability);
+
+          final minimumZoomLevel = camera.getMinZoomLevel();
+
+          verify(() => cameraSettings.getZoomLevelCapabilityForCamera(camera))
+              .called(1);
+
+          expect(
+            minimumZoomLevel,
+            equals(zoomLevelCapability.minimum),
+          );
+        });
+      });
+
+      group('setZoomLevel', () {
+        testWidgets(
+            'applies zoom on the video track '
+            'from CameraSettings.getZoomLevelCapabilityForCamera',
+            (tester) async {
+          final camera = Camera(
+            textureId: textureId,
+            cameraSettings: cameraSettings,
+          );
+
+          final videoTrack = MockMediaStreamTrack();
+
+          final zoomLevelCapability = ZoomLevelCapability(
+            minimum: 50.0,
+            maximum: 100.0,
+            videoTrack: videoTrack,
+          );
+
+          when(() => videoTrack.applyConstraints(any()))
+              .thenAnswer((_) async {});
+
+          when(() => cameraSettings.getZoomLevelCapabilityForCamera(camera))
+              .thenReturn(zoomLevelCapability);
+
+          const zoom = 75.0;
+
+          camera.setZoomLevel(zoom);
+
+          verify(
+            () => videoTrack.applyConstraints({
+              "advanced": [
+                {
+                  ZoomLevelCapability.constraintName: zoom,
+                }
+              ]
+            }),
+          ).called(1);
+        });
+
+        group('throws CameraWebException', () {
+          testWidgets(
+              'with zoomLevelInvalid error '
+              'when the provided zoom level is below minimum', (tester) async {
+            final camera = Camera(
+              textureId: textureId,
+              cameraSettings: cameraSettings,
+            );
+
+            final zoomLevelCapability = ZoomLevelCapability(
+              minimum: 50.0,
+              maximum: 100.0,
+              videoTrack: MockMediaStreamTrack(),
+            );
+
+            when(() => cameraSettings.getZoomLevelCapabilityForCamera(camera))
+                .thenReturn(zoomLevelCapability);
+
+            expect(
+                () => camera.setZoomLevel(45.0),
+                throwsA(
+                  isA<CameraWebException>()
+                      .having(
+                        (e) => e.cameraId,
+                        'cameraId',
+                        textureId,
+                      )
+                      .having(
+                        (e) => e.code,
+                        'code',
+                        CameraErrorCode.zoomLevelInvalid,
+                      ),
+                ));
+          });
+
+          testWidgets(
+              'with zoomLevelInvalid error '
+              'when the provided zoom level is below minimum', (tester) async {
+            final camera = Camera(
+              textureId: textureId,
+              cameraSettings: cameraSettings,
+            );
+
+            final zoomLevelCapability = ZoomLevelCapability(
+              minimum: 50.0,
+              maximum: 100.0,
+              videoTrack: MockMediaStreamTrack(),
+            );
+
+            when(() => cameraSettings.getZoomLevelCapabilityForCamera(camera))
+                .thenReturn(zoomLevelCapability);
+
+            expect(
+                () => camera.setZoomLevel(105.0),
+                throwsA(
+                  isA<CameraWebException>()
+                      .having(
+                        (e) => e.cameraId,
+                        'cameraId',
+                        textureId,
+                      )
+                      .having(
+                        (e) => e.code,
+                        'code',
+                        CameraErrorCode.zoomLevelInvalid,
+                      ),
+                ));
+          });
+        });
+      });
+    });
+
     group('getViewType', () {
       testWidgets('returns a correct view type', (tester) async {
         final camera = Camera(

--- a/packages/camera/camera_web/example/integration_test/camera_web_test.dart
+++ b/packages/camera/camera_web/example/integration_test/camera_web_test.dart
@@ -1131,28 +1131,302 @@ void main() {
       );
     });
 
-    testWidgets('getMaxZoomLevel throws UnimplementedError', (tester) async {
-      expect(
-        () => CameraPlatform.instance.getMaxZoomLevel(cameraId),
-        throwsUnimplementedError,
-      );
+    group('getMaxZoomLevel', () {
+      testWidgets('calls getMaxZoomLevel on the camera', (tester) async {
+        final camera = MockCamera();
+        const maximumZoomLevel = 100.0;
+
+        when(camera.getMaxZoomLevel).thenReturn(maximumZoomLevel);
+
+        // Save the camera in the camera plugin.
+        (CameraPlatform.instance as CameraPlugin).cameras[cameraId] = camera;
+
+        expect(
+          await CameraPlatform.instance.getMaxZoomLevel(
+            cameraId,
+          ),
+          equals(maximumZoomLevel),
+        );
+
+        verify(camera.getMaxZoomLevel).called(1);
+      });
+
+      group('throws PlatformException', () {
+        testWidgets(
+            'with notFound error '
+            'if the camera does not exist', (tester) async {
+          expect(
+            () async => await CameraPlatform.instance.getMaxZoomLevel(
+              cameraId,
+            ),
+            throwsA(
+              isA<PlatformException>().having(
+                (e) => e.code,
+                'code',
+                CameraErrorCode.notFound.toString(),
+              ),
+            ),
+          );
+        });
+
+        testWidgets('when getMaxZoomLevel throws DomException', (tester) async {
+          final camera = MockCamera();
+          final exception = FakeDomException(DomException.NOT_SUPPORTED);
+
+          when(camera.getMaxZoomLevel).thenThrow(exception);
+
+          // Save the camera in the camera plugin.
+          (CameraPlatform.instance as CameraPlugin).cameras[cameraId] = camera;
+
+          expect(
+            () async => await CameraPlatform.instance.getMaxZoomLevel(
+              cameraId,
+            ),
+            throwsA(
+              isA<PlatformException>().having(
+                (e) => e.code,
+                'code',
+                exception.name,
+              ),
+            ),
+          );
+        });
+
+        testWidgets('when getMaxZoomLevel throws CameraWebException',
+            (tester) async {
+          final camera = MockCamera();
+          final exception = CameraWebException(
+            cameraId,
+            CameraErrorCode.notStarted,
+            'description',
+          );
+
+          when(camera.getMaxZoomLevel).thenThrow(exception);
+
+          // Save the camera in the camera plugin.
+          (CameraPlatform.instance as CameraPlugin).cameras[cameraId] = camera;
+
+          expect(
+            () async => await CameraPlatform.instance.getMaxZoomLevel(
+              cameraId,
+            ),
+            throwsA(
+              isA<PlatformException>().having(
+                (e) => e.code,
+                'code',
+                exception.code.toString(),
+              ),
+            ),
+          );
+        });
+      });
     });
 
-    testWidgets('getMinZoomLevel throws UnimplementedError', (tester) async {
-      expect(
-        () => CameraPlatform.instance.getMinZoomLevel(cameraId),
-        throwsUnimplementedError,
-      );
+    group('getMinZoomLevel', () {
+      testWidgets('calls getMinZoomLevel on the camera', (tester) async {
+        final camera = MockCamera();
+        const minimumZoomLevel = 100.0;
+
+        when(camera.getMinZoomLevel).thenReturn(minimumZoomLevel);
+
+        // Save the camera in the camera plugin.
+        (CameraPlatform.instance as CameraPlugin).cameras[cameraId] = camera;
+
+        expect(
+          await CameraPlatform.instance.getMinZoomLevel(
+            cameraId,
+          ),
+          equals(minimumZoomLevel),
+        );
+
+        verify(camera.getMinZoomLevel).called(1);
+      });
+
+      group('throws PlatformException', () {
+        testWidgets(
+            'with notFound error '
+            'if the camera does not exist', (tester) async {
+          expect(
+            () async => await CameraPlatform.instance.getMinZoomLevel(
+              cameraId,
+            ),
+            throwsA(
+              isA<PlatformException>().having(
+                (e) => e.code,
+                'code',
+                CameraErrorCode.notFound.toString(),
+              ),
+            ),
+          );
+        });
+
+        testWidgets('when getMinZoomLevel throws DomException', (tester) async {
+          final camera = MockCamera();
+          final exception = FakeDomException(DomException.NOT_SUPPORTED);
+
+          when(camera.getMinZoomLevel).thenThrow(exception);
+
+          // Save the camera in the camera plugin.
+          (CameraPlatform.instance as CameraPlugin).cameras[cameraId] = camera;
+
+          expect(
+            () async => await CameraPlatform.instance.getMinZoomLevel(
+              cameraId,
+            ),
+            throwsA(
+              isA<PlatformException>().having(
+                (e) => e.code,
+                'code',
+                exception.name,
+              ),
+            ),
+          );
+        });
+
+        testWidgets('when getMinZoomLevel throws CameraWebException',
+            (tester) async {
+          final camera = MockCamera();
+          final exception = CameraWebException(
+            cameraId,
+            CameraErrorCode.notStarted,
+            'description',
+          );
+
+          when(camera.getMinZoomLevel).thenThrow(exception);
+
+          // Save the camera in the camera plugin.
+          (CameraPlatform.instance as CameraPlugin).cameras[cameraId] = camera;
+
+          expect(
+            () async => await CameraPlatform.instance.getMinZoomLevel(
+              cameraId,
+            ),
+            throwsA(
+              isA<PlatformException>().having(
+                (e) => e.code,
+                'code',
+                exception.code.toString(),
+              ),
+            ),
+          );
+        });
+      });
     });
 
-    testWidgets('setZoomLevel throws UnimplementedError', (tester) async {
-      expect(
-        () => CameraPlatform.instance.setZoomLevel(
-          cameraId,
-          1.0,
-        ),
-        throwsUnimplementedError,
-      );
+    group('setZoomLevel', () {
+      testWidgets('calls setZoomLevel on the camera', (tester) async {
+        final camera = MockCamera();
+
+        // Save the camera in the camera plugin.
+        (CameraPlatform.instance as CameraPlugin).cameras[cameraId] = camera;
+
+        const zoom = 100.0;
+
+        await CameraPlatform.instance.setZoomLevel(cameraId, zoom);
+
+        verify(() => camera.setZoomLevel(zoom)).called(1);
+      });
+
+      group('throws CameraException', () {
+        testWidgets(
+            'with notFound error '
+            'if the camera does not exist', (tester) async {
+          expect(
+            () async => await CameraPlatform.instance.setZoomLevel(
+              cameraId,
+              100.0,
+            ),
+            throwsA(
+              isA<CameraException>().having(
+                (e) => e.code,
+                'code',
+                CameraErrorCode.notFound.toString(),
+              ),
+            ),
+          );
+        });
+
+        testWidgets('when setZoomLevel throws DomException', (tester) async {
+          final camera = MockCamera();
+          final exception = FakeDomException(DomException.NOT_SUPPORTED);
+
+          when(() => camera.setZoomLevel(any())).thenThrow(exception);
+
+          // Save the camera in the camera plugin.
+          (CameraPlatform.instance as CameraPlugin).cameras[cameraId] = camera;
+
+          expect(
+            () async => await CameraPlatform.instance.setZoomLevel(
+              cameraId,
+              100.0,
+            ),
+            throwsA(
+              isA<CameraException>().having(
+                (e) => e.code,
+                'code',
+                exception.name,
+              ),
+            ),
+          );
+        });
+
+        testWidgets('when setZoomLevel throws PlatformException',
+            (tester) async {
+          final camera = MockCamera();
+          final exception = PlatformException(
+            code: CameraErrorCode.notSupported.toString(),
+            message: 'message',
+          );
+
+          when(() => camera.setZoomLevel(any())).thenThrow(exception);
+
+          // Save the camera in the camera plugin.
+          (CameraPlatform.instance as CameraPlugin).cameras[cameraId] = camera;
+
+          expect(
+            () async => await CameraPlatform.instance.setZoomLevel(
+              cameraId,
+              100.0,
+            ),
+            throwsA(
+              isA<CameraException>().having(
+                (e) => e.code,
+                'code',
+                exception.code,
+              ),
+            ),
+          );
+        });
+
+        testWidgets('when setZoomLevel throws CameraWebException',
+            (tester) async {
+          final camera = MockCamera();
+          final exception = CameraWebException(
+            cameraId,
+            CameraErrorCode.notStarted,
+            'description',
+          );
+
+          when(() => camera.setZoomLevel(any())).thenThrow(exception);
+
+          // Save the camera in the camera plugin.
+          (CameraPlatform.instance as CameraPlugin).cameras[cameraId] = camera;
+
+          expect(
+            () async => await CameraPlatform.instance.setZoomLevel(
+              cameraId,
+              100.0,
+            ),
+            throwsA(
+              isA<CameraException>().having(
+                (e) => e.code,
+                'code',
+                exception.code.toString(),
+              ),
+            ),
+          );
+        });
+      });
     });
 
     testWidgets(
@@ -1523,6 +1797,121 @@ void main() {
             ),
             throwsA(
               isA<PlatformException>(),
+            ),
+          );
+
+          expect(
+            await streamQueue.next,
+            equals(
+              CameraErrorEvent(
+                cameraId,
+                'Error code: ${exception.code}, error message: ${exception.description}',
+              ),
+            ),
+          );
+
+          await streamQueue.cancel();
+        });
+
+        testWidgets(
+            'emits a CameraErrorEvent '
+            'on getMaxZoomLevel error', (tester) async {
+          final exception = CameraWebException(
+            cameraId,
+            CameraErrorCode.zoomLevelNotSupported,
+            'description',
+          );
+
+          when(camera.getMaxZoomLevel).thenThrow(exception);
+
+          final Stream<CameraErrorEvent> eventStream =
+              CameraPlatform.instance.onCameraError(cameraId);
+
+          final streamQueue = StreamQueue(eventStream);
+
+          expect(
+            () async => await CameraPlatform.instance.getMaxZoomLevel(
+              cameraId,
+            ),
+            throwsA(
+              isA<PlatformException>(),
+            ),
+          );
+
+          expect(
+            await streamQueue.next,
+            equals(
+              CameraErrorEvent(
+                cameraId,
+                'Error code: ${exception.code}, error message: ${exception.description}',
+              ),
+            ),
+          );
+
+          await streamQueue.cancel();
+        });
+
+        testWidgets(
+            'emits a CameraErrorEvent '
+            'on getMinZoomLevel error', (tester) async {
+          final exception = CameraWebException(
+            cameraId,
+            CameraErrorCode.zoomLevelNotSupported,
+            'description',
+          );
+
+          when(camera.getMinZoomLevel).thenThrow(exception);
+
+          final Stream<CameraErrorEvent> eventStream =
+              CameraPlatform.instance.onCameraError(cameraId);
+
+          final streamQueue = StreamQueue(eventStream);
+
+          expect(
+            () async => await CameraPlatform.instance.getMinZoomLevel(
+              cameraId,
+            ),
+            throwsA(
+              isA<PlatformException>(),
+            ),
+          );
+
+          expect(
+            await streamQueue.next,
+            equals(
+              CameraErrorEvent(
+                cameraId,
+                'Error code: ${exception.code}, error message: ${exception.description}',
+              ),
+            ),
+          );
+
+          await streamQueue.cancel();
+        });
+
+        testWidgets(
+            'emits a CameraErrorEvent '
+            'on setZoomLevel error', (tester) async {
+          final exception = CameraWebException(
+            cameraId,
+            CameraErrorCode.zoomLevelNotSupported,
+            'description',
+          );
+
+          when(() => camera.setZoomLevel(any())).thenThrow(exception);
+
+          final Stream<CameraErrorEvent> eventStream =
+              CameraPlatform.instance.onCameraError(cameraId);
+
+          final streamQueue = StreamQueue(eventStream);
+
+          expect(
+            () async => await CameraPlatform.instance.setZoomLevel(
+              cameraId,
+              100.0,
+            ),
+            throwsA(
+              isA<CameraException>(),
             ),
           );
 

--- a/packages/camera/camera_web/lib/src/camera_web.dart
+++ b/packages/camera/camera_web/lib/src/camera_web.dart
@@ -481,18 +481,41 @@ class CameraPlugin extends CameraPlatform {
   }
 
   @override
-  Future<double> getMaxZoomLevel(int cameraId) {
-    throw UnimplementedError('getMaxZoomLevel() is not implemented.');
+  Future<double> getMaxZoomLevel(int cameraId) async {
+    try {
+      return getCamera(cameraId).getMaxZoomLevel();
+    } on html.DomException catch (e) {
+      throw PlatformException(code: e.name, message: e.message);
+    } on CameraWebException catch (e) {
+      _addCameraErrorEvent(e);
+      throw PlatformException(code: e.code.toString(), message: e.description);
+    }
   }
 
   @override
-  Future<double> getMinZoomLevel(int cameraId) {
-    throw UnimplementedError('getMinZoomLevel() is not implemented.');
+  Future<double> getMinZoomLevel(int cameraId) async {
+    try {
+      return getCamera(cameraId).getMinZoomLevel();
+    } on html.DomException catch (e) {
+      throw PlatformException(code: e.name, message: e.message);
+    } on CameraWebException catch (e) {
+      _addCameraErrorEvent(e);
+      throw PlatformException(code: e.code.toString(), message: e.description);
+    }
   }
 
   @override
-  Future<void> setZoomLevel(int cameraId, double zoom) {
-    throw UnimplementedError('setZoomLevel() is not implemented.');
+  Future<void> setZoomLevel(int cameraId, double zoom) async {
+    try {
+      getCamera(cameraId).setZoomLevel(zoom);
+    } on html.DomException catch (e) {
+      throw CameraException(e.name, e.message);
+    } on PlatformException catch (e) {
+      throw CameraException(e.code, e.message);
+    } on CameraWebException catch (e) {
+      _addCameraErrorEvent(e);
+      throw CameraException(e.code.toString(), e.description);
+    }
   }
 
   @override

--- a/packages/camera/camera_web/lib/src/types/camera_error_code.dart
+++ b/packages/camera/camera_web/lib/src/types/camera_error_code.dart
@@ -56,6 +56,14 @@ class CameraErrorCode {
   static const CameraErrorCode torchModeNotSupported =
       CameraErrorCode._('torchModeNotSupported');
 
+  /// The camera zoom level is not supported.
+  static const CameraErrorCode zoomLevelNotSupported =
+      CameraErrorCode._('zoomLevelNotSupported');
+
+  /// The camera zoom level is invalid.
+  static const CameraErrorCode zoomLevelInvalid =
+      CameraErrorCode._('zoomLevelInvalid');
+
   /// The camera has not been initialized or started.
   static const CameraErrorCode notStarted =
       CameraErrorCode._('cameraNotStarted');

--- a/packages/camera/camera_web/lib/src/types/types.dart
+++ b/packages/camera/camera_web/lib/src/types/types.dart
@@ -7,3 +7,4 @@ export 'camera_options.dart';
 export 'camera_web_exception.dart';
 export 'media_device_kind.dart';
 export 'orientation_type.dart';
+export 'zoom_level_capability.dart';

--- a/packages/camera/camera_web/lib/src/types/zoom_level_capability.dart
+++ b/packages/camera/camera_web/lib/src/types/zoom_level_capability.dart
@@ -1,0 +1,45 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:html' as html;
+import 'dart:ui' show hashValues;
+
+/// The possible range of values for the zoom level configurable
+/// on the camera video track.
+class ZoomLevelCapability {
+  /// Creates a new instance of [ZoomLevelCapability] with the given
+  /// zoom level range of [minimum] to [maximum] configurable
+  /// on the [videoTrack].
+  ZoomLevelCapability({
+    required this.minimum,
+    required this.maximum,
+    required this.videoTrack,
+  });
+
+  /// The zoom level constraint name.
+  /// See: https://w3c.github.io/mediacapture-image/#dom-mediatracksupportedconstraints-zoom
+  static const constraintName = "zoom";
+
+  /// The minimum zoom level.
+  final double minimum;
+
+  /// The maximum zoom level.
+  final double maximum;
+
+  /// The video track capable of configuring the zoom level.
+  final html.MediaStreamTrack videoTrack;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is ZoomLevelCapability &&
+        other.minimum == minimum &&
+        other.maximum == maximum &&
+        other.videoTrack == videoTrack;
+  }
+
+  @override
+  int get hashCode => hashValues(minimum, maximum, videoTrack);
+}

--- a/packages/camera/camera_web/pubspec.yaml
+++ b/packages/camera/camera_web/pubspec.yaml
@@ -30,4 +30,5 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  mocktail: ^0.1.4
   pedantic: ^1.11.1

--- a/packages/camera/camera_web/test/helpers/mocks.dart
+++ b/packages/camera/camera_web/test/helpers/mocks.dart
@@ -5,6 +5,9 @@
 import 'dart:html';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockMediaStreamTrack extends Mock implements MediaStreamTrack {}
 
 /// A fake [MediaError] that returns the provided error [_code].
 class FakeMediaError extends Fake implements MediaError {

--- a/packages/camera/camera_web/test/types/camera_error_code_test.dart
+++ b/packages/camera/camera_web/test/types/camera_error_code_test.dart
@@ -89,6 +89,20 @@ void main() {
         );
       });
 
+      test('zoomLevelNotSupported', () {
+        expect(
+          CameraErrorCode.zoomLevelNotSupported.toString(),
+          equals('zoomLevelNotSupported'),
+        );
+      });
+
+      test('zoomLevelInvalid', () {
+        expect(
+          CameraErrorCode.zoomLevelInvalid.toString(),
+          equals('zoomLevelInvalid'),
+        );
+      });
+
       test('notStarted', () {
         expect(
           CameraErrorCode.notStarted.toString(),

--- a/packages/camera/camera_web/test/types/zoom_level_capability_test.dart
+++ b/packages/camera/camera_web/test/types/zoom_level_capability_test.dart
@@ -1,0 +1,47 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:camera_web/src/types/types.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/helpers.dart';
+
+void main() {
+  group('ZoomLevelCapability', () {
+    test('sets all properties', () {
+      const minimum = 100.0;
+      const maximum = 400.0;
+      final videoTrack = MockMediaStreamTrack();
+
+      final capability = ZoomLevelCapability(
+        minimum: minimum,
+        maximum: maximum,
+        videoTrack: videoTrack,
+      );
+
+      expect(capability.minimum, equals(minimum));
+      expect(capability.maximum, equals(maximum));
+      expect(capability.videoTrack, equals(videoTrack));
+    });
+
+    test('supports value equality', () {
+      final videoTrack = MockMediaStreamTrack();
+
+      expect(
+        ZoomLevelCapability(
+          minimum: 0.0,
+          maximum: 100.0,
+          videoTrack: videoTrack,
+        ),
+        equals(
+          ZoomLevelCapability(
+            minimum: 0.0,
+            maximum: 100.0,
+            videoTrack: videoTrack,
+          ),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Adds support for a zoom level to the web camera platform.

- Added `getZoomLevelCapabilityForCamera` to `CameraSettings`.
  - Returns the zoom level capability for the given camera. Includes the minimum and maximum zoom levels and the video track capable of configuring the zoom level.
  - Throws a `CameraWebException` if the zoom level is not supported or the camera has not been initialized or started.
- Added `getMaxZoomLevel`, `getMinZoomLevel` and `setZoomLevel` to `Camera` and `CameraPlugin`.
  - Each method uses `CameraSettings.getZoomLevelCapabilityForCamera` to access the camera zoom level capability.
  - `setZoomLevel` throws a `CameraWebException` if the zoom level is invalid (not in the valid range).

Part of https://github.com/flutter/flutter/issues/45297.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code