### PR TITLE
Revert "[image_picker] add forceFullMetadata to interface"

### DIFF
--- a/packages/image_picker/image_picker_for_web/lib/image_picker_for_web.dart
+++ b/packages/image_picker/image_picker_for_web/lib/image_picker_for_web.dart
@@ -53,7 +53,6 @@ class ImagePickerPlugin extends ImagePickerPlatform {
     double? maxWidth,
     double? maxHeight,
     int? imageQuality,
-    bool forceFullMetadata = true,
     CameraDevice preferredCameraDevice = CameraDevice.rear,
   }) {
     String? capture = computeCaptureAttribute(source, preferredCameraDevice);
@@ -116,7 +115,6 @@ class ImagePickerPlugin extends ImagePickerPlatform {
     double? maxWidth,
     double? maxHeight,
     int? imageQuality,
-    bool forceFullMetadata = true,
     CameraDevice preferredCameraDevice = CameraDevice.rear,
   }) async {
     String? capture = computeCaptureAttribute(source, preferredCameraDevice);

--- a/packages/image_picker/image_picker_platform_interface/CHANGELOG.md
+++ b/packages/image_picker/image_picker_platform_interface/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 2.4.1
+
+* Reverts the changes from 2.4.0, which was a breaking change that
+  was incorrectly marked as a non-breaking change.
+
+## 2.4.0
+
+* Add `forceFullMetadata` option to `pickImage`.
+  * To keep this non-breaking `forceFullMetadata` defaults to `true`, so the plugin tries
+   to get the full image metadata which may require extra permission requests on certain platforms.
+  * If `forceFullMetadata` is set to `false`, the plugin fetches the image in a way that reduces
+   permission requests from the platform (e.g on iOS the plugin won’t ask for the `NSPhotoLibraryUsageDescription` permission).
+
 ## 2.3.0
 
 * Updated `LostDataResponse` to include a `files` property, in case more than one file was recovered.

--- a/packages/image_picker/image_picker_platform_interface/CHANGELOG.md
+++ b/packages/image_picker/image_picker_platform_interface/CHANGELOG.md
@@ -1,11 +1,3 @@
-## 2.4.0
-
-* Add `forceFullMetadata` option to `pickImage`.
-  * To keep this non-breaking `forceFullMetadata` defaults to `true`, so the plugin tries
-   to get the full image metadata which may require extra permission requests on certain platforms.
-  * If `forceFullMetadata` is set to `false`, the plugin fetches the image in a way that reduces
-   permission requests from the platform (e.g on iOS the plugin won’t ask for the `NSPhotoLibraryUsageDescription` permission).
-
 ## 2.3.0
 
 * Updated `LostDataResponse` to include a `files` property, in case more than one file was recovered.

--- a/packages/image_picker/image_picker_platform_interface/lib/src/method_channel/method_channel_image_picker.dart
+++ b/packages/image_picker/image_picker_platform_interface/lib/src/method_channel/method_channel_image_picker.dart
@@ -24,7 +24,6 @@ class MethodChannelImagePicker extends ImagePickerPlatform {
     double? maxWidth,
     double? maxHeight,
     int? imageQuality,
-    bool forceFullMetadata = true,
     CameraDevice preferredCameraDevice = CameraDevice.rear,
   }) async {
     String? path = await _getImagePath(
@@ -32,7 +31,6 @@ class MethodChannelImagePicker extends ImagePickerPlatform {
       maxWidth: maxWidth,
       maxHeight: maxHeight,
       imageQuality: imageQuality,
-      forceFullMetadata: forceFullMetadata,
       preferredCameraDevice: preferredCameraDevice,
     );
     return path != null ? PickedFile(path) : null;
@@ -87,7 +85,6 @@ class MethodChannelImagePicker extends ImagePickerPlatform {
     double? maxWidth,
     double? maxHeight,
     int? imageQuality,
-    bool forceFullMetadata = true,
     CameraDevice preferredCameraDevice = CameraDevice.rear,
   }) {
     if (imageQuality != null && (imageQuality < 0 || imageQuality > 100)) {
@@ -110,7 +107,6 @@ class MethodChannelImagePicker extends ImagePickerPlatform {
         'maxWidth': maxWidth,
         'maxHeight': maxHeight,
         'imageQuality': imageQuality,
-        'forceFullMetadata': forceFullMetadata,
         'cameraDevice': preferredCameraDevice.index
       },
     );
@@ -187,7 +183,6 @@ class MethodChannelImagePicker extends ImagePickerPlatform {
     double? maxWidth,
     double? maxHeight,
     int? imageQuality,
-    bool forceFullMetadata = true,
     CameraDevice preferredCameraDevice = CameraDevice.rear,
   }) async {
     String? path = await _getImagePath(
@@ -195,7 +190,6 @@ class MethodChannelImagePicker extends ImagePickerPlatform {
       maxWidth: maxWidth,
       maxHeight: maxHeight,
       imageQuality: imageQuality,
-      forceFullMetadata: forceFullMetadata,
       preferredCameraDevice: preferredCameraDevice,
     );
     return path != null ? XFile(path) : null;

--- a/packages/image_picker/image_picker_platform_interface/lib/src/platform_interface/image_picker_platform.dart
+++ b/packages/image_picker/image_picker_platform_interface/lib/src/platform_interface/image_picker_platform.dart
@@ -58,11 +58,6 @@ abstract class ImagePickerPlatform extends PlatformInterface {
   /// image types such as JPEG. If compression is not supported for the image that is picked,
   /// a warning message will be logged.
   ///
-  /// `forceFullMetadata` defaults to `true`, so the plugin tries to get the full image metadata which may require
-  /// extra permission requests on certain platforms.
-  /// If `forceFullMetadata` is set to `false`, the plugin fetches the image in a way that reduces permission requests
-  /// from the platform (e.g. on iOS the plugin won’t ask for the `NSPhotoLibraryUsageDescription` permission).
-  ///
   /// Use `preferredCameraDevice` to specify the camera to use when the `source` is [ImageSource.camera].
   /// The `preferredCameraDevice` is ignored when `source` is [ImageSource.gallery]. It is also ignored if the chosen camera is not supported on the device.
   /// Defaults to [CameraDevice.rear]. Note that Android has no documented parameter for an intent to specify if
@@ -78,7 +73,6 @@ abstract class ImagePickerPlatform extends PlatformInterface {
     double? maxWidth,
     double? maxHeight,
     int? imageQuality,
-    bool forceFullMetadata = true,
     CameraDevice preferredCameraDevice = CameraDevice.rear,
   }) {
     throw UnimplementedError('pickImage() has not been implemented.');
@@ -170,11 +164,6 @@ abstract class ImagePickerPlatform extends PlatformInterface {
   /// image types such as JPEG. If compression is not supported for the image that is picked,
   /// a warning message will be logged.
   ///
-  /// `forceFullMetadata` defaults to `true`, so the plugin tries to get the full image metadata which may require
-  /// extra permission requests on certain platforms.
-  /// If `forceFullMetadata` is set to `false`, the plugin fetches the image in a way that reduces permission requests
-  /// from the platform (e.g. on iOS the plugin won’t ask for the `NSPhotoLibraryUsageDescription` permission).
-  ///
   /// Use `preferredCameraDevice` to specify the camera to use when the `source` is [ImageSource.camera].
   /// The `preferredCameraDevice` is ignored when `source` is [ImageSource.gallery]. It is also ignored if the chosen camera is not supported on the device.
   /// Defaults to [CameraDevice.rear]. Note that Android has no documented parameter for an intent to specify if
@@ -190,7 +179,6 @@ abstract class ImagePickerPlatform extends PlatformInterface {
     double? maxWidth,
     double? maxHeight,
     int? imageQuality,
-    bool forceFullMetadata = true,
     CameraDevice preferredCameraDevice = CameraDevice.rear,
   }) {
     throw UnimplementedError('getImage() has not been implemented.');

--- a/packages/image_picker/image_picker_platform_interface/pubspec.yaml
+++ b/packages/image_picker/image_picker_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/master/packages/image_picker
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.3.0
+version: 2.4.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/image_picker/image_picker_platform_interface/pubspec.yaml
+++ b/packages/image_picker/image_picker_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/master/packages/image_picker
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.4.0
+version: 2.3.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/image_picker/image_picker_platform_interface/test/new_method_channel_image_picker_test.dart
+++ b/packages/image_picker/image_picker_platform_interface/test/new_method_channel_image_picker_test.dart
@@ -40,16 +40,14 @@ void main() {
               'maxWidth': null,
               'maxHeight': null,
               'imageQuality': null,
-              'cameraDevice': 0,
-              'forceFullMetadata': true,
+              'cameraDevice': 0
             }),
             isMethodCall('pickImage', arguments: <String, dynamic>{
               'source': 1,
               'maxWidth': null,
               'maxHeight': null,
               'imageQuality': null,
-              'cameraDevice': 0,
-              'forceFullMetadata': true,
+              'cameraDevice': 0
             }),
           ],
         );
@@ -95,56 +93,49 @@ void main() {
               'maxWidth': null,
               'maxHeight': null,
               'imageQuality': null,
-              'cameraDevice': 0,
-              'forceFullMetadata': true,
+              'cameraDevice': 0
             }),
             isMethodCall('pickImage', arguments: <String, dynamic>{
               'source': 0,
               'maxWidth': 10.0,
               'maxHeight': null,
               'imageQuality': null,
-              'cameraDevice': 0,
-              'forceFullMetadata': true,
+              'cameraDevice': 0
             }),
             isMethodCall('pickImage', arguments: <String, dynamic>{
               'source': 0,
               'maxWidth': null,
               'maxHeight': 10.0,
               'imageQuality': null,
-              'cameraDevice': 0,
-              'forceFullMetadata': true,
+              'cameraDevice': 0
             }),
             isMethodCall('pickImage', arguments: <String, dynamic>{
               'source': 0,
               'maxWidth': 10.0,
               'maxHeight': 20.0,
               'imageQuality': null,
-              'cameraDevice': 0,
-              'forceFullMetadata': true,
+              'cameraDevice': 0
             }),
             isMethodCall('pickImage', arguments: <String, dynamic>{
               'source': 0,
               'maxWidth': 10.0,
               'maxHeight': null,
               'imageQuality': 70,
-              'cameraDevice': 0,
-              'forceFullMetadata': true,
+              'cameraDevice': 0
             }),
             isMethodCall('pickImage', arguments: <String, dynamic>{
               'source': 0,
               'maxWidth': null,
               'maxHeight': 10.0,
               'imageQuality': 70,
-              'cameraDevice': 0,
-              'forceFullMetadata': true,
+              'cameraDevice': 0
             }),
             isMethodCall('pickImage', arguments: <String, dynamic>{
               'source': 0,
               'maxWidth': 10.0,
               'maxHeight': 20.0,
               'imageQuality': 70,
-              'cameraDevice': 0,
-              'forceFullMetadata': true,
+              'cameraDevice': 0
             }),
           ],
         );
