### PR TITLE
[camera]fix crash due to race condition in dispatch queue

### DIFF
--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 0.9.4+7
 
-* Minor internal code cleanup.
+* Fixes a crash in iOS when passing null queue pointer into AVFoundation API due to race condition.  
+* Minor iOS internal code cleanup.
 
 ## 0.9.4+6
 

--- a/packages/camera/camera/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/camera/camera/example/ios/Runner.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		E01EE4A82799F3A5008C1950 /* QueueHelperTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E01EE4A72799F3A5008C1950 /* QueueHelperTests.m */; };
+		E032F250279F5E94009E9028 /* CameraCaptureSessionQueueRaceConditionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E032F24F279F5E94009E9028 /* CameraCaptureSessionQueueRaceConditionTests.m */; };
 		E0C6E2002770F01A00EA6AA3 /* ThreadSafeMethodChannelTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E0C6E1FD2770F01A00EA6AA3 /* ThreadSafeMethodChannelTests.m */; };
 		E0C6E2012770F01A00EA6AA3 /* ThreadSafeTextureRegistryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E0C6E1FE2770F01A00EA6AA3 /* ThreadSafeTextureRegistryTests.m */; };
 		E0C6E2022770F01A00EA6AA3 /* ThreadSafeEventChannelTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E0C6E1FF2770F01A00EA6AA3 /* ThreadSafeEventChannelTests.m */; };
@@ -79,6 +80,7 @@
 		9C5CC6CAD53AD388B2694F3A /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		A24F9E418BA48BCC7409B117 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		E01EE4A72799F3A5008C1950 /* QueueHelperTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QueueHelperTests.m; sourceTree = "<group>"; };
+		E032F24F279F5E94009E9028 /* CameraCaptureSessionQueueRaceConditionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CameraCaptureSessionQueueRaceConditionTests.m; sourceTree = "<group>"; };
 		E0C6E1FD2770F01A00EA6AA3 /* ThreadSafeMethodChannelTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ThreadSafeMethodChannelTests.m; sourceTree = "<group>"; };
 		E0C6E1FE2770F01A00EA6AA3 /* ThreadSafeTextureRegistryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ThreadSafeTextureRegistryTests.m; sourceTree = "<group>"; };
 		E0C6E1FF2770F01A00EA6AA3 /* ThreadSafeEventChannelTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ThreadSafeEventChannelTests.m; sourceTree = "<group>"; };
@@ -122,6 +124,7 @@
 				E487C85F26D686A10034AC92 /* CameraPreviewPauseTests.m */,
 				F6EE622E2710A6FC00905E4A /* MockFLTThreadSafeFlutterResult.m */,
 				F63F9EED27143B19002479BF /* MockFLTThreadSafeFlutterResult.h */,
+				E032F24F279F5E94009E9028 /* CameraCaptureSessionQueueRaceConditionTests.m */,
 			);
 			path = RunnerTests;
 			sourceTree = "<group>";
@@ -390,6 +393,7 @@
 				E487C86026D686A10034AC92 /* CameraPreviewPauseTests.m in Sources */,
 				F6EE622F2710A6FC00905E4A /* MockFLTThreadSafeFlutterResult.m in Sources */,
 				334733EA2668111C00DCC49E /* CameraOrientationTests.m in Sources */,
+				E032F250279F5E94009E9028 /* CameraCaptureSessionQueueRaceConditionTests.m in Sources */,
 				E0C6E2022770F01A00EA6AA3 /* ThreadSafeEventChannelTests.m in Sources */,
 				E0C6E2012770F01A00EA6AA3 /* ThreadSafeTextureRegistryTests.m in Sources */,
 				E0C6E2002770F01A00EA6AA3 /* ThreadSafeMethodChannelTests.m in Sources */,

--- a/packages/camera/camera/example/ios/RunnerTests/CameraCaptureSessionQueueRaceConditionTests.m
+++ b/packages/camera/camera/example/ios/RunnerTests/CameraCaptureSessionQueueRaceConditionTests.m
@@ -1,0 +1,44 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@import camera;
+@import camera.Test;
+@import XCTest;
+
+@interface CameraCaptureSessionQueueRaceConditionTests : XCTestCase
+@end
+
+@implementation CameraCaptureSessionQueueRaceConditionTests
+
+- (void)testFixForCaptureSessionQueueNullPointerCrashDueToRaceCondition {
+  CameraPlugin *camera = [[CameraPlugin alloc] initWithRegistry:nil messenger:nil];
+
+  XCTestExpectation *disposeExpectation =
+      [self expectationWithDescription:@"dispose's result block must be called"];
+  XCTestExpectation *createExpectation =
+      [self expectationWithDescription:@"create's result block must be called"];
+  FlutterMethodCall *disposeCall = [FlutterMethodCall methodCallWithMethodName:@"dispose"
+                                                                     arguments:nil];
+  FlutterMethodCall *createCall = [FlutterMethodCall
+      methodCallWithMethodName:@"create"
+                     arguments:@{@"resolutionPreset" : @"medium", @"enableAudio" : @(1)}];
+  // Mimic a dispose call followed by a create call, which can be triggered by slightly dragging the
+  // home bar, causing the app to be inactive, and immediately regain active.
+  [camera handleMethodCall:disposeCall
+                    result:^(id _Nullable result) {
+                      [disposeExpectation fulfill];
+                    }];
+  [camera handleMethodCall:createCall
+                    result:^(id _Nullable result) {
+                      [createExpectation fulfill];
+                    }];
+  [self waitForExpectationsWithTimeout:1 handler:nil];
+  // `captureSessionQueue` must not be nil after `create` call. Otherwise a nil
+  // `captureSessionQueue` passed into `AVCaptureVideoDataOutput::setSampleBufferDelegate:queue:`
+  // API will cause a crash.
+  XCTAssertNotNil(camera.captureSessionQueue,
+                  @"captureSessionQueue must not be nil after create method. ");
+}
+
+@end

