### PR TITLE
Fix and test for 'implements' pubspec entry

### DIFF
--- a/packages/camera/camera_web/CHANGELOG.md
+++ b/packages/camera/camera_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0+1
+
+* Add `implements` to pubspec.
+
 ## 0.1.0
 
 * Initial release

--- a/packages/camera/camera_web/pubspec.yaml
+++ b/packages/camera/camera_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_web
 description: A Flutter plugin for getting information about and controlling the camera on Web.
 repository: https://github.com/flutter/plugins/tree/master/packages/camera/camera_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.1.0
+version: 0.1.0+1
 
 # This plugin is under development and will be published 
 # when the first working web camera implementation is added.

--- a/packages/connectivity/connectivity_for_web/CHANGELOG.md
+++ b/packages/connectivity/connectivity_for_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0+1
+
+* Add `implements` to pubspec.
+
 ## 0.4.0
 
 * Migrate to null-safety

--- a/packages/connectivity/connectivity_for_web/pubspec.yaml
+++ b/packages/connectivity/connectivity_for_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: connectivity_for_web
 description: An implementation for the web platform of the Flutter `connectivity` plugin. This uses the NetworkInformation Web API, with a fallback to Navigator.onLine.
 repository: https://github.com/flutter/plugins/tree/master/packages/connectivity/connectivity_for_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+connectivity%22
-version: 0.4.0
+version: 0.4.0+1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -10,6 +10,7 @@ environment:
 
 flutter:
   plugin:
+    implements: connectivity
     platforms:
       web:
         pluginClass: ConnectivityPlugin

--- a/packages/connectivity/connectivity_macos/CHANGELOG.md
+++ b/packages/connectivity/connectivity_macos/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 0.2.1+2
 
-* Add Swift language version to podspec.
+* Add Swift language version to podspec.##
+* Fix `implements` package name in pubspec.
 
 ## 0.2.1+1
 

--- a/packages/connectivity/connectivity_macos/CHANGELOG.md
+++ b/packages/connectivity/connectivity_macos/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.2.1+2
 
-* Add Swift language version to podspec.##
+* Add Swift language version to podspec.
 * Fix `implements` package name in pubspec.
 
 ## 0.2.1+1

--- a/packages/connectivity/connectivity_macos/pubspec.yaml
+++ b/packages/connectivity/connectivity_macos/pubspec.yaml
@@ -2,7 +2,7 @@ name: connectivity_macos
 description: macOS implementation of the connectivity plugin.
 repository: https://github.com/flutter/plugins/tree/master/packages/connectivity/connectivity_macos
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+connectivity%22
-version: 0.2.1+1
+version: 0.2.1+2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -10,7 +10,7 @@ environment:
 
 flutter:
   plugin:
-    implements: connectivity_platform_interface
+    implements: connectivity
     platforms:
       macos:
         pluginClass: ConnectivityPlugin

--- a/packages/file_selector/file_selector_web/CHANGELOG.md
+++ b/packages/file_selector/file_selector_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.1+2
+
+* Add `implements` to pubspec.
+
 # 0.8.1+1
 
 - Updated installation instructions in README.

--- a/packages/file_selector/file_selector_web/pubspec.yaml
+++ b/packages/file_selector/file_selector_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: file_selector_web
 description: Web platform implementation of file_selector
 repository: https://github.com/flutter/plugins/tree/master/packages/file_selector/file_selector_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
-version: 0.8.1+1
+version: 0.8.1+2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -10,6 +10,7 @@ environment:
 
 flutter:
   plugin:
+    implements: file_selector
     platforms:
       web:
         pluginClass: FileSelectorWeb

--- a/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0+4
+
+* Add `implements` to pubspec.
+
 ## 0.3.0+3
 
 * Update the `README.md` usage instructions to not be tied to explicit package versions.

--- a/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_web
 description: Web platform implementation of google_maps_flutter
 repository: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter/google_maps_flutter_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 0.3.0+3
+version: 0.3.0+4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -10,6 +10,7 @@ environment:
 
 flutter:
   plugin:
+    implements: google_maps_flutter
     platforms:
       web:
         pluginClass: GoogleMapsPlugin