@@ -205,7 +196,6 @@ void main() {
               'maxHeight': null,
               'imageQuality': null,
               'cameraDevice': 0,
-              'forceFullMetadata': true,
             }),
           ],
         );
@@ -225,7 +215,6 @@ void main() {
               'maxHeight': null,
               'imageQuality': null,
               'cameraDevice': 1,
-              'forceFullMetadata': true,
             }),
           ],
         );
@@ -520,16 +509,14 @@ void main() {
               'maxWidth': null,
               'maxHeight': null,
               'imageQuality': null,
-              'cameraDevice': 0,
-              'forceFullMetadata': true,
+              'cameraDevice': 0
             }),
             isMethodCall('pickImage', arguments: <String, dynamic>{
               'source': 1,
               'maxWidth': null,
               'maxHeight': null,
               'imageQuality': null,
-              'cameraDevice': 0,
-              'forceFullMetadata': true,
+              'cameraDevice': 0
             }),
           ],
         );
@@ -575,56 +562,49 @@ void main() {
               'maxWidth': null,
               'maxHeight': null,
               'imageQuality': null,
-              'cameraDevice': 0,
-              'forceFullMetadata': true,
+              'cameraDevice': 0
             }),
             isMethodCall('pickImage', arguments: <String, dynamic>{
               'source': 0,
               'maxWidth': 10.0,
               'maxHeight': null,
               'imageQuality': null,
-              'cameraDevice': 0,
-              'forceFullMetadata': true,
+              'cameraDevice': 0
             }),
             isMethodCall('pickImage', arguments: <String, dynamic>{
               'source': 0,
               'maxWidth': null,
               'maxHeight': 10.0,
               'imageQuality': null,
-              'cameraDevice': 0,
-              'forceFullMetadata': true,
+              'cameraDevice': 0
             }),
             isMethodCall('pickImage', arguments: <String, dynamic>{
               'source': 0,
               'maxWidth': 10.0,
               'maxHeight': 20.0,
               'imageQuality': null,
-              'cameraDevice': 0,
-              'forceFullMetadata': true,
+              'cameraDevice': 0
             }),
             isMethodCall('pickImage', arguments: <String, dynamic>{
               'source': 0,
               'maxWidth': 10.0,
               'maxHeight': null,
               'imageQuality': 70,
-              'cameraDevice': 0,
-              'forceFullMetadata': true,
+              'cameraDevice': 0
             }),
             isMethodCall('pickImage', arguments: <String, dynamic>{
               'source': 0,
               'maxWidth': null,
               'maxHeight': 10.0,
               'imageQuality': 70,
-              'cameraDevice': 0,
-              'forceFullMetadata': true,
+              'cameraDevice': 0
             }),
             isMethodCall('pickImage', arguments: <String, dynamic>{
               'source': 0,
               'maxWidth': 10.0,
               'maxHeight': 20.0,
               'imageQuality': 70,
-              'cameraDevice': 0,
-              'forceFullMetadata': true,
+              'cameraDevice': 0
             }),
           ],
         );
