### PR TITLE
[quick_actions] Bump minimum Flutter version and iOS deployment target

### DIFF
--- a/packages/quick_actions/quick_actions/CHANGELOG.md
+++ b/packages/quick_actions/quick_actions/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.0+7
+
+* Update minimum Flutter SDK to 2.5 and iOS deployment target to 9.0.
+
 ## 0.6.0+6
 
 * Updated Android lint settings.

--- a/packages/quick_actions/quick_actions/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/packages/quick_actions/quick_actions/example/ios/Flutter/AppFrameworkInfo.plist
@@ -25,6 +25,6 @@
     <string>arm64</string>
   </array>
   <key>MinimumOSVersion</key>
-  <string>8.0</string>
+  <string>9.0</string>
 </dict>
 </plist>

--- a/packages/quick_actions/quick_actions/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/quick_actions/quick_actions/example/ios/Runner.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		33E20B3526EFCDFC00A4A191 /* RunnerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 33E20B3426EFCDFC00A4A191 /* RunnerTests.m */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
+		50EB54C1FE43DB743F5DEC7C /* libPods-RunnerTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D1A69703A518C37D73BF8B91 /* libPods-RunnerTests.a */; };
 		686BE83025E58CCF00862533 /* RunnerUITests.m in Sources */ = {isa = PBXBuildFile; fileRef = 686BE82F25E58CCF00862533 /* RunnerUITests.m */; };
 		83C36CAF23D629E5ABE75B2A /* libPods-Runner.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CCC799F2B0AB50A9C34344F0 /* libPods-Runner.a */; };
 		978B8F6F1D3862AE00F588F7 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 7AFFD8EE1D35381100E5BB4D /* AppDelegate.m */; };
@@ -63,6 +64,7 @@
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		7AFFD8ED1D35381100E5BB4D /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		7AFFD8EE1D35381100E5BB4D /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		96F949A6B78E2DC62B93C4F8 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -71,7 +73,9 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9D27FE1F0F21D4D47DDA16DE /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		CCC799F2B0AB50A9C34344F0 /* libPods-Runner.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Runner.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D1A69703A518C37D73BF8B91 /* libPods-RunnerTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RunnerTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F0609304FBCAEC2289164BD5 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -80,6 +84,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				50EB54C1FE43DB743F5DEC7C /* libPods-RunnerTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -181,6 +186,7 @@
 			isa = PBXGroup;
 			children = (
 				CCC799F2B0AB50A9C34344F0 /* libPods-Runner.a */,
+				D1A69703A518C37D73BF8B91 /* libPods-RunnerTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -190,6 +196,8 @@
 			children = (
 				5278439583922091276A37C9 /* Pods-Runner.debug.xcconfig */,
 				F0609304FBCAEC2289164BD5 /* Pods-Runner.release.xcconfig */,
+				9D27FE1F0F21D4D47DDA16DE /* Pods-RunnerTests.debug.xcconfig */,
+				96F949A6B78E2DC62B93C4F8 /* Pods-RunnerTests.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -201,6 +209,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 33E20B3B26EFCDFC00A4A191 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				3B2E8279C112D7129C8D23F1 /* [CP] Check Pods Manifest.lock */,
 				33E20B2E26EFCDFC00A4A191 /* Sources */,
 				33E20B2F26EFCDFC00A4A191 /* Frameworks */,
 				33E20B3026EFCDFC00A4A191 /* Resources */,
@@ -340,6 +349,28 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
 		};
+		3B2E8279C112D7129C8D23F1 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -438,6 +469,7 @@
 /* Begin XCBuildConfiguration section */
 		33E20B3926EFCDFC00A4A191 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9D27FE1F0F21D4D47DDA16DE /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				INFOPLIST_FILE = RunnerTests/Info.plist;
@@ -450,6 +482,7 @@
 		};
 		33E20B3A26EFCDFC00A4A191 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 96F949A6B78E2DC62B93C4F8 /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				INFOPLIST_FILE = RunnerTests/Info.plist;