--- a/packages/google_sign_in/google_sign_in_web/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.0+2
+
+* Add `implements` to pubspec.
+
 ## 0.10.0+1
 
 * Updated installation instructions in README.

--- a/packages/google_sign_in/google_sign_in_web/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_web/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android, iOS and Web.
 repository: https://github.com/flutter/plugins/tree/master/packages/google_sign_in/google_sign_in_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
-version: 0.10.0+1
+version: 0.10.0+2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -11,6 +11,7 @@ environment:
 
 flutter:
   plugin:
+    implements: google_sign_in
     platforms:
       web:
         pluginClass: GoogleSignInPlugin

--- a/packages/image_picker/image_picker_for_web/CHANGELOG.md
+++ b/packages/image_picker/image_picker_for_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.3
+
+* Add `implements` to pubspec.
+
 ## 2.1.2
 
 * Updated installation instructions in README.

--- a/packages/image_picker/image_picker_for_web/pubspec.yaml
+++ b/packages/image_picker/image_picker_for_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker_for_web
 description: Web platform implementation of image_picker
 repository: https://github.com/flutter/plugins/tree/master/packages/image_picker/image_picker_for_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 2.1.2
+version: 2.1.3
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -10,6 +10,7 @@ environment:
 
 flutter:
   plugin:
+    implements: image_picker
     platforms:
       web:
         pluginClass: ImagePickerPlugin

--- a/packages/in_app_purchase/in_app_purchase_android/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.4+4
+
+* Add `implements` to pubspec.
+
 # 0.1.4+3
 
 - Updated installation instructions in README.

--- a/packages/in_app_purchase/in_app_purchase_android/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase_android
 description: An implementation for the Android platform of the Flutter `in_app_purchase` plugin. This uses the Android BillingClient APIs.
 repository: https://github.com/flutter/plugins/tree/master/packages/in_app_purchase/in_app_purchase_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 0.1.4+3
+version: 0.1.4+4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -10,6 +10,7 @@ environment:
 
 flutter:
   plugin:
+    implements: in_app_purchase
     platforms:
       android:
         package: io.flutter.plugins.inapppurchase

--- a/packages/in_app_purchase/in_app_purchase_ios/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3+2
+
+* Add `implements` to pubspec.
+
 # 0.1.3+1
 
 - Updated installation instructions in README.

--- a/packages/in_app_purchase/in_app_purchase_ios/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase_ios
 description: An implementation for the iOS platform of the Flutter `in_app_purchase` plugin. This uses the iOS StoreKit Framework.
 repository: https://github.com/flutter/plugins/tree/master/packages/in_app_purchase/in_app_purchase_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 0.1.3+1
+version: 0.1.3+2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -10,6 +10,7 @@ environment:
 
 flutter:
   plugin:
+    implements: in_app_purchase
     platforms:
       ios:
         pluginClass: InAppPurchasePlugin

--- a/packages/shared_preferences/shared_preferences_web/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.2
+
+* Add `implements` to pubspec.
+
 ## 2.0.1
 
 * Updated installation instructions in README.

--- a/packages/shared_preferences/shared_preferences_web/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: shared_preferences_web
 description: Web platform implementation of shared_preferences
 repository: https://github.com/flutter/plugins/tree/master/packages/shared_preferences/shared_preferences_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.0.1
+version: 2.0.2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -10,6 +10,7 @@ environment:
 
 flutter:
   plugin:
+    implements: shared_preferences
     platforms:
       web:
         pluginClass: SharedPreferencesPlugin

--- a/packages/url_launcher/url_launcher_web/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.4
+
+* Add `implements` to pubspec.
+
 ## 2.0.3
 
 - Replaced reference to `shared_preferences` plugin with the `url_launcher` in the README.

--- a/packages/url_launcher/url_launcher_web/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher_web
 description: Web platform implementation of url_launcher
 repository: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 2.0.3
+version: 2.0.4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -10,6 +10,7 @@ environment:
 
 flutter:
   plugin:
+    implements: url_launcher
     platforms:
       web:
         pluginClass: UrlLauncherPlugin

--- a/packages/video_player/video_player_web/CHANGELOG.md
+++ b/packages/video_player/video_player_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.3
+
+* Add `implements` to pubspec.
+
 ## 2.0.2
 
 * Updated installation instructions in README.

