### PR TITLE
[camera]call engine API in main thread to fix a crash

### DIFF
--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.9.4+6
 
-* Fixed a crash in iOS when using image stream due to calling Flutter engine API on non-main thread. 
+* Fixes a crash in iOS when using image stream due to calling Flutter engine API on non-main thread. 
 
 ## 0.9.4+5
 

--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,4 +1,8 @@
-##  0.9.4+5
+## 0.9.4+6
+
+* Fixed a crash in iOS when using image stream due to calling Flutter engine API on non-main thread. 
+
+## 0.9.4+5
 
 * Fixes bug where calling a method after the camera was closed resulted in a Java `IllegalStateException` exception.
 * Fixes integration tests.

--- a/packages/camera/camera/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/camera/camera/example/ios/Runner.xcodeproj/project.pbxproj
@@ -20,6 +20,9 @@
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		E0C6E2002770F01A00EA6AA3 /* ThreadSafeMethodChannelTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E0C6E1FD2770F01A00EA6AA3 /* ThreadSafeMethodChannelTests.m */; };
+		E0C6E2012770F01A00EA6AA3 /* ThreadSafeTextureRegistryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E0C6E1FE2770F01A00EA6AA3 /* ThreadSafeTextureRegistryTests.m */; };
+		E0C6E2022770F01A00EA6AA3 /* ThreadSafeEventChannelTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E0C6E1FF2770F01A00EA6AA3 /* ThreadSafeEventChannelTests.m */; };
 		E487C86026D686A10034AC92 /* CameraPreviewPauseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E487C85F26D686A10034AC92 /* CameraPreviewPauseTests.m */; };
 		F6EE622F2710A6FC00905E4A /* MockFLTThreadSafeFlutterResult.m in Sources */ = {isa = PBXBuildFile; fileRef = F6EE622E2710A6FC00905E4A /* MockFLTThreadSafeFlutterResult.m */; };
 /* End PBXBuildFile section */
@@ -74,6 +77,9 @@
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9C5CC6CAD53AD388B2694F3A /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		A24F9E418BA48BCC7409B117 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
+		E0C6E1FD2770F01A00EA6AA3 /* ThreadSafeMethodChannelTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ThreadSafeMethodChannelTests.m; sourceTree = "<group>"; };
+		E0C6E1FE2770F01A00EA6AA3 /* ThreadSafeTextureRegistryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ThreadSafeTextureRegistryTests.m; sourceTree = "<group>"; };
+		E0C6E1FF2770F01A00EA6AA3 /* ThreadSafeEventChannelTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ThreadSafeEventChannelTests.m; sourceTree = "<group>"; };
 		E487C85F26D686A10034AC92 /* CameraPreviewPauseTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CameraPreviewPauseTests.m; sourceTree = "<group>"; };
 		F63F9EED27143B19002479BF /* MockFLTThreadSafeFlutterResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MockFLTThreadSafeFlutterResult.h; sourceTree = "<group>"; };
 		F6EE622E2710A6FC00905E4A /* MockFLTThreadSafeFlutterResult.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MockFLTThreadSafeFlutterResult.m; sourceTree = "<group>"; };
@@ -107,6 +113,9 @@
 				03BB766C2665316900CE5A93 /* Info.plist */,
 				033B94BD269C40A200B4DF97 /* CameraMethodChannelTests.m */,
 				03F6F8B126CBB4670024B8D3 /* ThreadSafeFlutterResultTests.m */,
+				E0C6E1FF2770F01A00EA6AA3 /* ThreadSafeEventChannelTests.m */,
+				E0C6E1FD2770F01A00EA6AA3 /* ThreadSafeMethodChannelTests.m */,
+				E0C6E1FE2770F01A00EA6AA3 /* ThreadSafeTextureRegistryTests.m */,
 				E487C85F26D686A10034AC92 /* CameraPreviewPauseTests.m */,
 				F6EE622E2710A6FC00905E4A /* MockFLTThreadSafeFlutterResult.m */,
 				F63F9EED27143B19002479BF /* MockFLTThreadSafeFlutterResult.h */,
@@ -239,7 +248,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1100;
+				LastUpgradeCheck = 1300;
 				ORGANIZATIONNAME = "The Flutter Authors";
 				TargetAttributes = {
 					03BB76672665316900CE5A93 = {
@@ -378,6 +387,9 @@
 				E487C86026D686A10034AC92 /* CameraPreviewPauseTests.m in Sources */,
 				F6EE622F2710A6FC00905E4A /* MockFLTThreadSafeFlutterResult.m in Sources */,
 				334733EA2668111C00DCC49E /* CameraOrientationTests.m in Sources */,
+				E0C6E2022770F01A00EA6AA3 /* ThreadSafeEventChannelTests.m in Sources */,
+				E0C6E2012770F01A00EA6AA3 /* ThreadSafeTextureRegistryTests.m in Sources */,
+				E0C6E2002770F01A00EA6AA3 /* ThreadSafeMethodChannelTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/packages/camera/camera/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/camera/camera/example/ios/Runner.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		E01EE4A82799F3A5008C1950 /* QueueHelperTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E01EE4A72799F3A5008C1950 /* QueueHelperTests.m */; };
 		E0C6E2002770F01A00EA6AA3 /* ThreadSafeMethodChannelTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E0C6E1FD2770F01A00EA6AA3 /* ThreadSafeMethodChannelTests.m */; };
 		E0C6E2012770F01A00EA6AA3 /* ThreadSafeTextureRegistryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E0C6E1FE2770F01A00EA6AA3 /* ThreadSafeTextureRegistryTests.m */; };
 		E0C6E2022770F01A00EA6AA3 /* ThreadSafeEventChannelTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E0C6E1FF2770F01A00EA6AA3 /* ThreadSafeEventChannelTests.m */; };
@@ -77,6 +78,7 @@
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9C5CC6CAD53AD388B2694F3A /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		A24F9E418BA48BCC7409B117 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
+		E01EE4A72799F3A5008C1950 /* QueueHelperTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QueueHelperTests.m; sourceTree = "<group>"; };
 		E0C6E1FD2770F01A00EA6AA3 /* ThreadSafeMethodChannelTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ThreadSafeMethodChannelTests.m; sourceTree = "<group>"; };
 		E0C6E1FE2770F01A00EA6AA3 /* ThreadSafeTextureRegistryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ThreadSafeTextureRegistryTests.m; sourceTree = "<group>"; };
 		E0C6E1FF2770F01A00EA6AA3 /* ThreadSafeEventChannelTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ThreadSafeEventChannelTests.m; sourceTree = "<group>"; };
@@ -116,6 +118,7 @@
 				E0C6E1FF2770F01A00EA6AA3 /* ThreadSafeEventChannelTests.m */,
 				E0C6E1FD2770F01A00EA6AA3 /* ThreadSafeMethodChannelTests.m */,
 				E0C6E1FE2770F01A00EA6AA3 /* ThreadSafeTextureRegistryTests.m */,
+				E01EE4A72799F3A5008C1950 /* QueueHelperTests.m */,
 				E487C85F26D686A10034AC92 /* CameraPreviewPauseTests.m */,
 				F6EE622E2710A6FC00905E4A /* MockFLTThreadSafeFlutterResult.m */,
 				F63F9EED27143B19002479BF /* MockFLTThreadSafeFlutterResult.h */,
@@ -390,6 +393,7 @@
 				E0C6E2022770F01A00EA6AA3 /* ThreadSafeEventChannelTests.m in Sources */,
 				E0C6E2012770F01A00EA6AA3 /* ThreadSafeTextureRegistryTests.m in Sources */,
 				E0C6E2002770F01A00EA6AA3 /* ThreadSafeMethodChannelTests.m in Sources */,
