### PR TITLE
[camera]Fix crash due to calling engine APIs from background thread

### DIFF
--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,4 +1,8 @@
-##  0.9.4+5
+## NEXT
+
+* Fixed a crash in iOS when using image stream due to threading issue. 
+
+## 0.9.4+5
 
 * Fixes bug where calling a method after the camera was closed resulted in a Java `IllegalStateException` exception.
 * Fixes integration tests.

--- a/packages/camera/camera/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/camera/camera/example/ios/Runner.xcodeproj/project.pbxproj
@@ -20,6 +20,9 @@
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		E0C6E2002770F01A00EA6AA3 /* ThreadSafeMethodChannelTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E0C6E1FD2770F01A00EA6AA3 /* ThreadSafeMethodChannelTests.m */; };
+		E0C6E2012770F01A00EA6AA3 /* ThreadSafeTextureRegistryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E0C6E1FE2770F01A00EA6AA3 /* ThreadSafeTextureRegistryTests.m */; };
+		E0C6E2022770F01A00EA6AA3 /* ThreadSafeEventChannelTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E0C6E1FF2770F01A00EA6AA3 /* ThreadSafeEventChannelTests.m */; };
 		E487C86026D686A10034AC92 /* CameraPreviewPauseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E487C85F26D686A10034AC92 /* CameraPreviewPauseTests.m */; };
 		F6EE622F2710A6FC00905E4A /* MockFLTThreadSafeFlutterResult.m in Sources */ = {isa = PBXBuildFile; fileRef = F6EE622E2710A6FC00905E4A /* MockFLTThreadSafeFlutterResult.m */; };
 /* End PBXBuildFile section */
@@ -74,6 +77,9 @@
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9C5CC6CAD53AD388B2694F3A /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		A24F9E418BA48BCC7409B117 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
+		E0C6E1FD2770F01A00EA6AA3 /* ThreadSafeMethodChannelTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ThreadSafeMethodChannelTests.m; sourceTree = "<group>"; };
+		E0C6E1FE2770F01A00EA6AA3 /* ThreadSafeTextureRegistryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ThreadSafeTextureRegistryTests.m; sourceTree = "<group>"; };
+		E0C6E1FF2770F01A00EA6AA3 /* ThreadSafeEventChannelTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ThreadSafeEventChannelTests.m; sourceTree = "<group>"; };
 		E487C85F26D686A10034AC92 /* CameraPreviewPauseTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CameraPreviewPauseTests.m; sourceTree = "<group>"; };
 		F63F9EED27143B19002479BF /* MockFLTThreadSafeFlutterResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MockFLTThreadSafeFlutterResult.h; sourceTree = "<group>"; };
 		F6EE622E2710A6FC00905E4A /* MockFLTThreadSafeFlutterResult.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MockFLTThreadSafeFlutterResult.m; sourceTree = "<group>"; };
@@ -107,6 +113,9 @@
 				03BB766C2665316900CE5A93 /* Info.plist */,
 				033B94BD269C40A200B4DF97 /* CameraMethodChannelTests.m */,
 				03F6F8B126CBB4670024B8D3 /* ThreadSafeFlutterResultTests.m */,
+				E0C6E1FF2770F01A00EA6AA3 /* ThreadSafeEventChannelTests.m */,
+				E0C6E1FD2770F01A00EA6AA3 /* ThreadSafeMethodChannelTests.m */,
+				E0C6E1FE2770F01A00EA6AA3 /* ThreadSafeTextureRegistryTests.m */,
 				E487C85F26D686A10034AC92 /* CameraPreviewPauseTests.m */,
 				F6EE622E2710A6FC00905E4A /* MockFLTThreadSafeFlutterResult.m */,
 				F63F9EED27143B19002479BF /* MockFLTThreadSafeFlutterResult.h */,
