### PR TITLE
[google_maps_flutter] Bump minimum Flutter version and iOS deployment target

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.10
+
+* Update minimum Flutter SDK to 2.5 and iOS deployment target to 9.0.
+
 ## 2.0.9
 
 * Fix Android `NullPointerException` caused by the `GoogleMapController` being disposed before `GoogleMap` was ready.

--- a/packages/google_maps_flutter/google_maps_flutter/README.md
+++ b/packages/google_maps_flutter/google_maps_flutter/README.md
@@ -48,7 +48,7 @@ This means that app will only be available for users that run Android SDK 20 or 
 
 ### iOS
 
-Specify your API key in the application delegate `ios/Runner/AppDelegate.m`:
+This plugin requires iOS 9.0 or higher. To set up, specify your API key in the application delegate `ios/Runner/AppDelegate.m`:
 
 ```objectivec
 #include "AppDelegate.h"

--- a/packages/google_maps_flutter/google_maps_flutter/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the google_maps_flutter plugin.
 publish_to: none
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
-  flutter: ">=1.22.0"
+  sdk: ">=2.14.0 <3.0.0"
+  flutter: ">=2.5.0"
 
 dependencies:
   flutter:

--- a/packages/google_maps_flutter/google_maps_flutter/ios/google_maps_flutter.podspec
+++ b/packages/google_maps_flutter/google_maps_flutter/ios/google_maps_flutter.podspec
@@ -19,7 +19,7 @@ Downloaded by pub (not CocoaPods).
   s.dependency 'Flutter'
   s.dependency 'GoogleMaps'
   s.static_framework = true
-  s.platform = :ios, '8.0'
+  s.platform = :ios, '9.0'
   # GoogleMaps does not support arm64 simulators.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 end

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -2,11 +2,11 @@ name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 repository: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter/google_maps_flutter
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 2.0.9
+version: 2.0.10
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
-  flutter: ">=2.0.0"
+  sdk: ">=2.14.0 <3.0.0"
+  flutter: ">=2.5.0"
 
 flutter:
   plugin:


### PR DESCRIPTION
Flutter apps run on 2.4.0-0.0.pre and later [will be upgraded to a minimum of iOS 9.0](https://github.com/flutter/flutter/pull/85174).  Now that Flutter 2.5 has hit stable and [iOS 8 support has been dropped](https://flutter.dev/go/rfc-ios8-deprecation), change the plugin minimum iOS version to `9.0`.  

Bump the Flutter and dart version constraints to 2.5 and 2.14 respectively to enforce that the iOS 9.0 migration has happened on the app side, because an older 8.0 app won't build with a 9.0 plugin.  I believe the last time this was done was a few months ago for null safety adoption https://github.com/flutter/plugins/pull/3324 (there's recent precedent).

Users on Flutter versions lower than the current stable 2.5 will not be able to upgrade this plugin past this version.  

google_maps_flutter part of https://github.com/flutter/flutter/issues/84198

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.