### PR TITLE
[device_info] started using Background Platform Channels

### DIFF
--- a/packages/device_info/device_info/CHANGELOG.md
+++ b/packages/device_info/device_info/CHANGELOG.md
@@ -1,7 +1,8 @@
-## NEXT
+## 2.0.3
 
 * Remove references to the Android V1 embedding.
 * Updated Android lint settings.
+* Started using Background Platform Channels when available.
 
 ## 2.0.2
 

--- a/packages/device_info/device_info/android/src/main/java/io/flutter/plugins/deviceinfo/DeviceInfoPlugin.java
+++ b/packages/device_info/device_info/android/src/main/java/io/flutter/plugins/deviceinfo/DeviceInfoPlugin.java
@@ -5,13 +5,18 @@
 package io.flutter.plugins.deviceinfo;
 
 import android.content.Context;
+import android.util.Log;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodChannel;
+import io.flutter.plugin.common.MethodCodec;
+import io.flutter.plugin.common.StandardMethodCodec;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
 
 /** DeviceInfoPlugin */
 public class DeviceInfoPlugin implements FlutterPlugin {
-
+  static final String TAG = "DeviceInfoPlugin";
   MethodChannel channel;
 
   /** Plugin registration. */
@@ -32,7 +37,24 @@ public class DeviceInfoPlugin implements FlutterPlugin {
   }
 
   private void setupMethodChannel(BinaryMessenger messenger, Context context) {
-    channel = new MethodChannel(messenger, "plugins.flutter.io/device_info");
+    String channelName = "plugins.flutter.io/device_info";
+    // TODO(gaaclarke): Remove reflection guard when https://github.com/flutter/engine/pull/29147
+    // becomes available on the stable branch.
+    try {
+      Class methodChannelClass = Class.forName("io.flutter.plugin.common.MethodChannel");
+      Class taskQueueClass = Class.forName("io.flutter.plugin.common.BinaryMessenger$TaskQueue");
+      Method makeBackgroundTaskQueue = messenger.getClass().getMethod("makeBackgroundTaskQueue");
+      Object taskQueue = makeBackgroundTaskQueue.invoke(messenger);
+      Constructor<MethodChannel> constructor =
+          methodChannelClass.getConstructor(
+              BinaryMessenger.class, String.class, MethodCodec.class, taskQueueClass);
+      channel =
+          constructor.newInstance(messenger, channelName, StandardMethodCodec.INSTANCE, taskQueue);
+      Log.d(TAG, "Use TaskQueues.");
+    } catch (Exception ex) {
+      channel = new MethodChannel(messenger, channelName);
+      Log.d(TAG, "Don't use TaskQueues.");
+    }
     final MethodCallHandlerImpl handler =
         new MethodCallHandlerImpl(context.getContentResolver(), context.getPackageManager());
     channel.setMethodCallHandler(handler);

--- a/packages/device_info/device_info/pubspec.yaml
+++ b/packages/device_info/device_info/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin providing detailed information about the device
   (make, model, etc.), and Android or iOS version the app is running on.
 repository: https://github.com/flutter/plugins/tree/master/packages/device_info/device_info
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+device_info%22
-version: 2.0.2
+version: 2.0.3
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
Made device_info execute on background platform channels when it is available instead of managing its own thread.

b/203709390
issue: https://github.com/flutter/flutter/issues/91635

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