+				E01EE4A82799F3A5008C1950 /* QueueHelperTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/packages/camera/camera/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/packages/camera/camera/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1100"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/packages/camera/camera/example/ios/RunnerTests/QueueHelperTests.m
+++ b/packages/camera/camera/example/ios/RunnerTests/QueueHelperTests.m
@@ -1,0 +1,38 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@import camera;
+@import XCTest;
+
+@interface QueueHelperTests : XCTestCase
+
+@end
+
+@implementation QueueHelperTests
+
+- (void)testShouldStayOnMainQueueIfCalledFromMainQueue {
+  XCTestExpectation *expectation =
+      [self expectationWithDescription:@"Block must be run on the main queue."];
+  [QueueHelper ensureToRunOnMainQueue:^{
+    if (NSThread.isMainThread) {
+      [expectation fulfill];
+    }
+  }];
+  [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+- (void)testShouldDispatchToMainQueueIfCalledFromBackgroundQueue {
+  XCTestExpectation *expectation =
+      [self expectationWithDescription:@"Block must be run on the main queue."];
+  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    [QueueHelper ensureToRunOnMainQueue:^{
+      if (NSThread.isMainThread) {
+        [expectation fulfill];
+      }
+    }];
+  });
+  [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+@end

--- a/packages/camera/camera/example/ios/RunnerTests/ThreadSafeEventChannelTests.m
+++ b/packages/camera/camera/example/ios/RunnerTests/ThreadSafeEventChannelTests.m
@@ -7,57 +7,56 @@
 #import <OCMock/OCMock.h>
 
 @interface ThreadSafeEventChannelTests : XCTestCase
-@property(nonatomic, strong) FlutterEventChannel *mockEventChannel;
-@property(nonatomic, strong) FLTThreadSafeEventChannel *threadSafeEventChannel;
 @end
 
 @implementation ThreadSafeEventChannelTests
 
-- (void)setUp {
-  [super setUp];
-  _mockEventChannel = OCMClassMock([FlutterEventChannel class]);
-  _threadSafeEventChannel =
-      [[FLTThreadSafeEventChannel alloc] initWithEventChannel:_mockEventChannel];
-}
-
 - (void)testSetStreamHandler_shouldStayOnMainThreadIfCalledFromMainThread {
+  FlutterEventChannel *mockEventChannel = OCMClassMock([FlutterEventChannel class]);
+  FLTThreadSafeEventChannel *threadSafeEventChannel =
+      [[FLTThreadSafeEventChannel alloc] initWithEventChannel:mockEventChannel];
+
   XCTestExpectation *mainThreadExpectation = [[XCTestExpectation alloc]
       initWithDescription:@"setStreamHandler must be called on the main thread"];
   XCTestExpectation *mainThreadCompletionExpectation = [[XCTestExpectation alloc]
       initWithDescription:@"setStreamHandler's completion block must be called on the main thread"];
-  OCMStub([self.mockEventChannel setStreamHandler:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
+  OCMStub([mockEventChannel setStreamHandler:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
     if (NSThread.isMainThread) {
       [mainThreadExpectation fulfill];
     }
   });
 
-  [self.threadSafeEventChannel setStreamHandler:nil
-                                     completion:^{
-                                       if (NSThread.isMainThread) {
-                                         [mainThreadCompletionExpectation fulfill];
-                                       }
-                                     }];
+  [threadSafeEventChannel setStreamHandler:nil
+                                completion:^{
+                                  if (NSThread.isMainThread) {
+                                    [mainThreadCompletionExpectation fulfill];
+                                  }
+                                }];
   [self waitForExpectations:@[ mainThreadExpectation, mainThreadCompletionExpectation ] timeout:1];
 }
 
 - (void)testSetStreamHandler_shouldDispatchToMainThreadIfCalledFromBackgroundThread {
+  FlutterEventChannel *mockEventChannel = OCMClassMock([FlutterEventChannel class]);
+  FLTThreadSafeEventChannel *threadSafeEventChannel =
+      [[FLTThreadSafeEventChannel alloc] initWithEventChannel:mockEventChannel];
+
   XCTestExpectation *mainThreadExpectation = [[XCTestExpectation alloc]
       initWithDescription:@"setStreamHandler must be called on the main thread"];
   XCTestExpectation *mainThreadCompletionExpectation = [[XCTestExpectation alloc]
       initWithDescription:@"setStreamHandler's completion block must be called on the main thread"];
-  OCMStub([self.mockEventChannel setStreamHandler:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
+  OCMStub([mockEventChannel setStreamHandler:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
     if (NSThread.isMainThread) {
       [mainThreadExpectation fulfill];
     }
   });
 
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-    [self.threadSafeEventChannel setStreamHandler:nil
-                                       completion:^{
-                                         if (NSThread.isMainThread) {
-                                           [mainThreadCompletionExpectation fulfill];
-                                         }
-                                       }];
+    [threadSafeEventChannel setStreamHandler:nil
+                                  completion:^{
+                                    if (NSThread.isMainThread) {
+                                      [mainThreadCompletionExpectation fulfill];
+                                    }
+                                  }];
   });
   [self waitForExpectations:@[
     mainThreadExpectation,

--- a/packages/camera/camera/example/ios/RunnerTests/ThreadSafeEventChannelTests.m
+++ b/packages/camera/camera/example/ios/RunnerTests/ThreadSafeEventChannelTests.m
@@ -1,0 +1,63 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@import camera;
+@import XCTest;
+#import <OCMock/OCMock.h>
+
+@interface ThreadSafeEventChannelTests : XCTestCase
+@property(nonatomic, strong) FLTThreadSafeEventChannel *channel;
+@property(nonatomic, strong) XCTestExpectation *mainThreadExpectation;
+@property(nonatomic, strong) XCTestExpectation *mainThreadCompletionExpectation;
+@end
+
+@implementation ThreadSafeEventChannelTests
+
+- (void)setUp {
+  [super setUp];
+  id mockEventChannel = OCMClassMock([FlutterEventChannel class]);
+
+  _mainThreadExpectation = [[XCTestExpectation alloc]
+      initWithDescription:@"setStreamHandler must be called on the main thread"];
+  _mainThreadCompletionExpectation = [[XCTestExpectation alloc]
+      initWithDescription:@"setStreamHandler's completion block must be called on the main thread"];
+  _channel = [[FLTThreadSafeEventChannel alloc] initWithEventChannel:mockEventChannel];
+
+  OCMStub([mockEventChannel setStreamHandler:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
+    if (NSThread.isMainThread) {
+      [self.mainThreadExpectation fulfill];
+    }
+  });
+}
+
+- (void)testSetStreamHandler_shouldStayOnMainThreadIfCalledFromMainThread {
+  __weak XCTestExpectation *mainThreadCompletionExpectation = self.mainThreadCompletionExpectation;
+  [self.channel setStreamHandler:nil
+                      completion:^{
+                        if (NSThread.isMainThread) {
+                          [mainThreadCompletionExpectation fulfill];
+                        }
+                      }];
+  [self waitForExpectations:@[ self.mainThreadExpectation, self.mainThreadCompletionExpectation ]
+                    timeout:1];
+}
+
+- (void)testSetStreamHandler_shouldDispatchToMainThreadIfCalledFromBackgroundThread {
+  __weak XCTestExpectation *mainThreadCompletionExpectation = self.mainThreadCompletionExpectation;
+  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    [self.channel setStreamHandler:nil
+                        completion:^{
+                          if (NSThread.isMainThread) {
+                            [mainThreadCompletionExpectation fulfill];
+                          }
+                        }];
+  });
+  [self waitForExpectations:@[
+    self.mainThreadExpectation,
+    self.mainThreadCompletionExpectation,
+  ]
+                    timeout:1];
+}
+
+@end

--- a/packages/camera/camera/example/ios/RunnerTests/ThreadSafeEventChannelTests.m
+++ b/packages/camera/camera/example/ios/RunnerTests/ThreadSafeEventChannelTests.m
@@ -16,10 +16,11 @@
   FLTThreadSafeEventChannel *threadSafeEventChannel =
       [[FLTThreadSafeEventChannel alloc] initWithEventChannel:mockEventChannel];
 
-  XCTestExpectation *mainThreadExpectation = [[XCTestExpectation alloc]
-      initWithDescription:@"setStreamHandler must be called on the main thread"];
-  XCTestExpectation *mainThreadCompletionExpectation = [[XCTestExpectation alloc]
-      initWithDescription:@"setStreamHandler's completion block must be called on the main thread"];
+  XCTestExpectation *mainThreadExpectation =
+      [self expectationWithDescription:@"setStreamHandler must be called on the main thread"];
+  XCTestExpectation *mainThreadCompletionExpectation =
+      [self expectationWithDescription:
+                @"setStreamHandler's completion block must be called on the main thread"];
   OCMStub([mockEventChannel setStreamHandler:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
     if (NSThread.isMainThread) {
       [mainThreadExpectation fulfill];
@@ -32,7 +33,7 @@
                                     [mainThreadCompletionExpectation fulfill];
                                   }
                                 }];
-  [self waitForExpectations:@[ mainThreadExpectation, mainThreadCompletionExpectation ] timeout:1];
+  [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
 - (void)testSetStreamHandler_shouldDispatchToMainThreadIfCalledFromBackgroundThread {
@@ -40,10 +41,11 @@
   FLTThreadSafeEventChannel *threadSafeEventChannel =
       [[FLTThreadSafeEventChannel alloc] initWithEventChannel:mockEventChannel];
 
-  XCTestExpectation *mainThreadExpectation = [[XCTestExpectation alloc]
-      initWithDescription:@"setStreamHandler must be called on the main thread"];
-  XCTestExpectation *mainThreadCompletionExpectation = [[XCTestExpectation alloc]
-      initWithDescription:@"setStreamHandler's completion block must be called on the main thread"];
+  XCTestExpectation *mainThreadExpectation =
+      [self expectationWithDescription:@"setStreamHandler must be called on the main thread"];
+  XCTestExpectation *mainThreadCompletionExpectation =
+      [self expectationWithDescription:
+                @"setStreamHandler's completion block must be called on the main thread"];
   OCMStub([mockEventChannel setStreamHandler:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
     if (NSThread.isMainThread) {
       [mainThreadExpectation fulfill];
@@ -58,11 +60,7 @@
                                     }
                                   }];
   });
-  [self waitForExpectations:@[
-    mainThreadExpectation,
-    mainThreadCompletionExpectation,
-  ]
-                    timeout:1];
+  [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
 @end

--- a/packages/camera/camera/example/ios/RunnerTests/ThreadSafeFlutterResultTests.m
+++ b/packages/camera/camera/example/ios/RunnerTests/ThreadSafeFlutterResultTests.m
@@ -10,8 +10,7 @@
 
 @implementation ThreadSafeFlutterResultTests
 - (void)testAsyncSendSuccess_ShouldCallResultOnMainThread {
-  XCTestExpectation* expectation =
-      [[XCTestExpectation alloc] initWithDescription:@"Result finished"];
+  XCTestExpectation* expectation = [self expectationWithDescription:@"Result finished"];
 
   FLTThreadSafeFlutterResult* threadSafeFlutterResult =
       [[FLTThreadSafeFlutterResult alloc] initWithResult:^(id _Nullable result) {
@@ -23,12 +22,11 @@
     [threadSafeFlutterResult sendSuccess];
   });
 
-  [self waitForExpectations:[NSArray arrayWithObject:expectation] timeout:1];
+  [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
 - (void)testSyncSendSuccess_ShouldCallResultOnMainThread {
-  XCTestExpectation* expectation =
-      [[XCTestExpectation alloc] initWithDescription:@"Result finished"];
+  XCTestExpectation* expectation = [self expectationWithDescription:@"Result finished"];
 
   FLTThreadSafeFlutterResult* threadSafeFlutterResult =
       [[FLTThreadSafeFlutterResult alloc] initWithResult:^(id _Nullable result) {
@@ -36,12 +34,11 @@
         [expectation fulfill];
       }];
   [threadSafeFlutterResult sendSuccess];
-  [self waitForExpectations:[NSArray arrayWithObject:expectation] timeout:1];
+  [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
 - (void)testSendNotImplemented_ShouldSendNotImplementedToFlutterResult {
-  XCTestExpectation* expectation =
-      [[XCTestExpectation alloc] initWithDescription:@"Result finished"];
+  XCTestExpectation* expectation = [self expectationWithDescription:@"Result finished"];
 
   FLTThreadSafeFlutterResult* threadSafeFlutterResult =
       [[FLTThreadSafeFlutterResult alloc] initWithResult:^(id _Nullable result) {
@@ -53,15 +50,14 @@
     [threadSafeFlutterResult sendNotImplemented];
   });
 
-  [self waitForExpectations:[NSArray arrayWithObject:expectation] timeout:1];
+  [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
 - (void)testSendErrorDetails_ShouldSendErrorToFlutterResult {
   NSString* errorCode = @"errorCode";
   NSString* errorMessage = @"message";
   NSString* errorDetails = @"error details";
-  XCTestExpectation* expectation =
-      [[XCTestExpectation alloc] initWithDescription:@"Result finished"];
+  XCTestExpectation* expectation = [self expectationWithDescription:@"Result finished"];
 
   FLTThreadSafeFlutterResult* threadSafeFlutterResult =
       [[FLTThreadSafeFlutterResult alloc] initWithResult:^(id _Nullable result) {
@@ -77,13 +73,12 @@
     [threadSafeFlutterResult sendErrorWithCode:errorCode message:errorMessage details:errorDetails];
   });
 
-  [self waitForExpectations:[NSArray arrayWithObject:expectation] timeout:1];
+  [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
 - (void)testSendNSError_ShouldSendErrorToFlutterResult {
   NSError* originalError = [[NSError alloc] initWithDomain:NSURLErrorDomain code:404 userInfo:nil];
-  XCTestExpectation* expectation =
-      [[XCTestExpectation alloc] initWithDescription:@"Result finished"];
+  XCTestExpectation* expectation = [self expectationWithDescription:@"Result finished"];
 
   FLTThreadSafeFlutterResult* threadSafeFlutterResult =
       [[FLTThreadSafeFlutterResult alloc] initWithResult:^(id _Nullable result) {
@@ -99,13 +94,12 @@
     [threadSafeFlutterResult sendError:originalError];
   });
 
-  [self waitForExpectations:[NSArray arrayWithObject:expectation] timeout:1];
+  [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
 - (void)testSendResult_ShouldSendResultToFlutterResult {
   NSString* resultData = @"resultData";
-  XCTestExpectation* expectation =
-      [[XCTestExpectation alloc] initWithDescription:@"Result finished"];
+  XCTestExpectation* expectation = [self expectationWithDescription:@"Result finished"];
 
   FLTThreadSafeFlutterResult* threadSafeFlutterResult =
       [[FLTThreadSafeFlutterResult alloc] initWithResult:^(id _Nullable result) {
@@ -117,6 +111,6 @@
     [threadSafeFlutterResult sendSuccessWithData:resultData];
   });
 
-  [self waitForExpectations:[NSArray arrayWithObject:expectation] timeout:1];
+  [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 @end

--- a/packages/camera/camera/example/ios/RunnerTests/ThreadSafeMethodChannelTests.m
+++ b/packages/camera/camera/example/ios/RunnerTests/ThreadSafeMethodChannelTests.m
@@ -16,8 +16,8 @@
   FLTThreadSafeMethodChannel *threadSafeMethodChannel =
       [[FLTThreadSafeMethodChannel alloc] initWithMethodChannel:mockMethodChannel];
 
-  XCTestExpectation *mainThreadExpectation = [[XCTestExpectation alloc]
-      initWithDescription:@"invokeMethod must be called on the main thread"];
+  XCTestExpectation *mainThreadExpectation =
+      [self expectationWithDescription:@"invokeMethod must be called on the main thread"];
 
   OCMStub([mockMethodChannel invokeMethod:[OCMArg any] arguments:[OCMArg any]])
       .andDo(^(NSInvocation *invocation) {
@@ -27,7 +27,7 @@
       });
 
   [threadSafeMethodChannel invokeMethod:@"foo" arguments:nil];
-  [self waitForExpectations:@[ mainThreadExpectation ] timeout:1];
+  [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
 - (void)testInvokeMethod__shouldDispatchToMainThreadIfCalledFromBackgroundThread {
@@ -35,8 +35,8 @@
   FLTThreadSafeMethodChannel *threadSafeMethodChannel =
       [[FLTThreadSafeMethodChannel alloc] initWithMethodChannel:mockMethodChannel];
 
-  XCTestExpectation *mainThreadExpectation = [[XCTestExpectation alloc]
-      initWithDescription:@"invokeMethod must be called on the main thread"];
+  XCTestExpectation *mainThreadExpectation =
+      [self expectationWithDescription:@"invokeMethod must be called on the main thread"];
 
   OCMStub([mockMethodChannel invokeMethod:[OCMArg any] arguments:[OCMArg any]])
       .andDo(^(NSInvocation *invocation) {
@@ -48,7 +48,7 @@
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
     [threadSafeMethodChannel invokeMethod:@"foo" arguments:nil];
   });
-  [self waitForExpectations:@[ mainThreadExpectation ] timeout:1];
+  [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
 @end

--- a/packages/camera/camera/example/ios/RunnerTests/ThreadSafeMethodChannelTests.m
+++ b/packages/camera/camera/example/ios/RunnerTests/ThreadSafeMethodChannelTests.m
@@ -7,39 +7,38 @@
 #import <OCMock/OCMock.h>
 
 @interface ThreadSafeMethodChannelTests : XCTestCase
-@property(nonatomic, strong) FlutterMethodChannel *mockMethodChannel;
-@property(nonatomic, strong) FLTThreadSafeMethodChannel *threadSafeMethodChannel;
 @end
 
 @implementation ThreadSafeMethodChannelTests
 
-- (void)setUp {
-  [super setUp];
-  _mockMethodChannel = OCMClassMock([FlutterMethodChannel class]);
-  _threadSafeMethodChannel =
-      [[FLTThreadSafeMethodChannel alloc] initWithMethodChannel:_mockMethodChannel];
-}
-
 - (void)testInvokeMethod_shouldStayOnMainThreadIfCalledFromMainThread {
+  FlutterMethodChannel *mockMethodChannel = OCMClassMock([FlutterMethodChannel class]);
+  FLTThreadSafeMethodChannel *threadSafeMethodChannel =
+      [[FLTThreadSafeMethodChannel alloc] initWithMethodChannel:mockMethodChannel];
+
   XCTestExpectation *mainThreadExpectation = [[XCTestExpectation alloc]
       initWithDescription:@"invokeMethod must be called on the main thread"];
 
-  OCMStub([self.mockMethodChannel invokeMethod:[OCMArg any] arguments:[OCMArg any]])
+  OCMStub([mockMethodChannel invokeMethod:[OCMArg any] arguments:[OCMArg any]])
       .andDo(^(NSInvocation *invocation) {
         if (NSThread.isMainThread) {
           [mainThreadExpectation fulfill];
         }
       });
 
-  [self.threadSafeMethodChannel invokeMethod:@"foo" arguments:nil];
+  [threadSafeMethodChannel invokeMethod:@"foo" arguments:nil];
   [self waitForExpectations:@[ mainThreadExpectation ] timeout:1];
 }
 
 - (void)testInvokeMethod__shouldDispatchToMainThreadIfCalledFromBackgroundThread {
+  FlutterMethodChannel *mockMethodChannel = OCMClassMock([FlutterMethodChannel class]);
+  FLTThreadSafeMethodChannel *threadSafeMethodChannel =
+      [[FLTThreadSafeMethodChannel alloc] initWithMethodChannel:mockMethodChannel];
+
   XCTestExpectation *mainThreadExpectation = [[XCTestExpectation alloc]
       initWithDescription:@"invokeMethod must be called on the main thread"];
 
-  OCMStub([self.mockMethodChannel invokeMethod:[OCMArg any] arguments:[OCMArg any]])
+  OCMStub([mockMethodChannel invokeMethod:[OCMArg any] arguments:[OCMArg any]])
       .andDo(^(NSInvocation *invocation) {
         if (NSThread.isMainThread) {
           [mainThreadExpectation fulfill];
@@ -47,7 +46,7 @@
       });
 
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-    [self.threadSafeMethodChannel invokeMethod:@"foo" arguments:nil];
+    [threadSafeMethodChannel invokeMethod:@"foo" arguments:nil];
   });
   [self waitForExpectations:@[ mainThreadExpectation ] timeout:1];
 }

--- a/packages/camera/camera/example/ios/RunnerTests/ThreadSafeMethodChannelTests.m
+++ b/packages/camera/camera/example/ios/RunnerTests/ThreadSafeMethodChannelTests.m
@@ -7,39 +7,49 @@
 #import <OCMock/OCMock.h>
 
 @interface ThreadSafeMethodChannelTests : XCTestCase
-@property(nonatomic, strong) FLTThreadSafeMethodChannel *channel;
-@property(nonatomic, strong) XCTestExpectation *mainThreadExpectation;
+@property(nonatomic, strong) FlutterMethodChannel *mockMethodChannel;
+@property(nonatomic, strong) FLTThreadSafeMethodChannel *threadSafeMethodChannel;
 @end
 
 @implementation ThreadSafeMethodChannelTests
 
 - (void)setUp {
   [super setUp];
-  id mockMethodChannel = OCMClassMock([FlutterMethodChannel class]);
-
-  _mainThreadExpectation = [[XCTestExpectation alloc]
-      initWithDescription:@"invokeMethod must be called on the main thread"];
-  _channel = [[FLTThreadSafeMethodChannel alloc] initWithMethodChannel:mockMethodChannel];
-
-  OCMStub([mockMethodChannel invokeMethod:[OCMArg any] arguments:[OCMArg any]])
-      .andDo(^(NSInvocation *invocation) {
-        if (NSThread.isMainThread) {
-          [self.mainThreadExpectation fulfill];
-        }
-      });
+  _mockMethodChannel = OCMClassMock([FlutterMethodChannel class]);
+  _threadSafeMethodChannel =
+      [[FLTThreadSafeMethodChannel alloc] initWithMethodChannel:_mockMethodChannel];
 }
 
 - (void)testInvokeMethod_shouldStayOnMainThreadIfCalledFromMainThread {
-  [self.channel invokeMethod:@"foo" arguments:nil];
+  XCTestExpectation *mainThreadExpectation = [[XCTestExpectation alloc]
+      initWithDescription:@"invokeMethod must be called on the main thread"];
 
-  [self waitForExpectations:@[ self.mainThreadExpectation ] timeout:1];
+  OCMStub([self.mockMethodChannel invokeMethod:[OCMArg any] arguments:[OCMArg any]])
+      .andDo(^(NSInvocation *invocation) {
+        if (NSThread.isMainThread) {
+          [mainThreadExpectation fulfill];
+        }
+      });
+
+  [self.threadSafeMethodChannel invokeMethod:@"foo" arguments:nil];
+  [self waitForExpectations:@[ mainThreadExpectation ] timeout:1];
 }
 
 - (void)testInvokeMethod__shouldDispatchToMainThreadIfCalledFromBackgroundThread {
+  XCTestExpectation *mainThreadExpectation = [[XCTestExpectation alloc]
+      initWithDescription:@"invokeMethod must be called on the main thread"];
+
+  OCMStub([self.mockMethodChannel invokeMethod:[OCMArg any] arguments:[OCMArg any]])
+      .andDo(^(NSInvocation *invocation) {
+        if (NSThread.isMainThread) {
+          [mainThreadExpectation fulfill];
+        }
+      });
+
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-    [self.channel invokeMethod:@"foo" arguments:nil];
+    [self.threadSafeMethodChannel invokeMethod:@"foo" arguments:nil];
   });
-  [self waitForExpectations:@[ self.mainThreadExpectation ] timeout:1];
+  [self waitForExpectations:@[ mainThreadExpectation ] timeout:1];
 }
 
 @end

--- a/packages/camera/camera/example/ios/RunnerTests/ThreadSafeMethodChannelTests.m
+++ b/packages/camera/camera/example/ios/RunnerTests/ThreadSafeMethodChannelTests.m
@@ -1,0 +1,45 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@import camera;
+@import XCTest;
+#import <OCMock/OCMock.h>
+
+@interface ThreadSafeMethodChannelTests : XCTestCase
+@property(nonatomic, strong) FLTThreadSafeMethodChannel *channel;
+@property(nonatomic, strong) XCTestExpectation *mainThreadExpectation;
+@end
+
+@implementation ThreadSafeMethodChannelTests
+
+- (void)setUp {
+  [super setUp];
+  id mockMethodChannel = OCMClassMock([FlutterMethodChannel class]);
+
+  _mainThreadExpectation = [[XCTestExpectation alloc]
+      initWithDescription:@"invokeMethod must be called on the main thread"];
+  _channel = [[FLTThreadSafeMethodChannel alloc] initWithMethodChannel:mockMethodChannel];
+
+  OCMStub([mockMethodChannel invokeMethod:[OCMArg any] arguments:[OCMArg any]])
+      .andDo(^(NSInvocation *invocation) {
+        if (NSThread.isMainThread) {
+          [self.mainThreadExpectation fulfill];
+        }
+      });
+}
+
+- (void)testInvokeMethod_shouldStayOnMainThreadIfCalledFromMainThread {
+  [self.channel invokeMethod:@"foo" arguments:nil];
+
+  [self waitForExpectations:@[ self.mainThreadExpectation ] timeout:1];
+}
+
+- (void)testInvokeMethod__shouldDispatchToMainThreadIfCalledFromBackgroundThread {
+  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    [self.channel invokeMethod:@"foo" arguments:nil];
+  });
+  [self waitForExpectations:@[ self.mainThreadExpectation ] timeout:1];
+}
+
+@end

--- a/packages/camera/camera/example/ios/RunnerTests/ThreadSafeTextureRegistryTests.m
+++ b/packages/camera/camera/example/ios/RunnerTests/ThreadSafeTextureRegistryTests.m
@@ -1,0 +1,97 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@import camera;
+@import XCTest;
+#import <OCMock/OCMock.h>
+
+@interface ThreadSafeTextureRegistryTests : XCTestCase
+@property(nonatomic, strong) FLTThreadSafeTextureRegistry *registry;
+@property(nonatomic, strong) XCTestExpectation *registerTextureExpectation;
+@property(nonatomic, strong) XCTestExpectation *registerTextureCompletionExpectation;
+@property(nonatomic, strong) XCTestExpectation *unregisterTextureExpectation;
+@property(nonatomic, strong) XCTestExpectation *textureFrameAvailableExpectation;
+
+@end
+
+@implementation ThreadSafeTextureRegistryTests
+
+- (void)setUp {
+  [super setUp];
+  id mockTextureRegistry = OCMProtocolMock(@protocol(FlutterTextureRegistry));
+  _registry = [[FLTThreadSafeTextureRegistry alloc] initWithTextureRegistry:mockTextureRegistry];
+
+  _registerTextureExpectation = [[XCTestExpectation alloc]
+      initWithDescription:@"registerTexture must be called on the main thread"];
+  _unregisterTextureExpectation = [[XCTestExpectation alloc]
+      initWithDescription:@"unregisterTexture must be called on the main thread"];
+  _textureFrameAvailableExpectation = [[XCTestExpectation alloc]
+      initWithDescription:@"textureFrameAvailable must be called on the main thread"];
+  _registerTextureCompletionExpectation = [[XCTestExpectation alloc]
+      initWithDescription:@"registerTexture's completion block must be called on the main thread"];
+
+  OCMStub([mockTextureRegistry registerTexture:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
+    if (NSThread.isMainThread) {
+      [self.registerTextureExpectation fulfill];
+    }
+  });
+
+  OCMStub([mockTextureRegistry unregisterTexture:0]).andDo(^(NSInvocation *invocation) {
+    if (NSThread.isMainThread) {
+      [self.unregisterTextureExpectation fulfill];
+    }
+  });
+
+  OCMStub([mockTextureRegistry textureFrameAvailable:0]).andDo(^(NSInvocation *invocation) {
+    if (NSThread.isMainThread) {
+      [self.textureFrameAvailableExpectation fulfill];
+    }
+  });
+}
+
+- (void)testShouldStayOnMainThreadIfCalledFromMainThread {
+  NSObject<FlutterTexture> *anyTexture = OCMProtocolMock(@protocol(FlutterTexture));
+  __weak XCTestExpectation *registerTextureCompletionExpectation =
+      self.registerTextureCompletionExpectation;
+  [self.registry registerTexture:anyTexture
+                      completion:^(int64_t textureId) {
+                        if (NSThread.isMainThread) {
+                          [registerTextureCompletionExpectation fulfill];
+                        }
+                      }];
+  [self.registry textureFrameAvailable:0];
+  [self.registry unregisterTexture:0];
+  [self waitForExpectations:@[
+    self.registerTextureExpectation,
+    self.unregisterTextureExpectation,
+    self.textureFrameAvailableExpectation,
+    self.registerTextureCompletionExpectation,
+  ]
+                    timeout:1];
+}
+
+- (void)testShouldDispatchToMainThreadIfCalledFromBackgroundThread {
+  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    NSObject<FlutterTexture> *anyTexture = OCMProtocolMock(@protocol(FlutterTexture));
+    __weak XCTestExpectation *registerTextureCompletionExpectation =
+        self.registerTextureCompletionExpectation;
+    [self.registry registerTexture:anyTexture
+                        completion:^(int64_t textureId) {
+                          if (NSThread.isMainThread) {
+                            [registerTextureCompletionExpectation fulfill];
+                          }
+                        }];
+    [self.registry textureFrameAvailable:0];
+    [self.registry unregisterTexture:0];
+  });
+  [self waitForExpectations:@[
+    self.registerTextureExpectation,
+    self.unregisterTextureExpectation,
+    self.textureFrameAvailableExpectation,
+    self.registerTextureCompletionExpectation,
+  ]
+                    timeout:1];
+}
+
+@end

--- a/packages/camera/camera/example/ios/RunnerTests/ThreadSafeTextureRegistryTests.m
+++ b/packages/camera/camera/example/ios/RunnerTests/ThreadSafeTextureRegistryTests.m
@@ -7,89 +7,111 @@
 #import <OCMock/OCMock.h>
 
 @interface ThreadSafeTextureRegistryTests : XCTestCase
-@property(nonatomic, strong) FLTThreadSafeTextureRegistry *registry;
-@property(nonatomic, strong) XCTestExpectation *registerTextureExpectation;
-@property(nonatomic, strong) XCTestExpectation *registerTextureCompletionExpectation;
-@property(nonatomic, strong) XCTestExpectation *unregisterTextureExpectation;
-@property(nonatomic, strong) XCTestExpectation *textureFrameAvailableExpectation;
-
+@property(nonatomic, strong) NSObject<FlutterTextureRegistry> *mockTextureRegistry;
+@property(nonatomic, strong) FLTThreadSafeTextureRegistry *threadSafeTextureRegistry;
 @end
 
 @implementation ThreadSafeTextureRegistryTests
 
 - (void)setUp {
   [super setUp];
-  id mockTextureRegistry = OCMProtocolMock(@protocol(FlutterTextureRegistry));
-  _registry = [[FLTThreadSafeTextureRegistry alloc] initWithTextureRegistry:mockTextureRegistry];
-
-  _registerTextureExpectation = [[XCTestExpectation alloc]
-      initWithDescription:@"registerTexture must be called on the main thread"];
-  _unregisterTextureExpectation = [[XCTestExpectation alloc]
-      initWithDescription:@"unregisterTexture must be called on the main thread"];
-  _textureFrameAvailableExpectation = [[XCTestExpectation alloc]
-      initWithDescription:@"textureFrameAvailable must be called on the main thread"];
-  _registerTextureCompletionExpectation = [[XCTestExpectation alloc]
-      initWithDescription:@"registerTexture's completion block must be called on the main thread"];
-
-  OCMStub([mockTextureRegistry registerTexture:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
-    if (NSThread.isMainThread) {
-      [self.registerTextureExpectation fulfill];
-    }
-  });
-
-  OCMStub([mockTextureRegistry unregisterTexture:0]).andDo(^(NSInvocation *invocation) {
-    if (NSThread.isMainThread) {
-      [self.unregisterTextureExpectation fulfill];
-    }
-  });
-
-  OCMStub([mockTextureRegistry textureFrameAvailable:0]).andDo(^(NSInvocation *invocation) {
-    if (NSThread.isMainThread) {
-      [self.textureFrameAvailableExpectation fulfill];
-    }
-  });
+  _mockTextureRegistry = OCMProtocolMock(@protocol(FlutterTextureRegistry));
+  _threadSafeTextureRegistry =
+      [[FLTThreadSafeTextureRegistry alloc] initWithTextureRegistry:_mockTextureRegistry];
 }
 
 - (void)testShouldStayOnMainThreadIfCalledFromMainThread {
+  XCTestExpectation *registerTextureExpectation = [[XCTestExpectation alloc]
+      initWithDescription:@"registerTexture must be called on the main thread"];
+  XCTestExpectation *unregisterTextureExpectation = [[XCTestExpectation alloc]
+      initWithDescription:@"unregisterTexture must be called on the main thread"];
+  XCTestExpectation *textureFrameAvailableExpectation = [[XCTestExpectation alloc]
+      initWithDescription:@"textureFrameAvailable must be called on the main thread"];
+  XCTestExpectation *registerTextureCompletionExpectation = [[XCTestExpectation alloc]
+      initWithDescription:@"registerTexture's completion block must be called on the main thread"];
+
+  OCMStub([self.mockTextureRegistry registerTexture:[OCMArg any]])
+      .andDo(^(NSInvocation *invocation) {
+        if (NSThread.isMainThread) {
+          [registerTextureExpectation fulfill];
+        }
+      });
+
+  OCMStub([self.mockTextureRegistry unregisterTexture:0]).andDo(^(NSInvocation *invocation) {
+    if (NSThread.isMainThread) {
+      [unregisterTextureExpectation fulfill];
+    }
+  });
+
+  OCMStub([self.mockTextureRegistry textureFrameAvailable:0]).andDo(^(NSInvocation *invocation) {
+    if (NSThread.isMainThread) {
+      [textureFrameAvailableExpectation fulfill];
+    }
+  });
+
   NSObject<FlutterTexture> *anyTexture = OCMProtocolMock(@protocol(FlutterTexture));
-  __weak XCTestExpectation *registerTextureCompletionExpectation =
-      self.registerTextureCompletionExpectation;
-  [self.registry registerTexture:anyTexture
-                      completion:^(int64_t textureId) {
-                        if (NSThread.isMainThread) {
-                          [registerTextureCompletionExpectation fulfill];
-                        }
-                      }];
-  [self.registry textureFrameAvailable:0];
-  [self.registry unregisterTexture:0];
+  [self.threadSafeTextureRegistry registerTexture:anyTexture
+                                       completion:^(int64_t textureId) {
+                                         if (NSThread.isMainThread) {
+                                           [registerTextureCompletionExpectation fulfill];
+                                         }
+                                       }];
+  [self.threadSafeTextureRegistry textureFrameAvailable:0];
+  [self.threadSafeTextureRegistry unregisterTexture:0];
   [self waitForExpectations:@[
-    self.registerTextureExpectation,
-    self.unregisterTextureExpectation,
-    self.textureFrameAvailableExpectation,
-    self.registerTextureCompletionExpectation,
+    registerTextureExpectation,
+    unregisterTextureExpectation,
+    textureFrameAvailableExpectation,
+    registerTextureCompletionExpectation,
   ]
                     timeout:1];
 }
 
 - (void)testShouldDispatchToMainThreadIfCalledFromBackgroundThread {
+  XCTestExpectation *registerTextureExpectation = [[XCTestExpectation alloc]
+      initWithDescription:@"registerTexture must be called on the main thread"];
+  XCTestExpectation *unregisterTextureExpectation = [[XCTestExpectation alloc]
+      initWithDescription:@"unregisterTexture must be called on the main thread"];
+  XCTestExpectation *textureFrameAvailableExpectation = [[XCTestExpectation alloc]
+      initWithDescription:@"textureFrameAvailable must be called on the main thread"];
+  XCTestExpectation *registerTextureCompletionExpectation = [[XCTestExpectation alloc]
+      initWithDescription:@"registerTexture's completion block must be called on the main thread"];
+
+  OCMStub([self.mockTextureRegistry registerTexture:[OCMArg any]])
+      .andDo(^(NSInvocation *invocation) {
+        if (NSThread.isMainThread) {
+          [registerTextureExpectation fulfill];
+        }
+      });
+
+  OCMStub([self.mockTextureRegistry unregisterTexture:0]).andDo(^(NSInvocation *invocation) {
+    if (NSThread.isMainThread) {
+      [unregisterTextureExpectation fulfill];
+    }
+  });
+
+  OCMStub([self.mockTextureRegistry textureFrameAvailable:0]).andDo(^(NSInvocation *invocation) {
+    if (NSThread.isMainThread) {
+      [textureFrameAvailableExpectation fulfill];
+    }
+  });
+
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
     NSObject<FlutterTexture> *anyTexture = OCMProtocolMock(@protocol(FlutterTexture));
-    __weak XCTestExpectation *registerTextureCompletionExpectation =
-        self.registerTextureCompletionExpectation;
-    [self.registry registerTexture:anyTexture
-                        completion:^(int64_t textureId) {
-                          if (NSThread.isMainThread) {
-                            [registerTextureCompletionExpectation fulfill];
-                          }
-                        }];
-    [self.registry textureFrameAvailable:0];
-    [self.registry unregisterTexture:0];
+    [self.threadSafeTextureRegistry registerTexture:anyTexture
+                                         completion:^(int64_t textureId) {
+                                           if (NSThread.isMainThread) {
+                                             [registerTextureCompletionExpectation fulfill];
+                                           }
+                                         }];
+    [self.threadSafeTextureRegistry textureFrameAvailable:0];
+    [self.threadSafeTextureRegistry unregisterTexture:0];
   });
   [self waitForExpectations:@[
-    self.registerTextureExpectation,
-    self.unregisterTextureExpectation,
-    self.textureFrameAvailableExpectation,
-    self.registerTextureCompletionExpectation,
+    registerTextureExpectation,
+    unregisterTextureExpectation,
+    textureFrameAvailableExpectation,
+    registerTextureCompletionExpectation,
   ]
                     timeout:1];
 }

--- a/packages/camera/camera/example/ios/RunnerTests/ThreadSafeTextureRegistryTests.m
+++ b/packages/camera/camera/example/ios/RunnerTests/ThreadSafeTextureRegistryTests.m
@@ -17,14 +17,15 @@
   FLTThreadSafeTextureRegistry *threadSafeTextureRegistry =
       [[FLTThreadSafeTextureRegistry alloc] initWithTextureRegistry:mockTextureRegistry];
 
-  XCTestExpectation *registerTextureExpectation = [[XCTestExpectation alloc]
-      initWithDescription:@"registerTexture must be called on the main thread"];
-  XCTestExpectation *unregisterTextureExpectation = [[XCTestExpectation alloc]
-      initWithDescription:@"unregisterTexture must be called on the main thread"];
-  XCTestExpectation *textureFrameAvailableExpectation = [[XCTestExpectation alloc]
-      initWithDescription:@"textureFrameAvailable must be called on the main thread"];
-  XCTestExpectation *registerTextureCompletionExpectation = [[XCTestExpectation alloc]
-      initWithDescription:@"registerTexture's completion block must be called on the main thread"];
+  XCTestExpectation *registerTextureExpectation =
+      [self expectationWithDescription:@"registerTexture must be called on the main thread"];
+  XCTestExpectation *unregisterTextureExpectation =
+      [self expectationWithDescription:@"unregisterTexture must be called on the main thread"];
+  XCTestExpectation *textureFrameAvailableExpectation =
+      [self expectationWithDescription:@"textureFrameAvailable must be called on the main thread"];
+  XCTestExpectation *registerTextureCompletionExpectation =
+      [self expectationWithDescription:
+                @"registerTexture's completion block must be called on the main thread"];
 
   OCMStub([mockTextureRegistry registerTexture:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
     if (NSThread.isMainThread) {
@@ -53,13 +54,7 @@
                                   }];
   [threadSafeTextureRegistry textureFrameAvailable:0];
   [threadSafeTextureRegistry unregisterTexture:0];
-  [self waitForExpectations:@[
-    registerTextureExpectation,
-    unregisterTextureExpectation,
-    textureFrameAvailableExpectation,
-    registerTextureCompletionExpectation,
-  ]
-                    timeout:1];
+  [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
 - (void)testShouldDispatchToMainThreadIfCalledFromBackgroundThread {
@@ -68,14 +63,15 @@
   FLTThreadSafeTextureRegistry *threadSafeTextureRegistry =
       [[FLTThreadSafeTextureRegistry alloc] initWithTextureRegistry:mockTextureRegistry];
 
-  XCTestExpectation *registerTextureExpectation = [[XCTestExpectation alloc]
-      initWithDescription:@"registerTexture must be called on the main thread"];
-  XCTestExpectation *unregisterTextureExpectation = [[XCTestExpectation alloc]
-      initWithDescription:@"unregisterTexture must be called on the main thread"];
-  XCTestExpectation *textureFrameAvailableExpectation = [[XCTestExpectation alloc]
-      initWithDescription:@"textureFrameAvailable must be called on the main thread"];
-  XCTestExpectation *registerTextureCompletionExpectation = [[XCTestExpectation alloc]
-      initWithDescription:@"registerTexture's completion block must be called on the main thread"];
+  XCTestExpectation *registerTextureExpectation =
+      [self expectationWithDescription:@"registerTexture must be called on the main thread"];
+  XCTestExpectation *unregisterTextureExpectation =
+      [self expectationWithDescription:@"unregisterTexture must be called on the main thread"];
+  XCTestExpectation *textureFrameAvailableExpectation =
+      [self expectationWithDescription:@"textureFrameAvailable must be called on the main thread"];
+  XCTestExpectation *registerTextureCompletionExpectation =
+      [self expectationWithDescription:
+                @"registerTexture's completion block must be called on the main thread"];
 
   OCMStub([mockTextureRegistry registerTexture:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
     if (NSThread.isMainThread) {
@@ -106,13 +102,7 @@
     [threadSafeTextureRegistry textureFrameAvailable:0];
     [threadSafeTextureRegistry unregisterTexture:0];
   });
-  [self waitForExpectations:@[
-    registerTextureExpectation,
-    unregisterTextureExpectation,
-    textureFrameAvailableExpectation,
-    registerTextureCompletionExpectation,
-  ]
-                    timeout:1];
+  [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
 @end

--- a/packages/camera/camera/ios/Classes/CameraPlugin.m
+++ b/packages/camera/camera/ios/Classes/CameraPlugin.m
@@ -10,7 +10,10 @@
 #import <CoreMotion/CoreMotion.h>
 #import <libkern/OSAtomic.h>
 #import <uuid/uuid.h>
+#import "FLTThreadSafeEventChannel.h"
 #import "FLTThreadSafeFlutterResult.h"
+#import "FLTThreadSafeMethodChannel.h"
+#import "FLTThreadSafeTextureRegistry.h"
 
 @interface FLTSavePhotoDelegate : NSObject <AVCapturePhotoCaptureDelegate>
 @property(readonly, nonatomic) NSString *path;
@@ -305,7 +308,7 @@ static ResolutionPreset getResolutionPresetForString(NSString *preset) {
 @property(nonatomic, copy) void (^onFrameAvailable)(void);
 @property BOOL enableAudio;
 @property(nonatomic) FLTImageStreamHandler *imageStreamHandler;
-@property(nonatomic) FlutterMethodChannel *methodChannel;
+@property(nonatomic) FLTThreadSafeMethodChannel *methodChannel;
 @property(readonly, nonatomic) AVCaptureSession *captureSession;
 @property(readonly, nonatomic) AVCaptureDevice *captureDevice;
 @property(readonly, nonatomic) AVCapturePhotoOutput *capturePhotoOutput API_AVAILABLE(ios(10));
@@ -1115,11 +1118,16 @@ NSString *const errorMethod = @"error";
     FlutterEventChannel *eventChannel =
         [FlutterEventChannel eventChannelWithName:@"plugins.flutter.io/camera/imageStream"
                                   binaryMessenger:messenger];
+    FLTThreadSafeEventChannel *threadSafeEventChannel =
+        [[FLTThreadSafeEventChannel alloc] initWithEventChannel:eventChannel];
 
     _imageStreamHandler = [[FLTImageStreamHandler alloc] init];
-    [eventChannel setStreamHandler:_imageStreamHandler];
-
-    _isStreamingImages = YES;
+    [threadSafeEventChannel setStreamHandler:_imageStreamHandler
+                                  completion:^{
+                                    dispatch_async(self->_dispatchQueue, ^{
+                                      self->_isStreamingImages = YES;
+                                    });
+                                  }];
   } else {
     [_methodChannel invokeMethod:errorMethod
                        arguments:@"Images from camera are already streaming!"];
@@ -1285,10 +1293,10 @@ NSString *const errorMethod = @"error";
 @end
 
 @interface CameraPlugin ()
-@property(readonly, nonatomic) NSObject<FlutterTextureRegistry> *registry;
+@property(readonly, nonatomic) FLTThreadSafeTextureRegistry *registry;
 @property(readonly, nonatomic) NSObject<FlutterBinaryMessenger> *messenger;
 @property(readonly, nonatomic) FLTCam *camera;
-@property(readonly, nonatomic) FlutterMethodChannel *deviceEventMethodChannel;
+@property(readonly, nonatomic) FLTThreadSafeMethodChannel *deviceEventMethodChannel;
 @end
 
 @implementation CameraPlugin {
@@ -1308,7 +1316,7 @@ NSString *const errorMethod = @"error";
                        messenger:(NSObject<FlutterBinaryMessenger> *)messenger {
   self = [super init];
   NSAssert(self, @"super init cannot be nil");
-  _registry = registry;
+  _registry = [[FLTThreadSafeTextureRegistry alloc] initWithTextureRegistry:registry];
   _messenger = messenger;
   [self initDeviceEventMethodChannel];
   [self startOrientationListener];
@@ -1316,9 +1324,11 @@ NSString *const errorMethod = @"error";
 }
 
 - (void)initDeviceEventMethodChannel {
-  _deviceEventMethodChannel =
+  FlutterMethodChannel *methodChannel =
       [FlutterMethodChannel methodChannelWithName:@"flutter.io/cameraPlugin/device"
                                   binaryMessenger:_messenger];
+  _deviceEventMethodChannel =
+      [[FLTThreadSafeMethodChannel alloc] initWithMethodChannel:methodChannel];
 }
 
 - (void)startOrientationListener {
@@ -1417,11 +1427,13 @@ NSString *const errorMethod = @"error";
       if (_camera) {
         [_camera close];
       }
-      int64_t textureId = [self.registry registerTexture:cam];
       _camera = cam;
-      [result sendSuccessWithData:@{
-        @"cameraId" : @(textureId),
-      }];
+      [self.registry registerTexture:cam
+                          completion:^(int64_t textureId) {
+                            [result sendSuccessWithData:@{
+                              @"cameraId" : @(textureId),
+                            }];
+                          }];
     }
   } else if ([@"startImageStream" isEqualToString:call.method]) {
     [_camera startImageStreamWithMessenger:_messenger];
@@ -1446,8 +1458,10 @@ NSString *const errorMethod = @"error";
           methodChannelWithName:[NSString stringWithFormat:@"flutter.io/cameraPlugin/camera%lu",
                                                            (unsigned long)cameraId]
                 binaryMessenger:_messenger];
-      _camera.methodChannel = methodChannel;
-      [methodChannel
+      FLTThreadSafeMethodChannel *threadSafeMethodChannel =
+          [[FLTThreadSafeMethodChannel alloc] initWithMethodChannel:methodChannel];
+      _camera.methodChannel = threadSafeMethodChannel;
+      [threadSafeMethodChannel
           invokeMethod:@"initialized"
              arguments:@{
                @"previewWidth" : @(_camera.previewSize.width),

--- a/packages/camera/camera/ios/Classes/FLTThreadSafeEventChannel.h
+++ b/packages/camera/camera/ios/Classes/FLTThreadSafeEventChannel.h
@@ -1,0 +1,29 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <Flutter/Flutter.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Wrapper for FlutterEventChannel that always sends events on the main thread
+ */
+@interface FLTThreadSafeEventChannel : NSObject
+
+/**
+ * Creates a FLTThreadSafeEventChannel by wrapping a FlutterEventChannel object.
+ * @param channel The FlutterEventChannel object to be wrapped.
+ */
+- (instancetype)initWithEventChannel:(FlutterEventChannel *)channel;
+
+/*
+ * Registers a handler for stream setup requests from the Flutter side on main thread.
+ # Completion block runs on main thread.
+ */
+- (void)setStreamHandler:(nullable NSObject<FlutterStreamHandler> *)handler
+              completion:(void (^)(void))completion;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/camera/camera/ios/Classes/FLTThreadSafeEventChannel.h
+++ b/packages/camera/camera/ios/Classes/FLTThreadSafeEventChannel.h
@@ -7,7 +7,8 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- * Wrapper for FlutterEventChannel that always sends events on the main thread
+ * A thread safe wrapper for FlutterEventChannel that can be called from any thread, by dispatching
+ * its underlying engine APIs to the main thread.
  */
 @interface FLTThreadSafeEventChannel : NSObject
 

