### PR TITLE
[camera_web] Fix `getCapabilities` not supported error thrown when selecting a camera on Firefox

### DIFF
--- a/packages/camera/camera_web/example/integration_test/helpers/mocks.dart
+++ b/packages/camera/camera_web/example/integration_test/helpers/mocks.dart
@@ -8,6 +8,7 @@ import 'dart:ui';
 
 import 'package:camera_web/src/camera.dart';
 import 'package:camera_web/src/camera_service.dart';
+import 'package:camera_web/src/shims/dart_js_util.dart';
 import 'package:camera_web/src/types/types.dart';
 import 'package:cross_file/cross_file.dart';
 import 'package:mocktail/mocktail.dart';
@@ -37,6 +38,8 @@ class MockCameraOptions extends Mock implements CameraOptions {}
 class MockVideoElement extends Mock implements VideoElement {}
 
 class MockXFile extends Mock implements XFile {}
+
+class MockJsUtil extends Mock implements JsUtil {}
 
 /// A fake [MediaStream] that returns the provided [_videoTracks].
 class FakeMediaStream extends Fake implements MediaStream {

--- a/packages/camera/camera_web/lib/src/camera_service.dart
+++ b/packages/camera/camera_web/lib/src/camera_service.dart
@@ -4,10 +4,10 @@
 
 import 'dart:html' as html;
 import 'dart:ui';
-import 'dart:js_util' as js_util;
 
 import 'package:camera_platform_interface/camera_platform_interface.dart';
 import 'package:camera_web/src/camera.dart';
+import 'package:camera_web/src/shims/dart_js_util.dart';
 import 'package:camera_web/src/types/types.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
@@ -21,6 +21,10 @@ class CameraService {
   /// The current browser window used to access media devices.
   @visibleForTesting
   html.Window? window = html.window;
+
+  /// The utility to manipulate JavaScript interop objects.
+  @visibleForTesting
+  JsUtil jsUtil = JsUtil();
 
   /// Returns a media stream associated with the camera device
   /// with [cameraId] and constrained by [options].
@@ -143,8 +147,8 @@ class CameraService {
       // The zoom level capability is a nested JS object, therefore
       // we need to access its properties with the js_util library.
       // See: https://api.dart.dev/stable/2.13.4/dart-js_util/getProperty.html
-      final minimumZoomLevel = js_util.getProperty(zoomLevelCapability, 'min');
-      final maximumZoomLevel = js_util.getProperty(zoomLevelCapability, 'max');
+      final minimumZoomLevel = jsUtil.getProperty(zoomLevelCapability, 'min');
+      final maximumZoomLevel = jsUtil.getProperty(zoomLevelCapability, 'max');
 
       if (minimumZoomLevel != null && maximumZoomLevel != null) {
         return ZoomLevelCapability(
@@ -201,40 +205,32 @@ class CameraService {
     final facingMode = videoTrackSettings[_facingModeKey];
 
     if (facingMode == null) {
-      try {
-        // If the facing mode does not exist in the video track settings,
-        // check for the facing mode in the video track capabilities.
-        //
-        // MediaTrackCapabilities:
-        // https://www.w3.org/TR/mediacapture-streams/#dom-mediatrackcapabilities
-        //
-        // This may throw a not supported error on Firefox.
-        final videoTrackCapabilities = videoTrack.getCapabilities();
+      // If the facing mode does not exist in the video track settings,
+      // check for the facing mode in the video track capabilities.
+      //
+      // MediaTrackCapabilities:
+      // https://www.w3.org/TR/mediacapture-streams/#dom-mediatrackcapabilities
 
-        // A list of facing mode capabilities as
-        // the camera may support multiple facing modes.
-        final facingModeCapabilities =
-            List<String>.from(videoTrackCapabilities[_facingModeKey] ?? []);
+      // Getting the video track capabilities is not supported on Firefox.
+      // See: https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/getCapabilities#browser_compatibility
+      if (!jsUtil.hasProperty(videoTrack, 'getCapabilities')) {
+        // Return null if the video track capabilites are not supported.
+        return null;
+      }
 
-        if (facingModeCapabilities.isNotEmpty) {
-          final facingModeCapability = facingModeCapabilities.first;
-          return facingModeCapability;
-        } else {
-          // Return null if there are no facing mode capabilities.
-          return null;
-        }
-      } catch (e) {
-        switch (e.runtimeType.toString()) {
-          case 'JSNoSuchMethodError':
-            // Return null if getting capabilities is currently not supported.
-            return null;
-          default:
-            throw PlatformException(
-              code: CameraErrorCode.unknown.toString(),
-              message:
-                  'An unknown error occured when getting the video track capabilities.',
-            );
-        }
+      final videoTrackCapabilities = videoTrack.getCapabilities();
+
+      // A list of facing mode capabilities as
+      // the camera may support multiple facing modes.
+      final facingModeCapabilities =
+          List<String>.from(videoTrackCapabilities[_facingModeKey] ?? []);
+
+      if (facingModeCapabilities.isNotEmpty) {
+        final facingModeCapability = facingModeCapabilities.first;
+        return facingModeCapability;
+      } else {
+        // Return null if there are no facing mode capabilities.
+        return null;
       }
     }
 

--- a/packages/camera/camera_web/lib/src/camera_service.dart
+++ b/packages/camera/camera_web/lib/src/camera_service.dart
@@ -211,7 +211,9 @@ class CameraService {
       // MediaTrackCapabilities:
       // https://www.w3.org/TR/mediacapture-streams/#dom-mediatrackcapabilities
 
-      // Getting the video track capabilities is not supported on Firefox.
+      // Check if getting the video track capabilities is supported.
+      //
+      // The method may not be supported on Firefox.
       // See: https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/getCapabilities#browser_compatibility
       if (!jsUtil.hasProperty(videoTrack, 'getCapabilities')) {
         // Return null if the video track capabilites are not supported.

--- a/packages/camera/camera_web/lib/src/shims/dart_js_util.dart
+++ b/packages/camera/camera_web/lib/src/shims/dart_js_util.dart
@@ -1,0 +1,14 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:js_util' as js_util;
+
+/// A utility that shims dart:js_util to manipulate JavaScript interop objects.
+class JsUtil {
+  /// Returns true if the object [o] has the property [name].
+  bool hasProperty(Object o, Object name) => js_util.hasProperty(o, name);
+
+  /// Returns the value of the property [name] in the object [o].
+  dynamic getProperty(Object o, Object name) => js_util.getProperty(o, name);
+}


### PR DESCRIPTION
Fixed `getCapabilities` not supported error thrown when selecting a camera on Firefox. 

Before, the method was always called and an exception was thrown on Firefox with its runtime type checked against `JSNoSuchMethodError`. This caused issues as the runtime type was different depending on the build mode (release, profile, staging). Now, the method is called only if it is available on the video track (checked with `JsUtil.hasProperty`).

Part of https://github.com/flutter/flutter/issues/45297.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code