### PR TITLE
[package_info] Bump SDK version of example app

### DIFF
--- a/packages/package_info/CHANGELOG.md
+++ b/packages/package_info/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Remove references to the Android v1 embedding.
 * Updated Android lint settings.
+* Update Android compileSdkVersion to 30.
 
 ## 2.0.2
 
@@ -30,7 +31,7 @@
 
 ## 0.4.3+1
 
-* Update android compileSdkVersion to 29.
+* Update Android compileSdkVersion to 29.
 
 ## 0.4.3
 

--- a/packages/package_info/example/android/app/build.gradle
+++ b/packages/package_info/example/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     lintOptions {
         disable 'InvalidPackage'


### PR DESCRIPTION
Bumps package_info example app compileSdkVersion to 30 to match highest compileSdkVersion of dependencies.