### PR TITLE
[plugin_platform_interface] Add a new method `verify` that prevents use of `const Object()` as token.

### DIFF
--- a/packages/plugin_platform_interface/CHANGELOG.md
+++ b/packages/plugin_platform_interface/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.1.0
 
-* Assert that `const Object()` is not used as the token.
+* Add a new static method `verifyExtends`, preventing use of `const Object()` as instance token.
+* Soft deprecate `verifyToken`, to avoid breaking tests that check for use of deprecated APIs.
 * Update documentation.
 
 ## 2.0.2

--- a/packages/plugin_platform_interface/CHANGELOG.md
+++ b/packages/plugin_platform_interface/CHANGELOG.md
@@ -1,8 +1,7 @@
 ## 2.1.0
 
-* Add a new static method `verifyExtends`, preventing use of `const Object()` as instance token.
-* Soft deprecate `verifyToken`, to avoid breaking tests that check for use of deprecated APIs.
-* Update documentation.
+* Introduce `verify`, which prevents use of `const Object()` as instance token.
+* Add a comment indicating that `verifyToken` will be deprecated in a future release.
 
 ## 2.0.2
 

--- a/packages/plugin_platform_interface/CHANGELOG.md
+++ b/packages/plugin_platform_interface/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 2.0.3
+## 2.1.0
 
+* Assert that `const Object()` is not used as the token.
 * Update documentation.
 
 ## 2.0.2

--- a/packages/plugin_platform_interface/CHANGELOG.md
+++ b/packages/plugin_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.3
+
+* Update documentation.
+
 ## 2.0.2
 
 * Update package description.

--- a/packages/plugin_platform_interface/lib/plugin_platform_interface.dart
+++ b/packages/plugin_platform_interface/lib/plugin_platform_interface.dart
@@ -22,7 +22,7 @@ import 'package:meta/meta.dart';
 ///
 ///   static UrlLauncherPlatform _instance = MethodChannelUrlLauncher();
 ///
-///   static const Object _token = Object();
+///   static final Object _token = Object();
 ///
 ///   static UrlLauncherPlatform get instance => _instance;
 ///
