### PR TITLE
[flutter_plugin_tools] Add Linux support to native-test

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -128,7 +128,7 @@ task:
         - flutter config --enable-linux-desktop
         - ./script/tool_runner.sh build-examples --linux
       native_test_script:
-        - ./script/tool_runner.sh native-test --linux
+        - ./script/tool_runner.sh native-test --linux --no-integration
       drive_script:
         - xvfb-run ./script/tool_runner.sh drive-examples --linux
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -126,7 +126,6 @@ task:
           CHANNEL: "stable"
       build_script:
         - flutter config --enable-linux-desktop
-        - flutter doctor -v
         - ./script/tool_runner.sh build-examples --linux
       native_test_script:
         - ./script/tool_runner.sh native-test --linux --no-integration

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -127,6 +127,8 @@ task:
       build_script:
         - flutter config --enable-linux-desktop
         - ./script/tool_runner.sh build-examples --linux
+      native_test_script:
+        - ./script/tool_runner.sh native-test --linux
       drive_script:
         - xvfb-run ./script/tool_runner.sh drive-examples --linux
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -126,6 +126,7 @@ task:
           CHANNEL: "stable"
       build_script:
         - flutter config --enable-linux-desktop
+        - flutter doctor -v
         - ./script/tool_runner.sh build-examples --linux
       native_test_script:
         - ./script/tool_runner.sh native-test --linux --no-integration

--- a/packages/url_launcher/url_launcher_linux/example/linux/CMakeLists.txt
+++ b/packages/url_launcher/url_launcher_linux/example/linux/CMakeLists.txt
@@ -43,6 +43,9 @@ target_link_libraries(${BINARY_NAME} PRIVATE flutter)
 target_link_libraries(${BINARY_NAME} PRIVATE PkgConfig::GTK)
 add_dependencies(${BINARY_NAME} flutter_assemble)
 
+# Enable the test target.
+set(include_url_launcher_linux_tests TRUE)
+
 # Generated plugin build rules, which manage building the plugins and adding
 # them to the application.
 include(flutter/generated_plugins.cmake)

--- a/packages/url_launcher/url_launcher_linux/example/linux/flutter/CMakeLists.txt
+++ b/packages/url_launcher/url_launcher_linux/example/linux/flutter/CMakeLists.txt
@@ -78,7 +78,8 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.sh"
-      linux-x64 ${CMAKE_BUILD_TYPE}
+      ${FLUTTER_TARGET_PLATFORM} ${CMAKE_BUILD_TYPE}
+  VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS
   "${FLUTTER_LIBRARY}"

--- a/packages/url_launcher/url_launcher_linux/linux/CMakeLists.txt
+++ b/packages/url_launcher/url_launcher_linux/linux/CMakeLists.txt
@@ -4,8 +4,12 @@ project(${PROJECT_NAME} LANGUAGES CXX)
 
 set(PLUGIN_NAME "${PROJECT_NAME}_plugin")
 
