### PR TITLE
[webview_flutter] Expose loadData function for webviews

### DIFF
--- a/packages/webview_flutter/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.2.0
+* Add `loadData` call.
+
 ## 2.1.2
 
 * Fix typos in the README.

--- a/packages/webview_flutter/webview_flutter/lib/src/webview.dart
+++ b/packages/webview_flutter/webview_flutter/lib/src/webview.dart
@@ -495,6 +495,31 @@ class WebViewController {
     return _webViewPlatformController.loadUrl(url, headers);
   }
 
+  /// Loads the specified content data into the WebView.
+  ///
+  /// [baseUrl] is the apparent URL which the page was loaded at, used to resolve
+  /// relative paths.
+  ///
+  /// The [data] string will be interpreted as as string of the encoding specified by [encoding].
+  ///
+  /// Throws an ArgumentError if [baseUrl] is not a valid URL string.
+  Future<void> loadData(
+    String baseUrl,
+    String data,
+    String mimeType,
+    String encoding,
+  ) async {
+    assert(baseUrl != null);
+    assert(data != null);
+    _validateUrlString(baseUrl);
+    return _webViewPlatformController.loadData(
+      baseUrl,
+      data,
+      mimeType,
+      encoding,
+    );
+  }
+
   /// Accessor to the current URL that the WebView is displaying.
   ///
   /// If [WebView.initialUrl] was never specified, returns `null`.

--- a/packages/webview_flutter/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
 repository: https://github.com/flutter/plugins/tree/master/packages/webview_flutter/webview_flutter
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview%22
-version: 2.1.2
+version: 2.2.0
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -29,3 +29,8 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   pedantic: ^1.10.0
+
+# TODO: This is only for testing, remove it when it should be merged!
+dependency_overrides:
+  webview_flutter_platform_interface:
+    path: ../webview_flutter_platform_interface

--- a/packages/webview_flutter/webview_flutter/test/webview_flutter_test.dart
+++ b/packages/webview_flutter/webview_flutter/test/webview_flutter_test.dart
@@ -129,6 +129,28 @@ void main() {
     expect(await controller!.currentUrl(), equals('https://flutter.io'));
   });
 
