### PR TITLE
[camera] Expand CameraImage DTO with properties for lens aperture, exposure time and ISO. 

### DIFF
--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.1
+
+* Added `lensAperture`, `sensorExposureTime` and `sensorSensitivity` properties to the `CameraImage` dto.
+
 ## 0.9.0
 
 * Complete rewrite of Android plugin to fix many capture, focus, flash, orientation and exposure issues.

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
@@ -1048,8 +1048,9 @@ class Camera
           imageBuffer.put("planes", planes);
           imageBuffer.put("lensAperture", this.captureProps.getLastLensAperture());
           imageBuffer.put("sensorExposureTime", this.captureProps.getLastSensorExposureTime());
+          Integer sensorSensitivity = this.captureProps.getLastSensorSensitivity();
           imageBuffer.put(
-              "sensorSensitivity", (double) this.captureProps.getLastSensorSensitivity());
+              "sensorSensitivity", sensorSensitivity == null ? null : (double) sensorSensitivity);
 
           final Handler handler = new Handler(Looper.getMainLooper());
           handler.post(() -> imageStreamSink.success(imageBuffer));

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
@@ -61,6 +61,7 @@ import io.flutter.plugins.camera.features.sensororientation.DeviceOrientationMan
 import io.flutter.plugins.camera.features.sensororientation.SensorOrientationFeature;
 import io.flutter.plugins.camera.features.zoomlevel.ZoomLevelFeature;
 import io.flutter.plugins.camera.media.MediaRecorderBuilder;
+import io.flutter.plugins.camera.types.CameraCaptureProperties;
 import io.flutter.plugins.camera.types.CaptureTimeoutsWrapper;
 import io.flutter.view.TextureRegistry.SurfaceTextureEntry;
 import java.io.File;
@@ -130,6 +131,8 @@ class Camera
 
   /** Holds the current capture timeouts */
   private CaptureTimeoutsWrapper captureTimeouts;
+  /** Holds the last known capture properties */
+  private CameraCaptureProperties captureProps;
 
   private MethodChannel.Result flutterResult;
 
@@ -158,7 +161,8 @@ class Camera
 
     // Create capture callback.
     captureTimeouts = new CaptureTimeoutsWrapper(3000, 3000);
-    cameraCaptureCallback = CameraCaptureCallback.create(this, captureTimeouts);
+    captureProps = new CameraCaptureProperties();
+    cameraCaptureCallback = CameraCaptureCallback.create(this, captureTimeouts, captureProps);
 
     startBackgroundThread();
   }
@@ -1042,6 +1046,10 @@ class Camera
           imageBuffer.put("height", img.getHeight());
           imageBuffer.put("format", img.getFormat());
           imageBuffer.put("planes", planes);
