### PR TITLE
[camera]writing file on background queue

### DIFF
--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.4+10
+
+* iOS performance improvement by writing captured photo file on a background IO queue. 
+
 ## 0.9.4+9
 
 * iOS performance improvement by moving sample buffer handling from the main queue to a background session queue. 

--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.9.4+10
 
-* iOS performance improvement by writing captured photo file on a background IO queue. 
+* iOS performance improvement by moving file writing from the main queue to a background IO queue. 
 
 ## 0.9.4+9
 

--- a/packages/camera/camera/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/camera/camera/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 50;
 	objects = {
 
 /* Begin PBXBuildFile section */

--- a/packages/camera/camera/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/camera/camera/example/ios/Runner.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		E01EE4A82799F3A5008C1950 /* QueueHelperTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E01EE4A72799F3A5008C1950 /* QueueHelperTests.m */; };
 		E032F250279F5E94009E9028 /* CameraCaptureSessionQueueRaceConditionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E032F24F279F5E94009E9028 /* CameraCaptureSessionQueueRaceConditionTests.m */; };
+		E04F108627A87CA600573D0C /* FLTSavePhotoDelegateTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E04F108527A87CA600573D0C /* FLTSavePhotoDelegateTests.m */; };
 		E0C6E2002770F01A00EA6AA3 /* ThreadSafeMethodChannelTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E0C6E1FD2770F01A00EA6AA3 /* ThreadSafeMethodChannelTests.m */; };
 		E0C6E2012770F01A00EA6AA3 /* ThreadSafeTextureRegistryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E0C6E1FE2770F01A00EA6AA3 /* ThreadSafeTextureRegistryTests.m */; };
 		E0C6E2022770F01A00EA6AA3 /* ThreadSafeEventChannelTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E0C6E1FF2770F01A00EA6AA3 /* ThreadSafeEventChannelTests.m */; };
@@ -83,6 +84,7 @@
 		A24F9E418BA48BCC7409B117 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		E01EE4A72799F3A5008C1950 /* QueueHelperTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QueueHelperTests.m; sourceTree = "<group>"; };
 		E032F24F279F5E94009E9028 /* CameraCaptureSessionQueueRaceConditionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CameraCaptureSessionQueueRaceConditionTests.m; sourceTree = "<group>"; };
+		E04F108527A87CA600573D0C /* FLTSavePhotoDelegateTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FLTSavePhotoDelegateTests.m; sourceTree = "<group>"; };
 		E0C6E1FD2770F01A00EA6AA3 /* ThreadSafeMethodChannelTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ThreadSafeMethodChannelTests.m; sourceTree = "<group>"; };
 		E0C6E1FE2770F01A00EA6AA3 /* ThreadSafeTextureRegistryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ThreadSafeTextureRegistryTests.m; sourceTree = "<group>"; };
 		E0C6E1FF2770F01A00EA6AA3 /* ThreadSafeEventChannelTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ThreadSafeEventChannelTests.m; sourceTree = "<group>"; };
@@ -125,6 +127,7 @@
 				E0C6E1FD2770F01A00EA6AA3 /* ThreadSafeMethodChannelTests.m */,
 				E0C6E1FE2770F01A00EA6AA3 /* ThreadSafeTextureRegistryTests.m */,
 				E0F95E4327A36B9200699390 /* SampleBufferQueueTests.m */,
+				E04F108527A87CA600573D0C /* FLTSavePhotoDelegateTests.m */,
 				E01EE4A72799F3A5008C1950 /* QueueHelperTests.m */,
 				E487C85F26D686A10034AC92 /* CameraPreviewPauseTests.m */,
 				F6EE622E2710A6FC00905E4A /* MockFLTThreadSafeFlutterResult.m */,
@@ -399,6 +402,7 @@
 				E0F95E3D27A32AB900699390 /* CameraPropertiesTests.m in Sources */,
 				03BB766B2665316900CE5A93 /* CameraFocusTests.m in Sources */,
 				E487C86026D686A10034AC92 /* CameraPreviewPauseTests.m in Sources */,
