### PR TITLE
[camera] Add camera test module map

### DIFF
--- a/packages/camera/camera/example/ios/RunnerTests/CameraOrientationTests.m
+++ b/packages/camera/camera/example/ios/RunnerTests/CameraOrientationTests.m
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 @import camera;
+@import camera.Test;
 @import XCTest;
 
 #import <OCMock/OCMock.h>

--- a/packages/camera/camera/ios/Classes/CameraPlugin.m
+++ b/packages/camera/camera/ios/Classes/CameraPlugin.m
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 #import "CameraPlugin.h"
+#import "CameraPlugin_Test.h"
+
 #import <AVFoundation/AVFoundation.h>
 #import <Accelerate/Accelerate.h>
 #import <CoreMotion/CoreMotion.h>

--- a/packages/camera/camera/ios/Classes/CameraPlugin.modulemap
+++ b/packages/camera/camera/ios/Classes/CameraPlugin.modulemap
@@ -1,0 +1,10 @@
+framework module camera {
+  umbrella header "camera-umbrella.h"
+
+  export *
+  module * { export * }
+
+  explicit module Test {
+    header "CameraPlugin_Test.h"
+  }
+}

--- a/packages/camera/camera/ios/Classes/CameraPlugin_Test.h
+++ b/packages/camera/camera/ios/Classes/CameraPlugin_Test.h
@@ -1,0 +1,18 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// This header is available in the Test module. Import via "@import camera.Test;"
+
+#import <camera/CameraPlugin.h>
+
+/// Methods exposed for unit testing.
+@interface CameraPlugin ()
+
+- (instancetype)initWithRegistry:(NSObject<FlutterTextureRegistry> *)registry
+                       messenger:(NSObject<FlutterBinaryMessenger> *)messenger NS_DESIGNATED_INITIALIZER;
+- (instancetype)init NS_UNAVAILABLE;
+
+- (void)orientationChanged:(NSNotification *)notification;
+
+@end

--- a/packages/camera/camera/ios/Classes/camera-umbrella.h
+++ b/packages/camera/camera/ios/Classes/camera-umbrella.h
@@ -1,0 +1,9 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <Foundation/Foundation.h>
+#import <camera/CameraPlugin.h>
+
+FOUNDATION_EXPORT double cameraVersionNumber;
+FOUNDATION_EXPORT const unsigned char cameraVersionString[];

--- a/packages/camera/camera/ios/camera.podspec
+++ b/packages/camera/camera/ios/camera.podspec
@@ -13,8 +13,9 @@ A Flutter plugin to use the camera from your Flutter app.
   s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
   s.source           = { :http => 'https://github.com/flutter/plugins/tree/master/packages/camera' }
   s.documentation_url = 'https://pub.dev/packages/camera'
-  s.source_files = 'Classes/**/*'
+  s.source_files = 'Classes/**/*.{h,m}'
   s.public_header_files = 'Classes/**/*.h'
+  s.module_map = 'Classes/CameraPlugin.modulemap'
   s.dependency 'Flutter'
 
   s.platform = :ios, '9.0'


### PR DESCRIPTION
Create a test header for https://github.com/flutter/plugins/pull/4426.

Create `camera.Test` explicit clang module. Include new modulemap and umbrella header to support this.