+          imageBuffer.put("lensAperture", this.captureProps.getLastLensAperture());
+          imageBuffer.put("sensorExposureTime", this.captureProps.getLastSensorExposureTime());
+          imageBuffer.put(
+              "sensorSensitivity", (double) this.captureProps.getLastSensorSensitivity());
 
           final Handler handler = new Handler(Looper.getMainLooper());
           handler.post(() -> imageStreamSink.success(imageBuffer));

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/CameraCaptureCallback.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/CameraCaptureCallback.java
@@ -76,15 +76,9 @@ class CameraCaptureCallback extends CaptureCallback {
     Float lensAperture = result.get(CaptureResult.LENS_APERTURE);
     Long sensorExposureTime = result.get(CaptureResult.SENSOR_EXPOSURE_TIME);
     Integer sensorSensitivity = result.get(CaptureResult.SENSOR_SENSITIVITY);
-    if (lensAperture != null) {
-      this.captureProps.setLastLensAperture(lensAperture);
-    }
-    if (sensorExposureTime != null) {
-      this.captureProps.setLastSensorExposureTime(sensorExposureTime);
-    }
-    if (sensorSensitivity != null) {
-      this.captureProps.setLastSensorSensitivity(sensorSensitivity);
-    }
+    this.captureProps.setLastLensAperture(lensAperture);
+    this.captureProps.setLastSensorExposureTime(sensorExposureTime);
+    this.captureProps.setLastSensorSensitivity(sensorSensitivity);
 
     if (cameraState != CameraState.STATE_PREVIEW) {
       Log.d(

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/CameraCaptureCallback.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/CameraCaptureCallback.java
@@ -11,6 +11,7 @@ import android.hardware.camera2.CaptureResult;
 import android.hardware.camera2.TotalCaptureResult;
 import android.util.Log;
 import androidx.annotation.NonNull;
+import io.flutter.plugins.camera.types.CameraCaptureProperties;
 import io.flutter.plugins.camera.types.CaptureTimeoutsWrapper;
 
 /**
@@ -22,13 +23,16 @@ class CameraCaptureCallback extends CaptureCallback {
   private final CameraCaptureStateListener cameraStateListener;
   private CameraState cameraState;
   private final CaptureTimeoutsWrapper captureTimeouts;
+  private final CameraCaptureProperties captureProps;
 
   private CameraCaptureCallback(
       @NonNull CameraCaptureStateListener cameraStateListener,
-      @NonNull CaptureTimeoutsWrapper captureTimeouts) {
+      @NonNull CaptureTimeoutsWrapper captureTimeouts,
+      @NonNull CameraCaptureProperties captureProps) {
     cameraState = CameraState.STATE_PREVIEW;
     this.cameraStateListener = cameraStateListener;
     this.captureTimeouts = captureTimeouts;
+    this.captureProps = captureProps;
   }
 
   /**
@@ -41,8 +45,9 @@ class CameraCaptureCallback extends CaptureCallback {
    */
   public static CameraCaptureCallback create(
       @NonNull CameraCaptureStateListener cameraStateListener,
-      @NonNull CaptureTimeoutsWrapper captureTimeouts) {
-    return new CameraCaptureCallback(cameraStateListener, captureTimeouts);
+      @NonNull CaptureTimeoutsWrapper captureTimeouts,
+      @NonNull CameraCaptureProperties captureProps) {
+    return new CameraCaptureCallback(cameraStateListener, captureTimeouts, captureProps);
   }
 
   /**
@@ -66,6 +71,20 @@ class CameraCaptureCallback extends CaptureCallback {
   private void process(CaptureResult result) {
     Integer aeState = result.get(CaptureResult.CONTROL_AE_STATE);
     Integer afState = result.get(CaptureResult.CONTROL_AF_STATE);
+
+    // Update capture properties
+    Float lensAperture = result.get(CaptureResult.LENS_APERTURE);
+    Long sensorExposureTime = result.get(CaptureResult.SENSOR_EXPOSURE_TIME);
+    Integer sensorSensitivity = result.get(CaptureResult.SENSOR_SENSITIVITY);
+    if (lensAperture != null) {
+      this.captureProps.setLastLensAperture(lensAperture);
+    }
+    if (sensorExposureTime != null) {
+      this.captureProps.setLastSensorExposureTime(sensorExposureTime);
+    }
+    if (sensorSensitivity != null) {
+      this.captureProps.setLastSensorSensitivity(sensorSensitivity);
+    }
 
     if (cameraState != CameraState.STATE_PREVIEW) {
       Log.d(

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/CameraCaptureCallback.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/CameraCaptureCallback.java
@@ -73,12 +73,14 @@ class CameraCaptureCallback extends CaptureCallback {
     Integer afState = result.get(CaptureResult.CONTROL_AF_STATE);
 
     // Update capture properties
-    Float lensAperture = result.get(CaptureResult.LENS_APERTURE);
-    Long sensorExposureTime = result.get(CaptureResult.SENSOR_EXPOSURE_TIME);
-    Integer sensorSensitivity = result.get(CaptureResult.SENSOR_SENSITIVITY);
-    this.captureProps.setLastLensAperture(lensAperture);
-    this.captureProps.setLastSensorExposureTime(sensorExposureTime);
-    this.captureProps.setLastSensorSensitivity(sensorSensitivity);
+    if (result instanceof TotalCaptureResult) {
+      Float lensAperture = result.get(CaptureResult.LENS_APERTURE);
+      Long sensorExposureTime = result.get(CaptureResult.SENSOR_EXPOSURE_TIME);
+      Integer sensorSensitivity = result.get(CaptureResult.SENSOR_SENSITIVITY);
+      this.captureProps.setLastLensAperture(lensAperture);
+      this.captureProps.setLastSensorExposureTime(sensorExposureTime);
+      this.captureProps.setLastSensorSensitivity(sensorSensitivity);
+    }
 
     if (cameraState != CameraState.STATE_PREVIEW) {
       Log.d(

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/types/CameraCaptureProperties.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/types/CameraCaptureProperties.java
@@ -1,0 +1,67 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.plugins.camera.types;
+
+public class CameraCaptureProperties {
+
+  private Float lastLensAperture;
+  private Long lastSensorExposureTime;
+  private Integer lastSensorSensitivity;
+
+  /**
+   * Gets the last known lens aperture. (As f-stop value)
+   *
+   * @return the last known lens aperture. (As f-stop value)
+   */
+  public Float getLastLensAperture() {
+    return lastLensAperture;
+  }
+
+  /**
+   * Sets the last known lens aperture. (As f-stop value)
+   *
+   * @param lastLensAperture - The last known lens aperture to set. (As f-stop value)
+   */
+  public void setLastLensAperture(Float lastLensAperture) {
+    this.lastLensAperture = lastLensAperture;
+  }
+
+  /**
+   * Gets the last known sensor exposure time in nanoseconds.
+   *
+   * @return the last known sensor exposure time in nanoseconds.
+   */
+  public Long getLastSensorExposureTime() {
+    return lastSensorExposureTime;
+  }
+
+  /**
+   * Sets the last known sensor exposure time in nanoseconds.
+   *
+   * @param lastSensorExposureTime - The last known sensor exposure time to set, in nanoseconds.
+   */
+  public void setLastSensorExposureTime(Long lastSensorExposureTime) {
+    this.lastSensorExposureTime = lastSensorExposureTime;
+  }
+
+  /**
+   * Gets the last known sensor sensitivity in ISO arithmetic units.
+   *
+   * @return the last known sensor sensitivity in ISO arithmetic units.
+   */
+  public Integer getLastSensorSensitivity() {
+    return lastSensorSensitivity;
+  }
+
+  /**
+   * Sets the last known sensor sensitivity in ISO arithmetic units.
+   *
+   * @param lastSensorSensitivity - The last known sensor sensitivity to set, in ISO arithmetic
+   *     units.
+   */
+  public void setLastSensorSensitivity(Integer lastSensorSensitivity) {
+    this.lastSensorSensitivity = lastSensorSensitivity;
+  }
+}

--- a/packages/camera/camera/android/src/test/java/io/flutter/plugins/camera/CameraCaptureCallbackStatesTest.java
+++ b/packages/camera/camera/android/src/test/java/io/flutter/plugins/camera/CameraCaptureCallbackStatesTest.java
@@ -17,6 +17,7 @@ import android.hardware.camera2.CaptureResult;
 import android.hardware.camera2.CaptureResult.Key;
 import android.hardware.camera2.TotalCaptureResult;
 import io.flutter.plugins.camera.CameraCaptureCallback.CameraCaptureStateListener;
+import io.flutter.plugins.camera.types.CameraCaptureProperties;
 import io.flutter.plugins.camera.types.CaptureTimeoutsWrapper;
 import io.flutter.plugins.camera.types.Timeout;
 import io.flutter.plugins.camera.utils.TestUtils;
@@ -40,6 +41,7 @@ public class CameraCaptureCallbackStatesTest extends TestCase {
   private CaptureRequest mockCaptureRequest;
   private CaptureResult mockPartialCaptureResult;
   private CaptureTimeoutsWrapper mockCaptureTimeouts;
+  private CameraCaptureProperties mockCaptureProps;
   private TotalCaptureResult mockTotalCaptureResult;
   private MockedStatic<Timeout> mockedStaticTimeout;
   private Timeout mockTimeout;
@@ -83,6 +85,7 @@ public class CameraCaptureCallbackStatesTest extends TestCase {
     mockTotalCaptureResult = mock(TotalCaptureResult.class);
     mockTimeout = mock(Timeout.class);
     mockCaptureTimeouts = mock(CaptureTimeoutsWrapper.class);
+    mockCaptureProps = mock(CameraCaptureProperties.class);
     when(mockCaptureTimeouts.getPreCaptureFocusing()).thenReturn(mockTimeout);
     when(mockCaptureTimeouts.getPreCaptureMetering()).thenReturn(mockTimeout);
 
@@ -95,7 +98,8 @@ public class CameraCaptureCallbackStatesTest extends TestCase {
     mockedStaticTimeout.when(() -> Timeout.create(1000)).thenReturn(mockTimeout);
 
     cameraCaptureCallback =
-        CameraCaptureCallback.create(mockCaptureStateListener, mockCaptureTimeouts);
+        CameraCaptureCallback.create(
+            mockCaptureStateListener, mockCaptureTimeouts, mockCaptureProps);
   }
 
   @Override

--- a/packages/camera/camera/android/src/test/java/io/flutter/plugins/camera/CameraCaptureCallbackTest.java
+++ b/packages/camera/camera/android/src/test/java/io/flutter/plugins/camera/CameraCaptureCallbackTest.java
@@ -1,0 +1,71 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.plugins.camera;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.hardware.camera2.CameraCaptureSession;
+import android.hardware.camera2.CaptureRequest;
+import android.hardware.camera2.CaptureResult;
+import android.hardware.camera2.TotalCaptureResult;
+import io.flutter.plugins.camera.types.CameraCaptureProperties;
+import io.flutter.plugins.camera.types.CaptureTimeoutsWrapper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class CameraCaptureCallbackTest {
+
+  private CameraCaptureCallback cameraCaptureCallback;
+  private CameraCaptureProperties mockCaptureProps;
+
+  @Before
+  public void setUp() {
+    CameraCaptureCallback.CameraCaptureStateListener mockCaptureStateListener =
+        mock(CameraCaptureCallback.CameraCaptureStateListener.class);
+    CaptureTimeoutsWrapper mockCaptureTimeouts = mock(CaptureTimeoutsWrapper.class);
+    mockCaptureProps = mock(CameraCaptureProperties.class);
+    cameraCaptureCallback =
+        CameraCaptureCallback.create(
+            mockCaptureStateListener, mockCaptureTimeouts, mockCaptureProps);
+  }
+
+  @Test
+  public void onCaptureProgressed_updatesCameraCaptureProperties() {
+    CameraCaptureSession mockSession = mock(CameraCaptureSession.class);
+    CaptureRequest mockRequest = mock(CaptureRequest.class);
+    CaptureResult mockResult = mock(CaptureResult.class);
+    when(mockResult.get(CaptureResult.LENS_APERTURE)).thenReturn(1.0f);
+    when(mockResult.get(CaptureResult.SENSOR_EXPOSURE_TIME)).thenReturn(2L);
+    when(mockResult.get(CaptureResult.SENSOR_SENSITIVITY)).thenReturn(3);
+
+    cameraCaptureCallback.onCaptureProgressed(mockSession, mockRequest, mockResult);
+
+    verify(mockCaptureProps, times(1)).setLastLensAperture(1.0f);
+    verify(mockCaptureProps, times(1)).setLastSensorExposureTime(2L);
+    verify(mockCaptureProps, times(1)).setLastSensorSensitivity(3);
+  }
+
+  @Test
+  public void onCaptureCompleted_updatesCameraCaptureProperties() {
+    CameraCaptureSession mockSession = mock(CameraCaptureSession.class);
+    CaptureRequest mockRequest = mock(CaptureRequest.class);
+    TotalCaptureResult mockResult = mock(TotalCaptureResult.class);
+    when(mockResult.get(CaptureResult.LENS_APERTURE)).thenReturn(1.0f);
+    when(mockResult.get(CaptureResult.SENSOR_EXPOSURE_TIME)).thenReturn(2L);
+    when(mockResult.get(CaptureResult.SENSOR_SENSITIVITY)).thenReturn(3);
+
+    cameraCaptureCallback.onCaptureCompleted(mockSession, mockRequest, mockResult);
+
+    verify(mockCaptureProps, times(1)).setLastLensAperture(1.0f);
+    verify(mockCaptureProps, times(1)).setLastSensorExposureTime(2L);
+    verify(mockCaptureProps, times(1)).setLastSensorSensitivity(3);
+  }
+}

--- a/packages/camera/camera/android/src/test/java/io/flutter/plugins/camera/CameraCaptureCallbackTest.java
+++ b/packages/camera/camera/android/src/test/java/io/flutter/plugins/camera/CameraCaptureCallbackTest.java
@@ -4,7 +4,11 @@
 
 package io.flutter.plugins.camera;
 
+import static org.mockito.ArgumentMatchers.anyFloat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -38,19 +42,16 @@ public class CameraCaptureCallbackTest {
   }
 
   @Test
-  public void onCaptureProgressed_updatesCameraCaptureProperties() {
+  public void onCaptureProgressed_doesNotUpdateCameraCaptureProperties() {
     CameraCaptureSession mockSession = mock(CameraCaptureSession.class);
     CaptureRequest mockRequest = mock(CaptureRequest.class);
     CaptureResult mockResult = mock(CaptureResult.class);
-    when(mockResult.get(CaptureResult.LENS_APERTURE)).thenReturn(1.0f);
-    when(mockResult.get(CaptureResult.SENSOR_EXPOSURE_TIME)).thenReturn(2L);
-    when(mockResult.get(CaptureResult.SENSOR_SENSITIVITY)).thenReturn(3);
 
     cameraCaptureCallback.onCaptureProgressed(mockSession, mockRequest, mockResult);
 
-    verify(mockCaptureProps, times(1)).setLastLensAperture(1.0f);
-    verify(mockCaptureProps, times(1)).setLastSensorExposureTime(2L);
-    verify(mockCaptureProps, times(1)).setLastSensorSensitivity(3);
+    verify(mockCaptureProps, never()).setLastLensAperture(anyFloat());
+    verify(mockCaptureProps, never()).setLastSensorExposureTime(anyLong());
+    verify(mockCaptureProps, never()).setLastSensorSensitivity(anyInt());
   }
 
   @Test

--- a/packages/camera/camera/ios/Classes/CameraPlugin.m
+++ b/packages/camera/camera/ios/Classes/CameraPlugin.m
@@ -661,6 +661,11 @@ NSString *const errorMethod = @"error";
       imageBuffer[@"height"] = [NSNumber numberWithUnsignedLong:imageHeight];
       imageBuffer[@"format"] = @(videoFormat);
       imageBuffer[@"planes"] = planes;
+      imageBuffer[@"lensAperture"] = [NSNumber numberWithFloat:[_captureDevice lensAperture]];
+      Float64 exposureDuration = CMTimeGetSeconds([_captureDevice exposureDuration]);
+      Float64 nsExposureDuration = 1000000000 * exposureDuration;
+      imageBuffer[@"sensorExposureTime"] = [NSNumber numberWithInt:nsExposureDuration];
+      imageBuffer[@"sensorSensitivity"] = [NSNumber numberWithFloat:[_captureDevice ISO]];
 
       _imageStreamHandler.eventSink(imageBuffer);
 

--- a/packages/camera/camera/lib/src/camera_image.dart
+++ b/packages/camera/camera/lib/src/camera_image.dart
@@ -132,11 +132,11 @@ class CameraImage {
   /// The aperture settings for this image.
   ///
   /// Represented as an f-stop value.
-  final double lensAperture;
+  final double? lensAperture;
 
   /// The sensor exposure time for this image in nanoseconds.
-  final int sensorExposureTime;
+  final int? sensorExposureTime;
 
   /// The sensor sensitivity in standard ISO arithmetic units.
-  final double sensorSensitivity;
+  final double? sensorSensitivity;
 }

--- a/packages/camera/camera/lib/src/camera_image.dart
+++ b/packages/camera/camera/lib/src/camera_image.dart
@@ -100,6 +100,9 @@ class CameraImage {
       : format = ImageFormat._fromPlatformData(data['format']),
         height = data['height'],
         width = data['width'],
+        lensAperture = data['lensAperture'],
+        sensorExposureTime = data['sensorExposureTime'],
+        sensorSensitivity = data['sensorSensitivity'],
         planes = List<Plane>.unmodifiable(data['planes']
             .map((dynamic planeData) => Plane._fromPlatformData(planeData)));
 
@@ -125,4 +128,15 @@ class CameraImage {
   ///
   /// The number of planes is determined by the format of the image.
   final List<Plane> planes;
+
+  /// The aperture settings for this image.
+  ///
+  /// Represented as an f-stop value.
+  final double lensAperture;
+
+  /// The sensor exposure time for this image in nanoseconds.
+  final int sensorExposureTime;
+
+  /// The sensor sensitivity in standard ISO arithmetic units.
+  final double sensorSensitivity;
 }

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -4,7 +4,7 @@ description: A Flutter plugin for getting information about and controlling the
   and streaming image buffers to dart.
 repository: https://github.com/flutter/plugins/tree/master/packages/camera/camera
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.9.0
+version: 0.9.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/camera/camera/test/camera_image_test.dart
+++ b/packages/camera/camera/test/camera_image_test.dart
@@ -18,6 +18,9 @@ void main() {
         'format': 35,
         'height': 1,
         'width': 4,
+        'lensAperture': 1.8,
+        'sensorExposureTime': 9991324,
+        'sensorSensitivity': 92.0,
         'planes': [
           {
             'bytes': Uint8List.fromList([1, 2, 3, 4]),
@@ -41,6 +44,9 @@ void main() {
         'format': 875704438,
         'height': 1,
         'width': 4,
+        'lensAperture': 1.8,
+        'sensorExposureTime': 9991324,
+        'sensorSensitivity': 92.0,
         'planes': [
           {
             'bytes': Uint8List.fromList([1, 2, 3, 4]),
@@ -61,6 +67,9 @@ void main() {
         'format': 35,
         'height': 1,
         'width': 4,
+        'lensAperture': 1.8,
+        'sensorExposureTime': 9991324,
+        'sensorSensitivity': 92.0,
         'planes': [
           {
             'bytes': Uint8List.fromList([1, 2, 3, 4]),
@@ -81,6 +90,9 @@ void main() {
         'format': 1111970369,
         'height': 1,
         'width': 4,
+        'lensAperture': 1.8,
+        'sensorExposureTime': 9991324,
+        'sensorSensitivity': 92.0,
         'planes': [
           {
             'bytes': Uint8List.fromList([1, 2, 3, 4]),
@@ -98,6 +110,9 @@ void main() {
         'format': null,
         'height': 1,
         'width': 4,
+        'lensAperture': 1.8,
+        'sensorExposureTime': 9991324,
+        'sensorSensitivity': 92.0,
         'planes': [
           {
             'bytes': Uint8List.fromList([1, 2, 3, 4]),


### PR DESCRIPTION
(Resubmission of #4170)

This PR adds additional properties to the CameraImage DTO:

- `lensAperture`
- `sensorExposureTime`
- `sensorSensitivity`

Relevant issue:
- flutter/flutter#73250

This PR adds no breaking changes. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.
