### PR TITLE
[flutter_plugin_tools] Add 'main' support

### DIFF
--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -1,4 +1,4 @@
-## NEXT
+## 0.7.2
 
 - Update Firebase Testlab deprecated test device. (Pixel 4 API 29 -> Pixel 5 API 30).
 - `native-test --android`, `--ios`, and `--macos` now fail plugins that don't
@@ -15,6 +15,8 @@
   length.
 - Fix `license-check` when run on Windows with line ending conversion enabled.
 - Fixed `pubspec-check` on Windows.
+- Add support for `main` as a primary branch. `master` continues to work for
+  compatibility.
 
 ## 0.7.1
 

--- a/script/tool/lib/src/common/plugin_command.dart
+++ b/script/tool/lib/src/common/plugin_command.dart
@@ -81,7 +81,8 @@ abstract class PluginCommand extends Command<void> {
     argParser.addFlag(_packagesForBranchArg,
         help:
             'This runs on all packages (equivalent to no package selection flag)\n'
-            'on master, and behaves like --run-on-changed-packages on any other branch.\n\n'
+            'on main (or master), and behaves like --run-on-changed-packages on '
+            'any other branch.\n\n'
             'Cannot be combined with $_packagesArg.\n\n'
             'This is intended for use in CI.\n',
         hide: true);
@@ -301,7 +302,7 @@ abstract class PluginCommand extends Command<void> {
             'only be used in a git repository.');
         throw ToolExit(exitInvalidArguments);
       } else {
-        runOnChangedPackages = branch != 'master';
+        runOnChangedPackages = branch != 'master' && branch != 'main';
         // Log the mode for auditing what was intended to run.
         print('--$_packagesForBranchArg: running on '
             '${runOnChangedPackages ? 'changed' : 'all'} packages');

--- a/script/tool/lib/src/test_command.dart
+++ b/script/tool/lib/src/test_command.dart
@@ -24,7 +24,7 @@ class TestCommand extends PackageLoopingCommand {
       defaultsTo: '',
       help:
           'Runs Dart unit tests in Dart VM with the given experiments enabled. '
-          'See https://github.com/dart-lang/sdk/blob/master/docs/process/experimental-flags.md '
+          'See https://github.com/dart-lang/sdk/blob/main/docs/process/experimental-flags.md '
           'for details.',
     );
   }

--- a/script/tool/lib/src/version_check_command.dart
+++ b/script/tool/lib/src/version_check_command.dart
@@ -262,7 +262,9 @@ ${indentation}HTTP response: ${pubVersionFinderResponse.httpResponse.body}
     // This method isn't called unless `version` is non-null.
     final Version currentVersion = pubspec.version!;
     Version? previousVersion;
+    String previousVersionSource;
     if (getBoolArg(_againstPubFlag)) {
+      previousVersionSource = 'pub';
       previousVersion = await _fetchPreviousVersionFromPub(pubspec.name);
       if (previousVersion == null) {
         return _CurrentVersionState.unknown;
@@ -273,6 +275,7 @@ ${indentation}HTTP response: ${pubVersionFinderResponse.httpResponse.body}
       }
     } else {
       final GitVersionFinder gitVersionFinder = await retrieveVersionFinder();
+      previousVersionSource = await gitVersionFinder.getBaseSha();
       previousVersion = await _getPreviousVersionFromGit(package,
               gitVersionFinder: gitVersionFinder) ??
           Version.none;
@@ -310,9 +313,8 @@ ${indentation}HTTP response: ${pubVersionFinderResponse.httpResponse.body}
     if (allowedNextVersions.containsKey(currentVersion)) {
       print('$indentation$previousVersion -> $currentVersion');
     } else {
-      final String source = (getBoolArg(_againstPubFlag)) ? 'pub' : 'master';
       printError('${indentation}Incorrectly updated version.\n'
-          '${indentation}HEAD: $currentVersion, $source: $previousVersion.\n'
+          '${indentation}HEAD: $currentVersion, $previousVersionSource: $previousVersion.\n'
           '${indentation}Allowed versions: $allowedNextVersions');
       return _CurrentVersionState.invalidChange;
     }

--- a/script/tool/pubspec.yaml
+++ b/script/tool/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_plugin_tools
 description: Productivity utils for flutter/plugins and flutter/packages
 repository: https://github.com/flutter/plugins/tree/master/script/tool
-version: 0.7.1
+version: 0.7.2
 
 dependencies:
   args: ^2.1.0

--- a/script/tool/test/analyze_command_test.dart
+++ b/script/tool/test/analyze_command_test.dart
@@ -253,7 +253,7 @@ void main() {
   });
 
   // Ensure that the command used to analyze flutter/plugins in the Dart repo:
