### PR TITLE
[webview_flutter] Pre-emptively ignore prefer_const_constructor warning.

### DIFF
--- a/packages/webview_flutter/webview_flutter_android/example/lib/web_view.dart
+++ b/packages/webview_flutter/webview_flutter_android/example/lib/web_view.dart
@@ -568,6 +568,8 @@ class WebViewController {
     bool? hasNavigationDelegate;
     bool? hasProgressTracking;
     bool? debuggingEnabled;
+    // TODO(mvanbeusekom): Cleanup and convert to const constructor when platform_interface is fixed (see https://github.com/flutter/flutter/issues/94311)
+    // ignore: prefer_const_constructors
     WebSetting<String?> userAgent = WebSetting<String?>.absent();
     bool? zoomEnabled;
     if (currentValue.javascriptMode != newValue.javascriptMode) {

--- a/packages/webview_flutter/webview_flutter_android/test/webview_android_widget_test.dart
+++ b/packages/webview_flutter/webview_flutter_android/test/webview_android_widget_test.dart
@@ -70,6 +70,8 @@ void main() {
         creationParams: creationParams ??
             CreationParams(
                 webSettings: WebSettings(
+              // TODO(mvanbeusekom): Cleanup and convert to const constructor when platform_interface is fixed (see https://github.com/flutter/flutter/issues/94311)
+              // ignore: prefer_const_constructors
               userAgent: WebSetting<String?>.absent(),
               hasNavigationDelegate: hasNavigationDelegate,
               hasProgressTracking: hasProgressTracking,
@@ -121,6 +123,8 @@ void main() {
           creationParams: CreationParams(
             initialUrl: 'https://www.google.com',
             webSettings: WebSettings(
+              // TODO(mvanbeusekom): Cleanup and convert to const constructor when platform_interface is fixed (see https://github.com/flutter/flutter/issues/94311)
+              // ignore: prefer_const_constructors
               userAgent: WebSetting<String?>.absent(),
               hasNavigationDelegate: false,
             ),
@@ -138,6 +142,8 @@ void main() {
           creationParams: CreationParams(
             userAgent: 'MyUserAgent',
             webSettings: WebSettings(
+              // TODO(mvanbeusekom): Cleanup and convert to const constructor when platform_interface is fixed (see https://github.com/flutter/flutter/issues/94311)
+              // ignore: prefer_const_constructors
               userAgent: WebSetting<String?>.absent(),
               hasNavigationDelegate: false,
             ),
@@ -154,6 +160,8 @@ void main() {
             autoMediaPlaybackPolicy:
                 AutoMediaPlaybackPolicy.require_user_action_for_all_media_types,
             webSettings: WebSettings(
+              // TODO(mvanbeusekom): Cleanup and convert to const constructor when platform_interface is fixed (see https://github.com/flutter/flutter/issues/94311)
+              // ignore: prefer_const_constructors
               userAgent: WebSetting<String?>.absent(),
               hasNavigationDelegate: false,
             ),
@@ -169,6 +177,8 @@ void main() {
           creationParams: CreationParams(
             autoMediaPlaybackPolicy: AutoMediaPlaybackPolicy.always_allow,
             webSettings: WebSettings(
+              // TODO(mvanbeusekom): Cleanup and convert to const constructor when platform_interface is fixed (see https://github.com/flutter/flutter/issues/94311)
+              // ignore: prefer_const_constructors
               userAgent: WebSetting<String?>.absent(),
               hasNavigationDelegate: false,
             ),
@@ -184,6 +194,8 @@ void main() {
           creationParams: CreationParams(
             javascriptChannelNames: <String>{'a', 'b'},
             webSettings: WebSettings(
+              // TODO(mvanbeusekom): Cleanup and convert to const constructor when platform_interface is fixed (see https://github.com/flutter/flutter/issues/94311)
+              // ignore: prefer_const_constructors
               userAgent: WebSetting<String?>.absent(),
               hasNavigationDelegate: false,
             ),
@@ -202,6 +214,8 @@ void main() {
             tester,
             creationParams: CreationParams(
               webSettings: WebSettings(
+                // TODO(mvanbeusekom): Cleanup and convert to const constructor when platform_interface is fixed (see https://github.com/flutter/flutter/issues/94311)
+                // ignore: prefer_const_constructors
                 userAgent: WebSetting<String?>.absent(),
                 javascriptMode: JavascriptMode.unrestricted,
                 hasNavigationDelegate: false,
@@ -217,6 +231,8 @@ void main() {
             tester,
             creationParams: CreationParams(
               webSettings: WebSettings(
+                // TODO(mvanbeusekom): Cleanup and convert to const constructor when platform_interface is fixed (see https://github.com/flutter/flutter/issues/94311)
+                // ignore: prefer_const_constructors
                 userAgent: WebSetting<String?>.absent(),
                 hasNavigationDelegate: true,
               ),
@@ -232,6 +248,8 @@ void main() {
             tester,
             creationParams: CreationParams(
               webSettings: WebSettings(
+                // TODO(mvanbeusekom): Cleanup and convert to const constructor when platform_interface is fixed (see https://github.com/flutter/flutter/issues/94311)
+                // ignore: prefer_const_constructors
                 userAgent: WebSetting<String?>.absent(),
                 debuggingEnabled: true,
                 hasNavigationDelegate: false,
@@ -247,6 +265,8 @@ void main() {
             tester,
             creationParams: CreationParams(
               webSettings: WebSettings(
+                // TODO(mvanbeusekom): Cleanup and convert to const constructor when platform_interface is fixed (see https://github.com/flutter/flutter/issues/94311)
+                // ignore: prefer_const_constructors
                 userAgent: WebSetting<String?>.of('myUserAgent'),
                 hasNavigationDelegate: false,
               ),
@@ -261,6 +281,8 @@ void main() {
             tester,
             creationParams: CreationParams(
               webSettings: WebSettings(
+                // TODO(mvanbeusekom): Cleanup and convert to const constructor when platform_interface is fixed (see https://github.com/flutter/flutter/issues/94311)
+                // ignore: prefer_const_constructors
                 userAgent: WebSetting<String?>.absent(),
                 zoomEnabled: false,
                 hasNavigationDelegate: false,


### PR DESCRIPTION
This will pre-emptively ignore the `prefer_const_constructor` warning to make it possible to migrate the webview_flutter_platform_interface without breaking changes to the more strict analysis_options.yaml (see issue flutter/flutter#76229).

A cleanup issue also exist as a reminder to remove the temporary ignore statements and can be found here: flutter/flutter#94311

No version change: this is a temporary change and only necessary to land on master not to break the build when merging #4549. These changes will be undone as part of flutter/flutter#94311 as soon as #4549 lands.

No CHANGELOG change: this is a temporary change and only necessary to land on master not to break the build when merging #4549. These changes will be undone as part of flutter/flutter#94311 as soon as #4549 lands.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.