--- a/packages/video_player/video_player_web/pubspec.yaml
+++ b/packages/video_player/video_player_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_web
 description: Web platform implementation of video_player.
 repository: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.0.2
+version: 2.0.3
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -10,6 +10,7 @@ environment:
 
 flutter:
   plugin:
+    implements: video_player
     platforms:
       web:
         pluginClass: VideoPlayerPlugin

--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -23,6 +23,7 @@
   the new `native-test` command.
 - Commands that print a run summary at the end now track and log exclusions
   similarly to skips for easier auditing.
+- Pubspec validation now checks for `implements` in implementation packages.
 
 ## 0.4.1
 

--- a/script/tool/lib/src/pubspec_check_command.dart
+++ b/script/tool/lib/src/pubspec_check_command.dart
@@ -7,6 +7,7 @@ import 'package:git/git.dart';
 import 'package:platform/platform.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
 
+import 'common/core.dart';
 import 'common/package_looping_command.dart';
 import 'common/process_runner.dart';
 
@@ -65,8 +66,8 @@ class PubspecCheckCommand extends PackageLoopingCommand {
   @override
   Future<PackageResult> runForPackage(Directory package) async {
     final File pubspec = package.childFile('pubspec.yaml');
-    final bool passesCheck = !pubspec.existsSync() ||
-        await _checkPubspec(pubspec, packageName: package.basename);
+    final bool passesCheck =
+        !pubspec.existsSync() || await _checkPubspec(pubspec, package: package);
     if (!passesCheck) {
       return PackageResult.fail();
     }
@@ -75,7 +76,7 @@ class PubspecCheckCommand extends PackageLoopingCommand {
 
   Future<bool> _checkPubspec(
     File pubspecFile, {
-    required String packageName,
+    required Directory package,
   }) async {
     final String contents = pubspecFile.readAsStringSync();
     final Pubspec? pubspec = _tryParsePubspec(contents);
@@ -84,33 +85,42 @@ class PubspecCheckCommand extends PackageLoopingCommand {
     }
 
     final List<String> pubspecLines = contents.split('\n');
-    final List<String> sectionOrder = pubspecLines.contains('  plugin:')
-        ? _majorPluginSections
-        : _majorPackageSections;
+    final bool isPlugin = pubspec.flutter?.containsKey('plugin') ?? false;
+    final List<String> sectionOrder =
+        isPlugin ? _majorPluginSections : _majorPackageSections;
     bool passing = _checkSectionOrder(pubspecLines, sectionOrder);
     if (!passing) {
-      print('${indentation}Major sections should follow standard '
+      printError('${indentation}Major sections should follow standard '
           'repository ordering:');
       final String listIndentation = indentation * 2;
-      print('$listIndentation${sectionOrder.join('\n$listIndentation')}');
+      printError('$listIndentation${sectionOrder.join('\n$listIndentation')}');
     }
 
     if (pubspec.publishTo != 'none') {
       final List<String> repositoryErrors =
-          _checkForRepositoryLinkErrors(pubspec, packageName: packageName);
+          _checkForRepositoryLinkErrors(pubspec, packageName: package.basename);
       if (repositoryErrors.isNotEmpty) {
         for (final String error in repositoryErrors) {
-          print('$indentation$error');
+          printError('$indentation$error');
         }
         passing = false;
       }
 
       if (!_checkIssueLink(pubspec)) {
-        print(
+        printError(
             '${indentation}A package should have an "issue_tracker" link to a '
             'search for open flutter/flutter bugs with the relevant label:\n'
             '${indentation * 2}$_expectedIssueLinkFormat<package label>');
         passing = false;
+      }
+
+      if (isPlugin) {
+        final String? error =
+            _checkForImplementsError(pubspec, package: package);
+        if (error != null) {
+          printError('$indentation$error');
+          passing = false;
+        }
       }
     }
 
@@ -167,5 +177,53 @@ class PubspecCheckCommand extends PackageLoopingCommand {
             ?.toString()
             .startsWith(_expectedIssueLinkFormat) ==
         true;
+  }
+
+  // Validates the "implements" keyword for a plugin, returning an error
+  // string if there are any issues.
+  //
+  // Should only be called on plugin packages.
+  String? _checkForImplementsError(
+    Pubspec pubspec, {
+    required Directory package,
+  }) {
+    if (_isImplementationPackage(package)) {
+      final String? implements =
+          pubspec.flutter!['plugin']!['implements'] as String?;
+      final String expectedImplements = package.parent.basename;
+      if (implements == null) {
+        return 'Missing "implements: $expectedImplements" in "plugin" section.';
+      } else if (implements != expectedImplements) {
+        return 'Expecetd "implements: $expectedImplements"; '
+            'found "implements: $implements".';
+      }
+    }
+    return null;
+  }
+
+  // Returns true if [packageName] appears to be an implementation package
+  // according to repository conventions.
+  bool _isImplementationPackage(Directory package) {
+    // An implementation package should be in a group folder...
+    final Directory parentDir = package.parent;
+    if (parentDir.path == packagesDir.path) {
+      return false;
+    }
+    final String packageName = package.basename;
+    final String parentName = parentDir.basename;
+    // ... whose name is a prefix of the package name.
+    if (!packageName.startsWith(parentName)) {
+      return false;
+    }
+    // A few known package names are not implementation packages; assume
+    // anything else is. (This is done instead of listing known implementation
+    // suffixes to allow for non-standard suffixes; e.g., to put several
+    // platforms in one package for code-sharing purposes.)
+    const Set<String> nonImplementationSuffixes = <String>{
+      '', // App-facing package.
+      '_platform_interface', // Platform interface package.
+    };
+    final String suffix = packageName.substring(parentName.length);
+    return !nonImplementationSuffixes.contains(suffix);
   }
 }

--- a/script/tool/test/pubspec_check_command_test.dart
+++ b/script/tool/test/pubspec_check_command_test.dart
@@ -66,9 +66,13 @@ environment:
 ''';
     }
 
-    String flutterSection({bool isPlugin = false}) {
-      const String pluginEntry = '''
+    String flutterSection({
+      bool isPlugin = false,
+      String? implementedPackage,
+    }) {
+      final String pluginEntry = '''
   plugin:
+${implementedPackage == null ? '' : '    implements: $implementedPackage'}
     platforms:
 ''';
       return '''
@@ -177,12 +181,19 @@ ${dependenciesSection()}
 ${devDependenciesSection()}
 ''');
 
-      final Future<List<String>> result =
-          runCapturingPrint(runner, <String>['pubspec-check']);
+      Error? commandError;
+      final List<String> output = await runCapturingPrint(
+          runner, <String>['pubspec-check'], errorHandler: (Error e) {
+        commandError = e;
+      });
 
-      await expectLater(
-        result,
-        throwsA(isA<ToolExit>()),
+      expect(commandError, isA<ToolExit>());
+      expect(
+        output,
+        containsAllInOrder(<Matcher>[
+          contains(
+              'Found a "homepage" entry; only "repository" should be used.'),
+        ]),
       );
     });
 
@@ -197,12 +208,18 @@ ${dependenciesSection()}
 ${devDependenciesSection()}
 ''');
 
-      final Future<List<String>> result =
-          runCapturingPrint(runner, <String>['pubspec-check']);
+      Error? commandError;
+      final List<String> output = await runCapturingPrint(
+          runner, <String>['pubspec-check'], errorHandler: (Error e) {
+        commandError = e;
+      });
 
-      await expectLater(
-        result,
-        throwsA(isA<ToolExit>()),
+      expect(commandError, isA<ToolExit>());
+      expect(
+        output,
+        containsAllInOrder(<Matcher>[
+          contains('Missing "repository"'),
+        ]),
       );
     });
 
@@ -217,12 +234,19 @@ ${dependenciesSection()}
 ${devDependenciesSection()}
 ''');
 
-      final Future<List<String>> result =
-          runCapturingPrint(runner, <String>['pubspec-check']);
+      Error? commandError;
+      final List<String> output = await runCapturingPrint(
+          runner, <String>['pubspec-check'], errorHandler: (Error e) {
+        commandError = e;
+      });
 
-      await expectLater(
-        result,
-        throwsA(isA<ToolExit>()),
+      expect(commandError, isA<ToolExit>());
+      expect(
+        output,
+        containsAllInOrder(<Matcher>[
+          contains(
+              'Found a "homepage" entry; only "repository" should be used.'),
+        ]),
       );
     });
 
@@ -237,12 +261,18 @@ ${dependenciesSection()}
 ${devDependenciesSection()}
 ''');
 
-      final Future<List<String>> result =
-          runCapturingPrint(runner, <String>['pubspec-check']);
+      Error? commandError;
+      final List<String> output = await runCapturingPrint(
+          runner, <String>['pubspec-check'], errorHandler: (Error e) {
+        commandError = e;
+      });
 
-      await expectLater(
-        result,
-        throwsA(isA<ToolExit>()),
+      expect(commandError, isA<ToolExit>());
+      expect(
+        output,
+        containsAllInOrder(<Matcher>[
+          contains('A package should have an "issue_tracker" link'),
+        ]),
       );
     });
 
@@ -257,12 +287,19 @@ ${devDependenciesSection()}
 ${environmentSection()}
 ''');
 
-      final Future<List<String>> result =
-          runCapturingPrint(runner, <String>['pubspec-check']);
+      Error? commandError;
+      final List<String> output = await runCapturingPrint(
+          runner, <String>['pubspec-check'], errorHandler: (Error e) {
+        commandError = e;
+      });
 
-      await expectLater(
-        result,
-        throwsA(isA<ToolExit>()),
+      expect(commandError, isA<ToolExit>());
+      expect(
+        output,
+        containsAllInOrder(<Matcher>[
+          contains(
+              'Major sections should follow standard repository ordering:'),
+        ]),
       );
     });
 
