### PR TITLE
[camera_platform_interface] Fix asynchronous exceptions handling of the `initializeCamera` method

### DIFF
--- a/packages/camera/camera_platform_interface/CHANGELOG.md
+++ b/packages/camera/camera_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.5
+
+* Fixed asynchronous exceptions handling of the `initializeCamera` method.
+
 ## 2.1.4
 
 * Removes dependency on `meta`.

--- a/packages/camera/camera_platform_interface/CHANGELOG.md
+++ b/packages/camera/camera_platform_interface/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.1.5
 
-* Fixed asynchronous exceptions handling of the `initializeCamera` method.
+* Fixes asynchronous exceptions handling of the `initializeCamera` method.
 
 ## 2.1.4
 

--- a/packages/camera/camera_platform_interface/lib/src/method_channel/method_channel_camera.dart
+++ b/packages/camera/camera_platform_interface/lib/src/method_channel/method_channel_camera.dart
@@ -127,7 +127,7 @@ class MethodChannelCamera extends CameraPlatform {
         'imageFormatGroup': imageFormatGroup.name(),
       },
     ).catchError(
-      (Object error, StackTrace stackTrace) async {
+      (Object error, StackTrace stackTrace) {
         if (error is! PlatformException) {
           throw error;
         }

--- a/packages/camera/camera_platform_interface/lib/src/method_channel/method_channel_camera.dart
+++ b/packages/camera/camera_platform_interface/lib/src/method_channel/method_channel_camera.dart
@@ -126,6 +126,16 @@ class MethodChannelCamera extends CameraPlatform {
         'cameraId': cameraId,
         'imageFormatGroup': imageFormatGroup.name(),
       },
+    ).catchError(
+      (Object error, StackTrace stackTrace) async {
+        if (error is! PlatformException) {
+          throw error;
+        }
+        _completer.completeError(
+          CameraException(error.code, error.message),
+          stackTrace,
+        );
+      },
     );
 
     return _completer.future;

--- a/packages/camera/camera_platform_interface/pubspec.yaml
+++ b/packages/camera/camera_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/master/packages/camera/camer
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.1.4
+version: 2.1.5
 
 environment:
   sdk: '>=2.12.0 <3.0.0'

--- a/packages/camera/camera_platform_interface/test/method_channel/method_channel_camera_test.dart
+++ b/packages/camera/camera_platform_interface/test/method_channel/method_channel_camera_test.dart
@@ -126,6 +126,33 @@ void main() {
         );
       });
 
+      test(
+          'Should throw CameraException when initialize throws a PlatformException',
+          () {
+        // Arrange
+        MethodChannelMock(
+            channelName: 'plugins.flutter.io/camera',
+            methods: <String, dynamic>{
+              'initialize': PlatformException(
+                code: 'TESTING_ERROR_CODE',
+                message: 'Mock error message used during testing.',
+              )
+            });
+        final MethodChannelCamera camera = MethodChannelCamera();
+
+        // Act
+        expect(
+          () => camera.initializeCamera(0),
+          throwsA(
+            isA<CameraException>()
+                .having(
+                    (CameraException e) => e.code, 'code', 'TESTING_ERROR_CODE')
+                .having((CameraException e) => e.description, 'description',
+                    'Mock error message used during testing.'),
+          ),
+        );
+      });
+
       test('Should send initialization data', () async {
         // Arrange
         final MethodChannelMock cameraMockChannel = MethodChannelMock(

--- a/packages/camera/camera_platform_interface/test/method_channel/method_channel_camera_test.dart
+++ b/packages/camera/camera_platform_interface/test/method_channel/method_channel_camera_test.dart
@@ -127,31 +127,36 @@ void main() {
       });
 
       test(
-          'Should throw CameraException when initialize throws a PlatformException',
-          () {
-        // Arrange
-        MethodChannelMock(
+        'Should throw CameraException when initialize throws a PlatformException',
+        () {
+          // Arrange
+          MethodChannelMock(
             channelName: 'plugins.flutter.io/camera',
             methods: <String, dynamic>{
               'initialize': PlatformException(
                 code: 'TESTING_ERROR_CODE',
                 message: 'Mock error message used during testing.',
               )
-            });
-        final MethodChannelCamera camera = MethodChannelCamera();
+            },
+          );
+          final MethodChannelCamera camera = MethodChannelCamera();
 
-        // Act
-        expect(
-          () => camera.initializeCamera(0),
-          throwsA(
-            isA<CameraException>()
-                .having(
-                    (CameraException e) => e.code, 'code', 'TESTING_ERROR_CODE')
-                .having((CameraException e) => e.description, 'description',
-                    'Mock error message used during testing.'),
-          ),
-        );
-      });
+          // Act
+          expect(
+            () => camera.initializeCamera(0),
+            throwsA(
+              isA<CameraException>()
+                  .having((CameraException e) => e.code, 'code',
+                      'TESTING_ERROR_CODE')
+                  .having(
+                    (CameraException e) => e.description,
+                    'description',
+                    'Mock error message used during testing.',
+                  ),
+            ),
+          );
+        },
+      );
 
       test('Should send initialization data', () async {
         // Arrange


### PR DESCRIPTION
More details here https://github.com/flutter/flutter/issues/96405. The problem is that we are not using `await` for `invokeMapMethod` in the `MethodChannelCamera.initializeCamera` method:
https://github.com/flutter/plugins/blob/9aca084f4e02b8a887130e3a8cced87fb218cbf0/packages/camera/camera_platform_interface/lib/src/method_channel/method_channel_camera.dart#L118-L132
The solution to is to asynchronously catch `PlatformException` and passing it to `_completer`.

Fix https://github.com/flutter/flutter/issues/96405

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