+				E04F108627A87CA600573D0C /* FLTSavePhotoDelegateTests.m in Sources */,
 				F6EE622F2710A6FC00905E4A /* MockFLTThreadSafeFlutterResult.m in Sources */,
 				334733EA2668111C00DCC49E /* CameraOrientationTests.m in Sources */,
 				E032F250279F5E94009E9028 /* CameraCaptureSessionQueueRaceConditionTests.m in Sources */,

--- a/packages/camera/camera/example/ios/RunnerTests/FLTSavePhotoDelegateTests.m
+++ b/packages/camera/camera/example/ios/RunnerTests/FLTSavePhotoDelegateTests.m
@@ -1,0 +1,135 @@
+//
+//  FLTSavePhotoDelegateTests.m
+//  RunnerTests
+//
+//  Created by Huan Lin on 1/31/22.
+//  Copyright © 2022 The Flutter Authors. All rights reserved.
+//
+
+@import camera;
+@import camera.Test;
+@import AVFoundation;
+@import XCTest;
+#import <OCMock/OCMock.h>
+
+@interface FLTSavePhotoDelegate : NSObject <AVCapturePhotoCaptureDelegate>
+@property(readonly, nonatomic) NSString *path;
+- initWithPath:(NSString *)path
+        result:(FLTThreadSafeFlutterResult *)result
+       ioQueue:(dispatch_queue_t)ioQueue;
+- (void)handlePhotoCaptureResultWithError:(nullable NSError *)error
+                        photoDataProvider:(NSData * (^)(void))photoDataProvider;
+@end
+
+@interface FLTSavePhotoDelegateTests : XCTestCase
+
+@end
+
+@implementation FLTSavePhotoDelegateTests
+
+- (void)testHandlePhotoCaptureResult_mustSendErrorIfFailedToCapture {
+  NSError *error = [NSError errorWithDomain:@"test" code:0 userInfo:nil];
+  dispatch_queue_t ioQueue = dispatch_queue_create("test", NULL);
+  id mockResult = OCMClassMock([FLTThreadSafeFlutterResult class]);
+  FLTSavePhotoDelegate *delegate = [[FLTSavePhotoDelegate alloc] initWithPath:@"test"
+                                                                       result:mockResult
+                                                                      ioQueue:ioQueue];
+
+  [delegate handlePhotoCaptureResultWithError:error
+                            photoDataProvider:^NSData * {
+                              return nil;
+                            }];
+  OCMVerify(times(1), [mockResult sendError:error]);
+}
+
+- (void)testHandlePhotoCaptureResult_mustSendErrorIfFailedToWrite {
+  XCTestExpectation *resultExpectation =
+      [self expectationWithDescription:@"Must send IOError to the result if failed to write file."];
+  dispatch_queue_t ioQueue = dispatch_queue_create("test", NULL);
+  id mockResult = OCMClassMock([FLTThreadSafeFlutterResult class]);
+  OCMStub([mockResult sendErrorWithCode:@"IOError" message:@"Unable to write file" details:nil])
+      .andDo(^(NSInvocation *invocation) {
+        [resultExpectation fulfill];
+      });
+  FLTSavePhotoDelegate *delegate = [[FLTSavePhotoDelegate alloc] initWithPath:@"test"
+                                                                       result:mockResult
+                                                                      ioQueue:ioQueue];
+
+  // We can't use OCMClassMock for NSData because some XCTest APIs uses NSData (e.g.
+  // `XCTRunnerIDESession::logDebugMessage:`) on a private queue.
+  id mockData = OCMPartialMock([NSData data]);
+  OCMStub([mockData writeToFile:[OCMArg any] atomically:[OCMArg any]]).andReturn(NO);
+  [delegate handlePhotoCaptureResultWithError:nil
+                            photoDataProvider:^NSData * {
+                              return mockData;
+                            }];
+  [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+- (void)testHandlePhotoCaptureResult_mustSendSuccessIfSuccessToWrite {
+  XCTestExpectation *resultExpectation = [self
+      expectationWithDescription:@"Must send file path to the result if success to write file."];
+
+  dispatch_queue_t ioQueue = dispatch_queue_create("test", NULL);
+  id mockResult = OCMClassMock([FLTThreadSafeFlutterResult class]);
+  FLTSavePhotoDelegate *delegate = [[FLTSavePhotoDelegate alloc] initWithPath:@"test"
+                                                                       result:mockResult
+                                                                      ioQueue:ioQueue];
+  OCMStub([mockResult sendSuccessWithData:delegate.path]).andDo(^(NSInvocation *invocation) {
+    [resultExpectation fulfill];
+  });
+
+  // We can't use OCMClassMock for NSData because some XCTest APIs uses NSData (e.g.
+  // `XCTRunnerIDESession::logDebugMessage:`) on a private queue.
+  id mockData = OCMPartialMock([NSData data]);
+  OCMStub([mockData writeToFile:[OCMArg any] atomically:[OCMArg any]]).andReturn(YES);
+
+  [delegate handlePhotoCaptureResultWithError:nil
+                            photoDataProvider:^NSData * {
+                              return mockData;
+                            }];
+  [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+- (void)testHandlePhotoCaptureResult_bothProvideDataAndSaveFileMustRunOnIOQueue {
+  XCTestExpectation *dataProviderQueueExpectation =
+      [self expectationWithDescription:@"Data provider must run on io queue."];
+  XCTestExpectation *writeFileQueueExpectation =
+      [self expectationWithDescription:@"File writing must run on io queue"];
+  XCTestExpectation *resultExpectation = [self
+      expectationWithDescription:@"Must send file path to the result if success to write file."];
+
+  dispatch_queue_t ioQueue = dispatch_queue_create("test", NULL);
+  const char *ioQueueSpecific = "io_queue_specific";
+  dispatch_queue_set_specific(ioQueue, ioQueueSpecific, (void *)ioQueueSpecific, NULL);
+  id mockResult = OCMClassMock([FLTThreadSafeFlutterResult class]);
+  OCMStub([mockResult sendSuccessWithData:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
+    [resultExpectation fulfill];
+  });
+
+  // We can't use OCMClassMock for NSData because some XCTest APIs uses NSData (e.g.
+  // `XCTRunnerIDESession::logDebugMessage:`) on a private queue.
+  id mockData = OCMPartialMock([NSData data]);
+  OCMStub([mockData writeToFile:[OCMArg any] atomically:[OCMArg any]])
+      .andDo(^(NSInvocation *invocation) {
+        if (dispatch_get_specific(ioQueueSpecific)) {
+          [writeFileQueueExpectation fulfill];
+        }
+      })
+      .andReturn(YES);
+
+  FLTSavePhotoDelegate *delegate = [[FLTSavePhotoDelegate alloc] initWithPath:@"test"
+                                                                       result:mockResult
+                                                                      ioQueue:ioQueue];
+  [delegate handlePhotoCaptureResultWithError:nil
+                            photoDataProvider:^NSData * {
+                              if (dispatch_get_specific(ioQueueSpecific)) {
+                                [dataProviderQueueExpectation fulfill];
+                              }
+                              return mockData;
+                            }];
+
+  [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+@end

--- a/packages/camera/camera/example/ios/RunnerTests/FLTSavePhotoDelegateTests.m
+++ b/packages/camera/camera/example/ios/RunnerTests/FLTSavePhotoDelegateTests.m
@@ -26,7 +26,7 @@
                             photoDataProvider:^NSData * {
                               return nil;
                             }];
-  OCMVerify(times(1), [mockResult sendError:error]);
+  OCMVerify([mockResult sendError:error]);
 }
 
 - (void)testHandlePhotoCaptureResult_mustSendErrorIfFailedToWrite {
@@ -45,7 +45,7 @@
   // We can't use OCMClassMock for NSData because some XCTest APIs uses NSData (e.g.
   // `XCTRunnerIDESession::logDebugMessage:`) on a private queue.
   id mockData = OCMPartialMock([NSData data]);
-  OCMStub([mockData writeToFile:[OCMArg any] atomically:[OCMArg any]]).andReturn(NO);
+  OCMStub([mockData writeToFile:OCMOCK_ANY atomically:OCMOCK_ANY]).andReturn(NO);
   [delegate handlePhotoCaptureResultWithError:nil
                             photoDataProvider:^NSData * {
                               return mockData;
@@ -69,7 +69,7 @@
   // We can't use OCMClassMock for NSData because some XCTest APIs uses NSData (e.g.
   // `XCTRunnerIDESession::logDebugMessage:`) on a private queue.
   id mockData = OCMPartialMock([NSData data]);
-  OCMStub([mockData writeToFile:[OCMArg any] atomically:[OCMArg any]]).andReturn(YES);
+  OCMStub([mockData writeToFile:OCMOCK_ANY atomically:OCMOCK_ANY]).andReturn(YES);
 
   [delegate handlePhotoCaptureResultWithError:nil
                             photoDataProvider:^NSData * {
@@ -90,14 +90,14 @@
   const char *ioQueueSpecific = "io_queue_specific";
   dispatch_queue_set_specific(ioQueue, ioQueueSpecific, (void *)ioQueueSpecific, NULL);
   id mockResult = OCMClassMock([FLTThreadSafeFlutterResult class]);
-  OCMStub([mockResult sendSuccessWithData:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
+  OCMStub([mockResult sendSuccessWithData:OCMOCK_ANY]).andDo(^(NSInvocation *invocation) {
     [resultExpectation fulfill];
   });
 
   // We can't use OCMClassMock for NSData because some XCTest APIs uses NSData (e.g.
   // `XCTRunnerIDESession::logDebugMessage:`) on a private queue.
   id mockData = OCMPartialMock([NSData data]);
-  OCMStub([mockData writeToFile:[OCMArg any] atomically:[OCMArg any]])
+  OCMStub([mockData writeToFile:OCMOCK_ANY atomically:OCMOCK_ANY])
       .andDo(^(NSInvocation *invocation) {
         if (dispatch_get_specific(ioQueueSpecific)) {
           [writeFileQueueExpectation fulfill];

--- a/packages/camera/camera/example/ios/RunnerTests/FLTSavePhotoDelegateTests.m
+++ b/packages/camera/camera/example/ios/RunnerTests/FLTSavePhotoDelegateTests.m
@@ -8,15 +8,6 @@
 @import XCTest;
 #import <OCMock/OCMock.h>
 
-@interface FLTSavePhotoDelegate : NSObject <AVCapturePhotoCaptureDelegate>
-@property(readonly, nonatomic) NSString *path;
-- initWithPath:(NSString *)path
-        result:(FLTThreadSafeFlutterResult *)result
-       ioQueue:(dispatch_queue_t)ioQueue;
-- (void)handlePhotoCaptureResultWithError:(nullable NSError *)error
-                        photoDataProvider:(NSData * (^)(void))photoDataProvider;
-@end
-
 @interface FLTSavePhotoDelegateTests : XCTestCase
 
 @end

--- a/packages/camera/camera/example/ios/RunnerTests/FLTSavePhotoDelegateTests.m
+++ b/packages/camera/camera/example/ios/RunnerTests/FLTSavePhotoDelegateTests.m
@@ -1,10 +1,6 @@
-//
-//  FLTSavePhotoDelegateTests.m
-//  RunnerTests
-//
-//  Created by Huan Lin on 1/31/22.
-//  Copyright © 2022 The Flutter Authors. All rights reserved.
-//
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 @import camera;
 @import camera.Test;

--- a/packages/camera/camera/ios/Classes/CameraPlugin.modulemap
+++ b/packages/camera/camera/ios/Classes/CameraPlugin.modulemap
@@ -10,5 +10,10 @@ framework module camera {
     header "FLTCam.h"
     header "FLTCam_Test.h"
     header "FLTSavePhotoDelegate_Test.h"
+    header "FLTThreadSafeEventChannel.h"
+    header "FLTThreadSafeFlutterResult.h"
+    header "FLTThreadSafeMethodChannel.h"
+    header "FLTThreadSafeTextureRegistry.h"
+    header "QueueHelper.h"
   }
 }

--- a/packages/camera/camera/ios/Classes/CameraPlugin.modulemap
+++ b/packages/camera/camera/ios/Classes/CameraPlugin.modulemap
@@ -9,5 +9,6 @@ framework module camera {
     header "CameraProperties.h"
     header "FLTCam.h"
     header "FLTCam_Test.h"
+    header "FLTSavePhotoDelegate_Test.h"
   }
 }

--- a/packages/camera/camera/ios/Classes/FLTSavePhotoDelegate.h
+++ b/packages/camera/camera/ios/Classes/FLTSavePhotoDelegate.h
@@ -1,0 +1,37 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@import AVFoundation;
+@import Foundation;
+@import Flutter;
+
+#import "FLTThreadSafeFlutterResult.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Delegate object that handles photo capture results.
+ */
+@interface FLTSavePhotoDelegate : NSObject <AVCapturePhotoCaptureDelegate>
+/// The file path for the captured photo.
+@property(readonly, nonatomic) NSString *path;
+/// The thread safe flutter result wrapper to report the result.
+@property(readonly, nonatomic) FLTThreadSafeFlutterResult *result;
+/// The queue on which captured photos are wrote to disk.
+@property(strong, nonatomic) dispatch_queue_t ioQueue;
+/// Used to keep the delegate alive until didFinishProcessingPhotoSampleBuffer.
+@property(strong, nonatomic, nullable) FLTSavePhotoDelegate *selfReference;
+
+/**
+ * Initialize a photo capture delegate.
+ * @param path the path for captured photo file.
+ * @param result the thread safe flutter result wrapper to report the result.
+ * @param ioQueue the queue on which captured photos are wrote to disk.
+ */
+- (instancetype)initWithPath:(NSString *)path
+                      result:(FLTThreadSafeFlutterResult *)result
+                     ioQueue:(dispatch_queue_t)ioQueue;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/camera/camera/ios/Classes/FLTSavePhotoDelegate.m
+++ b/packages/camera/camera/ios/Classes/FLTSavePhotoDelegate.m
@@ -27,10 +27,13 @@
   }
   dispatch_async(self.ioQueue, ^{
     NSData *data = photoDataProvider();
-    if ([data writeToFile:self.path atomically:YES]) {
+    NSError *ioError;
+    if ([data writeToFile:self.path options:NSDataWritingAtomic error:&ioError]) {
       [self.result sendSuccessWithData:self.path];
     } else {
-      [self.result sendErrorWithCode:@"IOError" message:@"Unable to write file" details:nil];
+      [self.result sendErrorWithCode:@"IOError"
+                             message:@"Unable to write file"
+                             details:ioError.localizedDescription];
     }
   });
 }

--- a/packages/camera/camera/ios/Classes/FLTSavePhotoDelegate.m
+++ b/packages/camera/camera/ios/Classes/FLTSavePhotoDelegate.m
@@ -27,13 +27,11 @@
   }
   dispatch_async(self.ioQueue, ^{
     NSData *data = photoDataProvider();
-    bool success = [data writeToFile:self.path atomically:YES];
-
-    if (!success) {
+    if ([data writeToFile:self.path atomically:YES]) {
+      [self.result sendSuccessWithData:self.path];
+    } else {
       [self.result sendErrorWithCode:@"IOError" message:@"Unable to write file" details:nil];
-      return;
     }
-    [self.result sendSuccessWithData:self.path];
   });
 }
 

--- a/packages/camera/camera/ios/Classes/FLTSavePhotoDelegate.m
+++ b/packages/camera/camera/ios/Classes/FLTSavePhotoDelegate.m
@@ -1,0 +1,64 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "FLTSavePhotoDelegate.h"
+
+@implementation FLTSavePhotoDelegate
+
+- (instancetype)initWithPath:(NSString *)path
+                      result:(FLTThreadSafeFlutterResult *)result
+                     ioQueue:(dispatch_queue_t)ioQueue {
+  self = [super init];
+  NSAssert(self, @"super init cannot be nil");
+  _path = path;
+  _selfReference = self;
+  _result = result;
+  _ioQueue = ioQueue;
+  return self;
+}
+
+- (void)handlePhotoCaptureResultWithError:(NSError *)error
+                        photoDataProvider:(NSData * (^)(void))photoDataProvider {
+  self.selfReference = nil;
+  if (error) {
+    [self.result sendError:error];
+    return;
+  }
+  dispatch_async(self.ioQueue, ^{
+    NSData *data = photoDataProvider();
+    bool success = [data writeToFile:self.path atomically:YES];
+
+    if (!success) {
+      [self.result sendErrorWithCode:@"IOError" message:@"Unable to write file" details:nil];
+      return;
+    }
+    [self.result sendSuccessWithData:self.path];
+  });
+}
+
+- (void)captureOutput:(AVCapturePhotoOutput *)output
+    didFinishProcessingPhotoSampleBuffer:(CMSampleBufferRef)photoSampleBuffer
+                previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
+                        resolvedSettings:(AVCaptureResolvedPhotoSettings *)resolvedSettings
+                         bracketSettings:(AVCaptureBracketedStillImageSettings *)bracketSettings
+                                   error:(NSError *)error API_AVAILABLE(ios(10)) {
+  [self handlePhotoCaptureResultWithError:error
+                        photoDataProvider:^NSData * {
+                          return [AVCapturePhotoOutput
+                              JPEGPhotoDataRepresentationForJPEGSampleBuffer:photoSampleBuffer
+                                                    previewPhotoSampleBuffer:
+                                                        previewPhotoSampleBuffer];
+                        }];
+}
+
+- (void)captureOutput:(AVCapturePhotoOutput *)output
+    didFinishProcessingPhoto:(AVCapturePhoto *)photo
+                       error:(NSError *)error API_AVAILABLE(ios(11.0)) {
+  [self handlePhotoCaptureResultWithError:error
+                        photoDataProvider:^NSData * {
+                          return [photo fileDataRepresentation];
+                        }];
+}
+
+@end

--- a/packages/camera/camera/ios/Classes/FLTSavePhotoDelegate_Test.h
+++ b/packages/camera/camera/ios/Classes/FLTSavePhotoDelegate_Test.h
@@ -1,0 +1,17 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "FLTSavePhotoDelegate.h"
+
+/**
+ API exposed for unit tests.
+ */
+@interface FLTSavePhotoDelegate ()
+
+/// Handler to write captured photo data into a file.
+/// @param error the capture error.
+/// @param photoDataProvider a closure that provides photo data.
+- (void)handlePhotoCaptureResultWithError:(NSError *)error
+                        photoDataProvider:(NSData * (^)(void))photoDataProvider;
+@end

--- a/packages/camera/camera/ios/Classes/camera-umbrella.h
+++ b/packages/camera/camera/ios/Classes/camera-umbrella.h
@@ -4,11 +4,6 @@
 
 #import <Foundation/Foundation.h>
 #import <camera/CameraPlugin.h>
-#import <camera/FLTThreadSafeEventChannel.h>
-#import <camera/FLTThreadSafeFlutterResult.h>
-#import <camera/FLTThreadSafeMethodChannel.h>
-#import <camera/FLTThreadSafeTextureRegistry.h>
-#import <camera/QueueHelper.h>
 
 FOUNDATION_EXPORT double cameraVersionNumber;
 FOUNDATION_EXPORT const unsigned char cameraVersionString[];

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -4,7 +4,7 @@ description: A Flutter plugin for controlling the camera. Supports previewing
   Dart.
 repository: https://github.com/flutter/plugins/tree/main/packages/camera/camera
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.9.4+9
+version: 0.9.4+10
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
Writing photo files on background queue. A performance improvement similar to the previous PR that moves sample buffer handling to capture session queue. 

Very interesting learning related to mocking NSData: It turned out that we can't `OCMClassMock` NSData because XCTest infrastructure itself uses NSData (e.g. `XCTRunnerIDESession::logDebugMessage:`), which runs on a private queue (`com.apple.dt.xctest.default-debug-log-handler`). The race condition is pretty common and makes the test very fragile. Took me a while to debug. 

Issue: 
https://github.com/flutter/flutter/issues/96429

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
