### PR TITLE
[flutter_plugin_tools] Improve version check error handling

### DIFF
--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -6,6 +6,7 @@
   federated packages that have been done in such a way that they will pass in
   CI, but fail once the change is landed and published.
 - `publish-check` now validates that there is an `AUTHORS` file.
+- Improved error handling and error messages in CHANGELOG version checks.
 
 ## 0.7.1
 

--- a/script/tool/lib/src/version_check_command.dart
+++ b/script/tool/lib/src/version_check_command.dart
@@ -362,7 +362,7 @@ ${indentation}HTTP response: ${pubVersionFinderResponse.httpResponse.body}
     if (versionString == null) {
       printError('${indentation}Unable to find a version in CHANGELOG.md');
       print('${indentation}The current version should be on a line starting '
-          ' with "## ", either on the first non-empty line or after a "## NEXT" '
+          'with "## ", either on the first non-empty line or after a "## NEXT" '
           'section.');
       return false;
     }

--- a/script/tool/lib/src/version_check_command.dart
+++ b/script/tool/lib/src/version_check_command.dart
@@ -362,7 +362,7 @@ ${indentation}HTTP response: ${pubVersionFinderResponse.httpResponse.body}
     if (versionString == null) {
       printError('${indentation}Unable to find a version in CHANGELOG.md');
       print('${indentation}The current version should be on a line starting '
-          ' with"## ", either on the first non-empty line or after a "## NEXT" '
+          ' with "## ", either on the first non-empty line or after a "## NEXT" '
           'section.');
       return false;
     }

--- a/script/tool/lib/src/version_check_command.dart
+++ b/script/tool/lib/src/version_check_command.dart
@@ -348,8 +348,9 @@ ${indentation}HTTP response: ${pubVersionFinderResponse.httpResponse.body}
       print(
           '${indentation}Found NEXT; validating next version in the CHANGELOG.');
       // Ensure that the version in pubspec hasn't changed without updating
-      // CHANGELOG. That means the next version entry in the CHANGELOG pass the
-      // normal validation.
+      // CHANGELOG. That means the next version entry in the CHANGELOG should
+      // pass the normal validation.
+      versionString = null;
       while (iterator.moveNext()) {
         if (iterator.current.trim().startsWith('## ')) {
           versionString = iterator.current.trim().split(' ').last;
@@ -358,11 +359,19 @@ ${indentation}HTTP response: ${pubVersionFinderResponse.httpResponse.body}
       }
     }
 
-    final Version? fromChangeLog =
-        versionString == null ? null : Version.parse(versionString);
-    if (fromChangeLog == null) {
-      printError(
-          '${indentation}Cannot find version on the first line CHANGELOG.md');
+    if (versionString == null) {
+      printError('${indentation}Unable to find a version in CHANGELOG.md');
+      print('${indentation}The current version should be on a line starting '
+          ' with"## ", either on the first non-empty line or after a "## NEXT" '
+          'section.');
+      return false;
+    }
+
+    final Version fromChangeLog;
+    try {
+      fromChangeLog = Version.parse(versionString);
+    } on FormatException {
+      printError('"$versionString" could not be parsed as a version.');
       return false;
     }
 

--- a/script/tool/test/version_check_command_test.dart
+++ b/script/tool/test/version_check_command_test.dart
@@ -514,6 +514,73 @@ void main() {
       );
     });
 
+    test(
+        'fails gracefully if the version headers are not found due to using the wrong style',
+        () async {
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, version: '1.0.0');
+
+      const String changelog = '''
+## NEXT
+* Some changes for a later release.
+# 1.0.0
+* Some other changes.
+''';
+      createFakeCHANGELOG(pluginDirectory, changelog);
+      gitShowResponses = <String, String>{
+        'master:packages/plugin/pubspec.yaml': 'version: 1.0.0',
+      };
+
+      Error? commandError;
+      final List<String> output = await runCapturingPrint(runner, <String>[
+        'version-check',
+        '--base-sha=master',
+      ], errorHandler: (Error e) {
+        commandError = e;
+      });
+
+      expect(commandError, isA<ToolExit>());
+      expect(
+        output,
+        containsAllInOrder(<Matcher>[
+          contains('Unable to find a version in CHANGELOG.md'),
+          contains('The current version should be on a line starting with '
+              '"## ", either on the first non-empty line or after a "## NEXT" '
+              'section.'),
+        ]),
+      );
+    });
+
+    test('fails gracefully if the version is unparseable', () async {
+      final Directory pluginDirectory =
+          createFakePlugin('plugin', packagesDir, version: '1.0.0');
+
+      const String changelog = '''
+## Alpha
+* Some changes.
+''';
+      createFakeCHANGELOG(pluginDirectory, changelog);
+      gitShowResponses = <String, String>{
+        'master:packages/plugin/pubspec.yaml': 'version: 1.0.0',
+      };
+
+      Error? commandError;
+      final List<String> output = await runCapturingPrint(runner, <String>[
+        'version-check',
+        '--base-sha=master',
+      ], errorHandler: (Error e) {
+        commandError = e;
+      });
+
+      expect(commandError, isA<ToolExit>());
+      expect(
+        output,
+        containsAllInOrder(<Matcher>[
+          contains('"Alpha" could not be parsed as a version.'),
+        ]),
+      );
+    });
+
     test('allows valid against pub', () async {
       mockHttpResponse = <String, dynamic>{
         'name': 'some_package',


### PR DESCRIPTION
Catches invalid CHANGELOG formats and logs useful error messages for them,
rather than throwing FormatExceptions.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
