### PR TITLE
[webview_flutter] Adjust integration test domains

### DIFF
--- a/packages/webview_flutter/webview_flutter/example/integration_test/webview_flutter_test.dart
+++ b/packages/webview_flutter/webview_flutter/example/integration_test/webview_flutter_test.dart
@@ -58,9 +58,9 @@ void main() {
       ),
     );
     final WebViewController controller = await controllerCompleter.future;
-    await controller.loadUrl('https://www.google.com/');
+    await controller.loadUrl('https://www.example.com/');
     final String? currentUrl = await controller.currentUrl();
-    expect(currentUrl, 'https://www.google.com/');
+    expect(currentUrl, 'https://www.example.com/');
   }, skip: _skipDueToIssue86757);
 
   // TODO(bparrishMines): skipped due to https://github.com/flutter/flutter/issues/86757.
@@ -1100,11 +1100,11 @@ void main() {
       await pageLoads.stream.first; // Wait for initial page load.
       final WebViewController controller = await controllerCompleter.future;
       await controller
-          .evaluateJavascript('location.href = "https://www.google.com/"');
+          .evaluateJavascript('location.href = "https://www.example.com/"');
 
       await pageLoads.stream.first; // Wait for the next page load.
       final String? currentUrl = await controller.currentUrl();
-      expect(currentUrl, 'https://www.google.com/');
+      expect(currentUrl, 'https://www.example.com/');
     });
 
     testWidgets('onWebResourceError', (WidgetTester tester) async {
@@ -1272,11 +1272,11 @@ void main() {
       await pageLoads.stream.first; // Wait for initial page load.
       final WebViewController controller = await controllerCompleter.future;
       await controller
-          .evaluateJavascript('location.href = "https://www.google.com"');
+          .evaluateJavascript('location.href = "https://www.example.com"');
 
       await pageLoads.stream.first; // Wait for second page to load.
       final String? currentUrl = await controller.currentUrl();
-      expect(currentUrl, 'https://www.google.com/');
+      expect(currentUrl, 'https://www.example.com/');
     });
   });
 
@@ -1365,10 +1365,10 @@ void main() {
       pageLoaded = Completer<void>();
 
       await controller
-          .evaluateJavascript('window.open("https://www.google.com/")');
+          .evaluateJavascript('window.open("https://www.example.com/")');
       await pageLoaded.future;
       pageLoaded = Completer<void>();
-      expect(controller.currentUrl(), completion('https://www.google.com/'));
+      expect(controller.currentUrl(), completion('https://www.example.com/'));
 
       expect(controller.canGoBack(), completion(true));
       await controller.goBack();

--- a/packages/webview_flutter/webview_flutter_android/example/integration_test/webview_flutter_test.dart
+++ b/packages/webview_flutter/webview_flutter_android/example/integration_test/webview_flutter_test.dart
@@ -64,9 +64,9 @@ void main() {
       ),
     );
     final WebViewController controller = await controllerCompleter.future;
-    await controller.loadUrl('https://www.google.com/');
+    await controller.loadUrl('https://www.example.com/');
     final String? currentUrl = await controller.currentUrl();
-    expect(currentUrl, 'https://www.google.com/');
+    expect(currentUrl, 'https://www.example.com/');
   }, skip: _skipDueToIssue86757);
 
   // TODO(bparrishMines): skipped due to https://github.com/flutter/flutter/issues/86757.
