### PR TITLE
[video_player] Fix a disposed `VideoPlayerController` throwing an exception when being replaced in the `VideoPlayer`

### DIFF
--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.1
+
+* Fix a disposed `VideoPlayerController` throwing an exception when being replaced in the `VideoPlayer`.
+
 ## 2.2.0
 
 * Add `contentUri` based VideoPlayerController.

--- a/packages/video_player/video_player/example/integration_test/controller_swap_test.dart
+++ b/packages/video_player/video_player/example/integration_test/controller_swap_test.dart
@@ -1,0 +1,94 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:video_player/video_player.dart';
+
+const Duration _playDuration = Duration(seconds: 1);
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  testWidgets(
+    'can substitute one controller by another without crashing',
+    (WidgetTester tester) async {
+      VideoPlayerController controller = VideoPlayerController.network(
+        'https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4',
+      );
+      VideoPlayerController another = VideoPlayerController.network(
+        'https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4',
+      );
+      await controller.initialize();
+      await another.initialize();
+      await controller.setVolume(0);
+      await another.setVolume(0);
+
+      final Completer<void> started = Completer();
+      final Completer<void> ended = Completer();
+      bool startedBuffering = false;
+      bool endedBuffering = false;
+
+      another.addListener(() {
+        if (another.value.isBuffering && !startedBuffering) {
+          startedBuffering = true;
+          started.complete();
+        }
+        if (startedBuffering &&
+            !another.value.isBuffering &&
+            !endedBuffering) {
+          endedBuffering = true;
+          ended.complete();
+        }
+      });
+
+      // Inject a widget with `controller`...
+      await tester.pumpWidget(renderVideoWidget(controller));
+      await controller.play();
+      await tester.pumpAndSettle(_playDuration);
+      await controller.pause();
+
+      // Disposing controller causes the Widget to crash in the next line
+      // (Issue https://github.com/flutter/flutter/issues/90046)
+      await controller.dispose();
+
+      // Now replace it with `another` controller...
+      await tester.pumpWidget(renderVideoWidget(another));
+      await another.play();
+      await another.seekTo(const Duration(seconds: 5));
+      await tester.pumpAndSettle(_playDuration);
+      await another.pause();
+
+      // Expect that `another` played.
+      expect(another.value.position,
+          (Duration position) => position > const Duration(seconds: 0));
+
+      await started;
+      expect(startedBuffering, true);
+
+      await ended;
+      expect(endedBuffering, true);
+    },
+    skip: !(kIsWeb || defaultTargetPlatform == TargetPlatform.android),
+  );
+}
+
+Widget renderVideoWidget(VideoPlayerController controller) {
+  return Material(
+    elevation: 0,
+    child: Directionality(
+      textDirection: TextDirection.ltr,
+      child: Center(
+        child: AspectRatio(
+          key: Key('same'),
+          aspectRatio: controller.value.aspectRatio,
+          child: VideoPlayer(controller),
+        ),
+      ),
+    ),
+  );
+}

--- a/packages/video_player/video_player/example/integration_test/controller_swap_test.dart
+++ b/packages/video_player/video_player/example/integration_test/controller_swap_test.dart
@@ -38,9 +38,7 @@ void main() {
           startedBuffering = true;
           started.complete();
         }
-        if (startedBuffering &&
-            !another.value.isBuffering &&
-            !endedBuffering) {
+        if (startedBuffering && !another.value.isBuffering && !endedBuffering) {
           endedBuffering = true;
           ended.complete();
         }

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -594,6 +594,15 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
     value = value.copyWith(caption: _getCaptionAt(position));
   }
 
+  @override
+  void removeListener(VoidCallback listener) {
+    // Prevent VideoPlayer from causing an exception to be thrown when attempting to
+    // remove its own listener after the controller has already been disposed.
+    if (!_isDisposed) {
+      super.removeListener(listener);
+    }
+  }
+
   bool get _isDisposedOrNotInitialized => _isDisposed || !value.isInitialized;
 }
 

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android, iOS, and web.
 repository: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.2.0
+version: 2.2.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
When switching to a different `VideoPlayerController` in the `VideoPlayer` widget, the `VideoPlayer.didUpdateWidget` method will try to remove its own listener from the previous controller, which by this point has already been disposed.

Fixes https://github.com/flutter/flutter/issues/90046.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code