### PR TITLE
[in_app_purchase] Fix upgrading subscription by deferred proration mode on android.

### DIFF
--- a/packages/in_app_purchase/in_app_purchase_android/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.2
+
+* Fix `PurchaseStatus` return `error` when user upgrades subscription by deferred proration mode.
+
 ## 0.2.1
 
 * Deprecated the `InAppPurchaseAndroidPlatformAddition.enablePendingPurchases()` method and `InAppPurchaseAndroidPlatformAddition.enablePendingPurchase` property. Since Google Play no longer accepts App submissions that don't support pending purchases it is no longer necessary to acknowledge this through code.

--- a/packages/in_app_purchase/in_app_purchase_android/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_android/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.2.2
 
-* Fix `PurchaseStatus` return `error` when user upgrades subscription by deferred proration mode.
+* Fixes the `purchaseStream` incorrectly reporting `PurchaseStatus.error` when user upgrades subscription by deferred proration mode.
 
 ## 0.2.1
 

--- a/packages/in_app_purchase/in_app_purchase_android/lib/src/in_app_purchase_android_platform.dart
+++ b/packages/in_app_purchase/in_app_purchase_android/lib/src/in_app_purchase_android_platform.dart
@@ -270,13 +270,17 @@ class InAppPurchaseAndroidPlatform extends InAppPurchasePlatform {
     if (purchases.isNotEmpty) {
       return Future.wait(purchases);
     } else {
+      PurchaseStatus status = PurchaseStatus.error;
+      if (resultWrapper.responseCode == BillingResponse.userCanceled) {
+        status = PurchaseStatus.canceled;
+      } else if (resultWrapper.responseCode == BillingResponse.ok) {
+        status = PurchaseStatus.purchased;
+      }
       return [
         PurchaseDetails(
             purchaseID: '',
             productID: '',
-            status: resultWrapper.responseCode == BillingResponse.userCanceled
-                ? PurchaseStatus.canceled
-                : PurchaseStatus.error,
+            status: status,
             transactionDate: null,
             verificationData: PurchaseVerificationData(
                 localVerificationData: '',

--- a/packages/in_app_purchase/in_app_purchase_android/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase_android
 description: An implementation for the Android platform of the Flutter `in_app_purchase` plugin. This uses the Android BillingClient APIs.
 repository: https://github.com/flutter/plugins/tree/master/packages/in_app_purchase/in_app_purchase_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 0.2.1
+version: 0.2.2
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/in_app_purchase/in_app_purchase_android/test/in_app_purchase_android_platform_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_android/test/in_app_purchase_android_platform_test.dart
@@ -724,7 +724,6 @@ void main() {
           ));
       await iapAndroidPlatform.buyNonConsumable(purchaseParam: purchaseParam);
 
-      // Verify that the result has an error for the failed consumption
       PurchaseDetails result = await completer.future;
       expect(result.status, PurchaseStatus.purchased);
     });

--- a/packages/in_app_purchase/in_app_purchase_android/test/in_app_purchase_android_platform_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_android/test/in_app_purchase_android_platform_test.dart
@@ -682,6 +682,52 @@ void main() {
       GooglePlayPurchaseDetails result = await completer.future;
       expect(result.status, PurchaseStatus.canceled);
     });
+
+    test(
+        'should get purchased purchase status when upgrading subscription by deferred proration mode',
+        () async {
+      final SkuDetailsWrapper skuDetails = dummySkuDetails;
+      final String accountId = "hashedAccountId";
+      const String debugMessage = 'dummy message';
+      final BillingResponse sentCode = BillingResponse.ok;
+      final BillingResultWrapper expectedBillingResult = BillingResultWrapper(
+          responseCode: sentCode, debugMessage: debugMessage);
+      stubPlatform.addResponse(
+          name: launchMethodName,
+          value: buildBillingResultMap(expectedBillingResult),
+          additionalStepBeforeReturn: (_) {
+            // Mock java update purchase callback.
+            MethodCall call = MethodCall(kOnPurchasesUpdated, {
+              'billingResult': buildBillingResultMap(expectedBillingResult),
+              'responseCode': BillingResponseConverter().toJson(sentCode),
+              'purchasesList': []
+            });
+            iapAndroidPlatform.billingClient.callHandler(call);
+          });
+
+      Completer completer = Completer();
+      PurchaseDetails purchaseDetails;
+      Stream purchaseStream = iapAndroidPlatform.purchaseStream;
+      late StreamSubscription subscription;
+      subscription = purchaseStream.listen((_) {
+        purchaseDetails = _.first;
+        completer.complete(purchaseDetails);
+        subscription.cancel();
+      }, onDone: () {});
+      final GooglePlayPurchaseParam purchaseParam = GooglePlayPurchaseParam(
+          productDetails: GooglePlayProductDetails.fromSkuDetails(skuDetails),
+          applicationUserName: accountId,
+          changeSubscriptionParam: ChangeSubscriptionParam(
+            oldPurchaseDetails: GooglePlayPurchaseDetails.fromPurchase(
+                dummyUnacknowledgedPurchase),
+            prorationMode: ProrationMode.deferred,
+          ));
+      await iapAndroidPlatform.buyNonConsumable(purchaseParam: purchaseParam);
+
+      // Verify that the result has an error for the failed consumption
+      PurchaseDetails result = await completer.future;
+      expect(result.status, PurchaseStatus.purchased);
+    });
   });
 
   group('complete purchase', () {


### PR DESCRIPTION
This PR is for updating the bug of upgrading subscription by deferred mode on android, the purchaseStream of PurchaseStatus will return error.

Related issues:

Fixes [flutter/flutter#94439]

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[flutter/flutter#94439]: https://github.com/flutter/flutter/issues/94439