@@ -239,7 +248,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1100;
+				LastUpgradeCheck = 1300;
 				ORGANIZATIONNAME = "The Flutter Authors";
 				TargetAttributes = {
 					03BB76672665316900CE5A93 = {
@@ -378,6 +387,9 @@
 				E487C86026D686A10034AC92 /* CameraPreviewPauseTests.m in Sources */,
 				F6EE622F2710A6FC00905E4A /* MockFLTThreadSafeFlutterResult.m in Sources */,
 				334733EA2668111C00DCC49E /* CameraOrientationTests.m in Sources */,
+				E0C6E2022770F01A00EA6AA3 /* ThreadSafeEventChannelTests.m in Sources */,
+				E0C6E2012770F01A00EA6AA3 /* ThreadSafeTextureRegistryTests.m in Sources */,
+				E0C6E2002770F01A00EA6AA3 /* ThreadSafeMethodChannelTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/packages/camera/camera/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/packages/camera/camera/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1100"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/packages/camera/camera/example/ios/RunnerTests/ThreadSafeEventChannelTests.m
+++ b/packages/camera/camera/example/ios/RunnerTests/ThreadSafeEventChannelTests.m
@@ -1,0 +1,44 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@import camera;
+@import XCTest;
+#import <OCMock/OCMock.h>
+
+@interface ThreadSafeEventChannelTests : XCTestCase
+@end
+
+@implementation ThreadSafeEventChannelTests {
+  FLTThreadSafeEventChannel *_channel;
+  XCTestExpectation *_mainThreadExpectation;
+}
+
+- (void)setUp {
+  [super setUp];
+  id mockEventChannel = OCMClassMock([FlutterEventChannel class]);
+
+  _mainThreadExpectation =
+      [[XCTestExpectation alloc] initWithDescription:@"invokeMethod must be called in main thread"];
+  _channel = [[FLTThreadSafeEventChannel alloc] initWithEventChannel:mockEventChannel];
+
+  OCMStub([mockEventChannel setStreamHandler:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
+    if (NSThread.isMainThread) {
+      [self->_mainThreadExpectation fulfill];
+    }
+  });
+}
+
+- (void)testSetStreamHandler_shouldStayOnMainThreadIfCalledFromMainThread {
+  [_channel setStreamHandler:nil];
+  [self waitForExpectations:@[ _mainThreadExpectation ] timeout:1];
+}
+
+- (void)testSetStreamHandler_shouldDispatchToMainThreadIfCalledFromBackgroundThread {
+  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    [self->_channel setStreamHandler:nil];
+  });
+  [self waitForExpectations:@[ _mainThreadExpectation ] timeout:1];
+}
+
+@end

--- a/packages/camera/camera/example/ios/RunnerTests/ThreadSafeMethodChannelTests.m
+++ b/packages/camera/camera/example/ios/RunnerTests/ThreadSafeMethodChannelTests.m
@@ -1,0 +1,46 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@import camera;
+@import XCTest;
+#import <OCMock/OCMock.h>
+
+@interface ThreadSafeMethodChannelTests : XCTestCase
+@end
+
+@implementation ThreadSafeMethodChannelTests {
+  FLTThreadSafeMethodChannel *_channel;
+  XCTestExpectation *_mainThreadExpectation;
+}
+
+- (void)setUp {
+  [super setUp];
+  id mockMethodChannel = OCMClassMock([FlutterMethodChannel class]);
+
+  _mainThreadExpectation =
+      [[XCTestExpectation alloc] initWithDescription:@"invokeMethod must be called in main thread"];
+  _channel = [[FLTThreadSafeMethodChannel alloc] initWithMethodChannel:mockMethodChannel];
+
+  OCMStub([mockMethodChannel invokeMethod:[OCMArg any] arguments:[OCMArg any]])
+      .andDo(^(NSInvocation *invocation) {
+        if (NSThread.isMainThread) {
+          [self->_mainThreadExpectation fulfill];
+        }
+      });
+}
+
+- (void)testInvokeMethod_shouldStayOnMainThreadIfCalledFromMainThread {
+  [_channel invokeMethod:@"foo" arguments:nil];
+
+  [self waitForExpectations:@[ _mainThreadExpectation ] timeout:1];
+}
+
+- (void)testInvokeMethod__shouldDispatchToMainThreadIfCalledFromBackgroundThread {
+  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    [self->_channel invokeMethod:@"foo" arguments:nil];
+  });
+  [self waitForExpectations:@[ _mainThreadExpectation ] timeout:1];
+}
+
+@end

--- a/packages/camera/camera/example/ios/RunnerTests/ThreadSafeTextureRegistryTests.m
+++ b/packages/camera/camera/example/ios/RunnerTests/ThreadSafeTextureRegistryTests.m
@@ -1,0 +1,74 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@import camera;
+@import XCTest;
+#import <OCMock/OCMock.h>
+
+@interface ThreadSafeTextureRegistryTests : XCTestCase
+@end
+
+@implementation ThreadSafeTextureRegistryTests {
+  FLTThreadSafeTextureRegistry *_registry;
+  XCTestExpectation *_registerTextureExpectation;
+  XCTestExpectation *_unregisterTextureExpectation;
+  XCTestExpectation *_textureFrameAvailableExpectation;
+}
+
+- (void)setUp {
+  [super setUp];
+  id mockTextureRegistry = OCMProtocolMock(@protocol(FlutterTextureRegistry));
+  _registry = [[FLTThreadSafeTextureRegistry alloc] initWithTextureRegistry:mockTextureRegistry];
+
+  _registerTextureExpectation = [[XCTestExpectation alloc]
+      initWithDescription:@"registerTexture must be called in main thread"];
+  _unregisterTextureExpectation = [[XCTestExpectation alloc]
+      initWithDescription:@"unregisterTexture must be called in main thread"];
+  _textureFrameAvailableExpectation = [[XCTestExpectation alloc]
+      initWithDescription:@"textureFrameAvailable must be called in main thread"];
+
+  OCMStub([mockTextureRegistry registerTexture:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
+    if (NSThread.isMainThread) {
+      [self->_registerTextureExpectation fulfill];
+    }
+  });
+
+  OCMStub([mockTextureRegistry unregisterTexture:0]).andDo(^(NSInvocation *invocation) {
+    if (NSThread.isMainThread) {
+      [self->_unregisterTextureExpectation fulfill];
+    }
+  });
+
+  OCMStub([mockTextureRegistry textureFrameAvailable:0]).andDo(^(NSInvocation *invocation) {
+    if (NSThread.isMainThread) {
+      [self->_textureFrameAvailableExpectation fulfill];
+    }
+  });
+}
+
+- (void)testShouldStayOnMainThreadIfCalledFromMainThread {
+  NSObject<FlutterTexture> *anyTexture = OCMProtocolMock(@protocol(FlutterTexture));
+  [_registry registerTextureSync:anyTexture];
+  [_registry textureFrameAvailable:0];
+  [_registry unregisterTexture:0];
+  [self waitForExpectations:@[
+    _registerTextureExpectation, _unregisterTextureExpectation, _textureFrameAvailableExpectation
+  ]
+                    timeout:1];
+}
+
+- (void)testShouldDispatchToMainThreadIfCalledFromBackgroundThread {
+  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    NSObject<FlutterTexture> *anyTexture = OCMProtocolMock(@protocol(FlutterTexture));
+    [self->_registry registerTextureSync:anyTexture];
+    [self->_registry textureFrameAvailable:0];
+    [self->_registry unregisterTexture:0];
+  });
+  [self waitForExpectations:@[
+    _registerTextureExpectation, _unregisterTextureExpectation, _textureFrameAvailableExpectation
+  ]
+                    timeout:1];
+}
+
+@end

--- a/packages/camera/camera/ios/Classes/FLTThreadSafeEventChannel.h
+++ b/packages/camera/camera/ios/Classes/FLTThreadSafeEventChannel.h
@@ -1,0 +1,27 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <Flutter/Flutter.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Wrapper for FlutterEventChannel that always sends events on the main thread
+ */
+@interface FLTThreadSafeEventChannel : NSObject
+
+/**
+ * Creates a FLTThreadSafeEventChannel by wrapping a FlutterEventChannel object.
+ * @param channel The FlutterEventChannel object to be wrapped.
+ */
+- (instancetype)initWithEventChannel:(FlutterEventChannel *)channel;
+
+/*
+ * Registers a handler for stream setup requests from the Flutter side on main thread.
+ */
+- (void)setStreamHandler:(nullable NSObject<FlutterStreamHandler> *)handler;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/camera/camera/ios/Classes/FLTThreadSafeEventChannel.m
+++ b/packages/camera/camera/ios/Classes/FLTThreadSafeEventChannel.m
@@ -1,0 +1,29 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "FLTThreadSafeEventChannel.h"
+
+@implementation FLTThreadSafeEventChannel {
+  FlutterEventChannel *_channel;
+}
+
+- (instancetype)initWithEventChannel:(FlutterEventChannel *)channel {
+  self = [super init];
+  if (self) {
+    _channel = channel;
+  }
+  return self;
+}
+
+- (void)setStreamHandler:(NSObject<FlutterStreamHandler> *)handler {
+  if (!NSThread.isMainThread) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [self->_channel setStreamHandler:handler];
+    });
+  } else {
+    [_channel setStreamHandler:handler];
+  }
+}
+
+@end