-  // https://github.com/dart-lang/sdk/blob/master/tools/bots/flutter/analyze_flutter_plugins.sh
+  // https://github.com/dart-lang/sdk/blob/main/tools/bots/flutter/analyze_flutter_plugins.sh
   // continues to work.
   //
   // DO NOT remove or modify this test without a coordination plan in place to

--- a/script/tool/test/common/plugin_command_test.dart
+++ b/script/tool/test/common/plugin_command_test.dart
@@ -246,11 +246,8 @@ void main() {
       test('all plugins should be tested if there are no changes.', () async {
         final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
         final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
-        await runCapturingPrint(runner, <String>[
-          'sample',
-          '--base-sha=master',
-          '--run-on-changed-packages'
-        ]);
+        await runCapturingPrint(runner,
+            <String>['sample', '--base-sha=main', '--run-on-changed-packages']);
 
         expect(command.plugins,
             unorderedEquals(<String>[plugin1.path, plugin2.path]));
@@ -264,11 +261,8 @@ void main() {
         ];
         final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
         final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
-        await runCapturingPrint(runner, <String>[
-          'sample',
-          '--base-sha=master',
-          '--run-on-changed-packages'
-        ]);
+        await runCapturingPrint(runner,
+            <String>['sample', '--base-sha=main', '--run-on-changed-packages']);
 
         expect(command.plugins,
             unorderedEquals(<String>[plugin1.path, plugin2.path]));
@@ -283,11 +277,8 @@ packages/plugin1/CHANGELOG
         ];
         final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
         final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
-        await runCapturingPrint(runner, <String>[
-          'sample',
-          '--base-sha=master',
-          '--run-on-changed-packages'
-        ]);
+        await runCapturingPrint(runner,
+            <String>['sample', '--base-sha=main', '--run-on-changed-packages']);
 
         expect(command.plugins,
             unorderedEquals(<String>[plugin1.path, plugin2.path]));
@@ -302,11 +293,8 @@ packages/plugin1/CHANGELOG
         ];
         final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
         final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
-        await runCapturingPrint(runner, <String>[
-          'sample',
-          '--base-sha=master',
-          '--run-on-changed-packages'
-        ]);
+        await runCapturingPrint(runner,
+            <String>['sample', '--base-sha=main', '--run-on-changed-packages']);
 
         expect(command.plugins,
             unorderedEquals(<String>[plugin1.path, plugin2.path]));
@@ -322,11 +310,8 @@ packages/plugin1/CHANGELOG
         ];
         final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
         final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
-        await runCapturingPrint(runner, <String>[
-          'sample',
-          '--base-sha=master',
-          '--run-on-changed-packages'
-        ]);
+        await runCapturingPrint(runner,
+            <String>['sample', '--base-sha=main', '--run-on-changed-packages']);
 
         expect(command.plugins,
             unorderedEquals(<String>[plugin1.path, plugin2.path]));
@@ -342,11 +327,8 @@ packages/plugin1/CHANGELOG
         ];
         final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
         final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
-        await runCapturingPrint(runner, <String>[
-          'sample',
-          '--base-sha=master',
-          '--run-on-changed-packages'
-        ]);
+        await runCapturingPrint(runner,
+            <String>['sample', '--base-sha=main', '--run-on-changed-packages']);
 
         expect(command.plugins,
             unorderedEquals(<String>[plugin1.path, plugin2.path]));
@@ -362,11 +344,8 @@ packages/plugin1/CHANGELOG
         ];
         final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
         final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
-        await runCapturingPrint(runner, <String>[
-          'sample',
-          '--base-sha=master',
-          '--run-on-changed-packages'
-        ]);
+        await runCapturingPrint(runner,
+            <String>['sample', '--base-sha=main', '--run-on-changed-packages']);
 
         expect(command.plugins,
             unorderedEquals(<String>[plugin1.path, plugin2.path]));
