### PR TITLE
[video_player] Support for simultaneous playback of audio sources on iOS

### DIFF
--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.2.10
+* Support for iOS AVAudioSession Ambient mode which allows multiple
+  audio sources to play simultaneously and prevent background music
+  from stopping.
+* Uses '.setMixWithOthers(...)' on iOS to setup default AVAudioSession.
+
 ## 2.2.9
 
 * Adds compatibility with `video_player_platform_interface` 5.0, which does not

--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## 2.2.10
-* Support for iOS AVAudioSession Ambient mode which allows multiple
+* Adds support for iOS AVAudioSession Ambient mode which allows multiple
   audio sources to play simultaneously and prevent background music
   from stopping.
-* Uses '.setMixWithOthers(...)' on iOS to setup default AVAudioSession.
+* Uses `.setMixWithOthers(...)` on iOS to set up default AVAudioSession.
 
 ## 2.2.9
 

--- a/packages/video_player/video_player/android/src/main/java/io/flutter/plugins/videoplayer/Messages.java
+++ b/packages/video_player/video_player/android/src/main/java/io/flutter/plugins/videoplayer/Messages.java
@@ -297,25 +297,37 @@ public class Messages {
   /** Generated class from Pigeon that represents data sent in messages. */
   public static class MixWithOthersMessage {
     private Boolean mixWithOthers;
+    private Boolean ambient;
 
     public Boolean getMixWithOthers() {
       return mixWithOthers;
+    }
+
+    public Boolean getAmbient() {
+      return ambient;
     }
 
     public void setMixWithOthers(Boolean setterArg) {
       this.mixWithOthers = setterArg;
     }
 
+    public void setAmbient(Boolean setterArg) {
+      this.ambient = setterArg;
+    }
+
     HashMap toMap() {
       HashMap<String, Object> toMapResult = new HashMap<>();
       toMapResult.put("mixWithOthers", mixWithOthers);
+      toMapResult.put("ambient", ambient);
       return toMapResult;
     }
 
     static MixWithOthersMessage fromMap(HashMap map) {
       MixWithOthersMessage fromMapResult = new MixWithOthersMessage();
       Object mixWithOthers = map.get("mixWithOthers");
+      Object ambient = map.get("ambient");
       fromMapResult.mixWithOthers = (Boolean) mixWithOthers;
+      fromMapResult.ambient = (Boolean) ambient;
       return fromMapResult;
     }
   }

--- a/packages/video_player/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerOptions.java
+++ b/packages/video_player/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerOptions.java
@@ -6,4 +6,5 @@ package io.flutter.plugins.videoplayer;
 
 class VideoPlayerOptions {
   public boolean mixWithOthers;
+  public boolean ambient;
 }

--- a/packages/video_player/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/video_player/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -208,6 +208,7 @@ public class VideoPlayerPlugin implements FlutterPlugin, VideoPlayerApi {
   @Override
   public void setMixWithOthers(MixWithOthersMessage arg) {
     options.mixWithOthers = arg.getMixWithOthers();
+    options.ambient = arg.getAmbient();
   }
 
   private interface KeyForAssetFn {

--- a/packages/video_player/video_player/example/ios/RunnerTests/VideoPlayerTests.m
+++ b/packages/video_player/video_player/example/ios/RunnerTests/VideoPlayerTests.m
@@ -2,17 +2,80 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+@import AVFoundation;
 @import video_player;
 @import XCTest;
+
+#import <OCMock/OCMock.h>
+
+@interface FLTVideoPlayer : NSObject <FlutterStreamHandler>
+@property(readonly, nonatomic) AVPlayer *player;
+@end
+
+@interface FLTVideoPlayerPlugin (Test) <FLTVideoPlayerApi>
+@property(readonly, strong, nonatomic)
+    NSMutableDictionary<NSNumber *, FLTVideoPlayer *> *playersByTextureId;
+@end
 
 @interface VideoPlayerTests : XCTestCase
 @end
 
 @implementation VideoPlayerTests
 
-- (void)testPlugin {
-  FLTVideoPlayerPlugin* plugin = [[FLTVideoPlayerPlugin alloc] init];
-  XCTAssertNotNil(plugin);
+
+- (void)testSetMixWithOthersForPlayer {
+    FLTVideoPlayerPlugin* videoPlayer = [[FLTVideoPlayerPlugin alloc] init];
+    FLTMixWithOthersMessage* msg = [[FLTMixWithOthersMessage alloc] init];
+    AVAudioSession* session = [AVAudioSession sharedInstance];
+    FlutterError *error;
+
+    [videoPlayer initialize:&error];
+
+    msg.mixWithOthers = @0;
+    msg.ambient = @0;
+    [videoPlayer setMixWithOthers:msg error:&error];
+
+    XCTAssertEqual(session.category, AVAudioSessionCategoryPlayback);
+    XCTAssertNotEqual(session.mode, AVAudioSessionModeVoicePrompt);
+
+    msg.mixWithOthers = @1;
+    msg.ambient = @0;
+    [videoPlayer setMixWithOthers:msg error:&error];
+
+    XCTAssertEqual(session.category, AVAudioSessionCategoryPlayback);
+    XCTAssertEqual(session.categoryOptions, AVAudioSessionCategoryOptionMixWithOthers);
+
+    msg.mixWithOthers = @1;
+    msg.ambient = @1;
+    [videoPlayer setMixWithOthers:msg error:&error];
+
+    XCTAssertEqual(session.category, AVAudioSessionCategoryAmbient);
+    XCTAssertEqual(session.categoryOptions, AVAudioSessionCategoryOptionMixWithOthers);
+    XCTAssertEqual(session.mode, AVAudioSessionModeVoicePrompt);
+
+    msg.mixWithOthers = @0;
+    msg.ambient = @1;
+    [videoPlayer setMixWithOthers:msg error:&error];
+
+    XCTAssertEqual(session.category, AVAudioSessionCategoryAmbient);
+    XCTAssertEqual(session.mode, AVAudioSessionModeVoicePrompt);
+
+    msg.mixWithOthers = @1;
+    msg.ambient = @0;
+    [videoPlayer setMixWithOthers:msg error:&error];
+
+    XCTAssertEqual(session.category, AVAudioSessionCategoryPlayback);
+    XCTAssertEqual(session.categoryOptions, AVAudioSessionCategoryOptionMixWithOthers);
+    XCTAssertNotEqual(session.mode, AVAudioSessionModeVoicePrompt);
+
+    msg.mixWithOthers = @0;
+    msg.ambient = @0;
+    [videoPlayer setMixWithOthers:msg error:&error];
+
+    XCTAssertEqual(session.category, AVAudioSessionCategoryPlayback);
+    XCTAssertNotEqual(session.mode, AVAudioSessionModeVoicePrompt);
 }
+
+
 
 @end

--- a/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m
@@ -624,16 +624,23 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 
 - (void)setMixWithOthers:(FLTMixWithOthersMessage*)input
                    error:(FlutterError* _Nullable __autoreleasing*)error {
-  AVAudioSessionCategory sessionCategory = [input.ambient boolValue] ? AVAudioSessionCategoryAmbient : AVAudioSessionCategoryPlayback;
-  AVAudioSessionCategoryOptions categoryOptions = [input.mixWithOthers boolValue ] ? AVAudioSessionCategoryOptionMixWithOthers: 0x0;
+  AVAudioSessionCategory sessionCategory =
+      [input.ambient boolValue] ? AVAudioSessionCategoryAmbient : AVAudioSessionCategoryPlayback;
+  AVAudioSessionCategoryOptions categoryOptions = [input.mixWithOthers boolValue]
+                                                      ? AVAudioSessionCategoryOptionMixWithOthers
+                                                      : AVAudioSessionCategoryOptionDuckOthers;
 
   if (@available(iOS 12.0, *)) {
+    AVAudioSessionMode sessionMode =
+        [input.ambient boolValue] ? AVAudioSessionModeVoicePrompt : AVAudioSessionModeDefault;
     [[AVAudioSession sharedInstance] setCategory:sessionCategory
-                                            mode:AVAudioSessionModeVoicePrompt
+                                            mode:sessionMode
                                          options:categoryOptions
-                                             error:nil];
+                                           error:nil];
   } else {
-    [[AVAudioSession sharedInstance] setCategory:sessionCategory withOptions:categoryOptions error:nil];
+    [[AVAudioSession sharedInstance] setCategory:sessionCategory
+                                     withOptions:categoryOptions
+                                           error:nil];
   }
   return;
 }

--- a/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m
@@ -531,7 +531,7 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 }
 
 - (void)initialize:(FlutterError* __autoreleasing*)error {
-  // setup of 'AVAudioSession' is handled by '.setMixWithOthers(...)'
+  // The 'AVAudioSession' configuration is handled by '.setMixWithOthers(...)'.
 
   for (NSNumber* textureId in _players) {
     [_registry unregisterTexture:[textureId unsignedIntegerValue]];
@@ -624,30 +624,18 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
 
 - (void)setMixWithOthers:(FLTMixWithOthersMessage*)input
                    error:(FlutterError* _Nullable __autoreleasing*)error {
-  if ([input.mixWithOthers boolValue]) {
-    if ([input.ambient boolValue]) {
-      if (@available(iOS 12.0, *)) {
-        [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryAmbient
-                                                mode:AVAudioSessionModeVoicePrompt
-                                             options:AVAudioSessionCategoryOptionMixWithOthers
-                                               error:nil];
-      } else {
-        [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryAmbient
-                                         withOptions:AVAudioSessionCategoryOptionMixWithOthers
-                                               error:nil];
-      }
-    } else {
-      [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback
-                                       withOptions:AVAudioSessionCategoryOptionMixWithOthers
+  AVAudioSessionCategory sessionCategory = [input.ambient boolValue] ? AVAudioSessionCategoryAmbient : AVAudioSessionCategoryPlayback;
+  AVAudioSessionCategoryOptions categoryOptions = [input.mixWithOthers boolValue ] ? AVAudioSessionCategoryOptionMixWithOthers: 0x0;
+
+  if (@available(iOS 12.0, *)) {
+    [[AVAudioSession sharedInstance] setCategory:sessionCategory
+                                            mode:AVAudioSessionModeVoicePrompt
+                                         options:categoryOptions
                                              error:nil];
-    }
   } else {
-    if ([input.ambient boolValue]) {
-      [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryAmbient error:nil];
-      return;
-    }
-    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:nil];
+    [[AVAudioSession sharedInstance] setCategory:sessionCategory withOptions:categoryOptions error:nil];
   }
+  return;
 }
 
 @end

--- a/packages/video_player/video_player/ios/Classes/messages.h
+++ b/packages/video_player/video_player/ios/Classes/messages.h
@@ -19,6 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class FLTPositionMessage;
 @class FLTMixWithOthersMessage;
 
+
 @interface FLTTextureMessage : NSObject
 @property(nonatomic, strong, nullable) NSNumber *textureId;
 @end
@@ -53,6 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface FLTMixWithOthersMessage : NSObject
 @property(nonatomic, strong, nullable) NSNumber *mixWithOthers;
+@property(nonatomic, strong, nullable) NSNumber *ambient;
 @end
 
 @protocol FLTVideoPlayerApi

--- a/packages/video_player/video_player/ios/Classes/messages.m
+++ b/packages/video_player/video_player/ios/Classes/messages.m
@@ -199,15 +199,21 @@ static NSDictionary<NSString *, id> *wrapResult(NSDictionary *result, FlutterErr
 + (FLTMixWithOthersMessage *)fromMap:(NSDictionary *)dict {
   FLTMixWithOthersMessage *result = [[FLTMixWithOthersMessage alloc] init];
   result.mixWithOthers = dict[@"mixWithOthers"];
+  result.ambient = dict[@"ambient"];
   if ((NSNull *)result.mixWithOthers == [NSNull null]) {
     result.mixWithOthers = nil;
+  }
+  if ((NSNull *)result.ambient == [NSNull null]) {
+    result.ambient = nil;
   }
   return result;
 }
 - (NSDictionary *)toMap {
   return [NSDictionary
       dictionaryWithObjectsAndKeys:(self.mixWithOthers != nil ? self.mixWithOthers : [NSNull null]),
-                                   @"mixWithOthers", nil];
+                                   @"mixWithOthers",
+                                   (self.ambient != nil ? self.ambient : [NSNull null]), @"ambient",
+                                   nil];
 }
 @end
 

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -329,9 +329,12 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
         break;
     }
 
-    if (videoPlayerOptions?.mixWithOthers != null) {
+    if (videoPlayerOptions == null) {
       await _videoPlayerPlatform
-          .setMixWithOthers(videoPlayerOptions!.mixWithOthers);
+          .setMixWithOthers(false, false);
+    } else {
+      await _videoPlayerPlatform
+          .setMixWithOthers(videoPlayerOptions!.mixWithOthers, videoPlayerOptions!.ambient);
     }
 
     _textureId = (await _videoPlayerPlatform.create(dataSourceDescription)) ??

--- a/packages/video_player/video_player/pigeons/messages.dart
+++ b/packages/video_player/video_player/pigeons/messages.dart
@@ -40,6 +40,7 @@ class CreateMessage {
 
 class MixWithOthersMessage {
   bool mixWithOthers;
+  bool ambient;
 }
 
 @HostApi(dartHostTestHandler: 'TestHostVideoPlayerApi')

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android, iOS, and web.
 repository: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.2.9
+version: 2.2.10
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -33,3 +33,9 @@ dev_dependencies:
     sdk: flutter
   pedantic: ^1.10.0
   pigeon: ^0.1.21
+
+# FOR TESTING ONLY. DO NOT MERGE.
+dependency_overrides:
+  video_player_platform_interface:
+    path:
+      ../video_player_platform_interface

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -38,4 +38,4 @@ dev_dependencies:
 dependency_overrides:
   video_player_platform_interface:
     path:
-      ../video_player_platform_interface
+      ../video_player_platform_interface/

--- a/packages/video_player/video_player/test/video_player_test.dart
+++ b/packages/video_player/video_player/test/video_player_test.dart
@@ -793,9 +793,9 @@ void main() {
   test('setMixWithOthers', () async {
     final VideoPlayerController controller = VideoPlayerController.file(
         File(''),
-        videoPlayerOptions: VideoPlayerOptions(mixWithOthers: true));
+        videoPlayerOptions: VideoPlayerOptions(mixWithOthers: true, ambient: true));
     await controller.initialize();
-    expect(controller.videoPlayerOptions!.mixWithOthers, true);
+    expect(controller.videoPlayerOptions!.mixWithOthers && controller.videoPlayerOptions!.ambient, true);
   });
 }
 
@@ -880,7 +880,7 @@ class FakeVideoPlayerPlatform extends VideoPlayerPlatform {
   }
 
   @override
-  Future<void> setMixWithOthers(bool mixWithOthers) async {
+  Future<void> setMixWithOthers(bool mixWithOthers, bool ambient) async {
     calls.add('setMixWithOthers');
   }
 }

--- a/packages/video_player/video_player_platform_interface/CHANGELOG.md
+++ b/packages/video_player/video_player_platform_interface/CHANGELOG.md
@@ -1,13 +1,14 @@
 ## 5.0.1
+
 * Add ambient mode to `VideoPlayerOptions`
 
--## 5.0.0
--
--* **BREAKING CHANGES**:
--  * Updates to extending `PlatformInterface`. Removes `isMock`, in favor of the
--    now-standard `MockPlatformInterfaceMixin`.
--  * Removes test.dart from the public interface. Tests in other packages should
--    mock `VideoPlatformInterface` rather than the method channel.
+## 5.0.0
+
+* **BREAKING CHANGES**:
+  * Updates to extending `PlatformInterface`. Removes `isMock`, in favor of the
+    now-standard `MockPlatformInterfaceMixin`.
+  * Removes test.dart from the public interface. Tests in other packages should
+    mock `VideoPlatformInterface` rather than the method channel.
 
 ## 4.2.0
 

--- a/packages/video_player/video_player_platform_interface/CHANGELOG.md
+++ b/packages/video_player/video_player_platform_interface/CHANGELOG.md
@@ -1,10 +1,13 @@
-## 5.0.0
+## 5.0.1
+* Add ambient mode to `VideoPlayerOptions`
 
-* **BREAKING CHANGES**:
-  * Updates to extending `PlatformInterface`. Removes `isMock`, in favor of the
-    now-standard `MockPlatformInterfaceMixin`.
-  * Removes test.dart from the public interface. Tests in other packages should
-    mock `VideoPlatformInterface` rather than the method channel.
+-## 5.0.0
+-
+-* **BREAKING CHANGES**:
+-  * Updates to extending `PlatformInterface`. Removes `isMock`, in favor of the
+-    now-standard `MockPlatformInterfaceMixin`.
+-  * Removes test.dart from the public interface. Tests in other packages should
+-    mock `VideoPlatformInterface` rather than the method channel.
 
 ## 4.2.0
 

--- a/packages/video_player/video_player_platform_interface/lib/messages.dart
+++ b/packages/video_player/video_player_platform_interface/lib/messages.dart
@@ -132,17 +132,20 @@ class PositionMessage {
 
 class MixWithOthersMessage {
   bool? mixWithOthers;
+  bool? ambient;
 
   Object encode() {
     final Map<Object?, Object?> pigeonMap = <Object?, Object?>{};
     pigeonMap['mixWithOthers'] = mixWithOthers;
+    pigeonMap['ambient'] = ambient;
     return pigeonMap;
   }
 
   static MixWithOthersMessage decode(Object message) {
     final Map<Object?, Object?> pigeonMap = message as Map<Object?, Object?>;
     return MixWithOthersMessage()
-      ..mixWithOthers = pigeonMap['mixWithOthers'] as bool?;
+      ..mixWithOthers = pigeonMap['mixWithOthers'] as bool?
+      ..ambient = pigeonMap['ambient'] as bool?;
   }
 }
 

--- a/packages/video_player/video_player_platform_interface/lib/method_channel_video_player.dart
+++ b/packages/video_player/video_player_platform_interface/lib/method_channel_video_player.dart
@@ -139,9 +139,9 @@ class MethodChannelVideoPlayer extends VideoPlayerPlatform {
   }
 
   @override
-  Future<void> setMixWithOthers(bool mixWithOthers) {
+  Future<void> setMixWithOthers(bool mixWithOthers, bool ambient) {
     return _api.setMixWithOthers(
-      MixWithOthersMessage()..mixWithOthers = mixWithOthers,
+      MixWithOthersMessage()..mixWithOthers = mixWithOthers..ambient = ambient,
     );
   }
 

--- a/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
+++ b/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
@@ -100,7 +100,7 @@ abstract class VideoPlayerPlatform extends PlatformInterface {
   }
 
   /// Sets the audio mode to mix with other sources
-  Future<void> setMixWithOthers(bool mixWithOthers) {
+  Future<void> setMixWithOthers(bool mixWithOthers, bool ambient) {
     throw UnimplementedError('setMixWithOthers() has not been implemented.');
   }
 }
@@ -336,6 +336,13 @@ class VideoPlayerOptions {
   /// currently no way to implement this feature in this platform).
   final bool mixWithOthers;
 
+  /// Set this to true to mix the video players audio with other audio sources
+  /// within the app as well as background audio from other apps.
+  ///
+  /// Note: This option will be silently ignored in the web platform (there is
+  /// currently no way to implement this feature in this platform).
+  final bool ambient;
+
   /// set additional optional player settings
-  VideoPlayerOptions({this.mixWithOthers = false});
+  VideoPlayerOptions({this.mixWithOthers = false, this.ambient = false});
 }

--- a/packages/video_player/video_player_platform_interface/pubspec.yaml
+++ b/packages/video_player/video_player_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/master/packages/video_player
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 5.0.0
+version: 5.0.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/video_player/video_player_platform_interface/test/method_channel_video_player_test.dart
+++ b/packages/video_player/video_player_platform_interface/test/method_channel_video_player_test.dart
@@ -197,13 +197,20 @@ void main() {
     });
 
     test('setMixWithOthers', () async {
-      await player.setMixWithOthers(true);
+      await player.setMixWithOthers(true, false);
       expect(log.log.last, 'setMixWithOthers');
       expect(log.mixWithOthersMessage?.mixWithOthers, true);
+      expect(log.mixWithOthersMessage?.ambient, false);
 
-      await player.setMixWithOthers(false);
+      await player.setMixWithOthers(false, false);
       expect(log.log.last, 'setMixWithOthers');
       expect(log.mixWithOthersMessage?.mixWithOthers, false);
+      expect(log.mixWithOthersMessage?.ambient, false);
+
+      await player.setMixWithOthers(false, true);
+      expect(log.log.last, 'setMixWithOthers');
+      expect(log.mixWithOthersMessage?.mixWithOthers, false);
+      expect(log.mixWithOthersMessage?.ambient, true);
     });
 
     test('setVolume', () async {

--- a/packages/video_player/video_player_web/CHANGELOG.md
+++ b/packages/video_player/video_player_web/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.6
+* Supports 'ambinet' mode
+
 ## 2.0.5
 
 * Adds compatibility with `video_player_platform_interface` 5.0, which does not

--- a/packages/video_player/video_player_web/lib/video_player_web.dart
+++ b/packages/video_player/video_player_web/lib/video_player_web.dart
@@ -154,7 +154,7 @@ class VideoPlayerPlugin extends VideoPlayerPlatform {
 
   /// Sets the audio mode to mix with other sources (ignored)
   @override
-  Future<void> setMixWithOthers(bool mixWithOthers) => Future<void>.value();
+  Future<void> setMixWithOthers(bool mixWithOthers, bool ambient) => Future<void>.value();
 }
 
 class _VideoPlayer {

--- a/packages/video_player/video_player_web/pubspec.yaml
+++ b/packages/video_player/video_player_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_web
 description: Web platform implementation of video_player.
 repository: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.0.5
+version: 2.0.6
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -28,3 +28,9 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+
+# FOR TESTING ONLY. DO NOT MERGE.
+dependency_overrides:
+  video_player_platform_interface:
+    path:
+      ../video_player_platform_interface

--- a/packages/video_player/video_player_web/pubspec.yaml
+++ b/packages/video_player/video_player_web/pubspec.yaml
@@ -33,4 +33,4 @@ dev_dependencies:
 dependency_overrides:
   video_player_platform_interface:
     path:
-      ../video_player_platform_interface
+      ../video_player_platform_interface/


### PR DESCRIPTION
This PR adds support for  simultaneous playback of audio sources such as background music
along with video and other sources in iOS.

The _mixWithOthers_ option works as expected, as long as the video player is the **single**
audio source within the app. Therefore, the _mixWithOthers_ option alone, does not 
provide the flexibility of using the video player along with background music and other
audio sources within the app ( e.g. muted video + text-to-speech + background music ).

The proposed solution is to pass another argument to **VideoPlayerOptions** to setup ambient mode:
```dart
VideoPlayerOptions(mixWithOthers: true, ambient: true)
```

_Ambient_ mode allows mixing of audio sources within app with background sources.

This PR fixes issue [#94328](https://github.com/flutter/flutter/issues/94328).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.