--- a/packages/camera/camera/ios/Classes/FLTThreadSafeEventChannel.h
+++ b/packages/camera/camera/ios/Classes/FLTThreadSafeEventChannel.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * A thread safe wrapper for FlutterEventChannel that can be called from any thread, by dispatching
- * its underlying engine APIs to the main thread.
+ * its underlying engine calls to the main thread.
  */
 @interface FLTThreadSafeEventChannel : NSObject
 
@@ -19,8 +19,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithEventChannel:(FlutterEventChannel *)channel;
 
 /*
- * Registers a handler for stream setup requests from the Flutter side on main thread.
- # Completion block runs on main thread.
+ * Registers a handler on the main thread for stream setup requests from the Flutter side.
+ # The completion block runs on the main thread.
  */
 - (void)setStreamHandler:(nullable NSObject<FlutterStreamHandler> *)handler
               completion:(void (^)(void))completion;

--- a/packages/camera/camera/ios/Classes/FLTThreadSafeEventChannel.m
+++ b/packages/camera/camera/ios/Classes/FLTThreadSafeEventChannel.m
@@ -20,14 +20,15 @@
 
 - (void)setStreamHandler:(NSObject<FlutterStreamHandler> *)handler
               completion:(void (^)(void))completion {
-  if (!NSThread.isMainThread) {
-    dispatch_async(dispatch_get_main_queue(), ^{
-      [self.channel setStreamHandler:handler];
-      completion();
-    });
-  } else {
+  void (^block)(void) = ^{
     [self.channel setStreamHandler:handler];
     completion();
+  };
+
+  if (!NSThread.isMainThread) {
+    dispatch_async(dispatch_get_main_queue(), block);
+  } else {
+    block();
   }
 }
 

--- a/packages/camera/camera/ios/Classes/FLTThreadSafeEventChannel.m
+++ b/packages/camera/camera/ios/Classes/FLTThreadSafeEventChannel.m
@@ -1,0 +1,34 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "FLTThreadSafeEventChannel.h"
+
+@interface FLTThreadSafeEventChannel ()
+@property(nonatomic, strong) FlutterEventChannel *channel;
+@end
+
+@implementation FLTThreadSafeEventChannel
+
+- (instancetype)initWithEventChannel:(FlutterEventChannel *)channel {
+  self = [super init];
+  if (self) {
+    _channel = channel;
+  }
+  return self;
+}
+
+- (void)setStreamHandler:(NSObject<FlutterStreamHandler> *)handler
+              completion:(void (^)(void))completion {
+  if (!NSThread.isMainThread) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [self.channel setStreamHandler:handler];
+      completion();
+    });
+  } else {
+    [self.channel setStreamHandler:handler];
+    completion();
+  }
+}
+
+@end

