### PR TITLE
[camera] Fix IllegalStateException being thrown in Android implementation when switching activities.

### DIFF
--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.4+1
+
+* Fixed Android implementation throwing IllegalStateException when switching to a different activity.
+
 ## 0.9.4
 
 * Add web support by endorsing `package:camera_web`.

--- a/packages/camera/camera/android/build.gradle
+++ b/packages/camera/camera/android/build.gradle
@@ -60,7 +60,7 @@ android {
 dependencies {
     compileOnly 'androidx.annotation:annotation:1.1.0'
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-inline:3.11.1'
+    testImplementation 'org.mockito:mockito-inline:3.12.4'
     testImplementation 'androidx.test:core:1.3.0'
     testImplementation 'org.robolectric:robolectric:4.3'
 }

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
@@ -574,15 +574,17 @@ class Camera
 
   /** Starts a background thread and its {@link Handler}. */
   public void startBackgroundThread() {
-    if (backgroundHandlerThread == null) {
-      backgroundHandlerThread = HandlerThreadFactory.create("CameraBackground");
-      try {
-        backgroundHandlerThread.start();
-      } catch (IllegalThreadStateException e) {
-        // Ignore exception in case the thread has already started.
-      }
-      backgroundHandler = HandlerFactory.create(backgroundHandlerThread.getLooper());
+    if (backgroundHandlerThread != null) {
+      return;
     }
+
+    backgroundHandlerThread = HandlerThreadFactory.create("CameraBackground");
+    try {
+      backgroundHandlerThread.start();
+    } catch (IllegalThreadStateException e) {
+      // Ignore exception in case the thread has already started.
+    }
+    backgroundHandler = HandlerFactory.create(backgroundHandlerThread.getLooper());
   }
 
   /** Stops the background thread and its {@link Handler}. */

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
@@ -35,9 +35,6 @@ import android.view.Display;
 import android.view.Surface;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.lifecycle.Lifecycle;
-import androidx.lifecycle.LifecycleObserver;
-import androidx.lifecycle.OnLifecycleEvent;
 import io.flutter.embedding.engine.systemchannels.PlatformChannel;
 import io.flutter.plugin.common.EventChannel;
 import io.flutter.plugin.common.MethodChannel;
@@ -82,8 +79,7 @@ interface ErrorCallback {
 
 class Camera
     implements CameraCaptureCallback.CameraCaptureStateListener,
-        ImageReader.OnImageAvailableListener,
-        LifecycleObserver {
+        ImageReader.OnImageAvailableListener {
   private static final String TAG = "Camera";
 
   private static final HashMap<String, Integer> supportedImageFormats;
@@ -576,19 +572,19 @@ class Camera
   }
 
   /** Starts a background thread and its {@link Handler}. */
-  @OnLifecycleEvent(Lifecycle.Event.ON_RESUME)
   public void startBackgroundThread() {
-    backgroundHandlerThread = new HandlerThread("CameraBackground");
-    try {
-      backgroundHandlerThread.start();
-    } catch (IllegalThreadStateException e) {
-      // Ignore exception in case the thread has already started.
+    if (backgroundHandlerThread == null) {
+      backgroundHandlerThread = new HandlerThread("CameraBackground");
+      try {
+        backgroundHandlerThread.start();
+      } catch (IllegalThreadStateException e) {
+        // Ignore exception in case the thread has already started.
+      }
+      backgroundHandler = new Handler(backgroundHandlerThread.getLooper());
     }
-    backgroundHandler = new Handler(backgroundHandlerThread.getLooper());
   }
 
   /** Stops the background thread and its {@link Handler}. */
-  @OnLifecycleEvent(Lifecycle.Event.ON_PAUSE)
   public void stopBackgroundThread() {
     if (backgroundHandlerThread != null) {
       backgroundHandlerThread.quitSafely();

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
@@ -35,6 +35,7 @@ import android.view.Display;
 import android.view.Surface;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 import io.flutter.embedding.engine.systemchannels.PlatformChannel;
 import io.flutter.plugin.common.EventChannel;
 import io.flutter.plugin.common.MethodChannel;
@@ -574,13 +575,13 @@ class Camera
   /** Starts a background thread and its {@link Handler}. */
   public void startBackgroundThread() {
     if (backgroundHandlerThread == null) {
-      backgroundHandlerThread = new HandlerThread("CameraBackground");
+      backgroundHandlerThread = HandlerThreadFactory.create("CameraBackground");
       try {
         backgroundHandlerThread.start();
       } catch (IllegalThreadStateException e) {
         // Ignore exception in case the thread has already started.
       }
-      backgroundHandler = new Handler(backgroundHandlerThread.getLooper());
+      backgroundHandler = HandlerFactory.create(backgroundHandlerThread.getLooper());
     }
   }
 
@@ -1115,5 +1116,39 @@ class Camera
     close();
     flutterTexture.release();
     getDeviceOrientationManager().stop();
+  }
+
+  /** Factory class that assists in creating a {@link HandlerThread} instance. */
+  static class HandlerThreadFactory {
+    /**
+     * Creates a new instance of the {@link HandlerThread} class.
+     *
+     * <p>This method is visible for testing purposes only and should never be used outside this *
+     * class.
+     *
+     * @param name to give to the HandlerThread.
+     * @return new instance of the {@link HandlerThread} class.
+     */
+    @VisibleForTesting
+    public static HandlerThread create(String name) {
+      return new HandlerThread(name);
+    }
+  }
+
+  /** Factory class that assists in creating a {@link Handler} instance. */
+  static class HandlerFactory {
+    /**
+     * Creates a new instance of the {@link Handler} class.
+     *
+     * <p>This method is visible for testing purposes only and should never be used outside this *
+     * class.
+     *
+     * @param looper to give to the Handler.
+     * @return new instance of the {@link Handler} class.
+     */
+    @VisibleForTesting
+    public static Handler create(Looper looper) {
+      return new Handler(looper);
+    }
   }
 }

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/CameraPlugin.java
@@ -8,11 +8,9 @@ import android.app.Activity;
 import android.os.Build;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.lifecycle.Lifecycle;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.embedding.engine.plugins.activity.ActivityAware;
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
-import io.flutter.embedding.engine.plugins.lifecycle.FlutterLifecycleAdapter;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugins.camera.CameraPermissions.PermissionsRegistry;
 import io.flutter.view.TextureRegistry;
@@ -53,8 +51,7 @@ public final class CameraPlugin implements FlutterPlugin, ActivityAware {
         registrar.activity(),
         registrar.messenger(),
         registrar::addRequestPermissionsResultListener,
-        registrar.view(),
-        null);
+        registrar.view());
   }
 
   @Override
@@ -73,8 +70,7 @@ public final class CameraPlugin implements FlutterPlugin, ActivityAware {
         binding.getActivity(),
         flutterPluginBinding.getBinaryMessenger(),
         binding::addRequestPermissionsResultListener,
-        flutterPluginBinding.getTextureRegistry(),
-        FlutterLifecycleAdapter.getActivityLifecycle(binding));
+        flutterPluginBinding.getTextureRegistry());
   }
 
   @Override
@@ -100,8 +96,7 @@ public final class CameraPlugin implements FlutterPlugin, ActivityAware {
       Activity activity,
       BinaryMessenger messenger,
       PermissionsRegistry permissionsRegistry,
-      TextureRegistry textureRegistry,
-      @Nullable Lifecycle lifecycle) {
+      TextureRegistry textureRegistry) {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
       // If the sdk is less than 21 (min sdk for Camera2) we don't register the plugin.
       return;
@@ -109,11 +104,6 @@ public final class CameraPlugin implements FlutterPlugin, ActivityAware {
 
     methodCallHandler =
         new MethodCallHandlerImpl(
-            activity,
-            messenger,
-            new CameraPermissions(),
-            permissionsRegistry,
-            textureRegistry,
-            lifecycle);
+            activity, messenger, new CameraPermissions(), permissionsRegistry, textureRegistry);
   }
 }

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/MethodCallHandlerImpl.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/MethodCallHandlerImpl.java
@@ -10,8 +10,6 @@ import android.os.Handler;
 import android.os.Looper;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.lifecycle.Lifecycle;
