### PR TITLE
[webview_flutter] Add a backgroundColor option to the webview platform interface

### DIFF
--- a/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.7.0
+
+* Add an option to set the background color of the webview.
+
 ## 1.6.1
 
 * Revert deprecation of `clearCookies` in WebViewPlatform for later deprecation.

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/src/method_channel/webview_method_channel.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/src/method_channel/webview_method_channel.dart
@@ -266,6 +266,7 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
       'userAgent': creationParams.userAgent,
       'autoMediaPlaybackPolicy': creationParams.autoMediaPlaybackPolicy.index,
       'usesHybridComposition': usesHybridComposition,
+      'backgroundColor': creationParams.backgroundColor?.value,
       'cookies': creationParams.cookies
           .map((WebViewCookie cookie) => cookie.toJson())
           .toList()

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/src/types/creation_params.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/src/types/creation_params.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/widgets.dart';
 import 'package:webview_flutter_platform_interface/src/types/types.dart';
 
 import 'auto_media_playback_policy.dart';
@@ -22,6 +23,7 @@ class CreationParams {
     this.userAgent,
     this.autoMediaPlaybackPolicy =
         AutoMediaPlaybackPolicy.require_user_action_for_all_media_types,
+    this.backgroundColor,
     this.cookies = const <WebViewCookie>[],
   }) : assert(autoMediaPlaybackPolicy != null);
 
@@ -56,11 +58,16 @@ class CreationParams {
   /// Which restrictions apply on automatic media playback.
   final AutoMediaPlaybackPolicy autoMediaPlaybackPolicy;
 
+  /// The background color of the webview.
+  ///
+  /// When null the platform's webview default background color is used.
+  final Color? backgroundColor;
+
   /// The initial set of cookies to set before the webview does its first load.
   final List<WebViewCookie> cookies;
 
   @override
   String toString() {
-    return 'CreationParams(initialUrl: $initialUrl, settings: $webSettings, javascriptChannelNames: $javascriptChannelNames, UserAgent: $userAgent, cookies: $cookies)';
+    return 'CreationParams(initialUrl: $initialUrl, settings: $webSettings, javascriptChannelNames: $javascriptChannelNames, UserAgent: $userAgent, backgroundColor: $backgroundColor, cookies: $cookies)';
   }
 }

--- a/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/master/packages/webview_flut
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview_flutter%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.6.1
+version: 1.7.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/webview_flutter/webview_flutter_platform_interface/test/src/method_channel/webview_method_channel_test.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/test/src/method_channel/webview_method_channel_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:typed_data';
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
@@ -551,6 +552,32 @@ void main() {
           ),
         ],
       );
+    });
+
+    test('backgroundColor is null by default', () {
+      final CreationParams creationParams = CreationParams(
+        webSettings: WebSettings(
+          userAgent: const WebSetting<String?>.of('Dart Test'),
+        ),
+      );
+      final Map<String, dynamic> creationParamsMap =
+          MethodChannelWebViewPlatform.creationParamsToMap(creationParams);
+
+      expect(creationParamsMap['backgroundColor'], null);
+    });
+
+    test('backgroundColor is converted to an int', () {
+      const Color whiteColor = Color(0xFFFFFFFF);
+      final CreationParams creationParams = CreationParams(
+        backgroundColor: whiteColor,
+        webSettings: WebSettings(
+          userAgent: const WebSetting<String?>.of('Dart Test'),
+        ),
+      );
+      final Map<String, dynamic> creationParamsMap =
+          MethodChannelWebViewPlatform.creationParamsToMap(creationParams);
+
+      expect(creationParamsMap['backgroundColor'], whiteColor.value);
     });
   });
 


### PR DESCRIPTION
This PR add an option to set a transparent background for the webview.

Original PR (app-facing package, iOS, Android, platform interface): https://github.com/flutter/plugins/pull/3431

Part of https://github.com/flutter/flutter/issues/29300



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
