### PR TITLE
[path_provider] Switch Android to an internal method channel

### DIFF
--- a/packages/path_provider/path_provider_android/CHANGELOG.md
+++ b/packages/path_provider/path_provider_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.10
+
+* Switches to a package-internal implementation of the platform interface.
+
 ## 2.0.9
 
 * Updates Android compileSdkVersion to 31.

--- a/packages/path_provider/path_provider_android/android/src/main/java/io/flutter/plugins/pathprovider/PathProviderPlugin.java
+++ b/packages/path_provider/path_provider_android/android/src/main/java/io/flutter/plugins/pathprovider/PathProviderPlugin.java
@@ -153,7 +153,7 @@ public class PathProviderPlugin implements FlutterPlugin, MethodCallHandler {
   public PathProviderPlugin() {}
 
   private void setup(BinaryMessenger messenger, Context context) {
-    String channelName = "plugins.flutter.io/path_provider";
+    String channelName = "plugins.flutter.io/path_provider_android";
     // TODO(gaaclarke): Remove reflection guard when https://github.com/flutter/engine/pull/29147
     // becomes available on the stable branch.
     try {

--- a/packages/path_provider/path_provider_android/lib/path_provider_android.dart
+++ b/packages/path_provider/path_provider_android/lib/path_provider_android.dart
@@ -30,7 +30,7 @@ class PathProviderAndroid extends PathProviderPlatform {
 
   @override
   Future<String?> getLibraryPath() {
-    return methodChannel.invokeMethod<String>('getLibraryDirectory');
+    throw UnsupportedError('getLibraryPath is not supported on Android');
   }
 
   @override
@@ -41,25 +41,25 @@ class PathProviderAndroid extends PathProviderPlatform {
 
   @override
   Future<String?> getExternalStoragePath() async {
-    throw UnsupportedError(
-        'getExternalStoragePath is not supported on Android');
+    return methodChannel.invokeMethod<String>('getStorageDirectory');
   }
 
   @override
   Future<List<String>?> getExternalCachePaths() async {
-    throw UnsupportedError('getExternalCachePaths is not supported on Android');
+    return methodChannel
+        .invokeMethod<List<String>>('getExternalCacheDirectories');
   }
 
   @override
   Future<List<String>?> getExternalStoragePaths({
     StorageDirectory? type,
   }) async {
-    throw UnsupportedError(
-        'getExternalStoragePaths is not supported on Android');
+    return methodChannel
+        .invokeMethod<List<String>>('getExternalStorageDirectories');
   }
 
   @override
   Future<String?> getDownloadsPath() {
-    return methodChannel.invokeMethod<String>('getDownloadsDirectory');
+    throw UnsupportedError('getDownloadsPath is not supported on Android');
   }
 }

--- a/packages/path_provider/path_provider_android/lib/path_provider_android.dart
+++ b/packages/path_provider/path_provider_android/lib/path_provider_android.dart
@@ -1,0 +1,65 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/services.dart';
+import 'package:meta/meta.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+
+/// The Android implementation of [PathProviderPlatform].
+class PathProviderAndroid extends PathProviderPlatform {
+  /// The method channel used to interact with the native platform.
+  @visibleForTesting
+  MethodChannel methodChannel =
+      const MethodChannel('plugins.flutter.io/path_provider_android');
+
+  /// Registers this class as the default instance of [PathProviderPlatform]
+  static void registerWith() {
+    PathProviderPlatform.instance = PathProviderAndroid();
+  }
+
+  @override
+  Future<String?> getTemporaryPath() {
+    return methodChannel.invokeMethod<String>('getTemporaryDirectory');
+  }
+
+  @override
+  Future<String?> getApplicationSupportPath() {
+    return methodChannel.invokeMethod<String>('getApplicationSupportDirectory');
+  }
+
+  @override
+  Future<String?> getLibraryPath() {
+    return methodChannel.invokeMethod<String>('getLibraryDirectory');
+  }
+
+  @override
+  Future<String?> getApplicationDocumentsPath() {
+    return methodChannel
+        .invokeMethod<String>('getApplicationDocumentsDirectory');
+  }
+
+  @override
+  Future<String?> getExternalStoragePath() async {
+    throw UnsupportedError(
+        'getExternalStoragePath is not supported on Android');
+  }
+
+  @override
+  Future<List<String>?> getExternalCachePaths() async {
+    throw UnsupportedError('getExternalCachePaths is not supported on Android');
+  }
+
+  @override
+  Future<List<String>?> getExternalStoragePaths({
+    StorageDirectory? type,
+  }) async {
+    throw UnsupportedError(
+        'getExternalStoragePaths is not supported on Android');
+  }
+
+  @override
+  Future<String?> getDownloadsPath() {
+    return methodChannel.invokeMethod<String>('getDownloadsDirectory');
+  }
+}

--- a/packages/path_provider/path_provider_android/lib/path_provider_android.dart
+++ b/packages/path_provider/path_provider_android/lib/path_provider_android.dart
@@ -13,7 +13,7 @@ class PathProviderAndroid extends PathProviderPlatform {
   MethodChannel methodChannel =
       const MethodChannel('plugins.flutter.io/path_provider_android');
 
-  /// Registers this class as the default instance of [PathProviderPlatform]
+  /// Registers this class as the default instance of [PathProviderPlatform].
   static void registerWith() {
     PathProviderPlatform.instance = PathProviderAndroid();
   }
@@ -40,22 +40,24 @@ class PathProviderAndroid extends PathProviderPlatform {
   }
 
   @override
-  Future<String?> getExternalStoragePath() async {
+  Future<String?> getExternalStoragePath() {
     return methodChannel.invokeMethod<String>('getStorageDirectory');
   }
 
   @override
-  Future<List<String>?> getExternalCachePaths() async {
+  Future<List<String>?> getExternalCachePaths() {
     return methodChannel
-        .invokeMethod<List<String>>('getExternalCacheDirectories');
+        .invokeListMethod<String>('getExternalCacheDirectories');
   }
 
   @override
   Future<List<String>?> getExternalStoragePaths({
     StorageDirectory? type,
   }) async {
-    return methodChannel
-        .invokeMethod<List<String>>('getExternalStorageDirectories');
+    return methodChannel.invokeListMethod<String>(
+      'getExternalStorageDirectories',
+      <String, dynamic>{'type': type?.index},
+    );
   }
 
   @override

--- a/packages/path_provider/path_provider_android/lib/path_provider_android.dart
+++ b/packages/path_provider/path_provider_android/lib/path_provider_android.dart
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
-import 'package:meta/meta.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 
 /// The Android implementation of [PathProviderPlatform].

--- a/packages/path_provider/path_provider_android/pubspec.yaml
+++ b/packages/path_provider/path_provider_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: path_provider_android
 description: Android implementation of the path_provider plugin.
 repository: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+path_provider%22
-version: 2.0.9
+version: 2.0.10
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -15,11 +15,13 @@ flutter:
       android:
         package: io.flutter.plugins.pathprovider
         pluginClass: PathProviderPlugin
+        dartPluginClass: PathProviderAndroid
 
 dependencies:
   flutter:
     sdk: flutter
-  path_provider_platform_interface: ^2.0.0
+  meta: ^1.3.0
+  path_provider_platform_interface: ^2.0.1
 
 dev_dependencies:
   flutter_driver:

--- a/packages/path_provider/path_provider_android/pubspec.yaml
+++ b/packages/path_provider/path_provider_android/pubspec.yaml
@@ -20,7 +20,6 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.3.0
   path_provider_platform_interface: ^2.0.1
 
 dev_dependencies:

--- a/packages/path_provider/path_provider_android/test/path_provider_android_test.dart
+++ b/packages/path_provider/path_provider_android/test/path_provider_android_test.dart
@@ -10,9 +10,10 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   const String kTemporaryPath = 'temporaryPath';
   const String kApplicationSupportPath = 'applicationSupportPath';
-  const String kLibraryPath = 'libraryPath';
   const String kApplicationDocumentsPath = 'applicationDocumentsPath';
-  const String kDownloadsPath = 'downloadsPath';
+  const String kStoragePath = 'storagePath';
+  const List<String> kExternalCachePaths = <String>['externalCachePath'];
+  const List<String> kExternalStoragePaths = <String>['externalStoragePath'];
 
   group('PathProviderAndroid', () {
     late PathProviderAndroid pathProvider;
@@ -29,12 +30,14 @@ void main() {
             return kTemporaryPath;
           case 'getApplicationSupportDirectory':
             return kApplicationSupportPath;
-          case 'getLibraryDirectory':
-            return kLibraryPath;
           case 'getApplicationDocumentsDirectory':
             return kApplicationDocumentsPath;
-          case 'getDownloadsDirectory':
-            return kDownloadsPath;
+          case 'getStorageDirectory':
+            return kStoragePath;
+          case 'getExternalCacheDirectories':
+            return kExternalCachePaths;
+          case 'getExternalStorageDirectories':
+            return kExternalStoragePaths;
           default:
             return null;
         }
@@ -65,15 +68,6 @@ void main() {
       expect(path, kApplicationSupportPath);
     });
 
-    test('getLibraryPath', () async {
-      final String? path = await pathProvider.getLibraryPath();
-      expect(
-        log,
-        <Matcher>[isMethodCall('getLibraryDirectory', arguments: null)],
-      );
-      expect(path, kLibraryPath);
-    });
-
     test('getApplicationDocumentsPath', () async {
       final String? path = await pathProvider.getApplicationDocumentsPath();
       expect(
@@ -85,27 +79,41 @@ void main() {
       expect(path, kApplicationDocumentsPath);
     });
 
-    test('getDownloadsPath', () async {
-      final String? result = await pathProvider.getDownloadsPath();
+    test('getExternalStoragePath', () async {
+      final String? result = await pathProvider.getExternalStoragePath();
       expect(
         log,
-        <Matcher>[isMethodCall('getDownloadsDirectory', arguments: null)],
+        <Matcher>[isMethodCall('getStorageDirectory', arguments: null)],
       );
-      expect(result, kDownloadsPath);
+      expect(result, kStoragePath);
     });
 
-    test('getExternalCachePaths throws', () async {
-      expect(pathProvider.getExternalCachePaths(), throwsA(isUnsupportedError));
-    });
-
-    test('getExternalStoragePath throws', () async {
+    test('getExternalCachePaths', () async {
+      final List<String>? result = await pathProvider.getExternalCachePaths();
       expect(
-          pathProvider.getExternalStoragePath(), throwsA(isUnsupportedError));
+        log,
+        <Matcher>[isMethodCall('getExternalCacheDirectories', arguments: null)],
+      );
+      expect(result, kExternalCachePaths);
     });
 
-    test('getExternalStoragePaths throws', () async {
+    test('getExternalStoragePaths', () async {
+      final List<String>? result = await pathProvider.getExternalStoragePaths();
       expect(
-          pathProvider.getExternalStoragePaths(), throwsA(isUnsupportedError));
+        log,
+        <Matcher>[
+          isMethodCall('getExternalStorageDirectories', arguments: null)
+        ],
+      );
+      expect(result, kExternalStoragePaths);
+    });
+
+    test('getLibraryPath throws', () async {
+      expect(pathProvider.getLibraryPath(), throwsA(isUnsupportedError));
+    });
+
+    test('getDownloadsPath throws', () async {
+      expect(pathProvider.getDownloadsPath(), throwsA(isUnsupportedError));
     });
   });
 }

--- a/packages/path_provider/path_provider_android/test/path_provider_android_test.dart
+++ b/packages/path_provider/path_provider_android/test/path_provider_android_test.dart
@@ -5,15 +5,17 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path_provider_android/path_provider_android.dart';
+import 'package:path_provider_platform_interface/src/enums.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   const String kTemporaryPath = 'temporaryPath';
   const String kApplicationSupportPath = 'applicationSupportPath';
+  const String kLibraryPath = 'libraryPath';
   const String kApplicationDocumentsPath = 'applicationDocumentsPath';
-  const String kStoragePath = 'storagePath';
-  const List<String> kExternalCachePaths = <String>['externalCachePath'];
-  const List<String> kExternalStoragePaths = <String>['externalStoragePath'];
+  const String kExternalCachePaths = 'externalCachePaths';
+  const String kExternalStoragePaths = 'externalStoragePaths';
+  const String kDownloadsPath = 'downloadsPath';
 
   group('PathProviderAndroid', () {
     late PathProviderAndroid pathProvider;
@@ -30,14 +32,16 @@ void main() {
             return kTemporaryPath;
           case 'getApplicationSupportDirectory':
             return kApplicationSupportPath;
+          case 'getLibraryDirectory':
+            return kLibraryPath;
           case 'getApplicationDocumentsDirectory':
             return kApplicationDocumentsPath;
-          case 'getStorageDirectory':
-            return kStoragePath;
-          case 'getExternalCacheDirectories':
-            return kExternalCachePaths;
           case 'getExternalStorageDirectories':
-            return kExternalStoragePaths;
+            return <String>[kExternalStoragePaths];
+          case 'getExternalCacheDirectories':
+            return <String>[kExternalCachePaths];
+          case 'getDownloadsDirectory':
+            return kDownloadsPath;
           default:
             return null;
         }
@@ -79,14 +83,27 @@ void main() {
       expect(path, kApplicationDocumentsPath);
     });
 
-    test('getExternalStoragePath', () async {
-      final String? result = await pathProvider.getExternalStoragePath();
-      expect(
-        log,
-        <Matcher>[isMethodCall('getStorageDirectory', arguments: null)],
-      );
-      expect(result, kStoragePath);
-    });
+    for (final StorageDirectory? type in <StorageDirectory?>[
+      null,
+      ...StorageDirectory.values
+    ]) {
+      test('getExternalStoragePaths (type: $type) android succeeds', () async {
+        final List<String>? result =
+            await pathProvider.getExternalStoragePaths(type: type);
+        expect(
+          log,
+          <Matcher>[
+            isMethodCall(
+              'getExternalStorageDirectories',
+              arguments: <String, dynamic>{'type': type?.index},
+            )
+          ],
+        );
+
+        expect(result!.length, 1);
+        expect(result.first, kExternalStoragePaths);
+      });
+    } // end of for-loop
 
     test('getExternalCachePaths', () async {
       final List<String>? result = await pathProvider.getExternalCachePaths();

--- a/packages/path_provider/path_provider_android/test/path_provider_android_test.dart
+++ b/packages/path_provider/path_provider_android/test/path_provider_android_test.dart
@@ -5,7 +5,7 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path_provider_android/path_provider_android.dart';
-import 'package:path_provider_platform_interface/src/enums.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/packages/path_provider/path_provider_android/test/path_provider_android_test.dart
+++ b/packages/path_provider/path_provider_android/test/path_provider_android_test.dart
@@ -72,6 +72,15 @@ void main() {
       expect(path, kApplicationSupportPath);
     });
 
+    test('getLibraryPath fails', () async {
+      try {
+        await pathProvider.getLibraryPath();
+        fail('should throw UnsupportedError');
+      } catch (e) {
+        expect(e, isUnsupportedError);
+      }
+    });
+
     test('getApplicationDocumentsPath', () async {
       final String? path = await pathProvider.getApplicationDocumentsPath();
       expect(
@@ -81,6 +90,16 @@ void main() {
         ],
       );
       expect(path, kApplicationDocumentsPath);
+    });
+
+    test('getExternalCachePaths succeeds', () async {
+      final List<String>? result = await pathProvider.getExternalCachePaths();
+      expect(
+        log,
+        <Matcher>[isMethodCall('getExternalCacheDirectories', arguments: null)],
+      );
+      expect(result!.length, 1);
+      expect(result.first, kExternalCachePaths);
     });
 
     for (final StorageDirectory? type in <StorageDirectory?>[
@@ -104,36 +123,6 @@ void main() {
         expect(result.first, kExternalStoragePaths);
       });
     } // end of for-loop
-
-    test('getExternalCachePaths succeeds', () async {
-      final List<String>? result = await pathProvider.getExternalCachePaths();
-      expect(
-        log,
-        <Matcher>[isMethodCall('getExternalCacheDirectories', arguments: null)],
-      );
-      expect(result!.length, 1);
-      expect(result.first, kExternalCachePaths);
-    });
-
-    test('getExternalStoragePaths', () async {
-      final List<String>? result = await pathProvider.getExternalStoragePaths();
-      expect(
-        log,
-        <Matcher>[
-          isMethodCall('getExternalStorageDirectories', arguments: null)
-        ],
-      );
-      expect(result, kExternalStoragePaths);
-    });
-
-    test('getLibraryPath fails', () async {
-      try {
-        await pathProvider.getLibraryPath();
-        fail('should throw UnsupportedError');
-      } catch (e) {
-        expect(e, isUnsupportedError);
-      }
-    });
 
     test('getDownloadsPath fails', () async {
       try {

--- a/packages/path_provider/path_provider_android/test/path_provider_android_test.dart
+++ b/packages/path_provider/path_provider_android/test/path_provider_android_test.dart
@@ -108,12 +108,22 @@ void main() {
       expect(result, kExternalStoragePaths);
     });
 
-    test('getLibraryPath throws', () async {
-      expect(pathProvider.getLibraryPath(), throwsA(isUnsupportedError));
+    test('getLibraryPath fails', () async {
+      try {
+        await pathProvider.getLibraryPath();
+        fail('should throw UnsupportedError');
+      } catch (e) {
+        expect(e, isUnsupportedError);
+      }
     });
 
-    test('getDownloadsPath throws', () async {
-      expect(pathProvider.getDownloadsPath(), throwsA(isUnsupportedError));
+    test('getDownloadsPath fails', () async {
+      try {
+        await pathProvider.getDownloadsPath();
+        fail('should throw UnsupportedError');
+      } catch (e) {
+        expect(e, isUnsupportedError);
+      }
     });
   });
 }

--- a/packages/path_provider/path_provider_android/test/path_provider_android_test.dart
+++ b/packages/path_provider/path_provider_android/test/path_provider_android_test.dart
@@ -105,13 +105,14 @@ void main() {
       });
     } // end of for-loop
 
-    test('getExternalCachePaths', () async {
+    test('getExternalCachePaths succeeds', () async {
       final List<String>? result = await pathProvider.getExternalCachePaths();
       expect(
         log,
         <Matcher>[isMethodCall('getExternalCacheDirectories', arguments: null)],
       );
-      expect(result, kExternalCachePaths);
+      expect(result!.length, 1);
+      expect(result.first, kExternalCachePaths);
     });
 
     test('getExternalStoragePaths', () async {

--- a/packages/path_provider/path_provider_android/test/path_provider_android_test.dart
+++ b/packages/path_provider/path_provider_android/test/path_provider_android_test.dart
@@ -1,0 +1,111 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_android/path_provider_android.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const String kTemporaryPath = 'temporaryPath';
+  const String kApplicationSupportPath = 'applicationSupportPath';
+  const String kLibraryPath = 'libraryPath';
+  const String kApplicationDocumentsPath = 'applicationDocumentsPath';
+  const String kDownloadsPath = 'downloadsPath';
+
+  group('PathProviderAndroid', () {
+    late PathProviderAndroid pathProvider;
+    final List<MethodCall> log = <MethodCall>[];
+
+    setUp(() async {
+      pathProvider = PathProviderAndroid();
+      TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger
+          .setMockMethodCallHandler(pathProvider.methodChannel,
+              (MethodCall methodCall) async {
+        log.add(methodCall);
+        switch (methodCall.method) {
+          case 'getTemporaryDirectory':
+            return kTemporaryPath;
+          case 'getApplicationSupportDirectory':
+            return kApplicationSupportPath;
+          case 'getLibraryDirectory':
+            return kLibraryPath;
+          case 'getApplicationDocumentsDirectory':
+            return kApplicationDocumentsPath;
+          case 'getDownloadsDirectory':
+            return kDownloadsPath;
+          default:
+            return null;
+        }
+      });
+    });
+
+    tearDown(() {
+      log.clear();
+    });
+
+    test('getTemporaryPath', () async {
+      final String? path = await pathProvider.getTemporaryPath();
+      expect(
+        log,
+        <Matcher>[isMethodCall('getTemporaryDirectory', arguments: null)],
+      );
+      expect(path, kTemporaryPath);
+    });
+
+    test('getApplicationSupportPath', () async {
+      final String? path = await pathProvider.getApplicationSupportPath();
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('getApplicationSupportDirectory', arguments: null)
+        ],
+      );
+      expect(path, kApplicationSupportPath);
+    });
+
+    test('getLibraryPath', () async {
+      final String? path = await pathProvider.getLibraryPath();
+      expect(
+        log,
+        <Matcher>[isMethodCall('getLibraryDirectory', arguments: null)],
+      );
+      expect(path, kLibraryPath);
+    });
+
+    test('getApplicationDocumentsPath', () async {
+      final String? path = await pathProvider.getApplicationDocumentsPath();
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('getApplicationDocumentsDirectory', arguments: null)
+        ],
+      );
+      expect(path, kApplicationDocumentsPath);
+    });
+
+    test('getDownloadsPath', () async {
+      final String? result = await pathProvider.getDownloadsPath();
+      expect(
+        log,
+        <Matcher>[isMethodCall('getDownloadsDirectory', arguments: null)],
+      );
+      expect(result, kDownloadsPath);
+    });
+
+    test('getExternalCachePaths throws', () async {
+      expect(pathProvider.getExternalCachePaths(), throwsA(isUnsupportedError));
+    });
+
+    test('getExternalStoragePath throws', () async {
+      expect(
+          pathProvider.getExternalStoragePath(), throwsA(isUnsupportedError));
+    });
+
+    test('getExternalStoragePaths throws', () async {
+      expect(
+          pathProvider.getExternalStoragePaths(), throwsA(isUnsupportedError));
+    });
+  });
+}


### PR DESCRIPTION
Eliminates the path_provider_android reliance on the default, shared method channel implementation, in favor of an in-package implementation.

Part of https://github.com/flutter/flutter/issues/94224

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
