### PR TITLE
Prevent setting user agent string to default value on every rebuild

### DIFF
--- a/packages/webview_flutter/webview_flutter_android/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_android/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.8.1
+
+* Fixes bug where the default user agent string was being set for every rebuild. See
+  https://github.com/flutter/flutter/issues/94847.
+
 ## 2.8.0
 
 * Implements new cookie manager for setting cookies and providing initial cookies.

--- a/packages/webview_flutter/webview_flutter_android/lib/webview_android_widget.dart
+++ b/packages/webview_flutter/webview_flutter_android/lib/webview_android_widget.dart
@@ -418,11 +418,12 @@ class WebViewAndroidPlatformController extends WebViewPlatformController {
   }
 
   Future<void> _setUserAgent(WebSetting<String?> userAgent) {
-    if (userAgent.isPresent && userAgent.value != null) {
-      return webView.settings.setUserAgentString(userAgent.value!);
+    if (userAgent.isPresent) {
+      // If the string is empty, the system default value will be used.
+      return webView.settings.setUserAgentString(userAgent.value ?? '');
     }
 
-    return webView.settings.setUserAgentString('');
+    return Future<void>.value();
   }
 
   Future<void> _setZoomEnabled(bool zoomEnabled) {

--- a/packages/webview_flutter/webview_flutter_android/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter_android
 description: A Flutter plugin that provides a WebView widget on Android.
 repository: https://github.com/flutter/plugins/tree/master/packages/webview_flutter/webview_flutter_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview%22
-version: 2.8.0
+version: 2.8.1
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/webview_flutter/webview_flutter_android/test/webview_android_widget_test.dart
+++ b/packages/webview_flutter/webview_flutter_android/test/webview_android_widget_test.dart
@@ -483,6 +483,31 @@ void main() {
         });
       });
 
+      testWidgets('update userAgentString', (WidgetTester tester) async {
+        await buildWidget(tester);
+
+        reset(mockWebSettings);
+
+        await testController.updateSettings(WebSettings(
+          userAgent: const WebSetting<String>.absent(),
+        ));
+
+        verifyNever(mockWebSettings.setUserAgentString(any));
+      });
+
+      testWidgets('update null userAgentString with empty string',
+          (WidgetTester tester) async {
+        await buildWidget(tester);
+
+        reset(mockWebSettings);
+
+        await testController.updateSettings(WebSettings(
+          userAgent: const WebSetting<String?>.of(null),
+        ));
+
+        verify(mockWebSettings.setUserAgentString(''));
+      });
+
       testWidgets('currentUrl', (WidgetTester tester) async {
         await buildWidget(tester);
 

--- a/packages/webview_flutter/webview_flutter_android/test/webview_android_widget_test.dart
+++ b/packages/webview_flutter/webview_flutter_android/test/webview_android_widget_test.dart
@@ -483,7 +483,8 @@ void main() {
         });
       });
 
-      testWidgets('update userAgentString', (WidgetTester tester) async {
+      testWidgets('no update to userAgentString when there is no change',
+          (WidgetTester tester) async {
         await buildWidget(tester);
 
         reset(mockWebSettings);


### PR DESCRIPTION
The `webview_flutter_android` plugin was setting the `UserAgentString` to the default value whenever it was rebuilt. This should only be done when it was rebuilt with a `null` value.

Fixes: https://github.com/flutter/flutter/issues/94847

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