@@ -40,7 +40,7 @@ import 'package:meta/meta.dart';
 /// to include the [MockPlatformInterfaceMixin] for the verification to be temporarily disabled. See
 /// [MockPlatformInterfaceMixin] for a sample of using Mockito to mock a platform interface.
 abstract class PlatformInterface {
-  /// Pass a private, class-specific `const Object()` as the `token`.
+  /// Pass a private, class-specific `Object()` as the `token`.
   PlatformInterface({required Object token}) : _instanceToken = token;
 
   final Object? _instanceToken;
@@ -83,7 +83,7 @@ abstract class PlatformInterface {
 ///
 /// This class is intended for use in tests only.
 ///
-/// Sample usage (assuming UrlLauncherPlatform extends [PlatformInterface]:
+/// Sample usage (assuming `UrlLauncherPlatform` extends [PlatformInterface]):
 ///
 /// ```dart
 /// class UrlLauncherPlatformMock extends Mock

--- a/packages/plugin_platform_interface/lib/plugin_platform_interface.dart
+++ b/packages/plugin_platform_interface/lib/plugin_platform_interface.dart
@@ -29,7 +29,7 @@ import 'package:meta/meta.dart';
 ///   /// Platform-specific plugins should set this with their own platform-specific
 ///   /// class that extends [UrlLauncherPlatform] when they register themselves.
 ///   static set instance(UrlLauncherPlatform instance) {
-///     PlatformInterface.verifyExtends(instance, _token);
+///     PlatformInterface.verify(instance, _token);
 ///     _instance = instance;
 ///   }
 ///
@@ -58,22 +58,22 @@ abstract class PlatformInterface {
   ///
   /// This is implemented as a static method so that it cannot be overridden
   /// with `noSuchMethod`.
-  static void verifyExtends(PlatformInterface instance, Object token) {
+  static void verify(PlatformInterface instance, Object token) {
     if (identical(instance._instanceToken, const Object())) {
       throw AssertionError('`const Object()` cannot be used as `token`.');
     }
-    _verifyExtends(instance, token);
+    _verify(instance, token);
   }
 
-  /// Performs the same checks as `verifyExtends` but without throwing an
+  /// Performs the same checks as `verify` but without throwing an
   /// [AssertionError] if `const Object()` is used as the instance token.
   ///
   /// This method will be deprecated in a future release.
   static void verifyToken(PlatformInterface instance, Object token) {
-    _verifyExtends(instance, token);
+    _verify(instance, token);
   }
 
-  static void _verifyExtends(PlatformInterface instance, Object token) {
+  static void _verify(PlatformInterface instance, Object token) {
     if (instance is MockPlatformInterfaceMixin) {
       bool assertionsEnabled = false;
       assert(() {

--- a/packages/plugin_platform_interface/lib/plugin_platform_interface.dart
+++ b/packages/plugin_platform_interface/lib/plugin_platform_interface.dart
@@ -12,7 +12,7 @@ import 'package:meta/meta.dart';
 /// implemented using `extends` instead of `implements`.
 ///
 /// Platform interface classes are expected to have a private static token object which will be
-/// be passed to [verifyToken] along with a platform interface object for verification.
+/// be passed to [verify] along with a platform interface object for verification.
 ///
 /// Sample usage:
 ///
@@ -40,15 +40,16 @@ import 'package:meta/meta.dart';
 /// to include the [MockPlatformInterfaceMixin] for the verification to be temporarily disabled. See
 /// [MockPlatformInterfaceMixin] for a sample of using Mockito to mock a platform interface.
 abstract class PlatformInterface {
-  /// Constructs a PlatformInterface, for use only in constructors of abstract derived classes.
+  /// Constructs a PlatformInterface, for use only in constructors of abstract
+  /// derived classes.
   ///
-  /// @param token A non-`const` `Object` used to verify that implementations use `extends`.
+  /// @param token The same, non-`const` `Object` that will be passed to `verify`.
   PlatformInterface({required Object token}) : _instanceToken = token;
 
   final Object? _instanceToken;
 
-  /// Ensures that the platform instance has a non-`const` token that matches the
-  /// provided token and throws [AssertionError] if not.
+  /// Ensures that the platform instance was constructed with a non-`const` token
+  /// that matches the provided token and throws [AssertionError] if not.
   ///
   /// This is used to ensure that implementers are using `extends` rather than
   /// `implements`.
@@ -60,7 +61,7 @@ abstract class PlatformInterface {
   /// with `noSuchMethod`.
   static void verify(PlatformInterface instance, Object token) {
     if (identical(instance._instanceToken, const Object())) {
-      throw AssertionError('`const Object()` cannot be used as `token`.');
+      throw AssertionError('`const Object()` cannot be used as the instance token.');
     }
     _verify(instance, token);
   }
@@ -95,7 +96,7 @@ abstract class PlatformInterface {
 
 /// A [PlatformInterface] mixin that can be combined with mockito's `Mock`.
 ///
-/// It passes the [PlatformInterface.verifyToken] check even though it isn't
+/// It passes the [PlatformInterface.verify] check even though it isn't
 /// using `extends`.
 ///
 /// This class is intended for use in tests only.

--- a/packages/plugin_platform_interface/lib/plugin_platform_interface.dart
+++ b/packages/plugin_platform_interface/lib/plugin_platform_interface.dart
@@ -61,7 +61,7 @@ abstract class PlatformInterface {
   /// with `noSuchMethod`.
   static void verify(PlatformInterface instance, Object token) {
     if (identical(instance._instanceToken, const Object())) {
-      throw AssertionError('`const Object()` cannot be used as the instance token.');
+      throw AssertionError('`const Object()` cannot be used as the token.');
     }
     _verify(instance, token);
   }

--- a/packages/plugin_platform_interface/lib/plugin_platform_interface.dart
+++ b/packages/plugin_platform_interface/lib/plugin_platform_interface.dart
@@ -57,6 +57,7 @@ abstract class PlatformInterface {
   /// This is implemented as a static method so that it cannot be overridden
   /// with `noSuchMethod`.
   static void verifyToken(PlatformInterface instance, Object token) {
+    assert(token != const Object());
     if (instance is MockPlatformInterfaceMixin) {
       bool assertionsEnabled = false;
       assert(() {

--- a/packages/plugin_platform_interface/pubspec.yaml
+++ b/packages/plugin_platform_interface/pubspec.yaml
@@ -14,7 +14,7 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 # Please consider carefully before bumping the major version of this package, ideally it should only
 # be done when absolutely necessary and after the ecosystem has already migrated to 1.X.Y version
 # that is forward compatible with 2.0.0 (ideally the ecosystem have migrated to depend on:
-# `plugin_platform_interface: >=1.X.Y <3.0.0`).
+# `plugin_platform_interface: >=2.X.Y <4.0.0`).
 version: 2.1.0
 
 environment:

--- a/packages/plugin_platform_interface/pubspec.yaml
+++ b/packages/plugin_platform_interface/pubspec.yaml
@@ -9,7 +9,7 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 #
 # This package is used as a second level dependency for many plugins, a major version bump here
 # is guaranteed to lead the ecosystem to a version lock (the first plugin that upgrades to version
-# 2 of this package cannot be used with any other plugin that have not yet migrated).
+# 3 of this package cannot be used with any other plugin that have not yet migrated).
 #
 # Please consider carefully before bumping the major version of this package, ideally it should only
 # be done when absolutely necessary and after the ecosystem has already migrated to 1.X.Y version

--- a/packages/plugin_platform_interface/pubspec.yaml
+++ b/packages/plugin_platform_interface/pubspec.yaml
@@ -15,7 +15,7 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 # be done when absolutely necessary and after the ecosystem has already migrated to 1.X.Y version
 # that is forward compatible with 2.0.0 (ideally the ecosystem have migrated to depend on:
 # `plugin_platform_interface: >=1.X.Y <3.0.0`).
-version: 2.0.3
+version: 2.1.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/plugin_platform_interface/pubspec.yaml
+++ b/packages/plugin_platform_interface/pubspec.yaml
@@ -15,7 +15,7 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 # be done when absolutely necessary and after the ecosystem has already migrated to 1.X.Y version
 # that is forward compatible with 2.0.0 (ideally the ecosystem have migrated to depend on:
 # `plugin_platform_interface: >=1.X.Y <3.0.0`).
-version: 2.0.2
+version: 2.0.3
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/plugin_platform_interface/pubspec.yaml
+++ b/packages/plugin_platform_interface/pubspec.yaml
@@ -12,8 +12,8 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 # 3 of this package cannot be used with any other plugin that have not yet migrated).
 #
 # Please consider carefully before bumping the major version of this package, ideally it should only
-# be done when absolutely necessary and after the ecosystem has already migrated to 1.X.Y version
-# that is forward compatible with 2.0.0 (ideally the ecosystem have migrated to depend on:
+# be done when absolutely necessary and after the ecosystem has already migrated to 2.X.Y version
+# that is forward compatible with 3.0.0 (ideally the ecosystem have migrated to depend on:
 # `plugin_platform_interface: >=2.X.Y <4.0.0`).
 version: 2.1.0
 

--- a/packages/plugin_platform_interface/test/plugin_platform_interface_test.dart
+++ b/packages/plugin_platform_interface/test/plugin_platform_interface_test.dart
@@ -26,6 +26,18 @@ class ImplementsSamplePluginPlatformUsingMockPlatformInterfaceMixin extends Mock
 
 class ExtendsSamplePluginPlatform extends SamplePluginPlatform {}
 
+class InvalidPluginPlatform extends PlatformInterface {
+  SamplePluginPlatform() : super(token: _token);
+
+  const Object _token = Object();
+
+  static set instance(SamplePluginPlatform instance) {
+    PlatformInterface.verifyToken(instance, _token);
+  }
+}
+
+class ExtendsInvalidPluginPlatform extends InvalidPluginPlatform {}
+
 void main() {
   test('Cannot be implemented with `implements`', () {
     expect(() {
@@ -41,5 +53,11 @@ void main() {
 
   test('Can be extended', () {
     SamplePluginPlatform.instance = ExtendsSamplePluginPlatform();
-  });
+  );
+
+  test('Cannot use `const Object()` as token', () {
+    expect(() {
+      InvalidPluginPlatform.instance = ExtendsInvalidPluginPlatform();
+    }, throwsA(isA<AssertionError()));
+  })
 }

--- a/packages/plugin_platform_interface/test/plugin_platform_interface_test.dart
+++ b/packages/plugin_platform_interface/test/plugin_platform_interface_test.dart
@@ -12,7 +12,7 @@ class SamplePluginPlatform extends PlatformInterface {
   static final Object _token = Object();
 
   static set instance(SamplePluginPlatform instance) {
-    PlatformInterface.verifyToken(instance, _token);
+    PlatformInterface.verifyExtends(instance, _token);
     // A real implementation would set a static instance field here.
   }
 }
@@ -26,17 +26,17 @@ class ImplementsSamplePluginPlatformUsingMockPlatformInterfaceMixin extends Mock
 
 class ExtendsSamplePluginPlatform extends SamplePluginPlatform {}
 
-class InvalidPluginPlatform extends PlatformInterface {
-  SamplePluginPlatform() : super(token: _token);
+class ConstTokenPluginPlatform extends PlatformInterface {
+  ConstTokenPluginPlatform() : super(token: _token);
 
-  const Object _token = Object();
+  static const Object _token = Object(); // invalid
 
-  static set instance(SamplePluginPlatform instance) {
-    PlatformInterface.verifyToken(instance, _token);
+  static set instance(ConstTokenPluginPlatform instance) {
+    PlatformInterface.verifyExtends(instance, _token);
   }
 }
 
-class ExtendsInvalidPluginPlatform extends InvalidPluginPlatform {}
+class ExtendsConstTokenPluginPlatform extends ConstTokenPluginPlatform {}
 
 void main() {
   test('Cannot be implemented with `implements`', () {
@@ -53,11 +53,11 @@ void main() {
 
   test('Can be extended', () {
     SamplePluginPlatform.instance = ExtendsSamplePluginPlatform();
-  );
+  });
 
   test('Cannot use `const Object()` as token', () {
     expect(() {
-      InvalidPluginPlatform.instance = ExtendsInvalidPluginPlatform();
-    }, throwsA(isA<AssertionError()));
-  })
+      ConstTokenPluginPlatform.instance = ExtendsConstTokenPluginPlatform();
+    }, throwsA(isA<AssertionError>()));
+  });
 }

--- a/packages/plugin_platform_interface/test/plugin_platform_interface_test.dart
+++ b/packages/plugin_platform_interface/test/plugin_platform_interface_test.dart
@@ -12,7 +12,7 @@ class SamplePluginPlatform extends PlatformInterface {
   static final Object _token = Object();
 
   static set instance(SamplePluginPlatform instance) {
-    PlatformInterface.verifyExtends(instance, _token);
+    PlatformInterface.verify(instance, _token);
     // A real implementation would set a static instance field here.
   }
 }
@@ -32,7 +32,7 @@ class ConstTokenPluginPlatform extends PlatformInterface {
   static const Object _token = Object(); // invalid
 
   static set instance(ConstTokenPluginPlatform instance) {
-    PlatformInterface.verifyExtends(instance, _token);
+    PlatformInterface.verify(instance, _token);
   }
 }
 

--- a/packages/plugin_platform_interface/test/plugin_platform_interface_test.dart
+++ b/packages/plugin_platform_interface/test/plugin_platform_interface_test.dart
@@ -38,26 +38,69 @@ class ConstTokenPluginPlatform extends PlatformInterface {
 
 class ExtendsConstTokenPluginPlatform extends ConstTokenPluginPlatform {}
 
+class VerifyTokenPluginPlatform extends PlatformInterface {
+  VerifyTokenPluginPlatform() : super(token: _token);
+
+  static final Object _token = Object();
+
+  static set instance(VerifyTokenPluginPlatform instance) {
+    PlatformInterface.verifyToken(instance, _token);
+    // A real implementation would set a static instance field here.
+  }
+}
+
+class ImplementsVerifyTokenPluginPlatform extends Mock
+    implements VerifyTokenPluginPlatform {}
+
+class ImplementsVerifyTokenPluginPlatformUsingMockPlatformInterfaceMixin
+    extends Mock
+    with MockPlatformInterfaceMixin
+    implements VerifyTokenPluginPlatform {}
+
+class ExtendsVerifyTokenPluginPlatform extends VerifyTokenPluginPlatform {}
+
 void main() {
-  test('Cannot be implemented with `implements`', () {
-    expect(() {
-      SamplePluginPlatform.instance = ImplementsSamplePluginPlatform();
-    }, throwsA(isA<AssertionError>()));
+  group('`verify`', () {
+    test('prevents implementation with `implements`', () {
+      expect(() {
+        SamplePluginPlatform.instance = ImplementsSamplePluginPlatform();
+      }, throwsA(isA<AssertionError>()));
+    });
+
+    test('allows mocking with `implements`', () {
+      final SamplePluginPlatform mock =
+          ImplementsSamplePluginPlatformUsingMockPlatformInterfaceMixin();
+      SamplePluginPlatform.instance = mock;
+    });
+
+    test('allows extending', () {
+      SamplePluginPlatform.instance = ExtendsSamplePluginPlatform();
+    });
+
+    test('prevents `const Object()` token', () {
+      expect(() {
+        ConstTokenPluginPlatform.instance = ExtendsConstTokenPluginPlatform();
+      }, throwsA(isA<AssertionError>()));
+    });
   });
 
-  test('Can be mocked with `implements`', () {
-    final SamplePluginPlatform mock =
-        ImplementsSamplePluginPlatformUsingMockPlatformInterfaceMixin();
-    SamplePluginPlatform.instance = mock;
-  });
+  // Tests of the earlier, to-be-deprecated `verifyToken` method
+  group('`verifyToken`', () {
+    test('prevents implementation with `implements`', () {
+      expect(() {
+        VerifyTokenPluginPlatform.instance =
+            ImplementsVerifyTokenPluginPlatform();
+      }, throwsA(isA<AssertionError>()));
+    });
 
-  test('Can be extended', () {
-    SamplePluginPlatform.instance = ExtendsSamplePluginPlatform();
-  });
+    test('allows mocking with `implements`', () {
+      final VerifyTokenPluginPlatform mock =
+          ImplementsVerifyTokenPluginPlatformUsingMockPlatformInterfaceMixin();
+      VerifyTokenPluginPlatform.instance = mock;
+    });
 
-  test('Cannot use `const Object()` as token', () {
-    expect(() {
-      ConstTokenPluginPlatform.instance = ExtendsConstTokenPluginPlatform();
-    }, throwsA(isA<AssertionError>()));
+    test('allows extending', () {
+      VerifyTokenPluginPlatform.instance = ExtendsVerifyTokenPluginPlatform();
+    });
   });
 }


### PR DESCRIPTION
- Introduce `verify`, a more future-proof name. It throws `AssertionError` if `const Object()` used as the instance's token. 
- Soft-deprecate `verifyToken` with a comment. It will actually deprecated in a future release, to avoid breaking tests with this minor change.
- Update documentation for `PlatformInterface` to show new usage of `verify` and other cosmetic fixes.
- Add a test for the new assertion.

Fixes https://github.com/flutter/flutter/issues/96178.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.