### PR TITLE
[flutter_plugin_tool] Add support for running Windows unit tests

### DIFF
--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Pubspec validation now checks for `implements` in implementation packages.
 - Pubspec valitation now checks the full relative path of `repository` entries.
 - `build-examples` now supports UWP plugins via a `--winuwp` flag.
+- `native-test` now supports `--windows` for unit tests.
 
 ## 0.5.0
 

--- a/script/tool/lib/src/common/file_utils.dart
+++ b/script/tool/lib/src/common/file_utils.dart
@@ -1,0 +1,20 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file/file.dart';
+
+/// Returns a [File] created by appending all but the last item in [components]
+/// to [base] as subdirectories, then appending the last as a file.
+///
+/// Example:
+///   childFileWithSubcomponents(rootDir, ['foo', 'bar', 'baz.txt'])
+/// creates a File representing /rootDir/foo/bar/baz.txt.
+File childFileWithSubcomponents(Directory base, List<String> components) {
+  Directory dir = base;
+  final String basename = components.removeLast();
+  for (final String directoryName in components) {
+    dir = dir.childDirectory(directoryName);
+  }
+  return dir.childFile(basename);
+}

--- a/script/tool/lib/src/common/plugin_utils.dart
+++ b/script/tool/lib/src/common/plugin_utils.dart
@@ -17,7 +17,7 @@ enum PlatformSupport {
   federated,
 }
 
-/// Returns whether the given [package] is a Flutter [platform] plugin.
+/// Returns true if [package] is a Flutter [platform] plugin.
 ///
 /// It checks this by looking for the following pattern in the pubspec:
 ///
@@ -82,8 +82,8 @@ bool pluginSupportsPlatform(
   }
 }
 
