### PR TITLE
[ci] Add 'main' builders in bringup mode

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -48,6 +48,20 @@ targets:
         ]
     scheduler: luci
 
+  - name: Windows win32-platform_tests main
+    bringup: true
+    recipe: plugins/plugins
+    timeout: 30
+    properties:
+      add_recipes_cq: "true"
+      target_file: windows_build_and_platform_tests.yaml
+      channel: main
+      dependencies: >
+        [
+          {"dependency": "vs_build"}
+        ]
+    scheduler: luci
+
   - name: Windows win32-platform_tests stable
     recipe: plugins/plugins
     timeout: 30
@@ -73,6 +87,20 @@ targets:
         ]
     scheduler: luci
 
+  - name: Windows windows-build_all_plugins main
+    bringup: true
+    recipe: plugins/plugins
+    timeout: 30
+    properties:
+      add_recipes_cq: "true"
+      target_file: build_all_plugins.yaml
+      channel: main
+      dependencies: >
+        [
+          {"dependency": "vs_build"}
+        ]
+    scheduler: luci
+
   - name: Windows windows-build_all_plugins stable
     recipe: plugins/plugins
     timeout: 30
@@ -92,6 +120,20 @@ targets:
     properties:
       add_recipes_cq: "true"
       target_file: uwp_build_and_platform_tests.yaml
+      dependencies: >
+        [
+          {"dependency": "vs_build"}
+        ]
+    scheduler: luci
+
+  - name: Windows uwp-platform_tests main
+    bringup: true
+    recipe: plugins/plugins
+    timeout: 30
+    properties:
+      add_recipes_cq: "true"
+      target_file: uwp_build_and_platform_tests.yaml
+      channel: main
       dependencies: >
         [
           {"dependency": "vs_build"}


### PR DESCRIPTION
Creates `main` versions of the existing `master` CI builders, as the
first half of switching LUCI tests over to the `main` branch.

Part of https://github.com/flutter/flutter/issues/90476

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
