### PR TITLE
[ci] Exclude files generated by Pigeon from analysis.

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -57,6 +57,7 @@ analyzer:
     - '**/*.g.dart'
     - 'lib/src/generated/*.dart'
     - '**/*.mocks.dart' # Mockito @GenerateMocks
+    - '**/*.pigeon.dart' # Pigeon generated file
 
 linter:
   rules:

--- a/analysis_options_legacy.yaml
+++ b/analysis_options_legacy.yaml
@@ -5,6 +5,7 @@ analyzer:
     - '**/*.g.dart'
     - 'lib/src/generated/*.dart'
     - '**/*.mocks.dart' # Mockito @GenerateMocks
+    - '**/*.pigeon.dart' # Pigeon generated file
   errors:
     always_require_non_null_named_parameters: false # not needed with nnbd
     # TODO(https://github.com/flutter/flutter/issues/74381):


### PR DESCRIPTION
Excludes files generated by Pigeon and matches the `**/*.pigeon.dart` pattern from static code analysis. 

This change would make it easier to get changes to the webview_flutter_android package passed. It now needs manual editing of the *.pigeon.dart files each time they are generated.

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
