### PR TITLE
[video_player] Fix a flaky test

### DIFF
--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Fixes integration tests.
 * Updates Android compileSdkVersion to 31.
+* Minor test changes.
 
 ## 2.2.7
 

--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Fixes integration tests.
 * Updates Android compileSdkVersion to 31.
-* Minor test changes.
+* Fixes a flaky integration test.
 
 ## 2.2.7
 

--- a/packages/video_player/video_player/example/integration_test/video_player_test.dart
+++ b/packages/video_player/video_player/example/integration_test/video_player_test.dart
@@ -68,8 +68,8 @@ void main() {
         expect(networkController.value.position,
             (Duration position) => position > const Duration(seconds: 0));
 
-        await expectLater(started, completes);
-        await expectLater(ended, completes);
+        await expectLater(started.future, completes);
+        await expectLater(ended.future, completes);
       },
       skip: !(kIsWeb || defaultTargetPlatform == TargetPlatform.android),
     );

--- a/packages/video_player/video_player/example/integration_test/video_player_test.dart
+++ b/packages/video_player/video_player/example/integration_test/video_player_test.dart
@@ -48,17 +48,13 @@ void main() {
         await networkController.setVolume(0);
         final Completer<void> started = Completer();
         final Completer<void> ended = Completer();
-        bool startedBuffering = false;
-        bool endedBuffering = false;
         networkController.addListener(() {
-          if (networkController.value.isBuffering && !startedBuffering) {
-            startedBuffering = true;
+          if (!started.isCompleted && networkController.value.isBuffering) {
             started.complete();
           }
-          if (startedBuffering &&
+          if (started.isCompleted &&
               !networkController.value.isBuffering &&
-              !endedBuffering) {
-            endedBuffering = true;
+              !ended.isCompleted) {
             ended.complete();
           }
         });
@@ -72,11 +68,8 @@ void main() {
         expect(networkController.value.position,
             (Duration position) => position > const Duration(seconds: 0));
 
-        await started;
-        expect(startedBuffering, true);
-
-        await ended;
-        expect(endedBuffering, true);
+        await expectLater(started, completes);
+        await expectLater(ended, completes);
       },
       skip: !(kIsWeb || defaultTargetPlatform == TargetPlatform.android),
     );


### PR DESCRIPTION
The 'reports buffering status' test was written in an unnecessary complicated way that used pairs of completers and booleans that tracked the same thing, and more importantly had a bug (hidden by the fact that this package is still on legacy analysis options) where the `await` statements weren't actually doing anything, because they were not actually `await`ing futures.

This fixes the lack of awaits—which should fix the flake—and removes the unnecessary booleans.

Fixes https://github.com/flutter/flutter/issues/94775

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
