### PR TITLE
[flutter_plugin_tools] Improve process mocking

### DIFF
--- a/script/tool/test/analyze_command_test.dart
+++ b/script/tool/test/analyze_command_test.dart
@@ -211,7 +211,7 @@ void main() {
     createFakePlugin('foo', packagesDir);
 
     processRunner.mockProcessesForExecutable['flutter'] = <io.Process>[
-      MockProcess.failing() // flutter packages get
+      MockProcess(exitCode: 1) // flutter packages get
     ];
 
     Error? commandError;
@@ -233,7 +233,7 @@ void main() {
     createFakePlugin('foo', packagesDir);
 
     processRunner.mockProcessesForExecutable['dart'] = <io.Process>[
-      MockProcess.failing() // dart analyze
+      MockProcess(exitCode: 1) // dart analyze
     ];
 
     Error? commandError;

--- a/script/tool/test/build_examples_command_test.dart
+++ b/script/tool/test/build_examples_command_test.dart
@@ -63,7 +63,7 @@ void main() {
       processRunner
               .mockProcessesForExecutable[getFlutterCommand(mockPlatform)] =
           <io.Process>[
-        MockProcess.failing() // flutter packages get
+        MockProcess(exitCode: 1) // flutter packages get
       ];
 
       Error? commandError;

--- a/script/tool/test/common/gradle_test.dart
+++ b/script/tool/test/common/gradle_test.dart
@@ -168,7 +168,7 @@ void main() {
 
       processRunner.mockProcessesForExecutable[project.gradleWrapper.path] =
           <io.Process>[
-        MockProcess.failing(),
+        MockProcess(exitCode: 1),
       ];
 
       final int exitCode = await project.runCommand('foo');

--- a/script/tool/test/common/xcode_test.dart
+++ b/script/tool/test/common/xcode_test.dart
@@ -94,8 +94,9 @@ void main() {
         }
       };
 
-      processRunner.processToReturn = MockProcess.succeeding();
-      processRunner.resultStdout = jsonEncode(devices);
+      processRunner.mockProcessesForExecutable['xcrun'] = <io.Process>[
+        MockProcess(stdout: jsonEncode(devices)),
+      ];
 
       expect(await xcode.findBestAvailableIphoneSimulator(), expectedDeviceId);
     });
@@ -137,8 +138,9 @@ void main() {
         }
       };
 
-      processRunner.processToReturn = MockProcess.succeeding();
-      processRunner.resultStdout = jsonEncode(devices);
+      processRunner.mockProcessesForExecutable['xcrun'] = <io.Process>[
+        MockProcess(stdout: jsonEncode(devices)),
+      ];
 
       expect(await xcode.findBestAvailableIphoneSimulator(), null);
     });
