### PR TITLE
[image_picker][v0.8.4+2] suppress unchecked warning

### DIFF
--- a/packages/image_picker/image_picker/CHANGELOG.md
+++ b/packages/image_picker/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.4+3
+
+* Suppress a unchecked cast build warning
+
 ## 0.8.4+2
 
 * Update minimum Flutter SDK to 2.5 and iOS deployment target to 9.0.

--- a/packages/image_picker/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
+++ b/packages/image_picker/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
@@ -217,6 +217,7 @@ public class ImagePickerDelegate
 
   void retrieveLostImage(MethodChannel.Result result) {
     Map<String, Object> resultMap = cache.getCacheMap();
+    @SuppressWarnings("unchecked")
     ArrayList<String> pathList = (ArrayList<String>) resultMap.get(cache.MAP_KEY_PATH_LIST);
     ArrayList<String> newPathList = new ArrayList<>();
     if (pathList != null) {

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for selecting images from the Android and iOS image
   library, and taking new pictures with the camera.
 repository: https://github.com/flutter/plugins/tree/master/packages/image_picker/image_picker
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 0.8.4+2
+version: 0.8.4+3
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
Casting a `Object` to an `ArrayList` from a map causes an unchecked cast warning, which shows up during builds of the image_picker plugin. Looking at the code, we can verify that the only times the value belonging to `cache.MAP_KEY_PATH_LIST` is set, it is an `ArrayList`. 

```java
Map<String, Object> resultMap = new HashMap<>();
    ArrayList<String> pathList = new ArrayList<>();
    boolean hasData = false;

    if (prefs.contains(FLUTTER_IMAGE_PICKER_IMAGE_PATH_KEY)) {
      final Set<String> imagePathList =
          prefs.getStringSet(FLUTTER_IMAGE_PICKER_IMAGE_PATH_KEY, null);
      if (imagePathList != null) {
        pathList.addAll(imagePathList);
        resultMap.put(MAP_KEY_PATH_LIST, pathList); // here
        hasData = true;
      }
    }
```

and

```java
ArrayList<String> pathList = (ArrayList<String>) resultMap.get(cache.MAP_KEY_PATH_LIST);
    ArrayList<String> newPathList = new ArrayList<>();
    if (pathList != null) {
      for (String path : pathList) {
        Double maxWidth = (Double) resultMap.get(cache.MAP_KEY_MAX_WIDTH);
        Double maxHeight = (Double) resultMap.get(cache.MAP_KEY_MAX_HEIGHT);
        int imageQuality =
            resultMap.get(cache.MAP_KEY_IMAGE_QUALITY) == null
                ? 100
                : (int) resultMap.get(cache.MAP_KEY_IMAGE_QUALITY);

        newPathList.add(imageResizer.resizeImageIfNeeded(path, maxWidth, maxHeight, imageQuality));
      }
      resultMap.put(cache.MAP_KEY_PATH_LIST, newPathList); // and here
      resultMap.put(cache.MAP_KEY_PATH, newPathList.get(newPathList.size() - 1));
    }
```

Since `instanceof` checks cannot be done with generics (afaik, not a java pro here :sweat_smile:  ) and a ClassCastException has to be thrown either way, if the value is not an `ArrayList`, I think it can be suppressed.

*List which issues are fixed by this PR. You must list at least one issue.*
flutter/flutter#90811

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.
