### PR TITLE
[path_provider] Remove platform registration

### DIFF
--- a/packages/path_provider/path_provider/CHANGELOG.md
+++ b/packages/path_provider/path_provider/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 2.0.8
 
 * Updates example app Android compileSdkVersion to 31.
+* Removes obsolete manual registration of Windows and Linux implementations.
 
 ## 2.0.7
 

--- a/packages/path_provider/path_provider/lib/path_provider.dart
+++ b/packages/path_provider/path_provider/lib/path_provider.dart
@@ -2,14 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io' show Directory, Platform;
+import 'dart:io' show Directory;
 
-import 'package:flutter/foundation.dart' show kIsWeb, visibleForTesting;
-import 'package:path_provider_linux/path_provider_linux.dart';
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
-// ignore: implementation_imports
-import 'package:path_provider_platform_interface/src/method_channel_path_provider.dart';
-import 'package:path_provider_windows/path_provider_windows.dart';
 
 export 'package:path_provider_platform_interface/path_provider_platform_interface.dart'
     show StorageDirectory;
@@ -17,8 +13,6 @@ export 'package:path_provider_platform_interface/path_provider_platform_interfac
 @visibleForTesting
 @Deprecated('This is no longer necessary, and is now a no-op')
 set disablePathProviderPlatformOverride(bool override) {}
-
-bool _manualDartRegistrationNeeded = true;
 
 /// An exception thrown when a directory that should always be available on
 /// the current platform cannot be obtained.
@@ -41,24 +35,7 @@ class MissingPlatformDirectoryException implements Exception {
   }
 }
 
-PathProviderPlatform get _platform {
-  // TODO(egarciad): Remove once auto registration lands on Flutter stable.
-  // https://github.com/flutter/flutter/issues/81421.
-  if (_manualDartRegistrationNeeded) {
-    // Only do the initial registration if it hasn't already been overridden
-    // with a non-default instance.
-    if (!kIsWeb && PathProviderPlatform.instance is MethodChannelPathProvider) {
-      if (Platform.isLinux) {
-        PathProviderPlatform.instance = PathProviderLinux();
-      } else if (Platform.isWindows) {
-        PathProviderPlatform.instance = PathProviderWindows();
-      }
-    }
-    _manualDartRegistrationNeeded = false;
-  }
-
-  return PathProviderPlatform.instance;
-}
+PathProviderPlatform get _platform => PathProviderPlatform.instance;
 
 /// Path to the temporary directory on the device that is not backed up and is
 /// suitable for storing caches of downloaded files.

--- a/packages/path_provider/path_provider/pubspec.yaml
+++ b/packages/path_provider/path_provider/pubspec.yaml
@@ -2,7 +2,7 @@ name: path_provider
 description: Flutter plugin for getting commonly used locations on host platform file systems, such as the temp and app data directories.
 repository: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+path_provider%22
-version: 2.0.7
+version: 2.0.8
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -27,10 +27,10 @@ dependencies:
     sdk: flutter
   path_provider_android: ^2.0.6
   path_provider_ios: ^2.0.6
-  path_provider_linux: ^2.0.0
+  path_provider_linux: ^2.0.1
   path_provider_macos: ^2.0.0
   path_provider_platform_interface: ^2.0.0
-  path_provider_windows: ^2.0.0
+  path_provider_windows: ^2.0.2
 
 dev_dependencies:
   flutter_driver:


### PR DESCRIPTION
The plugin requires Flutter 2.5, which supports auto-registration of
Dart implementation code in platform packages, and the packages already
do auto-registration. This registration is therefore not needed, so can be
removed.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
