### PR TITLE
[url_launcher] Add null check for extracting browser headers

### DIFF
--- a/packages/url_launcher/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher/CHANGELOG.md
@@ -1,3 +1,6 @@
+## NEXT
+* Fixed extracting browser headers when they are null error.
+
 ## 6.0.12
 
 * Fixed an error where 'launch' method of url_launcher would cause an error if the provided URL was not valid by RFC 3986.

--- a/packages/url_launcher/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## NEXT
+
 * Fixed extracting browser headers when they are null error.
 
 ## 6.0.12

--- a/packages/url_launcher/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher/CHANGELOG.md
@@ -1,4 +1,4 @@
-## NEXT
+## 6.0.13
 
 * Fixed extracting browser headers when they are null error.
 

--- a/packages/url_launcher/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/WebViewActivity.java
+++ b/packages/url_launcher/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/WebViewActivity.java
@@ -144,7 +144,7 @@ public class WebViewActivity extends Activity {
     registerReceiver(broadcastReceiver, closeIntentFilter);
   }
 
-  private Map<String, String> extractHeaders(@Nullable Bundle headersBundle) {
+  public static Map<String, String> extractHeaders(@Nullable Bundle headersBundle) {
     if (headersBundle == null) {
       return Collections.emptyMap();
     }

--- a/packages/url_launcher/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/WebViewActivity.java
+++ b/packages/url_launcher/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/WebViewActivity.java
@@ -22,6 +22,7 @@ import android.webkit.WebViewClient;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
+import androidx.annotation.VisibleForTesting;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -144,6 +145,7 @@ public class WebViewActivity extends Activity {
     registerReceiver(broadcastReceiver, closeIntentFilter);
   }
 
+  @VisibleForTesting
   public static Map<String, String> extractHeaders(@Nullable Bundle headersBundle) {
     if (headersBundle == null) {
       return Collections.emptyMap();

--- a/packages/url_launcher/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/WebViewActivity.java
+++ b/packages/url_launcher/url_launcher/android/src/main/java/io/flutter/plugins/urllauncher/WebViewActivity.java
@@ -20,7 +20,9 @@ import android.webkit.WebResourceRequest;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -142,7 +144,10 @@ public class WebViewActivity extends Activity {
     registerReceiver(broadcastReceiver, closeIntentFilter);
   }
 
-  private Map<String, String> extractHeaders(Bundle headersBundle) {
+  private Map<String, String> extractHeaders(@Nullable Bundle headersBundle) {
+    if (headersBundle == null) {
+      return Collections.emptyMap();
+    }
     final Map<String, String> headersMap = new HashMap<>();
     for (String key : headersBundle.keySet()) {
       final String value = headersBundle.getString(key);

--- a/packages/url_launcher/url_launcher/android/src/test/java/io/flutter/plugins/urllauncher/WebViewActivityTest.java
+++ b/packages/url_launcher/url_launcher/android/src/test/java/io/flutter/plugins/urllauncher/WebViewActivityTest.java
@@ -14,9 +14,6 @@ import org.junit.Test;
 public class WebViewActivityTest {
   @Test
   public void extractHeaders_returnsEmptyMapWhenHeadersBundleNull() {
-    Bundle headersBundle = null;
-
-    Map<String, String> expectedExtractedHeaders = Collections.emptyMap();
-    assertEquals(WebViewActivity.extractHeaders(headersBundle), expectedExtractedHeaders);
+    assertEquals(WebViewActivity.extractHeaders(null), Collections.emptyMap());
   }
 }

--- a/packages/url_launcher/url_launcher/android/src/test/java/io/flutter/plugins/urllauncher/WebViewActivityTest.java
+++ b/packages/url_launcher/url_launcher/android/src/test/java/io/flutter/plugins/urllauncher/WebViewActivityTest.java
@@ -6,9 +6,7 @@ package io.flutter.plugins.urllauncher;
 
 import static org.junit.Assert.assertEquals;
 
-import android.os.Bundle;
 import java.util.Collections;
-import java.util.Map;
 import org.junit.Test;
 
 public class WebViewActivityTest {

--- a/packages/url_launcher/url_launcher/android/src/test/java/io/flutter/plugins/urllauncher/WebViewActivityTest.java
+++ b/packages/url_launcher/url_launcher/android/src/test/java/io/flutter/plugins/urllauncher/WebViewActivityTest.java
@@ -12,11 +12,11 @@ import java.util.Map;
 import org.junit.Test;
 
 public class WebViewActivityTest {
-    @Test
-    public void extractHeaders_returnsEmptyMapWhenHeadersBundleNull() {
-        Bundle headersBundle = null;
+  @Test
+  public void extractHeaders_returnsEmptyMapWhenHeadersBundleNull() {
+    Bundle headersBundle = null;
 
-        Map<String, String> expectedExtractedHeaders = Collections.emptyMap();
-        assertEquals(WebViewActivity.extractHeaders(headersBundle), expectedExtractedHeaders);
-    }  
+    Map<String, String> expectedExtractedHeaders = Collections.emptyMap();
+    assertEquals(WebViewActivity.extractHeaders(headersBundle), expectedExtractedHeaders);
+  }
 }

--- a/packages/url_launcher/url_launcher/android/src/test/java/io/flutter/plugins/urllauncher/WebViewActivityTest.java
+++ b/packages/url_launcher/url_launcher/android/src/test/java/io/flutter/plugins/urllauncher/WebViewActivityTest.java
@@ -13,7 +13,7 @@ import org.junit.Test;
 
 public class WebViewActivityTest {
     @Test
-    public void extractHeaders_returnsEmptyMapWithNoBrowserHeaders() {
+    public void extractHeaders_returnsEmptyMapWhenHeadersBundleNull() {
         Bundle headersBundle = null;
 
         Map<String, String> expectedExtractedHeaders = Collections.emptyMap();

--- a/packages/url_launcher/url_launcher/android/src/test/java/io/flutter/plugins/urllauncher/WebViewActivityTest.java
+++ b/packages/url_launcher/url_launcher/android/src/test/java/io/flutter/plugins/urllauncher/WebViewActivityTest.java
@@ -1,0 +1,22 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.plugins.urllauncher;
+
+import static org.junit.Assert.assertEquals;
+
+import android.os.Bundle;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.Test;
+
+public class WebViewActivityTest {
+    @Test
+    public void extractHeaders_returnsEmptyMapWithNoBrowserHeaders() {
+        Bundle headersBundle = null;
+
+        Map<String, String> expectedExtractedHeaders = Collections.emptyMap();
+        assertEquals(WebViewActivity.extractHeaders(headersBundle), expectedExtractedHeaders);
+    }  
+}

--- a/packages/url_launcher/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for launching a URL. Supports
   web, phone, SMS, and email schemes.
 repository: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 6.0.12
+version: 6.0.13
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
Adds null check for extracting browser headers.

Fixes https://github.com/flutter/flutter/issues/72863

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.