--- a/packages/camera/camera/ios/Classes/FLTThreadSafeEventChannel.m
+++ b/packages/camera/camera/ios/Classes/FLTThreadSafeEventChannel.m
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #import "FLTThreadSafeEventChannel.h"
+#import "QueueHelper.h"
 
 @interface FLTThreadSafeEventChannel ()
 @property(nonatomic, strong) FlutterEventChannel *channel;
@@ -20,16 +21,10 @@
 
 - (void)setStreamHandler:(NSObject<FlutterStreamHandler> *)handler
               completion:(void (^)(void))completion {
-  void (^block)(void) = ^{
+  [QueueHelper ensureToRunOnMainQueue:^{
     [self.channel setStreamHandler:handler];
     completion();
-  };
-
-  if (!NSThread.isMainThread) {
-    dispatch_async(dispatch_get_main_queue(), block);
-  } else {
-    block();
-  }
+  }];
 }
 
 @end

--- a/packages/camera/camera/ios/Classes/FLTThreadSafeFlutterResult.h
+++ b/packages/camera/camera/ios/Classes/FLTThreadSafeFlutterResult.h
@@ -6,7 +6,7 @@
 
 /**
  * A thread safe wrapper for FlutterResult that can be called from any thread, by dispatching its
- * underlying engine APIs to the main thread.
+ * underlying engine calls to the main thread.
  */
 @interface FLTThreadSafeFlutterResult : NSObject
 