@@ -382,11 +361,8 @@ packages/plugin1/CHANGELOG
         ];
         final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
         final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
-        await runCapturingPrint(runner, <String>[
-          'sample',
-          '--base-sha=master',
-          '--run-on-changed-packages'
-        ]);
+        await runCapturingPrint(runner,
+            <String>['sample', '--base-sha=main', '--run-on-changed-packages']);
 
         expect(command.plugins,
             unorderedEquals(<String>[plugin1.path, plugin2.path]));
@@ -398,17 +374,14 @@ packages/plugin1/CHANGELOG
         ];
         final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
         createFakePlugin('plugin2', packagesDir);
-        final List<String> output = await runCapturingPrint(runner, <String>[
-          'sample',
-          '--base-sha=master',
-          '--run-on-changed-packages'
-        ]);
+        final List<String> output = await runCapturingPrint(runner,
+            <String>['sample', '--base-sha=main', '--run-on-changed-packages']);
 
         expect(
             output,
             containsAllInOrder(<Matcher>[
               contains(
-                  'Running for all packages that have changed relative to "master"'),
+                  'Running for all packages that have changed relative to "main"'),
             ]));
 
         expect(command.plugins, unorderedEquals(<String>[plugin1.path]));
@@ -424,11 +397,8 @@ packages/plugin1/ios/plugin1.m
         ];
         final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
         createFakePlugin('plugin2', packagesDir);
-        await runCapturingPrint(runner, <String>[
-          'sample',
-          '--base-sha=master',
-          '--run-on-changed-packages'
-        ]);
+        await runCapturingPrint(runner,
+            <String>['sample', '--base-sha=main', '--run-on-changed-packages']);
 
         expect(command.plugins, unorderedEquals(<String>[plugin1.path]));
       });
@@ -444,11 +414,8 @@ packages/plugin2/ios/plugin2.m
         final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
         final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
         createFakePlugin('plugin3', packagesDir);
-        await runCapturingPrint(runner, <String>[
-          'sample',
-          '--base-sha=master',
-          '--run-on-changed-packages'
-        ]);
+        await runCapturingPrint(runner,
+            <String>['sample', '--base-sha=main', '--run-on-changed-packages']);
 
         expect(command.plugins,
             unorderedEquals(<String>[plugin1.path, plugin2.path]));
@@ -468,11 +435,8 @@ packages/plugin1/plugin1_web/plugin1_web.dart
             createFakePlugin('plugin1', packagesDir.childDirectory('plugin1'));
         createFakePlugin('plugin2', packagesDir);
         createFakePlugin('plugin3', packagesDir);
-        await runCapturingPrint(runner, <String>[
-          'sample',
-          '--base-sha=master',
-          '--run-on-changed-packages'
-        ]);
+        await runCapturingPrint(runner,
+            <String>['sample', '--base-sha=main', '--run-on-changed-packages']);
 
         expect(command.plugins, unorderedEquals(<String>[plugin1.path]));
       });
@@ -491,11 +455,8 @@ packages/plugin1/plugin1/plugin1.dart
             packagesDir.childDirectory('plugin1'));
         final Directory plugin3 = createFakePlugin(
             'plugin1_web', packagesDir.childDirectory('plugin1'));
-        await runCapturingPrint(runner, <String>[
-          'sample',
-          '--base-sha=master',
-          '--run-on-changed-packages'
-        ]);
+        await runCapturingPrint(runner,
+            <String>['sample', '--base-sha=main', '--run-on-changed-packages']);
 
         expect(
             command.plugins,
@@ -518,7 +479,7 @@ packages/plugin3/plugin3.dart
         await runCapturingPrint(runner, <String>[
           'sample',
           '--exclude=plugin2,plugin3',
-          '--base-sha=master',
+          '--base-sha=main',
           '--run-on-changed-packages'
         ]);
 
@@ -546,6 +507,28 @@ packages/plugin3/plugin3.dart
           output,
           containsAllInOrder(<Matcher>[
             contains('--packages-for-branch: running on changed packages'),
+          ]));
+    });
+
+    test('tests all packages on main', () async {
+      processRunner.mockProcessesForExecutable['git-diff'] = <Process>[
+        MockProcess(stdout: 'packages/plugin1/plugin1.dart'),
+      ];
+      processRunner.mockProcessesForExecutable['git-rev-parse'] = <Process>[
+        MockProcess(stdout: 'main'),
+      ];
+      final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
+      final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
+
+      final List<String> output = await runCapturingPrint(
+          runner, <String>['sample', '--packages-for-branch']);
+
+      expect(command.plugins,
+          unorderedEquals(<String>[plugin1.path, plugin2.path]));
+      expect(
+          output,
+          containsAllInOrder(<Matcher>[
+            contains('--packages-for-branch: running on all packages'),
           ]));
     });
 

