### PR TITLE
Run firebase test in flutter-cirrus

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -159,7 +159,7 @@ task:
           CHANNEL: "master"
           CHANNEL: "stable"
         MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
-        GCLOUD_FIREBASE_TESTLAB_KEY: ENCRYPTED[0e63b52bd7e4fda1cd7b7bf2b4fe515a27fadbeaced01f5ad8b699b81d3611ed64c5d3271bcd8426dd914ef41cba48a0]
+        GCLOUD_FIREBASE_TESTLAB_KEY: ENCRYPTED[!0e63b52bd7e4fda1cd7b7bf2b4fe515a27fadbeaced01f5ad8b699b81d3611ed64c5d3271bcd8426dd914ef41cba48a0!]
       build_script:
         # Unsetting CIRRUS_CHANGE_MESSAGE and CIRRUS_COMMIT_MESSAGE as they
         # might include non-ASCII characters which makes Gradle crash.

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -159,7 +159,7 @@ task:
           CHANNEL: "master"
           CHANNEL: "stable"
         MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
-        GCLOUD_FIREBASE_TESTLAB_KEY: ENCRYPTED[07586610af1fdfc894e5969f70ef2458341b9b7e9c3b7c4225a663b4a48732b7208a4d91c3b7d45305a6b55fa2a37fc4]
+        GCLOUD_FIREBASE_TESTLAB_KEY: ENCRYPTED[0e63b52bd7e4fda1cd7b7bf2b4fe515a27fadbeaced01f5ad8b699b81d3611ed64c5d3271bcd8426dd914ef41cba48a0]
       build_script:
         # Unsetting CIRRUS_CHANGE_MESSAGE and CIRRUS_COMMIT_MESSAGE as they
         # might include non-ASCII characters which makes Gradle crash.

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -159,7 +159,7 @@ task:
           CHANNEL: "master"
           CHANNEL: "stable"
         MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
-        GCLOUD_FIREBASE_TESTLAB_KEY: ENCRYPTED[0e63b52bd7e4fda1cd7b7bf2b4fe515a27fadbeaced01f5ad8b699b81d3611ed64c5d3271bcd8426dd914ef41cba48a0]
+        GCLOUD_FIREBASE_TESTLAB_KEY: ENCRYPTED[!0e63b52bd7e4fda1cd7b7bf2b4fe515a27fadbeaced01f5ad8b699b81d3611ed64c5d3271bcd8426dd914ef41cba48a0!]
       build_script:
         # Unsetting CIRRUS_CHANGE_MESSAGE and CIRRUS_COMMIT_MESSAGE as they
         # might include non-ASCII characters which makes Gradle crash.
@@ -190,12 +190,12 @@ task:
         # TODO(stuartmorgan): See https://github.com/flutter/flutter/issues/24935
         - export CIRRUS_CHANGE_MESSAGE=""
         - export CIRRUS_COMMIT_MESSAGE=""
-        - if [[ -n "$GCLOUD_FIREBASE_TESTLAB_KEY" ]]; then
-        -   echo $GCLOUD_FIREBASE_TESTLAB_KEY > ${HOME}/gcloud-service-key.json
-        -   ./script/tool_runner.sh firebase-test-lab --device model=flame,version=29 --device model=starqlteue,version=26 --exclude=script/configs/exclude_integration_android.yaml
-        - else
-        -   echo "This user does not have permission to run Firebase Test Lab tests."
-        - fi
+        # - if [[ -n "$GCLOUD_FIREBASE_TESTLAB_KEY" ]]; then
+        - echo $GCLOUD_FIREBASE_TESTLAB_KEY > ${HOME}/gcloud-service-key.json
+        - ./script/tool_runner.sh firebase-test-lab --device model=flame,version=29 --device model=starqlteue,version=26 --exclude=script/configs/exclude_integration_android.yaml
+        # - else
+        # -   echo "This user does not have permission to run Firebase Test Lab tests."
+        # - fi
       # Upload the full lint results to Cirrus to display in the results UI.
       always:
         android-lint_artifacts:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -159,7 +159,7 @@ task:
           CHANNEL: "master"
           CHANNEL: "stable"
         MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
-        GCLOUD_FIREBASE_TESTLAB_KEY: ENCRYPTED[!0e63b52bd7e4fda1cd7b7bf2b4fe515a27fadbeaced01f5ad8b699b81d3611ed64c5d3271bcd8426dd914ef41cba48a0!]
+        GCLOUD_FIREBASE_TESTLAB_KEY: ENCRYPTED[!c68d9f8ed3003871e40b045a9771582ac53575bf8a50d29cac1eb1b2eb2c823941a2daff9eb14a2694304756b3a25079!]
       build_script:
         # Unsetting CIRRUS_CHANGE_MESSAGE and CIRRUS_COMMIT_MESSAGE as they
         # might include non-ASCII characters which makes Gradle crash.

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -190,12 +190,12 @@ task:
         # TODO(stuartmorgan): See https://github.com/flutter/flutter/issues/24935
         - export CIRRUS_CHANGE_MESSAGE=""
         - export CIRRUS_COMMIT_MESSAGE=""
