### PR TITLE
[video_player]fix playing local file get illegal duration occasionally on iOS

### DIFF
--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,7 +1,8 @@
-## NEXT
+## 2.2.8
 
 * Fixes integration tests.
 * Updates Android compileSdkVersion to 31.
+* Fix playing local file get illegal duration occasionally on iOS #87334
 
 ## 2.2.7
 

--- a/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m
@@ -346,6 +346,7 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
       return;
     }
     // The player may be initialized but still needs to determine the duration.
+    // Fixes https://github.com/flutter/flutter/issues/87334
     if ([self duration] == 0 || [self duration] == TIME_UNSET) {
       return;
     }

--- a/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m
@@ -347,7 +347,15 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     }
     // The player may be initialized but still needs to determine the duration.
     // Fixes https://github.com/flutter/flutter/issues/87334
-    if ([self duration] == 0 || [self duration] == TIME_UNSET) {
+    BOOL isTypeNormal = true;
+    if([[_player currentItem].asset isKindOfClass:[AVURLAsset class]]){
+      NSURL* url = ((AVURLAsset*)[_player currentItem].asset).URL;
+      NSString* path = url.path;
+      if ([path hasSuffix:@".m3u8"]){
+        isTypeNormal = false;
+      }
+    }
+    if ([self duration] == 0 || (isTypeNormal && [self duration] == TIME_UNSET)) {
       return;
     }
 

--- a/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m
@@ -346,7 +346,7 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
       return;
     }
     // The player may be initialized but still needs to determine the duration.
-    if ([self duration] == 0) {
+    if ([self duration] == 0 || [self duration] == TIME_UNSET) {
       return;
     }
 

--- a/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m
@@ -348,10 +348,10 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     // The player may be initialized but still needs to determine the duration.
     // Fixes https://github.com/flutter/flutter/issues/87334
     BOOL isTypeNormal = true;
-    if([[_player currentItem].asset isKindOfClass:[AVURLAsset class]]){
+    if ([[_player currentItem].asset isKindOfClass:[AVURLAsset class]]) {
       NSURL* url = ((AVURLAsset*)[_player currentItem].asset).URL;
       NSString* path = url.path;
-      if ([path hasSuffix:@".m3u8"]){
+      if ([path hasSuffix:@".m3u8"]) {
         isTypeNormal = false;
       }
     }

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android, iOS, and web.
 repository: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.2.7
+version: 2.2.8
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This [commit](https://github.com/flutter/plugins/commit/3f940429d0e73e2cadfa8a3d487354e0e06f2206) update the `FLTCMTimeToMillis` function. This function may return 0 or TIME_UNSET. Before sending  initialized message to flutter, we should check duration to make sure it's not 0 or TIME_UNSET.
```
static inline int64_t FLTCMTimeToMillis(CMTime time) {
  // When CMTIME_IS_INDEFINITE return a value that matches TIME_UNSET from ExoPlayer2 on Android.
  // Fixes https://github.com/flutter/flutter/issues/48670
  if (CMTIME_IS_INDEFINITE(time)) return TIME_UNSET;
  if (time.timescale == 0) return 0;
  return time.value * 1000 / time.timescale;
}
```

*List which issues are fixed by this PR. You must list at least one issue.*
flutter/flutter#87334

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
