### PR TITLE
[image_picker] Refactored tests to expose private interface in separate test header.

### DIFF
--- a/packages/image_picker/image_picker/CHANGELOG.md
+++ b/packages/image_picker/image_picker/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.8.4+7
 
-* Refactores unit test to expose private interface via a separate test header instead of the inline declaration.
+* Refactors unit test to expose private interface via a separate test header instead of the inline declaration.
 
 ## 0.8.4+6
 

--- a/packages/image_picker/image_picker/CHANGELOG.md
+++ b/packages/image_picker/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.4+7
+
+* Refactores unit test to expose private interface via a separate test header instead of the inline declaration.
+
 ## 0.8.4+6
 
 * Fixes minor type issues in iOS implementation.

--- a/packages/image_picker/image_picker/example/ios/RunnerTests/ImagePickerPluginTests.m
+++ b/packages/image_picker/image_picker/example/ios/RunnerTests/ImagePickerPluginTests.m
@@ -5,6 +5,7 @@
 #import "ImagePickerTestImages.h"
 
 @import image_picker;
+@import image_picker.Test;
 @import XCTest;
 #import <OCMock/OCMock.h>
 
@@ -19,12 +20,6 @@
   return mockPresented;
 }
 
-@end
-
-@interface FLTImagePickerPlugin (Test)
-@property(copy, nonatomic) FlutterResult result;
-- (void)handleSavedPathList:(NSMutableArray *)pathList;
-- (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker;
 @end
 
 @interface ImagePickerPluginTests : XCTestCase

--- a/packages/image_picker/image_picker/example/ios/RunnerTests/ImageUtilTests.m
+++ b/packages/image_picker/image_picker/example/ios/RunnerTests/ImageUtilTests.m
@@ -5,6 +5,7 @@
 #import "ImagePickerTestImages.h"
 
 @import image_picker;
+@import image_picker.Test;
 @import XCTest;
 
 @interface ImageUtilTests : XCTestCase

--- a/packages/image_picker/image_picker/example/ios/RunnerTests/MetaDataUtilTests.m
+++ b/packages/image_picker/image_picker/example/ios/RunnerTests/MetaDataUtilTests.m
@@ -5,6 +5,7 @@
 #import "ImagePickerTestImages.h"
 
 @import image_picker;
+@import image_picker.Test;
 @import XCTest;
 
 @interface MetaDataUtilTests : XCTestCase

--- a/packages/image_picker/image_picker/example/ios/RunnerTests/PhotoAssetUtilTests.m
+++ b/packages/image_picker/image_picker/example/ios/RunnerTests/PhotoAssetUtilTests.m
@@ -5,6 +5,7 @@
 #import "ImagePickerTestImages.h"
 
 @import image_picker;
+@import image_picker.Test;
 @import XCTest;
 
 @interface PhotoAssetUtilTests : XCTestCase

--- a/packages/image_picker/image_picker/ios/Classes/FLTImagePickerPlugin.m
+++ b/packages/image_picker/image_picker/ios/Classes/FLTImagePickerPlugin.m
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #import "FLTImagePickerPlugin.h"
+#import "FLTImagePickerPlugin_Test.h"
 
 #import <AVFoundation/AVFoundation.h>
 #import <MobileCoreServices/MobileCoreServices.h>
@@ -29,8 +30,6 @@ id GetNullableValueForKey(NSDictionary *dict, NSString *key) {
                                     UIImagePickerControllerDelegate,
                                     PHPickerViewControllerDelegate,
                                     UIAdaptivePresentationControllerDelegate>
-
-@property(copy, nonatomic) FlutterResult result;
 
 @property(assign, nonatomic) int maxImagesAllowed;
 

--- a/packages/image_picker/image_picker/ios/Classes/FLTImagePickerPlugin_Test.h
+++ b/packages/image_picker/image_picker/ios/Classes/FLTImagePickerPlugin_Test.h
@@ -1,0 +1,16 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// This header is available in the Test module. Import via "@import image_picker.Test;"
+
+#import <image_picker/FLTImagePickerPlugin.h>
+
+/// Methods exposed for unit testing.
+@interface FLTImagePickerPlugin ()
+
+@property(copy, nonatomic) FlutterResult result;
+- (void)handleSavedPathList:(NSArray *)pathList;
+- (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker;
+
+@end

--- a/packages/image_picker/image_picker/ios/Classes/FLTImagePickerPlugin_Test.h
+++ b/packages/image_picker/image_picker/ios/Classes/FLTImagePickerPlugin_Test.h
@@ -6,11 +6,37 @@
 
 #import <image_picker/FLTImagePickerPlugin.h>
 
-/// Methods exposed for unit testing.
+/** Methods exposed for unit testing. */
 @interface FLTImagePickerPlugin ()
 
+/** The Flutter result callback use to report results back to Flutter App. */
 @property(copy, nonatomic) FlutterResult result;
+
+/**
+ * Applies NSMutableArray on the FLutterResult.
+ *
+ * NSString must be returned by FlutterResult if the single image
+ * mode is active. It is checked by maxImagesAllowed and
+ * returns the first object of the pathlist.
+ *
+ * NSMutableArray must be returned by FlutterResult if the multi-image
+ * mode is active. After the pathlist count is checked then it returns
+ * the pathlist.
+ *
+ * @param pathList that should be applied to FlutterResult.
+ */
 - (void)handleSavedPathList:(NSArray *)pathList;
-- (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker;
+
+/**
+ * Tells the delegate that the user cancelled the pick operation.
+ *
+ * Your delegate’s implementation of this method should dismiss the picker view
+ * by calling the dismissModalViewControllerAnimated: method of the parent
+ * view controller.
+ *
+ * Implementation of this method is optional, but expected.
+ *
+ * @param picker The controller object managing the image picker interface.
+ */- (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker;
 
 @end

--- a/packages/image_picker/image_picker/ios/Classes/FLTImagePickerPlugin_Test.h
+++ b/packages/image_picker/image_picker/ios/Classes/FLTImagePickerPlugin_Test.h
@@ -37,6 +37,7 @@
  * Implementation of this method is optional, but expected.
  *
  * @param picker The controller object managing the image picker interface.
- */- (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker;
+ */
+-(void)imagePickerControllerDidCancel : (UIImagePickerController *)picker;
 
 @end

--- a/packages/image_picker/image_picker/ios/Classes/FLTImagePickerPlugin_Test.h
+++ b/packages/image_picker/image_picker/ios/Classes/FLTImagePickerPlugin_Test.h
@@ -38,6 +38,6 @@
  *
  * @param picker The controller object managing the image picker interface.
  */
--(void)imagePickerControllerDidCancel : (UIImagePickerController *)picker;
+- (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker;
 
 @end

--- a/packages/image_picker/image_picker/ios/Classes/ImagePickerPlugin.modulemap
+++ b/packages/image_picker/image_picker/ios/Classes/ImagePickerPlugin.modulemap
@@ -1,0 +1,10 @@
+framework module image_picker {
+  umbrella header "image_picker-umbrella.h"
+  
+  export *
+  module * { export * }
+
+  explicit module Test {
+    header "FLTImagePickerPlugin_Test.h"
+  }
+}

--- a/packages/image_picker/image_picker/ios/Classes/ImagePickerPlugin.modulemap
+++ b/packages/image_picker/image_picker/ios/Classes/ImagePickerPlugin.modulemap
@@ -6,5 +6,9 @@ framework module image_picker {
 
   explicit module Test {
     header "FLTImagePickerPlugin_Test.h"
+    header "FLTImagePickerImageUtil.h"
+    header "FLTImagePickerMetaDataUtil.h"
+    header "FLTImagePickerPhotoAssetUtil.h"
+    header "FLTPHPickerSaveImageToPathOperation.h"
   }
 }

--- a/packages/image_picker/image_picker/ios/Classes/image_picker-umbrella.h
+++ b/packages/image_picker/image_picker/ios/Classes/image_picker-umbrella.h
@@ -3,8 +3,4 @@
 // found in the LICENSE file.
 
 #import <Foundation/Foundation.h>
-#import <image_picker/FLTImagePickerImageUtil.h>
-#import <image_picker/FLTImagePickerMetaDataUtil.h>
-#import <image_picker/FLTImagePickerPhotoAssetUtil.h>
 #import <image_picker/FLTImagePickerPlugin.h>
-#import <image_picker/FLTPHPickerSaveImageToPathOperation.h>

--- a/packages/image_picker/image_picker/ios/Classes/image_picker-umbrella.h
+++ b/packages/image_picker/image_picker/ios/Classes/image_picker-umbrella.h
@@ -1,0 +1,10 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <Foundation/Foundation.h>
+#import <image_picker/FLTImagePickerImageUtil.h>
+#import <image_picker/FLTImagePickerMetaDataUtil.h>
+#import <image_picker/FLTImagePickerPhotoAssetUtil.h>
+#import <image_picker/FLTImagePickerPlugin.h>
+#import <image_picker/FLTPHPickerSaveImageToPathOperation.h>

--- a/packages/image_picker/image_picker/ios/image_picker.podspec
+++ b/packages/image_picker/image_picker/ios/image_picker.podspec
@@ -14,8 +14,9 @@ Downloaded by pub (not CocoaPods).
   s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
   s.source           = { :http => 'https://github.com/flutter/plugins/tree/main/packages/image_picker' }
   s.documentation_url = 'https://pub.dev/packages/image_picker'
-  s.source_files = 'Classes/**/*'
+  s.source_files = 'Classes/**/*.{h,m}'
   s.public_header_files = 'Classes/**/*.h'
+  s.module_map = 'Classes/ImagePickerPlugin.modulemap'
   s.dependency 'Flutter'
   s.platform = :ios, '9.0'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for selecting images from the Android and iOS image
   library, and taking new pictures with the camera.
 repository: https://github.com/flutter/plugins/tree/main/packages/image_picker/image_picker
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 0.8.4+6
+version: 0.8.4+7
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
Refactored the existing unit tests to expose private interfaces in a separate test header instead of an inline interface. This was first introduced in the google_sign_in plugin (#4157) and after that also applied in the camera plugin (#4426) and the webview_flutter plugin (#4480).

I have moved this refactoring out of the changes I am working on for issue flutter/flutter#96903 and PR #4718.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.