### PR TITLE
[in_app-purchase] Updated the ReadMe to remove the deprecated `InAppPurchaseAndroidPlatformAddition.enablePendingPurchases ` method

### DIFF
--- a/packages/in_app_purchase/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+* Removes the instructions on initializing the plugin since this functionality is deprecated.
+
 ## 2.0.0
 
 * **BREAKING CHANGES**:

--- a/packages/in_app_purchase/in_app_purchase/README.md
+++ b/packages/in_app_purchase/in_app_purchase/README.md
@@ -64,6 +64,8 @@ This section has examples of code for the following tasks:
 * [Accessing platform specific product or purchase properties](#accessing-platform-specific-product-or-purchase-properties)
 * [Presenting a code redemption sheet (iOS 14)](#presenting-a-code-redemption-sheet-ios-14)
 
+**Note:** It is not necessary to depend on `com.android.billingclient:billing` in your own app's `android/app/build.gradle` file. If you choose to do so know that conflicts might occur.
+
 ### Listening to purchase updates
 
 In your app's `initState` method, subscribe to any incoming purchases. These

--- a/packages/in_app_purchase/in_app_purchase/README.md
+++ b/packages/in_app_purchase/in_app_purchase/README.md
@@ -54,7 +54,6 @@ See also the codelab for [in-app purchases in Flutter](https://codelabs.develope
 
 This section has examples of code for the following tasks:
 
-* [Initializing the plugin](#initializing-the-plugin)
 * [Listening to purchase updates](#listening-to-purchase-updates)
 * [Connecting to the underlying store](#connecting-to-the-underlying-store)
 * [Loading products for sale](#loading-products-for-sale)
@@ -64,29 +63,6 @@ This section has examples of code for the following tasks:
 * [Upgrading or downgrading an existing in-app subscription](#upgrading-or-downgrading-an-existing-in-app-subscription)
 * [Accessing platform specific product or purchase properties](#accessing-platform-specific-product-or-purchase-properties)
 * [Presenting a code redemption sheet (iOS 14)](#presenting-a-code-redemption-sheet-ios-14)
-
-### Initializing the plugin
-
-The following initialization code is required for Google Play:
-
-```dart
-// Import `in_app_purchase_android.dart` to be able to access the
-// `InAppPurchaseAndroidPlatformAddition` class.
-import 'package:in_app_purchase_android/in_app_purchase_android.dart';
-import 'package:flutter/foundation.dart';
-
-void main() {
-  // Inform the plugin that this app supports pending purchases on Android.
-  // An error will occur on Android if you access the plugin `instance`
-  // without this call.
-  if (defaultTargetPlatform == TargetPlatform.android) {
-    InAppPurchaseAndroidPlatformAddition.enablePendingPurchases();
-  }
-  runApp(MyApp());
-}
-```
-
-**Note:** It is not necessary to depend on `com.android.billingclient:billing` in your own app's `android/app/build.gradle` file. If you choose to do so know that conflicts might occur.
 
 ### Listening to purchase updates
 

--- a/packages/in_app_purchase/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase
 description: A Flutter plugin for in-app purchases. Exposes APIs for making in-app purchases through the App Store and Google Play.
 repository: https://github.com/flutter/plugins/tree/master/packages/in_app_purchase/in_app_purchase
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 2.0.0
+version: 2.0.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
This will resolve flutter/flutter#93837 & this work is just the follow-up from #4527 PR.

We need to update the documentation in the README.md of the in_app_purchase package to remove the instruction of initialization with the deprecated `InAppPurchaseAndroidPlatformAddition.enablePendingPurchases` method.

Fixes https://github.com/flutter/flutter/issues/94977


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
