### PR TITLE
[google_maps_flutter] Add new XCUITests that do not require permissions.

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/example/ios/RunnerUITests/GoogleMapsUITests.m
+++ b/packages/google_maps_flutter/google_maps_flutter/example/ios/RunnerUITests/GoogleMapsUITests.m
@@ -17,6 +17,8 @@
   self.app = [[XCUIApplication alloc] init];
   [self.app launch];
 
+  // The location permission interception is currently not working.
+  // See: https://github.com/flutter/flutter/issues/93325.
   [self
       addUIInterruptionMonitorWithDescription:@"Permission popups"
                                       handler:^BOOL(XCUIElement* _Nonnull interruptingElement) {
@@ -62,6 +64,61 @@
     XCTFail(@"Failed due to not able to find compass button");
   }
   [compass tap];
+}
+
+- (void)testMapCoordinatesPage {
+  XCUIApplication* app = self.app;
+  XCUIElement* mapCoordinates = app.staticTexts[@"Map coordinates"];
+  if (![mapCoordinates waitForExistenceWithTimeout:30.0]) {
+    os_log_error(OS_LOG_DEFAULT, "%@", app.debugDescription);
+    XCTFail(@"Failed due to not able to find 'Map coordinates''");
+  }
+  [mapCoordinates tap];
+
+  XCUIElement* platformView = app.otherElements[@"platform_view[0]"];
+  if (![platformView waitForExistenceWithTimeout:30.0]) {
+    os_log_error(OS_LOG_DEFAULT, "%@", app.debugDescription);
+    XCTFail(@"Failed due to not able to find platform view");
+  }
+
+  XCUIElement* getVisibleRegionBoundsButton = app.buttons[@"Get Visible Region Bounds"];
+  if (![getVisibleRegionBoundsButton waitForExistenceWithTimeout:30.0]) {
+    os_log_error(OS_LOG_DEFAULT, "%@", app.debugDescription);
+    XCTFail(@"Failed due to not able to find 'Get Visible Region Bounds''");
+  }
+  [getVisibleRegionBoundsButton tap];
+}
+
+- (void)testMapClickPage {
+  XCUIApplication* app = self.app;
+  XCUIElement* mapClick = app.staticTexts[@"Map click"];
+  if (![mapClick waitForExistenceWithTimeout:30.0]) {
+    os_log_error(OS_LOG_DEFAULT, "%@", app.debugDescription);
+    XCTFail(@"Failed due to not able to find 'Map click''");
+  }
+  [mapClick tap];
+
+  XCUIElement* platformView = app.otherElements[@"platform_view[0]"];
+  if (![platformView waitForExistenceWithTimeout:30.0]) {
+    os_log_error(OS_LOG_DEFAULT, "%@", app.debugDescription);
+    XCTFail(@"Failed due to not able to find platform view");
+  }
+
+  [platformView tap];
+
+  XCUIElement* tapped = app.staticTexts[@"Tapped"];
+  if (![tapped waitForExistenceWithTimeout:30.0]) {
+    os_log_error(OS_LOG_DEFAULT, "%@", app.debugDescription);
+    XCTFail(@"Failed due to not able to find 'tapped''");
+  }
+
+  [platformView pressForDuration:5.0];
+
+  XCUIElement* longPressed = app.staticTexts[@"Long pressed"];
+  if (![longPressed waitForExistenceWithTimeout:30.0]) {
+    os_log_error(OS_LOG_DEFAULT, "%@", app.debugDescription);
+    XCTFail(@"Failed due to not able to find 'longPressed''");
+  }
 }
 
 @end

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/map_click.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/map_click.dart
@@ -68,15 +68,27 @@ class _MapClickBodyState extends State<_MapClickBody> {
     if (mapController != null) {
       final String lastTap = 'Tap:\n${_lastTap ?? ""}\n';
       final String lastLongPress = 'Long press:\n${_lastLongPress ?? ""}';
-      columnChildren
-          .add(Center(child: Text(lastTap, textAlign: TextAlign.center)));
+      columnChildren.add(Center(
+          child: Text(
+        lastTap,
+        textAlign: TextAlign.center,
+      )));
+      columnChildren.add(Center(
+          child: Text(
+        _lastTap != null ? 'Tapped' : '',
+        textAlign: TextAlign.center,
+      )));
       columnChildren.add(Center(
           child: Text(
         lastLongPress,
         textAlign: TextAlign.center,
       )));
+      columnChildren.add(Center(
+          child: Text(
+        _lastLongPress != null ? 'Long pressed' : '',
+        textAlign: TextAlign.center,
+      )));
     }
-
     return Column(
       mainAxisAlignment: MainAxisAlignment.start,
       crossAxisAlignment: CrossAxisAlignment.stretch,


### PR DESCRIPTION
This PR adds 2 new XCUITests that doesn't require permissions.
Due to some issue with the permission popup in XCUITests, the only test in the plugin was disable. This leaves the plugin untested. This PR won't fix the permission popup issue, but can at least provide some tests for the plugin.

related to: https://github.com/flutter/flutter/issues/93325

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [ex empt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
