### PR TITLE
[webview_flutter] Adds the `loadFlutterAsset` method to the interface.

### DIFF
--- a/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.6.0
+
+* Adds the `loadFlutterAsset` method to the platform interface.
+
 ## 1.5.2
 
 * Mirgrates from analysis_options_legacy.yaml to the more strict analysis_options.yaml.

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/src/method_channel/webview_method_channel.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/src/method_channel/webview_method_channel.dart
@@ -84,13 +84,31 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
   @override
   Future<void> loadFile(String absoluteFilePath) async {
     assert(absoluteFilePath != null);
-    return _channel.invokeMethod<void>('loadFile', absoluteFilePath);
+
+    try {
+      return await _channel.invokeMethod<void>('loadFile', absoluteFilePath);
+    } on PlatformException catch (ex) {
+      if (ex.code == 'loadFile_failed') {
+        throw ArgumentError(ex.message);
+      }
+
+      rethrow;
+    }
   }
 
   @override
   Future<void> loadFlutterAsset(String key) async {
     assert(key.isNotEmpty);
-    return _channel.invokeMethod<void>('loadFlutterAsset', key);
+
+    try {
+      return await _channel.invokeMethod<void>('loadFlutterAsset', key);
+    } on PlatformException catch (ex) {
+      if (ex.code == 'loadFlutterAsset_failed') {
+        throw ArgumentError(ex.message);
+      }
+
+      rethrow;
+    }
   }
 
   @override

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/src/method_channel/webview_method_channel.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/src/method_channel/webview_method_channel.dart
@@ -103,7 +103,7 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
     try {
       return await _channel.invokeMethod<void>('loadFlutterAsset', key);
     } on PlatformException catch (ex) {
-      if (ex.code == 'loadFlutterAsset_failed') {
+      if (ex.code == 'loadFlutterAsset_invalidKey') {
         throw ArgumentError(ex.message);
       }
 

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/src/method_channel/webview_method_channel.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/src/method_channel/webview_method_channel.dart
@@ -88,6 +88,12 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
   }
 
   @override
+  Future<void> loadFlutterAsset(String key) async {
+    assert(key.isNotEmpty);
+    return _channel.invokeMethod<void>('loadFlutterAsset', key);
+  }
+
+  @override
   Future<void> loadHtmlString(
     String html, {
     String? baseUrl,

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_interface/webview_platform_controller.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_interface/webview_platform_controller.dart
@@ -37,6 +37,17 @@ abstract class WebViewPlatformController {
     String absoluteFilePath,
   ) {
     throw UnimplementedError(
+        'WebView loadFile is not implemented on the current platform');
+  }
+
+  /// Loads the Flutter asset specified in the pubspec.yaml file.
+  ///
+  /// Throws an ArgumentError if [key] is not part of the specified assets
+  /// in the pubspec.yaml file.
+  Future<void> loadFlutterAsset(
+    String key,
+  ) {
+    throw UnimplementedError(
         'WebView loadFlutterAsset is not implemented on the current platform');
   }
 

--- a/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/master/packages/webview_flut
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview_flutter%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.5.2
+version: 1.6.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/webview_flutter/webview_flutter_platform_interface/test/src/method_channel/webview_method_channel_test.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/test/src/method_channel/webview_method_channel_test.dart
@@ -38,13 +38,25 @@ void main() {
                 code: 'loadFile_failed',
                 message: 'Failed loading file.',
                 details: null);
+          } else if (methodCall.arguments == 'some error') {
+            throw PlatformException(
+              code: 'some_error',
+              message: 'Some error occurred.',
+              details: null,
+            );
           }
           return null;
         case 'loadFlutterAsset':
           if (methodCall.arguments == 'invalid key') {
             throw PlatformException(
-              code: 'loadFlutterAsset_failed',
+              code: 'loadFlutterAsset_invalidKey',
               message: 'Failed loading asset.',
+              details: null,
+            );
+          } else if (methodCall.arguments == 'some error') {
+            throw PlatformException(
+              code: 'some_error',
+              message: 'Some error occurred.',
               details: null,
             );
           }
@@ -103,6 +115,19 @@ void main() {
       );
     });
 
