### PR TITLE
[shared_preferences] Remove platform registration

### DIFF
--- a/packages/shared_preferences/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences/CHANGELOG.md
@@ -1,8 +1,11 @@
+## 2.0.10
+
+* Removes obsolete manual registration of Windows and Linux implementations.
+
 ## 2.0.9
 
 * Fixes newly enabled analyzer options.
 * Updates example app Android compileSdkVersion to 31.
-
 * Moved Android and iOS implementations to federated packages.
 
 ## 2.0.8

--- a/packages/shared_preferences/shared_preferences/lib/shared_preferences.dart
+++ b/packages/shared_preferences/shared_preferences/lib/shared_preferences.dart
@@ -3,14 +3,9 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io' show Platform;
 
-import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:meta/meta.dart';
-import 'package:shared_preferences_linux/shared_preferences_linux.dart';
-import 'package:shared_preferences_platform_interface/method_channel_shared_preferences.dart';
 import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
-import 'package:shared_preferences_windows/shared_preferences_windows.dart';
 
 /// Wraps NSUserDefaults (on iOS) and SharedPreferences (on Android), providing
 /// a persistent store for simple data.
@@ -21,28 +16,9 @@ class SharedPreferences {
 
   static const String _prefix = 'flutter.';
   static Completer<SharedPreferences>? _completer;
-  static bool _manualDartRegistrationNeeded = true;
 
-  static SharedPreferencesStorePlatform get _store {
-    // TODO(egarciad): Remove once auto registration lands on Flutter stable.
-    // https://github.com/flutter/flutter/issues/81421.
-    if (_manualDartRegistrationNeeded) {
-      // Only do the initial registration if it hasn't already been overridden
-      // with a non-default instance.
-      if (!kIsWeb &&
-          SharedPreferencesStorePlatform.instance
-              is MethodChannelSharedPreferencesStore) {
-        if (Platform.isLinux) {
-          SharedPreferencesStorePlatform.instance = SharedPreferencesLinux();
-        } else if (Platform.isWindows) {
-          SharedPreferencesStorePlatform.instance = SharedPreferencesWindows();
-        }
-      }
-      _manualDartRegistrationNeeded = false;
-    }
-
-    return SharedPreferencesStorePlatform.instance;
-  }
+  static SharedPreferencesStorePlatform get _store =>
+      SharedPreferencesStorePlatform.instance;
 
   /// Loads and parses the [SharedPreferences] for this app from disk.
   ///

--- a/packages/shared_preferences/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for reading and writing simple key-value pairs.
   Wraps NSUserDefaults on iOS and SharedPreferences on Android.
 repository: https://github.com/flutter/plugins/tree/master/packages/shared_preferences/shared_preferences
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.0.9
+version: 2.0.10
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -31,11 +31,11 @@ dependencies:
   meta: ^1.3.0
   shared_preferences_android: ^2.0.8
   shared_preferences_ios: ^2.0.8
-  shared_preferences_linux: ^2.0.0
+  shared_preferences_linux: ^2.0.1
   shared_preferences_macos: ^2.0.0
   shared_preferences_platform_interface: ^2.0.0
   shared_preferences_web: ^2.0.0
-  shared_preferences_windows: ^2.0.0
+  shared_preferences_windows: ^2.0.1
 
 dev_dependencies:
   flutter_driver:


### PR DESCRIPTION
The plugin requires Flutter 2.5, which supports auto-registration of
Dart implementation code in platform packages, and the packages already
do auto-registration. This registration is unused, so can be removed.

Fixes https://github.com/flutter/flutter/issues/81421

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
