### PR TITLE
[camera_web] Release the camera stream used to request video and audio permissions

### DIFF
--- a/packages/camera/camera_web/CHANGELOG.md
+++ b/packages/camera/camera_web/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.2.1
+## 0.2.0+1
 
 * Fix cameraNotReadable error that prevented access to the camera on some Android devices.
 

--- a/packages/camera/camera_web/CHANGELOG.md
+++ b/packages/camera/camera_web/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.2.0+1
+## NEXT
 
 * Fix cameraNotReadable error that prevented access to the camera on some Android devices.
 

--- a/packages/camera/camera_web/CHANGELOG.md
+++ b/packages/camera/camera_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1
+
+* Fix cameraNotReadable error that prevented access to the camera on some Android devices.
+
 ## 0.2.0
 
 * Initial release, adapted from the Flutter [I/O Photobooth](https://photobooth.flutter.dev/) project.

--- a/packages/camera/camera_web/README.md
+++ b/packages/camera/camera_web/README.md
@@ -9,7 +9,7 @@ The web implementation of [`camera`][camera].
 ### Depend on the package
 
 This package is not an [endorsed implementation](https://flutter.dev/docs/development/packages-and-plugins/developing-packages#endorsed-federated-plugin)
-of the google_maps_flutter plugin yet, so you'll need to [add it explicitly](https://pub.dev/packages/camera_web/install).
+of the camera plugin yet, so you'll need to [add it explicitly](https://pub.dev/packages/camera_web/install).
 
 ## Example
 

--- a/packages/camera/camera_web/example/integration_test/camera_web_test.dart
+++ b/packages/camera/camera_web/example/integration_test/camera_web_test.dart
@@ -111,6 +111,33 @@ void main() {
       });
 
       testWidgets(
+          'releases the camera stream '
+          'used to request video and audio permissions', (tester) async {
+        final videoTrack = MockMediaStreamTrack();
+
+        var videoTrackStopped = false;
+        when(videoTrack.stop).thenAnswer((_) {
+          videoTrackStopped = true;
+        });
+
+        when(
+          () => cameraService.getMediaStreamForOptions(
+            CameraOptions(
+              audio: AudioConstraints(enabled: true),
+            ),
+          ),
+        ).thenAnswer(
+          (_) => Future.value(
+            FakeMediaStream([videoTrack]),
+          ),
+        );
+
+        final _ = await CameraPlatform.instance.availableCameras();
+
+        expect(videoTrackStopped, isTrue);
+      });
+
+      testWidgets(
           'gets a video stream '
           'for a video input device', (tester) async {
         final videoDevice = FakeMediaDeviceInfo(

--- a/packages/camera/camera_web/lib/src/camera_web.dart
+++ b/packages/camera/camera_web/lib/src/camera_web.dart
@@ -89,11 +89,14 @@ class CameraPlugin extends CameraPlatform {
       }
 
       // Request video and audio permissions.
-      await _cameraService.getMediaStreamForOptions(
+      final cameraStream = await _cameraService.getMediaStreamForOptions(
         CameraOptions(
           audio: AudioConstraints(enabled: true),
         ),
       );
+
+      // Release the camera stream used to request video and audio permissions.
+      cameraStream.getVideoTracks().forEach((videoTrack) => videoTrack.stop());
 
       // Request available media devices.
       final devices = await mediaDevices.enumerateDevices();

--- a/packages/camera/camera_web/pubspec.yaml
+++ b/packages/camera/camera_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_web
 description: A Flutter plugin for getting information about and controlling the camera on Web.
 repository: https://github.com/flutter/plugins/tree/master/packages/camera/camera_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.2.0
+version: 0.2.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/camera/camera_web/pubspec.yaml
+++ b/packages/camera/camera_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_web
 description: A Flutter plugin for getting information about and controlling the camera on Web.
 repository: https://github.com/flutter/plugins/tree/master/packages/camera/camera_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.2.0+1
+version: 0.2.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/camera/camera_web/pubspec.yaml
+++ b/packages/camera/camera_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_web
 description: A Flutter plugin for getting information about and controlling the camera on Web.
 repository: https://github.com/flutter/plugins/tree/master/packages/camera/camera_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.2.1
+version: 0.2.0+1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
The camera stream used to request video and audio permissions is now released before accessing available camera devices. This solves a `cameraNotReadable` error thrown when requesting a camera stream that is already in use.

Fixes https://github.com/flutter/flutter/issues/90040.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code