### PR TITLE
[camera_web] Add support for pausing and resuming the camera preview

### DIFF
--- a/packages/camera/camera_web/example/integration_test/camera_test.dart
+++ b/packages/camera/camera_web/example/integration_test/camera_test.dart
@@ -214,6 +214,24 @@ void main() {
       });
     });
 
+    group('pause', () {
+      testWidgets('pauses the camera stream', (tester) async {
+        final camera = Camera(
+          textureId: textureId,
+          cameraService: cameraService,
+        );
+
+        await camera.initialize();
+        await camera.play();
+
+        expect(camera.videoElement.paused, isFalse);
+
+        camera.pause();
+
+        expect(camera.videoElement.paused, isTrue);
+      });
+    });
+
     group('stop', () {
       testWidgets('resets the camera stream', (tester) async {
         final camera = Camera(

--- a/packages/camera/camera_web/lib/src/camera.dart
+++ b/packages/camera/camera_web/lib/src/camera.dart
@@ -119,6 +119,11 @@ class Camera {
     await videoElement.play();
   }
 
+  /// Pauses the camera stream on the current frame.
+  void pause() async {
+    videoElement.pause();
+  }
+
   /// Stops the camera stream and resets the camera source.
   void stop() {
     final tracks = videoElement.srcObject?.getTracks();

--- a/packages/camera/camera_web/lib/src/camera_web.dart
+++ b/packages/camera/camera_web/lib/src/camera_web.dart
@@ -518,6 +518,27 @@ class CameraPlugin extends CameraPlatform {
   }
 
   @override
+  Future<void> pausePreview(int cameraId) async {
+    try {
+      getCamera(cameraId).pause();
+    } on html.DomException catch (e) {
+      throw PlatformException(code: e.name, message: e.message);
+    }
+  }
+
+  @override
+  Future<void> resumePreview(int cameraId) async {
+    try {
+      await getCamera(cameraId).play();
+    } on html.DomException catch (e) {
+      throw PlatformException(code: e.name, message: e.message);
+    } on CameraWebException catch (e) {
+      _addCameraErrorEvent(e);
+      throw PlatformException(code: e.code.toString(), message: e.description);
+    }
+  }
+
+  @override
   Widget buildPreview(int cameraId) {
     return HtmlElementView(
       viewType: getCamera(cameraId).getViewType(),

--- a/packages/camera/camera_web/pubspec.yaml
+++ b/packages/camera/camera_web/pubspec.yaml
@@ -21,7 +21,7 @@ flutter:
         fileName: camera_web.dart
 
 dependencies:
-  camera_platform_interface: ^2.0.1
+  camera_platform_interface: ^2.1.0
   flutter:
     sdk: flutter
   flutter_web_plugins:


### PR DESCRIPTION
Adds support for pausing and resuming the camera preview to the web camera platform.

- Added `pause` to `Camera`.
  - Pauses the video element stream ([HTMLMediaElement.pause](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/pause)).
- Added `pausePreview` implementation.
  - Calls `pause` on the camera with the given id.
  - Throws a `PlatformException` if the camera throws a `DomException`.
- Added `resumePreview` implementation.
  - Calls `play` on the camera with the given id.
  - Throws a `PlatformException` if the camera throws either a `DomException` or a `CameraWebException`.

Relates to https://github.com/flutter/plugins/pull/4191.
Part of https://github.com/flutter/flutter/issues/45297.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code