-import androidx.lifecycle.LifecycleObserver;
 import io.flutter.embedding.engine.systemchannels.PlatformChannel;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.EventChannel;
@@ -29,7 +27,7 @@ import io.flutter.view.TextureRegistry;
 import java.util.HashMap;
 import java.util.Map;
 
-final class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler, LifecycleObserver {
+final class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
   private final Activity activity;
   private final BinaryMessenger messenger;
   private final CameraPermissions cameraPermissions;
@@ -37,7 +35,6 @@ final class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler, Li
   private final TextureRegistry textureRegistry;
   private final MethodChannel methodChannel;
   private final EventChannel imageStreamChannel;
-  private final Lifecycle lifecycle;
   private @Nullable Camera camera;
 
   MethodCallHandlerImpl(
@@ -45,14 +42,12 @@ final class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler, Li
       BinaryMessenger messenger,
       CameraPermissions cameraPermissions,
       PermissionsRegistry permissionsAdder,
-      TextureRegistry textureRegistry,
-      @Nullable Lifecycle lifecycle) {
+      TextureRegistry textureRegistry) {
     this.activity = activity;
     this.messenger = messenger;
     this.cameraPermissions = cameraPermissions;
     this.permissionsRegistry = permissionsAdder;
     this.textureRegistry = textureRegistry;
-    this.lifecycle = lifecycle;
 
     methodChannel = new MethodChannel(messenger, "plugins.flutter.io/camera");
     imageStreamChannel = new EventChannel(messenger, "plugins.flutter.io/camera/imageStream");
@@ -387,10 +382,6 @@ final class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler, Li
         new CameraPropertiesImpl(cameraName, CameraUtils.getCameraManager(activity));
     ResolutionPreset resolutionPreset = ResolutionPreset.valueOf(preset);
 
-    if (camera != null && lifecycle != null) {
-      lifecycle.removeObserver(camera);
-    }
-
     camera =
         new Camera(
             activity,
@@ -400,10 +391,6 @@ final class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler, Li
             cameraProperties,
             resolutionPreset,
             enableAudio);
-
-    if (lifecycle != null) {
-      lifecycle.addObserver(camera);
-    }
 
     Map<String, Object> reply = new HashMap<>();
     reply.put("cameraId", flutterSurfaceTexture.id());

--- a/packages/camera/camera/android/src/test/java/io/flutter/plugins/camera/CameraTest.java
+++ b/packages/camera/camera/android/src/test/java/io/flutter/plugins/camera/CameraTest.java
@@ -26,7 +26,6 @@ import android.media.MediaRecorder;
 import android.os.Build;
 import android.os.Handler;
 import android.os.HandlerThread;
-import android.os.Looper;
 import androidx.annotation.NonNull;
 import io.flutter.embedding.engine.systemchannels.PlatformChannel;
 import io.flutter.plugin.common.MethodChannel;
@@ -794,13 +793,18 @@ public class CameraTest {
 
   @Test
   public void startBackgroundThread_shouldStartNewThread() {
-    Looper mockLooper = mock(Looper.class);
-    when(mockHandlerThread.getLooper()).thenReturn(mockLooper);
-
     camera.startBackgroundThread();
 
-    verify(mockHandlerThread).start();
+    verify(mockHandlerThread, times(1)).start();
     assertEquals(mockHandler, TestUtils.getPrivateField(camera, "backgroundHandler"));
+  }
+
+  @Test
+  public void startBackgroundThread_shouldNotStartNewThreadWhenAlreadyCreated() {
+    camera.startBackgroundThread();
+    camera.startBackgroundThread();
+
+    verify(mockHandlerThread, times(1)).start();
   }
 
   private static class TestCameraFeatureFactory implements CameraFeatureFactory {

--- a/packages/camera/camera/android/src/test/java/io/flutter/plugins/camera/CameraTest.java
+++ b/packages/camera/camera/android/src/test/java/io/flutter/plugins/camera/CameraTest.java
@@ -5,6 +5,7 @@
 package io.flutter.plugins.camera;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -27,6 +28,7 @@ import android.os.Build;
 import android.os.Handler;
 import android.os.HandlerThread;
 import androidx.annotation.NonNull;
+import androidx.lifecycle.LifecycleObserver;
 import io.flutter.embedding.engine.systemchannels.PlatformChannel;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugins.camera.features.CameraFeatureFactory;
@@ -110,6 +112,13 @@ public class CameraTest {
     TestUtils.setFinalStatic(Build.VERSION.class, "SDK_INT", 0);
     mockHandlerThreadFactory.close();
     mockHandlerFactory.close();
+  }
+
+  @Test
+  public void shouldNotImplementLifecycleObserverInterface() {
+    Class<Camera> cameraClass = Camera.class;
+
+    assertFalse(LifecycleObserver.class.isAssignableFrom(cameraClass));
   }
 
   @Test

--- a/packages/camera/camera/android/src/test/java/io/flutter/plugins/camera/MethodCallHandlerImplTest.java
+++ b/packages/camera/camera/android/src/test/java/io/flutter/plugins/camera/MethodCallHandlerImplTest.java
@@ -33,8 +33,7 @@ public class MethodCallHandlerImplTest {
             mock(BinaryMessenger.class),
             mock(CameraPermissions.class),
             mock(CameraPermissions.PermissionsRegistry.class),
-            mock(TextureRegistry.class),
-            null);
+            mock(TextureRegistry.class));
     mockResult = mock(MethodChannel.Result.class);
     mockCamera = mock(Camera.class);
     TestUtils.setPrivateField(handler, "camera", mockCamera);

--- a/packages/camera/camera/android/src/test/java/io/flutter/plugins/camera/MethodCallHandlerImplTest.java
+++ b/packages/camera/camera/android/src/test/java/io/flutter/plugins/camera/MethodCallHandlerImplTest.java
@@ -4,6 +4,7 @@
 
 package io.flutter.plugins.camera;
 
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -11,6 +12,7 @@ import static org.mockito.Mockito.verify;
 
 import android.app.Activity;
 import android.hardware.camera2.CameraAccessException;
+import androidx.lifecycle.LifecycleObserver;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
@@ -37,6 +39,13 @@ public class MethodCallHandlerImplTest {
     mockResult = mock(MethodChannel.Result.class);
     mockCamera = mock(Camera.class);
     TestUtils.setPrivateField(handler, "camera", mockCamera);
+  }
+
+  @Test
+  public void shouldNotImplementLifecycleObserverInterface() {
+    Class<MethodCallHandlerImpl> methodCallHandlerClass = MethodCallHandlerImpl.class;
+
+    assertFalse(LifecycleObserver.class.isAssignableFrom(methodCallHandlerClass));
   }
 
   @Test

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -4,7 +4,7 @@ description: A Flutter plugin for getting information about and controlling the
   and streaming image buffers to dart.
 repository: https://github.com/flutter/plugins/tree/master/packages/camera/camera
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.9.4
+version: 0.9.4+1
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR removes the lifecycle hooks from the Android implementation. I have a feeling these were added by accident during the recent refactor, as the example app already [puts this responsibility on the user of the plugin](https://github.com/flutter/plugins/blob/master/packages/camera/camera/example/lib/main.dart#L116). 
This is also described in the readme: https://github.com/flutter/plugins/tree/master/packages/camera/camera#handling-lifecycle-states

This should fix the issue with the IllegalStateException being thrown when switching to a different activity, for example when using `camera` in combination with `image_picker`, as can be seen in the issue linked below:

Relevant issues:
 - Fixes flutter/flutter#89352
 - Fixes flutter/flutter#89815
 - Fixes flutter/flutter#89431

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
  - No new public members to document, or existing ones to update.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.