### PR TITLE
[plugin_platform_interface] Fix 'verify' for Fakes

### DIFF
--- a/packages/plugin_platform_interface/CHANGELOG.md
+++ b/packages/plugin_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.1
+
+* Fixes `verify` to work with fake objects, not just `Mock`.
+
 ## 2.1.0
 
 * Introduce `verify`, which prevents use of `const Object()` as instance token.

--- a/packages/plugin_platform_interface/CHANGELOG.md
+++ b/packages/plugin_platform_interface/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.1.1
 
-* Fixes `verify` to work with fake objects, not just `Mock`.
+* Fixes `verify` to work with fake objects, not just mocks.
 
 ## 2.1.0
 

--- a/packages/plugin_platform_interface/lib/plugin_platform_interface.dart
+++ b/packages/plugin_platform_interface/lib/plugin_platform_interface.dart
@@ -60,10 +60,7 @@ abstract class PlatformInterface {
   /// This is implemented as a static method so that it cannot be overridden
   /// with `noSuchMethod`.
   static void verify(PlatformInterface instance, Object token) {
-    if (identical(instance._instanceToken, const Object())) {
-      throw AssertionError('`const Object()` cannot be used as the token.');
-    }
-    _verify(instance, token);
+    _verify(instance, token, preventConstObject: true);
   }
 
   /// Performs the same checks as `verify` but without throwing an
@@ -71,10 +68,14 @@ abstract class PlatformInterface {
   ///
   /// This method will be deprecated in a future release.
   static void verifyToken(PlatformInterface instance, Object token) {
-    _verify(instance, token);
+    _verify(instance, token, preventConstObject: false);
   }
 
-  static void _verify(PlatformInterface instance, Object token) {
+  static void _verify(
+    PlatformInterface instance,
+    Object token, {
+    required bool preventConstObject,
+  }) {
     if (instance is MockPlatformInterfaceMixin) {
       bool assertionsEnabled = false;
       assert(() {
@@ -87,6 +88,10 @@ abstract class PlatformInterface {
       }
       return;
     }
+    if (preventConstObject &&
+        identical(instance._instanceToken, const Object())) {
+      throw AssertionError('`const Object()` cannot be used as the token.');
+    }
     if (!identical(token, instance._instanceToken)) {
       throw AssertionError(
           'Platform interfaces must not be implemented with `implements`');
@@ -94,7 +99,8 @@ abstract class PlatformInterface {
   }
 }
 
-/// A [PlatformInterface] mixin that can be combined with mockito's `Mock`.
+/// A [PlatformInterface] mixin that can be combined with fake or mock objects,
+/// such as test's `Fake` or mockito's `Mock`.
 ///
 /// It passes the [PlatformInterface.verify] check even though it isn't
 /// using `extends`.

--- a/packages/plugin_platform_interface/pubspec.yaml
+++ b/packages/plugin_platform_interface/pubspec.yaml
@@ -15,7 +15,7 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 # be done when absolutely necessary and after the ecosystem has already migrated to 2.X.Y version
 # that is forward compatible with 3.0.0 (ideally the ecosystem have migrated to depend on:
 # `plugin_platform_interface: >=2.X.Y <4.0.0`).
-version: 2.1.0
+version: 2.1.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/plugin_platform_interface/test/plugin_platform_interface_test.dart
+++ b/packages/plugin_platform_interface/test/plugin_platform_interface_test.dart
@@ -24,6 +24,10 @@ class ImplementsSamplePluginPlatformUsingMockPlatformInterfaceMixin extends Mock
     with MockPlatformInterfaceMixin
     implements SamplePluginPlatform {}
 
+class ImplementsSamplePluginPlatformUsingFakePlatformInterfaceMixin extends Fake
+    with MockPlatformInterfaceMixin
+    implements SamplePluginPlatform {}
+
 class ExtendsSamplePluginPlatform extends SamplePluginPlatform {}
 
 class ConstTokenPluginPlatform extends PlatformInterface {
@@ -71,6 +75,12 @@ void main() {
       final SamplePluginPlatform mock =
           ImplementsSamplePluginPlatformUsingMockPlatformInterfaceMixin();
       SamplePluginPlatform.instance = mock;
+    });
+
+    test('allows faking with `implements`', () {
+      final SamplePluginPlatform fake =
+          ImplementsSamplePluginPlatformUsingFakePlatformInterfaceMixin();
+      SamplePluginPlatform.instance = fake;
     });
 
     test('allows extending', () {


### PR DESCRIPTION
The new `verify` method worked with `Mock` (since `_instanceToken`
returns a stub function in that case), but not `Fake` or a manual fake
since it was unconditionally accessing `_instanceToken`. This fixes that
new check to be gated behind the `MockPlatformInterfaceMixin` test, and
adds a unit test that covers `Fake` so this can't regress in the future.

Fixes post-publish breakage in the tree.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