--- a/packages/camera/camera/ios/Classes/FLTThreadSafeMethodChannel.h
+++ b/packages/camera/camera/ios/Classes/FLTThreadSafeMethodChannel.h
@@ -1,0 +1,27 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <Flutter/Flutter.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Wrapper for FlutterMethodChannel that always invokes messages on the main thread
+ */
+@interface FLTThreadSafeMethodChannel : NSObject
+
+/**
+ * Creates a FLTThreadSafeMethodChannel by wrapping a FlutterMethodChannel object.
+ * @param channel The FlutterMethodChannel object to be wrapped.
+ */
+- (instancetype)initWithMethodChannel:(FlutterMethodChannel *)channel;
+
+/**
+ * Invokes the specified flutter method with the specified arguments on main thread.
+ */
+- (void)invokeMethod:(NSString *)method arguments:(nullable id)arguments;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/camera/camera/ios/Classes/FLTThreadSafeMethodChannel.m
+++ b/packages/camera/camera/ios/Classes/FLTThreadSafeMethodChannel.m
@@ -1,0 +1,29 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "FLTThreadSafeMethodChannel.h"
+
+@implementation FLTThreadSafeMethodChannel {
+  FlutterMethodChannel *_channel;
+}
+
+- (instancetype)initWithMethodChannel:(FlutterMethodChannel *)channel {
+  self = [super init];
+  if (self) {
+    _channel = channel;
+  }
+  return self;
+}
+
+- (void)invokeMethod:(NSString *)method arguments:(id)arguments {
+  if (!NSThread.isMainThread) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [self->_channel invokeMethod:method arguments:arguments];
+    });
+  } else {
+    [_channel invokeMethod:method arguments:arguments];
+  }
+}
+
+@end

