### PR TITLE
Renew cirrus gcp credentials

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,4 +1,4 @@
-gcp_credentials: ENCRYPTED[!48cff44dd32e9cc412d4d381c7fe68d373ca04cf2639f8192d21cb1a9ab5e21129651423a1cf88f3fd7fe2125c1cabd9!]
+gcp_credentials: ENCRYPTED[!cc769765170bebc37e0556e2da5915ca64ee37f4ec8c966ec147e2f59578b476c99e457eafce4e2f8b1a4e305f7096b8!]
 
 # Don't run on release tags since it creates O(n^2) tasks where n is the
 # number of plugins


### PR DESCRIPTION
GCP account key expires every three months. This PR updates the GCP credential based on the renewed key.