### PR TITLE
Remove -Werror from deprecated plugin Android builds

### DIFF
--- a/packages/android_alarm_manager/CHANGELOG.md
+++ b/packages/android_alarm_manager/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Remove support for the V1 Android embedding.
 * Updated Android lint settings.
+* Removed `-Werror` in Android builds.
 
 ## 2.0.2
 

--- a/packages/android_alarm_manager/android/build.gradle
+++ b/packages/android_alarm_manager/android/build.gradle
@@ -1,6 +1,6 @@
 group 'io.flutter.plugins.androidalarmmanager'
 version '1.0-SNAPSHOT'
-def args = ["-Xlint:deprecation","-Xlint:unchecked","-Werror"]
+def args = ["-Xlint:deprecation","-Xlint:unchecked"]
 
 buildscript {
     repositories {

--- a/packages/android_intent/CHANGELOG.md
+++ b/packages/android_intent/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Remove references to the V1 Android embedding.
 * Updated Android lint settings.
 * Specify Java 8 for Android build.
+* Removed `-Werror` in Android builds.
 
 ## 2.0.2
 

--- a/packages/android_intent/android/build.gradle
+++ b/packages/android_intent/android/build.gradle
@@ -1,6 +1,6 @@
 group 'io.flutter.plugins.androidintent'
 version '1.0-SNAPSHOT'
-def args = ["-Xlint:deprecation","-Xlint:unchecked","-Werror"]
+def args = ["-Xlint:deprecation","-Xlint:unchecked"]
 
 buildscript {
     repositories {

--- a/packages/connectivity/connectivity/CHANGELOG.md
+++ b/packages/connectivity/connectivity/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Remove references to the Android V1 embedding.
 * Updated Android lint settings.
 * Specify Java 8 for Android build.
+* Removed `-Werror` in Android builds.
 
 ## 3.0.6
 

--- a/packages/connectivity/connectivity/android/build.gradle
+++ b/packages/connectivity/connectivity/android/build.gradle
@@ -1,6 +1,6 @@
 group 'io.flutter.plugins.connectivity'
 version '1.0-SNAPSHOT'
-def args = ["-Xlint:deprecation","-Xlint:unchecked","-Werror"]
+def args = ["-Xlint:deprecation","-Xlint:unchecked"]
 
 buildscript {
     repositories {


### PR DESCRIPTION
Now that the default Flutter app template uses a newer compile SDK on Android, the build_all test (which generates an application) is subject to new out-of-band deprecation warnings. For plugins with `-Werror` specified, these are errors, which break CI.

To prevent this, remove `-Werror` from the Android builds of all the deprecated plugins that used it.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