--- a/packages/camera/camera/ios/Classes/FLTThreadSafeTextureRegistry.h
+++ b/packages/camera/camera/ios/Classes/FLTThreadSafeTextureRegistry.h
@@ -1,0 +1,51 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <Flutter/Flutter.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Wrapper for FlutterTextureRegistry that always sends events on the main thread
+ */
+@interface FLTThreadSafeTextureRegistry : NSObject
+
+/**
+ * Creates a FLTThreadSafeTextureRegistry by wrapping an object conforming to
+ * FlutterTextureRegistry.
+ * @param registry The FlutterTextureRegistry object to be wrapped.
+ */
+- (instancetype)initWithTextureRegistry:(NSObject<FlutterTextureRegistry> *)registry;
+
+/**
+ * Registers a `FlutterTexture` for usage in Flutter and returns an id that can be used to reference
+ * that texture when calling into Flutter with channels. Textures must be registered on the
+ * main thread. On success returns the pointer to the registered texture, else returns 0.
+ *
+ * Runs on main thread.
+ */
+- (int64_t)registerTextureSync:(NSObject<FlutterTexture> *)texture;
+
+/**
+ * Notifies Flutter that the content of the previously registered texture has been updated.
+ *
+ * This will trigger a call to `-[FlutterTexture copyPixelBuffer]` on the raster thread.
+ *
+ * Runs on main thread.
+ */
+- (void)textureFrameAvailable:(int64_t)textureId;
+
+/**
+ * Unregisters a `FlutterTexture` that has previously regeistered with `registerTexture:`. Textures
+ * must be unregistered on the main thread.
+ *
+ * Runs on main thread.
+ *
+ * @param textureId The result that was previously returned from `registerTexture:`.
+ */
+- (void)unregisterTexture:(int64_t)textureId;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/camera/camera/ios/Classes/FLTThreadSafeTextureRegistry.m
+++ b/packages/camera/camera/ios/Classes/FLTThreadSafeTextureRegistry.m
@@ -1,0 +1,58 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "FLTThreadSafeTextureRegistry.h"
+
+@implementation FLTThreadSafeTextureRegistry {
+  NSObject<FlutterTextureRegistry> *_registry;
+}
+
+- (instancetype)initWithTextureRegistry:(NSObject<FlutterTextureRegistry> *)registry {
+  self = [super init];
+  if (self) {
+    _registry = registry;
+  }
+  return self;
+}
+
+- (int64_t)registerTextureSync:(NSObject<FlutterTexture> *)texture {
+  if (!NSThread.isMainThread) {
+    __block int64_t textureId;
+    // We cannot use async API (with completion block) because completion block does not work for
+    // separate functions (e.g. `dispose` and `create` are separately registered functions). It's
+    // hard to tell if the developers had made implicit assumption of the synchronous nature of the
+    // original API when implementing this plugin. Use dispatch_sync to keep
+    // FlutterTextureRegistry's sychronous API, so that we don't introduce new potential race
+    // conditions. We do not break priority inversion here since it's the background thread waiting
+    // for main thread.
+    dispatch_sync(dispatch_get_main_queue(), ^{
+      textureId = [self->_registry registerTexture:texture];
+    });
+    return textureId;
+  } else {
+    return [_registry registerTexture:texture];
+  }
+}
+
+- (void)textureFrameAvailable:(int64_t)textureId {
+  if (!NSThread.isMainThread) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [self->_registry textureFrameAvailable:textureId];
+    });
+  } else {
+    [_registry textureFrameAvailable:textureId];
+  }
+}
+
+- (void)unregisterTexture:(int64_t)textureId {
+  if (!NSThread.isMainThread) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [self->_registry unregisterTexture:textureId];
+    });
+  } else {
+    [_registry unregisterTexture:textureId];
+  }
+}
+
+@end

