### PR TITLE
[flutter_plugin_tools] Improve 'repository' check

### DIFF
--- a/packages/in_app_purchase/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.8
+
+* Fix repository link in pubspec.yaml.
+
 ## 1.0.7
 
 * Remove references to the Android V1 embedding.

--- a/packages/in_app_purchase/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase/pubspec.yaml
@@ -1,8 +1,8 @@
 name: in_app_purchase
 description: A Flutter plugin for in-app purchases. Exposes APIs for making in-app purchases through the App Store and Google Play.
-repository: https://github.com/flutter/plugins/tree/master/packages/in_app_purchase
+repository: https://github.com/flutter/plugins/tree/master/packages/in_app_purchase/in_app_purchase
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 1.0.7
+version: 1.0.8
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/ios_platform_images/CHANGELOG.md
+++ b/packages/ios_platform_images/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 0.2.0+1
 
 * Add iOS unit test target.
+* Fix repository link in pubspec.yaml.
 
 ## 0.2.0
 

--- a/packages/ios_platform_images/pubspec.yaml
+++ b/packages/ios_platform_images/pubspec.yaml
@@ -1,8 +1,8 @@
 name: ios_platform_images
 description: A plugin to share images between Flutter and iOS in add-to-app setups.
-repository: https://github.com/flutter/plugins/tree/master/packages/ios_platform_images/ios_platform_images
+repository: https://github.com/flutter/plugins/tree/master/packages/ios_platform_images
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+ios_platform_images%22
-version: 0.2.0
+version: 0.2.0+1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/quick_actions/quick_actions/CHANGELOG.md
+++ b/packages/quick_actions/quick_actions/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 0.6.0+6
 
 * Updated Android lint settings.
+* Fix repository link in pubspec.yaml.
 
 ## 0.6.0+5
 

--- a/packages/quick_actions/quick_actions/pubspec.yaml
+++ b/packages/quick_actions/quick_actions/pubspec.yaml
@@ -1,9 +1,9 @@
 name: quick_actions
 description: Flutter plugin for creating shortcuts on home screen, also known as
   Quick Actions on iOS and App Shortcuts on Android.
-repository: https://github.com/flutter/plugins/tree/master/packages/quick_actions
+repository: https://github.com/flutter/plugins/tree/master/packages/quick_actions/quick_actions
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+quick_actions%22
-version: 0.6.0+5
+version: 0.6.0+6
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Added Android native integration test support to `native-test`.
 - Added a new `android-lint` command to lint Android plugin native code.
 - Pubspec validation now checks for `implements` in implementation packages.
+- Pubspec valitation now checks the full relative path of `repository` entries.
 
 ## 0.5.0
 

