### PR TITLE
Remove dependencies on 'meta'

### DIFF
--- a/packages/camera/camera_platform_interface/CHANGELOG.md
+++ b/packages/camera/camera_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.3
+
+* Removes dependency on `meta`.
+
 ## 2.1.2
 
 * Adopts new analysis options and fixes all violations.

--- a/packages/camera/camera_platform_interface/lib/src/events/camera_event.dart
+++ b/packages/camera/camera_platform_interface/lib/src/events/camera_event.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:camera_platform_interface/src/types/focus_mode.dart';
-import 'package:meta/meta.dart';
+import 'package:flutter/foundation.dart' show immutable;
 
 import '../../camera_platform_interface.dart';
 

--- a/packages/camera/camera_platform_interface/lib/src/events/device_event.dart
+++ b/packages/camera/camera_platform_interface/lib/src/events/device_event.dart
@@ -3,8 +3,8 @@
 // found in the LICENSE file.
 
 import 'package:camera_platform_interface/src/utils/utils.dart';
+import 'package:flutter/foundation.dart' show immutable;
 import 'package:flutter/services.dart';
-import 'package:meta/meta.dart';
 
 /// Generic Event coming from the native side of Camera,
 /// not related to a specific camera module.

--- a/packages/camera/camera_platform_interface/lib/src/method_channel/method_channel_camera.dart
+++ b/packages/camera/camera_platform_interface/lib/src/method_channel/method_channel_camera.dart
@@ -14,7 +14,6 @@ import 'package:cross_file/cross_file.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
-import 'package:meta/meta.dart';
 import 'package:stream_transform/stream_transform.dart';
 
 const MethodChannel _channel = MethodChannel('plugins.flutter.io/camera');

