### PR TITLE
[path_provider] Android implementation of `getDownloadsDirectory`

### DIFF
--- a/packages/path_provider/path_provider/lib/path_provider.dart
+++ b/packages/path_provider/path_provider/lib/path_provider.dart
@@ -210,7 +210,7 @@ Future<List<Directory>?> getExternalStorageDirectories({
 /// Path to the directory where downloaded files can be stored.
 /// This is typically only relevant on desktop operating systems.
 ///
-/// On Android and on iOS, this function throws an [UnsupportedError] as no equivalent
+/// On iOS, this function throws an [UnsupportedError] as no equivalent
 /// path exists.
 Future<Directory?> getDownloadsDirectory() async {
   final String? path = await _platform.getDownloadsPath();

--- a/packages/path_provider/path_provider_android/CHANGELOG.md
+++ b/packages/path_provider/path_provider_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0
+
+* Added implementation of getDownloadsDirectory
+
 ## 2.0.9
 
 * Updates Android compileSdkVersion to 31.

--- a/packages/path_provider/path_provider_android/android/src/main/java/io/flutter/plugins/pathprovider/PathProviderPlugin.java
+++ b/packages/path_provider/path_provider_android/android/src/main/java/io/flutter/plugins/pathprovider/PathProviderPlugin.java
@@ -9,6 +9,7 @@ import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.os.Handler;
 import android.os.Looper;
+import android.os.Environment;
 import android.util.Log;
 import androidx.annotation.NonNull;
 import com.google.common.util.concurrent.FutureCallback;
@@ -55,6 +56,8 @@ public class PathProviderPlugin implements FlutterPlugin, MethodCallHandler {
 
     void getStorageDirectory(@NonNull Result result);
 
+    void getDownloadsDirectory(@NonNull Result result);
+
     void getExternalCacheDirectories(@NonNull Result result);
 
     void getExternalStorageDirectories(@NonNull String directoryName, @NonNull Result result);
@@ -82,6 +85,10 @@ public class PathProviderPlugin implements FlutterPlugin, MethodCallHandler {
 
     public void getStorageDirectory(@NonNull Result result) {
       executeInBackground(() -> getPathProviderStorageDirectory(), result);
+    }
+
+    public void getDownloadsDirectory(@NonNull Result result) {
+      executeInBackground(() -> getPathProviderDownloadsDirectory(), result);
     }
 
     public void getExternalCacheDirectories(@NonNull Result result) {
@@ -134,6 +141,10 @@ public class PathProviderPlugin implements FlutterPlugin, MethodCallHandler {
 
     public void getStorageDirectory(@NonNull Result result) {
       result.success(getPathProviderStorageDirectory());
+    }
+
+    public void getDownloadsDirectory(@NonNull Result result) {
+      result.success(getPathProviderDownloadsDirectory());
     }
 
     public void getExternalCacheDirectories(@NonNull Result result) {
@@ -206,6 +217,9 @@ public class PathProviderPlugin implements FlutterPlugin, MethodCallHandler {
       case "getStorageDirectory":
         impl.getStorageDirectory(result);
         break;
+      case "getDownloadsDirectory":
+        impl.getDownloadsDirectory(result);
+        break;
       case "getExternalCacheDirectories":
         impl.getExternalCacheDirectories(result);
         break;
@@ -240,6 +254,10 @@ public class PathProviderPlugin implements FlutterPlugin, MethodCallHandler {
       return null;
     }
     return dir.getAbsolutePath();
+  }
+
+  private String getPathProviderDownloadsDirectory() {
+    return Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).getAbsolutePath();
   }
 
   private List<String> getPathProviderExternalCacheDirectories() {

--- a/packages/path_provider/path_provider_android/example/lib/main.dart
+++ b/packages/path_provider/path_provider_android/example/lib/main.dart
@@ -36,6 +36,7 @@ class _MyHomePageState extends State<MyHomePage> {
   final PathProviderPlatform provider = PathProviderPlatform.instance;
   Future<String?>? _tempDirectory;
   Future<String?>? _appSupportDirectory;
+  Future<String?>? _downloadsDirectory;
   Future<String?>? _appDocumentsDirectory;
   Future<String?>? _externalDocumentsDirectory;
   Future<List<String>?>? _externalStorageDirectories;
@@ -90,6 +91,12 @@ class _MyHomePageState extends State<MyHomePage> {
     });
   }
 
+  void _requestDownloadsDirectory() {
+    setState(() {
+      _downloadsDirectory = provider.getDownloadsPath();
+    });
+  }
+
   void _requestExternalStorageDirectory() {
     setState(() {
       _externalDocumentsDirectory = provider.getExternalStoragePath();
@@ -141,6 +148,15 @@ class _MyHomePageState extends State<MyHomePage> {
               child: ElevatedButton(
                 child: const Text('Get Application Support Directory'),
                 onPressed: _requestAppSupportDirectory,
+              ),
+            ),
+            FutureBuilder<String?>(
+                future: _downloadsDirectory, builder: _buildDirectory),
+            Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: ElevatedButton(
+                child: const Text('Get Downloads Directory'),
+                onPressed: _requestDownloadsDirectory,
               ),
             ),
             FutureBuilder<String?>(

--- a/packages/path_provider/path_provider_android/pubspec.yaml
+++ b/packages/path_provider/path_provider_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: path_provider_android
 description: Android implementation of the path_provider plugin.
 repository: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+path_provider%22
-version: 2.0.9
+version: 2.1.0
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/path_provider/path_provider_platform_interface/CHANGELOG.md
+++ b/packages/path_provider/path_provider_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.2
+
+* Updated getDownloadsDirectory platform compatibility
+
 ## 2.0.1
 
 * Update platform_plugin_interface version requirement.

--- a/packages/path_provider/path_provider_platform_interface/lib/src/method_channel_path_provider.dart
+++ b/packages/path_provider/path_provider_platform_interface/lib/src/method_channel_path_provider.dart
@@ -84,8 +84,8 @@ class MethodChannelPathProvider extends PathProviderPlatform {
 
   @override
   Future<String?> getDownloadsPath() {
-    if (!_platform.isMacOS) {
-      throw UnsupportedError('Functionality only available on macOS');
+    if (_platform.isIOS) {
+      throw UnsupportedError('Functionality not available on iOS');
     }
     return methodChannel.invokeMethod<String>('getDownloadsDirectory');
   }

--- a/packages/path_provider/path_provider_platform_interface/pubspec.yaml
+++ b/packages/path_provider/path_provider_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/master/packages/path_provide
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+path_provider%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.0.1
+version: 2.0.2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/path_provider/path_provider_platform_interface/test/method_channel_path_provider_test.dart
+++ b/packages/path_provider/path_provider_platform_interface/test/method_channel_path_provider_test.dart
@@ -192,9 +192,20 @@ void main() {
       expect(result, kDownloadsPath);
     });
 
-    test('getDownloadsPath  non-macos fails', () async {
+    test('getDownloadsPath Android succeeds', () async {
       methodChannelPathProvider.setMockPathProviderPlatform(
           FakePlatform(operatingSystem: 'android'));
+      final String? result = await methodChannelPathProvider.getDownloadsPath();
+      expect(
+        log,
+        <Matcher>[isMethodCall('getDownloadsDirectory', arguments: null)],
+      );
+      expect(result, kDownloadsPath);
+    });
+
+    test('getDownloadsPath iOS fails', () async {
+      methodChannelPathProvider
+          .setMockPathProviderPlatform(FakePlatform(operatingSystem: 'ios'));
       try {
         await methodChannelPathProvider.getDownloadsPath();
         fail('should throw UnsupportedError');


### PR DESCRIPTION
This PR adds an Android implementation for the getDownloadsDirectory method in the path_provider interface, returning the public Android downloads directory path.

Resolves issue #93198: [path_provider] getDownloadsDirectory() doesn't work for iOS and Android.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
