### PR TITLE
[url_launcher] Error handling when URL cannot be parsed with Uri.parse

### DIFF
--- a/packages/url_launcher/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.12
+
+* Fixed an error where 'launch' method of url_launcher would cause an error if the provided URL was not valid by RFC 3986.
+
 ## 6.0.11
 
 * Update minimum Flutter SDK to 2.5 and iOS deployment target to 9.0.

--- a/packages/url_launcher/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/url_launcher/lib/url_launcher.dart
@@ -75,8 +75,8 @@ Future<bool> launch(
   try {
     final Uri url = Uri.parse(urlString.trimLeft());
     isWebURL = url.scheme == 'http' || url.scheme == 'https';
-  } on FormatException {}
-  
+  } on FormatException catch (_) {}
+
   if ((forceSafariVC == true || forceWebView == true) && !isWebURL) {
     throw PlatformException(
         code: 'NOT_A_WEB_SCHEME',

--- a/packages/url_launcher/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/url_launcher/lib/url_launcher.dart
@@ -71,11 +71,9 @@ Future<bool> launch(
   Brightness? statusBarBrightness,
   String? webOnlyWindowName,
 }) async {
-  bool isWebURL = false;
-  try {
-    final Uri url = Uri.parse(urlString.trimLeft());
-    isWebURL = url.scheme == 'http' || url.scheme == 'https';
-  } on FormatException catch (_) {}
+  final Uri? url = Uri.tryParse(urlString.trimLeft());
+  final bool isWebURL =
+      url != null && (url.scheme == 'http' || url.scheme == 'https');
 
   if ((forceSafariVC == true || forceWebView == true) && !isWebURL) {
     throw PlatformException(

--- a/packages/url_launcher/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/url_launcher/lib/url_launcher.dart
@@ -74,15 +74,15 @@ Future<bool> launch(
   bool isWebURL = false;
   try {
     final Uri url = Uri.parse(urlString.trimLeft());
-
     isWebURL = url.scheme == 'http' || url.scheme == 'https';
-    if ((forceSafariVC == true || forceWebView == true) && !isWebURL) {
-      throw PlatformException(
-          code: 'NOT_A_WEB_SCHEME',
-          message: 'To use webview or safariVC, you need to pass'
-              'in a web URL. This $urlString is not a web URL.');
-    }
-  } catch (e) {}
+  } on FormatException {}
+  
+  if ((forceSafariVC == true || forceWebView == true) && !isWebURL) {
+    throw PlatformException(
+        code: 'NOT_A_WEB_SCHEME',
+        message: 'To use webview or safariVC, you need to pass'
+            'in a web URL. This $urlString is not a web URL.');
+  }
 
   /// [true] so that ui is automatically computed if [statusBarBrightness] is set.
   bool previousAutomaticSystemUiAdjustment = true;

--- a/packages/url_launcher/url_launcher/lib/url_launcher.dart
+++ b/packages/url_launcher/url_launcher/lib/url_launcher.dart
@@ -71,14 +71,18 @@ Future<bool> launch(
   Brightness? statusBarBrightness,
   String? webOnlyWindowName,
 }) async {
-  final Uri url = Uri.parse(urlString.trimLeft());
-  final bool isWebURL = url.scheme == 'http' || url.scheme == 'https';
-  if ((forceSafariVC == true || forceWebView == true) && !isWebURL) {
-    throw PlatformException(
-        code: 'NOT_A_WEB_SCHEME',
-        message: 'To use webview or safariVC, you need to pass'
-            'in a web URL. This $urlString is not a web URL.');
-  }
+  bool isWebURL = false;
+  try {
+    final Uri url = Uri.parse(urlString.trimLeft());
+
+    isWebURL = url.scheme == 'http' || url.scheme == 'https';
+    if ((forceSafariVC == true || forceWebView == true) && !isWebURL) {
+      throw PlatformException(
+          code: 'NOT_A_WEB_SCHEME',
+          message: 'To use webview or safariVC, you need to pass'
+              'in a web URL. This $urlString is not a web URL.');
+    }
+  } catch (e) {}
 
   /// [true] so that ui is automatically computed if [statusBarBrightness] is set.
   bool previousAutomaticSystemUiAdjustment = true;

--- a/packages/url_launcher/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for launching a URL. Supports
   web, phone, SMS, and email schemes.
 repository: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 6.0.11
+version: 6.0.12
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/url_launcher/url_launcher/test/url_launcher_test.dart
+++ b/packages/url_launcher/url_launcher/test/url_launcher_test.dart
@@ -281,6 +281,39 @@ void main() {
       await launchResult;
       expect(binding.renderView.automaticSystemUiAdjustment, true);
     });
+    
+    test('open remote desktop url', () async {
+      mock
+        ..setLaunchExpectations(
+          url: 'rdp://full%20address=s:mypc:3389&audiomode=i:2&disable%20themes=i:1',
+          useSafariVC: false,
+          useWebView: false,
+          enableJavaScript: false,
+          enableDomStorage: false,
+          universalLinksOnly: false,
+          headers: <String, String>{},
+          webOnlyWindowName: null,
+        )
+        ..setResponse(true);
+      expect(await launch('rdp://full%20address=s:mypc:3389&audiomode=i:2&disable%20themes=i:1'),
+          isTrue);
+    });
+
+    test('cannot open remote desktop url with forceSafariVC: true', () async {
+      expect(
+          () async => await launch(
+              'rdp://full%20address=s:mypc:3389&audiomode=i:2&disable%20themes=i:1',
+              forceSafariVC: true),
+          throwsA(isA<PlatformException>()));
+    });
+
+    test('cannot open remote desktop url with forceWebView: true', () async {
+      expect(
+          () async => await launch(
+              'rdp://full%20address=s:mypc:3389&audiomode=i:2&disable%20themes=i:1',
+              forceWebView: true),
+          throwsA(isA<PlatformException>()));
+    });
   });
 }
 