--- a/packages/camera/camera/ios/Classes/CameraPlugin_Test.h
+++ b/packages/camera/camera/ios/Classes/CameraPlugin_Test.h
@@ -10,6 +10,9 @@
 /// Methods exposed for unit testing.
 @interface CameraPlugin ()
 
+// All FLTCam's state access and capture session related operations should be on run on this queue.
+@property(nonatomic, strong) dispatch_queue_t captureSessionQueue;
+
 /// Inject @p FlutterTextureRegistry and @p FlutterBinaryMessenger for unit testing.
 - (instancetype)initWithRegistry:(NSObject<FlutterTextureRegistry> *)registry
                        messenger:(NSObject<FlutterBinaryMessenger> *)messenger

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -4,7 +4,7 @@ description: A Flutter plugin for controlling the camera. Supports previewing
   Dart.
 repository: https://github.com/flutter/plugins/tree/master/packages/camera/camera
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.9.4+6
+version: 0.9.4+7
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR fixed a crash due to race condition of `_captureSessionQueue` ivar. This kind of race condition is annoying and hard to fix because it takes tons of luck to reproduce (I accidentally touched iPhone's home bar, causing the app to become active and then immediately inactive, forming a race condition). 

**Crash**
```
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[AVCaptureAudioDataOutput setSampleBufferDelegate:queue:] NULL queue passed'
terminating with uncaught exception of type NSException
```

**Reproduce**
(1) In sample app, start video recording then stop it. 
(2) Swipe home bar just a bit on iPhone X, so the app becomes inactive and immediately regain active. 
(3) Tap the video button again and observe this crash. 

**Root Cause**
`_captureSessionQueue` is checked in main thread, but set to nil in background thread, which is open to race condition: 
```
  // main thread: 
  if (_captureSessionQueue == nil) {
    _captureSessionQueue = dispatch_queue_create("io.flutter.camera.captureSessionQueue", NULL);
  } 

  // background thread 
 _captureSessionQueue = nil
```

**Explain**
In the above reproduce step, (1) is to assign a new `_captureSessionQueue`, (2) is to trigger "dispose" and "create" method calls consecutively, resulting in a race condition, and (3) will pass in the `_captureSessionQueue` which has been nil'ed out asynchronously by the `dispose` call in previous step. 

**Solution**
(1) It looks like the camera plugin has pretty complicated threading logic and it's getting hard to maintain. There have been multiple related issues. If we get time I am interested in refactoring the threading model in the future. 
(2) For now an easy fix to this race condition is not to nil out this `_captureSessionQueue`. DispatchQueues are quite lightweight as they are not actual threads. 
(3) Or we can dispatch to main thread again before setting nil, which should fix `_captureSessionQueue` race for this particular case, but may still open for other unknown cases

**Issues**
https://github.com/flutter/flutter/issues/96429
https://github.com/flutter/flutter/issues/59124
https://github.com/flutter/flutter/issues/52578#issuecomment-797688303


# Next Step

* This section is outdated. We wrote up [a formal proposal](https://docs.google.com/document/d/1UtKfFoHrQEr9Ehsx9oPGLqjcPT9IG3KjX0DSStkqHwU/edit#) to address various threading related issues. 

This PR should fix the crash, but we should start looking at simplifying the threading logic in this plugin. Ideally, a `DispatchQueue` should have its lifecycle scoped to the resource that the queue manages, instead of manually nil'ing out the reference. HOWEVER, let's step back a bit: **should this even be a plugin problem?** 

If we trace the execution from UI to plugin and back to UI, we get these thread hops: 
```
Flutter's UI thread ->
iOS platform thread ->
camera background thread -> 
iOS platform thread -> 
Flutter's UI thread
```
The iOS platform thread is involved twice, just to dispatch to another thread, which means the whole process could have been as simple as: 
```
Flutter's UI thread ->
camera background thread -> 
Flutter's UI thread
```

I think engine should support invoking plugin methods in background. The benefits are: 
- Avoid unnecessary thread hops, obviously;
- Plugin developers (e.g. camera) don't have to work on threading problems (if they simply want to run code in background thread). 
- Avoid crashes like this one. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests

