### PR TITLE
[video_player]fix video play() not update VideoPlayerValue when isInitialized is false

### DIFF
--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -499,7 +499,12 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
     } else if (position < const Duration()) {
       position = const Duration();
     }
-    await _videoPlayerPlatform.seekTo(_textureId, position);
+
+    try {
+      await _videoPlayerPlatform.seekTo(_textureId, position);
+    } catch (e) {
+      //
+    }
     _updatePosition(position);
   }
 


### PR DESCRIPTION
Before  `VideoPlayerController.initialize()` finished. 
Client maybe call `VideoPlayerController.play()`.
It's better to notify the `VideoPlayerValue` to client.

To make this work:

```dart
  Future<void> play() async {
    if (value.position == value.duration) {
      await seekTo(const Duration());              // <--- so seeTo() need to avoid exception before initialize() finished. 
    }
    value = value.copyWith(isPlaying: true);  // <--- this value better to update and notify. so 
    await _applyPlayPause();
  }
```

The exception on my android devices is:

      PlatformException (PlatformException(NullPointerException, java.lang.NullPointerException: Attempt to invoke virtual method 'void io.flutter.plugins.videoplayer.VideoPlayer.seekTo(int)' on a null object reference, null, null))

*List which issues are fixed by this PR. You must list at least one issue.*

https://github.com/flutter/flutter/issues/89259



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