--- a/script/tool/test/pubspec_check_command_test.dart
+++ b/script/tool/test/pubspec_check_command_test.dart
@@ -38,7 +38,7 @@ String _headerSection(
     'flutter',
     if (isPlugin) 'plugins' else 'packages',
     'tree',
-    'master',
+    'main',
     'packages',
     repositoryPath,
   ];

--- a/script/tool/test/version_check_command_test.dart
+++ b/script/tool/test/version_check_command_test.dart
@@ -22,15 +22,15 @@ import 'mocks.dart';
 import 'util.dart';
 
 void testAllowedVersion(
-  String masterVersion,
+  String mainVersion,
   String headVersion, {
   bool allowed = true,
   NextVersionType? nextVersionType,
 }) {
-  final Version master = Version.parse(masterVersion);
+  final Version main = Version.parse(mainVersion);
   final Version head = Version.parse(headVersion);
   final Map<Version, NextVersionType> allowedVersions =
-      getAllowedNextVersions(master, newVersion: head);
+      getAllowedNextVersions(main, newVersion: head);
   if (allowed) {
     expect(allowedVersions, contains(head));
     if (nextVersionType != null) {
@@ -109,10 +109,10 @@ void main() {
     test('allows valid version', () async {
       createFakePlugin('plugin', packagesDir, version: '2.0.0');
       gitShowResponses = <String, String>{
-        'master:packages/plugin/pubspec.yaml': 'version: 1.0.0',
+        'main:packages/plugin/pubspec.yaml': 'version: 1.0.0',
       };
       final List<String> output = await runCapturingPrint(
-          runner, <String>['version-check', '--base-sha=master']);
+          runner, <String>['version-check', '--base-sha=main']);
 
       expect(
         output,
@@ -125,17 +125,17 @@ void main() {
       expect(
           gitDirCommands,
           containsAll(<Matcher>[
-            equals(<String>['show', 'master:packages/plugin/pubspec.yaml']),
+            equals(<String>['show', 'main:packages/plugin/pubspec.yaml']),
           ]));
     });
 
     test('denies invalid version', () async {
       createFakePlugin('plugin', packagesDir, version: '0.2.0');
       gitShowResponses = <String, String>{
-        'master:packages/plugin/pubspec.yaml': 'version: 0.0.1',
+        'main:packages/plugin/pubspec.yaml': 'version: 0.0.1',
       };
       final Future<List<String>> result = runCapturingPrint(
-          runner, <String>['version-check', '--base-sha=master']);
+          runner, <String>['version-check', '--base-sha=main']);
 
       await expectLater(
         result,
@@ -145,7 +145,7 @@ void main() {
       expect(
           gitDirCommands,
           containsAll(<Matcher>[
-            equals(<String>['show', 'master:packages/plugin/pubspec.yaml']),
+            equals(<String>['show', 'main:packages/plugin/pubspec.yaml']),
           ]));
     });
 
@@ -229,11 +229,11 @@ void main() {
       createFakePlugin('plugin_platform_interface', packagesDir,
           version: '1.1.0');
       gitShowResponses = <String, String>{
-        'master:packages/plugin_platform_interface/pubspec.yaml':
+        'main:packages/plugin_platform_interface/pubspec.yaml':
             'version: 1.0.0',
       };
       final List<String> output = await runCapturingPrint(
-          runner, <String>['version-check', '--base-sha=master']);
+          runner, <String>['version-check', '--base-sha=main']);
       expect(
         output,
         containsAllInOrder(<Matcher>[
@@ -247,7 +247,7 @@ void main() {
           containsAll(<Matcher>[
             equals(<String>[
               'show',
-              'master:packages/plugin_platform_interface/pubspec.yaml'
+              'main:packages/plugin_platform_interface/pubspec.yaml'
             ]),
           ]));
     });
@@ -257,11 +257,11 @@ void main() {
       createFakePlugin('plugin_platform_interface', packagesDir,
           version: '2.0.0');
       gitShowResponses = <String, String>{
-        'master:packages/plugin_platform_interface/pubspec.yaml':
+        'main:packages/plugin_platform_interface/pubspec.yaml':
             'version: 1.0.0',
       };
       final Future<List<String>> output = runCapturingPrint(
-          runner, <String>['version-check', '--base-sha=master']);
+          runner, <String>['version-check', '--base-sha=main']);
       await expectLater(
         output,
         throwsA(isA<ToolExit>()),
@@ -272,7 +272,7 @@ void main() {
           containsAll(<Matcher>[
             equals(<String>[
               'show',
-              'master:packages/plugin_platform_interface/pubspec.yaml'
+              'main:packages/plugin_platform_interface/pubspec.yaml'
             ]),
           ]));
     });
@@ -282,7 +282,7 @@ void main() {
       createFakePlugin('plugin_platform_interface', packagesDir,
           version: '2.0.0');
       gitShowResponses = <String, String>{
-        'master:packages/plugin_platform_interface/pubspec.yaml':
+        'main:packages/plugin_platform_interface/pubspec.yaml':
             'version: 1.0.0',
       };
       final File changeDescriptionFile =
@@ -297,7 +297,7 @@ This is necessary because of X, Y, and Z
 ## Another section''');
       final List<String> output = await runCapturingPrint(runner, <String>[
         'version-check',
-        '--base-sha=master',
+        '--base-sha=main',
         '--change-description-file=${changeDescriptionFile.path}'
       ]);
 
@@ -317,14 +317,14 @@ This is necessary because of X, Y, and Z
       createFakePlugin('plugin_platform_interface', packagesDir,
           version: '2.0.0');
       gitShowResponses = <String, String>{
-        'master:packages/plugin_platform_interface/pubspec.yaml':
+        'main:packages/plugin_platform_interface/pubspec.yaml':
             'version: 1.0.0',
       };
 
       Error? commandError;
       final List<String> output = await runCapturingPrint(runner, <String>[
         'version-check',
-        '--base-sha=master',
+        '--base-sha=main',
         '--change-description-file=a_missing_file.txt'
       ], errorHandler: (Error e) {
         commandError = e;
@@ -344,12 +344,12 @@ This is necessary because of X, Y, and Z
       createFakePlugin('plugin_platform_interface', packagesDir,
           version: '2.0.0');
       gitShowResponses = <String, String>{
-        'master:packages/plugin_platform_interface/pubspec.yaml':
+        'main:packages/plugin_platform_interface/pubspec.yaml':
             'version: 1.0.0',
       };
       final List<String> output = await runCapturingPrint(runner, <String>[
         'version-check',
-        '--base-sha=master',
+        '--base-sha=main',
         '--ignore-platform-interface-breaks'
       ]);
 
@@ -375,7 +375,7 @@ This is necessary because of X, Y, and Z
 ''';
       createFakeCHANGELOG(pluginDirectory, changelog);
       final List<String> output = await runCapturingPrint(
-          runner, <String>['version-check', '--base-sha=master']);
+          runner, <String>['version-check', '--base-sha=main']);
       expect(
         output,
         containsAllInOrder(<Matcher>[
@@ -393,11 +393,9 @@ This is necessary because of X, Y, and Z
 ''';
       createFakeCHANGELOG(pluginDirectory, changelog);
       bool hasError = false;
-      final List<String> output = await runCapturingPrint(runner, <String>[
-        'version-check',
-        '--base-sha=master',
-        '--against-pub'
-      ], errorHandler: (Error e) {
+      final List<String> output = await runCapturingPrint(
+          runner, <String>['version-check', '--base-sha=main', '--against-pub'],
+          errorHandler: (Error e) {
         expect(e, isA<ToolExit>());
         hasError = true;
       });
@@ -422,7 +420,7 @@ This is necessary because of X, Y, and Z
 ''';
       createFakeCHANGELOG(pluginDirectory, changelog);
       final List<String> output = await runCapturingPrint(
-          runner, <String>['version-check', '--base-sha=master']);
+          runner, <String>['version-check', '--base-sha=main']);
       expect(
         output,
         containsAllInOrder(<Matcher>[
@@ -445,11 +443,9 @@ This is necessary because of X, Y, and Z
 ''';
       createFakeCHANGELOG(pluginDirectory, changelog);
       bool hasError = false;
-      final List<String> output = await runCapturingPrint(runner, <String>[
-        'version-check',
-        '--base-sha=master',
-        '--against-pub'
-      ], errorHandler: (Error e) {
+      final List<String> output = await runCapturingPrint(
+          runner, <String>['version-check', '--base-sha=main', '--against-pub'],
+          errorHandler: (Error e) {
         expect(e, isA<ToolExit>());
         hasError = true;
       });
@@ -477,11 +473,11 @@ This is necessary because of X, Y, and Z
 ''';
       createFakeCHANGELOG(pluginDirectory, changelog);
       gitShowResponses = <String, String>{
-        'master:packages/plugin/pubspec.yaml': 'version: 1.0.0',
+        'main:packages/plugin/pubspec.yaml': 'version: 1.0.0',
       };
 
       final List<String> output = await runCapturingPrint(
-          runner, <String>['version-check', '--base-sha=master']);
+          runner, <String>['version-check', '--base-sha=main']);
       await expectLater(
         output,
         containsAllInOrder(<Matcher>[
@@ -506,11 +502,9 @@ This is necessary because of X, Y, and Z
 ''';
       createFakeCHANGELOG(pluginDirectory, changelog);
       bool hasError = false;
-      final List<String> output = await runCapturingPrint(runner, <String>[
-        'version-check',
-        '--base-sha=master',
-        '--against-pub'
-      ], errorHandler: (Error e) {
+      final List<String> output = await runCapturingPrint(
+          runner, <String>['version-check', '--base-sha=main', '--against-pub'],
+          errorHandler: (Error e) {
         expect(e, isA<ToolExit>());
         hasError = true;
       });
@@ -541,15 +535,13 @@ This is necessary because of X, Y, and Z
 ''';
       createFakeCHANGELOG(pluginDirectory, changelog);
       gitShowResponses = <String, String>{
-        'master:packages/plugin/pubspec.yaml': 'version: 1.0.0',
+        'main:packages/plugin/pubspec.yaml': 'version: 1.0.0',
       };
 
       bool hasError = false;
-      final List<String> output = await runCapturingPrint(runner, <String>[
-        'version-check',
-        '--base-sha=master',
-        '--against-pub'
-      ], errorHandler: (Error e) {
+      final List<String> output = await runCapturingPrint(
+          runner, <String>['version-check', '--base-sha=main', '--against-pub'],
+          errorHandler: (Error e) {
         expect(e, isA<ToolExit>());
         hasError = true;
       });
@@ -578,15 +570,13 @@ This is necessary because of X, Y, and Z
 ''';
       createFakeCHANGELOG(pluginDirectory, changelog);
       gitShowResponses = <String, String>{
-        'master:packages/plugin/pubspec.yaml': 'version: 1.0.0',
+        'main:packages/plugin/pubspec.yaml': 'version: 1.0.0',
       };
 
       bool hasError = false;
-      final List<String> output = await runCapturingPrint(runner, <String>[
-        'version-check',
-        '--base-sha=master',
-        '--against-pub'
-      ], errorHandler: (Error e) {
+      final List<String> output = await runCapturingPrint(
+          runner, <String>['version-check', '--base-sha=main', '--against-pub'],
+          errorHandler: (Error e) {
         expect(e, isA<ToolExit>());
         hasError = true;
       });
@@ -615,13 +605,13 @@ This is necessary because of X, Y, and Z
 ''';
       createFakeCHANGELOG(pluginDirectory, changelog);
       gitShowResponses = <String, String>{
-        'master:packages/plugin/pubspec.yaml': 'version: 1.0.0',
+        'main:packages/plugin/pubspec.yaml': 'version: 1.0.0',
       };
 
       Error? commandError;
       final List<String> output = await runCapturingPrint(runner, <String>[
         'version-check',
-        '--base-sha=master',
+        '--base-sha=main',
       ], errorHandler: (Error e) {
         commandError = e;
       });
@@ -648,13 +638,13 @@ This is necessary because of X, Y, and Z
 ''';
       createFakeCHANGELOG(pluginDirectory, changelog);
       gitShowResponses = <String, String>{
-        'master:packages/plugin/pubspec.yaml': 'version: 1.0.0',
+        'main:packages/plugin/pubspec.yaml': 'version: 1.0.0',
       };
 
       Error? commandError;
       final List<String> output = await runCapturingPrint(runner, <String>[
         'version-check',
-        '--base-sha=master',
+        '--base-sha=main',
       ], errorHandler: (Error e) {
         commandError = e;
       });
@@ -680,10 +670,10 @@ This is necessary because of X, Y, and Z
 
       createFakePlugin('plugin', packagesDir, version: '2.0.0');
       gitShowResponses = <String, String>{
-        'master:packages/plugin/pubspec.yaml': 'version: 1.0.0',
+        'main:packages/plugin/pubspec.yaml': 'version: 1.0.0',
       };
       final List<String> output = await runCapturingPrint(runner,
-          <String>['version-check', '--base-sha=master', '--against-pub']);
+          <String>['version-check', '--base-sha=main', '--against-pub']);
 
       expect(
         output,
@@ -704,15 +694,13 @@ This is necessary because of X, Y, and Z
 
       createFakePlugin('plugin', packagesDir, version: '2.0.0');
       gitShowResponses = <String, String>{
-        'master:packages/plugin/pubspec.yaml': 'version: 1.0.0',
+        'main:packages/plugin/pubspec.yaml': 'version: 1.0.0',
       };
 
       bool hasError = false;
-      final List<String> result = await runCapturingPrint(runner, <String>[
-        'version-check',
-        '--base-sha=master',
-        '--against-pub'
-      ], errorHandler: (Error e) {
+      final List<String> result = await runCapturingPrint(
+          runner, <String>['version-check', '--base-sha=main', '--against-pub'],
+          errorHandler: (Error e) {
         expect(e, isA<ToolExit>());
         hasError = true;
       });
@@ -736,14 +724,12 @@ ${indentation}Allowed versions: {1.0.0: NextVersionType.BREAKING_MAJOR, 0.1.0: N
 
       createFakePlugin('plugin', packagesDir, version: '2.0.0');
       gitShowResponses = <String, String>{
-        'master:packages/plugin/pubspec.yaml': 'version: 1.0.0',
+        'main:packages/plugin/pubspec.yaml': 'version: 1.0.0',
       };
       bool hasError = false;
-      final List<String> result = await runCapturingPrint(runner, <String>[
-        'version-check',
-        '--base-sha=master',
-        '--against-pub'
-      ], errorHandler: (Error e) {
+      final List<String> result = await runCapturingPrint(
+          runner, <String>['version-check', '--base-sha=main', '--against-pub'],
+          errorHandler: (Error e) {
         expect(e, isA<ToolExit>());
         hasError = true;
       });
@@ -767,10 +753,10 @@ ${indentation}HTTP response: null
 
       createFakePlugin('plugin', packagesDir, version: '2.0.0');
       gitShowResponses = <String, String>{
-        'master:packages/plugin/pubspec.yaml': 'version: 1.0.0',
+        'main:packages/plugin/pubspec.yaml': 'version: 1.0.0',
       };
       final List<String> result = await runCapturingPrint(runner,
-          <String>['version-check', '--base-sha=master', '--against-pub']);
+          <String>['version-check', '--base-sha=main', '--against-pub']);
 
       expect(
         result,


### PR DESCRIPTION
Treat `main` the same as `master` for branch-based switching, in
preparation for switching the branch names in Flutter repositories.

Also updates all of the tests that used `master` as the explicit base to
use `main` instead; what the tests use is arbitrary, so they can be
switched now even though the repo itself hasn't switched.

Part of https://github.com/flutter/flutter/issues/90476

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
