### PR TITLE
[path_provider] Switch macOS to an internal method channel

### DIFF
--- a/packages/path_provider/path_provider_macos/CHANGELOG.md
+++ b/packages/path_provider/path_provider_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.4
+
+* Switches to a package-internal implementation of the platform interface.
+
 ## 2.0.3
 
 * Fixes link in README.

--- a/packages/path_provider/path_provider_macos/lib/path_provider_macos.dart
+++ b/packages/path_provider/path_provider_macos/lib/path_provider_macos.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:flutter/services.dart';
 import 'package:meta/meta.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
@@ -24,8 +26,15 @@ class PathProviderMacOS extends PathProviderPlatform {
   }
 
   @override
-  Future<String?> getApplicationSupportPath() {
-    return methodChannel.invokeMethod<String>('getApplicationSupportDirectory');
+  Future<String?> getApplicationSupportPath() async {
+    final String? path = await methodChannel
+        .invokeMethod<String>('getApplicationSupportDirectory');
+    if (path != null) {
+      // Ensure the directory exists before returning it, for consistency with
+      // other platforms.
+      await Directory(path).create(recursive: true);
+    }
+    return path;
   }
 
   @override

--- a/packages/path_provider/path_provider_macos/lib/path_provider_macos.dart
+++ b/packages/path_provider/path_provider_macos/lib/path_provider_macos.dart
@@ -11,7 +11,7 @@ class PathProviderMacOS extends PathProviderPlatform {
   /// The method channel used to interact with the native platform.
   @visibleForTesting
   MethodChannel methodChannel =
-      const MethodChannel('plugins.flutter.io/path_provider');
+      const MethodChannel('plugins.flutter.io/path_provider_macos');
 
   /// Registers this class as the default instance of [PathProviderPlatform]
   static void registerWith() {
@@ -40,12 +40,12 @@ class PathProviderMacOS extends PathProviderPlatform {
   }
 
   @override
-  Future<String?> getExternalStoragePath() {
+  Future<String?> getExternalStoragePath() async {
     throw UnsupportedError('getExternalStoragePath is not supported on macOS');
   }
 
   @override
-  Future<List<String>?> getExternalCachePaths() {
+  Future<List<String>?> getExternalCachePaths() async {
     throw UnsupportedError('getExternalCachePaths is not supported on macOS');
   }
 

--- a/packages/path_provider/path_provider_macos/lib/path_provider_macos.dart
+++ b/packages/path_provider/path_provider_macos/lib/path_provider_macos.dart
@@ -1,0 +1,63 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/services.dart';
+import 'package:meta/meta.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+
+/// The macOS implementation of [PathProviderPlatform].
+class PathProviderMacOS extends PathProviderPlatform {
+  /// The method channel used to interact with the native platform.
+  @visibleForTesting
+  MethodChannel methodChannel =
+      const MethodChannel('plugins.flutter.io/path_provider');
+
+  /// Registers this class as the default instance of [PathProviderPlatform]
+  static void registerWith() {
+    PathProviderPlatform.instance = PathProviderMacOS();
+  }
+
+  @override
+  Future<String?> getTemporaryPath() {
+    return methodChannel.invokeMethod<String>('getTemporaryDirectory');
+  }
+
+  @override
+  Future<String?> getApplicationSupportPath() {
+    return methodChannel.invokeMethod<String>('getApplicationSupportDirectory');
+  }
+
+  @override
+  Future<String?> getLibraryPath() {
+    return methodChannel.invokeMethod<String>('getLibraryDirectory');
+  }
+
+  @override
+  Future<String?> getApplicationDocumentsPath() {
+    return methodChannel
+        .invokeMethod<String>('getApplicationDocumentsDirectory');
+  }
+
+  @override
+  Future<String?> getExternalStoragePath() {
+    throw UnsupportedError('getExternalStoragePath is not supported on macOS');
+  }
+
+  @override
+  Future<List<String>?> getExternalCachePaths() {
+    throw UnsupportedError('getExternalCachePaths is not supported on macOS');
+  }
+
+  @override
+  Future<List<String>?> getExternalStoragePaths({
+    StorageDirectory? type,
+  }) async {
+    throw UnsupportedError('getExternalStoragePaths is not supported on macOS');
+  }
+
+  @override
+  Future<String?> getDownloadsPath() {
+    return methodChannel.invokeMethod<String>('getDownloadsDirectory');
+  }
+}

--- a/packages/path_provider/path_provider_macos/macos/Classes/PathProviderPlugin.swift
+++ b/packages/path_provider/path_provider_macos/macos/Classes/PathProviderPlugin.swift
@@ -25,16 +25,6 @@ public class PathProviderPlugin: NSObject, FlutterPlugin {
       if let basePath = path {
         let basePathURL = URL.init(fileURLWithPath: basePath)
         path = basePathURL.appendingPathComponent(Bundle.main.bundleIdentifier!).path
-        do {
-          try FileManager.default.createDirectory(atPath: path!, withIntermediateDirectories: true)
-        } catch {
-          result(
-            FlutterError(
-              code: "directory_creation_failure",
-              message: error.localizedDescription,
-              details: "\(error)"))
-          return
-        }
       }
       result(path)
     case "getLibraryDirectory":

--- a/packages/path_provider/path_provider_macos/macos/Classes/PathProviderPlugin.swift
+++ b/packages/path_provider/path_provider_macos/macos/Classes/PathProviderPlugin.swift
@@ -8,7 +8,7 @@ import Foundation
 public class PathProviderPlugin: NSObject, FlutterPlugin {
   public static func register(with registrar: FlutterPluginRegistrar) {
     let channel = FlutterMethodChannel(
-      name: "plugins.flutter.io/path_provider",
+      name: "plugins.flutter.io/path_provider_macos",
       binaryMessenger: registrar.messenger)
     let instance = PathProviderPlugin()
     registrar.addMethodCallDelegate(instance, channel: channel)

--- a/packages/path_provider/path_provider_macos/pubspec.yaml
+++ b/packages/path_provider/path_provider_macos/pubspec.yaml
@@ -14,10 +14,12 @@ flutter:
     platforms:
       macos:
         pluginClass: PathProviderPlugin
+        dartPluginClass: PathProviderMacOS
 
 dependencies:
   flutter:
     sdk: flutter
+  path_provider_platform_interface: ^2.0.1
 
 dev_dependencies:
   pedantic: ^1.10.0

--- a/packages/path_provider/path_provider_macos/pubspec.yaml
+++ b/packages/path_provider/path_provider_macos/pubspec.yaml
@@ -24,4 +24,5 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  path: ^1.8.0
   pedantic: ^1.10.0

--- a/packages/path_provider/path_provider_macos/pubspec.yaml
+++ b/packages/path_provider/path_provider_macos/pubspec.yaml
@@ -19,6 +19,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
+  meta: ^1.3.0
   path_provider_platform_interface: ^2.0.1
 
 dev_dependencies:

--- a/packages/path_provider/path_provider_macos/pubspec.yaml
+++ b/packages/path_provider/path_provider_macos/pubspec.yaml
@@ -22,4 +22,6 @@ dependencies:
   path_provider_platform_interface: ^2.0.1
 
 dev_dependencies:
+  flutter_test:
+    sdk: flutter
   pedantic: ^1.10.0

--- a/packages/path_provider/path_provider_macos/pubspec.yaml
+++ b/packages/path_provider/path_provider_macos/pubspec.yaml
@@ -2,7 +2,7 @@ name: path_provider_macos
 description: macOS implementation of the path_provider plugin
 repository: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider_macos
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+path_provider%22
-version: 2.0.3
+version: 2.0.4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/path_provider/path_provider_macos/test/path_provider_macos_test.dart
+++ b/packages/path_provider/path_provider_macos/test/path_provider_macos_test.dart
@@ -1,0 +1,111 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_macos/path_provider_macos.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const String kTemporaryPath = 'temporaryPath';
+  const String kApplicationSupportPath = 'applicationSupportPath';
+  const String kLibraryPath = 'libraryPath';
+  const String kApplicationDocumentsPath = 'applicationDocumentsPath';
+  const String kDownloadsPath = 'downloadsPath';
+
+  group('PathProviderMacOS', () {
+    late PathProviderMacOS pathProvider;
+    final List<MethodCall> log = <MethodCall>[];
+
+    setUp(() async {
+      pathProvider = PathProviderMacOS();
+      TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger
+          .setMockMethodCallHandler(pathProvider.methodChannel,
+              (MethodCall methodCall) async {
+        log.add(methodCall);
+        switch (methodCall.method) {
+          case 'getTemporaryDirectory':
+            return kTemporaryPath;
+          case 'getApplicationSupportDirectory':
+            return kApplicationSupportPath;
+          case 'getLibraryDirectory':
+            return kLibraryPath;
+          case 'getApplicationDocumentsDirectory':
+            return kApplicationDocumentsPath;
+          case 'getDownloadsDirectory':
+            return kDownloadsPath;
+          default:
+            return null;
+        }
+      });
+    });
+
+    tearDown(() {
+      log.clear();
+    });
+
+    test('getTemporaryPath', () async {
+      final String? path = await pathProvider.getTemporaryPath();
+      expect(
+        log,
+        <Matcher>[isMethodCall('getTemporaryDirectory', arguments: null)],
+      );
+      expect(path, kTemporaryPath);
+    });
+
+    test('getApplicationSupportPath', () async {
+      final String? path = await pathProvider.getApplicationSupportPath();
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('getApplicationSupportDirectory', arguments: null)
+        ],
+      );
+      expect(path, kApplicationSupportPath);
+    });
+
+    test('getLibraryPath', () async {
+      final String? path = await pathProvider.getLibraryPath();
+      expect(
+        log,
+        <Matcher>[isMethodCall('getLibraryDirectory', arguments: null)],
+      );
+      expect(path, kLibraryPath);
+    });
+
+    test('getApplicationDocumentsPath', () async {
+      final String? path = await pathProvider.getApplicationDocumentsPath();
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('getApplicationDocumentsDirectory', arguments: null)
+        ],
+      );
+      expect(path, kApplicationDocumentsPath);
+    });
+
+    test('getDownloadsPath', () async {
+      final String? result = await pathProvider.getDownloadsPath();
+      expect(
+        log,
+        <Matcher>[isMethodCall('getDownloadsDirectory', arguments: null)],
+      );
+      expect(result, kDownloadsPath);
+    });
+
+    test('getExternalCachePaths throws', () async {
+      expect(pathProvider.getExternalCachePaths(), throwsA(isUnsupportedError));
+    });
+
+    test('getExternalStoragePath throws', () async {
+      expect(
+          pathProvider.getExternalStoragePath(), throwsA(isUnsupportedError));
+    });
+
+    test('getExternalStoragePaths throws', () async {
+      expect(
+          pathProvider.getExternalStoragePaths(), throwsA(isUnsupportedError));
+    });
+  });
+}


### PR DESCRIPTION
Eliminates the path_provider_macos reliance on the default, shared method channel implementation, in favor of an in-package implementation.

Now that it's trivial to do so, also moves the creation of directories when necessary to the Dart side, and unit tests it there.

Part of https://github.com/flutter/flutter/issues/94224

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
