### PR TITLE
Update all plugins that use `verifyToken` to use `verify` instead

### DIFF
--- a/packages/camera/camera_platform_interface/CHANGELOG.md
+++ b/packages/camera/camera_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.3
+
+*  Update to use the `verify` method introduced in platform_plugin_interface 2.1.0.
+
 ## 2.1.2
 
 * Adopts new analysis options and fixes all violations.

--- a/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
+++ b/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
@@ -39,7 +39,7 @@ abstract class CameraPlatform extends PlatformInterface {
   /// Platform-specific plugins should set this with their own platform-specific
   /// class that extends [CameraPlatform] when they register themselves.
   static set instance(CameraPlatform instance) {
-    PlatformInterface.verifyToken(instance, _token);
+    PlatformInterface.verify(instance, _token);
     _instance = instance;
   }
 

--- a/packages/camera/camera_platform_interface/pubspec.yaml
+++ b/packages/camera/camera_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/master/packages/camera/camer
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.1.2
+version: 2.1.3
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
@@ -15,7 +15,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.3.0
-  plugin_platform_interface: ^2.0.0
+  plugin_platform_interface: ^2.1.0
   stream_transform: ^2.0.0
 
 dev_dependencies:

--- a/packages/camera/camera_platform_interface/pubspec.yaml
+++ b/packages/camera/camera_platform_interface/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.3.0
-  plugin_platform_interface: ^2.1.0
+  plugin_platform_interface: '>=2.1.0 <4.0.0'
   stream_transform: ^2.0.0
 
 dev_dependencies:

--- a/packages/camera/camera_platform_interface/pubspec.yaml
+++ b/packages/camera/camera_platform_interface/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.3.0
-  plugin_platform_interface: '>=2.1.0 <4.0.0'
+  plugin_platform_interface: ^2.1.0
   stream_transform: ^2.0.0
 
 dev_dependencies:

--- a/packages/file_selector/file_selector_platform_interface/CHANGELOG.md
+++ b/packages/file_selector/file_selector_platform_interface/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 2.0.3
 
 * Minor code cleanup for new analysis rules.
+* Update to use the `verify` method introduced in plugin_platform_interface 2.1.0.
 
 ## 2.0.2
 

--- a/packages/file_selector/file_selector_platform_interface/lib/src/platform_interface/file_selector_interface.dart
+++ b/packages/file_selector/file_selector_platform_interface/lib/src/platform_interface/file_selector_interface.dart
@@ -33,7 +33,7 @@ abstract class FileSelectorPlatform extends PlatformInterface {
   /// Platform-specific plugins should set this with their own platform-specific
   /// class that extends [FileSelectorPlatform] when they register themselves.
   static set instance(FileSelectorPlatform instance) {
-    PlatformInterface.verifyToken(instance, _token);
+    PlatformInterface.verify(instance, _token);
     _instance = instance;
   }
 

--- a/packages/file_selector/file_selector_platform_interface/pubspec.yaml
+++ b/packages/file_selector/file_selector_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/master/packages/file_selecto
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.0.2
+version: 2.0.3
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -16,7 +16,7 @@ dependencies:
     sdk: flutter
   http: ^0.13.0
   meta: ^1.3.0
-  plugin_platform_interface: ^2.0.0
+  plugin_platform_interface: ^2.1.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/file_selector/file_selector_platform_interface/pubspec.yaml
+++ b/packages/file_selector/file_selector_platform_interface/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
     sdk: flutter
   http: ^0.13.0
   meta: ^1.3.0
-  plugin_platform_interface: '>=2.1.0 <4.0.0'
+  plugin_platform_interface: ^2.1.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/file_selector/file_selector_platform_interface/pubspec.yaml
+++ b/packages/file_selector/file_selector_platform_interface/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
     sdk: flutter
   http: ^0.13.0
   meta: ^1.3.0
-  plugin_platform_interface: ^2.1.0
+  plugin_platform_interface: '>=2.1.0 <4.0.0'
 
 dev_dependencies:
   flutter_test:

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.4
+
+* Update to use the `verify` method introduced in plugin_platform_interface 2.1.0.
+
 ## 2.1.3
 
 * `LatLng` constructor maintains longitude precision when given within

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/platform_interface/google_maps_flutter_platform.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/platform_interface/google_maps_flutter_platform.dart
@@ -39,7 +39,7 @@ abstract class GoogleMapsFlutterPlatform extends PlatformInterface {
   /// Platform-specific plugins should set this with their own platform-specific
   /// class that extends [GoogleMapsFlutterPlatform] when they register themselves.
   static set instance(GoogleMapsFlutterPlatform instance) {
-    PlatformInterface.verifyToken(instance, _token);
+    PlatformInterface.verify(instance, _token);
     _instance = instance;
   }
 

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/master/packages/google_maps_
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.1.3
+version: 2.1.4
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
@@ -15,7 +15,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.3.0
-  plugin_platform_interface: ^2.0.0
+  plugin_platform_interface: ^2.1.0
   stream_transform: ^2.0.0
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.3.0
-  plugin_platform_interface: ^2.1.0
+  plugin_platform_interface: '>=2.1.0 <4.0.0'
   stream_transform: ^2.0.0
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.3.0
-  plugin_platform_interface: '>=2.1.0 <4.0.0'
+  plugin_platform_interface: ^2.1.0
   stream_transform: ^2.0.0
 
 dev_dependencies:

--- a/packages/image_picker/image_picker_platform_interface/CHANGELOG.md
+++ b/packages/image_picker/image_picker_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.2
+
+* Update to use the `verify` method introduced in plugin_platform_interface 2.1.0.
+
 ## 2.4.1
 
 * Reverts the changes from 2.4.0, which was a breaking change that

--- a/packages/image_picker/image_picker_platform_interface/lib/src/platform_interface/image_picker_platform.dart
+++ b/packages/image_picker/image_picker_platform_interface/lib/src/platform_interface/image_picker_platform.dart
@@ -34,7 +34,7 @@ abstract class ImagePickerPlatform extends PlatformInterface {
   // TODO(amirh): Extract common platform interface logic.
   // https://github.com/flutter/flutter/issues/43368
   static set instance(ImagePickerPlatform instance) {
-    PlatformInterface.verifyToken(instance, _token);
+    PlatformInterface.verify(instance, _token);
     _instance = instance;
   }
 

--- a/packages/image_picker/image_picker_platform_interface/pubspec.yaml
+++ b/packages/image_picker/image_picker_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/master/packages/image_picker
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.4.1
+version: 2.4.2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -15,7 +15,7 @@ dependencies:
     sdk: flutter
   http: ^0.13.0
   meta: ^1.3.0
-  plugin_platform_interface: ^2.0.0
+  plugin_platform_interface: ^2.1.0
   cross_file: ^0.3.1+1
 
 dev_dependencies:

--- a/packages/image_picker/image_picker_platform_interface/pubspec.yaml
+++ b/packages/image_picker/image_picker_platform_interface/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
     sdk: flutter
   http: ^0.13.0
   meta: ^1.3.0
-  plugin_platform_interface: ^2.1.0
+  plugin_platform_interface: '>=2.1.0 <4.0.0'
   cross_file: ^0.3.1+1
 
 dev_dependencies:

--- a/packages/image_picker/image_picker_platform_interface/pubspec.yaml
+++ b/packages/image_picker/image_picker_platform_interface/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
     sdk: flutter
   http: ^0.13.0
   meta: ^1.3.0
-  plugin_platform_interface: '>=2.1.0 <4.0.0'
+  plugin_platform_interface: ^2.1.0
   cross_file: ^0.3.1+1
 
 dev_dependencies:

--- a/packages/in_app_purchase/in_app_purchase_platform_interface/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.1
+
+* Update to use the `verify` method introduced in plugin_platform_interface 2.1.0.
+
 ## 1.3.0
 
 * Added new `PurchaseStatus` named `canceled` to distinguish between an error and user cancellation. 

--- a/packages/in_app_purchase/in_app_purchase_platform_interface/lib/src/in_app_purchase_platform.dart
+++ b/packages/in_app_purchase/in_app_purchase_platform_interface/lib/src/in_app_purchase_platform.dart
@@ -31,7 +31,7 @@ abstract class InAppPurchasePlatform extends PlatformInterface {
   // TODO(amirh): Extract common platform interface logic.
   // https://github.com/flutter/flutter/issues/43368
   static set instance(InAppPurchasePlatform instance) {
-    PlatformInterface.verifyToken(instance, _token);
+    PlatformInterface.verify(instance, _token);
     _instance = instance;
   }
 

--- a/packages/in_app_purchase/in_app_purchase_platform_interface/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/master/packages/in_app_purch
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.3.0
+version: 1.3.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -13,7 +13,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  plugin_platform_interface: ^2.0.0
+  plugin_platform_interface: ^2.1.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/in_app_purchase/in_app_purchase_platform_interface/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_platform_interface/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  plugin_platform_interface: ^2.1.0
+  plugin_platform_interface: '>=2.1.0 <4.0.0'
 
 dev_dependencies:
   flutter_test:

--- a/packages/in_app_purchase/in_app_purchase_platform_interface/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_platform_interface/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  plugin_platform_interface: '>=2.1.0 <4.0.0'
+  plugin_platform_interface: ^2.1.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/path_provider/path_provider_platform_interface/CHANGELOG.md
+++ b/packages/path_provider/path_provider_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.2
+
+* Update to use the `verify` method introduced in plugin_platform_interface 2.1.0.
+
 ## 2.0.1
 
 * Update platform_plugin_interface version requirement.

--- a/packages/path_provider/path_provider_platform_interface/lib/path_provider_platform_interface.dart
+++ b/packages/path_provider/path_provider_platform_interface/lib/path_provider_platform_interface.dart
@@ -32,7 +32,7 @@ abstract class PathProviderPlatform extends PlatformInterface {
   /// Platform-specific plugins should set this with their own platform-specific
   /// class that extends [PathProviderPlatform] when they register themselves.
   static set instance(PathProviderPlatform instance) {
-    PlatformInterface.verifyToken(instance, _token);
+    PlatformInterface.verify(instance, _token);
     _instance = instance;
   }
 

--- a/packages/path_provider/path_provider_platform_interface/pubspec.yaml
+++ b/packages/path_provider/path_provider_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/master/packages/path_provide
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+path_provider%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.0.1
+version: 2.0.2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -15,7 +15,7 @@ dependencies:
     sdk: flutter
   meta: ^1.3.0
   platform: ^3.0.0
-  plugin_platform_interface: ^2.0.0
+  plugin_platform_interface: ^2.1.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/path_provider/path_provider_platform_interface/pubspec.yaml
+++ b/packages/path_provider/path_provider_platform_interface/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
     sdk: flutter
   meta: ^1.3.0
   platform: ^3.0.0
-  plugin_platform_interface: '>=2.1.0 <4.0.0'
+  plugin_platform_interface: ^2.1.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/path_provider/path_provider_platform_interface/pubspec.yaml
+++ b/packages/path_provider/path_provider_platform_interface/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
     sdk: flutter
   meta: ^1.3.0
   platform: ^3.0.0
-  plugin_platform_interface: ^2.1.0
+  plugin_platform_interface: '>=2.1.0 <4.0.0'
 
 dev_dependencies:
   flutter_test:

--- a/packages/quick_actions/quick_actions_platform_interface/CHANGELOG.md
+++ b/packages/quick_actions/quick_actions_platform_interface/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 1.0.1
 
 * Updates code for analyzer changes.
+* Update to use the `verify` method introduced in plugin_platform_interface 2.1.0.
 
 ## 1.0.0
 

--- a/packages/quick_actions/quick_actions_platform_interface/lib/platform_interface/quick_actions_platform.dart
+++ b/packages/quick_actions/quick_actions_platform_interface/lib/platform_interface/quick_actions_platform.dart
@@ -32,7 +32,7 @@ abstract class QuickActionsPlatform extends PlatformInterface {
   // TODO(amirh): Extract common platform interface logic.
   // https://github.com/flutter/flutter/issues/43368
   static set instance(QuickActionsPlatform instance) {
-    PlatformInterface.verifyToken(instance, _token);
+    PlatformInterface.verify(instance, _token);
     _instance = instance;
   }
 

--- a/packages/quick_actions/quick_actions_platform_interface/pubspec.yaml
+++ b/packages/quick_actions/quick_actions_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/master/packages/quick_action
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+quick_actions%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.0.0
+version: 1.0.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -14,7 +14,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.3.0
-  plugin_platform_interface: ^2.0.0
+  plugin_platform_interface: ^2.1.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/quick_actions/quick_actions_platform_interface/pubspec.yaml
+++ b/packages/quick_actions/quick_actions_platform_interface/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.3.0
-  plugin_platform_interface: '>=2.1.0 <4.0.0'
+  plugin_platform_interface: ^2.1.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/quick_actions/quick_actions_platform_interface/pubspec.yaml
+++ b/packages/quick_actions/quick_actions_platform_interface/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.3.0
-  plugin_platform_interface: ^2.1.0
+  plugin_platform_interface: '>=2.1.0 <4.0.0'
 
 dev_dependencies:
   flutter_test:

--- a/packages/url_launcher/url_launcher_platform_interface/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_platform_interface/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 2.0.5
 
 * Updates code for new analysis options.
+* Update to use the `verify` method introduced in platform_plugin_interface 2.1.0.
 
 ## 2.0.4
 

--- a/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/lib/url_launcher_platform_interface.dart
@@ -34,7 +34,7 @@ abstract class UrlLauncherPlatform extends PlatformInterface {
   // TODO(amirh): Extract common platform interface logic.
   // https://github.com/flutter/flutter/issues/43368
   static set instance(UrlLauncherPlatform instance) {
-    PlatformInterface.verifyToken(instance, _token);
+    PlatformInterface.verify(instance, _token);
     _instance = instance;
   }
 

--- a/packages/url_launcher/url_launcher_platform_interface/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/master/packages/url_launcher
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.0.4
+version: 2.0.5
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -13,7 +13,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  plugin_platform_interface: ^2.0.0
+  plugin_platform_interface: ^2.1.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/url_launcher/url_launcher_platform_interface/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_platform_interface/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  plugin_platform_interface: ^2.1.0
+  plugin_platform_interface: '>=2.1.0 <4.0.0'
 
 dev_dependencies:
   flutter_test:

--- a/packages/url_launcher/url_launcher_platform_interface/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_platform_interface/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  plugin_platform_interface: '>=2.1.0 <4.0.0'
+  plugin_platform_interface: ^2.1.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/video_player/video_player_platform_interface/CHANGELOG.md
+++ b/packages/video_player/video_player_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.1
+
+* Update to use the `verify` method introduced in platform_plugin_interface 2.1.0.
+
 ## 5.0.0
 
 * **BREAKING CHANGES**:

--- a/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
+++ b/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
@@ -32,7 +32,7 @@ abstract class VideoPlayerPlatform extends PlatformInterface {
   /// platform-specific class that extends [VideoPlayerPlatform] when they
   /// register themselves.
   static set instance(VideoPlayerPlatform instance) {
-    PlatformInterface.verifyToken(instance, _token);
+    PlatformInterface.verify(instance, _token);
     _instance = instance;
   }
 

--- a/packages/video_player/video_player_platform_interface/pubspec.yaml
+++ b/packages/video_player/video_player_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/master/packages/video_player
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 5.0.0
+version: 5.0.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -13,7 +13,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  plugin_platform_interface: ^2.0.0
+  plugin_platform_interface: ^2.1.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/video_player/video_player_platform_interface/pubspec.yaml
+++ b/packages/video_player/video_player_platform_interface/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  plugin_platform_interface: ^2.1.0
+  plugin_platform_interface: '>=2.1.0 <4.0.0'
 
 dev_dependencies:
   flutter_test:

--- a/packages/video_player/video_player_platform_interface/pubspec.yaml
+++ b/packages/video_player/video_player_platform_interface/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  plugin_platform_interface: '>=2.1.0 <4.0.0'
+  plugin_platform_interface: ^2.1.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.8.1
+
+* Update to use the `verify` method introduced in platform_plugin_interface 2.1.0.
+
 ## 1.8.0
 
 * Adds the `loadFlutterAsset` method to the platform interface.

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_interface/webview_cookie_manager.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_interface/webview_cookie_manager.dart
@@ -30,7 +30,7 @@ abstract class WebViewCookieManagerPlatform extends PlatformInterface {
       throw AssertionError(
           'Platform interfaces can only be set to a non-null instance');
     }
-    PlatformInterface.verifyToken(instance, _token);
+    PlatformInterface.verify(instance, _token);
     _instance = instance;
   }
 

--- a/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/master/packages/webview_flut
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview_flutter%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.8.0
+version: 1.8.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -13,7 +13,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  plugin_platform_interface: ^2.0.0
+  plugin_platform_interface: ^2.1.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  plugin_platform_interface: ^2.1.0
+  plugin_platform_interface: '>=2.1.0 <4.0.0'
 
 dev_dependencies:
   flutter_test:

--- a/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  plugin_platform_interface: '>=2.1.0 <4.0.0'
+  plugin_platform_interface: ^2.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
#4640 (reviewed by @stuartmorgan) updated `plugin_plugin_interface` to 2.1.0, soft-deprecating `verifyToken` and introducing its replacement, `verify`.

Now that 2.1.0 has been [published](https://pub.dev/packages/plugin_platform_interface/versions/2.1.0), this PR updates all of the first-party plugins that used `verifyToken` to use `verify` and depend on `^2.1.0`:
- camera
- file_selector
- google_maps_flutter
- image_picker
- in_app_purchase
- path_provider
- quick_actions
- url_launcher
- video_player
- webview_flutter

It is a follow-on fix for https://github.com/flutter/flutter/issues/96178

## Test plan

This PR has no new tests because it's not possible to test; there was no semantic change to the above plugins. They are not using `const Object()` as their token so a test cannot cause the new `AssertionError` to be thrown. I believe this means @Hixie has to sign off on it and I've posted in #hackers-ecosystem about that.

However, this PR does contain new tests in the sense that there are new tests in https://github.com/flutter/plugins/pull/4640 and this is a follow-on PR that could only be landed after that one did because of the `plugin_platform_interface` dependency. In some sense this repo is a giant test case and we're testing https://github.com/flutter/plugins/pull/4640 by creating lots of sample apps that depend on it.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [too many plugins to list] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [need approval] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