@@ -277,12 +314,19 @@ ${dependenciesSection()}
 ${devDependenciesSection()}
 ''');
 
-      final Future<List<String>> result =
-          runCapturingPrint(runner, <String>['pubspec-check']);
+      Error? commandError;
+      final List<String> output = await runCapturingPrint(
+          runner, <String>['pubspec-check'], errorHandler: (Error e) {
+        commandError = e;
+      });
 
-      await expectLater(
-        result,
-        throwsA(isA<ToolExit>()),
+      expect(commandError, isA<ToolExit>());
+      expect(
+        output,
+        containsAllInOrder(<Matcher>[
+          contains(
+              'Major sections should follow standard repository ordering:'),
+        ]),
       );
     });
 
@@ -297,12 +341,19 @@ ${devDependenciesSection()}
 ${dependenciesSection()}
 ''');
 
-      final Future<List<String>> result =
-          runCapturingPrint(runner, <String>['pubspec-check']);
+      Error? commandError;
+      final List<String> output = await runCapturingPrint(
+          runner, <String>['pubspec-check'], errorHandler: (Error e) {
+        commandError = e;
+      });
 
-      await expectLater(
-        result,
-        throwsA(isA<ToolExit>()),
+      expect(commandError, isA<ToolExit>());
+      expect(
+        output,
+        containsAllInOrder(<Matcher>[
+          contains(
+              'Major sections should follow standard repository ordering:'),
+        ]),
       );
     });
 