--- a/packages/camera/camera/ios/Classes/camera-umbrella.h
+++ b/packages/camera/camera/ios/Classes/camera-umbrella.h
@@ -4,7 +4,10 @@
 
 #import <Foundation/Foundation.h>
 #import <camera/CameraPlugin.h>
+#import <camera/FLTThreadSafeEventChannel.h>
 #import <camera/FLTThreadSafeFlutterResult.h>
+#import <camera/FLTThreadSafeMethodChannel.h>
+#import <camera/FLTThreadSafeTextureRegistry.h>
 
 FOUNDATION_EXPORT double cameraVersionNumber;
 FOUNDATION_EXPORT const unsigned char cameraVersionString[];


### PR DESCRIPTION
The engine APIs used in camera plugin are required to be run on platform thread. Some of these APIs have explicit asserts (e.g. `MethodChannel`) and some have warning instructions in documentation (e.g. `TextureRegistry`). However, in camera plugin we are currently calling these APIs in background thread, causing the crash. 

There's already a `FLTThreadSafeFlutterResult` wrapper to invoke `FlutterResult` in main thread. This PR created similar "thread safe wrappers" for `EventChannel`, `MethodChannel` and `TextureRegistry`. 

This PR should fix the crash, but we should start looking into simplifying the threading logic in this plugin when we get time. I also wrote up [some ideas here](https://github.com/flutter/plugins/pull/4619).  

Note that there's a separate crash due to race condition, which is [fixed here](https://github.com/flutter/plugins/pull/4619). 


No version change: 
I want to update the pubspec.yaml file in next PR so that we can batch the change. 

## Issues: 

https://github.com/flutter/flutter/issues/94723
https://github.com/flutter/flutter/issues/52578


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
