### PR TITLE
Add unit tests to `quick_actions` plugin

### DIFF
--- a/packages/quick_actions/quick_actions/android/build.gradle
+++ b/packages/quick_actions/quick_actions/android/build.gradle
@@ -32,6 +32,15 @@ android {
         disable 'InvalidPackage'
     }
 
+    dependencies {
+        testImplementation 'junit:junit:4.12'
+        testImplementation 'org.mockito:mockito-core:3.2.4'
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 
     testOptions {
         unitTests.includeAndroidResources = true

--- a/packages/quick_actions/quick_actions/android/src/test/java/io/flutter/plugins/quickactions/QuickActionsTest.java
+++ b/packages/quick_actions/quick_actions/android/src/test/java/io/flutter/plugins/quickactions/QuickActionsTest.java
@@ -4,17 +4,17 @@
 
 package io.flutter.plugins.quickactions;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import org.junit.Test;
-import java.nio.ByteBuffer;
-
 import io.flutter.embedding.engine.plugins.FlutterPlugin.FlutterPluginBinding;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.StandardMethodCodec;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import java.nio.ByteBuffer;
+import org.junit.Test;
 
 public class QuickActionsTest {
   private static class TestBinaryMessenger implements BinaryMessenger {
@@ -26,9 +26,13 @@ public class QuickActionsTest {
     }
 
     @Override
-    public void send(@NonNull String channel, @Nullable ByteBuffer message, @Nullable final BinaryReply callback) {
+    public void send(
+        @NonNull String channel,
+        @Nullable ByteBuffer message,
+        @Nullable final BinaryReply callback) {
       if (channel.equals("plugins.flutter.io/quick_actions")) {
-        lastMethodCall = StandardMethodCodec.INSTANCE.decodeMethodCall((ByteBuffer) message.position(0));
+        lastMethodCall =
+            StandardMethodCodec.INSTANCE.decodeMethodCall((ByteBuffer) message.position(0));
       }
     }
 

--- a/packages/quick_actions/quick_actions/android/src/test/java/io/flutter/plugins/quickactions/QuickActionsTest.java
+++ b/packages/quick_actions/quick_actions/android/src/test/java/io/flutter/plugins/quickactions/QuickActionsTest.java
@@ -1,0 +1,50 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.plugins.quickactions;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import org.junit.Test;
+import java.nio.ByteBuffer;
+
+import io.flutter.embedding.engine.plugins.FlutterPlugin.FlutterPluginBinding;
+import io.flutter.plugin.common.BinaryMessenger;
+import io.flutter.plugin.common.MethodCall;
+import io.flutter.plugin.common.StandardMethodCodec;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class QuickActionsTest {
+  private static class TestBinaryMessenger implements BinaryMessenger {
+    public MethodCall lastMethodCall;
+
+    @Override
+    public void send(@NonNull String channel, @Nullable ByteBuffer message) {
+      send(channel, message, null);
+    }
+
+    @Override
+    public void send(@NonNull String channel, @Nullable ByteBuffer message, @Nullable final BinaryReply callback) {
+      if (channel.equals("plugins.flutter.io/quick_actions")) {
+        lastMethodCall = StandardMethodCodec.INSTANCE.decodeMethodCall((ByteBuffer) message.position(0));
+      }
+    }
+
+    @Override
+    public void setMessageHandler(@NonNull String channel, @Nullable BinaryMessageHandler handler) {
+      // Do nothing.
+    }
+  }
+
+  @Test
+  public void canAttachToEngine() {
+    final TestBinaryMessenger testBinaryMessenger = new TestBinaryMessenger();
+    final FlutterPluginBinding mockPluginBinding = mock(FlutterPluginBinding.class);
+    when(mockPluginBinding.getBinaryMessenger()).thenReturn(testBinaryMessenger);
+
+    final QuickActionsPlugin plugin = new QuickActionsPlugin();
+    plugin.onAttachedToEngine(mockPluginBinding);
+  }
+}


### PR DESCRIPTION
Add unit tests to `quick_actions` plugin

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