--- a/packages/camera/camera_platform_interface/lib/src/types/camera_description.dart
+++ b/packages/camera/camera_platform_interface/lib/src/types/camera_description.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/foundation.dart';
-import 'package:meta/meta.dart';
 
 /// The direction the camera is facing.
 enum CameraLensDirection {

--- a/packages/camera/camera_platform_interface/pubspec.yaml
+++ b/packages/camera/camera_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/master/packages/camera/camer
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.1.2
+version: 2.1.3
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
@@ -14,7 +14,6 @@ dependencies:
   cross_file: ^0.3.1
   flutter:
     sdk: flutter
-  meta: ^1.3.0
   plugin_platform_interface: ^2.0.0
   stream_transform: ^2.0.0
 

--- a/packages/file_selector/file_selector_platform_interface/CHANGELOG.md
+++ b/packages/file_selector/file_selector_platform_interface/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 2.0.3
 
 * Minor code cleanup for new analysis rules.
+* Removes dependency on `meta`.
 
 ## 2.0.2
 

--- a/packages/file_selector/file_selector_platform_interface/lib/src/method_channel/method_channel_file_selector.dart
+++ b/packages/file_selector/file_selector_platform_interface/lib/src/method_channel/method_channel_file_selector.dart
@@ -4,8 +4,8 @@
 
 import 'package:cross_file/cross_file.dart';
 import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter/services.dart';
-import 'package:meta/meta.dart';
 
 const MethodChannel _channel =
     MethodChannel('plugins.flutter.io/file_selector');

--- a/packages/file_selector/file_selector_platform_interface/pubspec.yaml
+++ b/packages/file_selector/file_selector_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/master/packages/file_selecto
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.0.2
+version: 2.0.3
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -15,7 +15,6 @@ dependencies:
   flutter:
     sdk: flutter
   http: ^0.13.0
-  meta: ^1.3.0
   plugin_platform_interface: ^2.0.0
 
 dev_dependencies:

--- a/packages/file_selector/file_selector_web/CHANGELOG.md
+++ b/packages/file_selector/file_selector_web/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 0.8.1+3
 
 * Minor code cleanup for new analysis rules.
+* Removes dependency on `meta`.
 
 ## 0.8.1+2
 

--- a/packages/file_selector/file_selector_web/lib/file_selector_web.dart
+++ b/packages/file_selector/file_selector_web/lib/file_selector_web.dart
@@ -7,8 +7,8 @@ import 'dart:async';
 import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
 import 'package:file_selector_web/src/dom_helper.dart';
 import 'package:file_selector_web/src/utils.dart';
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
-import 'package:meta/meta.dart';
 
 /// The web implementation of [FileSelectorPlatform].
 ///

--- a/packages/file_selector/file_selector_web/lib/src/dom_helper.dart
+++ b/packages/file_selector/file_selector_web/lib/src/dom_helper.dart
@@ -6,8 +6,8 @@ import 'dart:async';
 import 'dart:html';
 
 import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter/services.dart';
-import 'package:meta/meta.dart';
 
 /// Class to manipulate the DOM with the intention of reading files from it.
 class DomHelper {

--- a/packages/file_selector/file_selector_web/pubspec.yaml
+++ b/packages/file_selector/file_selector_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: file_selector_web
 description: Web platform implementation of file_selector
 repository: https://github.com/flutter/plugins/tree/master/packages/file_selector/file_selector_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
-version: 0.8.1+2
+version: 0.8.1+3
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -22,7 +22,6 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  meta: ^1.3.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.4
+
+Removes dependency on `meta`.
+
 ## 2.1.3
 
 * `LatLng` constructor maintains longitude precision when given within

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/cap.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/cap.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:meta/meta.dart' show immutable;
+import 'package:flutter/foundation.dart' show immutable;
 
 import 'types.dart';
 

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/circle.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/circle.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/foundation.dart' show VoidCallback;
 import 'package:flutter/material.dart' show Color, Colors;
-import 'package:meta/meta.dart' show immutable;
+import 'package:flutter/foundation.dart' show immutable;
 
 import 'types.dart';
 

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/joint_type.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/joint_type.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:meta/meta.dart' show immutable;
+import 'package:flutter/foundation.dart' show immutable;
 
 /// Joint types for [Polyline].
 @immutable

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/location.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/location.dart
@@ -4,7 +4,7 @@
 
 import 'dart:ui' show hashValues;
 
-import 'package:meta/meta.dart';
+import 'package:flutter/foundation.dart' show visibleForTesting;
 
 /// A pair of latitude and longitude coordinates, stored as degrees.
 class LatLng {

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/maps_object.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/maps_object.dart
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/foundation.dart' show objectRuntimeType;
-import 'package:meta/meta.dart' show immutable;
+import 'package:flutter/foundation.dart' show immutable, objectRuntimeType;
 
 /// Uniquely identifies object an among [GoogleMap] collections of a specific
 /// type.

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/marker.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/marker.dart
@@ -4,8 +4,8 @@
 
 import 'dart:ui' show hashValues, Offset;
 
-import 'package:flutter/foundation.dart' show ValueChanged, VoidCallback;
-import 'package:meta/meta.dart' show immutable;
+import 'package:flutter/foundation.dart'
+    show immutable, ValueChanged, VoidCallback;
 
 import 'types.dart';
 

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/pattern_item.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/pattern_item.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:meta/meta.dart' show immutable;
+import 'package:flutter/foundation.dart' show immutable;
 
 /// Item used in the stroke pattern for a Polyline.
 @immutable

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/polygon.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/polygon.dart
@@ -3,9 +3,9 @@
 // found in the LICENSE file.
 
 import 'package:collection/collection.dart';
-import 'package:flutter/foundation.dart' show listEquals, VoidCallback;
+import 'package:flutter/foundation.dart'
+    show immutable, listEquals, VoidCallback;
 import 'package:flutter/material.dart' show Color, Colors;
-import 'package:meta/meta.dart' show immutable;
 
 import 'types.dart';
 

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/polyline.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/polyline.dart
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/foundation.dart' show listEquals, VoidCallback;
+import 'package:flutter/foundation.dart'
+    show immutable, listEquals, VoidCallback;
 import 'package:flutter/material.dart' show Color, Colors;
-import 'package:meta/meta.dart' show immutable;
 
 import 'types.dart';
 

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/screen_coordinate.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/screen_coordinate.dart
@@ -4,7 +4,7 @@
 
 import 'dart:ui' show hashValues;
 
-import 'package:meta/meta.dart' show immutable;
+import 'package:flutter/foundation.dart' show immutable;
 
 /// Represents a point coordinate in the [GoogleMap]'s view.
 ///

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/tile.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/tile.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:typed_data';
-import 'package:meta/meta.dart' show immutable;
+import 'package:flutter/foundation.dart' show immutable;
 
 /// Contains information about a Tile that is returned by a [TileProvider].
 @immutable

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/tile_overlay.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/tile_overlay.dart
@@ -4,8 +4,7 @@
 
 import 'dart:ui' show hashValues;
 
-import 'package:flutter/foundation.dart';
-import 'package:meta/meta.dart' show immutable;
+import 'package:flutter/foundation.dart' show immutable;
 
 import 'types.dart';
 

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/master/packages/google_maps_
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.1.3
+version: 2.1.4
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
@@ -14,7 +14,6 @@ dependencies:
   collection: ^1.15.0
   flutter:
     sdk: flutter
-  meta: ^1.3.0
   plugin_platform_interface: ^2.0.0
   stream_transform: ^2.0.0
 

--- a/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
@@ -1,6 +1,10 @@
+## 0.3.2+1
+
+* Removes dependency on `meta`.
+
 ## 0.3.2
 
-Add `onDragStart` and `onDrag` to `Marker`
+* Add `onDragStart` and `onDrag` to `Marker`
 
 ## 0.3.1
 

--- a/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_web
 description: Web platform implementation of google_maps_flutter
 repository: https://github.com/flutter/plugins/tree/master/packages/google_maps_flutter/google_maps_flutter_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 0.3.2
+version: 0.3.2+1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -23,7 +23,6 @@ dependencies:
     sdk: flutter
   google_maps_flutter_platform_interface: ^2.1.2
   google_maps: ^5.2.0
-  meta: ^1.3.0
   pedantic: ^1.10.0
   sanitize_html: ^2.0.0
   stream_transform: ^2.0.0

--- a/packages/google_sign_in/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 5.2.2
 
 * Updates Android compileSdkVersion to 31.
+* Removes depenedncy on `meta`.
 
 ## 5.2.1
 

--- a/packages/google_sign_in/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android and iOS.
 repository: https://github.com/flutter/plugins/tree/master/packages/google_sign_in/google_sign_in
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
-version: 5.2.1
+version: 5.2.2
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -25,7 +25,6 @@ dependencies:
     sdk: flutter
   google_sign_in_platform_interface: ^2.1.0
   google_sign_in_web: ^0.10.0
-  meta: ^1.3.0
 
 dev_dependencies:
   flutter_driver:

--- a/packages/google_sign_in/google_sign_in_platform_interface/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.1
+
+* Removes dependency on `meta`.
+
 ## 2.1.0
 
 * Add serverAuthCode attribute to user data

--- a/packages/google_sign_in/google_sign_in_platform_interface/lib/google_sign_in_platform_interface.dart
+++ b/packages/google_sign_in/google_sign_in_platform_interface/lib/google_sign_in_platform_interface.dart
@@ -3,7 +3,9 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'package:meta/meta.dart' show visibleForTesting;
+
+import 'package:flutter/foundation.dart' show visibleForTesting;
+
 import 'src/method_channel_google_sign_in.dart';
 import 'src/types.dart';
 

--- a/packages/google_sign_in/google_sign_in_platform_interface/lib/src/method_channel_google_sign_in.dart
+++ b/packages/google_sign_in/google_sign_in_platform_interface/lib/src/method_channel_google_sign_in.dart
@@ -4,8 +4,8 @@
 
 import 'dart:async';
 
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter/services.dart';
-import 'package:meta/meta.dart' show visibleForTesting;
 
 import '../google_sign_in_platform_interface.dart';
 import 'types.dart';

--- a/packages/google_sign_in/google_sign_in_platform_interface/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/master/packages/google_sign_
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.1.0
+version: 2.1.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -13,7 +13,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.3.0
   quiver: ^3.0.0
 
 dev_dependencies:

--- a/packages/google_sign_in/google_sign_in_web/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.0+4
+
+* Removes dependency on `meta`.
+
 ## 0.10.0+3
 
 * Updated URL to the `google_sign_in` package in README.

--- a/packages/google_sign_in/google_sign_in_web/lib/google_sign_in_web.dart
+++ b/packages/google_sign_in/google_sign_in_web/lib/google_sign_in_web.dart
@@ -5,11 +5,11 @@
 import 'dart:async';
 import 'dart:html' as html;
 
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter/services.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:google_sign_in_platform_interface/google_sign_in_platform_interface.dart';
 import 'package:js/js.dart';
-import 'package:meta/meta.dart';
 
 import 'src/generated/gapiauth2.dart' as auth2;
 import 'src/load_gapi.dart' as gapi;

--- a/packages/google_sign_in/google_sign_in_web/lib/src/load_gapi.dart
+++ b/packages/google_sign_in/google_sign_in_web/lib/src/load_gapi.dart
@@ -8,7 +8,7 @@ library gapi_onload;
 import 'dart:async';
 
 import 'package:js/js.dart';
-import 'package:meta/meta.dart';
+import 'package:flutter/foundation.dart' show visibleForTesting;
 
 import 'generated/gapi.dart' as gapi;
 import 'utils.dart' show injectJSLibraries;

--- a/packages/google_sign_in/google_sign_in_web/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_web/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android, iOS and Web.
 repository: https://github.com/flutter/plugins/tree/master/packages/google_sign_in/google_sign_in_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
-version: 0.10.0+3
+version: 0.10.0+4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -24,7 +24,6 @@ dependencies:
     sdk: flutter
   google_sign_in_platform_interface: ^2.0.0
   js: ^0.6.3
-  meta: ^1.3.0
   pedantic: ^1.10.0
 
 dev_dependencies:

--- a/packages/image_picker/image_picker_for_web/CHANGELOG.md
+++ b/packages/image_picker/image_picker_for_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.5
+
+* Removes dependency on `meta`.
+
 ## 2.1.4
 
 * Implemented `maxWidth`, `maxHeight` and `imageQuality` when selecting images

--- a/packages/image_picker/image_picker_for_web/lib/image_picker_for_web.dart
+++ b/packages/image_picker/image_picker_for_web/lib/image_picker_for_web.dart
@@ -5,9 +5,9 @@
 import 'dart:async';
 import 'dart:html' as html;
 
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:image_picker_for_web/src/image_resizer.dart';
-import 'package:meta/meta.dart';
 import 'package:image_picker_platform_interface/image_picker_platform_interface.dart';
 
 final String _kImagePickerInputsDomId = '__image_picker_web-file-input';

--- a/packages/image_picker/image_picker_for_web/pubspec.yaml
+++ b/packages/image_picker/image_picker_for_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker_for_web
 description: Web platform implementation of image_picker
 repository: https://github.com/flutter/plugins/tree/master/packages/image_picker/image_picker_for_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 2.1.4
+version: 2.1.5
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -22,7 +22,6 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   image_picker_platform_interface: ^2.2.0
-  meta: ^1.3.0
   pedantic: ^1.10.0
 
 dev_dependencies:

--- a/packages/image_picker/image_picker_platform_interface/CHANGELOG.md
+++ b/packages/image_picker/image_picker_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.2
+
+* Removes dependency on `meta`.
+
 ## 2.4.1
 
 * Reverts the changes from 2.4.0, which was a breaking change that

--- a/packages/image_picker/image_picker_platform_interface/lib/src/method_channel/method_channel_image_picker.dart
+++ b/packages/image_picker/image_picker_platform_interface/lib/src/method_channel/method_channel_image_picker.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
-import 'package:meta/meta.dart' show visibleForTesting;
 
 import 'package:image_picker_platform_interface/image_picker_platform_interface.dart';
 

--- a/packages/image_picker/image_picker_platform_interface/lib/src/types/picked_file/base.dart
+++ b/packages/image_picker/image_picker_platform_interface/lib/src/types/picked_file/base.dart
@@ -5,7 +5,7 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:meta/meta.dart';
+import 'package:flutter/foundation.dart' show immutable;
 
 /// The interface for a PickedFile.
 ///

--- a/packages/image_picker/image_picker_platform_interface/pubspec.yaml
+++ b/packages/image_picker/image_picker_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/master/packages/image_picker
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.4.1
+version: 2.4.2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -14,7 +14,6 @@ dependencies:
   flutter:
     sdk: flutter
   http: ^0.13.0
-  meta: ^1.3.0
   plugin_platform_interface: ^2.0.0
   cross_file: ^0.3.1+1
 

--- a/packages/in_app_purchase/in_app_purchase_android/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.2+1
+
+* Removes the dependency on `meta`.
+
 ## 0.2.2
 
 * Fixes the `purchaseStream` incorrectly reporting `PurchaseStatus.error` when user upgrades subscription by deferred proration mode.

--- a/packages/in_app_purchase/in_app_purchase_android/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase_android
 description: An implementation for the Android platform of the Flutter `in_app_purchase` plugin. This uses the Android BillingClient APIs.
 repository: https://github.com/flutter/plugins/tree/master/packages/in_app_purchase/in_app_purchase_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 0.2.2
+version: 0.2.2+1
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -22,7 +22,6 @@ dependencies:
     sdk: flutter
   in_app_purchase_platform_interface: ^1.3.0
   json_annotation: ^4.3.0
-  meta: ^1.3.0
 
 dev_dependencies:
   build_runner: ^2.0.0

--- a/packages/in_app_purchase/in_app_purchase_storekit/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_storekit/CHANGELOG.md
@@ -1,6 +1,10 @@
+## 0.3.0+1
+
+* Removes dependency on `meta`.
+
 ## 0.3.0
 
-* **BREAKING CHANGE:** `InAppPurchaseStoreKitPlatform.restorePurchase()` emits an empty instance of `List<ProductDetails>` when there were no transactions to restore, indicating that the restore procedure has finished. 
+* **BREAKING CHANGE:** `InAppPurchaseStoreKitPlatform.restorePurchase()` emits an empty instance of `List<ProductDetails>` when there were no transactions to restore, indicating that the restore procedure has finished.
 
 ## 0.2.1
 

--- a/packages/in_app_purchase/in_app_purchase_storekit/lib/src/store_kit_wrappers/sk_payment_queue_wrapper.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/lib/src/store_kit_wrappers/sk_payment_queue_wrapper.dart
@@ -10,7 +10,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:in_app_purchase_storekit/store_kit_wrappers.dart';
 import 'package:json_annotation/json_annotation.dart';
-import 'package:meta/meta.dart';
 
 import '../channel.dart';
 import '../in_app_purchase_storekit_platform.dart';

--- a/packages/in_app_purchase/in_app_purchase_storekit/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_storekit/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase_storekit
 description: An implementation for the iOS platform of the Flutter `in_app_purchase` plugin. This uses the StoreKit Framework.
 repository: https://github.com/flutter/plugins/tree/master/packages/in_app_purchase/in_app_purchase_storekit
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 0.3.0
+version: 0.3.0+1
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -21,7 +21,6 @@ dependencies:
     sdk: flutter
   in_app_purchase_platform_interface: ^1.3.0
   json_annotation: ^4.3.0
-  meta: ^1.3.0
 
 dev_dependencies:
   build_runner: ^2.0.0

--- a/packages/local_auth/CHANGELOG.md
+++ b/packages/local_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.10
+
+* Removes dependency on `meta`.
+
 ## 1.1.9
 
 * Updates code for analysis option changes.

--- a/packages/local_auth/lib/local_auth.dart
+++ b/packages/local_auth/lib/local_auth.dart
@@ -10,8 +10,8 @@
 
 import 'dart:async';
 
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter/services.dart';
-import 'package:meta/meta.dart';
 import 'package:platform/platform.dart';
 
 import 'auth_strings.dart';

--- a/packages/local_auth/pubspec.yaml
+++ b/packages/local_auth/pubspec.yaml
@@ -23,7 +23,6 @@ dependencies:
     sdk: flutter
   flutter_plugin_android_lifecycle: ^2.0.1
   intl: ^0.17.0
-  meta: ^1.3.0
   platform: ^3.0.0
 
 dev_dependencies:

--- a/packages/local_auth/pubspec.yaml
+++ b/packages/local_auth/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Android and iOS devices to allow local
   authentication via fingerprint, touch ID, face ID, passcode, pin, or pattern.
 repository: https://github.com/flutter/plugins/tree/master/packages/local_auth
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+local_auth%22
-version: 1.1.9
+version: 1.1.10
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/path_provider/path_provider_linux/CHANGELOG.md
+++ b/packages/path_provider/path_provider_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.5
+
+* Removes dependency on `meta`.
+
 ## 2.1.4
 
 * Fixes `getApplicationSupportPath` handling of applications where the

--- a/packages/path_provider/path_provider_linux/lib/src/get_application_id_real.dart
+++ b/packages/path_provider/path_provider_linux/lib/src/get_application_id_real.dart
@@ -4,7 +4,7 @@
 
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
-import 'package:meta/meta.dart';
+import 'package:flutter/foundation.dart' show visibleForTesting;
 
 // GApplication* g_application_get_default();
 typedef _GApplicationGetDefaultC = IntPtr Function();

--- a/packages/path_provider/path_provider_linux/pubspec.yaml
+++ b/packages/path_provider/path_provider_linux/pubspec.yaml
@@ -2,7 +2,7 @@ name: path_provider_linux
 description: Linux implementation of the path_provider plugin
 repository: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider_linux
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+path_provider%22
-version: 2.1.4
+version: 2.1.5
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -19,7 +19,6 @@ dependencies:
   ffi: ^1.1.2
   flutter:
     sdk: flutter
-  meta: ^1.3.0
   path: ^1.8.0
   path_provider_platform_interface: ^2.0.0
   xdg_directories: ^0.2.0

--- a/packages/path_provider/path_provider_macos/CHANGELOG.md
+++ b/packages/path_provider/path_provider_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.5
+
+* Removes dependency on `meta`.
+
 ## 2.0.4
 
 * Switches to a package-internal implementation of the platform interface.

--- a/packages/path_provider/path_provider_macos/lib/path_provider_macos.dart
+++ b/packages/path_provider/path_provider_macos/lib/path_provider_macos.dart
@@ -4,8 +4,8 @@
 
 import 'dart:io';
 
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter/services.dart';
-import 'package:meta/meta.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 
 /// The macOS implementation of [PathProviderPlatform].

--- a/packages/path_provider/path_provider_macos/pubspec.yaml
+++ b/packages/path_provider/path_provider_macos/pubspec.yaml
@@ -2,7 +2,7 @@ name: path_provider_macos
 description: macOS implementation of the path_provider plugin
 repository: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider_macos
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+path_provider%22
-version: 2.0.4
+version: 2.0.5
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -19,7 +19,6 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.3.0
   path_provider_platform_interface: ^2.0.1
 
 dev_dependencies:

--- a/packages/path_provider/path_provider_platform_interface/CHANGELOG.md
+++ b/packages/path_provider/path_provider_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.2
+
+* Removes dependency on `meta`.
+
 ## 2.0.1
 
 * Update platform_plugin_interface version requirement.

--- a/packages/path_provider/path_provider_platform_interface/lib/src/method_channel_path_provider.dart
+++ b/packages/path_provider/path_provider_platform_interface/lib/src/method_channel_path_provider.dart
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter/services.dart';
-import 'package:meta/meta.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:platform/platform.dart';
 

--- a/packages/path_provider/path_provider_platform_interface/pubspec.yaml
+++ b/packages/path_provider/path_provider_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/master/packages/path_provide
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+path_provider%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.0.1
+version: 2.0.2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -13,7 +13,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.3.0
   platform: ^3.0.0
   plugin_platform_interface: ^2.0.0
 

--- a/packages/path_provider/path_provider_windows/CHANGELOG.md
+++ b/packages/path_provider/path_provider_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.5
+
+* Removes dependency on `meta`.
+
 ## 2.0.4
 
 * Removed obsolete `pluginClass: none` from pubpsec.

--- a/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_real.dart
+++ b/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_real.dart
@@ -6,7 +6,7 @@ import 'dart:ffi';
 import 'dart:io';
 
 import 'package:ffi/ffi.dart';
-import 'package:meta/meta.dart';
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:path/path.dart' as path;
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:win32/win32.dart';

--- a/packages/path_provider/path_provider_windows/pubspec.yaml
+++ b/packages/path_provider/path_provider_windows/pubspec.yaml
@@ -2,7 +2,7 @@ name: path_provider_windows
 description: Windows implementation of the path_provider plugin
 repository: https://github.com/flutter/plugins/tree/master/packages/path_provider/path_provider_windows
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+path_provider%22
-version: 2.0.4
+version: 2.0.5
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -19,7 +19,6 @@ dependencies:
   ffi: ^1.0.0
   flutter:
     sdk: flutter
-  meta: ^1.3.0
   path: ^1.8.0
   path_provider_platform_interface: ^2.0.0
   win32: ^2.0.0

--- a/packages/quick_actions/quick_actions/CHANGELOG.md
+++ b/packages/quick_actions/quick_actions/CHANGELOG.md
@@ -1,7 +1,8 @@
-## NEXT
+## 0.6.0+9
 
 * Updates Android compileSdkVersion to 31.
 * Updates code for analyzer changes.
+* Removes dependency on `meta`.
 
 ## 0.6.0+8
 

--- a/packages/quick_actions/quick_actions/pubspec.yaml
+++ b/packages/quick_actions/quick_actions/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for creating shortcuts on home screen, also known as
   Quick Actions on iOS and App Shortcuts on Android.
 repository: https://github.com/flutter/plugins/tree/master/packages/quick_actions/quick_actions
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+quick_actions%22
-version: 0.6.0+8
+version: 0.6.0+9
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -21,7 +21,6 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.3.0
   quick_actions_platform_interface: ^1.0.0
 
 dev_dependencies:

--- a/packages/quick_actions/quick_actions_platform_interface/CHANGELOG.md
+++ b/packages/quick_actions/quick_actions_platform_interface/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 1.0.1
 
 * Updates code for analyzer changes.
+* Removes dependency on `meta`.
 
 ## 1.0.0
 

--- a/packages/quick_actions/quick_actions_platform_interface/lib/method_channel/method_channel_quick_actions.dart
+++ b/packages/quick_actions/quick_actions_platform_interface/lib/method_channel/method_channel_quick_actions.dart
@@ -4,7 +4,6 @@
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
-import 'package:meta/meta.dart' show visibleForTesting;
 import 'package:quick_actions_platform_interface/types/types.dart';
 
 import '../platform_interface/quick_actions_platform.dart';

--- a/packages/quick_actions/quick_actions_platform_interface/pubspec.yaml
+++ b/packages/quick_actions/quick_actions_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/master/packages/quick_action
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+quick_actions%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.0.0
+version: 1.0.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -13,7 +13,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.3.0
   plugin_platform_interface: ^2.0.0
 
 dev_dependencies:

--- a/packages/shared_preferences/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.12
+
+* Removes dependency on `meta`.
+
 ## 2.0.11
 
 * Corrects example for mocking in readme.

--- a/packages/shared_preferences/shared_preferences/lib/shared_preferences.dart
+++ b/packages/shared_preferences/shared_preferences/lib/shared_preferences.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:meta/meta.dart';
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
 
 /// Wraps NSUserDefaults (on iOS) and SharedPreferences (on Android), providing

--- a/packages/shared_preferences/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for reading and writing simple key-value pairs.
   Wraps NSUserDefaults on iOS and SharedPreferences on Android.
 repository: https://github.com/flutter/plugins/tree/master/packages/shared_preferences/shared_preferences
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.0.11
+version: 2.0.12
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -28,7 +28,6 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.3.0
   shared_preferences_android: ^2.0.8
   shared_preferences_ios: ^2.0.8
   shared_preferences_linux: ^2.0.1

--- a/packages/shared_preferences/shared_preferences_android/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.10
+
+* Removes dependency on `meta`.
+
 ## 2.0.9
 
 * Updates compileSdkVersion to 31.

--- a/packages/shared_preferences/shared_preferences_android/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: shared_preferences_android
 description: Android implementation of the shared_preferences plugin
 repository: https://github.com/flutter/plugins/tree/master/packages/shared_preferences/shared_preferences_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.0.9
+version: 2.0.10
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -19,7 +19,6 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.3.0
   shared_preferences_platform_interface: ^2.0.0
 
 dev_dependencies:

--- a/packages/shared_preferences/shared_preferences_ios/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.9
+
+* Removes dependency on `meta`.
+
 ## 2.0.8
 
 * Split from `shared_preferences` as a federated implementation.

--- a/packages/shared_preferences/shared_preferences_ios/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: shared_preferences_ios
 description: iOS implementation of the shared_preferences plugin
 repository: https://github.com/flutter/plugins/tree/master/packages/shared_preferences/shared_preferences_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.0.8
+version: 2.0.9
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -18,7 +18,6 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.3.0
   shared_preferences_platform_interface: ^2.0.0
 
 dev_dependencies:

--- a/packages/shared_preferences/shared_preferences_linux/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.4
+
+* Removes dependency on `meta`.
+
 ## 2.0.3
 
 * Removed obsolete `pluginClass: none` from pubpsec.

--- a/packages/shared_preferences/shared_preferences_linux/lib/shared_preferences_linux.dart
+++ b/packages/shared_preferences/shared_preferences_linux/lib/shared_preferences_linux.dart
@@ -7,7 +7,7 @@ import 'dart:convert' show json;
 
 import 'package:file/file.dart';
 import 'package:file/local.dart';
-import 'package:meta/meta.dart';
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:path/path.dart' as path;
 import 'package:path_provider_linux/path_provider_linux.dart';
 import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';

--- a/packages/shared_preferences/shared_preferences_linux/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_linux/pubspec.yaml
@@ -2,7 +2,7 @@ name: shared_preferences_linux
 description: Linux implementation of the shared_preferences plugin
 repository: https://github.com/flutter/plugins/tree/master/packages/shared_preferences/shared_preferences_linux
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.0.3
+version: 2.0.4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -19,7 +19,6 @@ dependencies:
   file: ^6.0.0
   flutter:
     sdk: flutter
-  meta: ^1.3.0
   path: ^1.8.0
   path_provider_linux: ^2.0.0
   shared_preferences_platform_interface: ^2.0.0

--- a/packages/shared_preferences/shared_preferences_web/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_web/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 2.0.3
 
 * Fixes newly enabled analyzer options.
+* Removes dependency on `meta`.
 
 ## 2.0.2
 

--- a/packages/shared_preferences/shared_preferences_web/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: shared_preferences_web
 description: Web platform implementation of shared_preferences
 repository: https://github.com/flutter/plugins/tree/master/packages/shared_preferences/shared_preferences_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.0.2
+version: 2.0.3
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -21,7 +21,6 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  meta: ^1.3.0
   shared_preferences_platform_interface: ^2.0.0
 
 dev_dependencies:

--- a/packages/shared_preferences/shared_preferences_windows/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.4
+
+* Removes dependency on `meta`.
+
 ## 2.0.3
 
 * Removed obsolete `pluginClass: none` from pubpsec.

--- a/packages/shared_preferences/shared_preferences_windows/lib/shared_preferences_windows.dart
+++ b/packages/shared_preferences/shared_preferences_windows/lib/shared_preferences_windows.dart
@@ -7,7 +7,7 @@ import 'dart:convert' show json;
 
 import 'package:file/file.dart';
 import 'package:file/local.dart';
-import 'package:meta/meta.dart';
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:path/path.dart' as path;
 import 'package:path_provider_windows/path_provider_windows.dart';
 import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';

--- a/packages/shared_preferences/shared_preferences_windows/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_windows/pubspec.yaml
@@ -2,7 +2,7 @@ name: shared_preferences_windows
 description: Windows implementation of shared_preferences
 repository: https://github.com/flutter/plugins/tree/master/packages/shared_preferences/shared_preferences_windows
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.0.3
+version: 2.0.4
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
@@ -19,7 +19,6 @@ dependencies:
   file: ^6.0.0
   flutter:
     sdk: flutter
-  meta: ^1.3.0
   path: ^1.8.0
   path_provider_platform_interface: ^2.0.0
   path_provider_windows: ^2.0.0

--- a/packages/url_launcher/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.18
+
+* Removes dependency on `meta`.
+
 ## 6.0.17
 
 * Updates code for new analysis options.

--- a/packages/url_launcher/url_launcher/lib/src/link.dart
+++ b/packages/url_launcher/url_launcher/lib/src/link.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
-import 'package:meta/meta.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:url_launcher_platform_interface/link.dart';
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';

--- a/packages/url_launcher/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for launching a URL. Supports
   web, phone, SMS, and email schemes.
 repository: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 6.0.17
+version: 6.0.18
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -28,7 +28,6 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.3.0
   url_launcher_android: ^6.0.13
   url_launcher_ios: ^6.0.13
   url_launcher_linux: ^2.0.0

--- a/packages/url_launcher/url_launcher_android/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_android/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 6.0.14
 
 * Updates code for new analysis options.
+* Removes dependency on `meta`.
 
 ## 6.0.13
 

--- a/packages/url_launcher/url_launcher_android/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher_android
 description: Android implementation of the url_launcher plugin.
 repository: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 6.0.13
+version: 6.0.14
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -19,7 +19,6 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.3.0
   url_launcher_platform_interface: ^2.0.3
 
 dev_dependencies:

--- a/packages/url_launcher/url_launcher_ios/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_ios/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 6.0.14
 
 * Updates code for new analysis options.
+* Removes dependency on `meta`.
 
 ## 6.0.13
 

--- a/packages/url_launcher/url_launcher_ios/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher_ios
 description: iOS implementation of the url_launcher plugin.
 repository: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 6.0.13
+version: 6.0.14
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -18,7 +18,6 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.3.0
   url_launcher_platform_interface: ^2.0.3
 
 dev_dependencies:

--- a/packages/url_launcher/url_launcher_web/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.6
+
+* Removes dependency on `meta`.
+
 ## 2.0.5
 
 * Updates code for new analysis options.

--- a/packages/url_launcher/url_launcher_web/lib/url_launcher_web.dart
+++ b/packages/url_launcher/url_launcher_web/lib/url_launcher_web.dart
@@ -5,8 +5,8 @@
 import 'dart:async';
 import 'dart:html' as html;
 
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
-import 'package:meta/meta.dart';
 import 'package:url_launcher_platform_interface/link.dart';
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 

--- a/packages/url_launcher/url_launcher_web/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher_web
 description: Web platform implementation of url_launcher
 repository: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 2.0.5
+version: 2.0.6
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -21,7 +21,6 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  meta: ^1.3.0 # null safe
   url_launcher_platform_interface: ^2.0.0
 
 dev_dependencies:

--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.11
+
+* Removes dependency on `meta`.
+
 ## 2.2.10
 
 * iOS: Updates texture on `seekTo`.

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -8,7 +8,6 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:meta/meta.dart';
 import 'package:video_player_platform_interface/video_player_platform_interface.dart';
 
 export 'package:video_player_platform_interface/video_player_platform_interface.dart'

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android, iOS, and web.
 repository: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.2.10
+version: 2.2.11
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -23,7 +23,6 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.3.0
   video_player_platform_interface: ">=4.2.0 <6.0.0"
   video_player_web: ^2.0.0
   html: ^0.15.0

--- a/packages/video_player/video_player_web/CHANGELOG.md
+++ b/packages/video_player/video_player_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.6
+
+* Removes dependency on `meta`.
+
 ## 2.0.5
 
 * Adds compatibility with `video_player_platform_interface` 5.0, which does not

--- a/packages/video_player/video_player_web/pubspec.yaml
+++ b/packages/video_player/video_player_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_web
 description: Web platform implementation of video_player.
 repository: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.0.5
+version: 2.0.6
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -21,7 +21,6 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  meta: ^1.3.0
   pedantic: ^1.10.0
   video_player_platform_interface: ">=4.2.0 <6.0.0"
 


### PR DESCRIPTION
Flutter re-exports everything from meta that we actually use, and all plugins by definition require Flutter, so there's no need to use `meta` instead of Flutter to access common annotations (e.g., immutable, visibleForTesting).

This removes all use of `meta`, as well as dependencies on the package, from all plugins.

Fixes https://github.com/flutter/flutter/issues/95658

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