-        # - if [[ -n "$GCLOUD_FIREBASE_TESTLAB_KEY" ]]; then
-        - echo $GCLOUD_FIREBASE_TESTLAB_KEY > ${HOME}/gcloud-service-key.json
-        - ./script/tool_runner.sh firebase-test-lab --device model=flame,version=29 --device model=starqlteue,version=26 --exclude=script/configs/exclude_integration_android.yaml
-        # - else
-        # -   echo "This user does not have permission to run Firebase Test Lab tests."
-        # - fi
+        - if [[ -n "$GCLOUD_FIREBASE_TESTLAB_KEY" ]]; then
+        -   echo $GCLOUD_FIREBASE_TESTLAB_KEY > ${HOME}/gcloud-service-key.json
+        -   ./script/tool_runner.sh firebase-test-lab --device model=flame,version=29 --device model=starqlteue,version=26 --exclude=script/configs/exclude_integration_android.yaml
+        - else
+        -   echo "This user does not have permission to run Firebase Test Lab tests."
+        - fi
       # Upload the full lint results to Cirrus to display in the results UI.
       always:
         android-lint_artifacts:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -159,7 +159,7 @@ task:
           CHANNEL: "master"
           CHANNEL: "stable"
         MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
-        GCLOUD_FIREBASE_TESTLAB_KEY: ENCRYPTED[!c68d9f8ed3003871e40b045a9771582ac53575bf8a50d29cac1eb1b2eb2c823941a2daff9eb14a2694304756b3a25079!]
+        GCLOUD_FIREBASE_TESTLAB_KEY: ENCRYPTED[!c9446a7b11d5520c2ebce3c64ccc82fe6d146272cb06a4a4590e22c389f33153f951347a25422522df1a81fe2f085e9a!]
       build_script:
         # Unsetting CIRRUS_CHANGE_MESSAGE and CIRRUS_COMMIT_MESSAGE as they
         # might include non-ASCII characters which makes Gradle crash.

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -159,7 +159,7 @@ task:
           CHANNEL: "master"
           CHANNEL: "stable"
         MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
-        GCLOUD_FIREBASE_TESTLAB_KEY: ENCRYPTED[!0e63b52bd7e4fda1cd7b7bf2b4fe515a27fadbeaced01f5ad8b699b81d3611ed64c5d3271bcd8426dd914ef41cba48a0!]
+        GCLOUD_FIREBASE_TESTLAB_KEY: ENCRYPTED[0e63b52bd7e4fda1cd7b7bf2b4fe515a27fadbeaced01f5ad8b699b81d3611ed64c5d3271bcd8426dd914ef41cba48a0]
       build_script:
         # Unsetting CIRRUS_CHANGE_MESSAGE and CIRRUS_COMMIT_MESSAGE as they
         # might include non-ASCII characters which makes Gradle crash.

--- a/script/tool/lib/src/firebase_test_lab_command.dart
+++ b/script/tool/lib/src/firebase_test_lab_command.dart
@@ -27,7 +27,7 @@ class FirebaseTestLabCommand extends PackageLoopingCommand {
   }) : super(packagesDir, processRunner: processRunner, platform: platform) {
     argParser.addOption(
       'project',
-      defaultsTo: 'flutter-infra',
+      defaultsTo: 'flutter-cirrus',
       help: 'The Firebase project name.',
     );
     final String? homeDir = io.Platform.environment['HOME'];

--- a/script/tool/test/firebase_test_lab_command_test.dart
+++ b/script/tool/test/firebase_test_lab_command_test.dart
@@ -130,7 +130,7 @@ void main() {
                   .split(' '),
               null),
           ProcessCall(
-              'gcloud', 'config set project flutter-infra'.split(' '), null),
+              'gcloud', 'config set project flutter-cirrus'.split(' '), null),
           ProcessCall(
               '/packages/plugin1/example/android/gradlew',
               'app:assembleAndroidTest -Pverbose=true'.split(' '),
@@ -207,7 +207,7 @@ void main() {
                   .split(' '),
               null),
           ProcessCall(
-              'gcloud', 'config set project flutter-infra'.split(' '), null),
+              'gcloud', 'config set project flutter-cirrus'.split(' '), null),
           ProcessCall(
               '/packages/plugin/example/android/gradlew',
               'app:assembleAndroidTest -Pverbose=true'.split(' '),
@@ -433,7 +433,7 @@ void main() {
                   .split(' '),
               null),
           ProcessCall(
-              'gcloud', 'config set project flutter-infra'.split(' '), null),
+              'gcloud', 'config set project flutter-cirrus'.split(' '), null),
           ProcessCall(
               '/packages/plugin/example/android/gradlew',
               'app:assembleAndroidTest -Pverbose=true'.split(' '),
@@ -588,7 +588,7 @@ void main() {
                   .split(' '),
               null),
           ProcessCall(
-              'gcloud', 'config set project flutter-infra'.split(' '), null),
+              'gcloud', 'config set project flutter-cirrus'.split(' '), null),
           ProcessCall(
               '/packages/plugin/example/android/gradlew',
               'app:assembleAndroidTest -Pverbose=true -Pextra-front-end-options=--enable-experiment%3Dexp1 -Pextra-gen-snapshot-options=--enable-experiment%3Dexp1'


### PR DESCRIPTION
This PR try migrating firebase test to run in `flutter-cirrus` project, instead of `flutter-infra` project.

Context: b/197632425