### PR TITLE
[WIP] Delete deprecated v1 code

### DIFF
--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AndroidAlarmManagerPlugin.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/AndroidAlarmManagerPlugin.java
@@ -46,21 +46,6 @@ public class AndroidAlarmManagerPlugin implements FlutterPlugin, MethodCallHandl
   private Object initializationLock = new Object();
   private MethodChannel alarmManagerPluginChannel;
 
-  /**
-   * Registers this plugin with an associated Flutter execution context, represented by the given
-   * {@link io.flutter.plugin.common.PluginRegistry.Registrar}.
-   *
-   * <p>Once this method is executed, an instance of {@code AndroidAlarmManagerPlugin} will be
-   * connected to, and running against, the associated Flutter execution context.
-   */
-  @SuppressWarnings("deprecation")
-  public static void registerWith(io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
-    if (instance == null) {
-      instance = new AndroidAlarmManagerPlugin();
-    }
-    instance.onAttachedToEngine(registrar.context(), registrar.messenger());
-  }
-
   @Override
   public void onAttachedToEngine(FlutterPluginBinding binding) {
     onAttachedToEngine(binding.getApplicationContext(), binding.getBinaryMessenger());

--- a/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/FlutterBackgroundExecutor.java
+++ b/packages/android_alarm_manager/android/src/main/java/io/flutter/plugins/androidalarmmanager/FlutterBackgroundExecutor.java
@@ -12,7 +12,6 @@ import android.util.Log;
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.embedding.engine.dart.DartExecutor.DartCallback;
-import io.flutter.embedding.engine.plugins.shim.ShimPluginRegistry;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.JSONMethodCodec;
 import io.flutter.plugin.common.MethodCall;
@@ -149,12 +148,6 @@ public class FlutterBackgroundExecutor implements MethodCallHandler {
       DartCallback dartCallback = new DartCallback(assets, appBundlePath, flutterCallback);
 
       executor.executeDartCallback(dartCallback);
-
-      // The pluginRegistrantCallback should only be set in the V1 embedding as
-      // plugin registration is done via reflection in the V2 embedding.
-      if (pluginRegistrantCallback != null) {
-        pluginRegistrantCallback.registerWith(new ShimPluginRegistry(backgroundFlutterEngine));
-      }
     }
   }
 

--- a/packages/android_intent/android/src/main/java/io/flutter/plugins/androidintent/AndroidIntentPlugin.java
+++ b/packages/android_intent/android/src/main/java/io/flutter/plugins/androidintent/AndroidIntentPlugin.java
@@ -28,20 +28,6 @@ public final class AndroidIntentPlugin implements FlutterPlugin, ActivityAware {
     impl = new MethodCallHandlerImpl(sender);
   }
 
-  /**
-   * Registers a plugin implementation that uses the stable {@code io.flutter.plugin.common}
-   * package.
-   *
-   * <p>Calling this automatically initializes the plugin. However plugins initialized this way
-   * won't react to changes in activity or context, unlike {@link AndroidIntentPlugin}.
-   */
-  @SuppressWarnings("deprecation")
-  public static void registerWith(io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
-    IntentSender sender = new IntentSender(registrar.activity(), registrar.context());
-    MethodCallHandlerImpl impl = new MethodCallHandlerImpl(sender);
-    impl.startListening(registrar.messenger());
-  }
-
   @Override
   public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
     sender.setApplicationContext(binding.getApplicationContext());

--- a/packages/battery/battery/android/src/main/java/io/flutter/plugins/battery/BatteryPlugin.java
+++ b/packages/battery/battery/android/src/main/java/io/flutter/plugins/battery/BatteryPlugin.java
@@ -30,13 +30,6 @@ public class BatteryPlugin implements MethodCallHandler, StreamHandler, FlutterP
   private MethodChannel methodChannel;
   private EventChannel eventChannel;
 
