### PR TITLE
[path_provider] Fix Android compatibility with 2.5

### DIFF
--- a/packages/path_provider/path_provider_android/CHANGELOG.md
+++ b/packages/path_provider/path_provider_android/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.11
+
+* Temporarily reverts the platform channel name change from 2.0.10 in order to
+  restore compatibility with Flutter versions earlier than 2.8.
+
 ## 2.0.10
 
 * Switches to a package-internal implementation of the platform interface.

--- a/packages/path_provider/path_provider_android/android/src/main/java/io/flutter/plugins/pathprovider/PathProviderPlugin.java
+++ b/packages/path_provider/path_provider_android/android/src/main/java/io/flutter/plugins/pathprovider/PathProviderPlugin.java
@@ -153,7 +153,7 @@ public class PathProviderPlugin implements FlutterPlugin, MethodCallHandler {
   public PathProviderPlugin() {}
 
   private void setup(BinaryMessenger messenger, Context context) {
-    String channelName = "plugins.flutter.io/path_provider_android";
+    String channelName = "plugins.flutter.io/path_provider";
     // TODO(gaaclarke): Remove reflection guard when https://github.com/flutter/engine/pull/29147
     // becomes available on the stable branch.
     try {

--- a/packages/path_provider/path_provider_android/lib/path_provider_android.dart
+++ b/packages/path_provider/path_provider_android/lib/path_provider_android.dart
@@ -11,7 +11,7 @@ class PathProviderAndroid extends PathProviderPlatform {
   /// The method channel used to interact with the native platform.
   @visibleForTesting
   MethodChannel methodChannel =
-      const MethodChannel('plugins.flutter.io/path_provider_android');
+      const MethodChannel('plugins.flutter.io/path_provider');
 
   /// Registers this class as the default instance of [PathProviderPlatform].
   static void registerWith() {

--- a/packages/path_provider/path_provider_android/pubspec.yaml
+++ b/packages/path_provider/path_provider_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: path_provider_android
 description: Android implementation of the path_provider plugin.
 repository: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+path_provider%22
-version: 2.0.10
+version: 2.0.11
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/path_provider/path_provider_android/test/path_provider_android_test.dart
+++ b/packages/path_provider/path_provider_android/test/path_provider_android_test.dart
@@ -52,6 +52,14 @@ void main() {
       log.clear();
     });
 
+    // TODO(stuartmorgan): Change this to a test that it uses a different name,
+    // to avoid potential confusion, once the SDK is changed to 2.8+. See
+    // https://github.com/flutter/plugins/pull/4617#discussion_r774673962
+    test('channel name is compatible with shared method channel', () async {
+      expect(
+          pathProvider.methodChannel.name, 'plugins.flutter.io/path_provider');
+    });
+
     test('getTemporaryPath', () async {
       final String? path = await pathProvider.getTemporaryPath();
       expect(


### PR DESCRIPTION
PR #4617 added a dependency on Dart auto-registration, but forgot to
bump the SDK requirement to 2.8 (where that feature was introduced for
Android). In order to fix older versions, this restores the previous
channel name so that the implementation here is compatible with the
default method channel registration used by Flutter 2.5 and earlier.

A follow-up will restore the package-specific channel name, but also
change the SDK requirement to >=2.8. This must be published first so
that the last published version that claims 2.5 compatibility actually
works with 2.5.

Fixes https://github.com/flutter/flutter/issues/95706

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
