### PR TITLE
[in_app_purchase] Fix CHANGELOG for 0.2.0.

### DIFF
--- a/packages/in_app_purchase/in_app_purchase_ios/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_ios/CHANGELOG.md
@@ -1,12 +1,12 @@
 ## 0.2.0+1
 
-* Fix CHANGELOG for 0.2.0 (added missing information regarding the implementation of promotional offers).
+* Fixes CHANGELOG for 0.2.0 (added missing information regarding the implementation of promotional offers).
 
 ## 0.2.0
 
 * BREAKING CHANGE : Refactor to handle new `PurchaseStatus` named `canceled`. This means developers
   can distinguish between an error and user cancellation;
-* Added support for promotional offers on the store_kit_wrappers Dart API.
+* Adds support for promotional offers on the store_kit_wrappers Dart API.
 
 ## 0.1.4
 

--- a/packages/in_app_purchase/in_app_purchase_ios/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_ios/CHANGELOG.md
@@ -1,7 +1,12 @@
+## 0.2.0+1
+
+* Fix CHANGELOG for 0.2.0 (added missing information regarding the implementation of promotional offers).
+
 ## 0.2.0
 
 * BREAKING CHANGE : Refactor to handle new `PurchaseStatus` named `canceled`. This means developers
-  can distinguish between an error and user cancellation.
+  can distinguish between an error and user cancellation;
+* Added support for promotional offers on the store_kit_wrappers Dart API.
 
 ## 0.1.4
 

--- a/packages/in_app_purchase/in_app_purchase_ios/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase_ios
 description: An implementation for the iOS platform of the Flutter `in_app_purchase` plugin. This uses the iOS StoreKit Framework.
 repository: https://github.com/flutter/plugins/tree/master/packages/in_app_purchase/in_app_purchase_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 0.2.0
+version: 0.2.0+1
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
PR #4458 was merged without having the version updated and the functionality is now published as part of in_app_purchase_ios version 0.2.0 (that was release with PR #4094). 

This PR adds a belated correction to version 0.2.0 in the CHANGELOG to ensure the changes made in #4458 don't go undocumented.

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
  - Only a documentation change in the CHANGELOG.md and a corresponding version bump in pubspec.yaml. So no new tests were added.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
