### PR TITLE
[webview_flutter] Revert deprecation of clearCookies

### DIFF
--- a/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.6.1
+
+* Revert deprecation of `clearCookies` in WebViewPlatform for later deprecation.
+
 ## 1.6.0
 
 * Adds platform interface for cookie manager.

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_interface/webview_platform.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_interface/webview_platform.dart
@@ -59,7 +59,7 @@ abstract class WebViewPlatform {
   /// Clears all cookies for all [WebView] instances.
   ///
   /// Returns true if cookies were present before clearing, else false.
-  @Deprecated('Use `WebViewCookieManagerPlatform.clearCookies` instead.')
+  /// Soon to be deprecated. 'Use `WebViewCookieManagerPlatform.clearCookies` instead.
   Future<bool> clearCookies() {
     throw UnimplementedError(
         'WebView clearCookies is not implemented on the current platform');

--- a/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/master/packages/webview_flut
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview_flutter%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.6.0
+version: 1.6.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
Reverts the deprecation of `clearCookies` in the platform interface from #4555, as it broke the tree.

Relevant comment: https://github.com/flutter/plugins/pull/4555#discussion_r761123734