### PR TITLE
[video_player] Remove KVO observer on AVPlayerItem on iOS

### DIFF
--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.14
+
+* Remove KVO observer on AVPlayerItem on iOS.
+
 ## 2.2.13
 
 * Fixes persisting of hasError even after successful initialize.

--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.2.14
 
-* Remove KVO observer on AVPlayerItem on iOS.
+* Removes KVO observer on AVPlayerItem on iOS.
 
 ## 2.2.13
 

--- a/packages/video_player/video_player/example/ios/RunnerTests/VideoPlayerTests.m
+++ b/packages/video_player/video_player/example/ios/RunnerTests/VideoPlayerTests.m
@@ -2,20 +2,25 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+@import AVFoundation;
 @import video_player;
 @import XCTest;
 
 #import <OCMock/OCMock.h>
 
+@interface FLTVideoPlayer : NSObject
+@property(readonly, nonatomic) AVPlayer *player;
+@end
+
+@interface FLTVideoPlayerPlugin (Test) <FLTVideoPlayerApi>
+@property(readonly, strong, nonatomic)
+    NSMutableDictionary<NSNumber *, FLTVideoPlayer *> *playersByTextureId;
+@end
+
 @interface VideoPlayerTests : XCTestCase
 @end
 
 @implementation VideoPlayerTests
-
-- (void)testPlugin {
-  FLTVideoPlayerPlugin *plugin = [[FLTVideoPlayerPlugin alloc] init];
-  XCTAssertNotNil(plugin);
-}
 
 - (void)testSeekToInvokesTextureFrameAvailableOnTextureRegistry {
   NSObject<FlutterTextureRegistry> *mockTextureRegistry =
@@ -23,19 +28,46 @@
   NSObject<FlutterPluginRegistry> *registry =
       (NSObject<FlutterPluginRegistry> *)[[UIApplication sharedApplication] delegate];
   NSObject<FlutterPluginRegistrar> *registrar =
-      [registry registrarForPlugin:@"TEST_FLTVideoPlayerPlugin"];
+      [registry registrarForPlugin:@"SeekToInvokestextureFrameAvailable"];
   NSObject<FlutterPluginRegistrar> *partialRegistrar = OCMPartialMock(registrar);
   OCMStub([partialRegistrar textures]).andReturn(mockTextureRegistry);
-  [FLTVideoPlayerPlugin registerWithRegistrar:partialRegistrar];
-  FLTVideoPlayerPlugin<FLTVideoPlayerApi> *videoPlayerPlugin =
-      (FLTVideoPlayerPlugin<FLTVideoPlayerApi> *)[[FLTVideoPlayerPlugin alloc]
-          initWithRegistrar:partialRegistrar];
+  FLTVideoPlayerPlugin *videoPlayerPlugin =
+      (FLTVideoPlayerPlugin *)[[FLTVideoPlayerPlugin alloc] initWithRegistrar:partialRegistrar];
   FLTPositionMessage *message = [[FLTPositionMessage alloc] init];
   message.textureId = @101;
   message.position = @0;
   FlutterError *error;
   [videoPlayerPlugin seekTo:message error:&error];
   OCMVerify([mockTextureRegistry textureFrameAvailable:message.textureId.intValue]);
+}
+
+- (void)testDeregistersFromPlayer {
+  NSObject<FlutterPluginRegistry> *registry =
+      (NSObject<FlutterPluginRegistry> *)[[UIApplication sharedApplication] delegate];
+  NSObject<FlutterPluginRegistrar> *registrar =
+      [registry registrarForPlugin:@"testDeregistersFromPlayer"];
+  FLTVideoPlayerPlugin *videoPlayerPlugin =
+      (FLTVideoPlayerPlugin *)[[FLTVideoPlayerPlugin alloc] initWithRegistrar:registrar];
+
+  FlutterError *error;
+  [videoPlayerPlugin initialize:&error];
+  XCTAssertNil(error);
+
+  FLTCreateMessage *create = [[FLTCreateMessage alloc] init];
+  create.uri = @"https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4";
+  FLTTextureMessage *textureMessage = [videoPlayerPlugin create:create error:&error];
+  XCTAssertNil(error);
+  XCTAssertNotNil(textureMessage);
+  FLTVideoPlayer *player = videoPlayerPlugin.playersByTextureId[textureMessage.textureId];
+  XCTAssertNotNil(player);
+  AVPlayer *avPlayer = player.player;
+
+  [videoPlayerPlugin dispose:textureMessage error:&error];
+  XCTAssertEqual(videoPlayerPlugin.playersByTextureId.count, 0);
+  XCTAssertNil(error);
+
+  [self keyValueObservingExpectationForObject:avPlayer keyPath:@"currentItem" expectedValue:nil];
+  [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
 @end

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android, iOS, and web.
 repository: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.2.13
+version: 2.2.14
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
In https://github.com/flutter/plugins/pull/4438 the `AVPlayerItem` `presentationSize` and `duration` properties are KVO observed, but the observation was not removed when the texture is disposed.  Remove the observer.  

Also clean up a few things in the plugin, like using `BOOL` instead of `bool`, lightweight generics, rename `players` dictionary to the more descriptive `playersByTextureId`, prefer `NS_INLINE` to `static inline`.

Fixes https://github.com/flutter/flutter/issues/96849

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