@@ -22,31 +22,31 @@
 - (nonnull instancetype)initWithResult:(nonnull FlutterResult)result;
 
 /**
- * Sends a successful result without any data.
+ * Sends a successful result on the main thread without any data.
  */
 - (void)sendSuccess;
 
 /**
- * Sends a successful result with data.
+ * Sends a successful result on the main thread with data.
  * @param data Result data that is send to the Flutter Dart side.
  */
 - (void)sendSuccessWithData:(nonnull id)data;
 
 /**
- * Sends an NSError as result
+ * Sends an NSError as result on the main thread.
  * @param error Error that will be send as FlutterError.
  */
 - (void)sendError:(nonnull NSError*)error;
 
 /**
- * Sends a FlutterError as result.
+ * Sends a FlutterError as result on the main thread.
  */
 - (void)sendErrorWithCode:(nonnull NSString*)code
                   message:(nullable NSString*)message
                   details:(nullable id)details;
 
 /**
- * Sends FlutterMethodNotImplemented as result.
+ * Sends FlutterMethodNotImplemented as result on the main thread.
  */
 - (void)sendNotImplemented;
 @end

--- a/packages/camera/camera/ios/Classes/FLTThreadSafeFlutterResult.h
+++ b/packages/camera/camera/ios/Classes/FLTThreadSafeFlutterResult.h
@@ -5,7 +5,8 @@
 #import <Flutter/Flutter.h>
 
 /**
- * Wrapper for FlutterResult  that always delivers the result on the main thread.
+ * A thread safe wrapper for FlutterResult that can be called from any thread, by dispatching its
+ * underlying engine APIs to the main thread.
  */
 @interface FLTThreadSafeFlutterResult : NSObject
 