@@ -247,8 +249,7 @@ void main() {
 
   group('projectHasTarget', () {
     test('returns true when present', () async {
-      processRunner.processToReturn = MockProcess.succeeding();
-      processRunner.resultStdout = '''
+      const String stdout = '''
 {
   "project" : {
     "configurations" : [
@@ -266,6 +267,9 @@ void main() {
     ]
   }
 }''';
+      processRunner.mockProcessesForExecutable['xcrun'] = <io.Process>[
+        MockProcess(stdout: stdout),
+      ];
 
       final Directory project =
           const LocalFileSystem().directory('/foo.xcodeproj');
@@ -287,8 +291,7 @@ void main() {
     });
 
     test('returns false when not present', () async {
-      processRunner.processToReturn = MockProcess.succeeding();
-      processRunner.resultStdout = '''
+      const String stdout = '''
 {
   "project" : {
     "configurations" : [
@@ -305,6 +308,9 @@ void main() {
     ]
   }
 }''';
+      processRunner.mockProcessesForExecutable['xcrun'] = <io.Process>[
+        MockProcess(stdout: stdout),
+      ];
 
       final Directory project =
           const LocalFileSystem().directory('/foo.xcodeproj');
@@ -326,8 +332,9 @@ void main() {
     });
 
     test('returns null for unexpected output', () async {
-      processRunner.processToReturn = MockProcess.succeeding();
-      processRunner.resultStdout = '{}';
+      processRunner.mockProcessesForExecutable['xcrun'] = <io.Process>[
+        MockProcess(stdout: '{}'),
+      ];
 
       final Directory project =
           const LocalFileSystem().directory('/foo.xcodeproj');
@@ -349,8 +356,9 @@ void main() {
     });
 
     test('returns null for invalid output', () async {
-      processRunner.processToReturn = MockProcess.succeeding();
-      processRunner.resultStdout = ':)';
+      processRunner.mockProcessesForExecutable['xcrun'] = <io.Process>[
+        MockProcess(stdout: ':)'),
+      ];
 
       final Directory project =
           const LocalFileSystem().directory('/foo.xcodeproj');
@@ -372,7 +380,9 @@ void main() {
     });
 
     test('returns null for failure', () async {
-      processRunner.processToReturn = MockProcess.failing();
+      processRunner.mockProcessesForExecutable['xcrun'] = <io.Process>[
+        MockProcess.failing(), // xcodebuild -list
+      ];
 
       final Directory project =
           const LocalFileSystem().directory('/foo.xcodeproj');

--- a/script/tool/test/common/xcode_test.dart
+++ b/script/tool/test/common/xcode_test.dart
@@ -147,7 +147,7 @@ void main() {
 
     test('returns null if simctl fails', () async {
       processRunner.mockProcessesForExecutable['xcrun'] = <io.Process>[
-        MockProcess.failing(),
+        MockProcess(exitCode: 1),
       ];
 
       expect(await xcode.findBestAvailableIphoneSimulator(), null);
@@ -218,7 +218,7 @@ void main() {
 
     test('returns error codes', () async {
       processRunner.mockProcessesForExecutable['xcrun'] = <io.Process>[
-        MockProcess.failing(),
+        MockProcess(exitCode: 1),
       ];
       final Directory directory = const LocalFileSystem().currentDirectory;
 
@@ -381,7 +381,7 @@ void main() {
 
     test('returns null for failure', () async {
       processRunner.mockProcessesForExecutable['xcrun'] = <io.Process>[
-        MockProcess.failing(), // xcodebuild -list
+        MockProcess(exitCode: 1), // xcodebuild -list
       ];
 
       final Directory project =

--- a/script/tool/test/drive_examples_command_test.dart
+++ b/script/tool/test/drive_examples_command_test.dart
@@ -60,12 +60,10 @@ void main() {
       final String output =
           '''${includeBanner ? updateBanner : ''}[${devices.join(',')}]''';
 
-      final MockProcess mockDevicesProcess = MockProcess.succeeding();
-      mockDevicesProcess.stdoutController.close(); // ignore: unawaited_futures
+      final MockProcess mockDevicesProcess = MockProcess(stdout: output);
       processRunner
               .mockProcessesForExecutable[getFlutterCommand(mockPlatform)] =
           <io.Process>[mockDevicesProcess];
-      processRunner.resultStdout = output;
     }
 
     test('fails if no platforms are provided', () async {

--- a/script/tool/test/drive_examples_command_test.dart
+++ b/script/tool/test/drive_examples_command_test.dart
@@ -149,7 +149,7 @@ void main() {
       // Simulate failure from `flutter devices`.
       processRunner
               .mockProcessesForExecutable[getFlutterCommand(mockPlatform)] =
-          <io.Process>[MockProcess.failing()];
+          <io.Process>[MockProcess(exitCode: 1)];
 
       Error? commandError;
       final List<String> output = await runCapturingPrint(
@@ -952,8 +952,8 @@ void main() {
               .mockProcessesForExecutable[getFlutterCommand(mockPlatform)] =
           <io.Process>[
         // No mock for 'devices', since it's running for macOS.
-        MockProcess.failing(), // 'drive' #1
-        MockProcess.failing(), // 'drive' #2
+        MockProcess(exitCode: 1), // 'drive' #1
+        MockProcess(exitCode: 1), // 'drive' #2
       ];
 
       Error? commandError;

--- a/script/tool/test/firebase_test_lab_command_test.dart
+++ b/script/tool/test/firebase_test_lab_command_test.dart
@@ -64,7 +64,7 @@ void main() {
 
     test('retries gcloud set', () async {
       processRunner.mockProcessesForExecutable['gcloud'] = <Process>[
-        MockProcess.succeeding(), // auth
+        MockProcess(), // auth
         MockProcess.failing(), // config
       ];
       createFakePlugin('plugin', packagesDir, extraFiles: <String>[
@@ -245,10 +245,10 @@ void main() {
       ]);
 
       processRunner.mockProcessesForExecutable['gcloud'] = <Process>[
-        MockProcess.succeeding(), // auth
-        MockProcess.succeeding(), // config
+        MockProcess(), // auth
+        MockProcess(), // config
         MockProcess.failing(), // integration test #1
-        MockProcess.succeeding(), // integration test #2
+        MockProcess(), // integration test #2
       ];
 
       Error? commandError;
@@ -533,7 +533,7 @@ void main() {
           .childFile('gradlew')
           .path;
       processRunner.mockProcessesForExecutable[gradlewPath] = <Process>[
-        MockProcess.succeeding(), // assembleAndroidTest
+        MockProcess(), // assembleAndroidTest
         MockProcess.failing(), // assembleDebug
       ];
 

--- a/script/tool/test/firebase_test_lab_command_test.dart
+++ b/script/tool/test/firebase_test_lab_command_test.dart
@@ -40,7 +40,7 @@ void main() {
 
     test('fails if gcloud auth fails', () async {
       processRunner.mockProcessesForExecutable['gcloud'] = <Process>[
-        MockProcess.failing()
+        MockProcess(exitCode: 1)
       ];
       createFakePlugin('plugin', packagesDir, extraFiles: <String>[
         'example/integration_test/foo_test.dart',
@@ -65,7 +65,7 @@ void main() {
     test('retries gcloud set', () async {
       processRunner.mockProcessesForExecutable['gcloud'] = <Process>[
         MockProcess(), // auth
-        MockProcess.failing(), // config
+        MockProcess(exitCode: 1), // config
       ];
       createFakePlugin('plugin', packagesDir, extraFiles: <String>[
         'example/integration_test/foo_test.dart',
@@ -247,7 +247,7 @@ void main() {
       processRunner.mockProcessesForExecutable['gcloud'] = <Process>[
         MockProcess(), // auth
         MockProcess(), // config
-        MockProcess.failing(), // integration test #1
+        MockProcess(exitCode: 1), // integration test #1
         MockProcess(), // integration test #2
       ];
 
@@ -459,7 +459,7 @@ void main() {
       ]);
 
       processRunner.mockProcessesForExecutable['flutter'] = <Process>[
-        MockProcess.failing() // flutter build
+        MockProcess(exitCode: 1) // flutter build
       ];
 
       Error? commandError;
@@ -496,7 +496,7 @@ void main() {
           .childFile('gradlew')
           .path;
       processRunner.mockProcessesForExecutable[gradlewPath] = <Process>[
-        MockProcess.failing()
+        MockProcess(exitCode: 1)
       ];
 
       Error? commandError;
@@ -534,7 +534,7 @@ void main() {
           .path;
       processRunner.mockProcessesForExecutable[gradlewPath] = <Process>[
         MockProcess(), // assembleAndroidTest
-        MockProcess.failing(), // assembleDebug
+        MockProcess(exitCode: 1), // assembleDebug
       ];
 
       Error? commandError;

--- a/script/tool/test/format_command_test.dart
+++ b/script/tool/test/format_command_test.dart
@@ -115,7 +115,7 @@ void main() {
     createFakePlugin('a_plugin', packagesDir, extraFiles: files);
 
     processRunner.mockProcessesForExecutable[getFlutterCommand(mockPlatform)] =
-        <io.Process>[MockProcess.failing()];
+        <io.Process>[MockProcess(exitCode: 1)];
     Error? commandError;
     final List<String> output = await runCapturingPrint(
         runner, <String>['format'], errorHandler: (Error e) {
@@ -167,7 +167,7 @@ void main() {
     createFakePlugin('a_plugin', packagesDir, extraFiles: files);
 
     processRunner.mockProcessesForExecutable['java'] = <io.Process>[
-      MockProcess.failing()
+      MockProcess(exitCode: 1)
     ];
     Error? commandError;
     final List<String> output = await runCapturingPrint(
@@ -194,7 +194,7 @@ void main() {
 
     processRunner.mockProcessesForExecutable['java'] = <io.Process>[
       MockProcess(), // check for working java
-      MockProcess.failing(), // format
+      MockProcess(exitCode: 1), // format
     ];
     Error? commandError;
     final List<String> output = await runCapturingPrint(
@@ -280,7 +280,7 @@ void main() {
     createFakePlugin('a_plugin', packagesDir, extraFiles: files);
 
     processRunner.mockProcessesForExecutable['clang-format'] = <io.Process>[
-      MockProcess.failing()
+      MockProcess(exitCode: 1)
     ];
     Error? commandError;
     final List<String> output = await runCapturingPrint(
@@ -336,7 +336,7 @@ void main() {
 
     processRunner.mockProcessesForExecutable['clang-format'] = <io.Process>[
       MockProcess(), // check for working clang-format
-      MockProcess.failing(), // format
+      MockProcess(exitCode: 1), // format
     ];
     Error? commandError;
     final List<String> output = await runCapturingPrint(
@@ -448,7 +448,7 @@ void main() {
     createFakePlugin('a_plugin', packagesDir, extraFiles: files);
 
     processRunner.mockProcessesForExecutable['git'] = <io.Process>[
-      MockProcess.failing()
+      MockProcess(exitCode: 1)
     ];
     Error? commandError;
     final List<String> output =
@@ -475,7 +475,7 @@ void main() {
     const String changedFilePath = 'packages/a_plugin/linux/foo_plugin.cc';
     processRunner.mockProcessesForExecutable['git'] = <io.Process>[
       MockProcess(stdout: changedFilePath), // ls-files
-      MockProcess.failing(), // diff
+      MockProcess(exitCode: 1), // diff
     ];
 
     Error? commandError;

--- a/script/tool/test/format_command_test.dart
+++ b/script/tool/test/format_command_test.dart
@@ -193,7 +193,7 @@ void main() {
     createFakePlugin('a_plugin', packagesDir, extraFiles: files);
 
     processRunner.mockProcessesForExecutable['java'] = <io.Process>[
-      MockProcess.succeeding(), // check for working java
+      MockProcess(), // check for working java
       MockProcess.failing(), // format
     ];
     Error? commandError;
@@ -335,7 +335,7 @@ void main() {
     createFakePlugin('a_plugin', packagesDir, extraFiles: files);
 
     processRunner.mockProcessesForExecutable['clang-format'] = <io.Process>[
-      MockProcess.succeeding(), // check for working clang-format
+      MockProcess(), // check for working clang-format
       MockProcess.failing(), // format
     ];
     Error? commandError;
@@ -418,11 +418,11 @@ void main() {
     ];
     createFakePlugin('a_plugin', packagesDir, extraFiles: files);
 
-    processRunner.mockProcessesForExecutable['git'] = <io.Process>[
-      MockProcess.succeeding(),
-    ];
     const String changedFilePath = 'packages/a_plugin/linux/foo_plugin.cc';
-    processRunner.resultStdout = changedFilePath;
+    processRunner.mockProcessesForExecutable['git'] = <io.Process>[
+      MockProcess(stdout: changedFilePath),
+    ];
+
     Error? commandError;
     final List<String> output =
         await runCapturingPrint(runner, <String>['format', '--fail-on-change'],
@@ -472,12 +472,12 @@ void main() {
     ];
     createFakePlugin('a_plugin', packagesDir, extraFiles: files);
 
+    const String changedFilePath = 'packages/a_plugin/linux/foo_plugin.cc';
     processRunner.mockProcessesForExecutable['git'] = <io.Process>[
-      MockProcess.succeeding(), // ls-files
+      MockProcess(stdout: changedFilePath), // ls-files
       MockProcess.failing(), // diff
     ];
-    const String changedFilePath = 'packages/a_plugin/linux/foo_plugin.cc';
-    processRunner.resultStdout = changedFilePath;
+
     Error? commandError;
     final List<String> output =
         await runCapturingPrint(runner, <String>['format', '--fail-on-change'],

--- a/script/tool/test/lint_android_command_test.dart
+++ b/script/tool/test/lint_android_command_test.dart
@@ -101,7 +101,7 @@ void main() {
           });
 
       processRunner.mockProcessesForExecutable['gradlew'] = <io.Process>[
-        MockProcess.failing(),
+        MockProcess(exitCode: 1),
       ];
 
       Error? commandError;

--- a/script/tool/test/lint_podspecs_command_test.dart
+++ b/script/tool/test/lint_podspecs_command_test.dart
@@ -75,11 +75,9 @@ void main() {
       );
 
       processRunner.mockProcessesForExecutable['pod'] = <io.Process>[
-        MockProcess.succeeding(),
-        MockProcess.succeeding(),
+        MockProcess(stdout: 'Foo', stderr: 'Bar'),
+        MockProcess(),
       ];
-      processRunner.resultStdout = 'Foo';
-      processRunner.resultStderr = 'Bar';
 
       final List<String> output =
           await runCapturingPrint(runner, <String>['podspecs']);
@@ -227,7 +225,7 @@ void main() {
 
       // Simulate failure from the second call to `pod`.
       processRunner.mockProcessesForExecutable['pod'] = <io.Process>[
-        MockProcess.succeeding(),
+        MockProcess(),
         MockProcess.failing(),
       ];
 

--- a/script/tool/test/lint_podspecs_command_test.dart
+++ b/script/tool/test/lint_podspecs_command_test.dart
@@ -171,7 +171,7 @@ void main() {
 
       // Simulate failure from `which pod`.
       processRunner.mockProcessesForExecutable['which'] = <io.Process>[
-        MockProcess.failing(),
+        MockProcess(exitCode: 1),
       ];
 
       Error? commandError;
@@ -197,7 +197,7 @@ void main() {
 
       // Simulate failure from `pod`.
       processRunner.mockProcessesForExecutable['pod'] = <io.Process>[
-        MockProcess.failing(),
+        MockProcess(exitCode: 1),
       ];
 
       Error? commandError;
@@ -226,7 +226,7 @@ void main() {
       // Simulate failure from the second call to `pod`.
       processRunner.mockProcessesForExecutable['pod'] = <io.Process>[
         MockProcess(),
-        MockProcess.failing(),
+        MockProcess(exitCode: 1),
       ];
 
       Error? commandError;

--- a/script/tool/test/mocks.dart
+++ b/script/tool/test/mocks.dart
@@ -55,9 +55,6 @@ class MockProcess extends Mock implements io.Process {
     _stderrController.close();
   }
 
-  /// A mock process that terminates with exitCode 1.
-  MockProcess.failing() : this(exitCode: 1);
-
   final int _exitCode;
   final StreamController<List<int>> _stdoutController =
       StreamController<List<int>>();

--- a/script/tool/test/mocks.dart
+++ b/script/tool/test/mocks.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io' as io;
 
 import 'package:file/file.dart';
@@ -32,22 +33,35 @@ class MockPlatform extends Mock implements Platform {
 }
 
 class MockProcess extends Mock implements io.Process {
-  MockProcess();
-
-  /// A mock process that terminates with exitCode 0.
-  MockProcess.succeeding() {
-    exitCodeCompleter.complete(0);
+  /// Creates a mock process with the given results.
+  ///
+  /// The default encodings match the ProcessRunner defaults; mocks for
+  /// processes run with a different encoding will need to be created with
+  /// the matching encoding.
+  MockProcess({
+    int exitCode = 0,
+    String? stdout,
+    String? stderr,
+    Encoding stdoutEncoding = io.systemEncoding,
+    Encoding stderrEncoding = io.systemEncoding,
+  }) : _exitCode = exitCode {
+    if (stdout != null) {
+      _stdoutController.add(stdoutEncoding.encoder.convert(stdout));
+    }
+    if (stderr != null) {
+      _stderrController.add(stderrEncoding.encoder.convert(stderr));
+    }
+    _stdoutController.close();
+    _stderrController.close();
   }
 
   /// A mock process that terminates with exitCode 1.
-  MockProcess.failing() {
-    exitCodeCompleter.complete(1);
-  }
+  MockProcess.failing() : this(exitCode: 1);
 
-  final Completer<int> exitCodeCompleter = Completer<int>();
-  final StreamController<List<int>> stdoutController =
+  final int _exitCode;
+  final StreamController<List<int>> _stdoutController =
       StreamController<List<int>>();
-  final StreamController<List<int>> stderrController =
+  final StreamController<List<int>> _stderrController =
       StreamController<List<int>>();
   final MockIOSink stdinMock = MockIOSink();
 
@@ -55,13 +69,13 @@ class MockProcess extends Mock implements io.Process {
   int get pid => 99;
 
   @override
-  Future<int> get exitCode => exitCodeCompleter.future;
+  Future<int> get exitCode async => _exitCode;
 
   @override
-  Stream<List<int>> get stdout => stdoutController.stream;
+  Stream<List<int>> get stdout => _stdoutController.stream;
 
   @override
-  Stream<List<int>> get stderr => stderrController.stream;
+  Stream<List<int>> get stderr => _stderrController.stream;
 
   @override
   IOSink get stdin => stdinMock;

--- a/script/tool/test/native_test_command_test.dart
+++ b/script/tool/test/native_test_command_test.dart
@@ -122,11 +122,9 @@ void main() {
       final Directory pluginExampleDirectory =
           pluginDirectory1.childDirectory('example');
 
-      // Exit code 66 from testing indicates no tests.
-      final MockProcess noTestsProcessResult = MockProcess();
-      noTestsProcessResult.exitCodeCompleter.complete(66);
       processRunner.mockProcessesForExecutable['xcrun'] = <io.Process>[
-        noTestsProcessResult,
+        // Exit code 66 from testing indicates no tests.
+        MockProcess(exitCode: 66),
       ];
       final List<String> output =
           await runCapturingPrint(runner, <String>['native-test', '--macos']);
@@ -239,12 +237,13 @@ void main() {
             'plugin', packagesDir, platformSupport: <String, PlatformSupport>{
           kPlatformIos: PlatformSupport.inline
         });
-
         final Directory pluginExampleDirectory =
             pluginDirectory.childDirectory('example');
 
-        processRunner.processToReturn = MockProcess.succeeding();
-        processRunner.resultStdout = jsonEncode(_kDeviceListMap);
+        processRunner.mockProcessesForExecutable['xcrun'] = <io.Process>[
+          MockProcess(stdout: jsonEncode(_kDeviceListMap)), // simctl
+        ];
+
         await runCapturingPrint(runner, <String>['native-test', '--ios']);
 
         expect(
@@ -775,9 +774,11 @@ void main() {
         final Directory pluginExampleDirectory =
             pluginDirectory1.childDirectory('example');
 
-        processRunner.processToReturn = MockProcess.succeeding();
-        processRunner.resultStdout =
+        const String projectListOutput =
             '{"project":{"targets":["RunnerTests", "RunnerUITests"]}}';
+        processRunner.mockProcessesForExecutable['xcrun'] = <io.Process>[
+          MockProcess(stdout: projectListOutput), // xcodebuild -list
+        ];
 
         final List<String> output = await runCapturingPrint(runner, <String>[
           'native-test',
@@ -835,9 +836,11 @@ void main() {
         final Directory pluginExampleDirectory =
             pluginDirectory1.childDirectory('example');
 
-        processRunner.processToReturn = MockProcess.succeeding();
-        processRunner.resultStdout =
+        const String projectListOutput =
             '{"project":{"targets":["RunnerTests", "RunnerUITests"]}}';
+        processRunner.mockProcessesForExecutable['xcrun'] = <io.Process>[
+          MockProcess(stdout: projectListOutput), // xcodebuild -list
+        ];
 
         final List<String> output = await runCapturingPrint(runner, <String>[
           'native-test',
@@ -895,9 +898,13 @@ void main() {
         final Directory pluginExampleDirectory =
             pluginDirectory1.childDirectory('example');
 
-        processRunner.processToReturn = MockProcess.succeeding();
         // Simulate a project with unit tests but no integration tests...
-        processRunner.resultStdout = '{"project":{"targets":["RunnerTests"]}}';
+        const String projectListOutput =
+            '{"project":{"targets":["RunnerTests"]}}';
+        processRunner.mockProcessesForExecutable['xcrun'] = <io.Process>[
+          MockProcess(stdout: projectListOutput), // xcodebuild -list
+        ];
+
         // ... then try to run only integration tests.
         final List<String> output = await runCapturingPrint(runner, <String>[
           'native-test',
@@ -941,7 +948,9 @@ void main() {
         final Directory pluginExampleDirectory =
             pluginDirectory1.childDirectory('example');
 
-        processRunner.processToReturn = MockProcess.failing();
+        processRunner.mockProcessesForExecutable['xcrun'] = <io.Process>[
+          MockProcess.failing(), // xcodebuild -list
+        ];
 
         Error? commandError;
         final List<String> output = await runCapturingPrint(runner, <String>[

--- a/script/tool/test/native_test_command_test.dart
+++ b/script/tool/test/native_test_command_test.dart
@@ -672,7 +672,7 @@ void main() {
             .childFile('gradlew')
             .path;
         processRunner.mockProcessesForExecutable[gradlewPath] = <io.Process>[
-          MockProcess.failing()
+          MockProcess(exitCode: 1)
         ];
 
         Error? commandError;
@@ -744,7 +744,7 @@ void main() {
             });
 
         processRunner.mockProcessesForExecutable['xcrun'] = <io.Process>[
-          MockProcess.failing()
+          MockProcess(exitCode: 1)
         ];
 
         Error? commandError;
@@ -774,10 +774,13 @@ void main() {
         final Directory pluginExampleDirectory =
             pluginDirectory1.childDirectory('example');
 
-        const String projectListOutput =
-            '{"project":{"targets":["RunnerTests", "RunnerUITests"]}}';
+        const Map<String, dynamic> projects = <String, dynamic>{
+          'project': <String, dynamic>{
+            'targets': <String>['RunnerTests', 'RunnerUITests']
+          }
+        };
         processRunner.mockProcessesForExecutable['xcrun'] = <io.Process>[
-          MockProcess(stdout: projectListOutput), // xcodebuild -list
+          MockProcess(stdout: jsonEncode(projects)), // xcodebuild -list
         ];
 
         final List<String> output = await runCapturingPrint(runner, <String>[
@@ -836,10 +839,13 @@ void main() {
         final Directory pluginExampleDirectory =
             pluginDirectory1.childDirectory('example');
 
-        const String projectListOutput =
-            '{"project":{"targets":["RunnerTests", "RunnerUITests"]}}';
+        const Map<String, dynamic> projects = <String, dynamic>{
+          'project': <String, dynamic>{
+            'targets': <String>['RunnerTests', 'RunnerUITests']
+          }
+        };
         processRunner.mockProcessesForExecutable['xcrun'] = <io.Process>[
-          MockProcess(stdout: projectListOutput), // xcodebuild -list
+          MockProcess(stdout: jsonEncode(projects)), // xcodebuild -list
         ];
 
         final List<String> output = await runCapturingPrint(runner, <String>[
@@ -899,10 +905,13 @@ void main() {
             pluginDirectory1.childDirectory('example');
 
         // Simulate a project with unit tests but no integration tests...
-        const String projectListOutput =
-            '{"project":{"targets":["RunnerTests"]}}';
+        const Map<String, dynamic> projects = <String, dynamic>{
+          'project': <String, dynamic>{
+            'targets': <String>['RunnerTests']
+          }
+        };
         processRunner.mockProcessesForExecutable['xcrun'] = <io.Process>[
-          MockProcess(stdout: projectListOutput), // xcodebuild -list
+          MockProcess(stdout: jsonEncode(projects)), // xcodebuild -list
         ];
 
         // ... then try to run only integration tests.
@@ -949,7 +958,7 @@ void main() {
             pluginDirectory1.childDirectory('example');
 
         processRunner.mockProcessesForExecutable['xcrun'] = <io.Process>[
-          MockProcess.failing(), // xcodebuild -list
+          MockProcess(exitCode: 1), // xcodebuild -list
         ];
 
         Error? commandError;
@@ -1201,7 +1210,7 @@ void main() {
             .childFile('gradlew')
             .path;
         processRunner.mockProcessesForExecutable[gradlewPath] = <io.Process>[
-          MockProcess.failing()
+          MockProcess(exitCode: 1)
         ];
 
         Error? commandError;
@@ -1252,11 +1261,11 @@ void main() {
             .childFile('gradlew')
             .path;
         processRunner.mockProcessesForExecutable[gradlewPath] = <io.Process>[
-          MockProcess.failing()
+          MockProcess(exitCode: 1)
         ];
         // Simulate failing Android.
         processRunner.mockProcessesForExecutable['xcrun'] = <io.Process>[
-          MockProcess.failing()
+          MockProcess(exitCode: 1)
         ];
 
         Error? commandError;

--- a/script/tool/test/publish_check_command_test.dart
+++ b/script/tool/test/publish_check_command_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:collection';
 import 'dart:convert';
 import 'dart:io' as io;
 
@@ -19,18 +18,18 @@ import 'mocks.dart';
 import 'util.dart';
 
 void main() {
-  group('$PublishCheckProcessRunner tests', () {
+  group('$PublishCheckCommand tests', () {
     FileSystem fileSystem;
     late MockPlatform mockPlatform;
     late Directory packagesDir;
-    late PublishCheckProcessRunner processRunner;
+    late RecordingProcessRunner processRunner;
     late CommandRunner<void> runner;
 
     setUp(() {
       fileSystem = MemoryFileSystem();
       mockPlatform = MockPlatform();
       packagesDir = createPackagesDirectory(fileSystem: fileSystem);
-      processRunner = PublishCheckProcessRunner();
+      processRunner = RecordingProcessRunner();
       final PublishCheckCommand publishCheckCommand = PublishCheckCommand(
         packagesDir,
         processRunner: processRunner,
@@ -50,12 +49,11 @@ void main() {
       final Directory plugin2Dir =
           createFakePlugin('plugin_tools_test_package_b', packagesDir);
 
-      processRunner.processesToReturn.add(
-        MockProcess.succeeding(),
-      );
-      processRunner.processesToReturn.add(
-        MockProcess.succeeding(),
-      );
+      processRunner.mockProcessesForExecutable['flutter'] = <io.Process>[
+        MockProcess(),
+        MockProcess(),
+      ];
+
       await runCapturingPrint(runner, <String>['publish-check']);
 
       expect(
@@ -75,11 +73,9 @@ void main() {
     test('fail on negative test', () async {
       createFakePlugin('plugin_tools_test_package_a', packagesDir);
 
-      final MockProcess process = MockProcess.failing();
-      process.stdoutController.close(); // ignore: unawaited_futures
-      process.stderrController.close(); // ignore: unawaited_futures
-
-      processRunner.processesToReturn.add(process);
+      processRunner.mockProcessesForExecutable['flutter'] = <io.Process>[
+        MockProcess.failing()
+      ];
 
       expect(
         () => runCapturingPrint(runner, <String>['publish-check']),
@@ -91,8 +87,9 @@ void main() {
       final Directory dir = createFakePlugin('c', packagesDir);
       await dir.childFile('pubspec.yaml').writeAsString('bad-yaml');
 
-      final MockProcess process = MockProcess();
-      processRunner.processesToReturn.add(process);
+      processRunner.mockProcessesForExecutable['flutter'] = <io.Process>[
+        MockProcess(),
+      ];
 
       expect(() => runCapturingPrint(runner, <String>['publish-check']),
           throwsA(isA<ToolExit>()));
@@ -101,15 +98,14 @@ void main() {
     test('pass on prerelease if --allow-pre-release flag is on', () async {
       createFakePlugin('d', packagesDir);
 
-      const String preReleaseOutput = 'Package has 1 warning.'
-          'Packages with an SDK constraint on a pre-release of the Dart SDK should themselves be published as a pre-release version.';
-
-      final MockProcess process = MockProcess.failing();
-      process.stdoutController.add(preReleaseOutput.codeUnits);
-      process.stdoutController.close(); // ignore: unawaited_futures
-      process.stderrController.close(); // ignore: unawaited_futures
-
-      processRunner.processesToReturn.add(process);
+      final MockProcess process = MockProcess(
+          exitCode: 1,
+          stdout: 'Package has 1 warning.\n'
+              'Packages with an SDK constraint on a pre-release of the Dart '
+              'SDK should themselves be published as a pre-release version.');
+      processRunner.mockProcessesForExecutable['flutter'] = <io.Process>[
+        process,
+      ];
 
       expect(
           runCapturingPrint(
@@ -120,15 +116,14 @@ void main() {
     test('fail on prerelease if --allow-pre-release flag is off', () async {
       createFakePlugin('d', packagesDir);
 
-      const String preReleaseOutput = 'Package has 1 warning.'
-          'Packages with an SDK constraint on a pre-release of the Dart SDK should themselves be published as a pre-release version.';
-
-      final MockProcess process = MockProcess.failing();
-      process.stdoutController.add(preReleaseOutput.codeUnits);
-      process.stdoutController.close(); // ignore: unawaited_futures
-      process.stderrController.close(); // ignore: unawaited_futures
-
-      processRunner.processesToReturn.add(process);
+      final MockProcess process = MockProcess(
+          exitCode: 1,
+          stdout: 'Package has 1 warning.\n'
+              'Packages with an SDK constraint on a pre-release of the Dart '
+              'SDK should themselves be published as a pre-release version.');
+      processRunner.mockProcessesForExecutable['flutter'] = <io.Process>[
+        process,
+      ];
 
       expect(runCapturingPrint(runner, <String>['publish-check']),
           throwsA(isA<ToolExit>()));
@@ -137,14 +132,9 @@ void main() {
     test('Success message on stderr is not printed as an error', () async {
       createFakePlugin('d', packagesDir);
 
-      const String publishOutput = 'Package has 0 warnings.';
-
-      final MockProcess process = MockProcess.succeeding();
-      process.stderrController.add(publishOutput.codeUnits);
-      process.stdoutController.close(); // ignore: unawaited_futures
-      process.stderrController.close(); // ignore: unawaited_futures
-
-      processRunner.processesToReturn.add(process);
+      processRunner.mockProcessesForExecutable['flutter'] = <io.Process>[
+        MockProcess(stdout: 'Package has 0 warnings.'),
+      ];
 
       final List<String> output =
           await runCapturingPrint(runner, <String>['publish-check']);
@@ -192,9 +182,6 @@ void main() {
       createFakePlugin('no_publish_a', packagesDir, version: '0.1.0');
       createFakePlugin('no_publish_b', packagesDir, version: '0.2.0');
 
-      processRunner.processesToReturn.add(
-        MockProcess.succeeding(),
-      );
       final List<String> output = await runCapturingPrint(
           runner, <String>['publish-check', '--machine']);
 
@@ -258,9 +245,9 @@ void main() {
       createFakePlugin('no_publish_a', packagesDir, version: '0.1.0');
       createFakePlugin('no_publish_b', packagesDir, version: '0.2.0');
 
-      processRunner.processesToReturn.add(
-        MockProcess.succeeding(),
-      );
+      processRunner.mockProcessesForExecutable['flutter'] = <io.Process>[
+        MockProcess(),
+      ];
 
       final List<String> output = await runCapturingPrint(
           runner, <String>['publish-check', '--machine']);
@@ -331,9 +318,9 @@ void main() {
 
       await plugin1Dir.childFile('pubspec.yaml').writeAsString('bad-yaml');
 
-      processRunner.processesToReturn.add(
-        MockProcess.succeeding(),
-      );
+      processRunner.mockProcessesForExecutable['flutter'] = <io.Process>[
+        MockProcess(),
+      ];
 
       bool hasError = false;
       final List<String> output = await runCapturingPrint(
@@ -368,11 +355,4 @@ void main() {
 }'''));
     });
   });
-}
-
-class PublishCheckProcessRunner extends RecordingProcessRunner {
-  final Queue<MockProcess> processesToReturn = Queue<MockProcess>();
-
-  @override
-  io.Process get processToReturn => processesToReturn.removeFirst();
 }

--- a/script/tool/test/publish_check_command_test.dart
+++ b/script/tool/test/publish_check_command_test.dart
@@ -74,7 +74,7 @@ void main() {
       createFakePlugin('plugin_tools_test_package_a', packagesDir);
 
       processRunner.mockProcessesForExecutable['flutter'] = <io.Process>[
-        MockProcess.failing()
+        MockProcess(exitCode: 1)
       ];
 
       expect(

--- a/script/tool/test/publish_plugin_command_test.dart
+++ b/script/tool/test/publish_plugin_command_test.dart
@@ -1098,13 +1098,14 @@ class TestProcessRunner extends ProcessRunner {
         args[1] == 'publish');
     mockPublishArgs.addAll(args);
 
-    return MockProcess(
+    mockPublishProcess = MockProcess(
       exitCode: mockPublishCompleteCode,
       stdout: mockPublishStdout,
       stderr: mockPublishStderr,
       stdoutEncoding: utf8,
       stderrEncoding: utf8,
     );
+    return mockPublishProcess;
   }
 }
 

--- a/script/tool/test/publish_plugin_command_test.dart
+++ b/script/tool/test/publish_plugin_command_test.dart
@@ -1060,7 +1060,7 @@ class TestProcessRunner extends ProcessRunner {
 
   String? mockPublishStdout;
   String? mockPublishStderr;
-  int? mockPublishCompleteCode;
+  int mockPublishCompleteCode = 0;
 
   @override
   Future<io.ProcessResult> run(
@@ -1097,18 +1097,14 @@ class TestProcessRunner extends ProcessRunner {
         args[0] == 'pub' &&
         args[1] == 'publish');
     mockPublishArgs.addAll(args);
-    mockPublishProcess = MockProcess();
-    if (mockPublishStdout != null) {
-      mockPublishProcess.stdoutController.add(utf8.encode(mockPublishStdout!));
-    }
-    if (mockPublishStderr != null) {
-      mockPublishProcess.stderrController.add(utf8.encode(mockPublishStderr!));
-    }
-    if (mockPublishCompleteCode != null) {
-      mockPublishProcess.exitCodeCompleter.complete(mockPublishCompleteCode);
-    }
 
-    return mockPublishProcess;
+    return MockProcess(
+      exitCode: mockPublishCompleteCode,
+      stdout: mockPublishStdout,
+      stderr: mockPublishStderr,
+      stdoutEncoding: utf8,
+      stderrEncoding: utf8,
+    );
   }
 }
 

--- a/script/tool/test/test_command_test.dart
+++ b/script/tool/test/test_command_test.dart
@@ -67,7 +67,7 @@ void main() {
       processRunner
               .mockProcessesForExecutable[getFlutterCommand(mockPlatform)] =
           <io.Process>[
-        MockProcess.failing(), // plugin 1 test
+        MockProcess(exitCode: 1), // plugin 1 test
         MockProcess(), // plugin 2 test
       ];
 
@@ -132,7 +132,7 @@ void main() {
           extraFiles: <String>['test/empty_test.dart']);
 
       processRunner.mockProcessesForExecutable['dart'] = <io.Process>[
-        MockProcess.failing(), // dart pub get
+        MockProcess(exitCode: 1), // dart pub get
       ];
 
       Error? commandError;
@@ -157,7 +157,7 @@ void main() {
 
       processRunner.mockProcessesForExecutable['dart'] = <io.Process>[
         MockProcess(), // dart pub get
-        MockProcess.failing(), // dart pub run test
+        MockProcess(exitCode: 1), // dart pub run test
       ];
 
       Error? commandError;

--- a/script/tool/test/test_command_test.dart
+++ b/script/tool/test/test_command_test.dart
@@ -68,7 +68,7 @@ void main() {
               .mockProcessesForExecutable[getFlutterCommand(mockPlatform)] =
           <io.Process>[
         MockProcess.failing(), // plugin 1 test
-        MockProcess.succeeding(), // plugin 2 test
+        MockProcess(), // plugin 2 test
       ];
 
       Error? commandError;
@@ -156,7 +156,7 @@ void main() {
           extraFiles: <String>['test/empty_test.dart']);
 
       processRunner.mockProcessesForExecutable['dart'] = <io.Process>[
-        MockProcess.succeeding(), // dart pub get
+        MockProcess(), // dart pub get
         MockProcess.failing(), // dart pub run test
       ];
 

--- a/script/tool/test/util.dart
+++ b/script/tool/test/util.dart
@@ -265,15 +265,6 @@ class RecordingProcessRunner extends ProcessRunner {
   final Map<String, List<io.Process>> mockProcessesForExecutable =
       <String, List<io.Process>>{};
 
-  /// Populate for [io.ProcessResult] to use a String [stdout] instead of a [List] of [int].
-  String? resultStdout;
-
-  /// Populate for [io.ProcessResult] to use a String [stderr] instead of a [List] of [int].
-  String? resultStderr;
-
-  // Deprecated--do not add new uses. Use mockProcessesForExecutable instead.
-  io.Process? processToReturn;
-
   @override
   Future<int> runAndStream(
     String executable,
@@ -291,8 +282,7 @@ class RecordingProcessRunner extends ProcessRunner {
     return Future<int>.value(exitCode);
   }
 
-  /// Returns [io.ProcessResult] created from [mockProcessesForExecutable],
-  /// [resultStdout], and [resultStderr].
+  /// Returns [io.ProcessResult] created from [mockProcessesForExecutable].
   @override
   Future<io.ProcessResult> run(
     String executable,
@@ -306,10 +296,16 @@ class RecordingProcessRunner extends ProcessRunner {
     recordedCalls.add(ProcessCall(executable, args, workingDir?.path));
 
     final io.Process? process = _getProcessToReturn(executable);
+    final List<String>? processStdout =
+        await process?.stdout.transform(stdoutEncoding.decoder).toList();
+    final String stdout = processStdout?.join('') ?? '';
+    final List<String>? processStderr =
+        await process?.stderr.transform(stderrEncoding.decoder).toList();
+    final String stderr = processStderr?.join('') ?? '';
+
     final io.ProcessResult result = process == null
         ? io.ProcessResult(1, 0, '', '')
-        : io.ProcessResult(process.pid, await process.exitCode,
-            resultStdout ?? process.stdout, resultStderr ?? process.stderr);
+        : io.ProcessResult(process.pid, await process.exitCode, stdout, stderr);
 
     if (exitOnError && (result.exitCode != 0)) {
       throw io.ProcessException(executable, args);
@@ -326,13 +322,11 @@ class RecordingProcessRunner extends ProcessRunner {
   }
 
   io.Process? _getProcessToReturn(String executable) {
-    io.Process? process;
     final List<io.Process>? processes = mockProcessesForExecutable[executable];
     if (processes != null && processes.isNotEmpty) {
-      process = mockProcessesForExecutable[executable]!.removeAt(0);
+      return processes.removeAt(0);
     }
-    // Fall back to `processToReturn` for backwards compatibility.
-    return process ?? processToReturn;
+    return null;
   }
 }
 

--- a/script/tool/test/xcode_analyze_command_test.dart
+++ b/script/tool/test/xcode_analyze_command_test.dart
@@ -131,7 +131,7 @@ void main() {
             });
 
         processRunner.mockProcessesForExecutable['xcrun'] = <io.Process>[
-          MockProcess.failing()
+          MockProcess(exitCode: 1)
         ];
 
         Error? commandError;
@@ -228,7 +228,7 @@ void main() {
             });
 
         processRunner.mockProcessesForExecutable['xcrun'] = <io.Process>[
-          MockProcess.failing()
+          MockProcess(exitCode: 1)
         ];
 
         Error? commandError;


### PR DESCRIPTION
The mock process runner used in most of the tests had poor handling of
stdout/stderr:
- By default it would return the `List<int>` output from the mock
  process, which was never correct since the parent process runner
  interface always sets encodings, thus the `dynamic` should always be
  of type `String`
- The process for setting output on a `MockProcess` was awkward, since
  it was based on a `Stream<Lint<int>>`, even though in every case what
  we actually want to do is just set the full output to a string.
- A hack was at some point added (presumably due to the above isssues)
  to bypass that flow at the process runner level, and instead return a
  `String` set there. That meant there were two ways of setting output
  (one of which that only worked for one of the ways of running
  processes)
  - That hack wasn't updated when the ability to return multiple mock
    processes instead of a single global mock process was added, so the
    API was even more confusing, and there was no way to set different
    output for different processes.

This changes the test APIs so that:
- `MockProcess` takes stdout and stderr as strings, and internally
  manages converting them to a `Stream<List<int>>`.
- `RecordingProcessRunner` correctly decodes and returns the output
  streams when constructing a process result.

It also removes the resultStdout and resultStderr hacks, as well as the
legacy `processToReturn` API, and converts all uses to the new
structure, which is both simpler to use, and clearly associates output
with specific processes.

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
