### PR TITLE
[flutter_plugin_tools] Fix federated safety check

### DIFF
--- a/script/tool/lib/src/federation_safety_check_command.dart
+++ b/script/tool/lib/src/federation_safety_check_command.dart
@@ -135,6 +135,13 @@ class FederationSafetyCheckCommand extends PackageLoopingCommand {
       return PackageResult.success();
     }
 
+    final List<String> changedPackageFiles =
+        _changedDartFiles[package.directory.basename] ?? <String>[];
+    if (changedPackageFiles.isEmpty) {
+      print('No Dart changes.');
+      return PackageResult.success();
+    }
+
     // If the change would be flagged, but it appears to be a mass change
     // rather than a plugin-specific change, allow it with a warning.
     //


### PR DESCRIPTION
The new safety check doesn't allow simple platform-interface-only
changes because it doesn't actually check that a non-interface package
is actually modified before failing it for a modified platform
interface.

This fixes that, and adds a test case covering it.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