@@ -684,7 +664,6 @@ void main() {
               'maxHeight': null,
               'imageQuality': null,
               'cameraDevice': 0,
-              'forceFullMetadata': true,
             }),
           ],
         );
@@ -704,7 +683,6 @@ void main() {
               'maxHeight': null,
               'imageQuality': null,
               'cameraDevice': 1,
-              'forceFullMetadata': true,
             }),
           ],
         );


### PR DESCRIPTION
Reverts flutter/plugins#4288

FYI @cpboyd 

This commit appears to be breaking the framework tree somehow: https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20flutter_plugins/3301/overview

```
Running command: "dart analyze --fatal-infos" in /b/s/w/ir/x/t/flutter_plugins.DYUYDK/packages/image_picker/image_picker_for_web
Analyzing image_picker_for_web...

  error - lib/image_picker_for_web.dart:51:22 - 'ImagePickerPlugin.pickImage' ('Future<PickedFile> Function({int? imageQuality, double? maxHeight, double? maxWidth, CameraDevice preferredCameraDevice, required ImageSource source})') isn't a valid override of 'ImagePickerPlatform.pickImage' ('Future<PickedFile?> Function({bool forceFullMetadata, int? imageQuality, double? maxHeight, double? maxWidth, CameraDevice preferredCameraDevice, required ImageSource source})'). - invalid_override
  error - lib/image_picker_for_web.dart:113:17 - 'ImagePickerPlugin.getImage' ('Future<XFile> Function({int? imageQuality, double? maxHeight, double? maxWidth, CameraDevice preferredCameraDevice, required ImageSource source})') isn't a valid override of 'ImagePickerPlatform.getImage' ('Future<XFile?> Function({bool forceFullMetadata, int? imageQuality, double? maxHeight, double? maxWidth, CameraDevice preferredCameraDevice, required ImageSource source})'). - invalid_override

2 issues found.
```

Fixes https://github.com/flutter/flutter/issues/89517