### PR TITLE
[webview_flutter] Revert addition of onUrlChanged

### DIFF
--- a/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.5.1
+
+* Reverts the addition of `onUrlChanged`, which was unintentionally a breaking
+  change.
+
+## 1.5.0
+
+* Added `onUrlChanged` callback to platform callback handler.
+
 ## 1.4.0
 
 * Added `loadFile` and `loadHtml` interface methods.

--- a/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 1.5.0
-
-* Added `onUrlChanged` callback to platform callback handler.
-
 ## 1.4.0
 
 * Added `loadFile` and `loadHtml` interface methods.

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/src/method_channel/webview_method_channel.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/src/method_channel/webview_method_channel.dart
@@ -53,9 +53,6 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
       case 'onPageStarted':
         _platformCallbacksHandler.onPageStarted(call.arguments['url']!);
         return null;
-      case 'onUrlChanged':
-        _platformCallbacksHandler.onUrlChanged(call.arguments['url']!);
-        return null;
       case 'onWebResourceError':
         _platformCallbacksHandler.onWebResourceError(
           WebResourceError(

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_interface/webview_platform_callbacks_handler.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_interface/webview_platform_callbacks_handler.dart
@@ -24,15 +24,8 @@ abstract class WebViewPlatformCallbacksHandler {
   void onPageFinished(String url);
 
   /// Invoked by [WebViewPlatformController] when a page is loading.
-  /// Only works when [WebSettings.hasProgressTracking] is set to `true`.
+  /// /// Only works when [WebSettings.hasProgressTracking] is set to `true`.
   void onProgress(int progress);
-
-  /// Invoked by [WebViewPlatformController] when the webview's URL has changed.
-  ///
-  /// Unlike [onPageStarted], [onProgress], and [onPageFinished],
-  /// [onUrlChanged] also fires when navigating without a full page load
-  /// e.g. when navigating within a single page application.
-  void onUrlChanged(String url);
 
   /// Report web resource loading error to the host application.
   void onWebResourceError(WebResourceError error);

--- a/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/master/packages/webview_flut
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview_flutter%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.4.0
+version: 1.5.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/master/packages/webview_flut
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview_flutter%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.5.0
+version: 1.4.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/webview_flutter/webview_flutter_platform_interface/test/src/method_channel/webview_method_channel_test.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/test/src/method_channel/webview_method_channel_test.dart
@@ -13,9 +13,7 @@ import 'package:webview_flutter_platform_interface/webview_flutter_platform_inte
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  group(
-      'Tests on `plugin.flutter.io/webview_<channel_id>` channel dart->native',
-      () {
+  group('Tests on `plugin.flutter.io/webview_<channel_id>` channel', () {
     const int channelId = 1;
     const MethodChannel channel =
         MethodChannel('plugins.flutter.io/webview_$channelId');
@@ -553,40 +551,6 @@ void main() {
           ),
         ],
       );
-    });
-  });
-
-  group(
-      'Tests on `plugin.flutter.io/webview_<channel_id>` channel native->dart',
-      () {
-    const int channelId = 1;
-    final WebViewPlatformCallbacksHandler callbacksHandler =
-        MockWebViewPlatformCallbacksHandler();
-    final JavascriptChannelRegistry javascriptChannelRegistry =
-        MockJavascriptChannelRegistry();
-
-    MethodChannelWebViewPlatform(
-      channelId,
-      callbacksHandler,
-      javascriptChannelRegistry,
-    );
-
-    tearDown(() {
-      reset(callbacksHandler);
-    });
-
-    test('onUrlChanged', () async {
-      // Run
-      await ServicesBinding.instance!.defaultBinaryMessenger
-          .handlePlatformMessage(
-        'plugins.flutter.io/webview_$channelId',
-        StandardMethodCodec()
-            .encodeMethodCall(MethodCall('onUrlChanged', {'url': 'Test Url'})),
-        null,
-      );
-
-      // Verify
-      verify(callbacksHandler.onUrlChanged('Test Url'));
     });
   });
 


### PR DESCRIPTION
Reverts https://github.com/flutter/plugins/pull/4509, which is ecosystem-breaking since it adds a new method to the interface that no existing code implements.

Note that while this PR is technically a breaking change, it is deliberately versioned as a non-breaking change so that people will automatically pick up the fix for the previous accidentally-breaking change. (In practice, this revert would only breaking if someone implemented this new method in an unendorsed webview implementation sometime in the last ~12 hours that the change was live).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
