### PR TITLE
[webview_flutter] Deprecate evaluateJavascript in favour of runJavaScript and runJavaScriptForResult.

### DIFF
--- a/packages/webview_flutter/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.2.0
 
-*
+* Added `runJavaScript` and `runJavaScriptForResult` to supersede `evaluateJavascript`.
+* Deprecated `evaluateJavascript`.
 
 ## 2.1.1
 

--- a/packages/webview_flutter/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.0
+
+*
+
 ## 2.1.1
 
 * Fixed `_CastError` that was thrown when running the example App.

--- a/packages/webview_flutter/webview_flutter/example/integration_test/webview_flutter_test.dart
+++ b/packages/webview_flutter/webview_flutter/example/integration_test/webview_flutter_test.dart
@@ -101,7 +101,7 @@ void main() {
     await pageLoads.stream.firstWhere((String url) => url == currentUrl);
 
     final String content = await controller
-        .evaluateJavascript('document.documentElement.innerText');
+        .runJavaScriptForResult('document.documentElement.innerText');
     expect(content.contains('flutter_test_header'), isTrue);
   }, skip: Platform.isAndroid && _skipDueToIssue86757);
 
@@ -146,11 +146,7 @@ void main() {
     await pageLoaded.future;
 
     expect(messagesReceived, isEmpty);
-    // Append a return value "1" in the end will prevent an iOS platform exception.
-    // See: https://github.com/flutter/flutter/issues/66318#issuecomment-701105380
-    // TODO(cyanglaz): remove the workaround "1" in the end when the below issue is fixed.
-    // https://github.com/flutter/flutter/issues/66318
-    await controller.evaluateJavascript('Echo.postMessage("hello");1;');
+    await controller.runJavaScript('Echo.postMessage("hello");');
     expect(messagesReceived, equals(<String>['hello']));
   }, skip: Platform.isAndroid && _skipDueToIssue86757);
 
@@ -397,7 +393,7 @@ void main() {
       WebViewController controller = await controllerCompleter.future;
       await pageLoaded.future;
 
-      String isPaused = await controller.evaluateJavascript('isPaused();');
+      String isPaused = await controller.runJavaScriptForResult('isPaused();');
       expect(isPaused, _webviewBool(false));
 
       controllerCompleter = Completer<WebViewController>();
@@ -426,7 +422,7 @@ void main() {
       controller = await controllerCompleter.future;
       await pageLoaded.future;
 
-      isPaused = await controller.evaluateJavascript('isPaused();');
+      isPaused = await controller.runJavaScriptForResult('isPaused();');
       expect(isPaused, _webviewBool(true));
     });
 
@@ -457,7 +453,7 @@ void main() {
       final WebViewController controller = await controllerCompleter.future;
       await pageLoaded.future;
 
-      String isPaused = await controller.evaluateJavascript('isPaused();');
+      String isPaused = await controller.runJavaScriptForResult('isPaused();');
       expect(isPaused, _webviewBool(false));
 
       pageLoaded = Completer<void>();
@@ -485,7 +481,7 @@ void main() {
 
       await pageLoaded.future;
 
-      isPaused = await controller.evaluateJavascript('isPaused();');
+      isPaused = await controller.runJavaScriptForResult('isPaused();');
       expect(isPaused, _webviewBool(false));
     });
 
@@ -535,7 +531,7 @@ void main() {
       await videoPlaying.future;
 
       String fullScreen =
-          await controller.evaluateJavascript('isFullScreen();');
+          await controller.runJavaScriptForResult('isFullScreen();');
       expect(fullScreen, _webviewBool(false));
     });
 
@@ -587,7 +583,7 @@ void main() {
       await videoPlaying.future;
 
       String fullScreen =
-          await controller.evaluateJavascript('isFullScreen();');
+          await controller.runJavaScriptForResult('isFullScreen();');
       expect(fullScreen, _webviewBool(true));
     }, skip: Platform.isAndroid);
   });
@@ -653,7 +649,7 @@ void main() {
       await pageStarted.future;
       await pageLoaded.future;
 
-      String isPaused = await controller.evaluateJavascript('isPaused();');
+      String isPaused = await controller.runJavaScriptForResult('isPaused();');
       expect(isPaused, _webviewBool(false));
 
       controllerCompleter = Completer<WebViewController>();
@@ -687,7 +683,7 @@ void main() {
       await pageStarted.future;
       await pageLoaded.future;
 
-      isPaused = await controller.evaluateJavascript('isPaused();');
+      isPaused = await controller.runJavaScriptForResult('isPaused();');
       expect(isPaused, _webviewBool(true));
     });
 
@@ -723,7 +719,7 @@ void main() {
       await pageStarted.future;
       await pageLoaded.future;
 
-      String isPaused = await controller.evaluateJavascript('isPaused();');
+      String isPaused = await controller.runJavaScriptForResult('isPaused();');
       expect(isPaused, _webviewBool(false));
 
       pageStarted = Completer<void>();
@@ -756,7 +752,7 @@ void main() {
       await pageStarted.future;
       await pageLoaded.future;
 
-      isPaused = await controller.evaluateJavascript('isPaused();');
+      isPaused = await controller.runJavaScriptForResult('isPaused();');
       expect(isPaused, _webviewBool(false));
     });
   });
