### PR TITLE
[video_player] add support for content-uri based videos (android only)

### DIFF
--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 2.1.15
 
+* Add `contentUri` based VideoPlayerController.
 * Updated Android lint settings.
 
 ## 2.1.14

--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.1.15
+## 2.2.0
 
 * Add `contentUri` based VideoPlayerController.
 * Updated Android lint settings.

--- a/packages/video_player/video_player/example/pubspec.yaml
+++ b/packages/video_player/video_player/example/pubspec.yaml
@@ -33,3 +33,9 @@ flutter:
    - assets/flutter-mark-square-64.png
    - assets/Butterfly-209.mp4
    - assets/bumble_bee_captions.srt
+
+# FOR TESTING ONLY. DO NOT MERGE.
+dependency_overrides:
+  video_player_platform_interface:
+    path:
+      ../../video_player_platform_interface

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -222,6 +222,21 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
         httpHeaders = const {},
         super(VideoPlayerValue(duration: Duration.zero));
 
+  /// Constructs a [VideoPlayerController] playing a video from a contentUri.
+  ///
+  /// This will load the video from the input content-URI.
+  /// This is supported on Android only.
+  VideoPlayerController.contentUri(Uri contentUri,
+      {this.closedCaptionFile, this.videoPlayerOptions})
+      : assert(defaultTargetPlatform == TargetPlatform.android,
+            'VideoPlayerController.contentUri is only supported on Android.'),
+        dataSource = contentUri.toString(),
+        dataSourceType = DataSourceType.contentUri,
+        package = null,
+        formatHint = null,
+        httpHeaders = const {},
+        super(VideoPlayerValue(duration: Duration.zero));
+
   /// The URI to the video file. This will be in different formats depending on
   /// the [DataSourceType] of the original video.
   final String dataSource;
@@ -295,6 +310,12 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
       case DataSourceType.file:
         dataSourceDescription = DataSource(
           sourceType: DataSourceType.file,
+          uri: dataSource,
+        );
+        break;
+      case DataSourceType.contentUri:
+        dataSourceDescription = DataSource(
+          sourceType: DataSourceType.contentUri,
           uri: dataSource,
         );
         break;

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android, iOS, and web.
 repository: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.1.14
+version: 2.1.15
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -24,7 +24,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.3.0
-  video_player_platform_interface: ^4.1.0
+  video_player_platform_interface: ^4.2.0
   # The design on https://flutter.dev/go/federated-plugins was to leave
   # this constraint as "any". We cannot do it right now as it fails pub publish
   # validation, so we set a ^ constraint. The exact value doesn't matter since
@@ -38,3 +38,9 @@ dev_dependencies:
     sdk: flutter
   pedantic: ^1.10.0
   pigeon: ^0.1.21
+
+# FOR TESTING ONLY. DO NOT MERGE.
+dependency_overrides:
+  video_player_platform_interface:
+    path:
+      ../video_player_platform_interface

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android, iOS, and web.
 repository: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.1.15
+version: 2.2.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/video_player/video_player/test/video_player_test.dart
+++ b/packages/video_player/video_player/test/video_player_test.dart
@@ -284,6 +284,15 @@ void main() {
       });
     });
 
+    test('contentUri', () async {
+      final VideoPlayerController controller =
+          VideoPlayerController.contentUri(Uri.parse('content://video'));
+      await controller.initialize();
+
+      expect(fakeVideoPlayerPlatform.dataSourceDescriptions[0].uri,
+          'content://video');
+    });
+
     test('dispose', () async {
       final VideoPlayerController controller = VideoPlayerController.network(
         'https://127.0.0.1',

--- a/packages/video_player/video_player_platform_interface/CHANGELOG.md
+++ b/packages/video_player/video_player_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.2.0
+
+* Add `contentUri` to `DataSourceType`.
+
 ## 4.1.0
 
 * Add `httpHeaders` to `DataSource`
@@ -29,7 +33,7 @@
 
 ## 2.1.0
 
-* Add VideoPlayerOptions with audo mix mode
+* Add VideoPlayerOptions with audio mix mode
 
 ## 2.0.2
 

--- a/packages/video_player/video_player_platform_interface/lib/method_channel_video_player.dart
+++ b/packages/video_player/video_player_platform_interface/lib/method_channel_video_player.dart
@@ -42,6 +42,9 @@ class MethodChannelVideoPlayer extends VideoPlayerPlatform {
       case DataSourceType.file:
         message.uri = dataSource.uri;
         break;
+      case DataSourceType.contentUri:
+        message.uri = dataSource.uri;
+        break;
     }
 
     TextureMessage response = await _api.create(message);

--- a/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
+++ b/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
@@ -196,6 +196,9 @@ enum DataSourceType {
 
   /// The video was loaded off of the local filesystem.
   file,
+
+  /// The video is available via contentUri. Android only.
+  contentUri,
 }
 
 /// The file format of the given video.

--- a/packages/video_player/video_player_platform_interface/pubspec.yaml
+++ b/packages/video_player/video_player_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/master/packages/video_player
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 4.1.0
+version: 4.2.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

This PR adds playback from contentUri support for the video_player plugin (Android only).

The current Android implementation uses ExoPlayer, which already supports playback from uri, so this change is just to surface contentUri as a valid video datasource on the dart side.

*List which issues are fixed by this PR. You must list at least one issue.*
https://github.com/flutter/flutter/issues/88130

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
