### PR TITLE
[webview_flutter] Update webview platform interface with new methods for running JavaScript.

### DIFF
--- a/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+
+* Added `runJavaScript` and `runJavaScriptForResult` interface methods to supersede `evaluateJavaScript`.
+
 ## 1.0.0
 
 * Extracted platform interface from `webview_flutter`.

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/src/method_channel/webview_method_channel.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/src/method_channel/webview_method_channel.dart
@@ -130,6 +130,18 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
   }
 
   @override
+  Future<void> runJavaScript(String javaScriptString) async {
+    await _channel.invokeMethod<String>('runJavaScript', javaScriptString);
+  }
+
+  @override
+  Future<String> runJavaScriptForResult(String javaScriptString) {
+    return _channel
+        .invokeMethod<String>('runJavaScriptForResult', javaScriptString)
+        .then((result) => result!);
+  }
+
+  @override
   Future<void> addJavascriptChannels(Set<String> javascriptChannelNames) {
     return _channel.invokeMethod<void>(
         'addJavascriptChannels', javascriptChannelNames.toList());

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_interface/webview_platform_controller.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_interface/webview_platform_controller.dart
@@ -112,6 +112,23 @@ abstract class WebViewPlatformController {
         "WebView evaluateJavascript is not implemented on the current platform");
   }
 
+  /// Runs the given JavaScript in the context of the current page.
+  ///
+  /// The Future completes with an error if a JavaScript error occurred.
+  Future<void> runJavaScript(String javaScriptString) {
+    throw UnimplementedError(
+        "WebView runJavaScript is not implemented on the current platform");
+  }
+
+  /// Runs the given JavaScript in the context of the current page, and returns the result.
+  ///
+  /// The Future completes with an error if a JavaScript error occurred, or successfully completes with a null value
+  /// if the type of the value is not supported(e.g on iOS not all non primitive type can be evaluated).
+  Future<String> runJavaScriptForResult(String javaScriptString) {
+    throw UnimplementedError(
+        "WebView runJavaScriptForResult is not implemented on the current platform");
+  }
+
   /// Adds new JavaScript channels to the set of enabled channels.
   ///
   /// For each value in this list the platform's webview should make sure that a corresponding

--- a/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/master/packages/webview_flut
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview_flutter%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.0.0
+version: 1.1.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/webview_flutter/webview_flutter_platform_interface/test/src/method_channel/webview_method_channel_test.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/test/src/method_channel/webview_method_channel_test.dart
@@ -31,6 +31,7 @@ void main() {
         case 'canGoBack':
         case 'canGoForward':
           return true;
+        case 'runJavaScriptForResult':
         case 'evaluateJavascript':
           return methodCall.arguments as String;
         case 'getScrollX':
@@ -280,27 +281,25 @@ void main() {
       );
     });
 
-    test('evaluateJavascript', () async {
-      final String evaluateJavascript =
-          await webViewPlatform.evaluateJavascript(
+    test('runJavaScript', () async {
+      await webViewPlatform.runJavaScript(
         'This simulates some Javascript code.',
       );
 
-      expect('This simulates some Javascript code.', evaluateJavascript);
       expect(
         log,
         <Matcher>[
           isMethodCall(
-            'evaluateJavascript',
+            'runJavaScript',
             arguments: 'This simulates some Javascript code.',
           ),
         ],
       );
     });
 
-    test('evaluateJavascript', () async {
+    test('runJavaScriptForResult', () async {
       final String evaluateJavascript =
-          await webViewPlatform.evaluateJavascript(
+          await webViewPlatform.runJavaScriptForResult(
         'This simulates some Javascript code.',
       );
 
@@ -309,7 +308,7 @@ void main() {
         log,
         <Matcher>[
           isMethodCall(
-            'evaluateJavascript',
+            'runJavaScriptForResult',
             arguments: 'This simulates some Javascript code.',
           ),
         ],

--- a/packages/webview_flutter/webview_flutter_platform_interface/test/src/method_channel/webview_method_channel_test.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/test/src/method_channel/webview_method_channel_test.dart
@@ -280,6 +280,42 @@ void main() {
       );
     });
 
+    test('evaluateJavascript', () async {
+      final String evaluateJavascript =
+          await webViewPlatform.evaluateJavascript(
+        'This simulates some Javascript code.',
+      );
+
+      expect('This simulates some Javascript code.', evaluateJavascript);
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall(
+            'evaluateJavascript',
+            arguments: 'This simulates some Javascript code.',
+          ),
+        ],
+      );
+    });
+
+    test('evaluateJavascript', () async {
+      final String evaluateJavascript =
+          await webViewPlatform.evaluateJavascript(
+        'This simulates some Javascript code.',
+      );
+
+      expect('This simulates some Javascript code.', evaluateJavascript);
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall(
+            'evaluateJavascript',
+            arguments: 'This simulates some Javascript code.',
+          ),
+        ],
+      );
+    });
+
     test('addJavascriptChannels', () async {
       final Set<String> channels = <String>{'channel one', 'channel two'};
       await webViewPlatform.addJavascriptChannels(channels);


### PR DESCRIPTION
This PR adds two new platform interface methods, `runJavaScript` and `runJavaScriptForResult`, to supersede `evaluateJavascript`. 

This is meant as a solution to the issue mentioned in flutter/flutter#66318, and was discussed offline with @mvanbeusekom and @stuartmorgan.

Relevant issue:
- flutter/flutter#66318

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.