--- a/packages/url_launcher/url_launcher/test/url_launcher_test.dart
+++ b/packages/url_launcher/url_launcher/test/url_launcher_test.dart
@@ -282,7 +282,7 @@ void main() {
       expect(binding.renderView.automaticSystemUiAdjustment, true);
     });
 
-    test('open remote desktop url', () async {
+    test('open non-parseable url', () async {
       mock
         ..setLaunchExpectations(
           url:
@@ -302,7 +302,7 @@ void main() {
           isTrue);
     });
 
-    test('cannot open remote desktop url with forceSafariVC: true', () async {
+    test('cannot open non-parseable url with forceSafariVC: true', () async {
       expect(
           () async => await launch(
               'rdp://full%20address=s:mypc:3389&audiomode=i:2&disable%20themes=i:1',
@@ -310,7 +310,7 @@ void main() {
           throwsA(isA<PlatformException>()));
     });
 
-    test('cannot open remote desktop url with forceWebView: true', () async {
+    test('cannot open non-parseable url with forceWebView: true', () async {
       expect(
           () async => await launch(
               'rdp://full%20address=s:mypc:3389&audiomode=i:2&disable%20themes=i:1',

--- a/packages/url_launcher/url_launcher/test/url_launcher_test.dart
+++ b/packages/url_launcher/url_launcher/test/url_launcher_test.dart
@@ -281,11 +281,12 @@ void main() {
       await launchResult;
       expect(binding.renderView.automaticSystemUiAdjustment, true);
     });
-    
+
     test('open remote desktop url', () async {
       mock
         ..setLaunchExpectations(
-          url: 'rdp://full%20address=s:mypc:3389&audiomode=i:2&disable%20themes=i:1',
+          url:
+              'rdp://full%20address=s:mypc:3389&audiomode=i:2&disable%20themes=i:1',
           useSafariVC: false,
           useWebView: false,
           enableJavaScript: false,
@@ -295,7 +296,9 @@ void main() {
           webOnlyWindowName: null,
         )
         ..setResponse(true);
-      expect(await launch('rdp://full%20address=s:mypc:3389&audiomode=i:2&disable%20themes=i:1'),
+      expect(
+          await launch(
+              'rdp://full%20address=s:mypc:3389&audiomode=i:2&disable%20themes=i:1'),
           isTrue);
     });
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15670271/134138590-90c0e92a-c295-4a1f-bcaf-a3c06cd7d061.png)

Uri.parse cannot parse some app scheme URLs.
Use try-catch to handle errors.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