--- a/packages/camera/camera/ios/Classes/FLTThreadSafeFlutterResult.m
+++ b/packages/camera/camera/ios/Classes/FLTThreadSafeFlutterResult.m
@@ -4,6 +4,7 @@
 
 #import "FLTThreadSafeFlutterResult.h"
 #import <Foundation/Foundation.h>
+#import "QueueHelper.h"
 
 @implementation FLTThreadSafeFlutterResult {
 }
@@ -46,13 +47,9 @@
  * Sends result to flutterResult on the main thread.
  */
 - (void)send:(id _Nullable)result {
-  if (!NSThread.isMainThread) {
-    dispatch_async(dispatch_get_main_queue(), ^{
-      self->_flutterResult(result);
-    });
-  } else {
-    _flutterResult(result);
-  }
+  [QueueHelper ensureToRunOnMainQueue:^{
+    self.flutterResult(result);
+  }];
 }
 
 @end

--- a/packages/camera/camera/ios/Classes/FLTThreadSafeMethodChannel.h
+++ b/packages/camera/camera/ios/Classes/FLTThreadSafeMethodChannel.h
@@ -1,0 +1,27 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <Flutter/Flutter.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Wrapper for FlutterMethodChannel that always invokes messages on the main thread
+ */
+@interface FLTThreadSafeMethodChannel : NSObject
+
+/**
+ * Creates a FLTThreadSafeMethodChannel by wrapping a FlutterMethodChannel object.
+ * @param channel The FlutterMethodChannel object to be wrapped.
+ */
+- (instancetype)initWithMethodChannel:(FlutterMethodChannel *)channel;
+
+/**
+ * Invokes the specified flutter method with the specified arguments on main thread.
+ */
+- (void)invokeMethod:(NSString *)method arguments:(nullable id)arguments;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/camera/camera/ios/Classes/FLTThreadSafeMethodChannel.h
+++ b/packages/camera/camera/ios/Classes/FLTThreadSafeMethodChannel.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * A thread safe wrapper for FlutterMethodChannel that can be called from any thread, by dispatching
- * its underlying engine APIs to the main thread.
+ * its underlying engine calls to the main thread.
  */
 @interface FLTThreadSafeMethodChannel : NSObject
 
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithMethodChannel:(FlutterMethodChannel *)channel;
 
 /**
- * Invokes the specified flutter method with the specified arguments on main thread.
+ * Invokes the specified flutter method on the main thread with the specified arguments.
  */
 - (void)invokeMethod:(NSString *)method arguments:(nullable id)arguments;
 

