### PR TITLE
[google_sign_in] Bump minimum Flutter version and iOS deployment target

### DIFF
--- a/packages/google_sign_in/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.2.0
+
+* Update minimum Flutter SDK to 2.5 and iOS deployment target to 9.0.
+
 ## 5.1.0
 
 * Add reAuthenticate option to signInSilently to allow re-authentication to be requested

--- a/packages/google_sign_in/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 5.2.0
+## 5.1.1
 
 * Update minimum Flutter SDK to 2.5 and iOS deployment target to 9.0.
 

--- a/packages/google_sign_in/google_sign_in/README.md
+++ b/packages/google_sign_in/google_sign_in/README.md
@@ -27,6 +27,8 @@ Otherwise, you may encounter `APIException` errors.
 
 ### iOS integration
 
+This plugin requires iOS 9.0 or higher.
+
 1. [First register your application](https://firebase.google.com/docs/ios/setup).
 2. Make sure the file you download in step 1 is named
    `GoogleService-Info.plist`.

--- a/packages/google_sign_in/google_sign_in/example/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Example of Google Sign-In plugin.
 publish_to: none
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.4"
+  sdk: ">=2.14.0 <3.0.0"
+  flutter: ">=2.5.0"
 
 dependencies:
   flutter:

--- a/packages/google_sign_in/google_sign_in/ios/google_sign_in.podspec
+++ b/packages/google_sign_in/google_sign_in/ios/google_sign_in.podspec
@@ -19,7 +19,7 @@ Enables Google Sign-In in Flutter apps.
   s.dependency 'GoogleSignIn', '~> 5.0'
   s.static_framework = true
 
-  s.platform = :ios, '8.0'
+  s.platform = :ios, '9.0'
 
   # GoogleSignIn ~> 5.0 does not support arm64 simulators.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }

--- a/packages/google_sign_in/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in/pubspec.yaml
@@ -3,11 +3,11 @@ description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android and iOS.
 repository: https://github.com/flutter/plugins/tree/master/packages/google_sign_in/google_sign_in
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
-version: 5.1.0
+version: 5.2.0
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"
+  sdk: ">=2.14.0 <3.0.0"
+  flutter: ">=2.5.0"
 
 flutter:
   plugin:

--- a/packages/google_sign_in/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android and iOS.
 repository: https://github.com/flutter/plugins/tree/master/packages/google_sign_in/google_sign_in
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
-version: 5.2.0
+version: 5.1.1
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
Flutter apps run on 2.4.0-0.0.pre and later [will be upgraded to a minimum of iOS 9.0](https://github.com/flutter/flutter/pull/85174).  Now that Flutter 2.5 has hit stable and [iOS 8 support has been dropped](https://flutter.dev/go/rfc-ios8-deprecation), change the plugin minimum iOS version to `9.0`.  

Bump the Flutter and dart version constraints to 2.5 and 2.14 respectively to enforce that the iOS 9.0 migration has happened on the app side, because an older 8.0 app won't build with a 9.0 plugin.  I believe the last time this was done was a few months ago for null safety adoption https://github.com/flutter/plugins/pull/3324 (there's recent precedent).

Users on Flutter versions lower than the current stable 2.5 will not be able to upgrade this plugin past this version.  

google_sign_in part of https://github.com/flutter/flutter/issues/84198

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.