@@ -1021,14 +1017,14 @@ void main() {
 
       final WebViewController controller = await controllerCompleter.future;
       await pageLoaded.future;
-      final String viewportRectJSON = await _evaluateJavascript(
+      final String viewportRectJSON = await _runJavaScriptForResult(
           controller, 'JSON.stringify(viewport.getBoundingClientRect())');
       final Map<String, dynamic> viewportRectRelativeToViewport =
           jsonDecode(viewportRectJSON);
 
       // Check that the input is originally outside of the viewport.
 
-      final String initialInputClientRectJSON = await _evaluateJavascript(
+      final String initialInputClientRectJSON = await _runJavaScriptForResult(
           controller, 'JSON.stringify(inputEl.getBoundingClientRect())');
       final Map<String, dynamic> initialInputClientRectRelativeToViewport =
           jsonDecode(initialInputClientRectJSON);
@@ -1038,11 +1034,11 @@ void main() {
               viewportRectRelativeToViewport['bottom'],
           isFalse);
 
-      await controller.evaluateJavascript('inputEl.focus()');
+      await controller.runJavaScript('inputEl.focus()');
 
       // Check that focusing the input brought it into view.
 
-      final String lastInputClientRectJSON = await _evaluateJavascript(
+      final String lastInputClientRectJSON = await _runJavaScriptForResult(
           controller, 'JSON.stringify(inputEl.getBoundingClientRect())');
       final Map<String, dynamic> lastInputClientRectRelativeToViewport =
           jsonDecode(lastInputClientRectJSON);
@@ -1100,7 +1096,7 @@ void main() {
       await pageLoads.stream.first; // Wait for initial page load.
       final WebViewController controller = await controllerCompleter.future;
       await controller
-          .evaluateJavascript('location.href = "https://www.example.com/"');
+          .runJavaScript('location.href = "https://www.example.com/"');
 
       await pageLoads.stream.first; // Wait for the next page load.
       final String? currentUrl = await controller.currentUrl();
@@ -1231,7 +1227,7 @@ void main() {
       await pageLoads.stream.first; // Wait for initial page load.
       final WebViewController controller = await controllerCompleter.future;
       await controller
-          .evaluateJavascript('location.href = "https://www.youtube.com/"');
+          .runJavaScript('location.href = "https://www.youtube.com/"');
 
       // There should never be any second page load, since our new URL is
       // blocked. Still wait for a potential page change for some time in order
@@ -1272,7 +1268,7 @@ void main() {
       await pageLoads.stream.first; // Wait for initial page load.
       final WebViewController controller = await controllerCompleter.future;
       await controller
-          .evaluateJavascript('location.href = "https://www.example.com"');
+          .runJavaScript('location.href = "https://www.example.com"');
 
       await pageLoads.stream.first; // Wait for second page to load.
       final String? currentUrl = await controller.currentUrl();
@@ -1328,7 +1324,7 @@ void main() {
     );
     final WebViewController controller = await controllerCompleter.future;
     await controller
-        .evaluateJavascript('window.open("https://flutter.dev/", "_blank")');
+        .runJavaScript('window.open("https://flutter.dev/", "_blank")');
     await pageLoaded.future;
     final String? currentUrl = await controller.currentUrl();
     expect(currentUrl, 'https://flutter.dev/');
@@ -1364,8 +1360,7 @@ void main() {
       await pageLoaded.future;
       pageLoaded = Completer<void>();
 
-      await controller
-          .evaluateJavascript('window.open("https://www.example.com/")');
+      await controller.runJavaScript('window.open("https://www.example.com/")');
       await pageLoaded.future;
       pageLoaded = Completer<void>();
       expect(controller.currentUrl(), completion('https://www.example.com/'));
@@ -1436,9 +1431,10 @@ void main() {
       final WebViewController controller = await controllerCompleter.future;
       await pageLoadCompleter.future;
 
-      expect(controller.evaluateJavascript('iframeLoaded'), completion('true'));
+      expect(controller.runJavaScriptForResult('iframeLoaded'),
+          completion('true'));
       expect(
-        controller.evaluateJavascript(
+        controller.runJavaScriptForResult(
             'document.querySelector("p") && document.querySelector("p").textContent'),
         completion('null'),
       );
@@ -1458,13 +1454,13 @@ String _webviewBool(bool value) {
 
 /// Returns the value used for the HTTP User-Agent: request header in subsequent HTTP requests.
 Future<String> _getUserAgent(WebViewController controller) async {
-  return _evaluateJavascript(controller, 'navigator.userAgent;');
+  return _runJavaScriptForResult(controller, 'navigator.userAgent;');
 }
 
-Future<String> _evaluateJavascript(
+Future<String> _runJavaScriptForResult(
     WebViewController controller, String js) async {
   if (defaultTargetPlatform == TargetPlatform.iOS) {
-    return await controller.evaluateJavascript(js);
+    return await controller.runJavaScriptForResult(js);
   }
-  return jsonDecode(await controller.evaluateJavascript(js));
+  return jsonDecode(await controller.runJavaScriptForResult(js));
 }

--- a/packages/webview_flutter/webview_flutter/example/lib/main.dart
+++ b/packages/webview_flutter/webview_flutter/example/lib/main.dart
@@ -210,14 +210,14 @@ class SampleMenu extends StatelessWidget {
       WebViewController controller, BuildContext context) async {
     // Send a message with the user agent string to the Toaster JavaScript channel we registered
     // with the WebView.
-    await controller.evaluateJavascript(
+    await controller.runJavaScript(
         'Toaster.postMessage("User Agent: " + navigator.userAgent);');
   }
 
   void _onListCookies(
       WebViewController controller, BuildContext context) async {
     final String cookies =
-        await controller.evaluateJavascript('document.cookie');
+        await controller.runJavaScriptForResult('document.cookie');
     // ignore: deprecated_member_use
     Scaffold.of(context).showSnackBar(SnackBar(
       content: Column(
@@ -232,7 +232,7 @@ class SampleMenu extends StatelessWidget {
   }
 
   void _onAddToCache(WebViewController controller, BuildContext context) async {
-    await controller.evaluateJavascript(
+    await controller.runJavaScript(
         'caches.open("test_caches_entry"); localStorage["test_localStorage"] = "dummy_entry";');
     // ignore: deprecated_member_use
     Scaffold.of(context).showSnackBar(const SnackBar(
@@ -241,7 +241,7 @@ class SampleMenu extends StatelessWidget {
   }
 
   void _onListCache(WebViewController controller, BuildContext context) async {
-    await controller.evaluateJavascript('caches.keys()'
+    await controller.runJavaScript('caches.keys()'
         '.then((cacheKeys) => JSON.stringify({"cacheKeys" : cacheKeys, "localStorage" : localStorage}))'
         '.then((caches) => Toaster.postMessage(caches))');
   }

--- a/packages/webview_flutter/webview_flutter/lib/src/webview.dart
+++ b/packages/webview_flutter/webview_flutter/lib/src/webview.dart
@@ -604,15 +604,50 @@ class WebViewController {
   /// When evaluating Javascript in a [WebView], it is best practice to wait for
   /// the [WebView.onPageFinished] callback. This guarantees all the Javascript
   /// embedded in the main frame HTML has been loaded.
+  @Deprecated('Use [runJavaScript] or [runJavascriptForResult]')
   Future<String> evaluateJavascript(String javascriptString) {
     if (_settings.javascriptMode == JavascriptMode.disabled) {
       return Future<String>.error(FlutterError(
           'JavaScript mode must be enabled/unrestricted when calling evaluateJavascript.'));
     }
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
     return _webViewPlatformController.evaluateJavascript(javascriptString);
+  }
+
+  /// Runs the given JavaScript in the context of the current page.
+  /// If you are looking for the result, use [runJavascriptForResult] instead.
+  /// The Future completes with an error if a JavaScript error occurred.
+  ///
+  /// When running Javascript in a [WebView], it is best practice to wait for
+  //  the [WebView.onPageFinished] callback. This guarantees all the Javascript
+  //  embedded in the main frame HTML has been loaded.
+  Future<void> runJavaScript(String javaScriptString) {
+    if (_settings.javascriptMode == JavascriptMode.disabled) {
+      return Future<void>.error(FlutterError(
+          'JavaScript mode must be enabled/unrestricted when calling runJavaScript.'));
+    }
+    return _webViewPlatformController.runJavaScript(javaScriptString);
+  }
+
+  /// Runs the given JavaScript in the context of the current page, and returns the result.
+  ///
+  /// On Android returns the evaluation result as a JSON formatted string.
+  ///
+  /// On iOS depending on the value type the return value would be one of:
+  ///  - For primitive JavaScript types: the value string formatted (e.g JavaScript 100 returns '100').
+  ///  - For JavaScript arrays of supported types: a string formatted NSArray(e.g '(1,2,3), note that the string for NSArray is formatted and might contain newlines and extra spaces.').
+  ///  - Other non-primitive types are not supported on iOS and will return as null.
+  ///
+  /// The Future completes with an error if a JavaScript error occurred.
+  ///
+  /// When evaluating Javascript in a [WebView], it is best practice to wait for
+  /// the [WebView.onPageFinished] callback. This guarantees all the Javascript
+  /// embedded in the main frame HTML has been loaded.
+  Future<String> runJavaScriptForResult(String javaScriptString) {
+    if (_settings.javascriptMode == JavascriptMode.disabled) {
+      return Future<String>.error(FlutterError(
+          'JavaScript mode must be enabled/unrestricted when calling runJavaScriptForResult.'));
+    }
+    return _webViewPlatformController.runJavaScriptForResult(javaScriptString);
   }
 
   /// Returns the title of the currently loaded page.

--- a/packages/webview_flutter/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
 repository: https://github.com/flutter/plugins/tree/master/packages/webview_flutter/webview_flutter
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview%22
-version: 2.1.1
+version: 2.2.0
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -19,9 +19,15 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  webview_flutter_platform_interface: ^1.0.0
-  webview_flutter_android: ^2.0.13
-  webview_flutter_wkwebview: ^2.0.13
+  # TODO (BeMacized): Change to version dependency once interface is published
+  webview_flutter_platform_interface:
+    path: ../webview_flutter_platform_interface
+  # TODO (BeMacized): Change to version dependency once interface is published
+  webview_flutter_android:
+    path: ../webview_flutter_android
+  # TODO (BeMacized): Change to version dependency once interface is published
+  webview_flutter_wkwebview:
+    path: ../webview_flutter_wkwebview
 
 dev_dependencies:
   flutter_driver:

--- a/packages/webview_flutter/webview_flutter_android/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0
+
+* Implemented new `runJavaScript` and `runJavaScriptForResult` methods in platform interface.
+
 ## 2.0.15
 
 * Added Overrides in  FlutterWebView.java 

--- a/packages/webview_flutter/webview_flutter_android/android/build.gradle
+++ b/packages/webview_flutter/webview_flutter_android/android/build.gradle
@@ -54,4 +54,8 @@ android {
             }
         }
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }

--- a/packages/webview_flutter/webview_flutter_android/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/webview_flutter_android/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -244,7 +244,11 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
         currentUrl(result);
         break;
       case "evaluateJavascript":
-        evaluateJavaScript(methodCall, result);
+      case "runJavaScriptForResult":
+        evaluateJavaScript(methodCall, result, true);
+        break;
+      case "runJavaScript":
+        evaluateJavaScript(methodCall, result, false);
         break;
       case "addJavascriptChannels":
         addJavaScriptChannels(methodCall, result);
@@ -325,7 +329,8 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
   }
 
   @TargetApi(Build.VERSION_CODES.KITKAT)
-  private void evaluateJavaScript(MethodCall methodCall, final Result result) {
+  private void evaluateJavaScript(
+      MethodCall methodCall, final Result result, final boolean returnValue) {
     String jsString = (String) methodCall.arguments;
     if (jsString == null) {
       throw new UnsupportedOperationException("JavaScript string cannot be null");
@@ -335,7 +340,11 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
         new android.webkit.ValueCallback<String>() {
           @Override
           public void onReceiveValue(String value) {
-            result.success(value);
+            if (returnValue) {
+              result.success(value);
+            } else {
+              result.success(null);
+            }
           }
         });
   }

--- a/packages/webview_flutter/webview_flutter_android/android/src/test/java/io/flutter/plugins/webviewflutter/FlutterWebViewTest.java
+++ b/packages/webview_flutter/webview_flutter_android/android/src/test/java/io/flutter/plugins/webviewflutter/FlutterWebViewTest.java
@@ -6,31 +6,46 @@ package io.flutter.plugins.webviewflutter;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import android.content.Context;
 import android.webkit.DownloadListener;
 import android.webkit.WebChromeClient;
 import android.webkit.WebView;
+import io.flutter.plugin.common.MethodCall;
+import io.flutter.plugin.common.MethodChannel;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockedStatic;
 
 public class FlutterWebViewTest {
   private WebChromeClient mockWebChromeClient;
   private DownloadListener mockDownloadListener;
   private WebViewBuilder mockWebViewBuilder;
   private WebView mockWebView;
+  private MethodChannel.Result mockResult;
+  private Context mockContext;
+  private MethodChannel mockMethodChannel;
 
   @Before
   public void before() {
+
     mockWebChromeClient = mock(WebChromeClient.class);
     mockWebViewBuilder = mock(WebViewBuilder.class);
     mockWebView = mock(WebView.class);
     mockDownloadListener = mock(DownloadListener.class);
+    mockResult = mock(MethodChannel.Result.class);
+    mockContext = mock(Context.class);
+    mockMethodChannel = mock(MethodChannel.class);
 
     when(mockWebViewBuilder.setDomStorageEnabled(anyBoolean())).thenReturn(mockWebViewBuilder);
     when(mockWebViewBuilder.setJavaScriptCanOpenWindowsAutomatically(anyBoolean()))
@@ -41,12 +56,11 @@ public class FlutterWebViewTest {
         .thenReturn(mockWebViewBuilder);
     when(mockWebViewBuilder.setDownloadListener(any(DownloadListener.class)))
         .thenReturn(mockWebViewBuilder);
-
     when(mockWebViewBuilder.build()).thenReturn(mockWebView);
   }
 
   @Test
-  public void createWebView_should_create_webview_with_default_configuration() {
+  public void createWebView_shouldCreateWebViewWithDefaultConfiguration() {
     FlutterWebView.createWebView(
         mockWebViewBuilder, createParameterMap(false), mockWebChromeClient, mockDownloadListener);
 
@@ -55,6 +69,97 @@ public class FlutterWebViewTest {
     verify(mockWebViewBuilder, times(1)).setSupportMultipleWindows(true);
     verify(mockWebViewBuilder, times(1)).setUsesHybridComposition(false);
     verify(mockWebViewBuilder, times(1)).setWebChromeClient(mockWebChromeClient);
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void evaluateJavaScript_shouldThrowForNullString() {
+    try (MockedStatic<FlutterWebView> mockedFlutterWebView = mockStatic(FlutterWebView.class)) {
+      // Setup
+      mockedFlutterWebView
+          .when(
+              new MockedStatic.Verification() {
+                @Override
+                public void apply() throws Throwable {
+                  FlutterWebView.createWebView(
+                      (WebViewBuilder) any(),
+                      (Map<String, Object>) any(),
+                      (WebChromeClient) any(),
+                      (DownloadListener) any());
+                }
+              })
+          .thenReturn(mockWebView);
+      FlutterWebView flutterWebView =
+          new FlutterWebView(mockContext, mockMethodChannel, new HashMap<String, Object>(), null);
+
+      // Run
+      flutterWebView.onMethodCall(new MethodCall("runJavaScript", null), mockResult);
+    }
+  }
+
+  @Test
+  public void evaluateJavaScript_shouldReturnValueOnSuccessForReturnValue() {
+    try (MockedStatic<FlutterWebView> mockedFlutterWebView = mockStatic(FlutterWebView.class)) {
+      // Setup
+      mockedFlutterWebView
+          .when(
+              () ->
+                  FlutterWebView.createWebView(
+                      (WebViewBuilder) any(),
+                      (Map<String, Object>) any(),
+                      (WebChromeClient) any(),
+                      (DownloadListener) any()))
+          .thenReturn(mockWebView);
+      doAnswer(
+              invocation -> {
+                android.webkit.ValueCallback<String> callback = invocation.getArgument(1);
+                callback.onReceiveValue("Test JavaScript Result");
+                return null;
+              })
+          .when(mockWebView)
+          .evaluateJavascript(eq("Test JavaScript String"), any());
+      FlutterWebView flutterWebView =
+          new FlutterWebView(mockContext, mockMethodChannel, new HashMap<String, Object>(), null);
+
+      // Run
+      flutterWebView.onMethodCall(
+          new MethodCall("runJavaScriptForResult", "Test JavaScript String"), mockResult);
+
+      // Verify
+      verify(mockResult, times(1)).success("Test JavaScript Result");
+    }
+  }
+
+  @Test
+  public void evaluateJavaScript_shouldReturnNilOnSuccessForNoReturnValue() {
+    try (MockedStatic<FlutterWebView> mockedFlutterWebView = mockStatic(FlutterWebView.class)) {
+      // Setup
+      mockedFlutterWebView
+          .when(
+              () ->
+                  FlutterWebView.createWebView(
+                      (WebViewBuilder) any(),
+                      (Map<String, Object>) any(),
+                      (WebChromeClient) any(),
+                      (DownloadListener) any()))
+          .thenReturn(mockWebView);
+      doAnswer(
+              invocation -> {
+                android.webkit.ValueCallback<String> callback = invocation.getArgument(1);
+                callback.onReceiveValue("Test JavaScript Result");
+                return null;
+              })
+          .when(mockWebView)
+          .evaluateJavascript(eq("Test JavaScript String"), any());
+      FlutterWebView flutterWebView =
+          new FlutterWebView(mockContext, mockMethodChannel, new HashMap<String, Object>(), null);
+
+      // Run
+      flutterWebView.onMethodCall(
+          new MethodCall("runJavaScript", "Test JavaScript String"), mockResult);
+
+      // Verify
+      verify(mockResult, times(1)).success(isNull());
+    }
   }
 
   private Map<String, Object> createParameterMap(boolean usesHybridComposition) {

--- a/packages/webview_flutter/webview_flutter_android/example/integration_test/webview_flutter_test.dart
+++ b/packages/webview_flutter/webview_flutter_android/example/integration_test/webview_flutter_test.dart
@@ -107,7 +107,7 @@ void main() {
     await pageLoads.stream.firstWhere((String url) => url == currentUrl);
 
     final String content = await controller
-        .evaluateJavascript('document.documentElement.innerText');
+        .runJavaScriptForResult('document.documentElement.innerText');
     expect(content.contains('flutter_test_header'), isTrue);
   }, skip: _skipDueToIssue86757);
 
@@ -156,7 +156,7 @@ void main() {
     // See: https://github.com/flutter/flutter/issues/66318#issuecomment-701105380
     // TODO(cyanglaz): remove the workaround "1" in the end when the below issue is fixed.
     // https://github.com/flutter/flutter/issues/66318
-    await controller.evaluateJavascript('Echo.postMessage("hello");1;');
+    await controller.runJavaScriptForResult('Echo.postMessage("hello");1;');
     expect(messagesReceived, equals(<String>['hello']));
   }, skip: _skipDueToIssue86757);
 
@@ -403,7 +403,7 @@ void main() {
       WebViewController controller = await controllerCompleter.future;
       await pageLoaded.future;
 
-      String isPaused = await controller.evaluateJavascript('isPaused();');
+      String isPaused = await controller.runJavaScriptForResult('isPaused();');
       expect(isPaused, _webviewBool(false));
 
       controllerCompleter = Completer<WebViewController>();
@@ -432,7 +432,7 @@ void main() {
       controller = await controllerCompleter.future;
       await pageLoaded.future;
 
-      isPaused = await controller.evaluateJavascript('isPaused();');
+      isPaused = await controller.runJavaScriptForResult('isPaused();');
       expect(isPaused, _webviewBool(true));
     });
 
@@ -463,7 +463,7 @@ void main() {
       final WebViewController controller = await controllerCompleter.future;
       await pageLoaded.future;
 
-      String isPaused = await controller.evaluateJavascript('isPaused();');
+      String isPaused = await controller.runJavaScriptForResult('isPaused();');
       expect(isPaused, _webviewBool(false));
 
       pageLoaded = Completer<void>();
@@ -491,7 +491,7 @@ void main() {
 
       await pageLoaded.future;
 
-      isPaused = await controller.evaluateJavascript('isPaused();');
+      isPaused = await controller.runJavaScriptForResult('isPaused();');
       expect(isPaused, _webviewBool(false));
     });
 
@@ -541,7 +541,7 @@ void main() {
       await videoPlaying.future;
 
       String fullScreen =
-          await controller.evaluateJavascript('isFullScreen();');
+          await controller.runJavaScriptForResult('isFullScreen();');
       expect(fullScreen, _webviewBool(false));
     });
   });
@@ -607,7 +607,7 @@ void main() {
       await pageStarted.future;
       await pageLoaded.future;
 
-      String isPaused = await controller.evaluateJavascript('isPaused();');
+      String isPaused = await controller.runJavaScriptForResult('isPaused();');
       expect(isPaused, _webviewBool(false));
 
       controllerCompleter = Completer<WebViewController>();
@@ -641,7 +641,7 @@ void main() {
       await pageStarted.future;
       await pageLoaded.future;
 
-      isPaused = await controller.evaluateJavascript('isPaused();');
+      isPaused = await controller.runJavaScriptForResult('isPaused();');
       expect(isPaused, _webviewBool(true));
     });
 
@@ -677,7 +677,7 @@ void main() {
       await pageStarted.future;
       await pageLoaded.future;
 
-      String isPaused = await controller.evaluateJavascript('isPaused();');
+      String isPaused = await controller.runJavaScriptForResult('isPaused();');
       expect(isPaused, _webviewBool(false));
 
       pageStarted = Completer<void>();
@@ -710,7 +710,7 @@ void main() {
       await pageStarted.future;
       await pageLoaded.future;
 
-      isPaused = await controller.evaluateJavascript('isPaused();');
+      isPaused = await controller.runJavaScriptForResult('isPaused();');
       expect(isPaused, _webviewBool(false));
     });
   });
@@ -975,14 +975,14 @@ void main() {
 
       final WebViewController controller = await controllerCompleter.future;
       await pageLoaded.future;
-      final String viewportRectJSON = await _evaluateJavascript(
+      final String viewportRectJSON = await _runJavaScriptForResult(
           controller, 'JSON.stringify(viewport.getBoundingClientRect())');
       final Map<String, dynamic> viewportRectRelativeToViewport =
           jsonDecode(viewportRectJSON);
 
       // Check that the input is originally outside of the viewport.
 
-      final String initialInputClientRectJSON = await _evaluateJavascript(
+      final String initialInputClientRectJSON = await _runJavaScriptForResult(
           controller, 'JSON.stringify(inputEl.getBoundingClientRect())');
       final Map<String, dynamic> initialInputClientRectRelativeToViewport =
           jsonDecode(initialInputClientRectJSON);
@@ -992,11 +992,11 @@ void main() {
               viewportRectRelativeToViewport['bottom'],
           isFalse);
 
-      await controller.evaluateJavascript('inputEl.focus()');
+      await controller.runJavaScript('inputEl.focus()');
 
       // Check that focusing the input brought it into view.
 
-      final String lastInputClientRectJSON = await _evaluateJavascript(
+      final String lastInputClientRectJSON = await _runJavaScriptForResult(
           controller, 'JSON.stringify(inputEl.getBoundingClientRect())');
       final Map<String, dynamic> lastInputClientRectRelativeToViewport =
           jsonDecode(lastInputClientRectJSON);
@@ -1054,7 +1054,7 @@ void main() {
       await pageLoads.stream.first; // Wait for initial page load.
       final WebViewController controller = await controllerCompleter.future;
       await controller
-          .evaluateJavascript('location.href = "https://www.example.com/"');
+          .runJavaScript('location.href = "https://www.example.com/"');
 
       await pageLoads.stream.first; // Wait for the next page load.
       final String? currentUrl = await controller.currentUrl();
@@ -1180,7 +1180,7 @@ void main() {
       await pageLoads.stream.first; // Wait for initial page load.
       final WebViewController controller = await controllerCompleter.future;
       await controller
-          .evaluateJavascript('location.href = "https://www.youtube.com/"');
+          .runJavaScript('location.href = "https://www.youtube.com/"');
 
       // There should never be any second page load, since our new URL is
       // blocked. Still wait for a potential page change for some time in order
@@ -1221,7 +1221,7 @@ void main() {
       await pageLoads.stream.first; // Wait for initial page load.
       final WebViewController controller = await controllerCompleter.future;
       await controller
-          .evaluateJavascript('location.href = "https://www.example.com"');
+          .runJavaScript('location.href = "https://www.example.com"');
 
       await pageLoads.stream.first; // Wait for second page to load.
       final String? currentUrl = await controller.currentUrl();
@@ -1277,7 +1277,7 @@ void main() {
     );
     final WebViewController controller = await controllerCompleter.future;
     await controller
-        .evaluateJavascript('window.open("https://flutter.dev/", "_blank")');
+        .runJavaScript('window.open("https://flutter.dev/", "_blank")');
     await pageLoaded.future;
     final String? currentUrl = await controller.currentUrl();
     expect(currentUrl, 'https://flutter.dev/');
@@ -1313,8 +1313,7 @@ void main() {
       await pageLoaded.future;
       pageLoaded = Completer<void>();
 
-      await controller
-          .evaluateJavascript('window.open("https://www.example.com/")');
+      await controller.runJavaScript('window.open("https://www.example.com/")');
       await pageLoaded.future;
       pageLoaded = Completer<void>();
       expect(controller.currentUrl(), completion('https://www.example.com/'));
@@ -1385,9 +1384,10 @@ void main() {
       final WebViewController controller = await controllerCompleter.future;
       await pageLoadCompleter.future;
 
-      expect(controller.evaluateJavascript('iframeLoaded'), completion('true'));
+      expect(controller.runJavaScriptForResult('iframeLoaded'),
+          completion('true'));
       expect(
-        controller.evaluateJavascript(
+        controller.runJavaScriptForResult(
             'document.querySelector("p") && document.querySelector("p").textContent'),
         completion('null'),
       );
@@ -1406,10 +1406,10 @@ String _webviewBool(bool value) {
 
 /// Returns the value used for the HTTP User-Agent: request header in subsequent HTTP requests.
 Future<String> _getUserAgent(WebViewController controller) async {
-  return _evaluateJavascript(controller, 'navigator.userAgent;');
+  return _runJavaScriptForResult(controller, 'navigator.userAgent;');
 }
 
-Future<String> _evaluateJavascript(
+Future<String> _runJavaScriptForResult(
     WebViewController controller, String js) async {
-  return jsonDecode(await controller.evaluateJavascript(js));
+  return jsonDecode(await controller.runJavaScriptForResult(js));
 }

--- a/packages/webview_flutter/webview_flutter_android/example/lib/main.dart
+++ b/packages/webview_flutter/webview_flutter_android/example/lib/main.dart
@@ -195,14 +195,14 @@ class _SampleMenu extends StatelessWidget {
       WebViewController controller, BuildContext context) async {
     // Send a message with the user agent string to the Snackbar JavaScript channel we registered
     // with the WebView.
-    await controller.evaluateJavascript(
+    await controller.runJavaScript(
         'Snackbar.postMessage("User Agent: " + navigator.userAgent);');
   }
 
   void _onListCookies(
       WebViewController controller, BuildContext context) async {
     final String cookies =
-        await controller.evaluateJavascript('document.cookie');
+        await controller.runJavaScriptForResult('document.cookie');
     // ignore: deprecated_member_use
     Scaffold.of(context).showSnackBar(SnackBar(
       content: Column(
@@ -217,7 +217,7 @@ class _SampleMenu extends StatelessWidget {
   }
 
   void _onAddToCache(WebViewController controller, BuildContext context) async {
-    await controller.evaluateJavascript(
+    await controller.runJavaScript(
         'caches.open("test_caches_entry"); localStorage["test_localStorage"] = "dummy_entry";');
     // ignore: deprecated_member_use
     Scaffold.of(context).showSnackBar(const SnackBar(
@@ -226,7 +226,7 @@ class _SampleMenu extends StatelessWidget {
   }
 
   void _onListCache(WebViewController controller, BuildContext context) async {
-    await controller.evaluateJavascript('caches.keys()'
+    await controller.runJavaScript('caches.keys()'
         '.then((cacheKeys) => JSON.stringify({"cacheKeys" : cacheKeys, "localStorage" : localStorage}))'
         '.then((caches) => Snackbar.postMessage(caches))');
   }

--- a/packages/webview_flutter/webview_flutter_android/example/lib/web_view.dart
+++ b/packages/webview_flutter/webview_flutter_android/example/lib/web_view.dart
@@ -481,31 +481,41 @@ class WebViewController {
     _javascriptChannelRegistry.updateJavascriptChannelsFromSet(newChannels);
   }
 
-  /// Evaluates a JavaScript expression in the context of the current page.
+  /// Runs the given JavaScript in the context of the current page.
+  /// If you are looking for the result, use [runJavascriptForResult] instead.
+  /// The Future completes with an error if a JavaScript error occurred.
+  ///
+  /// When running Javascript in a [WebView], it is best practice to wait for
+  //  the [WebView.onPageFinished] callback. This guarantees all the Javascript
+  //  embedded in the main frame HTML has been loaded.
+  Future<void> runJavaScript(String javaScriptString) {
+    if (_settings.javascriptMode == JavascriptMode.disabled) {
+      return Future<void>.error(FlutterError(
+          'JavaScript mode must be enabled/unrestricted when calling runJavaScript.'));
+    }
+    return _webViewPlatformController.runJavaScript(javaScriptString);
+  }
+
+  /// Runs the given JavaScript in the context of the current page, and returns the result.
   ///
   /// On Android returns the evaluation result as a JSON formatted string.
   ///
   /// On iOS depending on the value type the return value would be one of:
-  ///
   ///  - For primitive JavaScript types: the value string formatted (e.g JavaScript 100 returns '100').
   ///  - For JavaScript arrays of supported types: a string formatted NSArray(e.g '(1,2,3), note that the string for NSArray is formatted and might contain newlines and extra spaces.').
-  ///  - Other non-primitive types are not supported on iOS and will complete the Future with an error.
+  ///  - Other non-primitive types are not supported on iOS and will return as null.
   ///
-  /// The Future completes with an error if a JavaScript error occurred, or on iOS, if the type of the
-  /// evaluated expression is not supported as described above.
+  /// The Future completes with an error if a JavaScript error occurred.
   ///
   /// When evaluating Javascript in a [WebView], it is best practice to wait for
   /// the [WebView.onPageFinished] callback. This guarantees all the Javascript
   /// embedded in the main frame HTML has been loaded.
-  Future<String> evaluateJavascript(String javascriptString) {
+  Future<String> runJavaScriptForResult(String javaScriptString) {
     if (_settings.javascriptMode == JavascriptMode.disabled) {
       return Future<String>.error(FlutterError(
-          'JavaScript mode must be enabled/unrestricted when calling evaluateJavascript.'));
+          'JavaScript mode must be enabled/unrestricted when calling runJavaScriptForResult.'));
     }
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return _webViewPlatformController.evaluateJavascript(javascriptString);
+    return _webViewPlatformController.runJavaScriptForResult(javaScriptString);
   }
 
   /// Returns the title of the currently loaded page.

--- a/packages/webview_flutter/webview_flutter_android/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter_android
 description: A Flutter plugin that provides a WebView widget on Android.
 repository: https://github.com/flutter/plugins/tree/master/packages/webview_flutter/webview_flutter_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview%22
-version: 2.0.15
+version: 2.1.0
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -20,7 +20,9 @@ dependencies:
   flutter:
     sdk: flutter
 
-  webview_flutter_platform_interface: ^1.0.0
+  # TODO (BeMacized): Change to version dependency once interface is published
+  webview_flutter_platform_interface:
+    path: ../webview_flutter_platform_interface
 
 dev_dependencies:
   flutter_driver:

--- a/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+
+* Added `runJavaScript` and `runJavaScriptForResult` interface methods to supersede `evaluateJavaScript`.
+
 ## 1.0.0
 
 * Extracted platform interface from `webview_flutter`.

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/src/method_channel/webview_method_channel.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/src/method_channel/webview_method_channel.dart
@@ -130,6 +130,18 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
   }
 
   @override
+  Future<void> runJavaScript(String javaScriptString) async {
+    await _channel.invokeMethod<String>('runJavaScript', javaScriptString);
+  }
+
+  @override
+  Future<String> runJavaScriptForResult(String javaScriptString) {
+    return _channel
+        .invokeMethod<String>('runJavaScriptForResult', javaScriptString)
+        .then((result) => result!);
+  }
+
+  @override
   Future<void> addJavascriptChannels(Set<String> javascriptChannelNames) {
     return _channel.invokeMethod<void>(
         'addJavascriptChannels', javascriptChannelNames.toList());

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_interface/webview_platform_controller.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_interface/webview_platform_controller.dart
@@ -112,6 +112,23 @@ abstract class WebViewPlatformController {
         "WebView evaluateJavascript is not implemented on the current platform");
   }
 
+  /// Runs the given JavaScript in the context of the current page.
+  ///
+  /// The Future completes with an error if a JavaScript error occurred.
+  Future<void> runJavaScript(String javaScriptString) {
+    throw UnimplementedError(
+        "WebView runJavaScript is not implemented on the current platform");
+  }
+
+  /// Runs the given JavaScript in the context of the current page, and returns the result.
+  ///
+  /// The Future completes with an error if a JavaScript error occurred, or successfully completes with a null value
+  /// if the type of the value is not supported(e.g on iOS not all non primitive type can be evaluated).
+  Future<String> runJavaScriptForResult(String javaScriptString) {
+    throw UnimplementedError(
+        "WebView runJavaScriptForResult is not implemented on the current platform");
+  }
+
   /// Adds new JavaScript channels to the set of enabled channels.
   ///
   /// For each value in this list the platform's webview should make sure that a corresponding

--- a/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/master/packages/webview_flut
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview_flutter%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.0.0
+version: 1.1.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/webview_flutter/webview_flutter_platform_interface/test/src/method_channel/webview_method_channel_test.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/test/src/method_channel/webview_method_channel_test.dart
@@ -31,6 +31,7 @@ void main() {
         case 'canGoBack':
         case 'canGoForward':
           return true;
+        case 'runJavaScriptForResult':
         case 'evaluateJavascript':
           return methodCall.arguments as String;
         case 'getScrollX':
@@ -280,27 +281,25 @@ void main() {
       );
     });
 
-    test('evaluateJavascript', () async {
-      final String evaluateJavascript =
-          await webViewPlatform.evaluateJavascript(
+    test('runJavaScript', () async {
+      await webViewPlatform.runJavaScript(
         'This simulates some Javascript code.',
       );
 
-      expect('This simulates some Javascript code.', evaluateJavascript);
       expect(
         log,
         <Matcher>[
           isMethodCall(
-            'evaluateJavascript',
+            'runJavaScript',
             arguments: 'This simulates some Javascript code.',
           ),
         ],
       );
     });
 
-    test('evaluateJavascript', () async {
+    test('runJavaScriptForResult', () async {
       final String evaluateJavascript =
-          await webViewPlatform.evaluateJavascript(
+          await webViewPlatform.runJavaScriptForResult(
         'This simulates some Javascript code.',
       );
 
@@ -309,7 +308,7 @@ void main() {
         log,
         <Matcher>[
           isMethodCall(
-            'evaluateJavascript',
+            'runJavaScriptForResult',
             arguments: 'This simulates some Javascript code.',
           ),
         ],

--- a/packages/webview_flutter/webview_flutter_platform_interface/test/src/method_channel/webview_method_channel_test.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/test/src/method_channel/webview_method_channel_test.dart
@@ -280,6 +280,42 @@ void main() {
       );
     });
 
+    test('evaluateJavascript', () async {
+      final String evaluateJavascript =
+          await webViewPlatform.evaluateJavascript(
+        'This simulates some Javascript code.',
+      );
+
+      expect('This simulates some Javascript code.', evaluateJavascript);
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall(
+            'evaluateJavascript',
+            arguments: 'This simulates some Javascript code.',
+          ),
+        ],
+      );
+    });
+
+    test('evaluateJavascript', () async {
+      final String evaluateJavascript =
+          await webViewPlatform.evaluateJavascript(
+        'This simulates some Javascript code.',
+      );
+
+      expect('This simulates some Javascript code.', evaluateJavascript);
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall(
+            'evaluateJavascript',
+            arguments: 'This simulates some Javascript code.',
+          ),
+        ],
+      );
+    });
+
     test('addJavascriptChannels', () async {
       final Set<String> channels = <String>{'channel one', 'channel two'};
       await webViewPlatform.addJavascriptChannels(channels);

--- a/packages/webview_flutter/webview_flutter_wkwebview/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_wkwebview/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0
+
+* Implemented new `runJavaScript` and `runJavaScriptForResult` methods in platform interface.
+
 ## 2.0.14
 
 * Update example App so navigation menu loads immediatly but only becomes available when `WebViewController` is available (same behavior as example App in webview_flutter package). 

--- a/packages/webview_flutter/webview_flutter_wkwebview/example/integration_test/webview_flutter_test.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/example/integration_test/webview_flutter_test.dart
@@ -103,7 +103,7 @@ void main() {
     await pageLoads.stream.firstWhere((String url) => url == currentUrl);
 
     final String content = await controller
-        .evaluateJavascript('document.documentElement.innerText');
+        .runJavaScriptForResult('document.documentElement.innerText');
     expect(content.contains('flutter_test_header'), isTrue);
   });
 
@@ -151,7 +151,7 @@ void main() {
     // See: https://github.com/flutter/flutter/issues/66318#issuecomment-701105380
     // TODO(cyanglaz): remove the workaround "1" in the end when the below issue is fixed.
     // https://github.com/flutter/flutter/issues/66318
-    await controller.evaluateJavascript('Echo.postMessage("hello");1;');
+    await controller.runJavaScriptForResult('Echo.postMessage("hello");1;');
     expect(messagesReceived, equals(<String>['hello']));
   });
 
@@ -397,7 +397,7 @@ void main() {
       WebViewController controller = await controllerCompleter.future;
       await pageLoaded.future;
 
-      String isPaused = await controller.evaluateJavascript('isPaused();');
+      String isPaused = await controller.runJavaScriptForResult('isPaused();');
       expect(isPaused, _webviewBool(false));
 
       controllerCompleter = Completer<WebViewController>();
@@ -426,7 +426,7 @@ void main() {
       controller = await controllerCompleter.future;
       await pageLoaded.future;
 
-      isPaused = await controller.evaluateJavascript('isPaused();');
+      isPaused = await controller.runJavaScriptForResult('isPaused();');
       expect(isPaused, _webviewBool(true));
     });
 
@@ -457,7 +457,7 @@ void main() {
       final WebViewController controller = await controllerCompleter.future;
       await pageLoaded.future;
 
-      String isPaused = await controller.evaluateJavascript('isPaused();');
+      String isPaused = await controller.runJavaScriptForResult('isPaused();');
       expect(isPaused, _webviewBool(false));
 
       pageLoaded = Completer<void>();
@@ -485,7 +485,7 @@ void main() {
 
       await pageLoaded.future;
 
-      isPaused = await controller.evaluateJavascript('isPaused();');
+      isPaused = await controller.runJavaScriptForResult('isPaused();');
       expect(isPaused, _webviewBool(false));
     });
 
@@ -535,7 +535,7 @@ void main() {
       await videoPlaying.future;
 
       String fullScreen =
-          await controller.evaluateJavascript('isFullScreen();');
+          await controller.runJavaScriptForResult('isFullScreen();');
       expect(fullScreen, _webviewBool(false));
     });
 
@@ -586,7 +586,7 @@ void main() {
       await videoPlaying.future;
 
       String fullScreen =
-          await controller.evaluateJavascript('isFullScreen();');
+          await controller.runJavaScriptForResult('isFullScreen();');
       expect(fullScreen, _webviewBool(true));
     });
   });
@@ -652,7 +652,7 @@ void main() {
       await pageStarted.future;
       await pageLoaded.future;
 
-      String isPaused = await controller.evaluateJavascript('isPaused();');
+      String isPaused = await controller.runJavaScriptForResult('isPaused();');
       expect(isPaused, _webviewBool(false));
 
       controllerCompleter = Completer<WebViewController>();
@@ -686,7 +686,7 @@ void main() {
       await pageStarted.future;
       await pageLoaded.future;
 
-      isPaused = await controller.evaluateJavascript('isPaused();');
+      isPaused = await controller.runJavaScriptForResult('isPaused();');
       expect(isPaused, _webviewBool(true));
     });
 
@@ -722,7 +722,7 @@ void main() {
       await pageStarted.future;
       await pageLoaded.future;
 
-      String isPaused = await controller.evaluateJavascript('isPaused();');
+      String isPaused = await controller.runJavaScriptForResult('isPaused();');
       expect(isPaused, _webviewBool(false));
 
       pageStarted = Completer<void>();
@@ -755,7 +755,7 @@ void main() {
       await pageStarted.future;
       await pageLoaded.future;
 
-      isPaused = await controller.evaluateJavascript('isPaused();');
+      isPaused = await controller.runJavaScriptForResult('isPaused();');
       expect(isPaused, _webviewBool(false));
     });
   });
@@ -913,7 +913,7 @@ void main() {
       await pageLoads.stream.first; // Wait for initial page load.
       final WebViewController controller = await controllerCompleter.future;
       await controller
-          .evaluateJavascript('location.href = "https://www.example.com/"');
+          .runJavaScript('location.href = "https://www.example.com/"');
 
       await pageLoads.stream.first; // Wait for the next page load.
       final String? currentUrl = await controller.currentUrl();
@@ -1044,7 +1044,7 @@ void main() {
       await pageLoads.stream.first; // Wait for initial page load.
       final WebViewController controller = await controllerCompleter.future;
       await controller
-          .evaluateJavascript('location.href = "https://www.youtube.com/"');
+          .runJavaScript('location.href = "https://www.youtube.com/"');
 
       // There should never be any second page load, since our new URL is
       // blocked. Still wait for a potential page change for some time in order
@@ -1085,7 +1085,7 @@ void main() {
       await pageLoads.stream.first; // Wait for initial page load.
       final WebViewController controller = await controllerCompleter.future;
       await controller
-          .evaluateJavascript('location.href = "https://www.example.com"');
+          .runJavaScript('location.href = "https://www.example.com"');
 
       await pageLoads.stream.first; // Wait for second page to load.
       final String? currentUrl = await controller.currentUrl();
@@ -1141,7 +1141,7 @@ void main() {
     );
     final WebViewController controller = await controllerCompleter.future;
     await controller
-        .evaluateJavascript('window.open("https://flutter.dev/", "_blank")');
+        .runJavaScript('window.open("https://flutter.dev/", "_blank")');
     await pageLoaded.future;
     final String? currentUrl = await controller.currentUrl();
     expect(currentUrl, 'https://flutter.dev/');
@@ -1175,8 +1175,7 @@ void main() {
       await pageLoaded.future;
       pageLoaded = Completer<void>();
 
-      await controller
-          .evaluateJavascript('window.open("https://www.example.com/")');
+      await controller.runJavaScript('window.open("https://www.example.com/")');
       await pageLoaded.future;
       pageLoaded = Completer<void>();
       expect(controller.currentUrl(), completion('https://www.example.com/'));
@@ -1201,13 +1200,13 @@ String _webviewBool(bool value) {
 
 /// Returns the value used for the HTTP User-Agent: request header in subsequent HTTP requests.
 Future<String> _getUserAgent(WebViewController controller) async {
-  return _evaluateJavascript(controller, 'navigator.userAgent;');
+  return _runJavaScriptForResult(controller, 'navigator.userAgent;');
 }
 
-Future<String> _evaluateJavascript(
+Future<String> _runJavaScriptForResult(
     WebViewController controller, String js) async {
   if (defaultTargetPlatform == TargetPlatform.iOS) {
-    return await controller.evaluateJavascript(js);
+    return await controller.runJavaScriptForResult(js);
   }
-  return jsonDecode(await controller.evaluateJavascript(js));
+  return jsonDecode(await controller.runJavaScriptForResult(js));
 }

--- a/packages/webview_flutter/webview_flutter_wkwebview/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/webview_flutter/webview_flutter_wkwebview/example/ios/Runner.xcodeproj/project.pbxproj
@@ -277,16 +277,13 @@
 				ORGANIZATIONNAME = "The Flutter Authors";
 				TargetAttributes = {
 					68BDCAE823C3F7CB00D9C032 = {
-						DevelopmentTeam = 7624MWN53C;
 						ProvisioningStyle = Automatic;
 					};
 					97C146ED1CF9000F007C117D = {
 						CreatedOnToolsVersion = 7.3.1;
-						DevelopmentTeam = 7624MWN53C;
 					};
 					F7151F73266057800028CB91 = {
 						CreatedOnToolsVersion = 12.5;
-						DevelopmentTeam = 7624MWN53C;
 						ProvisioningStyle = Automatic;
 						TestTargetID = 97C146ED1CF9000F007C117D;
 					};
@@ -480,7 +477,6 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 7624MWN53C;
 				INFOPLIST_FILE = RunnerTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.RunnerTests;
@@ -495,7 +491,6 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 7624MWN53C;
 				INFOPLIST_FILE = RunnerTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.RunnerTests;
@@ -616,7 +611,6 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = 7624MWN53C;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -640,7 +634,6 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = 7624MWN53C;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -662,7 +655,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 7624MWN53C;
 				INFOPLIST_FILE = RunnerUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_FAST_MATH = YES;
@@ -676,7 +668,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 7624MWN53C;
 				INFOPLIST_FILE = RunnerUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_FAST_MATH = YES;

--- a/packages/webview_flutter/webview_flutter_wkwebview/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/webview_flutter/webview_flutter_wkwebview/example/ios/Runner.xcodeproj/project.pbxproj
@@ -277,13 +277,16 @@
 				ORGANIZATIONNAME = "The Flutter Authors";
 				TargetAttributes = {
 					68BDCAE823C3F7CB00D9C032 = {
+						DevelopmentTeam = 7624MWN53C;
 						ProvisioningStyle = Automatic;
 					};
 					97C146ED1CF9000F007C117D = {
 						CreatedOnToolsVersion = 7.3.1;
+						DevelopmentTeam = 7624MWN53C;
 					};
 					F7151F73266057800028CB91 = {
 						CreatedOnToolsVersion = 12.5;
+						DevelopmentTeam = 7624MWN53C;
 						ProvisioningStyle = Automatic;
 						TestTargetID = 97C146ED1CF9000F007C117D;
 					};
@@ -477,6 +480,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 7624MWN53C;
 				INFOPLIST_FILE = RunnerTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.RunnerTests;
@@ -491,6 +495,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 7624MWN53C;
 				INFOPLIST_FILE = RunnerTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = dev.flutter.plugins.RunnerTests;
@@ -611,6 +616,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = 7624MWN53C;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -634,6 +640,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = 7624MWN53C;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -655,6 +662,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 7624MWN53C;
 				INFOPLIST_FILE = RunnerUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_FAST_MATH = YES;
@@ -668,6 +676,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 7624MWN53C;
 				INFOPLIST_FILE = RunnerUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_FAST_MATH = YES;

--- a/packages/webview_flutter/webview_flutter_wkwebview/example/ios/RunnerTests/FLTWebViewTests.m
+++ b/packages/webview_flutter/webview_flutter_wkwebview/example/ios/RunnerTests/FLTWebViewTests.m
@@ -88,4 +88,250 @@ static bool feq(CGFloat a, CGFloat b) { return fabs(b - a) < FLT_EPSILON; }
   }
 }
 
+- (void)testRunJavaScriptFailsForNullString {
+  // Setup
+  FLTWebViewController *controller =
+      [[FLTWebViewController alloc] initWithFrame:CGRectMake(0, 0, 300, 400)
+                                   viewIdentifier:1
+                                        arguments:nil
+                                  binaryMessenger:self.mockBinaryMessenger];
+  XCTestExpectation *resultExpectation =
+      [self expectationWithDescription:@"Should return error result over the method channel."];
+
+  // Run
+  [controller onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"runJavaScript"
+                                                             arguments:nil]
+                    result:^(id _Nullable result) {
+                      XCTAssertTrue([result class] == [FlutterError class]);
+                      [resultExpectation fulfill];
+                    }];
+
+  // Verify
+  [self waitForExpectationsWithTimeout:30.0 handler:nil];
+}
+
+- (void)testRunJavaScriptRunsStringWithSuccessResult {
+  // Setup
+  FLTWebViewController *controller =
+      [[FLTWebViewController alloc] initWithFrame:CGRectMake(0, 0, 300, 400)
+                                   viewIdentifier:1
+                                        arguments:nil
+                                  binaryMessenger:self.mockBinaryMessenger];
+  XCTestExpectation *resultExpectation =
+      [self expectationWithDescription:@"Should return successful result over the method channel."];
+  FLTWKWebView *mockView = OCMClassMock(FLTWKWebView.class);
+  [OCMStub([mockView evaluateJavaScript:[OCMArg any]
+                      completionHandler:[OCMArg any]]) andDo:^(NSInvocation *invocation) {
+    // __unsafe_unretained: https://github.com/erikdoe/ocmock/issues/384#issuecomment-589376668
+    __unsafe_unretained void (^evalResultHandler)(id, NSError *);
+    [invocation getArgument:&evalResultHandler atIndex:3];
+    evalResultHandler(@"RESULT", nil);
+  }];
+  controller.webView = mockView;
+
+  // Run
+  [controller onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"runJavaScript"
+                                                             arguments:@"Test JavaScript String"]
+                    result:^(id _Nullable result) {
+                      XCTAssertNil(result);
+                      [resultExpectation fulfill];
+                    }];
+
+  // Verify
+  [self waitForExpectationsWithTimeout:30.0 handler:nil];
+}
+
+- (void)testRunJavaScriptReturnsErrorResultForWKError {
+  // Setup
+  FLTWebViewController *controller =
+      [[FLTWebViewController alloc] initWithFrame:CGRectMake(0, 0, 300, 400)
+                                   viewIdentifier:1
+                                        arguments:nil
+                                  binaryMessenger:self.mockBinaryMessenger];
+  XCTestExpectation *resultExpectation =
+      [self expectationWithDescription:@"Should return error result over the method channel."];
+  NSError *testError =
+      [NSError errorWithDomain:@""
+                          // Any error code but WKErrorJavaScriptResultTypeIsUnsupported
+                          code:WKErrorJavaScriptResultTypeIsUnsupported + 1
+                      userInfo:@{NSLocalizedDescriptionKey : @"Test Error"}];
+  FLTWKWebView *mockView = OCMClassMock(FLTWKWebView.class);
+  [OCMStub([mockView evaluateJavaScript:[OCMArg any]
+                      completionHandler:[OCMArg any]]) andDo:^(NSInvocation *invocation) {
+    // __unsafe_unretained: https://github.com/erikdoe/ocmock/issues/384#issuecomment-589376668
+    __unsafe_unretained void (^evalResultHandler)(id, NSError *);
+    [invocation getArgument:&evalResultHandler atIndex:3];
+    evalResultHandler(nil, testError);
+  }];
+  controller.webView = mockView;
+
+  // Run
+  [controller onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"runJavaScript"
+                                                             arguments:@"Test JavaScript String"]
+                    result:^(id _Nullable result) {
+                      XCTAssertTrue([result class] == [FlutterError class]);
+                      [resultExpectation fulfill];
+                    }];
+
+  // Verify
+  [self waitForExpectationsWithTimeout:30.0 handler:nil];
+}
+
+- (void)testRunJavaScriptReturnsSuccessForWKErrorJavaScriptResultTypeIsUnsupported {
+  // Setup
+  FLTWebViewController *controller =
+      [[FLTWebViewController alloc] initWithFrame:CGRectMake(0, 0, 300, 400)
+                                   viewIdentifier:1
+                                        arguments:nil
+                                  binaryMessenger:self.mockBinaryMessenger];
+  XCTestExpectation *resultExpectation =
+      [self expectationWithDescription:@"Should return nil result over the method channel."];
+  NSError *testError = [NSError errorWithDomain:@""
+                                           code:WKErrorJavaScriptResultTypeIsUnsupported
+                                       userInfo:@{NSLocalizedDescriptionKey : @"Test Error"}];
+  FLTWKWebView *mockView = OCMClassMock(FLTWKWebView.class);
+  [OCMStub([mockView evaluateJavaScript:[OCMArg any]
+                      completionHandler:[OCMArg any]]) andDo:^(NSInvocation *invocation) {
+    // __unsafe_unretained: https://github.com/erikdoe/ocmock/issues/384#issuecomment-589376668
+    __unsafe_unretained void (^evalResultHandler)(id, NSError *);
+    [invocation getArgument:&evalResultHandler atIndex:3];
+    evalResultHandler(nil, testError);
+  }];
+  controller.webView = mockView;
+
+  // Run
+  [controller onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"runJavaScript"
+                                                             arguments:@"Test JavaScript String"]
+                    result:^(id _Nullable result) {
+                      XCTAssertNil(result);
+                      [resultExpectation fulfill];
+                    }];
+
+  // Verify
+  [self waitForExpectationsWithTimeout:30.0 handler:nil];
+}
+
+- (void)testRunJavaScriptForResultFailsForNullString {
+  // Setup
+  FLTWebViewController *controller =
+      [[FLTWebViewController alloc] initWithFrame:CGRectMake(0, 0, 300, 400)
+                                   viewIdentifier:1
+                                        arguments:nil
+                                  binaryMessenger:self.mockBinaryMessenger];
+  XCTestExpectation *resultExpectation =
+      [self expectationWithDescription:@"Should return error result over the method channel."];
+
+  // Run
+  [controller onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"runJavaScriptForResult"
+                                                             arguments:nil]
+                    result:^(id _Nullable result) {
+                      XCTAssertTrue([result class] == [FlutterError class]);
+                      [resultExpectation fulfill];
+                    }];
+
+  // Verify
+  [self waitForExpectationsWithTimeout:30.0 handler:nil];
+}
+
+- (void)testRunJavaScriptForResultRunsStringWithSuccessResult {
+  // Setup
+  FLTWebViewController *controller =
+      [[FLTWebViewController alloc] initWithFrame:CGRectMake(0, 0, 300, 400)
+                                   viewIdentifier:1
+                                        arguments:nil
+                                  binaryMessenger:self.mockBinaryMessenger];
+  XCTestExpectation *resultExpectation =
+      [self expectationWithDescription:@"Should return successful result over the method channel."];
+  FLTWKWebView *mockView = OCMClassMock(FLTWKWebView.class);
+  [OCMStub([mockView evaluateJavaScript:[OCMArg any]
+                      completionHandler:[OCMArg any]]) andDo:^(NSInvocation *invocation) {
+    // __unsafe_unretained: https://github.com/erikdoe/ocmock/issues/384#issuecomment-589376668
+    __unsafe_unretained void (^evalResultHandler)(id, NSError *);
+    [invocation getArgument:&evalResultHandler atIndex:3];
+    evalResultHandler(@"RESULT", nil);
+  }];
+  controller.webView = mockView;
+
+  // Run
+  [controller onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"runJavaScriptForResult"
+                                                             arguments:@"Test JavaScript String"]
+                    result:^(id _Nullable result) {
+                      XCTAssertTrue([@"RESULT" isEqualToString:result]);
+                      [resultExpectation fulfill];
+                    }];
+
+  // Verify
+  [self waitForExpectationsWithTimeout:30.0 handler:nil];
+}
+
+- (void)testRunJavaScriptForResultReturnsErrorResultForWKError {
+  // Setup
+  FLTWebViewController *controller =
+      [[FLTWebViewController alloc] initWithFrame:CGRectMake(0, 0, 300, 400)
+                                   viewIdentifier:1
+                                        arguments:nil
+                                  binaryMessenger:self.mockBinaryMessenger];
+  XCTestExpectation *resultExpectation =
+      [self expectationWithDescription:@"Should return error result over the method channel."];
+  NSError *testError =
+      [NSError errorWithDomain:@""
+                          // Any error code but WKErrorJavaScriptResultTypeIsUnsupported
+                          code:WKErrorJavaScriptResultTypeIsUnsupported + 1
+                      userInfo:@{NSLocalizedDescriptionKey : @"Test Error"}];
+  FLTWKWebView *mockView = OCMClassMock(FLTWKWebView.class);
+  [OCMStub([mockView evaluateJavaScript:[OCMArg any]
+                      completionHandler:[OCMArg any]]) andDo:^(NSInvocation *invocation) {
+    // __unsafe_unretained: https://github.com/erikdoe/ocmock/issues/384#issuecomment-589376668
+    __unsafe_unretained void (^evalResultHandler)(id, NSError *);
+    [invocation getArgument:&evalResultHandler atIndex:3];
+    evalResultHandler(nil, testError);
+  }];
+  controller.webView = mockView;
+
+  // Run
+  [controller onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"runJavaScriptForResult"
+                                                             arguments:@"Test JavaScript String"]
+                    result:^(id _Nullable result) {
+                      XCTAssertTrue([result class] == [FlutterError class]);
+                      [resultExpectation fulfill];
+                    }];
+
+  // Verify
+  [self waitForExpectationsWithTimeout:30.0 handler:nil];
+}
+
+- (void)testRunJavaScriptForResultReturnsNilForWKErrorJavaScriptResultTypeIsUnsupported {
+  // Setup
+  FLTWebViewController *controller =
+      [[FLTWebViewController alloc] initWithFrame:CGRectMake(0, 0, 300, 400)
+                                   viewIdentifier:1
+                                        arguments:nil
+                                  binaryMessenger:self.mockBinaryMessenger];
+  XCTestExpectation *resultExpectation =
+      [self expectationWithDescription:@"Should return nil result over the method channel."];
+  NSError *testError = [NSError errorWithDomain:@""
+                                           code:WKErrorJavaScriptResultTypeIsUnsupported
+                                       userInfo:@{NSLocalizedDescriptionKey : @"Test Error"}];
+  FLTWKWebView *mockView = OCMClassMock(FLTWKWebView.class);
+  [OCMStub([mockView evaluateJavaScript:[OCMArg any]
+                      completionHandler:[OCMArg any]]) andDo:^(NSInvocation *invocation) {
+    // __unsafe_unretained: https://github.com/erikdoe/ocmock/issues/384#issuecomment-589376668
+    __unsafe_unretained void (^evalResultHandler)(id, NSError *);
+    [invocation getArgument:&evalResultHandler atIndex:3];
+    evalResultHandler(nil, testError);
+  }];
+  controller.webView = mockView;
+
+  // Run
+  [controller onMethodCall:[FlutterMethodCall methodCallWithMethodName:@"runJavaScriptForResult"
+                                                             arguments:@"Test JavaScript String"]
+                    result:^(id _Nullable result) {
+                      XCTAssertNil(result);
+                      [resultExpectation fulfill];
+                    }];
+
+  // Verify
+  [self waitForExpectationsWithTimeout:30.0 handler:nil];
+}
+
 @end

--- a/packages/webview_flutter/webview_flutter_wkwebview/example/lib/main.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/example/lib/main.dart
@@ -199,14 +199,14 @@ class _SampleMenu extends StatelessWidget {
       WebViewController controller, BuildContext context) async {
     // Send a message with the user agent string to the Snackbar JavaScript channel we registered
     // with the WebView.
-    await controller.evaluateJavascript(
+    await controller.runJavaScript(
         'Snackbar.postMessage("User Agent: " + navigator.userAgent);');
   }
 
   void _onListCookies(
       WebViewController controller, BuildContext context) async {
     final String cookies =
-        await controller.evaluateJavascript('document.cookie');
+        await controller.runJavaScriptForResult('document.cookie');
     ScaffoldMessenger.of(context).showSnackBar(SnackBar(
       content: Column(
         mainAxisAlignment: MainAxisAlignment.end,
@@ -220,7 +220,7 @@ class _SampleMenu extends StatelessWidget {
   }
 
   void _onAddToCache(WebViewController controller, BuildContext context) async {
-    await controller.evaluateJavascript(
+    await controller.runJavaScript(
         'caches.open("test_caches_entry"); localStorage["test_localStorage"] = "dummy_entry";');
     ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
       content: Text('Added a test entry to cache.'),
@@ -228,7 +228,7 @@ class _SampleMenu extends StatelessWidget {
   }
 
   void _onListCache(WebViewController controller, BuildContext context) async {
-    await controller.evaluateJavascript('caches.keys()'
+    await controller.runJavaScript('caches.keys()'
         '.then((cacheKeys) => JSON.stringify({"cacheKeys" : cacheKeys, "localStorage" : localStorage}))'
         '.then((caches) => Snackbar.postMessage(caches))');
   }

--- a/packages/webview_flutter/webview_flutter_wkwebview/example/lib/web_view.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/example/lib/web_view.dart
@@ -410,31 +410,41 @@ class WebViewController {
     _javascriptChannelRegistry.updateJavascriptChannelsFromSet(newChannels);
   }
 
-  /// Evaluates a JavaScript expression in the context of the current page.
+  /// Runs the given JavaScript in the context of the current page.
+  /// If you are looking for the result, use [runJavascriptForResult] instead.
+  /// The Future completes with an error if a JavaScript error occurred.
+  ///
+  /// When running Javascript in a [WebView], it is best practice to wait for
+  //  the [WebView.onPageFinished] callback. This guarantees all the Javascript
+  //  embedded in the main frame HTML has been loaded.
+  Future<void> runJavaScript(String javaScriptString) {
+    if (_settings.javascriptMode == JavascriptMode.disabled) {
+      return Future<void>.error(FlutterError(
+          'JavaScript mode must be enabled/unrestricted when calling runJavaScript.'));
+    }
+    return _webViewPlatformController.runJavaScript(javaScriptString);
+  }
+
+  /// Runs the given JavaScript in the context of the current page, and returns the result.
   ///
   /// On Android returns the evaluation result as a JSON formatted string.
   ///
   /// On iOS depending on the value type the return value would be one of:
-  ///
   ///  - For primitive JavaScript types: the value string formatted (e.g JavaScript 100 returns '100').
   ///  - For JavaScript arrays of supported types: a string formatted NSArray(e.g '(1,2,3), note that the string for NSArray is formatted and might contain newlines and extra spaces.').
-  ///  - Other non-primitive types are not supported on iOS and will complete the Future with an error.
+  ///  - Other non-primitive types are not supported on iOS and will return as null.
   ///
-  /// The Future completes with an error if a JavaScript error occurred, or on iOS, if the type of the
-  /// evaluated expression is not supported as described above.
+  /// The Future completes with an error if a JavaScript error occurred.
   ///
   /// When evaluating Javascript in a [WebView], it is best practice to wait for
   /// the [WebView.onPageFinished] callback. This guarantees all the Javascript
   /// embedded in the main frame HTML has been loaded.
-  Future<String> evaluateJavascript(String javascriptString) {
+  Future<String> runJavaScriptForResult(String javaScriptString) {
     if (_settings.javascriptMode == JavascriptMode.disabled) {
       return Future<String>.error(FlutterError(
-          'JavaScript mode must be enabled/unrestricted when calling evaluateJavascript.'));
+          'JavaScript mode must be enabled/unrestricted when calling runJavaScriptForResult.'));
     }
-    // TODO(amirh): remove this on when the invokeMethod update makes it to stable Flutter.
-    // https://github.com/flutter/flutter/issues/26431
-    // ignore: strong_mode_implicit_dynamic_method
-    return _webViewPlatformController.evaluateJavascript(javascriptString);
+    return _webViewPlatformController.runJavaScriptForResult(javaScriptString);
   }
 
   /// Returns the title of the currently loaded page.

--- a/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FlutterWebView.h
+++ b/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FlutterWebView.h
@@ -7,7 +7,17 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ * The WkWebView used for the plugin.
+ *
+ * This class overrides some methods in `WKWebView` to serve the needs for the plugin.
+ */
+@interface FLTWKWebView : WKWebView
+@end
+
 @interface FLTWebViewController : NSObject <FlutterPlatformView, WKUIDelegate>
+
+@property(nonatomic) FLTWKWebView* webView;
 
 - (instancetype)initWithFrame:(CGRect)frame
                viewIdentifier:(int64_t)viewId
@@ -15,18 +25,12 @@ NS_ASSUME_NONNULL_BEGIN
               binaryMessenger:(NSObject<FlutterBinaryMessenger>*)messenger;
 
 - (UIView*)view;
+
+- (void)onMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result;
 @end
 
 @interface FLTWebViewFactory : NSObject <FlutterPlatformViewFactory>
 - (instancetype)initWithMessenger:(NSObject<FlutterBinaryMessenger>*)messenger;
-@end
-
-/**
- * The WkWebView used for the plugin.
- *
- * This class overrides some methods in `WKWebView` to serve the needs for the plugin.
- */
-@interface FLTWKWebView : WKWebView
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/webview_flutter/webview_flutter_wkwebview/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_wkwebview/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter_wkwebview
 description: A Flutter plugin that provides a WebView widget based on Apple's WKWebView control.
 repository: https://github.com/flutter/plugins/tree/master/packages/webview_flutter/webview_flutter_wkwebview
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview%22
-version: 2.0.14
+version: 2.1.0
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -19,7 +19,9 @@ dependencies:
   flutter:
     sdk: flutter
 
-  webview_flutter_platform_interface: ^1.0.0
+  # TODO (BeMacized): Change to version dependency once interface is published
+  webview_flutter_platform_interface:
+    path: ../webview_flutter_platform_interface
 
 dev_dependencies:
   flutter_driver:


### PR DESCRIPTION
This PR adds two new methods, `runJavaScript` and `runJavaScriptForResult`, to supersede `evaluateJavascript`.

This is meant as a solution to the issue mentioned in flutter/flutter#66318, and was discussed offline with @mvanbeusekom and @stuartmorgan.

As this PR also depends on and includes the changes from #4401 and #4402, this PR will remain in draft state until those PR s are merged and published.

Relevant issue:
- flutter/flutter#66318

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.