--- a/packages/camera/camera/ios/Classes/FLTThreadSafeMethodChannel.h
+++ b/packages/camera/camera/ios/Classes/FLTThreadSafeMethodChannel.h
@@ -7,7 +7,8 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- * Wrapper for FlutterMethodChannel that always invokes messages on the main thread
+ * A thread safe wrapper for FlutterMethodChannel that can be called from any thread, by dispatching
+ * its underlying engine APIs to the main thread.
  */
 @interface FLTThreadSafeMethodChannel : NSObject
 

--- a/packages/camera/camera/ios/Classes/FLTThreadSafeMethodChannel.m
+++ b/packages/camera/camera/ios/Classes/FLTThreadSafeMethodChannel.m
@@ -1,0 +1,31 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "FLTThreadSafeMethodChannel.h"
+
+@interface FLTThreadSafeMethodChannel ()
+@property(nonatomic, strong) FlutterMethodChannel *channel;
+@end
+
+@implementation FLTThreadSafeMethodChannel
+
+- (instancetype)initWithMethodChannel:(FlutterMethodChannel *)channel {
+  self = [super init];
+  if (self) {
+    _channel = channel;
+  }
+  return self;
+}
+
+- (void)invokeMethod:(NSString *)method arguments:(id)arguments {
+  if (!NSThread.isMainThread) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [self.channel invokeMethod:method arguments:arguments];
+    });
+  } else {
+    [self.channel invokeMethod:method arguments:arguments];
+  }
+}
+
+@end

--- a/packages/camera/camera/ios/Classes/FLTThreadSafeMethodChannel.m
+++ b/packages/camera/camera/ios/Classes/FLTThreadSafeMethodChannel.m
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #import "FLTThreadSafeMethodChannel.h"
+#import "QueueHelper.h"
 
 @interface FLTThreadSafeMethodChannel ()
 @property(nonatomic, strong) FlutterMethodChannel *channel;
@@ -19,13 +20,9 @@
 }
 
 - (void)invokeMethod:(NSString *)method arguments:(id)arguments {
-  if (!NSThread.isMainThread) {
-    dispatch_async(dispatch_get_main_queue(), ^{
-      [self.channel invokeMethod:method arguments:arguments];
-    });
-  } else {
+  [QueueHelper ensureToRunOnMainQueue:^{
     [self.channel invokeMethod:method arguments:arguments];
-  }
+  }];
 }
 
 @end

--- a/packages/camera/camera/ios/Classes/FLTThreadSafeTextureRegistry.h
+++ b/packages/camera/camera/ios/Classes/FLTThreadSafeTextureRegistry.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * A thread safe wrapper for FlutterTextureRegistry that can be called from any thread, by
- * dispatching its underlying engine APIs to the main thread.
+ * dispatching its underlying engine calls to the main thread.
  */
 @interface FLTThreadSafeTextureRegistry : NSObject
 
