### PR TITLE
[script]update the version check error output to include information …

### DIFF
--- a/script/tool/lib/src/version_check_command.dart
+++ b/script/tool/lib/src/version_check_command.dart
@@ -577,7 +577,9 @@ ${indentation}The first version listed in CHANGELOG.md is $fromChangeLog.
             'repository policy. If this is a false positive, please '
             'add a line starting with\n'
             '$_missingVersionChangeJustificationMarker\n'
-            'to your PR description with an explanation of why it is exempt.');
+            'to your PR description with an explanation of why it is exempt.'
+            'If editing PR description does not work, try rehashing your '
+            'commit to trigger the upload.\n');
         return 'Missing version change';
       }
     }


### PR DESCRIPTION
…about how to trigger PR description upload

I had this issue when I was trying to land flutter/plugins#4608. I got this error:

```
No version change found, but the change to this package could not be verified to be exempt from version changes according to repository policy. If this is a false positive, please add a line starting with
No version change:
to your PR description with an explanation of why it is exempt.

```

So I updated the PR description and re-run the check, but still not working.

I suspected that it's because the PR description is not uploaded after edited for some reason. In order to verify this assumption, I rehashed the commit, which will most likely trigger the whole pipeline, and the error is gone.

For now, I figured that it may be helpful to include this as temp workaround in the error output.

*List which issues are fixed by this PR. You must list at least one issue.*
https://github.com/flutter/flutter/issues/95594

No version change:
This is only CI script. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]` *
(I used [script] since it's not a plugin specific change)
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