+    test('loadFile with some error.', () async {
+      expect(
+        () => webViewPlatform.loadFile('some error'),
+        throwsA(
+          isA<PlatformException>().having(
+            (PlatformException error) => error.message,
+            'message',
+            'Some error occurred.',
+          ),
+        ),
+      );
+    });
+
     test('loadFlutterAsset', () async {
       await webViewPlatform.loadFlutterAsset(
         'folder/asset.html',
@@ -131,6 +156,19 @@ void main() {
             (ArgumentError error) => error.message,
             'message',
             'Failed loading asset.',
+          ),
+        ),
+      );
+    });
+
+    test('loadFlutterAsset with some error.', () async {
+      expect(
+        () => webViewPlatform.loadFlutterAsset('some error'),
+        throwsA(
+          isA<PlatformException>().having(
+            (PlatformException error) => error.message,
+            'message',
+            'Some error occurred.',
           ),
         ),
       );

--- a/packages/webview_flutter/webview_flutter_platform_interface/test/src/method_channel/webview_method_channel_test.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/test/src/method_channel/webview_method_channel_test.dart
@@ -32,6 +32,23 @@ void main() {
         case 'canGoBack':
         case 'canGoForward':
           return true;
+        case 'loadFile':
+          if (methodCall.arguments == 'invalid file') {
+            throw PlatformException(
+                code: 'loadFile_failed',
+                message: 'Failed loading file.',
+                details: null);
+          }
+          return null;
+        case 'loadFlutterAsset':
+          if (methodCall.arguments == 'invalid key') {
+            throw PlatformException(
+              code: 'loadFlutterAsset_failed',
+              message: 'Failed loading asset.',
+              details: null,
+            );
+          }
+          return null;
         case 'runJavascriptReturningResult':
         case 'evaluateJavascript':
           return methodCall.arguments as String;
@@ -73,6 +90,19 @@ void main() {
       );
     });
 
+    test('loadFile with invalid file', () async {
+      expect(
+        () => webViewPlatform.loadFile('invalid file'),
+        throwsA(
+          isA<ArgumentError>().having(
+            (ArgumentError error) => error.message,
+            'message',
+            'Failed loading file.',
+          ),
+        ),
+      );
+    });
+
     test('loadFlutterAsset', () async {
       await webViewPlatform.loadFlutterAsset(
         'folder/asset.html',
@@ -91,6 +121,19 @@ void main() {
 
     test('loadFlutterAsset with empty key', () async {
       expect(() => webViewPlatform.loadFlutterAsset(''), throwsAssertionError);
+    });
+
+    test('loadFlutterAsset with invalid key', () async {
+      expect(
+        () => webViewPlatform.loadFlutterAsset('invalid key'),
+        throwsA(
+          isA<ArgumentError>().having(
+            (ArgumentError error) => error.message,
+            'message',
+            'Failed loading asset.',
+          ),
+        ),
+      );
     });
 
     test('loadHtmlString without base URL', () async {

--- a/packages/webview_flutter/webview_flutter_platform_interface/test/src/method_channel/webview_method_channel_test.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/test/src/method_channel/webview_method_channel_test.dart
@@ -73,6 +73,26 @@ void main() {
       );
     });
 
+    test('loadFlutterAsset', () async {
+      await webViewPlatform.loadFlutterAsset(
+        'folder/asset.html',
+      );
+
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall(
+            'loadFlutterAsset',
+            arguments: 'folder/asset.html',
+          ),
+        ],
+      );
+    });
+
+    test('loadFlutterAsset with empty key', () async {
+      expect(() => webViewPlatform.loadFlutterAsset(''), throwsAssertionError);
+    });
+
     test('loadHtmlString without base URL', () async {
       await webViewPlatform.loadHtmlString(
         'Test HTML string',


### PR DESCRIPTION
Adds the `loadFlutterAsset` method to the platform interface. This method, when implemented, is responsible for correctly loading HTML content that  is part of the Flutter asset bundle.

flutter/flutter#27086

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.