@@ -317,12 +368,150 @@ ${flutterSection(isPlugin: true)}
 ${dependenciesSection()}
 ''');
 
-      final Future<List<String>> result =
-          runCapturingPrint(runner, <String>['pubspec-check']);
+      Error? commandError;
+      final List<String> output = await runCapturingPrint(
+          runner, <String>['pubspec-check'], errorHandler: (Error e) {
+        commandError = e;
+      });
 
-      await expectLater(
-        result,
-        throwsA(isA<ToolExit>()),
+      expect(commandError, isA<ToolExit>());
+      expect(
+        output,
+        containsAllInOrder(<Matcher>[
+          contains(
+              'Major sections should follow standard repository ordering:'),
+        ]),
+      );
+    });
+
+    test('fails when an implemenation package is missing "implements"',
+        () async {
+      final Directory pluginDirectory = createFakePlugin(
+          'plugin_a_foo', packagesDir.childDirectory('plugin_a'));
+
+      pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
+${headerSection('plugin_a_foo', isPlugin: true)}
+${environmentSection()}
+${flutterSection(isPlugin: true)}
+${dependenciesSection()}
+${devDependenciesSection()}
+''');
+
+      Error? commandError;
+      final List<String> output = await runCapturingPrint(
+          runner, <String>['pubspec-check'], errorHandler: (Error e) {
+        commandError = e;
+      });
+
+      expect(commandError, isA<ToolExit>());
+      expect(
+        output,
+        containsAllInOrder(<Matcher>[
+          contains('Missing "implements: plugin_a" in "plugin" section.'),
+        ]),
+      );
+    });
+
+    test('fails when an implemenation package has the wrong "implements"',
+        () async {
+      final Directory pluginDirectory = createFakePlugin(
+          'plugin_a_foo', packagesDir.childDirectory('plugin_a'));
+
+      pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
+${headerSection('plugin_a_foo', isPlugin: true)}
+${environmentSection()}
+${flutterSection(isPlugin: true, implementedPackage: 'plugin_a_foo')}
+${dependenciesSection()}
+${devDependenciesSection()}
+''');
+
+      Error? commandError;
+      final List<String> output = await runCapturingPrint(
+          runner, <String>['pubspec-check'], errorHandler: (Error e) {
+        commandError = e;
+      });
+
+      expect(commandError, isA<ToolExit>());
+      expect(
+        output,
+        containsAllInOrder(<Matcher>[
+          contains('Expecetd "implements: plugin_a"; '
+              'found "implements: plugin_a_foo".'),
+        ]),
+      );
+    });
+
+    test('passes for a correct implemenation package', () async {
+      final Directory pluginDirectory = createFakePlugin(
+          'plugin_a_foo', packagesDir.childDirectory('plugin_a'));
+
+      pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
+${headerSection('plugin_a_foo', isPlugin: true)}
+${environmentSection()}
+${flutterSection(isPlugin: true, implementedPackage: 'plugin_a')}
+${dependenciesSection()}
+${devDependenciesSection()}
+''');
+
+      final List<String> output =
+          await runCapturingPrint(runner, <String>['pubspec-check']);
+
+      expect(
+        output,
+        containsAllInOrder(<Matcher>[
+          contains('Running for plugin_a_foo...'),
+          contains('No issues found!'),
+        ]),
+      );
+    });
+
+    test('passes for an app-facing package without "implements"', () async {
+      final Directory pluginDirectory =
+          createFakePlugin('plugin_a', packagesDir.childDirectory('plugin_a'));
+
+      pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
+${headerSection('plugin_a', isPlugin: true)}
+${environmentSection()}
+${flutterSection(isPlugin: true)}
+${dependenciesSection()}
+${devDependenciesSection()}
+''');
+
+      final List<String> output =
+          await runCapturingPrint(runner, <String>['pubspec-check']);
+
+      expect(
+        output,
+        containsAllInOrder(<Matcher>[
+          contains('Running for plugin_a/plugin_a...'),
+          contains('No issues found!'),
+        ]),
+      );
+    });
+
+    test('passes for a platform interface package without "implements"',
+        () async {
+      final Directory pluginDirectory = createFakePlugin(
+          'plugin_a_platform_interface',
+          packagesDir.childDirectory('plugin_a'));
+
+      pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
+${headerSection('plugin_a_platform_interface', isPlugin: true)}
+${environmentSection()}
+${flutterSection(isPlugin: true)}
+${dependenciesSection()}
+${devDependenciesSection()}
+''');
+
+      final List<String> output =
+          await runCapturingPrint(runner, <String>['pubspec-check']);
+
+      expect(
+        output,
+        containsAllInOrder(<Matcher>[
+          contains('Running for plugin_a_platform_interface...'),
+          contains('No issues found!'),
+        ]),
       );
     });
   });


### PR DESCRIPTION
The federated plugin spec calls for implementation packages to include an `implements` entry in the `plugins` section of the `pubspec.yaml` indicating what app-facing package it implements. Most of the described behaviors of the `flutter` tool aren't implemented yet, and the pub.dev features have `default_plugin` as a backstop, so we haven't noticed that they are mostly missing (or in one case, incorrect).

To better future-proof the plugins, and to provide a better example to people looking at our plugins as examples of federation, this adds a CI check to make sure that we are correctly adding it, and fixes all of the missing/incorrect values it turned up.

Fixes https://github.com/flutter/flutter/issues/88222

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
