### PR TITLE
[flutter_plugin_tools] Switch 'publish' from --package to --packages

### DIFF
--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -7,6 +7,8 @@
 - `build-examples` now supports UWP plugins via a `--winuwp` flag.
 - **Breaking change**: `publish` no longer accepts `--no-tag-release` or
   `--no-push-flags`. Releases now always tag and push.
+- **Breaking change**: `publish`'s `--package` flag has been replaced with the
+  `--packages` flag used by most other packages.
 
 ## 0.5.0
 

--- a/script/tool/lib/src/publish_plugin_command.dart
+++ b/script/tool/lib/src/publish_plugin_command.dart
@@ -244,7 +244,7 @@ class PublishPluginCommand extends PluginCommand {
   }) async {
     if (!pubspecFile.existsSync()) {
       print('''
-The file at The pubspec file at ${pubspecFile.path} does not exist. Publishing will not happen for ${pubspecFile.parent.basename}.
+The pubspec file at ${pubspecFile.path} does not exist. Publishing will not happen for ${pubspecFile.parent.basename}.
 Safe to ignore if the package is deleted in this commit.
 ''');
       return _CheckNeedsReleaseResult.noRelease;
@@ -269,7 +269,8 @@ Safe to ignore if the package is deleted in this commit.
       return _CheckNeedsReleaseResult.failure;
     }
 
-    // Check if the package named `packageName` with `version` has already published.
+    // Check if the package named `packageName` with `version` has already
+    // been published.
     final Version version = pubspec.version!;
     final PubVersionFinderResponse pubVersionFinderResponse =
         await _pubVersionFinder.getPackageVersion(packageName: pubspec.name);

--- a/script/tool/lib/src/publish_plugin_command.dart
+++ b/script/tool/lib/src/publish_plugin_command.dart
@@ -71,7 +71,7 @@ class PublishPluginCommand extends PluginCommand {
     argParser.addFlag(
       _allChangedFlag,
       help:
-          'Release all plugins that contains pubspec changes at the current commit compares to the base-sha.\n'
+          'Release all packages that contains pubspec changes at the current commit compares to the base-sha.\n'
           'The --packages option is ignored if this is on.',
       defaultsTo: false,
     );
@@ -108,7 +108,7 @@ class PublishPluginCommand extends PluginCommand {
 
   @override
   final String description =
-      'Attempts to publish the given plugin and tag its release on GitHub.\n'
+      'Attempts to publish the given packages and tag the release(s) on GitHub.\n'
       'If running this on CI, an environment variable named $_pubCredentialName must be set to a String that represents the pub credential JSON.\n'
       'WARNING: Do not check in the content of pub credential JSON, it should only come from secure sources.';
 
@@ -225,7 +225,7 @@ class PublishPluginCommand extends PluginCommand {
     RepositoryPackage package, {
     _RemoteInfo? remoteForTagPush,
   }) async {
-    if (!await _publishPlugin(package)) {
+    if (!await _publishPackage(package)) {
       return false;
     }
     if (!await _tagRelease(
@@ -295,10 +295,10 @@ Safe to ignore if the package is deleted in this commit.
     return _CheckNeedsReleaseResult.release;
   }
 
-  // Publish the plugin.
+  // Publish the package.
   //
   // Returns `true` if successful, `false` otherwise.
-  Future<bool> _publishPlugin(RepositoryPackage package) async {
+  Future<bool> _publishPackage(RepositoryPackage package) async {
     final bool gitStatusOK = await _checkGitStatus(package);
     if (!gitStatusOK) {
       return false;
@@ -311,7 +311,7 @@ Safe to ignore if the package is deleted in this commit.
     return true;
   }
 
-  // Tag the release with <plugin-name>-v<version>, and, if [remoteForTagPush]
+  // Tag the release with <package-name>-v<version>, and, if [remoteForTagPush]
   // is provided, push it to that remote.
   //
   // Return `true` if successful, `false` otherwise.

--- a/script/tool/test/publish_plugin_command_test.dart
+++ b/script/tool/test/publish_plugin_command_test.dart
@@ -63,34 +63,6 @@ void main() {
   });
 
   group('Initial validation', () {
-    test('requires a package flag', () async {
-      Error? commandError;
-      final List<String> output = await runCapturingPrint(
-          commandRunner, <String>['publish-plugin'], errorHandler: (Error e) {
-        commandError = e;
-      });
-
-      expect(commandError, isA<ToolExit>());
-      expect(
-          output,
-          containsAllInOrder(<Matcher>[
-            contains('Must specify a package to publish.'),
-          ]));
-    });
-
-    test('requires an existing flag', () async {
-      Error? commandError;
-      final List<String> output = await runCapturingPrint(
-          commandRunner, <String>['publish-plugin', '--package', 'iamerror'],
-          errorHandler: (Error e) {
-        commandError = e;
-      });
-
-      expect(commandError, isA<ToolExit>());
-      expect(output,
-          containsAllInOrder(<Matcher>[contains('iamerror does not exist')]));
-    });
-
     test('refuses to proceed with dirty files', () async {
       final Directory pluginDir =
           createFakePlugin('foo', packagesDir, examples: <String>[]);
@@ -100,9 +72,11 @@ void main() {
       ];
 
       Error? commandError;
-      final List<String> output = await runCapturingPrint(
-          commandRunner, <String>['publish-plugin', '--package', 'foo'],
-          errorHandler: (Error e) {
+      final List<String> output =
+          await runCapturingPrint(commandRunner, <String>[
+        'publish-plugin',
+        '--packages=foo',
+      ], errorHandler: (Error e) {
         commandError = e;
       });
 
@@ -128,7 +102,7 @@ void main() {
 
       Error? commandError;
       final List<String> output = await runCapturingPrint(
-          commandRunner, <String>['publish-plugin', '--package', 'foo'],
+          commandRunner, <String>['publish-plugin', '--packages=foo'],
           errorHandler: (Error e) {
         commandError = e;
       });
@@ -156,7 +130,7 @@ void main() {
       ];
 
       final List<String> output = await runCapturingPrint(
-          commandRunner, <String>['publish-plugin', '--package', 'foo']);
+          commandRunner, <String>['publish-plugin', '--packages=foo']);
 
       expect(
           output,
@@ -172,7 +146,7 @@ void main() {
       mockStdin.mockUserInputs.add(utf8.encode('user input'));
 
       await runCapturingPrint(
-          commandRunner, <String>['publish-plugin', '--package', 'foo']);
+          commandRunner, <String>['publish-plugin', '--packages=foo']);
 
       expect(processRunner.mockPublishProcess.stdinMock.lines,
           contains('user input'));
@@ -184,17 +158,16 @@ void main() {
 
       await runCapturingPrint(commandRunner, <String>[
         'publish-plugin',
-        '--package',
-        'foo',
+        '--packages=foo',
         '--pub-publish-flags',
-        '--dry-run,--server=foo'
+        '--dry-run,--server=bar'
       ]);
 
       expect(
           processRunner.recordedCalls,
           contains(ProcessCall(
               flutterCommand,
-              const <String>['pub', 'publish', '--dry-run', '--server=foo'],
+              const <String>['pub', 'publish', '--dry-run', '--server=bar'],
               pluginDir.path)));
     });
 
@@ -207,18 +180,17 @@ void main() {
 
       await runCapturingPrint(commandRunner, <String>[
         'publish-plugin',
-        '--package',
-        'foo',
+        '--packages=foo',
         '--skip-confirmation',
         '--pub-publish-flags',
-        '--server=foo'
+        '--server=bar'
       ]);
 
       expect(
           processRunner.recordedCalls,
           contains(ProcessCall(
               flutterCommand,
-              const <String>['pub', 'publish', '--server=foo', '--force'],
+              const <String>['pub', 'publish', '--server=bar', '--force'],
               pluginDir.path)));
     });
 
@@ -233,8 +205,7 @@ void main() {
       final List<String> output =
           await runCapturingPrint(commandRunner, <String>[
         'publish-plugin',
-        '--package',
-        'foo',
+        '--packages=foo',
       ], errorHandler: (Error e) {
         commandError = e;
       });
@@ -254,8 +225,7 @@ void main() {
       final List<String> output =
           await runCapturingPrint(commandRunner, <String>[
         'publish-plugin',
-        '--package',
-        'foo',
+        '--packages=foo',
         '--dry-run',
       ]);
 
@@ -300,8 +270,7 @@ void main() {
       createFakePlugin('foo', packagesDir, examples: <String>[]);
       await runCapturingPrint(commandRunner, <String>[
         'publish-plugin',
-        '--package',
-        'foo',
+        '--packages=foo',
       ]);
 
       expect(processRunner.recordedCalls,
@@ -319,8 +288,7 @@ void main() {
       final List<String> output =
           await runCapturingPrint(commandRunner, <String>[
         'publish-plugin',
-        '--package',
-        'foo',
+        '--packages=foo',
       ], errorHandler: (Error e) {
         commandError = e;
       });
@@ -347,8 +315,7 @@ void main() {
       final List<String> output =
           await runCapturingPrint(commandRunner, <String>[
         'publish-plugin',
-        '--package',
-        'foo',
+        '--packages=foo',
       ]);
 
       expect(
@@ -371,8 +338,7 @@ void main() {
           await runCapturingPrint(commandRunner, <String>[
         'publish-plugin',
         '--skip-confirmation',
-        '--package',
-        'foo',
+        '--packages=foo',
       ]);
 
       expect(
@@ -393,7 +359,7 @@ void main() {
       mockStdin.readLineOutput = 'y';
 
       final List<String> output = await runCapturingPrint(commandRunner,
-          <String>['publish-plugin', '--package', 'foo', '--dry-run']);
+          <String>['publish-plugin', '--packages=foo', '--dry-run']);
 
       expect(
           processRunner.recordedCalls
@@ -418,8 +384,7 @@ void main() {
       final List<String> output =
           await runCapturingPrint(commandRunner, <String>[
         'publish-plugin',
-        '--package',
-        'foo',
+        '--packages=foo',
         '--remote',
         'origin',
       ]);

--- a/script/tool/test/publish_plugin_command_test.dart
+++ b/script/tool/test/publish_plugin_command_test.dart
@@ -214,7 +214,7 @@ void main() {
       expect(
           output,
           containsAllInOrder(<Matcher>[
-            contains('Publish foo failed.'),
+            contains('Publishing foo failed.'),
           ]));
     });
 
@@ -249,8 +249,7 @@ void main() {
       final List<String> output =
           await runCapturingPrint(commandRunner, <String>[
         'publish-plugin',
-        '--package',
-        packageName,
+        '--packages=$packageName',
       ]);
 
       expect(
@@ -297,7 +296,7 @@ void main() {
       expect(
           output,
           containsAllInOrder(<Matcher>[
-            contains('Publish foo failed.'),
+            contains('Publishing foo failed.'),
           ]));
       expect(
           processRunner.recordedCalls,
@@ -325,7 +324,7 @@ void main() {
       expect(
           output,
           containsAllInOrder(<Matcher>[
-            contains('Released [foo] successfully.'),
+            contains('Published foo successfully.'),
           ]));
     });
 
@@ -348,7 +347,7 @@ void main() {
       expect(
           output,
           containsAllInOrder(<Matcher>[
-            contains('Released [foo] successfully.'),
+            contains('Published foo successfully.'),
           ]));
     });
 
@@ -396,7 +395,7 @@ void main() {
       expect(
           output,
           containsAllInOrder(<Matcher>[
-            contains('Released [foo] successfully.'),
+            contains('Published foo successfully.'),
           ]));
     });
   });
@@ -751,7 +750,7 @@ void main() {
             'Checking local repo...',
             'Local repo is ready!',
             'Running `pub publish ` in ${pluginDir1.path}...\n',
-            'The file at The pubspec file at ${pluginDir2.childFile('pubspec.yaml').path} does not exist. Publishing will not happen for plugin2.\nSafe to ignore if the package is deleted in this commit.\n',
+            'The pubspec file at ${pluginDir2.childFile('pubspec.yaml').path} does not exist. Publishing will not happen for plugin2.\nSafe to ignore if the package is deleted in this commit.\n',
             'Packages released: plugin1',
             'Done!'
           ]));

--- a/script/tool/test/publish_plugin_command_test.dart
+++ b/script/tool/test/publish_plugin_command_test.dart
@@ -119,24 +119,34 @@ void main() {
 
   group('Publishes package', () {
     test('while showing all output from pub publish to the user', () async {
-      createFakePlugin('foo', packagesDir, examples: <String>[]);
+      createFakePlugin('plugin1', packagesDir, examples: <String>[]);
+      createFakePlugin('plugin2', packagesDir, examples: <String>[]);
 
       processRunner.mockProcessesForExecutable[flutterCommand] = <io.Process>[
         MockProcess(
             stdout: 'Foo',
             stderr: 'Bar',
             stdoutEncoding: utf8,
-            stderrEncoding: utf8) // pub publish
+            stderrEncoding: utf8), // pub publish for plugin1
+        MockProcess(
+            stdout: 'Baz',
+            stdoutEncoding: utf8,
+            stderrEncoding: utf8), // pub publish for plugin1
       ];
 
-      final List<String> output = await runCapturingPrint(
-          commandRunner, <String>['publish-plugin', '--packages=foo']);
+      final List<String> output = await runCapturingPrint(commandRunner,
+          <String>['publish-plugin', '--packages=plugin1,plugin2']);
 
       expect(
           output,
           containsAllInOrder(<Matcher>[
+            contains('Running `pub publish ` in /packages/plugin1...'),
             contains('Foo'),
             contains('Bar'),
+            contains('Package published!'),
+            contains('Running `pub publish ` in /packages/plugin2...'),
+            contains('Baz'),
+            contains('Package published!'),
           ]));
     });
 


### PR DESCRIPTION
Replaces the `publish`-command-specific `--package` flag with support for `--packages`, and unifies the flow with the existing looping for `--all-changed`.

This better aligns the command's API with the rest of the commands, and reduces divergence in the two flows (e.g., `--package` would attempt to publish and fail if the package was already published, whereas now using `--packages` will use the flow that pre-checks against `pub.dev`). It also sets up a structure that will allow easily converting it to the new base package looping command that most other commands now use, which will be done in a follow-up.

Since all calls now attempt to contact `pub.dev`, the tests have been adjusted to always mock the HTTP client so they will be hermetic.

Part of https://github.com/flutter/flutter/issues/83413

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
