### PR TITLE
[ci.yaml] Add linux platform properties

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -9,6 +9,17 @@ enabled_branches:
   - master
 
 platform_properties:
+  linux:
+    properties:
+      caches: >-
+        [
+        ]
+      dependencies: >
+        [
+          {"dependency": "curl"}
+        ]
+      device_type: none
+      os: Linux
   windows:
     properties:
       caches: >-


### PR DESCRIPTION
This is missing, which causes ci_yaml starlark module to fail to find default values.

https://github.com/flutter/flutter/issues/84998

https://flutter-review.googlesource.com/c/infra/+/17460 - Manual roll of this config

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [X] I signed the [CLA].
- [X] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [ ] All existing and new tests are passing.
