### PR TITLE
[path_provider] Fix handling of null application ID

### DIFF
--- a/packages/path_provider/path_provider_linux/CHANGELOG.md
+++ b/packages/path_provider/path_provider_linux/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.4
+
+* Fixes `getApplicationSupportPath` handling of applications where the
+  application ID is not set.
+
 ## 2.1.3
 
 * Change getApplicationSupportPath from using executable name to application ID (if provided).

--- a/packages/path_provider/path_provider_linux/lib/src/get_application_id_real.dart
+++ b/packages/path_provider/path_provider_linux/lib/src/get_application_id_real.dart
@@ -4,6 +4,7 @@
 
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
+import 'package:meta/meta.dart';
 
 // GApplication* g_application_get_default();
 typedef _GApplicationGetDefaultC = IntPtr Function();
@@ -13,30 +14,65 @@ typedef _GApplicationGetDefaultDart = int Function();
 typedef _GApplicationGetApplicationIdC = Pointer<Utf8> Function(IntPtr);
 typedef _GApplicationGetApplicationIdDart = Pointer<Utf8> Function(int);
 
+/// Interface for interacting with libgio.
+@visibleForTesting
+class GioUtils {
+  /// Creates a default instance that uses the real libgio.
+  GioUtils() {
+    try {
+      _gio = DynamicLibrary.open('libgio-2.0.so');
+    } on ArgumentError {
+      _gio = null;
+    }
+  }
+
+  DynamicLibrary? _gio;
+
+  /// True if libgio was opened successfully.
+  bool get libraryIsPresent => _gio != null;
+
+  /// Wraps `g_application_get_default`.
+  int gApplicationGetDefault() {
+    if (_gio == null) {
+      return 0;
+    }
+    final _GApplicationGetDefaultDart getDefault = _gio!
+        .lookupFunction<_GApplicationGetDefaultC, _GApplicationGetDefaultDart>(
+            'g_application_get_default');
+    return getDefault();
+  }
+
+  /// Wraps g_application_get_application_id.
+  Pointer<Utf8> gApplicationGetApplicationId(int app) {
+    if (_gio == null) {
+      return nullptr;
+    }
+    final _GApplicationGetApplicationIdDart gApplicationGetApplicationId = _gio!
+        .lookupFunction<_GApplicationGetApplicationIdC,
+                _GApplicationGetApplicationIdDart>(
+            'g_application_get_application_id');
+    return gApplicationGetApplicationId(app);
+  }
+}
+
+/// Allows overriding the defaul GioUtils instance with a fake for testing.
+@visibleForTesting
+GioUtils? gioUtilsOverride;
+
 /// Gets the application ID for this app.
 String? getApplicationId() {
-  DynamicLibrary gio;
-  try {
-    gio = DynamicLibrary.open('libgio-2.0.so');
-  } on ArgumentError {
+  final GioUtils gio = gioUtilsOverride ?? GioUtils();
+  if (!gio.libraryIsPresent) {
     return null;
   }
-  final _GApplicationGetDefaultDart gApplicationGetDefault =
-      gio.lookupFunction<_GApplicationGetDefaultC, _GApplicationGetDefaultDart>(
-          'g_application_get_default');
-  final int app = gApplicationGetDefault();
+
+  final int app = gio.gApplicationGetDefault();
   if (app == 0) {
     return null;
   }
-
-  final _GApplicationGetApplicationIdDart gApplicationGetApplicationId =
-      gio.lookupFunction<_GApplicationGetApplicationIdC,
-              _GApplicationGetApplicationIdDart>(
-          'g_application_get_application_id');
-  final Pointer<Utf8> appId = gApplicationGetApplicationId(app);
-  if (appId == null) {
+  final Pointer<Utf8> appId = gio.gApplicationGetApplicationId(app);
+  if (appId == null || appId == nullptr) {
     return null;
   }
-
   return appId.toDartString();
 }

--- a/packages/path_provider/path_provider_linux/lib/src/get_application_id_real.dart
+++ b/packages/path_provider/path_provider_linux/lib/src/get_application_id_real.dart
@@ -55,7 +55,7 @@ class GioUtils {
   }
 }
 
-/// Allows overriding the defaul GioUtils instance with a fake for testing.
+/// Allows overriding the default GioUtils instance with a fake for testing.
 @visibleForTesting
 GioUtils? gioUtilsOverride;
 

--- a/packages/path_provider/path_provider_linux/pubspec.yaml
+++ b/packages/path_provider/path_provider_linux/pubspec.yaml
@@ -2,7 +2,7 @@ name: path_provider_linux
 description: Linux implementation of the path_provider plugin
 repository: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider_linux
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+path_provider%22
-version: 2.1.3
+version: 2.1.4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -19,6 +19,7 @@ dependencies:
   ffi: ^1.1.2
   flutter:
     sdk: flutter
+  meta: ^1.3.0
   path: ^1.8.0
   path_provider_platform_interface: ^2.0.0
   xdg_directories: ^0.2.0

--- a/packages/path_provider/path_provider_linux/test/get_application_id_test.dart
+++ b/packages/path_provider/path_provider_linux/test/get_application_id_test.dart
@@ -1,0 +1,61 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+import 'dart:ffi';
+
+import 'package:ffi/ffi.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_linux/src/get_application_id_real.dart';
+
+class FakeGioUtils implements GioUtils {
+  int? application = 0;
+  Pointer<Utf8>? applicationId = nullptr;
+
+  @override
+  bool libraryIsPresent = false;
+
+  @override
+  int gApplicationGetDefault() => application!;
+
+  @override
+  Pointer<Utf8> gApplicationGetApplicationId(int app) => applicationId!;
+}
+
+void main() {
+  final FakeGioUtils fakeGio = FakeGioUtils();
+
+  setUp(() {
+    gioUtilsOverride = fakeGio;
+  });
+
+  tearDown(() {
+    gioUtilsOverride = null;
+  });
+
+  test('returns null if libgio is not available', () {
+    expect(getApplicationId(), null);
+  });
+
+  test('returns null if g_paplication_get_default returns 0', () {
+    fakeGio.libraryIsPresent = true;
+    fakeGio.application = 0;
+    expect(getApplicationId(), null);
+  });
+
+  test('returns null if g_application_get_application_id returns nullptr', () {
+    fakeGio.libraryIsPresent = true;
+    fakeGio.application = 1;
+    fakeGio.applicationId = nullptr;
+    expect(getApplicationId(), null);
+  });
+
+  test('returns value if g_application_get_application_id returns a value', () {
+    fakeGio.libraryIsPresent = true;
+    fakeGio.application = 1;
+    const String id = 'foo';
+    final Pointer<Utf8> idPtr = id.toNativeUtf8();
+    fakeGio.applicationId = idPtr;
+    expect(getApplicationId(), id);
+    calloc.free(idPtr);
+  });
+}

--- a/packages/path_provider/path_provider_linux/test/get_application_id_test.dart
+++ b/packages/path_provider/path_provider_linux/test/get_application_id_test.dart
@@ -7,9 +7,9 @@ import 'package:ffi/ffi.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path_provider_linux/src/get_application_id_real.dart';
 
-class FakeGioUtils implements GioUtils {
-  int? application = 0;
-  Pointer<Utf8>? applicationId = nullptr;
+class _FakeGioUtils implements GioUtils {
+  int? application;
+  Pointer<Utf8>? applicationId;
 
   @override
   bool libraryIsPresent = false;
@@ -22,9 +22,10 @@ class FakeGioUtils implements GioUtils {
 }
 
 void main() {
-  final FakeGioUtils fakeGio = FakeGioUtils();
+  late _FakeGioUtils fakeGio;
 
   setUp(() {
+    fakeGio = _FakeGioUtils();
     gioUtilsOverride = fakeGio;
   });
 


### PR DESCRIPTION
The lookup of application ID was handling `null` (Dart null), but not
`nullptr` (Dart representation of a C null pointer), so was throwing an
exception in applications without an application ID.

Refactors the FFI calls into a wrapper so that they can be faked for
unit testing.

This includes the `shared_preferences_linux` example application, so
this fixes tree breakage.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
