### PR TITLE
Remove some trivial custom analysis options files

### DIFF
--- a/packages/cross_file/analysis_options.yaml
+++ b/packages/cross_file/analysis_options.yaml
@@ -1,1 +1,0 @@
-include: ../../analysis_options_legacy.yaml

--- a/packages/flutter_plugin_android_lifecycle/analysis_options.yaml
+++ b/packages/flutter_plugin_android_lifecycle/analysis_options.yaml
@@ -1,1 +1,0 @@
-include: ../../analysis_options_legacy.yaml

--- a/packages/flutter_plugin_android_lifecycle/example/integration_test/flutter_plugin_android_lifecycle_test.dart
+++ b/packages/flutter_plugin_android_lifecycle/example/integration_test/flutter_plugin_android_lifecycle_test.dart
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter_plugin_android_lifecycle_example/main.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
-import 'package:flutter_plugin_android_lifecycle_example/main.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();

--- a/packages/flutter_plugin_android_lifecycle/example/lib/main.dart
+++ b/packages/flutter_plugin_android_lifecycle/example/lib/main.dart
@@ -16,7 +16,7 @@ class MyApp extends StatelessWidget {
         appBar: AppBar(
           title: const Text('Sample flutter_plugin_android_lifecycle usage'),
         ),
-        body: Center(
+        body: const Center(
             child: Text(
                 'This plugin only provides Android Lifecycle API\n for other Android plugins.')),
       ),

--- a/packages/flutter_plugin_android_lifecycle/example/pubspec.yaml
+++ b/packages/flutter_plugin_android_lifecycle/example/pubspec.yaml
@@ -17,9 +17,9 @@ dependencies:
     path: ../
 
 dev_dependencies:
-  integration_test:
-    sdk: flutter
   flutter_test:
+    sdk: flutter
+  integration_test:
     sdk: flutter
   pedantic: ^1.8.0
 

--- a/packages/plugin_platform_interface/analysis_options.yaml
+++ b/packages/plugin_platform_interface/analysis_options.yaml
@@ -1,1 +1,0 @@
-include: ../../analysis_options_legacy.yaml

--- a/packages/plugin_platform_interface/pubspec.yaml
+++ b/packages/plugin_platform_interface/pubspec.yaml
@@ -24,5 +24,5 @@ dependencies:
 
 dev_dependencies:
   mockito: ^5.0.0
-  test: ^1.16.0
   pedantic: ^1.10.0
+  test: ^1.16.0

--- a/packages/plugin_platform_interface/test/plugin_platform_interface_test.dart
+++ b/packages/plugin_platform_interface/test/plugin_platform_interface_test.dart
@@ -3,9 +3,8 @@
 // found in the LICENSE file.
 
 import 'package:mockito/mockito.dart';
-import 'package:test/test.dart';
-
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:test/test.dart';
 
 class SamplePluginPlatform extends PlatformInterface {
   SamplePluginPlatform() : super(token: _token);

--- a/script/configs/custom_analysis.yaml
+++ b/script/configs/custom_analysis.yaml
@@ -21,7 +21,6 @@
 - google_sign_in
 - image_picker
 - in_app_purchase
-- integration_test
 - ios_platform_images
 - local_auth
 - quick_actions

--- a/script/configs/custom_analysis.yaml
+++ b/script/configs/custom_analysis.yaml
@@ -25,7 +25,6 @@
 - integration_test
 - ios_platform_images
 - local_auth
-- plugin_platform_interface
 - quick_actions
 - shared_preferences
 - url_launcher

--- a/script/configs/custom_analysis.yaml
+++ b/script/configs/custom_analysis.yaml
@@ -17,7 +17,6 @@
 # https://github.com/flutter/flutter/issues/76229
 - camera
 - file_selector
-- flutter_plugin_android_lifecycle
 - google_maps_flutter
 - google_sign_in
 - image_picker


### PR DESCRIPTION
Remove a few of the trivial-to-fix legacy analysis option files that were bulk added in the transition to matching flutter/flutter's analysis options.

Part of https://github.com/flutter/flutter/issues/76229

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