@@ -20,31 +20,23 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithTextureRegistry:(NSObject<FlutterTextureRegistry> *)registry;
 
 /**
- * Registers a `FlutterTexture` for usage in Flutter and returns an id that can be used to reference
- * that texture when calling into Flutter with channels. Textures must be registered on the
- * main thread.
+ * Registers a `FlutterTexture` on the main thread for usage in Flutter and returns an id that can
+ * be used to reference that texture when calling into Flutter with channels.
  *
  * On success the completion block completes with the pointer to the registered texture, else with
- * 0.
+ * 0. The completion block runs on the main thread.
  */
 - (void)registerTexture:(NSObject<FlutterTexture> *)texture
              completion:(void (^)(int64_t))completion;
 
 /**
- * Notifies Flutter that the content of the previously registered texture has been updated.
- *
- * This will trigger a call to `-[FlutterTexture copyPixelBuffer]` on the raster thread.
- *
- * Runs on main thread.
+ * Notifies the Flutter engine on the main thread that the given texture has been updated.
  */
 - (void)textureFrameAvailable:(int64_t)textureId;
 
 /**
- * Unregisters a `FlutterTexture` that has previously regeistered with `registerTexture:`. Textures
- * must be unregistered on the main thread.
- *
- * Runs on main thread.
- *
+ * Notifies the Flutter engine on the main thread to unregister a `FlutterTexture` that has been
+ * previously registered with `registerTexture:`.
  * @param textureId The result that was previously returned from `registerTexture:`.
  */
 - (void)unregisterTexture:(int64_t)textureId;

--- a/packages/camera/camera/ios/Classes/FLTThreadSafeTextureRegistry.h
+++ b/packages/camera/camera/ios/Classes/FLTThreadSafeTextureRegistry.h
@@ -7,7 +7,8 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- * Wrapper for FlutterTextureRegistry that always sends events on the main thread
+ * A thread safe wrapper for FlutterTextureRegistry that can be called from any thread, by
+ * dispatching its underlying engine APIs to the main thread.
  */
 @interface FLTThreadSafeTextureRegistry : NSObject
 

--- a/packages/camera/camera/ios/Classes/FLTThreadSafeTextureRegistry.h
+++ b/packages/camera/camera/ios/Classes/FLTThreadSafeTextureRegistry.h
@@ -1,0 +1,53 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <Flutter/Flutter.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Wrapper for FlutterTextureRegistry that always sends events on the main thread
+ */
+@interface FLTThreadSafeTextureRegistry : NSObject
+
+/**
+ * Creates a FLTThreadSafeTextureRegistry by wrapping an object conforming to
+ * FlutterTextureRegistry.
+ * @param registry The FlutterTextureRegistry object to be wrapped.
+ */
+- (instancetype)initWithTextureRegistry:(NSObject<FlutterTextureRegistry> *)registry;
+
+/**
+ * Registers a `FlutterTexture` for usage in Flutter and returns an id that can be used to reference
+ * that texture when calling into Flutter with channels. Textures must be registered on the
+ * main thread.
+ *
+ * On success the completion block completes with the pointer to the registered texture, else with
+ * 0.
+ */
+- (void)registerTexture:(NSObject<FlutterTexture> *)texture
+             completion:(void (^)(int64_t))completion;
+
+/**
+ * Notifies Flutter that the content of the previously registered texture has been updated.
+ *
+ * This will trigger a call to `-[FlutterTexture copyPixelBuffer]` on the raster thread.
+ *
+ * Runs on main thread.
+ */
+- (void)textureFrameAvailable:(int64_t)textureId;
+
+/**
+ * Unregisters a `FlutterTexture` that has previously regeistered with `registerTexture:`. Textures
+ * must be unregistered on the main thread.
+ *
+ * Runs on main thread.
+ *
+ * @param textureId The result that was previously returned from `registerTexture:`.
+ */
+- (void)unregisterTexture:(int64_t)textureId;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/camera/camera/ios/Classes/FLTThreadSafeTextureRegistry.m
+++ b/packages/camera/camera/ios/Classes/FLTThreadSafeTextureRegistry.m
@@ -1,0 +1,52 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "FLTThreadSafeTextureRegistry.h"
+
+@interface FLTThreadSafeTextureRegistry ()
+@property(nonatomic, strong) NSObject<FlutterTextureRegistry> *registry;
+@end
+
+@implementation FLTThreadSafeTextureRegistry
+
+- (instancetype)initWithTextureRegistry:(NSObject<FlutterTextureRegistry> *)registry {
+  self = [super init];
+  if (self) {
+    _registry = registry;
+  }
+  return self;
+}
+
+- (void)registerTexture:(NSObject<FlutterTexture> *)texture
+             completion:(void (^)(int64_t))completion {
+  if (!NSThread.isMainThread) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      completion([self.registry registerTexture:texture]);
+    });
+  } else {
+    completion([self.registry registerTexture:texture]);
+  }
+}
+
+- (void)textureFrameAvailable:(int64_t)textureId {
+  if (!NSThread.isMainThread) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [self.registry textureFrameAvailable:textureId];
+    });
+  } else {
+    [self.registry textureFrameAvailable:textureId];
+  }
+}
+
+- (void)unregisterTexture:(int64_t)textureId {
+  if (!NSThread.isMainThread) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [self.registry unregisterTexture:textureId];
+    });
+  } else {
+    [self.registry unregisterTexture:textureId];
+  }
+}
+
+@end

--- a/packages/camera/camera/ios/Classes/FLTThreadSafeTextureRegistry.m
+++ b/packages/camera/camera/ios/Classes/FLTThreadSafeTextureRegistry.m
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #import "FLTThreadSafeTextureRegistry.h"
+#import "QueueHelper.h"
 
 @interface FLTThreadSafeTextureRegistry ()
 @property(nonatomic, strong) NSObject<FlutterTextureRegistry> *registry;
@@ -20,33 +21,21 @@
 
 - (void)registerTexture:(NSObject<FlutterTexture> *)texture
              completion:(void (^)(int64_t))completion {
-  if (!NSThread.isMainThread) {
-    dispatch_async(dispatch_get_main_queue(), ^{
-      completion([self.registry registerTexture:texture]);
-    });
-  } else {
+  [QueueHelper ensureToRunOnMainQueue:^{
     completion([self.registry registerTexture:texture]);
-  }
+  }];
 }
 
 - (void)textureFrameAvailable:(int64_t)textureId {
-  if (!NSThread.isMainThread) {
-    dispatch_async(dispatch_get_main_queue(), ^{
-      [self.registry textureFrameAvailable:textureId];
-    });
-  } else {
+  [QueueHelper ensureToRunOnMainQueue:^{
     [self.registry textureFrameAvailable:textureId];
-  }
+  }];
 }
 
 - (void)unregisterTexture:(int64_t)textureId {
-  if (!NSThread.isMainThread) {
-    dispatch_async(dispatch_get_main_queue(), ^{
-      [self.registry unregisterTexture:textureId];
-    });
-  } else {
+  [QueueHelper ensureToRunOnMainQueue:^{
     [self.registry unregisterTexture:textureId];
-  }
+  }];
 }
 
 @end

--- a/packages/camera/camera/ios/Classes/QueueHelper.h
+++ b/packages/camera/camera/ios/Classes/QueueHelper.h
@@ -1,0 +1,13 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface QueueHelper : NSObject
++ (void)ensureToRunOnMainQueue:(void (^)(void))block;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/camera/camera/ios/Classes/QueueHelper.m
+++ b/packages/camera/camera/ios/Classes/QueueHelper.m
@@ -1,0 +1,15 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "QueueHelper.h"
+
+@implementation QueueHelper
++ (void)ensureToRunOnMainQueue:(void (^)(void))block {
+  if (!NSThread.isMainThread) {
+    dispatch_async(dispatch_get_main_queue(), block);
+  } else {
+    block();
+  }
+}
+@end

--- a/packages/camera/camera/ios/Classes/camera-umbrella.h
+++ b/packages/camera/camera/ios/Classes/camera-umbrella.h
@@ -4,7 +4,10 @@
 
 #import <Foundation/Foundation.h>
 #import <camera/CameraPlugin.h>
+#import <camera/FLTThreadSafeEventChannel.h>
 #import <camera/FLTThreadSafeFlutterResult.h>
+#import <camera/FLTThreadSafeMethodChannel.h>
+#import <camera/FLTThreadSafeTextureRegistry.h>
 
 FOUNDATION_EXPORT double cameraVersionNumber;
 FOUNDATION_EXPORT const unsigned char cameraVersionString[];

--- a/packages/camera/camera/ios/Classes/camera-umbrella.h
+++ b/packages/camera/camera/ios/Classes/camera-umbrella.h
@@ -8,6 +8,7 @@
 #import <camera/FLTThreadSafeFlutterResult.h>
 #import <camera/FLTThreadSafeMethodChannel.h>
 #import <camera/FLTThreadSafeTextureRegistry.h>
+#import <camera/QueueHelper.h>
 
 FOUNDATION_EXPORT double cameraVersionNumber;
 FOUNDATION_EXPORT const unsigned char cameraVersionString[];

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -4,7 +4,7 @@ description: A Flutter plugin for controlling the camera. Supports previewing
   Dart.
 repository: https://github.com/flutter/plugins/tree/master/packages/camera/camera
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.9.4+5
+version: 0.9.4+6
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR is part of a larger project to fix the thread model for iOS camera plugin. The formal proposal can be found [here](https://docs.google.com/document/d/1Znjp-BduXIb1Ix3JOE1YKyJi1Z0d6rB-2q6Lt7j8xSo/edit#)

The engine APIs used in camera plugin are required to be run on platform thread. Some of these APIs have explicit asserts (e.g. MethodChannel) and some have warning instructions in documentation (e.g. TextureRegistry). However, in camera plugin we are currently calling these APIs in background thread, causing the crash.

There's already a FLTThreadSafeFlutterResult wrapper to invoke FlutterResult in main thread. This PR created similar "thread safe wrappers" for EventChannel, MethodChannel and TextureRegistry.

## Issues

flutter/flutter#94723
flutter/flutter#52578

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