-  /** Plugin registration. */
-  @SuppressWarnings("deprecation")
-  public static void registerWith(io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
-    final BatteryPlugin instance = new BatteryPlugin();
-    instance.onAttachedToEngine(registrar.context(), registrar.messenger());
-  }
-
   @Override
   public void onAttachedToEngine(FlutterPluginBinding binding) {
     onAttachedToEngine(binding.getApplicationContext(), binding.getBinaryMessenger());

--- a/packages/device_info/device_info/android/src/main/java/io/flutter/plugins/deviceinfo/DeviceInfoPlugin.java
+++ b/packages/device_info/device_info/android/src/main/java/io/flutter/plugins/deviceinfo/DeviceInfoPlugin.java
@@ -19,13 +19,6 @@ public class DeviceInfoPlugin implements FlutterPlugin {
   static final String TAG = "DeviceInfoPlugin";
   MethodChannel channel;
 
-  /** Plugin registration. */
-  @SuppressWarnings("deprecation")
-  public static void registerWith(io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
-    DeviceInfoPlugin plugin = new DeviceInfoPlugin();
-    plugin.setupMethodChannel(registrar.messenger(), registrar.context());
-  }
-
   @Override
   public void onAttachedToEngine(FlutterPlugin.FlutterPluginBinding binding) {
     setupMethodChannel(binding.getBinaryMessenger(), binding.getApplicationContext());

--- a/packages/espresso/android/src/main/java/com/example/espresso/EspressoPlugin.java
+++ b/packages/espresso/android/src/main/java/com/example/espresso/EspressoPlugin.java
@@ -20,21 +20,6 @@ public class EspressoPlugin implements FlutterPlugin, MethodCallHandler {
     channel.setMethodCallHandler(new EspressoPlugin());
   }
 
-  // This static function is optional and equivalent to onAttachedToEngine. It supports the old
-  // pre-Flutter-1.12 Android projects. You are encouraged to continue supporting
-  // plugin registration via this function while apps migrate to use the new Android APIs
-  // post-flutter-1.12 via https://flutter.dev/go/android-project-migration.
-  //
-  // It is encouraged to share logic between onAttachedToEngine and registerWith to keep
-  // them functionally equivalent. Only one of onAttachedToEngine or registerWith will be called
-  // depending on the user's project. onAttachedToEngine or registerWith must both be defined
-  // in the same class.
-  @SuppressWarnings("deprecation")
-  public static void registerWith(io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
-    final MethodChannel channel = new MethodChannel(registrar.messenger(), "espresso");
-    channel.setMethodCallHandler(new EspressoPlugin());
-  }
-
   @Override
   public void onMethodCall(@NonNull MethodCall call, @NonNull Result result) {
     if (call.method.equals("getPlatformVersion")) {

--- a/packages/flutter_plugin_android_lifecycle/android/src/main/java/io/flutter/plugins/flutter_plugin_android_lifecycle/FlutterAndroidLifecyclePlugin.java
+++ b/packages/flutter_plugin_android_lifecycle/android/src/main/java/io/flutter/plugins/flutter_plugin_android_lifecycle/FlutterAndroidLifecyclePlugin.java
@@ -14,11 +14,6 @@ import io.flutter.embedding.engine.plugins.FlutterPlugin;
  * <p><strong>DO NOT USE THIS CLASS.</strong>
  */
 public class FlutterAndroidLifecyclePlugin implements FlutterPlugin {
-  @SuppressWarnings("deprecation")
-  public static void registerWith(io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
-    // no-op
-  }
-
   @Override
   public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
     // no-op

--- a/packages/image_picker/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/image_picker/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -111,22 +111,6 @@ public class ImagePickerPlugin
   private Lifecycle lifecycle;
   private LifeCycleObserver observer;
 
-  @SuppressWarnings("deprecation")
-  public static void registerWith(io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
-    if (registrar.activity() == null) {
-      // If a background flutter view tries to register the plugin, there will be no activity from the registrar,
-      // we stop the registering process immediately because the ImagePicker requires an activity.
-      return;
-    }
-    Activity activity = registrar.activity();
-    Application application = null;
-    if (registrar.context() != null) {
-      application = (Application) (registrar.context().getApplicationContext());
-    }
-    ImagePickerPlugin plugin = new ImagePickerPlugin();
-    plugin.setup(registrar.messenger(), application, activity, registrar, null);
-  }
-
   /**
    * Default constructor for the plugin.
    *

--- a/packages/image_picker/image_picker/android/src/test/java/io/flutter/plugins/imagepicker/ImagePickerPluginTest.java
+++ b/packages/image_picker/image_picker/android/src/test/java/io/flutter/plugins/imagepicker/ImagePickerPluginTest.java
@@ -148,14 +148,6 @@ public class ImagePickerPluginTest {
   }
 
   @Test
-  public void onResiter_WhenAcitivityIsNull_ShouldNotCrash() {
-    when(mockRegistrar.activity()).thenReturn(null);
-    ImagePickerPlugin.registerWith((mockRegistrar));
-    assertTrue(
-        "No exception thrown when ImagePickerPlugin.registerWith ran with activity = null", true);
-  }
-
-  @Test
   public void onConstructor_WhenContextTypeIsActivity_ShouldNotCrash() {
     new ImagePickerPlugin(mockImagePickerDelegate, mockActivity);
     assertTrue(

--- a/packages/in_app_purchase/in_app_purchase_android/android/src/main/java/io/flutter/plugins/inapppurchase/InAppPurchasePlugin.java
+++ b/packages/in_app_purchase/in_app_purchase_android/android/src/main/java/io/flutter/plugins/inapppurchase/InAppPurchasePlugin.java
@@ -55,15 +55,6 @@ public class InAppPurchasePlugin implements FlutterPlugin, ActivityAware {
   private MethodChannel methodChannel;
   private MethodCallHandlerImpl methodCallHandler;
 
-  /** Plugin registration. */
-  @SuppressWarnings("deprecation")
-  public static void registerWith(io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
-    InAppPurchasePlugin plugin = new InAppPurchasePlugin();
-    registrar.activity().getIntent().putExtra(PROXY_PACKAGE_KEY, PROXY_VALUE);
-    ((Application) registrar.context().getApplicationContext())
-        .registerActivityLifecycleCallbacks(plugin.methodCallHandler);
-  }
-
   @Override
   public void onAttachedToEngine(FlutterPlugin.FlutterPluginBinding binding) {
     setupMethodChannel(

--- a/packages/in_app_purchase/in_app_purchase_android/android/src/test/java/io/flutter/plugins/inapppurchase/InAppPurchasePluginTest.java
+++ b/packages/in_app_purchase/in_app_purchase_android/android/src/test/java/io/flutter/plugins/inapppurchase/InAppPurchasePluginTest.java
@@ -46,27 +46,6 @@ public class InAppPurchasePluginTest {
     when(flutterPluginBinding.getApplicationContext()).thenReturn(context);
   }
 
-  @Test
-  public void registerWith_doNotCrashWhenRegisterContextIsActivity_V1Embedding() {
-    when(mockRegistrar.context()).thenReturn(activity);
-    when(activity.getApplicationContext()).thenReturn(mockApplication);
-    InAppPurchasePlugin.registerWith(mockRegistrar);
-  }
-
-  // The PROXY_PACKAGE_KEY value of this test (io.flutter.plugins.inapppurchase) should never be changed.
-  // In case there's a strong reason to change it, please inform the current code owner of the plugin.
-  @Test
-  public void registerWith_proxyIsSet_V1Embedding() {
-    when(mockRegistrar.context()).thenReturn(activity);
-    when(activity.getApplicationContext()).thenReturn(mockApplication);
-    InAppPurchasePlugin.registerWith(mockRegistrar);
-    // The `PROXY_PACKAGE_KEY` value is hard coded in the plugin code as "io.flutter.plugins.inapppurchase".
-    // We cannot use `BuildConfig.LIBRARY_PACKAGE_NAME` directly in the plugin code because whether to read BuildConfig.APPLICATION_ID or LIBRARY_PACKAGE_NAME
-    // depends on the "APP's" Android Gradle plugin version. Newer versions of AGP use LIBRARY_PACKAGE_NAME, whereas older ones use BuildConfig.APPLICATION_ID.
-    Mockito.verify(mockIntent).putExtra(PROXY_PACKAGE_KEY, "io.flutter.plugins.inapppurchase");
-    assertEquals("io.flutter.plugins.inapppurchase", BuildConfig.LIBRARY_PACKAGE_NAME);
-  }
-
   // The PROXY_PACKAGE_KEY value of this test (io.flutter.plugins.inapppurchase) should never be changed.
   // In case there's a strong reason to change it, please inform the current code owner of the plugin.
   @Test

--- a/packages/local_auth/android/src/main/java/io/flutter/plugins/localauth/LocalAuthPlugin.java
+++ b/packages/local_auth/android/src/main/java/io/flutter/plugins/localauth/LocalAuthPlugin.java
@@ -69,25 +69,6 @@ public class LocalAuthPlugin implements MethodCallHandler, FlutterPlugin, Activi
       };
 
   /**
-   * Registers a plugin with the v1 embedding api {@code io.flutter.plugin.common}.
-   *
-   * <p>Calling this will register the plugin with the passed registrar. However, plugins
-   * initialized this way won't react to changes in activity or context.
-   *
-   * @param registrar attaches this plugin's {@link
-   *     io.flutter.plugin.common.MethodChannel.MethodCallHandler} to the registrar's {@link
-   *     io.flutter.plugin.common.BinaryMessenger}.
-   */
-  @SuppressWarnings("deprecation")
-  public static void registerWith(Registrar registrar) {
-    final MethodChannel channel = new MethodChannel(registrar.messenger(), CHANNEL_NAME);
-    final LocalAuthPlugin plugin = new LocalAuthPlugin();
-    plugin.activity = registrar.activity();
-    channel.setMethodCallHandler(plugin);
-    registrar.addActivityResultListener(plugin.resultListener);
-  }
-
-  /**
    * Default constructor for LocalAuthPlugin.
    *
    * <p>Use this constructor when adding this plugin to an app with v2 embedding.

--- a/packages/package_info/android/src/main/java/io/flutter/plugins/packageinfo/PackageInfoPlugin.java
+++ b/packages/package_info/android/src/main/java/io/flutter/plugins/packageinfo/PackageInfoPlugin.java
@@ -22,13 +22,6 @@ public class PackageInfoPlugin implements MethodCallHandler, FlutterPlugin {
   private Context applicationContext;
   private MethodChannel methodChannel;
 
-  /** Plugin registration. */
-  @SuppressWarnings("deprecation")
-  public static void registerWith(io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
-    final PackageInfoPlugin instance = new PackageInfoPlugin();
-    instance.onAttachedToEngine(registrar.context(), registrar.messenger());
-  }
-
   @Override
   public void onAttachedToEngine(FlutterPluginBinding binding) {
     onAttachedToEngine(binding.getApplicationContext(), binding.getBinaryMessenger());

--- a/packages/path_provider/path_provider/android/src/main/java/io/flutter/plugins/pathprovider/PathProviderPlugin.java
+++ b/packages/path_provider/path_provider/android/src/main/java/io/flutter/plugins/pathprovider/PathProviderPlugin.java
@@ -177,12 +177,6 @@ public class PathProviderPlugin implements FlutterPlugin, MethodCallHandler {
     channel.setMethodCallHandler(this);
   }
 
-  @SuppressWarnings("deprecation")
-  public static void registerWith(io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
-    PathProviderPlugin instance = new PathProviderPlugin();
-    instance.setup(registrar.messenger(), registrar.context());
-  }
-
   @Override
   public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
     setup(binding.getBinaryMessenger(), binding.getApplicationContext());

--- a/packages/quick_actions/quick_actions/android/src/main/java/io/flutter/plugins/quickactions/QuickActionsPlugin.java
+++ b/packages/quick_actions/quick_actions/android/src/main/java/io/flutter/plugins/quickactions/QuickActionsPlugin.java
@@ -22,17 +22,6 @@ public class QuickActionsPlugin implements FlutterPlugin, ActivityAware, NewInte
   private MethodChannel channel;
   private MethodCallHandlerImpl handler;
 
-  /**
-   * Plugin registration.
-   *
-   * <p>Must be called when the application is created.
-   */
-  @SuppressWarnings("deprecation")
-  public static void registerWith(io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
-    final QuickActionsPlugin plugin = new QuickActionsPlugin();
-    plugin.setupChannel(registrar.messenger(), registrar.context(), registrar.activity());
-  }
-
   @Override
   public void onAttachedToEngine(FlutterPluginBinding binding) {
     setupChannel(binding.getBinaryMessenger(), binding.getApplicationContext(), null);

--- a/packages/sensors/android/src/main/java/io/flutter/plugins/sensors/SensorsPlugin.java
+++ b/packages/sensors/android/src/main/java/io/flutter/plugins/sensors/SensorsPlugin.java
@@ -23,13 +23,6 @@ public class SensorsPlugin implements FlutterPlugin {
   private EventChannel userAccelChannel;
   private EventChannel gyroscopeChannel;
 
-  /** Plugin registration. */
-  @SuppressWarnings("deprecation")
-  public static void registerWith(io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
-    SensorsPlugin plugin = new SensorsPlugin();
-    plugin.setupEventChannels(registrar.context(), registrar.messenger());
-  }
-
   @Override
   public void onAttachedToEngine(FlutterPluginBinding binding) {
     final Context context = binding.getApplicationContext();

--- a/packages/share/android/src/main/java/io/flutter/plugins/share/SharePlugin.java
+++ b/packages/share/android/src/main/java/io/flutter/plugins/share/SharePlugin.java
@@ -20,12 +20,6 @@ public class SharePlugin implements FlutterPlugin, ActivityAware {
   private Share share;
   private MethodChannel methodChannel;
 
-  @SuppressWarnings("deprecation")
-  public static void registerWith(io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
-    SharePlugin plugin = new SharePlugin();
-    plugin.setUpChannel(registrar.context(), registrar.activity(), registrar.messenger());
-  }
-
   @Override
   public void onAttachedToEngine(FlutterPluginBinding binding) {
     setUpChannel(binding.getApplicationContext(), null, binding.getBinaryMessenger());

--- a/packages/shared_preferences/shared_preferences/android/src/main/java/io/flutter/plugins/sharedpreferences/SharedPreferencesPlugin.java
+++ b/packages/shared_preferences/shared_preferences/android/src/main/java/io/flutter/plugins/sharedpreferences/SharedPreferencesPlugin.java
@@ -15,12 +15,6 @@ public class SharedPreferencesPlugin implements FlutterPlugin {
   private MethodChannel channel;
   private MethodCallHandlerImpl handler;
 
-  @SuppressWarnings("deprecation")
-  public static void registerWith(io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
-    final SharedPreferencesPlugin plugin = new SharedPreferencesPlugin();
-    plugin.setupChannel(registrar.messenger(), registrar.context());
-  }
-
   @Override
   public void onAttachedToEngine(FlutterPlugin.FlutterPluginBinding binding) {
     setupChannel(binding.getBinaryMessenger(), binding.getApplicationContext());

--- a/packages/url_launcher/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/UrlLauncherPlugin.java
+++ b/packages/url_launcher/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/UrlLauncherPlugin.java
@@ -21,20 +21,6 @@ public final class UrlLauncherPlugin implements FlutterPlugin, ActivityAware {
   @Nullable private MethodCallHandlerImpl methodCallHandler;
   @Nullable private UrlLauncher urlLauncher;
 
-  /**
-   * Registers a plugin implementation that uses the stable {@code io.flutter.plugin.common}
-   * package.
-   *
-   * <p>Calling this automatically initializes the plugin. However plugins initialized this way
-   * won't react to changes in activity or context, unlike {@link UrlLauncherPlugin}.
-   */
-  @SuppressWarnings("deprecation")
-  public static void registerWith(io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
-    MethodCallHandlerImpl handler =
-        new MethodCallHandlerImpl(new UrlLauncher(registrar.context(), registrar.activity()));
-    handler.startListening(registrar.messenger());
-  }
-
   @Override
   public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
     urlLauncher = new UrlLauncher(binding.getApplicationContext(), /*activity=*/ null);

--- a/packages/video_player/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -48,17 +48,6 @@ public class VideoPlayerPlugin implements FlutterPlugin, VideoPlayerApi {
     flutterState.startListening(this, registrar.messenger());
   }
 
-  /** Registers this with the stable v1 embedding. Will not respond to lifecycle events. */
-  @SuppressWarnings("deprecation")
-  public static void registerWith(io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
-    final VideoPlayerPlugin plugin = new VideoPlayerPlugin(registrar);
-    registrar.addViewDestroyListener(
-        view -> {
-          plugin.onDestroy();
-          return false; // We are not interested in assuming ownership of the NativeView.
-        });
-  }
-
   @Override
   public void onAttachedToEngine(FlutterPluginBinding binding) {
 

--- a/packages/webview_flutter/webview_flutter_android/android/src/main/java/io/flutter/plugins/webviewflutter/WebViewFlutterPlugin.java
+++ b/packages/webview_flutter/webview_flutter_android/android/src/main/java/io/flutter/plugins/webviewflutter/WebViewFlutterPlugin.java
@@ -11,9 +11,6 @@ import io.flutter.plugin.common.BinaryMessenger;
  * Java platform implementation of the webview_flutter plugin.
  *
  * <p>Register this in an add to app scenario to gracefully handle activity and context changes.
- *
- * <p>Call {@link #registerWith(Registrar)} to use the stable {@code io.flutter.plugin.common}
- * package instead.
  */
 public class WebViewFlutterPlugin implements FlutterPlugin {
 
@@ -23,32 +20,10 @@ public class WebViewFlutterPlugin implements FlutterPlugin {
    * Add an instance of this to {@link io.flutter.embedding.engine.plugins.PluginRegistry} to
    * register it.
    *
-   * <p>THIS PLUGIN CODE PATH DEPENDS ON A NEWER VERSION OF FLUTTER THAN THE ONE DEFINED IN THE
-   * PUBSPEC.YAML. Text input will fail on some Android devices unless this is used with at least
-   * flutter/flutter@1d4d63ace1f801a022ea9ec737bf8c15395588b9. Use the V1 embedding with {@link
-   * #registerWith(Registrar)} to use this plugin with older Flutter versions.
-   *
    * <p>Registration should eventually be handled automatically by v2 of the
    * GeneratedPluginRegistrant. https://github.com/flutter/flutter/issues/42694
    */
   public WebViewFlutterPlugin() {}
-
-  /**
-   * Registers a plugin implementation that uses the stable {@code io.flutter.plugin.common}
-   * package.
-   *
-   * <p>Calling this automatically initializes the plugin. However plugins initialized this way
-   * won't react to changes in activity or context, unlike {@link CameraPlugin}.
-   */
-  @SuppressWarnings("deprecation")
-  public static void registerWith(io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
-    registrar
-        .platformViewRegistry()
-        .registerViewFactory(
-            "plugins.flutter.io/webview",
-            new FlutterWebViewFactory(registrar.messenger(), registrar.view()));
-    new FlutterCookieManager(registrar.messenger());
-  }
 
   @Override
   public void onAttachedToEngine(FlutterPluginBinding binding) {

--- a/packages/wifi_info_flutter/wifi_info_flutter/android/src/main/java/io/flutter/plugins/wifi_info_flutter/WifiInfoFlutterPlugin.java
+++ b/packages/wifi_info_flutter/wifi_info_flutter/android/src/main/java/io/flutter/plugins/wifi_info_flutter/WifiInfoFlutterPlugin.java
@@ -14,13 +14,6 @@ import io.flutter.plugin.common.MethodChannel;
 public class WifiInfoFlutterPlugin implements FlutterPlugin {
   private MethodChannel methodChannel;
 
-  /** Plugin registration. */
-  @SuppressWarnings("deprecation")
-  public static void registerWith(io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
-    WifiInfoFlutterPlugin plugin = new WifiInfoFlutterPlugin();
-    plugin.setupChannels(registrar.messenger(), registrar.context());
-  }
-
   @Override
   public void onAttachedToEngine(FlutterPluginBinding binding) {
     setupChannels(binding.getBinaryMessenger(), binding.getApplicationContext());


### PR DESCRIPTION
We plan on deleting the v1 Android embedding, so we should no longer use the deprecated code.

Part of https://github.com/flutter/flutter/pull/92643 which is an experimental run of deleting v1 embedding.

This change is breaking as it drops support for old non-migrated apps.