### PR TITLE
[local_auth] opening dialog fix 

### DIFF
--- a/packages/local_auth/CHANGELOG.md
+++ b/packages/local_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.11
+
+* Fix the issue: "authenticate" with parameter "useErrorDialogs = true" does not open a dialog #96646
+
 ## 1.1.10
 
 * Removes dependency on `meta`.

--- a/packages/local_auth/android/src/main/java/io/flutter/plugins/localauth/LocalAuthPlugin.java
+++ b/packages/local_auth/android/src/main/java/io/flutter/plugins/localauth/LocalAuthPlugin.java
@@ -294,7 +294,9 @@ public class LocalAuthPlugin implements MethodCallHandler, FlutterPlugin, Activi
 
   private boolean canAuthenticateWithBiometrics() {
     if (biometricManager == null) return false;
-    return biometricManager.canAuthenticate() == BiometricManager.BIOMETRIC_SUCCESS;
+    int biometricStatus = biometricManager.canAuthenticate();
+    return biometricStatus == BiometricManager.BIOMETRIC_SUCCESS 
+      || biometricStatus == BiometricManager.BIOMETRIC_STATUS_UNKNOWN;
   }
 
   private boolean hasBiometricHardware() {

--- a/packages/local_auth/pubspec.yaml
+++ b/packages/local_auth/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Android and iOS devices to allow local
   authentication via fingerprint, touch ID, face ID, passcode, pin, or pattern.
 repository: https://github.com/flutter/plugins/tree/master/packages/local_auth
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+local_auth%22
-version: 1.1.10
+version: 1.1.11
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
Fix an issue when on Android devices you try to authenticate with parameter `useErrorDialogs = true` and the device has hardware biometrics but it is `not enrolled` - the exception "not enrolled" appear but dialog for going to enroll does not.

This PR fixes #96646


## Pre-launch Checklist

- [V] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [V] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [V] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [V] I signed the [CLA].
- [V] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [V] I listed at least one issue that this PR fixes in the description above.
- [V] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [V] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [V] I updated/added relevant documentation (doc comments with `///`).
