### PR TITLE
Remove the PR review section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,28 +42,6 @@ use, and use auto-formatters:
 - [Objective-C](https://google.github.io/styleguide/objcguide.html) formatted with
   `clang-format`
 
-### The review process
-
-Reviewing PRs often requires a non-trivial amount of time. We prioritize issues, not PRs, so that we use our maintainers' time in the most impactful way. Issues pertaining to this repository are managed in the [flutter/flutter issue tracker and are labeled with "plugin"](https://github.com/flutter/flutter/issues?q=is%3Aopen+is%3Aissue+label%3Aplugin+sort%3Areactions-%2B1-desc). Non-trivial PRs should have an associated issue that will be used for prioritization. See the [prioritization section](https://github.com/flutter/flutter/wiki/Issue-hygiene#prioritization) in the Flutter wiki to understand how issues are prioritized.
-
-Newly opened PRs first go through initial triage which results in one of:
-  * **Merging the PR** - if the PR can be quickly reviewed and looks good.
-  * **Requesting minor changes** - if the PR can be quickly reviewed, but needs changes.
-  * **Moving the PR to the backlog** - if the review requires non-trivial effort and the issue isn't currently a priority; in this case the maintainer will:
-    * Add the "backlog" label to the issue.
-    * Leave a comment on the PR explaining that the review is not trivial and that the issue will be looked at according to priority order.
-  * **Starting a non-trivial review** - if the review requires non-trivial effort and the issue is a priority; in this case the maintainer will:
-    * Add the "in review" label to the issue.
-    * Self assign the PR.
-  * **Closing the PR** - if the PR maintainer decides that the PR should not be merged.
-
-Please be aware that there is currently a significant backlog, so reviews for plugin PRs will
-in most cases take significantly longer to begin than the two-week timeframe given in the
-main Flutter PR guide. An effort is underway to work through the backlog, but it will
-take time. If you are interested in hepling out (e.g., by doing initial reviews looking
-for obvious problems like missing or failing tests), please reach out
-[on Discord](https://github.com/flutter/flutter/wiki/Chat) in `#hackers-ecosystem`.
-
 ### Releasing
 
 If you are a team member landing a PR, or just want to know what the release


### PR DESCRIPTION
The plugins repository is now aligned with normal Flutter review process. There are no longer any open issues with the `backlog` label, and the intent is not to use it going forward due to the issues (bitrot, authors no longer being available, duplication of work) caused by leaving PRs open in limbo for a long period of time.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
