### PR TITLE
[path_provider] Add `getFlutterAssetsPath()` interface method.

### DIFF
--- a/packages/path_provider/path_provider_platform_interface/AUTHORS
+++ b/packages/path_provider/path_provider_platform_interface/AUTHORS
@@ -64,3 +64,4 @@ Aleksandr Yurkovskiy <sanekyy@gmail.com>
 Anton Borries <mail@antonborri.es>
 Alex Li <google@alexv525.com>
 Rahul Raj <64.rahulraj@gmail.com>
+Maurits van Beusekom <maurits@baseflow.com>

--- a/packages/path_provider/path_provider_platform_interface/CHANGELOG.md
+++ b/packages/path_provider/path_provider_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0
+
+* Added `getFlutterAssetsPath` interface method which when implemented should return the path where Flutter stored the assets registered in the pubspec.yaml file.
+
 ## 2.0.1
 
 * Update platform_plugin_interface version requirement.

--- a/packages/path_provider/path_provider_platform_interface/lib/path_provider_platform_interface.dart
+++ b/packages/path_provider/path_provider_platform_interface/lib/path_provider_platform_interface.dart
@@ -96,4 +96,11 @@ abstract class PathProviderPlatform extends PlatformInterface {
   Future<String?> getDownloadsPath() {
     throw UnimplementedError('getDownloadsPath() has not been implemented.');
   }
+
+  /// Path to the directory where the assets registered in the
+  /// pubspec.yaml of a Flutter application are stored.
+  Future<String?> getFlutterAssetsPath() {
+    throw UnimplementedError(
+        'getFlutterAssetsPath() has not been implemented.');
+  }
 }

--- a/packages/path_provider/path_provider_platform_interface/lib/src/method_channel_path_provider.dart
+++ b/packages/path_provider/path_provider_platform_interface/lib/src/method_channel_path_provider.dart
@@ -89,4 +89,9 @@ class MethodChannelPathProvider extends PathProviderPlatform {
     }
     return methodChannel.invokeMethod<String>('getDownloadsDirectory');
   }
+
+  @override
+  Future<String?> getFlutterAssetsPath() {
+    return methodChannel.invokeMethod<String>('getFlutterAssetsPath');
+  }
 }

--- a/packages/path_provider/path_provider_platform_interface/pubspec.yaml
+++ b/packages/path_provider/path_provider_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/master/packages/path_provide
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+path_provider%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.0.1
+version: 2.1.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/path_provider/path_provider_platform_interface/test/method_channel_path_provider_test.dart
+++ b/packages/path_provider/path_provider_platform_interface/test/method_channel_path_provider_test.dart
@@ -17,6 +17,7 @@ void main() {
   const String kExternalCachePaths = 'externalCachePaths';
   const String kExternalStoragePaths = 'externalStoragePaths';
   const String kDownloadsPath = 'downloadsPath';
+  const String kFlutterAssetsPath = 'flutterAssetsPath';
 
   group('$MethodChannelPathProvider', () {
     late MethodChannelPathProvider methodChannelPathProvider;
@@ -43,6 +44,8 @@ void main() {
             return <String>[kExternalCachePaths];
           case 'getDownloadsDirectory':
             return kDownloadsPath;
+          case 'getFlutterAssetsPath':
+            return kFlutterAssetsPath;
           default:
             return null;
         }
@@ -201,6 +204,16 @@ void main() {
       } catch (e) {
         expect(e, isUnsupportedError);
       }
+    });
+
+    test('getFlutterAssetsPath', () async {
+      final String? path =
+          await methodChannelPathProvider.getFlutterAssetsPath();
+      expect(
+        log,
+        <Matcher>[isMethodCall('getFlutterAssetsPath', arguments: null)],
+      );
+      expect(path, kFlutterAssetsPath);
     });
   });
 }


### PR DESCRIPTION
Adds the `getFlutterAssetsPath()` method to the path_provider_platform_interface. Platform implementations of the `getFlutterAssetsPath()` method should return the path to the directory which is used by the Flutter framework to store
the assets registered in the pubspec.yaml file of a Flutter application.

Related to issue flutter/flutter#34026

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
