### PR TITLE
[camera] Check supportsAVCaptureSessionPreset for init camera on iOS

### DIFF
--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+##  0.9.4+6
+
+* Fix iOS crash when selecting an unsupported AVCaptureSessionPresetHigh.
+
 ##  0.9.4+5
 
 * Fixes bug where calling a method after the camera was closed resulted in a Java `IllegalStateException` exception.

--- a/packages/camera/camera/example/ios/RunnerTests/CameraMethodChannelTests.m
+++ b/packages/camera/camera/example/ios/RunnerTests/CameraMethodChannelTests.m
@@ -28,6 +28,10 @@
   id avCaptureSessionMock = OCMClassMock([AVCaptureSession class]);
   OCMStub([avCaptureSessionMock alloc]).andReturn(avCaptureSessionMock);
   OCMStub([avCaptureSessionMock canSetSessionPreset:[OCMArg any]]).andReturn(YES);
+    
+  id avCaptureDeviceMock = OCMClassMock([AVCaptureDevice class]);
+  OCMStub([avCaptureDeviceMock deviceWithUniqueID:[OCMArg any]]).andReturn(avCaptureDeviceMock);
+  OCMStub([avCaptureDeviceMock supportsAVCaptureSessionPreset:[OCMArg any]]).andReturn(YES);
 
   MockFLTThreadSafeFlutterResult *resultObject =
       [[MockFLTThreadSafeFlutterResult alloc] initWithExpectation:expectation];

--- a/packages/camera/camera/example/ios/RunnerTests/CameraMethodChannelTests.m
+++ b/packages/camera/camera/example/ios/RunnerTests/CameraMethodChannelTests.m
@@ -28,7 +28,7 @@
   id avCaptureSessionMock = OCMClassMock([AVCaptureSession class]);
   OCMStub([avCaptureSessionMock alloc]).andReturn(avCaptureSessionMock);
   OCMStub([avCaptureSessionMock canSetSessionPreset:[OCMArg any]]).andReturn(YES);
-    
+
   id avCaptureDeviceMock = OCMClassMock([AVCaptureDevice class]);
   OCMStub([avCaptureDeviceMock deviceWithUniqueID:[OCMArg any]]).andReturn(avCaptureDeviceMock);
   OCMStub([avCaptureDeviceMock supportsAVCaptureSessionPreset:[OCMArg any]]).andReturn(YES);

--- a/packages/camera/camera/ios/Classes/CameraPlugin.m
+++ b/packages/camera/camera/ios/Classes/CameraPlugin.m
@@ -525,16 +525,21 @@ NSString *const errorMethod = @"error";
   return file;
 }
 