-add_library(${PLUGIN_NAME} SHARED
+list(APPEND PLUGIN_SOURCES
   "url_launcher_plugin.cc"
+)
+
+add_library(${PLUGIN_NAME} SHARED
+  ${PLUGIN_SOURCES}
 )
 apply_standard_settings(${PLUGIN_NAME})
 set_target_properties(${PLUGIN_NAME} PROPERTIES
@@ -15,3 +19,49 @@ target_include_directories(${PLUGIN_NAME} INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/include")
 target_link_libraries(${PLUGIN_NAME} PRIVATE flutter)
 target_link_libraries(${PLUGIN_NAME} PRIVATE PkgConfig::GTK)
+
+
+# === Tests ===
+
+if (${include_${PROJECT_NAME}_tests})
+if(${CMAKE_VERSION} VERSION_LESS "3.11.0")
+message("Unit tests require CMake 3.11.0 or later")
+else()
+set(TEST_RUNNER "${PROJECT_NAME}_test")
+enable_testing()
+# TODO(stuartmorgan): Consider using a single shared, pre-checked-in googletest
+# instance rather than downloading for each plugin. This approach makes sense
+# for a template, but not for a monorepo with many plugins.
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/release-1.11.0.zip
+)
+# Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+# Disable install commands for gtest so it doesn't end up in the bundle.
+set(INSTALL_GTEST OFF CACHE BOOL "Disable installation of googletest" FORCE)
+
+FetchContent_MakeAvailable(googletest)
+
+# The plugin's exported API is not very useful for unit testing, so build the
+# sources directly into the test binary rather than using the shared library.
+add_executable(${TEST_RUNNER}
+  test/url_launcher_linux_test.cc
+  ${PLUGIN_SOURCES}
+)
+apply_standard_settings(${TEST_RUNNER})
+target_include_directories(${TEST_RUNNER} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+target_link_libraries(${TEST_RUNNER} PRIVATE flutter)
+target_link_libraries(${TEST_RUNNER} PRIVATE PkgConfig::GTK)
+target_link_libraries(${TEST_RUNNER} PRIVATE gtest_main gmock)
+# flutter_wrapper_plugin has link dependencies on the Flutter shared library.
+#add_custom_command(TARGET ${TEST_RUNNER} POST_BUILD
+#  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+#  "${FLUTTER_LIBRARY}" $<TARGET_FILE_DIR:${TEST_RUNNER}>
+#)
+
+include(GoogleTest)
+gtest_discover_tests(${TEST_RUNNER})
+endif()  # CMake version check
+endif()  # include_${PROJECT_NAME}_tests

--- a/packages/url_launcher/url_launcher_linux/linux/CMakeLists.txt
+++ b/packages/url_launcher/url_launcher_linux/linux/CMakeLists.txt
@@ -55,11 +55,6 @@ target_include_directories(${TEST_RUNNER} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
 target_link_libraries(${TEST_RUNNER} PRIVATE flutter)
 target_link_libraries(${TEST_RUNNER} PRIVATE PkgConfig::GTK)
 target_link_libraries(${TEST_RUNNER} PRIVATE gtest_main gmock)
-# flutter_wrapper_plugin has link dependencies on the Flutter shared library.
-#add_custom_command(TARGET ${TEST_RUNNER} POST_BUILD
-#  COMMAND ${CMAKE_COMMAND} -E copy_if_different
-#  "${FLUTTER_LIBRARY}" $<TARGET_FILE_DIR:${TEST_RUNNER}>
-#)
 
 include(GoogleTest)
 gtest_discover_tests(${TEST_RUNNER})

--- a/packages/url_launcher/url_launcher_linux/linux/test/url_launcher_linux_test.cc
+++ b/packages/url_launcher/url_launcher_linux/linux/test/url_launcher_linux_test.cc
@@ -1,0 +1,57 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+#include <flutter_linux/flutter_linux.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+#include "include/url_launcher_linux/url_launcher_plugin.h"
+#include "url_launcher_plugin_private.h"
+
+namespace url_launcher_plugin {
+namespace test {
+
+TEST(UrlLauncherPlugin, CanLaunchSuccess) {
+  g_autoptr(FlValue) args = fl_value_new_map();
+  fl_value_set_string_take(args, "url",
+                           fl_value_new_string("https://flutter.dev"));
+  FlMethodResponse* response = can_launch(nullptr, args);
+  ASSERT_NE(response, nullptr);
+  ASSERT_TRUE(FL_IS_METHOD_SUCCESS_RESPONSE(response));
+  g_autoptr(FlValue) expected = fl_value_new_bool(true);
+  EXPECT_TRUE(fl_value_equal(fl_method_success_response_get_result(
+                                 FL_METHOD_SUCCESS_RESPONSE(response)),
+                             expected));
+}
+
+TEST(UrlLauncherPlugin, CanLaunchFailureUnhandled) {
+  g_autoptr(FlValue) args = fl_value_new_map();
+  fl_value_set_string_take(args, "url", fl_value_new_string("madeup:scheme"));
+  FlMethodResponse* response = can_launch(nullptr, args);
+  ASSERT_NE(response, nullptr);
+  ASSERT_TRUE(FL_IS_METHOD_SUCCESS_RESPONSE(response));
+  g_autoptr(FlValue) expected = fl_value_new_bool(false);
+  EXPECT_TRUE(fl_value_equal(fl_method_success_response_get_result(
+                                 FL_METHOD_SUCCESS_RESPONSE(response)),
+                             expected));
+}
+
+// For consistency with the established mobile implementations,
+// an invalid URL should return false, not an error.
+TEST(UrlLauncherPlugin, CanLaunchFailureInvalidUrl) {
+  g_autoptr(FlValue) args = fl_value_new_map();
+  fl_value_set_string_take(args, "url", fl_value_new_string(""));
+  FlMethodResponse* response = can_launch(nullptr, args);
+  ASSERT_NE(response, nullptr);
+  ASSERT_TRUE(FL_IS_METHOD_SUCCESS_RESPONSE(response));
+  g_autoptr(FlValue) expected = fl_value_new_bool(false);
+  EXPECT_TRUE(fl_value_equal(fl_method_success_response_get_result(
+                                 FL_METHOD_SUCCESS_RESPONSE(response)),
+                             expected));
+}
+
+}  // namespace test
+}  // namespace url_launcher_plugin

--- a/packages/url_launcher/url_launcher_linux/linux/url_launcher_plugin.cc
+++ b/packages/url_launcher/url_launcher_linux/linux/url_launcher_plugin.cc
@@ -9,6 +9,8 @@
 
 #include <cstring>
 
+#include "url_launcher_plugin_private.h"
+
 // See url_launcher_channel.dart for documentation.
 const char kChannelName[] = "plugins.flutter.io/url_launcher";
 const char kBadArgumentsError[] = "Bad Arguments";
@@ -44,7 +46,7 @@ static gchar* get_url(FlValue* args, GError** error) {
 }
 
 // Called to check if a URL can be launched.
-static FlMethodResponse* can_launch(FlUrlLauncherPlugin* self, FlValue* args) {
+FlMethodResponse* can_launch(FlUrlLauncherPlugin* self, FlValue* args) {
   g_autoptr(GError) error = nullptr;
   g_autofree gchar* url = get_url(args, &error);
   if (url == nullptr) {

--- a/packages/url_launcher/url_launcher_linux/linux/url_launcher_plugin_private.h
+++ b/packages/url_launcher/url_launcher_linux/linux/url_launcher_plugin_private.h
@@ -1,0 +1,13 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "include/url_launcher_linux/url_launcher_plugin.h"
+
+#include <flutter_linux/flutter_linux.h>
+
+// Handles the canLaunch method call.
+//
+// Temporarily exposed for testing due to
+// https://github.com/flutter/flutter/issues/88724
+FlMethodResponse* can_launch(FlUrlLauncherPlugin* self, FlValue* args);

--- a/packages/url_launcher/url_launcher_linux/linux/url_launcher_plugin_private.h
+++ b/packages/url_launcher/url_launcher_linux/linux/url_launcher_plugin_private.h
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "include/url_launcher_linux/url_launcher_plugin.h"
-
 #include <flutter_linux/flutter_linux.h>
+
+#include "include/url_launcher_linux/url_launcher_plugin.h"
 
 // Handles the canLaunch method call.
 //

--- a/packages/url_launcher/url_launcher_linux/linux/url_launcher_plugin_private.h
+++ b/packages/url_launcher/url_launcher_linux/linux/url_launcher_plugin_private.h
@@ -6,8 +6,9 @@
 
 #include "include/url_launcher_linux/url_launcher_plugin.h"
 
+// TODO(stuartmorgan): Remove this private header and change the below back to
+// a static function once https://github.com/flutter/flutter/issues/88724
+// is fixed, and test through the public API instead.
+
 // Handles the canLaunch method call.
-//
-// Temporarily exposed for testing due to
-// https://github.com/flutter/flutter/issues/88724
 FlMethodResponse* can_launch(FlUrlLauncherPlugin* self, FlValue* args);

--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+- `native-test` now supports `--linux` for unit tests.
+
 ## 0.6.0
 
 - Added Android native integration test support to `native-test`.

--- a/script/tool/lib/src/native_test_command.dart
+++ b/script/tool/lib/src/native_test_command.dart
@@ -21,7 +21,9 @@ const String _iosDestinationFlag = 'ios-destination';
 const int _exitNoIosSimulators = 3;
 
 /// The command to run native tests for plugins:
-/// - iOS and macOS: XCTests (XCUnitTest and XCUITest) in plugins.
+/// - iOS and macOS: XCTests (XCUnitTest and XCUITest)
+/// - Android: JUnit tests
+/// - Windows and Linux: GoogleTest tests
 class NativeTestCommand extends PackageLoopingCommand {
   /// Creates an instance of the test command.
   NativeTestCommand(
@@ -39,6 +41,7 @@ class NativeTestCommand extends PackageLoopingCommand {
     );
     argParser.addFlag(kPlatformAndroid, help: 'Runs Android tests');
     argParser.addFlag(kPlatformIos, help: 'Runs iOS tests');
+    argParser.addFlag(kPlatformLinux, help: 'Runs Linux tests');
     argParser.addFlag(kPlatformMacos, help: 'Runs macOS tests');
     argParser.addFlag(kPlatformWindows, help: 'Runs Windows tests');
 
@@ -63,9 +66,11 @@ class NativeTestCommand extends PackageLoopingCommand {
 Runs native unit tests and native integration tests.
 
 Currently supported platforms:
-- Android (unit tests only)
+- Android
 - iOS: requires 'xcrun' to be in your path.
+- Linux (unit tests only)
 - macOS: requires 'xcrun' to be in your path.
+- Windows (unit tests only)
 
 The example app(s) must be built for all targeted platforms before running
 this command.
@@ -80,6 +85,7 @@ this command.
     _platforms = <String, _PlatformDetails>{
       kPlatformAndroid: _PlatformDetails('Android', _testAndroid),
       kPlatformIos: _PlatformDetails('iOS', _testIos),
+      kPlatformLinux: _PlatformDetails('Linux', _testLinux),
       kPlatformMacos: _PlatformDetails('macOS', _testMacOS),
       kPlatformWindows: _PlatformDetails('Windows', _testWindows),
     };
@@ -101,6 +107,11 @@ this command.
     if (getBoolArg(kPlatformWindows) && getBoolArg(_integrationTestFlag)) {
       logWarning('This command currently only supports unit tests for Windows. '
           'See https://github.com/flutter/flutter/issues/70233.');
+    }
+
+    if (getBoolArg(kPlatformLinux) && getBoolArg(_integrationTestFlag)) {
+      logWarning('This command currently only supports unit tests for Linux. '
+          'See https://github.com/flutter/flutter/issues/70235.');
     }
 
     // iOS-specific run-level state.
@@ -416,6 +427,21 @@ this command.
 
     return _runGoogleTestTests(plugin,
         buildDirectoryName: 'windows', isTestBinary: isTestBinary);
+  }
+
+  Future<_PlatformResult> _testLinux(
+      RepositoryPackage plugin, _TestMode mode) async {
+    if (mode.integrationOnly) {
+      return _PlatformResult(RunState.skipped);
+    }
+
+    bool isTestBinary(File file) {
+      return file.basename.endsWith('_test') ||
+          file.basename.endsWith('_tests');
+    }
+
+    return _runGoogleTestTests(plugin,
+        buildDirectoryName: 'linux', isTestBinary: isTestBinary);
   }
 
   /// Finds every file in the [buildDirectoryName] subdirectory of [plugin]'s

--- a/script/tool/lib/src/native_test_command.dart
+++ b/script/tool/lib/src/native_test_command.dart
@@ -468,10 +468,11 @@ this command.
           .whereType<File>()
           .where(isTestBinary)
           .where((File file) {
-        // Only run the debug build of the unit tests, to avoid running the
-        // same tests multiple times.
+        // Only run the release build of the unit tests, to avoid running the
+        // same tests multiple times. Release is used rather than debug since
+        // `build-examples` builds release versions.
         final List<String> components = path.split(file.path);
-        return components.contains('debug') || components.contains('Debug');
+        return components.contains('release') || components.contains('Release');
       }));
     }
 

--- a/script/tool/test/native_test_command_test.dart
+++ b/script/tool/test/native_test_command_test.dart
@@ -739,7 +739,7 @@ void main() {
     group('Linux', () {
       test('runs unit tests', () async {
         const String testBinaryRelativePath =
-            'build/linux/foo/debug/bar/plugin_test';
+            'build/linux/foo/release/bar/plugin_test';
         final Directory pluginDirectory =
             createFakePlugin('plugin', packagesDir, extraFiles: <String>[
           'example/$testBinaryRelativePath'
@@ -771,7 +771,7 @@ void main() {
             ]));
       });
 
-      test('only runs debug unit tests', () async {
+      test('only runs release unit tests', () async {
         const String debugTestBinaryRelativePath =
             'build/linux/foo/debug/bar/plugin_test';
         const String releaseTestBinaryRelativePath =
@@ -784,8 +784,9 @@ void main() {
           kPlatformLinux: const PlatformDetails(PlatformSupport.inline),
         });
 
-        final File debugTestBinary = childFileWithSubcomponents(pluginDirectory,
-            <String>['example', ...debugTestBinaryRelativePath.split('/')]);
+        final File releaseTestBinary = childFileWithSubcomponents(
+            pluginDirectory,
+            <String>['example', ...releaseTestBinaryRelativePath.split('/')]);
 
         final List<String> output = await runCapturingPrint(runner, <String>[
           'native-test',
@@ -801,11 +802,11 @@ void main() {
           ]),
         );
 
-        // Only the debug version should be run.
+        // Only the release version should be run.
         expect(
             processRunner.recordedCalls,
             orderedEquals(<ProcessCall>[
-              ProcessCall(debugTestBinary.path, const <String>[], null),
+              ProcessCall(releaseTestBinary.path, const <String>[], null),
             ]));
       });
 
@@ -837,7 +838,7 @@ void main() {
 
       test('fails if a unit test fails', () async {
         const String testBinaryRelativePath =
-            'build/linux/foo/debug/bar/plugin_test';
+            'build/linux/foo/release/bar/plugin_test';
         final Directory pluginDirectory =
             createFakePlugin('plugin', packagesDir, extraFiles: <String>[
           'example/$testBinaryRelativePath'
@@ -1492,7 +1493,7 @@ void main() {
     group('Windows', () {
       test('runs unit tests', () async {
         const String testBinaryRelativePath =
-            'build/windows/foo/Debug/bar/plugin_test.exe';
+            'build/windows/foo/Release/bar/plugin_test.exe';
         final Directory pluginDirectory =
             createFakePlugin('plugin', packagesDir, extraFiles: <String>[
           'example/$testBinaryRelativePath'
@@ -1524,7 +1525,7 @@ void main() {
             ]));
       });
 
-      test('only runs debug unit tests', () async {
+      test('only runs release unit tests', () async {
         const String debugTestBinaryRelativePath =
             'build/windows/foo/Debug/bar/plugin_test.exe';
         const String releaseTestBinaryRelativePath =
@@ -1537,8 +1538,9 @@ void main() {
           kPlatformWindows: const PlatformDetails(PlatformSupport.inline),
         });
 
-        final File debugTestBinary = childFileWithSubcomponents(pluginDirectory,
-            <String>['example', ...debugTestBinaryRelativePath.split('/')]);
+        final File releaseTestBinary = childFileWithSubcomponents(
+            pluginDirectory,
+            <String>['example', ...releaseTestBinaryRelativePath.split('/')]);
 
         final List<String> output = await runCapturingPrint(runner, <String>[
           'native-test',
@@ -1554,11 +1556,11 @@ void main() {
           ]),
         );
 
-        // Only the debug version should be run.
+        // Only the release version should be run.
         expect(
             processRunner.recordedCalls,
             orderedEquals(<ProcessCall>[
-              ProcessCall(debugTestBinary.path, const <String>[], null),
+              ProcessCall(releaseTestBinary.path, const <String>[], null),
             ]));
       });
 
@@ -1590,7 +1592,7 @@ void main() {
 
       test('fails if a unit test fails', () async {
         const String testBinaryRelativePath =
-            'build/windows/foo/Debug/bar/plugin_test.exe';
+            'build/windows/foo/Release/bar/plugin_test.exe';
         final Directory pluginDirectory =
             createFakePlugin('plugin', packagesDir, extraFiles: <String>[
           'example/$testBinaryRelativePath'


### PR DESCRIPTION
- Adds a minimal unit test to url_launcher_linux as a proof of concept. This uses almost exactly the same CMake structure as the Windows version that was added recently.
- Adds Linux support for unit tests to `native-test`, sharing almost all of the existing Windows codepath.
- Fixes the fact that it it was running the debug version of the unit tests, but `build-examples` only builds release. (On other platforms we run debug unit tests, but on those platforms the test command internally builds the requested unit tests, so the mismatch doesn't matter.)
- Enables the new test in CI.

Also opportunistically fixes some documentation in `native_test_command.dart` that wasn't updated as more platform support was added.

Linux portion of https://github.com/flutter/flutter/issues/82445

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
