### PR TITLE
Add false secret lists, and enforce ordering

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
@@ -31,3 +31,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   pedantic: ^1.10.0
+
+# The example deliberately includes limited-use secrets.
+false_secrets:
+  - /example/web/index.html

--- a/packages/google_sign_in/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in/pubspec.yaml
@@ -36,3 +36,11 @@ dev_dependencies:
   integration_test:
     sdk: flutter
   pedantic: ^1.10.0
+
+# The example deliberately includes limited-use secrets.
+false_secrets:
+  - /example/android/app/google-services.json
+  - /example/ios/Runner/GoogleService-Info.plist
+  - /example/ios/RunnerTests/GoogleSignInTests.m
+  - /example/lib/main.dart
+  - /example/web/index.html

--- a/script/tool/lib/src/pubspec_check_command.dart
+++ b/script/tool/lib/src/pubspec_check_command.dart
@@ -39,6 +39,7 @@ class PubspecCheckCommand extends PackageLoopingCommand {
     'flutter:',
     'dependencies:',
     'dev_dependencies:',
+    'false_secrets:',
   ];
 
   static const List<String> _majorPackageSections = <String>[
@@ -46,6 +47,7 @@ class PubspecCheckCommand extends PackageLoopingCommand {
     'dependencies:',
     'dev_dependencies:',
     'flutter:',
+    'false_secrets:',
   ];
 
   static const String _expectedIssueLinkFormat =

--- a/script/tool/test/pubspec_check_command_test.dart
+++ b/script/tool/test/pubspec_check_command_test.dart
@@ -113,6 +113,13 @@ dev_dependencies:
 ''';
     }
 
+    String falseSecretsSection() {
+      return '''
+false_secrets:
+  - /lib/main.dart
+''';
+    }
+
     test('passes for a plugin following conventions', () async {
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir);
 
@@ -122,6 +129,7 @@ ${environmentSection()}
 ${flutterSection(isPlugin: true)}
 ${dependenciesSection()}
 ${devDependenciesSection()}
+${falseSecretsSection()}
 ''');
 
       final List<String> output = await runCapturingPrint(runner, <String>[
@@ -147,6 +155,7 @@ ${environmentSection()}
 ${dependenciesSection()}
 ${devDependenciesSection()}
 ${flutterSection()}
+${falseSecretsSection()}
 ''');
 
       final List<String> output = await runCapturingPrint(runner, <String>[
@@ -399,7 +408,7 @@ ${dependenciesSection()}
       );
     });
 
-    test('fails when devDependencies section is out of order', () async {
+    test('fails when dev_dependencies section is out of order', () async {
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir);
 
       pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
@@ -408,6 +417,34 @@ ${environmentSection()}
 ${devDependenciesSection()}
 ${flutterSection(isPlugin: true)}
 ${dependenciesSection()}
+''');
+
+      Error? commandError;
+      final List<String> output = await runCapturingPrint(
+          runner, <String>['pubspec-check'], errorHandler: (Error e) {
+        commandError = e;
+      });
+
+      expect(commandError, isA<ToolExit>());
+      expect(
+        output,
+        containsAllInOrder(<Matcher>[
+          contains(
+              'Major sections should follow standard repository ordering:'),
+        ]),
+      );
+    });
+
+    test('fails when false_secrets section is out of order', () async {
+      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir);
+
+      pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
+${headerSection('plugin', isPlugin: true)}
+${environmentSection()}
+${flutterSection(isPlugin: true)}
+${dependenciesSection()}
+${falseSecretsSection()}
+${devDependenciesSection()}
 ''');
 
       Error? commandError;


### PR DESCRIPTION
Updates plugins to pass the new publish check against leaking secrets, and adds the new `false_secrets` section to the enforced section ordering in the tool. This prevents future unrelated failures when trying to publish these plugins.

Fixes https://github.com/flutter/flutter/issues/90477

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
