### PR TITLE
[ci] Fix and standardize target/task names

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -62,7 +62,7 @@ targets:
         ]
     scheduler: luci
 
-  - name: Windows win32_build+platform-tests master
+  - name: Windows win32-platform_tests master
     recipe: plugins/plugins
     bringup: true
     timeout: 30
@@ -76,14 +76,14 @@ targets:
         ]
     scheduler: luci
 
-  - name: Windows win32_build+platform-tests stable
+  - name: Windows win32-platform_tests stable
     recipe: plugins/plugins
     bringup: true
     timeout: 30
     properties:
       # TODO(stuartmorgan): Uncomment when removing bringup.
       #add_recipes_cq: "true"
-      target_file: uwp_build_and_platform_tests.yaml
+      target_file: windows_build_and_platform_tests.yaml
       channel: stable
       dependencies: >
         [
@@ -91,7 +91,7 @@ targets:
         ]
     scheduler: luci
 
-  - name: Windows build_all_plugins master
+  - name: Windows windows-build_all_plugins master
     recipe: plugins/plugins
     bringup: true
     timeout: 30
@@ -105,7 +105,7 @@ targets:
         ]
     scheduler: luci
 
-  - name: Windows build_all_plugins stable
+  - name: Windows windows-build_all_plugins stable
     recipe: plugins/plugins
     bringup: true
     timeout: 30
@@ -120,7 +120,7 @@ targets:
         ]
     scheduler: luci
 
-  - name: Windows uwp-build+platform-tests master
+  - name: Windows uwp-platform_tests master
     recipe: plugins/plugins
     bringup: true
     timeout: 30

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -63,7 +63,7 @@ task:
     namespace: default
   matrix:
     ### Platform-agnostic tasks ###
-    - name: plugin_tools_tests
+    - name: Linux plugin_tools_tests
       script:
         - cd script/tool
         - dart pub run test
@@ -74,7 +74,7 @@ task:
       format_script: ./script/tool_runner.sh format --fail-on-change
       pubspec_script: ./script/tool_runner.sh pubspec-check
       license_script: dart $PLUGIN_TOOL license-check
-    - name: test
+    - name: dart_unit_tests
       env:
         matrix:
           CHANNEL: "master"
@@ -94,7 +94,7 @@ task:
         # See the comment in script/configs/custom_analysis.yaml for details.
         - ./script/tool_runner.sh analyze --custom-analysis=script/configs/custom_analysis.yaml
     ### Android tasks ###
-    - name: build_all_plugins_apk
+    - name: android-build_all_plugins
       env:
         BUILD_ALL_ARGS: "apk"
         matrix:
@@ -102,7 +102,7 @@ task:
           CHANNEL: "stable"
       << : *BUILD_ALL_PLUGINS_APP_TEMPLATE
     ### Web tasks ###
-    - name: build_all_plugins_web
+    - name: web-build_all_plugins
       env:
         BUILD_ALL_ARGS: "web"
         matrix:
@@ -110,7 +110,7 @@ task:
           CHANNEL: "stable"
       << : *BUILD_ALL_PLUGINS_APP_TEMPLATE
     ### Linux desktop tasks ###
-    - name: build_all_plugins_linux
+    - name: linux-build_all_plugins
       env:
         BUILD_ALL_ARGS: "linux"
         matrix:
@@ -119,7 +119,7 @@ task:
       setup_script:
         - flutter config --enable-linux-desktop
       << : *BUILD_ALL_PLUGINS_APP_TEMPLATE
-    - name: linux-build+platform-tests
+    - name: linux-platform_tests
       env:
         matrix:
           CHANNEL: "master"
@@ -148,7 +148,7 @@ task:
     memory: 12G
   matrix:
     ### Android tasks ###
-    - name: android-build+platform-tests
+    - name: android-platform_tests
       env:
         matrix:
           PLUGIN_SHARDING: "--shardIndex 0 --shardCount 4"
@@ -202,7 +202,7 @@ task:
           type: text/xml
           format: android-lint
     ### Web tasks ###
-    - name: web-build+platform-tests
+    - name: web-platform_tests
       env:
         matrix:
           CHANNEL: "master"
@@ -224,18 +224,18 @@ task:
   << : *FLUTTER_UPGRADE_TEMPLATE
   matrix:
     ### iOS+macOS tasks ***
-    - name: lint_darwin_plugins
+    - name: darwin-lint_podspecs
       script:
         - ./script/tool_runner.sh podspecs
     ### iOS tasks ###
-    - name: build_all_plugins_ipa
+    - name: ios-build_all_plugins
       env:
         BUILD_ALL_ARGS: "ios --no-codesign"
         matrix:
           CHANNEL: "master"
           CHANNEL: "stable"
       << : *BUILD_ALL_PLUGINS_APP_TEMPLATE
-    - name: ios-build+platform-tests
+    - name: ios-platform_tests
       env:
         PATH: $PATH:/usr/local/bin
         matrix:
@@ -262,7 +262,7 @@ task:
         # So we run `drive-examples` after `native-test`; changing the order will result ci failure.
         - ./script/tool_runner.sh drive-examples --ios --exclude=script/configs/exclude_integration_ios.yaml
     ### macOS desktop tasks ###
-    - name: build_all_plugins_macos
+    - name: macos-build_all_plugins
       env:
         BUILD_ALL_ARGS: "macos"
         matrix:
@@ -271,7 +271,7 @@ task:
       setup_script:
         - flutter config --enable-macos-desktop
       << : *BUILD_ALL_PLUGINS_APP_TEMPLATE
-    - name: macos-build+platform-tests
+    - name: macos-platform_tests
       env:
         matrix:
           CHANNEL: "master"


### PR DESCRIPTION
Fixes the target names in LUCI to not use '+', since it's not supported.

To better align the names between the two different infrastructures,
also updates the task naming in cirrus.yml to not use +. It also
standardizes the naming form across both systems as:
`<Host platform> <target platform>-<test_name> <extra info>`
where:
- `<Host platform>` is always there on LUCI, where required, but only
  added where it's potentially ambiguous on Cirrus
- `<target platform>' is omitted when the test is not target-platform
  specific
- `<test_name>' uses underscores, which is consistent with
  flutter/flutter (and with Cirrus step naming).
- `<extra info>` is only explicitly set (to the channel) on LUCI; Cirrus
  automatically adds channel info there due to the way `matrix` works.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
