### PR TITLE
[webview_flutter] Implements the loadFlutterAsset in the app facing package.

### DIFF
--- a/packages/webview_flutter/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.7.0
+
+* Adds support for the `loadFlutterAsset` method.
+
 ## 2.6.0
 
 * Adds support for the `loadRequest` method.

--- a/packages/webview_flutter/webview_flutter/example/assets/www/index.html
+++ b/packages/webview_flutter/webview_flutter/example/assets/www/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<!-- Copyright 2013 The Flutter Authors. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file. -->
+<html lang="en">
+<head>
+<title>Load file or HTML string example</title>
+<link rel="stylesheet" href="styles/style.css" />
+</head>
+<body>
+
+<h1>Local demo page</h1>
+<p>
+  This is an example page used to demonstrate how to load a local file or HTML 
+  string using the <a href="https://pub.dev/packages/webview_flutter">Flutter 
+  webview</a> plugin.
+</p>
+
+</body>
+</html>

--- a/packages/webview_flutter/webview_flutter/example/assets/www/styles/style.css
+++ b/packages/webview_flutter/webview_flutter/example/assets/www/styles/style.css
@@ -1,0 +1,3 @@
+h1 {
+    color: blue;
+}

--- a/packages/webview_flutter/webview_flutter/example/lib/main.dart
+++ b/packages/webview_flutter/webview_flutter/example/lib/main.dart
@@ -179,6 +179,7 @@ enum MenuOptions {
   navigationDelegate,
   doPostRequest,
   loadLocalFile,
+  loadFlutterAsset,
   loadHtmlString,
   transparentBackground,
 }
@@ -225,6 +226,9 @@ class SampleMenu extends StatelessWidget {
                 break;
               case MenuOptions.loadLocalFile:
                 _onLoadLocalFileExample(controller.data!, context);
+                break;
+              case MenuOptions.loadFlutterAsset:
+                _onLoadFlutterAssetExample(controller.data!, context);
                 break;
               case MenuOptions.loadHtmlString:
                 _onLoadHtmlStringExample(controller.data!, context);
@@ -275,6 +279,10 @@ class SampleMenu extends StatelessWidget {
             const PopupMenuItem<MenuOptions>(
               value: MenuOptions.loadLocalFile,
               child: Text('Load local file'),
+            ),
+            const PopupMenuItem<MenuOptions>(
+              value: MenuOptions.loadFlutterAsset,
+              child: Text('Load Flutter Asset'),
             ),
             const PopupMenuItem<MenuOptions>(
               key: ValueKey<String>('ShowTransparentBackgroundExample'),
@@ -373,6 +381,11 @@ class SampleMenu extends StatelessWidget {
     final String pathToIndex = await _prepareLocalFile();
 
     await controller.loadFile(pathToIndex);
+  }
+
+  Future<void> _onLoadFlutterAssetExample(
+      WebViewController controller, BuildContext context) async {
+    await controller.loadFlutterAsset('assets/www/index.html');
   }
 
   Future<void> _onLoadHtmlStringExample(

--- a/packages/webview_flutter/webview_flutter/example/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter/example/pubspec.yaml
@@ -33,3 +33,5 @@ flutter:
   assets:
     - assets/sample_audio.ogg
     - assets/sample_video.mp4
+    - assets/www/index.html
+    - assets/www/styles/style.css

--- a/packages/webview_flutter/webview_flutter/lib/src/webview.dart
+++ b/packages/webview_flutter/webview_flutter/lib/src/webview.dart
@@ -518,6 +518,15 @@ class WebViewController {
     return _webViewPlatformController.loadFile(absoluteFilePath);
   }
 
+  /// Loads the Flutter asset specified in the pubspec.yaml file.
+  ///
+  /// Throws an ArgumentError if [key] is not part of the specified assets
+  /// in the pubspec.yaml file.
+  Future<void> loadFlutterAsset(String key) {
+    assert(key.isNotEmpty);
+    return _webViewPlatformController.loadFlutterAsset(key);
+  }
+
   /// Loads the supplied HTML string.
   ///
   /// The [baseUrl] parameter is used when resolving relative URLs within the

--- a/packages/webview_flutter/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
 repository: https://github.com/flutter/plugins/tree/master/packages/webview_flutter/webview_flutter
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview%22
-version: 2.6.0
+version: 2.7.0
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/webview_flutter/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter/pubspec.yaml
@@ -19,7 +19,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  webview_flutter_android: ^2.7.0
+  webview_flutter_android: ^2.8.0
   webview_flutter_platform_interface: ^1.8.0
   webview_flutter_wkwebview: ^2.5.0
 

--- a/packages/webview_flutter/webview_flutter/test/webview_flutter_test.dart
+++ b/packages/webview_flutter/webview_flutter/test/webview_flutter_test.dart
@@ -124,6 +124,40 @@ void main() {
     expect(() => controller!.loadFile(''), throwsAssertionError);
   });
 
+  testWidgets('Load Flutter asset', (WidgetTester tester) async {
+    WebViewController? controller;
+    await tester.pumpWidget(
+      WebView(
+        onWebViewCreated: (WebViewController webViewController) {
+          controller = webViewController;
+        },
+      ),
+    );
+
+    expect(controller, isNotNull);
+
+    await controller!.loadFlutterAsset('assets/index.html');
+
+    verify(mockWebViewPlatformController.loadFlutterAsset(
+      'assets/index.html',
+    ));
+  });
+
+  testWidgets('Load Flutter asset with empty key', (WidgetTester tester) async {
+    WebViewController? controller;
+    await tester.pumpWidget(
+      WebView(
+        onWebViewCreated: (WebViewController webViewController) {
+          controller = webViewController;
+        },
+      ),
+    );
+
+    expect(controller, isNotNull);
+
+    expect(() => controller!.loadFlutterAsset(''), throwsAssertionError);
+  });
+
   testWidgets('Load HTML string without base URL', (WidgetTester tester) async {
     WebViewController? controller;
     await tester.pumpWidget(


### PR DESCRIPTION
Adds app facing implementation of the `loadFlutterAsset` method.

~~DRAFT: waiting for #4582 to land and be published. Afterwards the dependency on webview_flutter_wkwebview needs to be updated.~~

Resolves flutter/flutter#27086

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