@@ -553,7 +586,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -603,7 +636,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/packages/quick_actions/quick_actions/ios/Classes/FLTQuickActionsPlugin.m
+++ b/packages/quick_actions/quick_actions/ios/Classes/FLTQuickActionsPlugin.m
@@ -24,21 +24,16 @@ static NSString *const CHANNEL_NAME = @"plugins.flutter.io/quick_actions";
 }
 
 - (void)handleMethodCall:(FlutterMethodCall *)call result:(FlutterResult)result {
-  if (@available(iOS 9.0, *)) {
-    if ([call.method isEqualToString:@"setShortcutItems"]) {
-      _setShortcutItems(call.arguments);
-      result(nil);
-    } else if ([call.method isEqualToString:@"clearShortcutItems"]) {
-      [UIApplication sharedApplication].shortcutItems = @[];
-      result(nil);
-    } else if ([call.method isEqualToString:@"getLaunchAction"]) {
-      result(nil);
-    } else {
-      result(FlutterMethodNotImplemented);
-    }
-  } else {
-    NSLog(@"Shortcuts are not supported prior to iOS 9.");
+  if ([call.method isEqualToString:@"setShortcutItems"]) {
+    _setShortcutItems(call.arguments);
     result(nil);
+  } else if ([call.method isEqualToString:@"clearShortcutItems"]) {
+    [UIApplication sharedApplication].shortcutItems = @[];
+    result(nil);
+  } else if ([call.method isEqualToString:@"getLaunchAction"]) {
+    result(nil);
+  } else {
+    result(FlutterMethodNotImplemented);
   }
 }
 
@@ -57,21 +52,19 @@ static NSString *const CHANNEL_NAME = @"plugins.flutter.io/quick_actions";
 
 - (BOOL)application:(UIApplication *)application
     didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-  if (@available(iOS 9.0, *)) {
-    UIApplicationShortcutItem *shortcutItem =
-        launchOptions[UIApplicationLaunchOptionsShortcutItemKey];
-    if (shortcutItem) {
-      // Keep hold of the shortcut type and handle it in the
-      // `applicationDidBecomeActure:` method once the Dart MethodChannel
-      // is initialized.
-      self.shortcutType = shortcutItem.type;
+  UIApplicationShortcutItem *shortcutItem =
+      launchOptions[UIApplicationLaunchOptionsShortcutItemKey];
+  if (shortcutItem) {
+    // Keep hold of the shortcut type and handle it in the
+    // `applicationDidBecomeActure:` method once the Dart MethodChannel
+    // is initialized.
+    self.shortcutType = shortcutItem.type;
 
-      // Return NO to indicate we handled the quick action to ensure
-      // the `application:performActionFor:` method is not called (as
-      // per Apple's documentation:
-      // https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1622935-application?language=objc).
-      return NO;
-    }
+    // Return NO to indicate we handled the quick action to ensure
+    // the `application:performActionFor:` method is not called (as
+    // per Apple's documentation:
+    // https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1622935-application?language=objc).
+    return NO;
   }
   return YES;
 }

--- a/packages/quick_actions/quick_actions/ios/quick_actions.podspec
+++ b/packages/quick_actions/quick_actions/ios/quick_actions.podspec
@@ -17,6 +17,6 @@ Downloaded by pub (not CocoaPods).
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.platform = :ios, '8.0'
-  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
+  s.platform = :ios, '9.0'
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 end

--- a/packages/quick_actions/quick_actions/pubspec.yaml
+++ b/packages/quick_actions/quick_actions/pubspec.yaml
@@ -3,11 +3,11 @@ description: Flutter plugin for creating shortcuts on home screen, also known as
   Quick Actions on iOS and App Shortcuts on Android.
 repository: https://github.com/flutter/plugins/tree/master/packages/quick_actions/quick_actions
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+quick_actions%22
-version: 0.6.0+6
+version: 0.6.0+7
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"
+  sdk: ">=2.14.0 <3.0.0"
+  flutter: ">=2.5.0"
 
 flutter:
   plugin:


### PR DESCRIPTION
Flutter apps run on 2.4.0-0.0.pre and later [will be upgraded to a minimum of iOS 9.0](https://github.com/flutter/flutter/pull/85174).  Now that Flutter 2.5 has hit stable and [iOS 8 support has been dropped](https://flutter.dev/go/rfc-ios8-deprecation), change the plugin minimum iOS version to `9.0`.  

- Bump the Flutter and dart version constraints to 2.5 and 2.14 respectively to enforce that the iOS 9.0 migration has happened on the app side, because an older 8.0 app won't build with a 9.0 plugin.
- Remove `@available(iOS 9.0, *)` checks.
- Remove reference to deprecated `VALID_ARCHS` Xcode build setting.  Confirmed this plugin builds for arm64 simulators.
- Let CocoaPods edit the Xcode project.

Users on Flutter versions lower than the current stable 2.5 will not be able to upgrade this plugin past this version.  

quick_actions part of https://github.com/flutter/flutter/issues/84198

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.