### PR TITLE
[video_player] add support for content-uri based videos

### DIFF
--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,9 +1,10 @@
-## 2.1.16
+## 2.2.0
 
-* Ensured seekTo isn't called before video player is initialized. Fixes [#89259](https://github.com/flutter/flutter/issues/89259).
+* Add `contentUri` based VideoPlayerController.
 
 ## 2.1.15
 
+* Ensured seekTo isn't called before video player is initialized. Fixes [#89259](https://github.com/flutter/flutter/issues/89259).
 * Updated Android lint settings.
 
 ## 2.1.14

--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,6 +1,9 @@
-## 2.1.15
+## 2.1.16
 
 * Ensured seekTo isn't called before video player is initialized. Fixes [#89259](https://github.com/flutter/flutter/issues/89259).
+
+## 2.1.15
+
 * Updated Android lint settings.
 
 ## 2.1.14

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -222,6 +222,21 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
         httpHeaders = const {},
         super(VideoPlayerValue(duration: Duration.zero));
 
+  /// Constructs a [VideoPlayerController] playing a video from a contentUri.
+  ///
+  /// This will load the video from the input content-URI.
+  /// This is supported on Android only.
+  VideoPlayerController.contentUri(Uri contentUri,
+      {this.closedCaptionFile, this.videoPlayerOptions})
+      : assert(defaultTargetPlatform == TargetPlatform.android,
+            'VideoPlayerController.contentUri is only supported on Android.'),
+        dataSource = contentUri.toString(),
+        dataSourceType = DataSourceType.contentUri,
+        package = null,
+        formatHint = null,
+        httpHeaders = const {},
+        super(VideoPlayerValue(duration: Duration.zero));
+
   /// The URI to the video file. This will be in different formats depending on
   /// the [DataSourceType] of the original video.
   final String dataSource;
@@ -295,6 +310,12 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
       case DataSourceType.file:
         dataSourceDescription = DataSource(
           sourceType: DataSourceType.file,
+          uri: dataSource,
+        );
+        break;
+      case DataSourceType.contentUri:
+        dataSourceDescription = DataSource(
+          sourceType: DataSourceType.contentUri,
           uri: dataSource,
         );
         break;

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android, iOS, and web.
 repository: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.1.16
+version: 2.2.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android, iOS, and web.
 repository: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.1.15
+version: 2.1.16
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -24,7 +24,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.3.0
-  video_player_platform_interface: ^4.1.0
+  video_player_platform_interface: ^4.2.0
   # The design on https://flutter.dev/go/federated-plugins was to leave
   # this constraint as "any". We cannot do it right now as it fails pub publish
   # validation, so we set a ^ constraint. The exact value doesn't matter since

--- a/packages/video_player/video_player/test/video_player_test.dart
+++ b/packages/video_player/video_player/test/video_player_test.dart
@@ -284,6 +284,15 @@ void main() {
       });
     });
 
+    test('contentUri', () async {
+      final VideoPlayerController controller =
+          VideoPlayerController.contentUri(Uri.parse('content://video'));
+      await controller.initialize();
+
+      expect(fakeVideoPlayerPlatform.dataSourceDescriptions[0].uri,
+          'content://video');
+    });
+
     test('dispose', () async {
       final VideoPlayerController controller = VideoPlayerController.network(
         'https://127.0.0.1',

--- a/packages/video_player/video_player_web/CHANGELOG.md
+++ b/packages/video_player/video_player_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.4
+
+* Adopt `video_player_platform_interface` 4.2 and opt out of `contentUri` data source.
+  
 ## 2.0.3
 
 * Add `implements` to pubspec.

--- a/packages/video_player/video_player_web/example/integration_test/video_player_web_test.dart
+++ b/packages/video_player/video_player_web/example/integration_test/video_player_web_test.dart
@@ -68,6 +68,17 @@ void main() {
           throwsUnimplementedError);
     });
 
+    testWidgets('cannot create from content URI', (WidgetTester tester) async {
+      expect(
+          VideoPlayerPlatform.instance.create(
+            DataSource(
+              sourceType: DataSourceType.contentUri,
+              uri: 'content://video',
+            ),
+          ),
+          throwsUnimplementedError);
+    });
+
     testWidgets('can dispose', (WidgetTester tester) async {
       expect(VideoPlayerPlatform.instance.dispose(await textureId), completes);
     });

--- a/packages/video_player/video_player_web/lib/video_player_web.dart
+++ b/packages/video_player/video_player_web/lib/video_player_web.dart
@@ -86,6 +86,7 @@ class VideoPlayerPlugin extends VideoPlayerPlatform {
         uri = assetUrl;
         break;
       case DataSourceType.file:
+      case DataSourceType.contentUri:
         return Future.error(UnimplementedError(
             'web implementation of video_player cannot play local files'));
     }

--- a/packages/video_player/video_player_web/lib/video_player_web.dart
+++ b/packages/video_player/video_player_web/lib/video_player_web.dart
@@ -86,9 +86,11 @@ class VideoPlayerPlugin extends VideoPlayerPlatform {
         uri = assetUrl;
         break;
       case DataSourceType.file:
-      case DataSourceType.contentUri:
         return Future.error(UnimplementedError(
             'web implementation of video_player cannot play local files'));
+      case DataSourceType.contentUri:
+        return Future.error(UnimplementedError(
+            'web implementation of video_player cannot play content uri'));
     }
 
     final _VideoPlayer player = _VideoPlayer(

--- a/packages/video_player/video_player_web/pubspec.yaml
+++ b/packages/video_player/video_player_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_web
 description: Web platform implementation of video_player.
 repository: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.0.3
+version: 2.0.4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -22,7 +22,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   meta: ^1.3.0
-  video_player_platform_interface: ^4.0.0
+  video_player_platform_interface: ^4.2.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Interface change https://github.com/flutter/plugins/pull/4307 caused flutter/flutter analysis failure https://github.com/flutter/flutter/issues/89792 and failed on [plugins master](https://cirrus-ci.com/task/4582367093325824).  https://github.com/flutter/plugins/pull/4261 needs to be rebased and merged ASAP to unblock the tree.

It unfortunately has merge conflicts on #4300 and the relative paths need to be removed from the pubspec, but I don't have permissions on @byunme's branch to push the fixes there.  So I need to create a new PR.

Also adopted the new interface for `video_player_web`.

Fixes flutter/flutter#88130

The following is copied from https://github.com/flutter/plugins/pull/4261, authored by @byunme.
_________________
This PR adds playback from contentUri support for the video_player plugin (Android only).

The current Android implementation uses ExoPlayer, which already supports playback from uri, so this change is just to surface contentUri as a valid video datasource on the dart side.

*List which issues are fixed by this PR. You must list at least one issue.*
https://github.com/flutter/flutter/issues/88130

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].