### PR TITLE
[webview_flutter] Adjust getTitle test

### DIFF
--- a/packages/webview_flutter/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
 * Updates example app Android compileSdkVersion to 31.
+* Integration test fixes.
 
 ## 2.3.1
 

--- a/packages/webview_flutter/webview_flutter/example/integration_test/webview_flutter_test.dart
+++ b/packages/webview_flutter/webview_flutter/example/integration_test/webview_flutter_test.dart
@@ -748,7 +748,6 @@ void main() {
     final Completer<WebViewController> controllerCompleter =
         Completer<WebViewController>();
 
-
     final testUrl = 'data:text/html;charset=utf-8;base64,$getTitleTestBase64';
     await tester.pumpWidget(
       Directionality(
@@ -759,6 +758,8 @@ void main() {
             controllerCompleter.complete(controller);
           },
           onPageStarted: (String url) {
+            // Ensure that this update is for the test page, in case any other
+            // URL (e.g., about:blank) fires earlier notifications.
             if (url == testUrl) {
               pageStarted.complete(null);
             }

--- a/packages/webview_flutter/webview_flutter/example/integration_test/webview_flutter_test.dart
+++ b/packages/webview_flutter/webview_flutter/example/integration_test/webview_flutter_test.dart
@@ -748,19 +748,25 @@ void main() {
     final Completer<WebViewController> controllerCompleter =
         Completer<WebViewController>();
 
+
+    final testUrl = 'data:text/html;charset=utf-8;base64,$getTitleTestBase64';
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
         child: WebView(
-          initialUrl: 'data:text/html;charset=utf-8;base64,$getTitleTestBase64',
+          initialUrl: testUrl,
           onWebViewCreated: (WebViewController controller) {
             controllerCompleter.complete(controller);
           },
           onPageStarted: (String url) {
-            pageStarted.complete(null);
+            if (url == testUrl) {
+              pageStarted.complete(null);
+            }
           },
           onPageFinished: (String url) {
-            pageLoaded.complete(null);
+            if (url == testUrl) {
+              pageLoaded.complete(null);
+            }
           },
         ),
       ),

--- a/packages/webview_flutter/webview_flutter_wkwebview/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_wkwebview/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Integration test fixes.
+
 ## 2.4.0
 
 * Implemented new `loadFile` and `loadHtmlString` methods from the platform interface.

--- a/packages/webview_flutter/webview_flutter_wkwebview/example/integration_test/webview_flutter_test.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/example/integration_test/webview_flutter_test.dart
@@ -733,19 +733,24 @@ void main() {
     final Completer<WebViewController> controllerCompleter =
         Completer<WebViewController>();
 
+    final testUrl = 'data:text/html;charset=utf-8;base64,$getTitleTestBase64';
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
         child: WebView(
-          initialUrl: 'data:text/html;charset=utf-8;base64,$getTitleTestBase64',
+          initialUrl: testUrl,
           onWebViewCreated: (WebViewController controller) {
             controllerCompleter.complete(controller);
           },
           onPageStarted: (String url) {
-            pageStarted.complete(null);
+            if (url == testUrl) {
+              pageStarted.complete(null);
+            }
           },
           onPageFinished: (String url) {
-            pageLoaded.complete(null);
+            if (url == testUrl) {
+              pageLoaded.complete(null);
+            }
           },
         ),
       ),

--- a/packages/webview_flutter/webview_flutter_wkwebview/example/integration_test/webview_flutter_test.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/example/integration_test/webview_flutter_test.dart
@@ -743,6 +743,8 @@ void main() {
             controllerCompleter.complete(controller);
           },
           onPageStarted: (String url) {
+            // Ensure that this update is for the test page, in case any other
+            // URL (e.g., about:blank) fires earlier notifications.
             if (url == testUrl) {
               pageStarted.complete(null);
             }


### PR DESCRIPTION
The getTitle test has been flaking on iOS, for reasons that are not
clear. This is a highly speculative attempted fix, in case the issue is
that the futere is completing too early (e.g., if 'about:blank' is
triggering a completion).

Fixes https://github.com/flutter/flutter/issues/94117

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