@@ -1054,11 +1054,11 @@ void main() {
       await pageLoads.stream.first; // Wait for initial page load.
       final WebViewController controller = await controllerCompleter.future;
       await controller
-          .evaluateJavascript('location.href = "https://www.google.com/"');
+          .evaluateJavascript('location.href = "https://www.example.com/"');
 
       await pageLoads.stream.first; // Wait for the next page load.
       final String? currentUrl = await controller.currentUrl();
-      expect(currentUrl, 'https://www.google.com/');
+      expect(currentUrl, 'https://www.example.com/');
     });
 
     testWidgets('onWebResourceError', (WidgetTester tester) async {
@@ -1221,11 +1221,11 @@ void main() {
       await pageLoads.stream.first; // Wait for initial page load.
       final WebViewController controller = await controllerCompleter.future;
       await controller
-          .evaluateJavascript('location.href = "https://www.google.com"');
+          .evaluateJavascript('location.href = "https://www.example.com"');
 
       await pageLoads.stream.first; // Wait for second page to load.
       final String? currentUrl = await controller.currentUrl();
-      expect(currentUrl, 'https://www.google.com/');
+      expect(currentUrl, 'https://www.example.com/');
     });
   });
 
@@ -1314,10 +1314,10 @@ void main() {
       pageLoaded = Completer<void>();
 
       await controller
-          .evaluateJavascript('window.open("https://www.google.com/")');
+          .evaluateJavascript('window.open("https://www.example.com/")');
       await pageLoaded.future;
       pageLoaded = Completer<void>();
-      expect(controller.currentUrl(), completion('https://www.google.com/'));
+      expect(controller.currentUrl(), completion('https://www.example.com/'));
 
       expect(controller.canGoBack(), completion(true));
       await controller.goBack();

--- a/packages/webview_flutter/webview_flutter_wkwebview/example/integration_test/webview_flutter_test.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/example/integration_test/webview_flutter_test.dart
@@ -61,9 +61,9 @@ void main() {
       ),
     );
     final WebViewController controller = await controllerCompleter.future;
-    await controller.loadUrl('https://www.google.com/');
+    await controller.loadUrl('https://www.example.com/');
     final String? currentUrl = await controller.currentUrl();
-    expect(currentUrl, 'https://www.google.com/');
+    expect(currentUrl, 'https://www.example.com/');
   }, skip: _skipDueToIssue86757);
 
   testWidgets('loadUrl with headers', (WidgetTester tester) async {
@@ -913,11 +913,11 @@ void main() {
       await pageLoads.stream.first; // Wait for initial page load.
       final WebViewController controller = await controllerCompleter.future;
       await controller
-          .evaluateJavascript('location.href = "https://www.google.com/"');
+          .evaluateJavascript('location.href = "https://www.example.com/"');
 
       await pageLoads.stream.first; // Wait for the next page load.
       final String? currentUrl = await controller.currentUrl();
-      expect(currentUrl, 'https://www.google.com/');
+      expect(currentUrl, 'https://www.example.com/');
     });
 
     testWidgets('onWebResourceError', (WidgetTester tester) async {
@@ -1085,11 +1085,11 @@ void main() {
       await pageLoads.stream.first; // Wait for initial page load.
       final WebViewController controller = await controllerCompleter.future;
       await controller
-          .evaluateJavascript('location.href = "https://www.google.com"');
+          .evaluateJavascript('location.href = "https://www.example.com"');
 
       await pageLoads.stream.first; // Wait for second page to load.
       final String? currentUrl = await controller.currentUrl();
-      expect(currentUrl, 'https://www.google.com/');
+      expect(currentUrl, 'https://www.example.com/');
     });
   });
 
@@ -1176,10 +1176,10 @@ void main() {
       pageLoaded = Completer<void>();
 
       await controller
-          .evaluateJavascript('window.open("https://www.google.com/")');
+          .evaluateJavascript('window.open("https://www.example.com/")');
       await pageLoaded.future;
       pageLoaded = Completer<void>();
-      expect(controller.currentUrl(), completion('https://www.google.com/'));
+      expect(controller.currentUrl(), completion('https://www.example.com/'));
 
       expect(controller.canGoBack(), completion(true));
       await controller.goBack();


### PR DESCRIPTION
Tests that load https://www.google.com and then assert that that's the
current URL are failing, because Google is redirecting our tests to a
"suspicious activity" page. Switch to example.com, as a domain that is
less likely to do traffic-based redirection.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