--- a/script/tool/lib/src/pubspec_check_command.dart
+++ b/script/tool/lib/src/pubspec_check_command.dart
@@ -160,9 +160,9 @@ class PubspecCheckCommand extends PackageLoopingCommand {
     if (pubspec.repository == null) {
       errorMessages.add('Missing "repository"');
     } else {
-      final String packagePath =
+      final String relativePackagePath =
           path.relative(package.path, from: packagesDir.parent.path);
-      if (!pubspec.repository!.path.endsWith(packagePath)) {
+      if (!pubspec.repository!.path.endsWith(relativePackagePath)) {
         errorMessages
             .add('The "repository" link should end with the package path.');
       }

--- a/script/tool/lib/src/pubspec_check_command.dart
+++ b/script/tool/lib/src/pubspec_check_command.dart
@@ -98,7 +98,7 @@ class PubspecCheckCommand extends PackageLoopingCommand {
 
     if (pubspec.publishTo != 'none') {
       final List<String> repositoryErrors =
-          _checkForRepositoryLinkErrors(pubspec, packageName: package.basename);
+          _checkForRepositoryLinkErrors(pubspec, package: package);
       if (repositoryErrors.isNotEmpty) {
         for (final String error in repositoryErrors) {
           printError('$indentation$error');
@@ -154,14 +154,18 @@ class PubspecCheckCommand extends PackageLoopingCommand {
 
   List<String> _checkForRepositoryLinkErrors(
     Pubspec pubspec, {
-    required String packageName,
+    required Directory package,
   }) {
     final List<String> errorMessages = <String>[];
     if (pubspec.repository == null) {
       errorMessages.add('Missing "repository"');
-    } else if (!pubspec.repository!.path.endsWith(packageName)) {
-      errorMessages
-          .add('The "repository" link should end with the package name.');
+    } else {
+      final String packagePath =
+          path.relative(package.path, from: packagesDir.parent.path);
+      if (!pubspec.repository!.path.endsWith(packagePath)) {
+        errorMessages
+            .add('The "repository" link should end with the package path.');
+      }
     }
 
     if (pubspec.homepage != null) {

--- a/script/tool/test/pubspec_check_command_test.dart
+++ b/script/tool/test/pubspec_check_command_test.dart
@@ -37,15 +37,25 @@ void main() {
       runner.addCommand(command);
     });
 
+    /// Returns the top section of a pubspec.yaml for a package named [name],
+    /// for either a flutter/packages or flutter/plugins package depending on
+    /// the values of [isPlugin].
+    ///
+    /// By default it will create a header that includes all of the expected
+    /// values, elements can be changed via arguments to create incorrect
+    /// entries.
     String headerSection(
       String name, {
       bool isPlugin = false,
       bool includeRepository = true,
+      String? repositoryPackageRelativePath,
       bool includeHomepage = false,
       bool includeIssueTracker = true,
     }) {
+      final String repositoryPath = repositoryPackageRelativePath ?? name;
       final String repoLink = 'https://github.com/flutter/'
-          '${isPlugin ? 'plugins' : 'packages'}/tree/master/packages/$name';
+          '${isPlugin ? 'plugins' : 'packages'}/tree/master/'
+          'packages/$repositoryPath';
       final String issueTrackerLink =
           'https://github.com/flutter/flutter/issues?'
           'q=is%3Aissue+is%3Aopen+label%3A%22p%3A+$name%22';
@@ -250,6 +260,32 @@ ${devDependenciesSection()}
       );
     });
 
+    test('fails when repository is incorrect', () async {
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir);
+
+      pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
+${headerSection('plugin', isPlugin: true, repositoryPackageRelativePath: 'different_plugin')}
+${environmentSection()}
+${flutterSection(isPlugin: true)}
+${dependenciesSection()}
+${devDependenciesSection()}
+''');
+
+      Error? commandError;
+      final List<String> output = await runCapturingPrint(
+          runner, <String>['pubspec-check'], errorHandler: (Error e) {
+        commandError = e;
+      });
+
+      expect(commandError, isA<ToolExit>());
+      expect(
+        output,
+        containsAllInOrder(<Matcher>[
+          contains('The "repository" link should end with the package path.'),
+        ]),
+      );
+    });
+
     test('fails when issue tracker is missing', () async {
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir);
 
@@ -446,7 +482,11 @@ ${devDependenciesSection()}
           'plugin_a_foo', packagesDir.childDirectory('plugin_a'));
 
       pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
-${headerSection('plugin_a_foo', isPlugin: true)}
+${headerSection(
+        'plugin_a_foo',
+        isPlugin: true,
+        repositoryPackageRelativePath: 'plugin_a/plugin_a_foo',
+      )}
 ${environmentSection()}
 ${flutterSection(isPlugin: true, implementedPackage: 'plugin_a')}
 ${dependenciesSection()}
@@ -470,7 +510,11 @@ ${devDependenciesSection()}
           createFakePlugin('plugin_a', packagesDir.childDirectory('plugin_a'));
 
       pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
-${headerSection('plugin_a', isPlugin: true)}
+${headerSection(
+        'plugin_a',
+        isPlugin: true,
+        repositoryPackageRelativePath: 'plugin_a/plugin_a',
+      )}
 ${environmentSection()}
 ${flutterSection(isPlugin: true)}
 ${dependenciesSection()}
@@ -496,7 +540,11 @@ ${devDependenciesSection()}
           packagesDir.childDirectory('plugin_a'));
 
       pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
-${headerSection('plugin_a_platform_interface', isPlugin: true)}
+${headerSection(
+        'plugin_a_platform_interface',
+        isPlugin: true,
+        repositoryPackageRelativePath: 'plugin_a/plugin_a_platform_interface',
+      )}
 ${environmentSection()}
 ${flutterSection(isPlugin: true)}
 ${dependenciesSection()}

--- a/script/tool/test/pubspec_check_command_test.dart
+++ b/script/tool/test/pubspec_check_command_test.dart
@@ -44,15 +44,19 @@ void main() {
     /// By default it will create a header that includes all of the expected
     /// values, elements can be changed via arguments to create incorrect
     /// entries.
+    ///
+    /// If [includeRepository] is true, by default the path in the link will
+    /// be "packages/[name]"; a different "packages"-relative path can be
+    /// provided with [repositoryPackagesDirRelativePath].
     String headerSection(
       String name, {
       bool isPlugin = false,
       bool includeRepository = true,
-      String? repositoryPackageRelativePath,
+      String? repositoryPackagesDirRelativePath,
       bool includeHomepage = false,
       bool includeIssueTracker = true,
     }) {
-      final String repositoryPath = repositoryPackageRelativePath ?? name;
+      final String repositoryPath = repositoryPackagesDirRelativePath ?? name;
       final String repoLink = 'https://github.com/flutter/'
           '${isPlugin ? 'plugins' : 'packages'}/tree/master/'
           'packages/$repositoryPath';
@@ -264,7 +268,7 @@ ${devDependenciesSection()}
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir);
 
       pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
-${headerSection('plugin', isPlugin: true, repositoryPackageRelativePath: 'different_plugin')}
+${headerSection('plugin', isPlugin: true, repositoryPackagesDirRelativePath: 'different_plugin')}
 ${environmentSection()}
 ${flutterSection(isPlugin: true)}
 ${dependenciesSection()}
@@ -485,7 +489,7 @@ ${devDependenciesSection()}
 ${headerSection(
         'plugin_a_foo',
         isPlugin: true,
-        repositoryPackageRelativePath: 'plugin_a/plugin_a_foo',
+        repositoryPackagesDirRelativePath: 'plugin_a/plugin_a_foo',
       )}
 ${environmentSection()}
 ${flutterSection(isPlugin: true, implementedPackage: 'plugin_a')}
@@ -513,7 +517,7 @@ ${devDependenciesSection()}
 ${headerSection(
         'plugin_a',
         isPlugin: true,
-        repositoryPackageRelativePath: 'plugin_a/plugin_a',
+        repositoryPackagesDirRelativePath: 'plugin_a/plugin_a',
       )}
 ${environmentSection()}
 ${flutterSection(isPlugin: true)}
@@ -543,7 +547,8 @@ ${devDependenciesSection()}
 ${headerSection(
         'plugin_a_platform_interface',
         isPlugin: true,
-        repositoryPackageRelativePath: 'plugin_a/plugin_a_platform_interface',
+        repositoryPackagesDirRelativePath:
+            'plugin_a/plugin_a_platform_interface',
       )}
 ${environmentSection()}
 ${flutterSection(isPlugin: true)}


### PR DESCRIPTION
Ensures that the full relative path in the 'repository' link is correct,
not just the last segment. This ensure that path-level errors (e.g.,
linking to the group directory rather than the package itself for
app-facing packages) are caught.

Also fixes the errors that this improved check catches, including
several cases where a previously unfederated package wasn't fixed when
it was moved to a subdirectory.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