-/// Returns whether the given [plugin] includes native code for [platform], as
-/// opposed to being implemented entirely in Dart.
+/// Returns true if [plugin] includes native code for [platform], as opposed to
+/// being implemented entirely in Dart.
 bool pluginHasNativeCodeForPlatform(String platform, RepositoryPackage plugin) {
   if (platform == kPlatformWeb) {
     // Web plugins are always Dart-only.

--- a/script/tool/lib/src/common/plugin_utils.dart
+++ b/script/tool/lib/src/common/plugin_utils.dart
@@ -30,7 +30,7 @@ enum PlatformSupport {
 /// implementation in order to return true.
 bool pluginSupportsPlatform(
   String platform,
-  RepositoryPackage package, {
+  RepositoryPackage plugin, {
   PlatformSupport? requiredMode,
   String? variant,
 }) {
@@ -41,32 +41,12 @@ bool pluginSupportsPlatform(
       platform == kPlatformWindows ||
       platform == kPlatformLinux);
   try {
-    final YamlMap pubspecYaml =
-        loadYaml(package.pubspecFile.readAsStringSync()) as YamlMap;
-    final YamlMap? flutterSection = pubspecYaml['flutter'] as YamlMap?;
-    if (flutterSection == null) {
-      return false;
-    }
-    final YamlMap? pluginSection = flutterSection['plugin'] as YamlMap?;
-    if (pluginSection == null) {
-      return false;
-    }
-    final YamlMap? platforms = pluginSection['platforms'] as YamlMap?;
-    if (platforms == null) {
-      // Legacy plugin specs are assumed to support iOS and Android. They are
-      // never federated.
-      if (requiredMode == PlatformSupport.federated) {
-        return false;
-      }
-      if (!pluginSection.containsKey('platforms')) {
-        return platform == kPlatformIos || platform == kPlatformAndroid;
-      }
-      return false;
-    }
-    final YamlMap? platformEntry = platforms[platform] as YamlMap?;
+    final YamlMap? platformEntry =
+        _readPlatformPubspecSectionForPlugin(platform, plugin);
     if (platformEntry == null) {
       return false;
     }
+
     // If the platform entry is present, then it supports the platform. Check
     // for required mode if specified.
     if (requiredMode != null) {
@@ -97,9 +77,67 @@ bool pluginSupportsPlatform(
     }
 
     return true;
+  } on YamlException {
+    return false;
+  }
+}
+
+/// Returns whether the given [plugin] includes native code for [platform], as
+/// opposed to being implemented entirely in Dart.
+bool pluginHasNativeCodeForPlatform(String platform, RepositoryPackage plugin) {
+  if (platform == kPlatformWeb) {
+    // Web plugins are always Dart-only.
+    return false;
+  }
+  try {
+    final YamlMap? platformEntry =
+        _readPlatformPubspecSectionForPlugin(platform, plugin);
+    if (platformEntry == null) {
+      return false;
+    }
+    // All other platforms currently use pluginClass for indicating the native
+    // code in the plugin.
+    final String? pluginClass = platformEntry['pluginClass'] as String?;
+    // TODO(stuartmorgan): Remove the check for 'none' once none of the plugins
+    // in the repository use that workaround. See
+    // https://github.com/flutter/flutter/issues/57497 for context.
+    return pluginClass != null && pluginClass != 'none';
   } on FileSystemException {
     return false;
   } on YamlException {
     return false;
+  }
+}
+
+/// Returns the
+///   flutter:
+///     plugin:
+///       platforms:
+///         [platform]:
+/// section from [plugin]'s pubspec.yaml, or null if either it is not present,
+/// or the pubspec couldn't be read.
+YamlMap? _readPlatformPubspecSectionForPlugin(
+    String platform, RepositoryPackage plugin) {
+  try {
+    final File pubspecFile = plugin.pubspecFile;
+    final YamlMap pubspecYaml =
+        loadYaml(pubspecFile.readAsStringSync()) as YamlMap;
+    final YamlMap? flutterSection = pubspecYaml['flutter'] as YamlMap?;
+    if (flutterSection == null) {
+      return null;
+    }
+    final YamlMap? pluginSection = flutterSection['plugin'] as YamlMap?;
+    if (pluginSection == null) {
+      return null;
+    }
+    final YamlMap? platforms = pluginSection['platforms'] as YamlMap?;
+    if (platforms == null) {
+      return null;
+    }
+    return platforms[platform] as YamlMap?;
+  } on FileSystemException {
+    return null;
+  } on YamlException {
+    return null;
   }
 }

--- a/script/tool/lib/src/publish_plugin_command.dart
+++ b/script/tool/lib/src/publish_plugin_command.dart
@@ -18,6 +18,7 @@ import 'package:pubspec_parse/pubspec_parse.dart';
 import 'package:yaml/yaml.dart';
 
 import 'common/core.dart';
+import 'common/file_utils.dart';
 import 'common/git_version_finder.dart';
 import 'common/plugin_command.dart';
 import 'common/process_runner.dart';
@@ -154,13 +155,10 @@ class PublishPluginCommand extends PluginCommand {
           await gitVersionFinder.getChangedPubSpecs();
 
       for (final String pubspecPath in changedPubspecs) {
-        // Convert git's Posix-style paths to a path that matches the current
-        // filesystem.
-        final String localStylePubspecPath =
-            path.joinAll(p.posix.split(pubspecPath));
-        final File pubspecFile = packagesDir.fileSystem
-            .directory((await gitDir).path)
-            .childFile(localStylePubspecPath);
+        // git outputs a relativa, Posix-style path.
+        final File pubspecFile = childFileWithSubcomponents(
+            packagesDir.fileSystem.directory((await gitDir).path),
+            p.posix.split(pubspecPath));
         yield PackageEnumerationEntry(RepositoryPackage(pubspecFile.parent),
             excluded: false);
       }

--- a/script/tool/test/common/file_utils_test.dart
+++ b/script/tool/test/common/file_utils_test.dart
@@ -2,15 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io' as io;
-
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common/file_utils.dart';
 import 'package:test/test.dart';
-
-import '../mocks.dart';
-import '../util.dart';
 
 void main() {
   test('works on Posix', () async {

--- a/script/tool/test/common/file_utils_test.dart
+++ b/script/tool/test/common/file_utils_test.dart
@@ -1,0 +1,37 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io' as io;
+
+import 'package:file/file.dart';
+import 'package:file/memory.dart';
+import 'package:flutter_plugin_tools/src/common/file_utils.dart';
+import 'package:test/test.dart';
+
+import '../mocks.dart';
+import '../util.dart';
+
+void main() {
+  test('works on Posix', () async {
+    final FileSystem fileSystem =
+        MemoryFileSystem(style: FileSystemStyle.posix);
+
+    final Directory base = fileSystem.directory('/').childDirectory('base');
+    final File file =
+        childFileWithSubcomponents(base, <String>['foo', 'bar', 'baz.txt']);
+
+    expect(file.absolute.path, '/base/foo/bar/baz.txt');
+  });
+
+  test('works on Windows', () async {
+    final FileSystem fileSystem =
+        MemoryFileSystem(style: FileSystemStyle.windows);
+
+    final Directory base = fileSystem.directory(r'C:\').childDirectory('base');
+    final File file =
+        childFileWithSubcomponents(base, <String>['foo', 'bar', 'baz.txt']);
+
+    expect(file.absolute.path, r'C:\base\foo\bar\baz.txt');
+  });
+}

--- a/script/tool/test/common/plugin_utils_test.dart
+++ b/script/tool/test/common/plugin_utils_test.dart
@@ -273,4 +273,72 @@ void main() {
           isTrue);
     });
   });
+
+  group('pluginHasNativeCodeForPlatform', () {
+    test('returns false for web', () async {
+      final RepositoryPackage plugin = RepositoryPackage(createFakePlugin(
+        'plugin',
+        packagesDir,
+        platformSupport: <String, PlatformDetails>{
+          kPlatformWeb: const PlatformDetails(PlatformSupport.inline),
+        },
+      ));
+
+      expect(pluginHasNativeCodeForPlatform(kPlatformWeb, plugin), isFalse);
+    });
+
+    test('returns false for a native-only plugin', () async {
+      final RepositoryPackage plugin = RepositoryPackage(createFakePlugin(
+        'plugin',
+        packagesDir,
+        platformSupport: <String, PlatformDetails>{
+          kPlatformLinux: const PlatformDetails(PlatformSupport.inline),
+          kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
+          kPlatformWindows: const PlatformDetails(PlatformSupport.inline),
+        },
+      ));
+
+      expect(pluginHasNativeCodeForPlatform(kPlatformLinux, plugin), isTrue);
+      expect(pluginHasNativeCodeForPlatform(kPlatformMacos, plugin), isTrue);
+      expect(pluginHasNativeCodeForPlatform(kPlatformWindows, plugin), isTrue);
+    });
+
+    test('returns true for a native+Dart plugin', () async {
+      final RepositoryPackage plugin = RepositoryPackage(createFakePlugin(
+        'plugin',
+        packagesDir,
+        platformSupport: <String, PlatformDetails>{
+          kPlatformLinux: const PlatformDetails(PlatformSupport.inline,
+              hasNativeCode: true, hasDartCode: true),
+          kPlatformMacos: const PlatformDetails(PlatformSupport.inline,
+              hasNativeCode: true, hasDartCode: true),
+          kPlatformWindows: const PlatformDetails(PlatformSupport.inline,
+              hasNativeCode: true, hasDartCode: true),
+        },
+      ));
+
+      expect(pluginHasNativeCodeForPlatform(kPlatformLinux, plugin), isTrue);
+      expect(pluginHasNativeCodeForPlatform(kPlatformMacos, plugin), isTrue);
+      expect(pluginHasNativeCodeForPlatform(kPlatformWindows, plugin), isTrue);
+    });
+
+    test('returns false for a Dart-only plugin', () async {
+      final RepositoryPackage plugin = RepositoryPackage(createFakePlugin(
+        'plugin',
+        packagesDir,
+        platformSupport: <String, PlatformDetails>{
+          kPlatformLinux: const PlatformDetails(PlatformSupport.inline,
+              hasNativeCode: false, hasDartCode: true),
+          kPlatformMacos: const PlatformDetails(PlatformSupport.inline,
+              hasNativeCode: false, hasDartCode: true),
+          kPlatformWindows: const PlatformDetails(PlatformSupport.inline,
+              hasNativeCode: false, hasDartCode: true),
+        },
+      ));
+
+      expect(pluginHasNativeCodeForPlatform(kPlatformLinux, plugin), isFalse);
+      expect(pluginHasNativeCodeForPlatform(kPlatformMacos, plugin), isFalse);
+      expect(pluginHasNativeCodeForPlatform(kPlatformWindows, plugin), isFalse);
+    });
+  });
 }

--- a/script/tool/test/native_test_command_test.dart
+++ b/script/tool/test/native_test_command_test.dart
@@ -9,6 +9,7 @@ import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
+import 'package:flutter_plugin_tools/src/common/file_utils.dart';
 import 'package:flutter_plugin_tools/src/common/plugin_utils.dart';
 import 'package:flutter_plugin_tools/src/native_test_command.dart';
 import 'package:test/test.dart';
@@ -1359,9 +1360,8 @@ void main() {
           kPlatformWindows: const PlatformDetails(PlatformSupport.inline),
         });
 
-        final File testBinary = pluginDirectory
-            .childDirectory('example')
-            .childFile(testBinaryRelativePath.split('/').join(r'\'));
+        final File testBinary = childFileWithSubcomponents(pluginDirectory,
+            <String>['example', ...testBinaryRelativePath.split('/')]);
 
         final List<String> output = await runCapturingPrint(runner, <String>[
           'native-test',
@@ -1397,9 +1397,8 @@ void main() {
           kPlatformWindows: const PlatformDetails(PlatformSupport.inline),
         });
 
-        final File debugTestBinary = pluginDirectory
-            .childDirectory('example')
-            .childFile(debugTestBinaryRelativePath.split('/').join(r'\'));
+        final File debugTestBinary = childFileWithSubcomponents(pluginDirectory,
+            <String>['example', ...debugTestBinaryRelativePath.split('/')]);
 
         final List<String> output = await runCapturingPrint(runner, <String>[
           'native-test',
@@ -1459,9 +1458,8 @@ void main() {
           kPlatformWindows: const PlatformDetails(PlatformSupport.inline),
         });
 
-        final File testBinary = pluginDirectory
-            .childDirectory('example')
-            .childFile(testBinaryRelativePath.split('/').join(r'\'));
+        final File testBinary = childFileWithSubcomponents(pluginDirectory,
+            <String>['example', ...testBinaryRelativePath.split('/')]);
 
         processRunner.mockProcessesForExecutable[testBinary.path] =
             <io.Process>[MockProcess(exitCode: 1)];

--- a/script/tool/test/util.dart
+++ b/script/tool/test/util.dart
@@ -47,6 +47,8 @@ class PlatformDetails {
   const PlatformDetails(
     this.type, {
     this.variants = const <String>[],
+    this.hasNativeCode = true,
+    this.hasDartCode = false,
   });
 
   /// The type of support for the platform.
@@ -54,6 +56,16 @@ class PlatformDetails {
 
   /// Any 'supportVariants' to list in the pubspec.
   final List<String> variants;
+
+  /// Whether or not the plugin includes native code.
+  ///
+  /// Ignored for web, which does not have native code.
+  final bool hasNativeCode;
+
+  /// Whether or not the plugin includes Dart code.
+  ///
+  /// Ignored for web, which always has native code.
+  final bool hasDartCode;
 }
 
 /// Creates a plugin package with the given [name] in [packagesDirectory].
@@ -209,49 +221,38 @@ String _pluginPlatformSection(
         default_package: ${packageName}_$platform
 ''';
   } else {
+    final List<String> lines = <String>[
+      '      $platform:',
+    ];
     switch (platform) {
       case kPlatformAndroid:
-        entry = '''
-      android:
-        package: io.flutter.plugins.fake
-        pluginClass: FakePlugin
-''';
-        break;
+        lines.add('        package: io.flutter.plugins.fake');
+        continue nativeByDefault;
+      nativeByDefault:
       case kPlatformIos:
-        entry = '''
-      ios:
-        pluginClass: FLTFakePlugin
-''';
-        break;
       case kPlatformLinux:
-        entry = '''
-      linux:
-        pluginClass: FakePlugin
-''';
-        break;
       case kPlatformMacos:
-        entry = '''
-      macos:
-        pluginClass: FakePlugin
-''';
+      case kPlatformWindows:
+        if (support.hasNativeCode) {
+          final String className =
+              platform == kPlatformIos ? 'FLTFakePlugin' : 'FakePlugin';
+          lines.add('        pluginClass: $className');
+        }
+        if (support.hasDartCode) {
+          lines.add('        dartPluginClass: FakeDartPlugin');
+        }
         break;
       case kPlatformWeb:
-        entry = '''
-      web:
-        pluginClass: FakePlugin
-        fileName: ${packageName}_web.dart
-''';
-        break;
-      case kPlatformWindows:
-        entry = '''
-      windows:
-        pluginClass: FakePlugin
-''';
+        lines.addAll(<String>[
+          '        pluginClass: FakePlugin',
+          '        fileName: ${packageName}_web.dart',
+        ]);
         break;
       default:
         assert(false, 'Unrecognized platform: $platform');
         break;
     }
+    entry = lines.join('\n') + '\n';
   }
 
   // Add any variants.

--- a/script/tool/test/util.dart
+++ b/script/tool/test/util.dart
@@ -10,6 +10,7 @@ import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
+import 'package:flutter_plugin_tools/src/common/file_utils.dart';
 import 'package:flutter_plugin_tools/src/common/plugin_utils.dart';
 import 'package:flutter_plugin_tools/src/common/process_runner.dart';
 import 'package:meta/meta.dart';
@@ -142,15 +143,10 @@ Directory createFakePackage(
     }
   }
 
-  final FileSystem fileSystem = packageDirectory.fileSystem;
   final p.Context posixContext = p.posix;
   for (final String file in extraFiles) {
-    final List<String> newFilePath = <String>[
-      packageDirectory.path,
-      ...posixContext.split(file)
-    ];
-    final File newFile = fileSystem.file(fileSystem.path.joinAll(newFilePath));
-    newFile.createSync(recursive: true);
+    childFileWithSubcomponents(packageDirectory, posixContext.split(file))
+        .createSync(recursive: true);
   }
 
   return packageDirectory;


### PR DESCRIPTION
Implements support for `--windows` in `native-test`, for unit tests only. The structure of the new code has most of the new functionality in a generic utility for running GoogleTest test binaries, so that it can be trivially extended to Linux support in a follow-up once the Linux test PoC has landed.

This runs the recently-added `url_launcher_windows` unit test. However, it's not yet run in CI since it needs LUCI bringup; that will be done one this support is in place.

Requires new logic to check if a plugin contains native code, and some new test utility plumbing to generate plugins whose pubspecs indicate that they only contain Dart code to test it, to allow filtering filtering out the FFI-based Windows plugins.

Part of flutter/flutter#82445

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