+- (BOOL)supportsAVCaptureSessionPreset:(AVCaptureSessionPreset)preset {
+    return [_captureDevice supportsAVCaptureSessionPreset:preset] &&
+           [_captureSession canSetSessionPreset:preset];
+}
+
 - (void)setCaptureSessionPreset:(ResolutionPreset)resolutionPreset {
   switch (resolutionPreset) {
     case max:
     case ultraHigh:
-      if ([_captureSession canSetSessionPreset:AVCaptureSessionPreset3840x2160]) {
+      if ([self supportsAVCaptureSessionPreset:AVCaptureSessionPreset3840x2160]) {
         _captureSession.sessionPreset = AVCaptureSessionPreset3840x2160;
         _previewSize = CGSizeMake(3840, 2160);
         break;
       }
-      if ([_captureSession canSetSessionPreset:AVCaptureSessionPresetHigh]) {
+      if ([self supportsAVCaptureSessionPreset:AVCaptureSessionPresetHigh]) {
         _captureSession.sessionPreset = AVCaptureSessionPresetHigh;
         _previewSize =
             CGSizeMake(_captureDevice.activeFormat.highResolutionStillImageDimensions.width,
@@ -542,31 +547,31 @@ NSString *const errorMethod = @"error";
         break;
       }
     case veryHigh:
-      if ([_captureSession canSetSessionPreset:AVCaptureSessionPreset1920x1080]) {
+      if ([self supportsAVCaptureSessionPreset:AVCaptureSessionPreset1920x1080]) {
         _captureSession.sessionPreset = AVCaptureSessionPreset1920x1080;
         _previewSize = CGSizeMake(1920, 1080);
         break;
       }
     case high:
-      if ([_captureSession canSetSessionPreset:AVCaptureSessionPreset1280x720]) {
+      if ([self supportsAVCaptureSessionPreset:AVCaptureSessionPreset1280x720]) {
         _captureSession.sessionPreset = AVCaptureSessionPreset1280x720;
         _previewSize = CGSizeMake(1280, 720);
         break;
       }
     case medium:
-      if ([_captureSession canSetSessionPreset:AVCaptureSessionPreset640x480]) {
+      if ([self supportsAVCaptureSessionPreset:AVCaptureSessionPreset640x480]) {
         _captureSession.sessionPreset = AVCaptureSessionPreset640x480;
         _previewSize = CGSizeMake(640, 480);
         break;
       }
     case low:
-      if ([_captureSession canSetSessionPreset:AVCaptureSessionPreset352x288]) {
+      if ([self supportsAVCaptureSessionPreset:AVCaptureSessionPreset352x288]) {
         _captureSession.sessionPreset = AVCaptureSessionPreset352x288;
         _previewSize = CGSizeMake(352, 288);
         break;
       }
     default:
-      if ([_captureSession canSetSessionPreset:AVCaptureSessionPresetLow]) {
+      if ([self supportsAVCaptureSessionPreset:AVCaptureSessionPresetLow]) {
         _captureSession.sessionPreset = AVCaptureSessionPresetLow;
         _previewSize = CGSizeMake(352, 288);
       } else {

--- a/packages/camera/camera/ios/Classes/CameraPlugin.m
+++ b/packages/camera/camera/ios/Classes/CameraPlugin.m
@@ -526,8 +526,8 @@ NSString *const errorMethod = @"error";
 }
 
 - (BOOL)supportsAVCaptureSessionPreset:(AVCaptureSessionPreset)preset {
-    return [_captureDevice supportsAVCaptureSessionPreset:preset] &&
-           [_captureSession canSetSessionPreset:preset];
+  return [_captureDevice supportsAVCaptureSessionPreset:preset] &&
+         [_captureSession canSetSessionPreset:preset];
 }
 
 - (void)setCaptureSessionPreset:(ResolutionPreset)resolutionPreset {

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -4,7 +4,7 @@ description: A Flutter plugin for controlling the camera. Supports previewing
   Dart.
 repository: https://github.com/flutter/plugins/tree/master/packages/camera/camera
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.9.4+5
+version: 0.9.4+6
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
We have a recurring crash from users with iPhone 7 and iPhone 7 Plus 

```
Crashed: Thread
NSInvalidArgumentException *** -[AVCaptureSession addInputWithNoConnections:] Can't add <AVCaptureDeviceInput: 0x28b27c760 [Камера на передней панели]> because the device does not support AVCaptureSessionPresetHigh - Use -[AVCaptureDevice supportsAVCaptureSessionPreset:]
0  CoreFoundation           __exceptionPreprocess + 216
1  libobjc.A.dylib          objc_exception_throw + 56
2  AVFCapture               -[AVCaptureSession _addInputWithNoConnections:exceptionReason:] + 0
3  camera                   -[FLTCam initWithCameraName:resolutionPreset:enableAudio:orientation:dispatchQueue:error:] + 988
4  camera                   -[CameraPlugin handleMethodCallAsync:result:] + 1264
5  libdispatch.dylib        _dispatch_call_block_and_release + 24
6  libdispatch.dylib        _dispatch_client_callout + 16
7  libdispatch.dylib        _dispatch_lane_serial_drain$VARIANT$mp + 612
8  libdispatch.dylib        _dispatch_lane_invoke$VARIANT$mp + 424
9  libdispatch.dylib        _dispatch_workloop_worker_thread + 712
10 libsystem_pthread.dylib  _pthread_wqthread + 272
11 libsystem_pthread.dylib  start_wqthread + 8
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