+  testWidgets('Load data', (WidgetTester tester) async {
+    WebViewController? controller;
+    await tester.pumpWidget(
+      WebView(
+        onWebViewCreated: (WebViewController webViewController) {
+          controller = webViewController;
+        },
+      ),
+    );
+
+    expect(controller, isNotNull);
+
+    await controller!.loadData(
+      'https://flutter.io',
+      '<title>test!</title>',
+      'text/html',
+      'UTF-8',
+    );
+
+    expect(await controller!.currentUrl(), 'https://flutter.io');
+  });
+
   testWidgets("Can't go back before loading a page",
       (WidgetTester tester) async {
     WebViewController? controller;
@@ -965,6 +987,10 @@ class FakePlatformWebView {
       case 'loadUrl':
         final Map<dynamic, dynamic> request = call.arguments;
         _loadUrl(request['url']);
+        return Future<void>.sync(() {});
+      case 'loadData':
+        final Map<dynamic, dynamic> request = call.arguments;
+        _loadUrl(request['baseUrl']);
         return Future<void>.sync(() {});
       case 'updateSettings':
         if (call.arguments['jsMode'] != null) {

--- a/packages/webview_flutter/webview_flutter_android/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_android/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.3.0
+* Add `loadData` call.
+
 ## 2.2.0
 
 * Implemented new `runJavascript` and `runJavascriptReturningResult` methods in platform interface.

--- a/packages/webview_flutter/webview_flutter_android/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
+++ b/packages/webview_flutter/webview_flutter_android/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebView.java
@@ -223,6 +223,9 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
       case "loadUrl":
         loadUrl(methodCall, result);
         break;
+      case "loadData":
+        loadData(methodCall, result);
+        break;
       case "updateSettings":
         updateSettings(methodCall, result);
         break;
@@ -291,6 +294,18 @@ public class FlutterWebView implements PlatformView, MethodCallHandler {
     webView.loadUrl(url, headers);
     result.success(null);
   }
+
+  @SuppressWarnings("unchecked")
+  private void loadData(MethodCall methodCall, Result result) {
+    Map<String, Object> request = (Map<String, Object>) methodCall.arguments;
+    String baseUrl = (String) request.get("baseUrl");
+    String data = (String) request.get("data");
+    String mimeType = (String) request.get("mimeType");
+    String encoding = (String) request.get("encoding");
+    webView.loadDataWithBaseURL(baseUrl, data, mimeType, encoding, "");
+    result.success(null);
+  }
+
 
   private void canGoBack(Result result) {
     result.success(webView.canGoBack());

--- a/packages/webview_flutter/webview_flutter_android/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter_android
 description: A Flutter plugin that provides a WebView widget on Android.
 repository: https://github.com/flutter/plugins/tree/master/packages/webview_flutter/webview_flutter_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview%22
-version: 2.2.0
+version: 2.3.0
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.3.0
+* Add `loadData` call.
+
 ## 1.2.0
 
 * Added `runJavascript` and `runJavascriptReturningResult` interface methods to supersede `evaluateJavascript`.

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/src/method_channel/webview_method_channel.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/src/method_channel/webview_method_channel.dart
@@ -92,6 +92,21 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
   }
 
   @override
+  Future<void> loadData(
+    String baseUrl,
+    String data,
+    String mimeType,
+    String encoding,
+  ) async {
+    return _channel.invokeMethod<void>('loadData', <String, dynamic>{
+      'baseUrl': baseUrl,
+      'data': data,
+      'mimeType': mimeType,
+      'encoding': encoding,
+    });
+  }
+
+  @override
   Future<String?> currentUrl() => _channel.invokeMethod<String>('currentUrl');
 
   @override

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_interface/webview_platform_controller.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_interface/webview_platform_controller.dart
@@ -39,6 +39,16 @@ abstract class WebViewPlatformController {
         "WebView loadUrl is not implemented on the current platform");
   }
 
+  Future<void> loadData(
+    String baseUrl,
+    String data,
+    String mimeType,
+    String encoding,
+  ) {
+    throw UnimplementedError(
+        "WebView loadData is not implemented on the current platform");
+  }
+
   /// Updates the webview settings.
   ///
   /// Any non null field in `settings` will be set as the new setting value.

--- a/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/master/packages/webview_flut
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview_flutter%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.2.0
+version: 1.3.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/webview_flutter/webview_flutter_wkwebview/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_wkwebview/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.3.0
+* Add `loadData` call.
+
 ## 2.2.0
 
 * Implemented new `runJavascript` and `runJavascriptReturningResult` methods in platform interface.

--- a/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FlutterWebView.m
+++ b/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FlutterWebView.m
@@ -137,6 +137,8 @@
     [self onUpdateSettings:call result:result];
   } else if ([[call method] isEqualToString:@"loadUrl"]) {
     [self onLoadUrl:call result:result];
+  } else if ([[call method] isEqualToString:@"loadData"]) {
+    [self onLoadData:call result:result];
   } else if ([[call method] isEqualToString:@"canGoBack"]) {
     [self onCanGoBack:call result:result];
   } else if ([[call method] isEqualToString:@"canGoForward"]) {
@@ -190,6 +192,17 @@
     result([FlutterError
         errorWithCode:@"loadUrl_failed"
               message:@"Failed parsing the URL"
+              details:[NSString stringWithFormat:@"Request was: '%@'", [call arguments]]]);
+  } else {
+    result(nil);
+  }
+}
+
+- (void)onLoadData:(FlutterMethodCall*)call result:(FlutterResult)result {
+  if (![self loadData:[call arguments]]) {
+    result([FlutterError
+        errorWithCode:@"loadData_failed"
+              message:@"Failed parsing the data"
               details:[NSString stringWithFormat:@"Request was: '%@'", [call arguments]]]);
   } else {
     result(nil);
@@ -490,6 +503,20 @@
   [request setAllHTTPHeaderFields:headers];
   [_webView loadRequest:request];
   return true;
+}
+
+- (bool)loadData:(NSDictionary<NSString*, id>*)request {
+  if (!request) {
+    return false;
+  }
+
+  NSString* data = request[@"data"];
+  NSString* baseUrl = request[@"baseUrl"];
+  NSString* mimeType = request[@"mimeType"];
+  NSString* encoding = request[@"encoding"];
+  NSData* nsData = [data dataUsingEncoding:NSUTF8StringEncoding];
+  NSURL* nsUrl = [NSURL URLWithString:baseUrl];
+  return [_webView loadData:nsData MIMEType:mimeType characterEncodingName:encoding baseURL:nsUrl];
 }
 
 - (void)registerJavaScriptChannels:(NSSet*)channelNames

--- a/packages/webview_flutter/webview_flutter_wkwebview/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_wkwebview/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter_wkwebview
 description: A Flutter plugin that provides a WebView widget based on Apple's WKWebView control.
 repository: https://github.com/flutter/plugins/tree/master/packages/webview_flutter/webview_flutter_wkwebview
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview%22
-version: 2.2.0
+version: 2.3.0
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
## Description
Expose loadData on the webview controller. This allows developers to load html directly into the webview.

## Related
Retry of https://github.com/flutter/plugins/pull/2463 and https://github.com/flutter/plugins/pull/3214

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.