### PR TITLE
[camera] Fix a disposed `CameraController` error thrown when changing a camera

### DIFF
--- a/packages/camera/camera/example/lib/main.dart
+++ b/packages/camera/camera/example/lib/main.dart
@@ -594,16 +594,20 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
   }
 
   void onNewCameraSelected(CameraDescription cameraDescription) async {
-    if (controller != null) {
-      await controller!.dispose();
-    }
+    final previousCameraController = controller;
+
     final CameraController cameraController = CameraController(
       cameraDescription,
       ResolutionPreset.medium,
       enableAudio: enableAudio,
       imageFormatGroup: ImageFormatGroup.jpeg,
     );
+
     controller = cameraController;
+
+    if (mounted) {
+      setState(() {});
+    }
 
     // If the controller is updated then update the UI.
     cameraController.addListener(() {
@@ -637,6 +641,8 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
     if (mounted) {
       setState(() {});
     }
+
+    await previousCameraController?.dispose();
   }
 
   void onTakePictureButtonPressed() {


### PR DESCRIPTION
Fixes a disposed `CameraController` error thrown when changing the camera in the camera example. 

The error is thrown by the `ValueListenableBuilder` in the `CameraPreview`. Changing a camera disposes the previous `CameraController` before the widget state is updated causing the `ValueListenableBuilder` to listen to the disposed controller. This PR solves the issue by disposing the previous `CameraController` after the new one is initialized.

Error:
```
The following assertion was thrown building CameraPreview:
A CameraController was used after being disposed.
Once you have called dispose() on a CameraController, it can no longer be
used.

The relevant error-causing widget was:
  CameraPreview
  file:///Users/.../Projects/plugins/packages/camera/camera/example/lib/main.dart:188:16
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code