### PR TITLE
Fix order-dependant platform interface tests

### DIFF
--- a/packages/file_selector/file_selector_platform_interface/test/file_selector_platform_interface_test.dart
+++ b/packages/file_selector/file_selector_platform_interface/test/file_selector_platform_interface_test.dart
@@ -7,10 +7,12 @@ import 'package:file_selector_platform_interface/src/method_channel/method_chann
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  // Store the initial instance before any tests change it.
+  final FileSelectorPlatform initialInstance = FileSelectorPlatform.instance;
+
   group('$FileSelectorPlatform', () {
     test('$MethodChannelFileSelector() is the default instance', () {
-      expect(FileSelectorPlatform.instance,
-          isInstanceOf<MethodChannelFileSelector>());
+      expect(initialInstance, isInstanceOf<MethodChannelFileSelector>());
     });
 
     test('Can be extended', () {

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/platform_interface/google_maps_flutter_platform_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/platform_interface/google_maps_flutter_platform_test.dart
@@ -16,10 +16,13 @@ import 'package:google_maps_flutter_platform_interface/google_maps_flutter_platf
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  // Store the initial instance before any tests change it.
+  final GoogleMapsFlutterPlatform initialInstance =
+      GoogleMapsFlutterPlatform.instance;
+
   group('$GoogleMapsFlutterPlatform', () {
     test('$MethodChannelGoogleMapsFlutter() is the default instance', () {
-      expect(GoogleMapsFlutterPlatform.instance,
-          isInstanceOf<MethodChannelGoogleMapsFlutter>());
+      expect(initialInstance, isInstanceOf<MethodChannelGoogleMapsFlutter>());
     });
 
     test('Cannot be implemented with `implements`', () {

--- a/packages/google_sign_in/google_sign_in_platform_interface/test/google_sign_in_platform_interface_test.dart
+++ b/packages/google_sign_in/google_sign_in_platform_interface/test/google_sign_in_platform_interface_test.dart
@@ -7,9 +7,12 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 
 void main() {
+  // Store the initial instance before any tests change it.
+  final GoogleSignInPlatform initialInstance = GoogleSignInPlatform.instance;
+
   group('$GoogleSignInPlatform', () {
     test('$MethodChannelGoogleSignIn is the default instance', () {
-      expect(GoogleSignInPlatform.instance, isA<MethodChannelGoogleSignIn>());
+      expect(initialInstance, isA<MethodChannelGoogleSignIn>());
     });
 
     test('Cannot be implemented with `implements`', () {

--- a/packages/quick_actions/quick_actions_platform_interface/test/quick_actions_platform_interface_test.dart
+++ b/packages/quick_actions/quick_actions_platform_interface/test/quick_actions_platform_interface_test.dart
@@ -9,9 +9,12 @@ import 'package:quick_actions_platform_interface/platform_interface/quick_action
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  // Store the initial instance before any tests change it.
+  final QuickActionsPlatform initialInstance = QuickActionsPlatform.instance;
+
   group('$QuickActionsPlatform', () {
     test('$MethodChannelQuickActions is the default instance', () {
-      expect(QuickActionsPlatform.instance, isA<MethodChannelQuickActions>());
+      expect(initialInstance, isA<MethodChannelQuickActions>());
     });
 
     test('Cannot be implemented with `implements`', () {

--- a/packages/url_launcher/url_launcher_platform_interface/test/method_channel_url_launcher_test.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/test/method_channel_url_launcher_test.dart
@@ -14,10 +14,12 @@ import 'package:url_launcher_platform_interface/url_launcher_platform_interface.
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  // Store the initial instance before any tests change it.
+  final UrlLauncherPlatform initialInstance = UrlLauncherPlatform.instance;
+
   group('$UrlLauncherPlatform', () {
     test('$MethodChannelUrlLauncher() is the default instance', () {
-      expect(UrlLauncherPlatform.instance,
-          isInstanceOf<MethodChannelUrlLauncher>());
+      expect(initialInstance, isInstanceOf<MethodChannelUrlLauncher>());
     });
 
     test('Cannot be implemented with `implements`', () {

--- a/packages/video_player/video_player_platform_interface/test/method_channel_video_player_test.dart
+++ b/packages/video_player/video_player_platform_interface/test/method_channel_video_player_test.dart
@@ -92,10 +92,12 @@ class _ApiLogger implements TestHostVideoPlayerApi {
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  // Store the initial instance before any tests change it.
+  final VideoPlayerPlatform initialInstance = VideoPlayerPlatform.instance;
+
   group('$VideoPlayerPlatform', () {
     test('$MethodChannelVideoPlayer() is the default instance', () {
-      expect(VideoPlayerPlatform.instance,
-          isInstanceOf<MethodChannelVideoPlayer>());
+      expect(initialInstance, isInstanceOf<MethodChannelVideoPlayer>());
     });
   });
 


### PR DESCRIPTION
Fixes all instance of an anti-pattern that was cloned among many of our
platform interfaces, where one test asserts that the static instance is
of a specific class, but other tests change that static instance, such
that the initial test fails if not run first.

Fixes https://github.com/flutter/flutter/issues/52690
Fixes https://github.com/flutter/flutter/issues/52689

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
