### PR TITLE
[video_player] Update iOS README section

### DIFF
--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.15
+
+* Updates README discussion of permissions.
+
 ## 2.2.14
 
 * Removes KVO observer on AVPlayerItem on iOS.

--- a/packages/video_player/video_player/README.md
+++ b/packages/video_player/video_player/README.md
@@ -12,31 +12,22 @@ First, add `video_player` as a [dependency in your pubspec.yaml file](https://fl
 
 ### iOS
 
-This plugin requires iOS 9.0 or higher. Add the following entry to your _Info.plist_ file, located in `<project root>/ios/Runner/Info.plist`:
-
-```xml
-<key>NSAppTransportSecurity</key>
-<dict>
-  <key>NSAllowsArbitraryLoads</key>
-  <true/>
-</dict>
-```
-
-This entry allows your app to access video files by URL.
+If you need to access videos using `http` (rather than `https`) URLs, you will need to add
+the appropriate `NSAppTransportSecurity` permissions to your app's _Info.plist_ file, located
+in `<project root>/ios/Runner/Info.plist`. See
+[Apple's documentation](https://developer.apple.com/documentation/bundleresources/information_property_list/nsapptransportsecurity?language=objc)
+to determine the right combination of entries for your use case and supported iOS versions.
 
 ### Android
 
-Ensure the following permission is present in your Android Manifest file, located in `<project root>/android/app/src/main/AndroidManifest.xml`:
+If you are using network-based videos, ensure the following permission is present in your
+Android Manifest file, located in `<project root>/android/app/src/main/AndroidManifest.xml`:
 
 ```xml
 <uses-permission android:name="android.permission.INTERNET"/>
 ```
 
-The Flutter project template adds it, so it may already be there.
-
 ### Web
-
-This plugin compiles for the web platform since version `0.10.5`, in recent enough versions of Flutter (`>=1.12.13+hotfix.4`).
 
 > The Web platform does **not** suppport `dart:io`, so avoid using the `VideoPlayerController.file` constructor for the plugin. Using the constructor attempts to create a `VideoPlayerController.file` that will throw an `UnimplementedError`.
 

--- a/packages/video_player/video_player/README.md
+++ b/packages/video_player/video_player/README.md
@@ -15,7 +15,7 @@ First, add `video_player` as a [dependency in your pubspec.yaml file](https://fl
 If you need to access videos using `http` (rather than `https`) URLs, you will need to add
 the appropriate `NSAppTransportSecurity` permissions to your app's _Info.plist_ file, located
 in `<project root>/ios/Runner/Info.plist`. See
-[Apple's documentation](https://developer.apple.com/documentation/bundleresources/information_property_list/nsapptransportsecurity?language=objc)
+[Apple's documentation](https://developer.apple.com/documentation/bundleresources/information_property_list/nsapptransportsecurity)
 to determine the right combination of entries for your use case and supported iOS versions.
 
 ### Android

--- a/packages/video_player/video_player/README.md
+++ b/packages/video_player/video_player/README.md
@@ -20,7 +20,7 @@ to determine the right combination of entries for your use case and supported iO
 
 ### Android
 
-If you are using network-based videos, ensure the following permission is present in your
+If you are using network-based videos, ensure that the following permission is present in your
 Android Manifest file, located in `<project root>/android/app/src/main/AndroidManifest.xml`:
 
 ```xml

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android, iOS, and web.
 repository: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.2.14
+version: 2.2.15
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
Removes the suggestion to just use the strongly-discouraged-by-Apple `NSAllowsArbitraryLoads`, and instead links to Apple's docs about the various options.

This removes the example entirely since there's no one-size-fits-all case; some clients would just need `NSExceptionDomains` (this seems likely to be the more common case?), others `NSAllowsArbitraryLoadsForMedia`, others `NSAllowsArbitraryLoadsForMedia`+` NSAllowsArbitraryLoads` (to support iOS 9). And of course hopefully these days most people are using https and don't need anything at all. Given that the narrowest option that works for someone is the best option, having them actually research the options is the best thing to steer people toward, even if that's not as simple as "copy and paste the following".

Also opportunistically removes a couple of obsolete items:
- An incorrect note that `android.permission.INTERNET` is likely already present in the
  main Android manifest file; it was made debug-only a while ago.
- An old note about web version compatibility; we only support Flutter 2+ now anyway.

Fixes https://github.com/flutter/flutter/issues/54955

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
