### PR TITLE
[shared_preferences] Move away from shared method channel implementation in native packages.

### DIFF
--- a/packages/shared_preferences/shared_preferences/test/shared_preferences_test.dart
+++ b/packages/shared_preferences/shared_preferences/test/shared_preferences_test.dart
@@ -47,11 +47,6 @@ void main() {
       store.log.clear();
     });
 
-    tearDown(() async {
-      await preferences.clear();
-      await store.clear();
-    });
-
     test('reading', () async {
       expect(preferences.get('String'), testString);
       expect(preferences.get('bool'), testBool);

--- a/packages/shared_preferences/shared_preferences_android/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.11
+
+* Removes use of shared method channel implementation. 
+
 ## 2.0.10
 
 * Removes dependency on `meta`.

--- a/packages/shared_preferences/shared_preferences_android/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_android/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.0.11
 
-* Removes use of shared method channel implementation. 
+* Switches to an in-package method channel implementation.
 
 ## 2.0.10
 

--- a/packages/shared_preferences/shared_preferences_android/android/src/main/java/io/flutter/plugins/sharedpreferences/SharedPreferencesPlugin.java
+++ b/packages/shared_preferences/shared_preferences_android/android/src/main/java/io/flutter/plugins/sharedpreferences/SharedPreferencesPlugin.java
@@ -11,7 +11,7 @@ import io.flutter.plugin.common.MethodChannel;
 
 /** SharedPreferencesPlugin */
 public class SharedPreferencesPlugin implements FlutterPlugin {
-  private static final String CHANNEL_NAME = "plugins.flutter.io/shared_preferences";
+  private static final String CHANNEL_NAME = "plugins.flutter.io/shared_preferences_android";
   private MethodChannel channel;
   private MethodCallHandlerImpl handler;
 

--- a/packages/shared_preferences/shared_preferences_android/lib/shared_preferences_android.dart
+++ b/packages/shared_preferences/shared_preferences_android/lib/shared_preferences_android.dart
@@ -10,7 +10,9 @@ import 'package:shared_preferences_platform_interface/shared_preferences_platfor
 const MethodChannel _kChannel =
     MethodChannel('plugins.flutter.io/shared_preferences_android');
 
-/// An implementation of [SharedPreferencesStorePlatform] that uses method channels.
+/// The macOS implementation of [SharedPreferencesStorePlatform].
+///
+/// This class implements the `package:shared_preferences` functionality for Android.
 class SharedPreferencesAndroid extends SharedPreferencesStorePlatform {
   /// Registers this class as the default instance of [SharedPreferencesStorePlatform].
   static void registerWith() {

--- a/packages/shared_preferences/shared_preferences_android/lib/shared_preferences_android.dart
+++ b/packages/shared_preferences/shared_preferences_android/lib/shared_preferences_android.dart
@@ -1,0 +1,51 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
+
+const MethodChannel _kChannel =
+    MethodChannel('plugins.flutter.io/shared_preferences_android');
+
+/// An implementation of [SharedPreferencesStorePlatform] that uses method channels.
+class SharedPreferencesAndroid extends SharedPreferencesStorePlatform {
+  /// Registers this class as the default instance of [SharedPreferencesStorePlatform].
+  static void registerWith() {
+    SharedPreferencesStorePlatform.instance = SharedPreferencesAndroid();
+  }
+
+  @override
+  Future<bool> remove(String key) async {
+    return (await _kChannel.invokeMethod<bool>(
+      'remove',
+      <String, dynamic>{'key': key},
+    ))!;
+  }
+
+  @override
+  Future<bool> setValue(String valueType, String key, Object value) async {
+    return (await _kChannel.invokeMethod<bool>(
+      'set$valueType',
+      <String, dynamic>{'key': key, 'value': value},
+    ))!;
+  }
+
+  @override
+  Future<bool> clear() async {
+    return (await _kChannel.invokeMethod<bool>('clear'))!;
+  }
+
+  @override
+  Future<Map<String, Object>> getAll() async {
+    final Map<String, Object>? preferences =
+        await _kChannel.invokeMapMethod<String, Object>('getAll');
+
+    if (preferences == null) {
+      return <String, Object>{};
+    }
+    return preferences;
+  }
+}

--- a/packages/shared_preferences/shared_preferences_android/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_android/pubspec.yaml
@@ -25,4 +25,3 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.10.0

--- a/packages/shared_preferences/shared_preferences_android/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_android/pubspec.yaml
@@ -2,11 +2,11 @@ name: shared_preferences_android
 description: Android implementation of the shared_preferences plugin
 repository: https://github.com/flutter/plugins/tree/main/packages/shared_preferences/shared_preferences_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.0.10
+version: 2.0.11
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.5.0"
+  flutter: ">=2.8.0"
 
 flutter:
   plugin:
@@ -15,6 +15,7 @@ flutter:
       android:
         package: io.flutter.plugins.sharedpreferences
         pluginClass: SharedPreferencesPlugin
+        dartPluginClass: SharedPreferencesAndroid
 
 dependencies:
   flutter:

--- a/packages/shared_preferences/shared_preferences_android/test/shared_preferences_android_test.dart
+++ b/packages/shared_preferences/shared_preferences_android/test/shared_preferences_android_test.dart
@@ -1,0 +1,111 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences_android/shared_preferences_android.dart';
+import 'package:shared_preferences_platform_interface/method_channel_shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group(MethodChannelSharedPreferencesStore, () {
+    const MethodChannel channel = MethodChannel(
+      'plugins.flutter.io/shared_preferences_android',
+    );
+
+    const Map<String, Object> kTestValues = <String, Object>{
+      'flutter.String': 'hello world',
+      'flutter.Bool': true,
+      'flutter.Int': 42,
+      'flutter.Double': 3.14159,
+      'flutter.StringList': <String>['foo', 'bar'],
+    };
+
+    late InMemorySharedPreferencesStore testData;
+
+    final List<MethodCall> log = <MethodCall>[];
+    late SharedPreferencesStorePlatform store;
+
+    setUp(() async {
+      testData = InMemorySharedPreferencesStore.empty();
+
+      channel.setMockMethodCallHandler((MethodCall methodCall) async {
+        log.add(methodCall);
+        if (methodCall.method == 'getAll') {
+          return await testData.getAll();
+        }
+        if (methodCall.method == 'remove') {
+          final String key = (methodCall.arguments['key'] as String?)!;
+          return await testData.remove(key);
+        }
+        if (methodCall.method == 'clear') {
+          return await testData.clear();
+        }
+        final RegExp setterRegExp = RegExp(r'set(.*)');
+        final Match? match = setterRegExp.matchAsPrefix(methodCall.method);
+        if (match?.groupCount == 1) {
+          final String valueType = match!.group(1)!;
+          final String key = (methodCall.arguments['key'] as String?)!;
+          final Object value = (methodCall.arguments['value'] as Object?)!;
+          return await testData.setValue(valueType, key, value);
+        }
+        fail('Unexpected method call: ${methodCall.method}');
+      });
+      store = SharedPreferencesAndroid();
+      log.clear();
+    });
+
+    tearDown(() async {
+      await testData.clear();
+    });
+
+    test('getAll', () async {
+      testData = InMemorySharedPreferencesStore.withData(kTestValues);
+      expect(await store.getAll(), kTestValues);
+      expect(log.single.method, 'getAll');
+    });
+
+    test('remove', () async {
+      testData = InMemorySharedPreferencesStore.withData(kTestValues);
+      expect(await store.remove('flutter.String'), true);
+      expect(await store.remove('flutter.Bool'), true);
+      expect(await store.remove('flutter.Int'), true);
+      expect(await store.remove('flutter.Double'), true);
+      expect(await testData.getAll(), <String, dynamic>{
+        'flutter.StringList': <String>['foo', 'bar'],
+      });
+
+      expect(log, hasLength(4));
+      for (final MethodCall call in log) {
+        expect(call.method, 'remove');
+      }
+    });
+
+    test('setValue', () async {
+      expect(await testData.getAll(), isEmpty);
+      for (final String key in kTestValues.keys) {
+        final Object value = kTestValues[key]!;
+        expect(await store.setValue(key.split('.').last, key, value), true);
+      }
+      expect(await testData.getAll(), kTestValues);
+
+      expect(log, hasLength(5));
+      expect(log[0].method, 'setString');
+      expect(log[1].method, 'setBool');
+      expect(log[2].method, 'setInt');
+      expect(log[3].method, 'setDouble');
+      expect(log[4].method, 'setStringList');
+    });
+
+    test('clear', () async {
+      testData = InMemorySharedPreferencesStore.withData(kTestValues);
+      expect(await testData.getAll(), isNotEmpty);
+      expect(await store.clear(), true);
+      expect(await testData.getAll(), isEmpty);
+      expect(log.single.method, 'clear');
+    });
+  });
+}

--- a/packages/shared_preferences/shared_preferences_android/test/shared_preferences_android_test.dart
+++ b/packages/shared_preferences/shared_preferences_android/test/shared_preferences_android_test.dart
@@ -62,6 +62,12 @@ void main() {
       await testData.clear();
     });
 
+    test('registered instance', () {
+      SharedPreferencesAndroid.registerWith();
+      expect(SharedPreferencesStorePlatform.instance,
+          isA<SharedPreferencesAndroid>());
+    });
+
     test('getAll', () async {
       testData = InMemorySharedPreferencesStore.withData(kTestValues);
       expect(await store.getAll(), kTestValues);

--- a/packages/shared_preferences/shared_preferences_ios/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_ios/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.0.10
 
-* Removes use of shared method channel implementation.
+* Switches to an in-package method channel implementation.
 
 ## 2.0.9
 

--- a/packages/shared_preferences/shared_preferences_ios/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.10
+
+* Removes use of shared method channel implementation.
+
 ## 2.0.9
 
 * Removes dependency on `meta`.

--- a/packages/shared_preferences/shared_preferences_ios/ios/Classes/FLTSharedPreferencesPlugin.m
+++ b/packages/shared_preferences/shared_preferences_ios/ios/Classes/FLTSharedPreferencesPlugin.m
@@ -4,7 +4,7 @@
 
 #import "FLTSharedPreferencesPlugin.h"
 
-static NSString *const CHANNEL_NAME = @"plugins.flutter.io/shared_preferences";
+static NSString *const CHANNEL_NAME = @"plugins.flutter.io/shared_preferences_ios";
 
 @implementation FLTSharedPreferencesPlugin
 

--- a/packages/shared_preferences/shared_preferences_ios/lib/shared_preferences_ios.dart
+++ b/packages/shared_preferences/shared_preferences_ios/lib/shared_preferences_ios.dart
@@ -10,7 +10,9 @@ import 'package:shared_preferences_platform_interface/shared_preferences_platfor
 const MethodChannel _kChannel =
     MethodChannel('plugins.flutter.io/shared_preferences_ios');
 
-/// An implementation of [SharedPreferencesStorePlatform] that uses method channels.
+/// The macOS implementation of [SharedPreferencesStorePlatform].
+///
+/// This class implements the `package:shared_preferences` functionality for iOS.
 class SharedPreferencesIOS extends SharedPreferencesStorePlatform {
   /// Registers this class as the default instance of [SharedPreferencesStorePlatform].
   static void registerWith() {

--- a/packages/shared_preferences/shared_preferences_ios/lib/shared_preferences_ios.dart
+++ b/packages/shared_preferences/shared_preferences_ios/lib/shared_preferences_ios.dart
@@ -1,0 +1,51 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
+
+const MethodChannel _kChannel =
+    MethodChannel('plugins.flutter.io/shared_preferences_ios');
+
+/// An implementation of [SharedPreferencesStorePlatform] that uses method channels.
+class SharedPreferencesIOS extends SharedPreferencesStorePlatform {
+  /// Registers this class as the default instance of [SharedPreferencesStorePlatform].
+  static void registerWith() {
+    SharedPreferencesStorePlatform.instance = SharedPreferencesIOS();
+  }
+
+  @override
+  Future<bool> remove(String key) async {
+    return (await _kChannel.invokeMethod<bool>(
+      'remove',
+      <String, dynamic>{'key': key},
+    ))!;
+  }
+
+  @override
+  Future<bool> setValue(String valueType, String key, Object value) async {
+    return (await _kChannel.invokeMethod<bool>(
+      'set$valueType',
+      <String, dynamic>{'key': key, 'value': value},
+    ))!;
+  }
+
+  @override
+  Future<bool> clear() async {
+    return (await _kChannel.invokeMethod<bool>('clear'))!;
+  }
+
+  @override
+  Future<Map<String, Object>> getAll() async {
+    final Map<String, Object>? preferences =
+        await _kChannel.invokeMapMethod<String, Object>('getAll');
+
+    if (preferences == null) {
+      return <String, Object>{};
+    }
+    return preferences;
+  }
+}

--- a/packages/shared_preferences/shared_preferences_ios/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_ios/pubspec.yaml
@@ -24,4 +24,3 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.10.0

--- a/packages/shared_preferences/shared_preferences_ios/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_ios/pubspec.yaml
@@ -2,11 +2,11 @@ name: shared_preferences_ios
 description: iOS implementation of the shared_preferences plugin
 repository: https://github.com/flutter/plugins/tree/main/packages/shared_preferences/shared_preferences_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.0.9
+version: 2.0.10
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.5.0"
+  flutter: ">=2.8.0"
 
 flutter:
   plugin:
@@ -14,6 +14,7 @@ flutter:
     platforms:
       ios:
         pluginClass: FLTSharedPreferencesPlugin
+        dartPluginClass: SharedPreferencesIOS
 
 dependencies:
   flutter:

--- a/packages/shared_preferences/shared_preferences_ios/test/shared_preferences_ios_test.dart
+++ b/packages/shared_preferences/shared_preferences_ios/test/shared_preferences_ios_test.dart
@@ -1,0 +1,111 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences_ios/shared_preferences_ios.dart';
+import 'package:shared_preferences_platform_interface/method_channel_shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group(MethodChannelSharedPreferencesStore, () {
+    const MethodChannel channel = MethodChannel(
+      'plugins.flutter.io/shared_preferences_ios',
+    );
+
+    const Map<String, Object> kTestValues = <String, Object>{
+      'flutter.String': 'hello world',
+      'flutter.Bool': true,
+      'flutter.Int': 42,
+      'flutter.Double': 3.14159,
+      'flutter.StringList': <String>['foo', 'bar'],
+    };
+
+    late InMemorySharedPreferencesStore testData;
+
+    final List<MethodCall> log = <MethodCall>[];
+    late SharedPreferencesStorePlatform store;
+
+    setUp(() async {
+      testData = InMemorySharedPreferencesStore.empty();
+
+      channel.setMockMethodCallHandler((MethodCall methodCall) async {
+        log.add(methodCall);
+        if (methodCall.method == 'getAll') {
+          return await testData.getAll();
+        }
+        if (methodCall.method == 'remove') {
+          final String key = (methodCall.arguments['key'] as String?)!;
+          return await testData.remove(key);
+        }
+        if (methodCall.method == 'clear') {
+          return await testData.clear();
+        }
+        final RegExp setterRegExp = RegExp(r'set(.*)');
+        final Match? match = setterRegExp.matchAsPrefix(methodCall.method);
+        if (match?.groupCount == 1) {
+          final String valueType = match!.group(1)!;
+          final String key = (methodCall.arguments['key'] as String?)!;
+          final Object value = (methodCall.arguments['value'] as Object?)!;
+          return await testData.setValue(valueType, key, value);
+        }
+        fail('Unexpected method call: ${methodCall.method}');
+      });
+      store = SharedPreferencesIOS();
+      log.clear();
+    });
+
+    tearDown(() async {
+      await testData.clear();
+    });
+
+    test('getAll', () async {
+      testData = InMemorySharedPreferencesStore.withData(kTestValues);
+      expect(await store.getAll(), kTestValues);
+      expect(log.single.method, 'getAll');
+    });
+
+    test('remove', () async {
+      testData = InMemorySharedPreferencesStore.withData(kTestValues);
+      expect(await store.remove('flutter.String'), true);
+      expect(await store.remove('flutter.Bool'), true);
+      expect(await store.remove('flutter.Int'), true);
+      expect(await store.remove('flutter.Double'), true);
+      expect(await testData.getAll(), <String, dynamic>{
+        'flutter.StringList': <String>['foo', 'bar'],
+      });
+
+      expect(log, hasLength(4));
+      for (final MethodCall call in log) {
+        expect(call.method, 'remove');
+      }
+    });
+
+    test('setValue', () async {
+      expect(await testData.getAll(), isEmpty);
+      for (final String key in kTestValues.keys) {
+        final Object value = kTestValues[key]!;
+        expect(await store.setValue(key.split('.').last, key, value), true);
+      }
+      expect(await testData.getAll(), kTestValues);
+
+      expect(log, hasLength(5));
+      expect(log[0].method, 'setString');
+      expect(log[1].method, 'setBool');
+      expect(log[2].method, 'setInt');
+      expect(log[3].method, 'setDouble');
+      expect(log[4].method, 'setStringList');
+    });
+
+    test('clear', () async {
+      testData = InMemorySharedPreferencesStore.withData(kTestValues);
+      expect(await testData.getAll(), isNotEmpty);
+      expect(await store.clear(), true);
+      expect(await testData.getAll(), isEmpty);
+      expect(log.single.method, 'clear');
+    });
+  });
+}

--- a/packages/shared_preferences/shared_preferences_ios/test/shared_preferences_ios_test.dart
+++ b/packages/shared_preferences/shared_preferences_ios/test/shared_preferences_ios_test.dart
@@ -62,6 +62,12 @@ void main() {
       await testData.clear();
     });
 
+    test('registered instance', () {
+      SharedPreferencesIOS.registerWith();
+      expect(
+          SharedPreferencesStorePlatform.instance, isA<SharedPreferencesIOS>());
+    });
+
     test('getAll', () async {
       testData = InMemorySharedPreferencesStore.withData(kTestValues);
       expect(await store.getAll(), kTestValues);

--- a/packages/shared_preferences/shared_preferences_ios/test/shared_preferences_ios_test.dart
+++ b/packages/shared_preferences/shared_preferences_ios/test/shared_preferences_ios_test.dart
@@ -23,7 +23,8 @@ void main() {
       'flutter.Double': 3.14159,
       'flutter.StringList': <String>['foo', 'bar'],
     };
-
+    // Create a dummy in-memory implementation to back the mocked method channel
+    // API to simplify validation of the expected calls.
     late InMemorySharedPreferencesStore testData;
 
     final List<MethodCall> log = <MethodCall>[];
@@ -38,7 +39,7 @@ void main() {
           return await testData.getAll();
         }
         if (methodCall.method == 'remove') {
-          final String key = (methodCall.arguments['key'] as String?)!;
+          final String key = methodCall.arguments['key'] as String;
           return await testData.remove(key);
         }
         if (methodCall.method == 'clear') {
@@ -48,18 +49,13 @@ void main() {
         final Match? match = setterRegExp.matchAsPrefix(methodCall.method);
         if (match?.groupCount == 1) {
           final String valueType = match!.group(1)!;
-          final String key = (methodCall.arguments['key'] as String?)!;
-          final Object value = (methodCall.arguments['value'] as Object?)!;
+          final String key = methodCall.arguments['key'] as String;
+          final Object value = methodCall.arguments['value'] as Object;
           return await testData.setValue(valueType, key, value);
         }
         fail('Unexpected method call: ${methodCall.method}');
       });
-      store = SharedPreferencesIOS();
       log.clear();
-    });
-
-    tearDown(() async {
-      await testData.clear();
     });
 
     test('registered instance', () {
@@ -69,12 +65,14 @@ void main() {
     });
 
     test('getAll', () async {
+      store = SharedPreferencesIOS();
       testData = InMemorySharedPreferencesStore.withData(kTestValues);
       expect(await store.getAll(), kTestValues);
       expect(log.single.method, 'getAll');
     });
 
     test('remove', () async {
+      store = SharedPreferencesIOS();
       testData = InMemorySharedPreferencesStore.withData(kTestValues);
       expect(await store.remove('flutter.String'), true);
       expect(await store.remove('flutter.Bool'), true);
@@ -91,6 +89,7 @@ void main() {
     });
 
     test('setValue', () async {
+      store = SharedPreferencesIOS();
       expect(await testData.getAll(), isEmpty);
       for (final String key in kTestValues.keys) {
         final Object value = kTestValues[key]!;
@@ -107,6 +106,7 @@ void main() {
     });
 
     test('clear', () async {
+      store = SharedPreferencesIOS();
       testData = InMemorySharedPreferencesStore.withData(kTestValues);
       expect(await testData.getAll(), isNotEmpty);
       expect(await store.clear(), true);

--- a/packages/shared_preferences/shared_preferences_linux/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.5
+
+* Updated to make use of `dartPluginClass` only.
+
 ## 2.0.4
 
 * Removes dependency on `meta`.

--- a/packages/shared_preferences/shared_preferences_linux/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_linux/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 2.0.5
+## 2.1.0
 
 * Updated to make use of `dartPluginClass` only.
+* Deprecated `SharedPreferencesWindows.instance` in favor of `SharedPreferencesStorePlatform.instance`.
 
 ## 2.0.4
 

--- a/packages/shared_preferences/shared_preferences_linux/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_linux/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## 2.1.0
 
-* Updated to make use of `dartPluginClass` only.
 * Deprecated `SharedPreferencesWindows.instance` in favor of `SharedPreferencesStorePlatform.instance`.
 
 ## 2.0.4

--- a/packages/shared_preferences/shared_preferences_linux/example/integration_test/shared_preferences_test.dart
+++ b/packages/shared_preferences/shared_preferences_linux/example/integration_test/shared_preferences_test.dart
@@ -31,7 +31,7 @@ void main() {
     late SharedPreferencesLinux preferences;
 
     setUp(() async {
-      preferences = SharedPreferencesLinux.instance;
+      preferences = SharedPreferencesLinux();
     });
 
     tearDown(() {

--- a/packages/shared_preferences/shared_preferences_linux/example/lib/main.dart
+++ b/packages/shared_preferences/shared_preferences_linux/example/lib/main.dart
@@ -31,7 +31,7 @@ class SharedPreferencesDemo extends StatefulWidget {
 }
 
 class SharedPreferencesDemoState extends State<SharedPreferencesDemo> {
-  final SharedPreferencesLinux prefs = SharedPreferencesLinux.instance;
+  final SharedPreferencesLinux prefs = SharedPreferencesLinux();
   late Future<int> _counter;
 
   Future<void> _incrementCounter() async {

--- a/packages/shared_preferences/shared_preferences_linux/lib/shared_preferences_linux.dart
+++ b/packages/shared_preferences/shared_preferences_linux/lib/shared_preferences_linux.dart
@@ -16,14 +16,9 @@ import 'package:shared_preferences_platform_interface/shared_preferences_platfor
 ///
 /// This class implements the `package:shared_preferences` functionality for Linux.
 class SharedPreferencesLinux extends SharedPreferencesStorePlatform {
-  /// The default instance of [SharedPreferencesLinux] to use.
-  // TODO(egarciad): Remove when the Dart plugin registrant lands on Flutter stable.
-  // https://github.com/flutter/flutter/issues/81421
-  static SharedPreferencesLinux instance = SharedPreferencesLinux();
-
   /// Registers the Linux implementation.
   static void registerWith() {
-    SharedPreferencesStorePlatform.instance = instance;
+    SharedPreferencesStorePlatform.instance = SharedPreferencesLinux();
   }
 
   /// Local copy of preferences
@@ -33,9 +28,12 @@ class SharedPreferencesLinux extends SharedPreferencesStorePlatform {
   @visibleForTesting
   FileSystem fs = const LocalFileSystem();
 
+  /// The path_provider_linux instance used to find the support directory.
+  @visibleForTesting
+  PathProviderLinux pathProvider = PathProviderLinux();
+
   /// Gets the file where the preferences are stored.
   Future<File?> _getLocalDataFile() async {
-    final PathProviderLinux pathProvider = PathProviderLinux();
     final String? directory = await pathProvider.getApplicationSupportPath();
     if (directory == null) {
       return null;

--- a/packages/shared_preferences/shared_preferences_linux/lib/shared_preferences_linux.dart
+++ b/packages/shared_preferences/shared_preferences_linux/lib/shared_preferences_linux.dart
@@ -16,6 +16,11 @@ import 'package:shared_preferences_platform_interface/shared_preferences_platfor
 ///
 /// This class implements the `package:shared_preferences` functionality for Linux.
 class SharedPreferencesLinux extends SharedPreferencesStorePlatform {
+  /// Deprecated instance of [SharedPreferencesLinux].
+  /// Use [SharedPreferencesStorePlatform.instance] instead.
+  @Deprecated('Use `SharedPreferencesStorePlatform.instance` instead.')
+  static SharedPreferencesLinux instance = SharedPreferencesLinux();
+
   /// Registers the Linux implementation.
   static void registerWith() {
     SharedPreferencesStorePlatform.instance = SharedPreferencesLinux();

--- a/packages/shared_preferences/shared_preferences_linux/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_linux/pubspec.yaml
@@ -27,4 +27,3 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.10.0

--- a/packages/shared_preferences/shared_preferences_linux/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_linux/pubspec.yaml
@@ -2,7 +2,7 @@ name: shared_preferences_linux
 description: Linux implementation of the shared_preferences plugin
 repository: https://github.com/flutter/plugins/tree/main/packages/shared_preferences/shared_preferences_linux
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.0.5
+version: 2.1.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/shared_preferences/shared_preferences_linux/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_linux/pubspec.yaml
@@ -2,11 +2,11 @@ name: shared_preferences_linux
 description: Linux implementation of the shared_preferences plugin
 repository: https://github.com/flutter/plugins/tree/main/packages/shared_preferences/shared_preferences_linux
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.0.4
+version: 2.0.5
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"
+  flutter: ">=2.5.0"
 
 flutter:
   plugin:
@@ -21,6 +21,7 @@ dependencies:
     sdk: flutter
   path: ^1.8.0
   path_provider_linux: ^2.0.0
+  path_provider_platform_interface: ^2.0.0
   shared_preferences_platform_interface: ^2.0.0
 
 dev_dependencies:

--- a/packages/shared_preferences/shared_preferences_linux/test/shared_preferences_linux_test.dart
+++ b/packages/shared_preferences/shared_preferences_linux/test/shared_preferences_linux_test.dart
@@ -43,6 +43,7 @@ void main() {
   }
 
   test('registered instance', () {
+    SharedPreferencesLinux.registerWith();
     expect(
         SharedPreferencesStorePlatform.instance, isA<SharedPreferencesLinux>());
   });
@@ -85,11 +86,11 @@ void main() {
   });
 }
 
-/// Fake implementation of PathProviderWindows that returns hard-coded paths,
+/// Fake implementation of PathProviderLinux that returns hard-coded paths,
 /// allowing tests to run on any platform.
 ///
 /// Note that this should only be used with an in-memory filesystem, as the
-/// path it returns is a root path that does not actually exist on Windows.
+/// path it returns is a root path that does not actually exist on Linux.
 class FakePathProviderLinux extends PathProviderPlatform
     implements PathProviderLinux {
   @override

--- a/packages/shared_preferences/shared_preferences_linux/test/shared_preferences_linux_test.dart
+++ b/packages/shared_preferences/shared_preferences_linux/test/shared_preferences_linux_test.dart
@@ -5,20 +5,22 @@ import 'package:file/memory.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as path;
 import 'package:path_provider_linux/path_provider_linux.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:shared_preferences_linux/shared_preferences_linux.dart';
 import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
 
 void main() {
   late MemoryFileSystem fs;
+  late PathProviderLinux pathProvider;
 
   SharedPreferencesLinux.registerWith();
 
   setUp(() {
     fs = MemoryFileSystem.test();
+    pathProvider = FakePathProviderLinux();
   });
 
   Future<String> _getFilePath() async {
-    final PathProviderLinux pathProvider = PathProviderLinux();
     final String? directory = await pathProvider.getApplicationSupportPath();
     return path.join(directory!, 'shared_preferences.json');
   }
@@ -36,6 +38,7 @@ void main() {
   SharedPreferencesLinux _getPreferences() {
     final SharedPreferencesLinux prefs = SharedPreferencesLinux();
     prefs.fs = fs;
+    prefs.pathProvider = pathProvider;
     return prefs;
   }
 
@@ -80,4 +83,30 @@ void main() {
     await prefs.clear();
     expect(await _readTestFile(), '{}');
   });
+}
+
+/// Fake implementation of PathProviderWindows that returns hard-coded paths,
+/// allowing tests to run on any platform.
+///
+/// Note that this should only be used with an in-memory filesystem, as the
+/// path it returns is a root path that does not actually exist on Windows.
+class FakePathProviderLinux extends PathProviderPlatform
+    implements PathProviderLinux {
+  @override
+  Future<String?> getApplicationSupportPath() async => r'/appsupport';
+
+  @override
+  Future<String?> getTemporaryPath() async => null;
+
+  @override
+  Future<String?> getLibraryPath() async => null;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => null;
+
+  @override
+  Future<String?> getDownloadsPath() async => null;
+
+  @override
+  Future<String> getPath(String folderID) async => '';
 }

--- a/packages/shared_preferences/shared_preferences_linux/test/shared_preferences_linux_test.dart
+++ b/packages/shared_preferences/shared_preferences_linux/test/shared_preferences_linux_test.dart
@@ -106,7 +106,4 @@ class FakePathProviderLinux extends PathProviderPlatform
 
   @override
   Future<String?> getDownloadsPath() async => null;
-
-  @override
-  Future<String> getPath(String folderID) async => '';
 }

--- a/packages/shared_preferences/shared_preferences_macos/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_macos/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 2.0.3
 
+* Removes use of shared method channel implementation.
 * Fixes newly enabled analyzer options.
 
 ## 2.0.2

--- a/packages/shared_preferences/shared_preferences_macos/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_macos/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.0.3
 
-* Removes use of shared method channel implementation.
+* Switches to an in-package method channel implementation.
 * Fixes newly enabled analyzer options.
 
 ## 2.0.2

--- a/packages/shared_preferences/shared_preferences_macos/lib/shared_preferences_macos.dart
+++ b/packages/shared_preferences/shared_preferences_macos/lib/shared_preferences_macos.dart
@@ -1,0 +1,51 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
+
+const MethodChannel _kChannel =
+    MethodChannel('plugins.flutter.io/shared_preferences_macos');
+
+/// An implementation of [SharedPreferencesStorePlatform] that uses method channels.
+class SharedPreferencesMacOS extends SharedPreferencesStorePlatform {
+  /// Registers this class as the default instance of [SharedPreferencesStorePlatform].
+  static void registerWith() {
+    SharedPreferencesStorePlatform.instance = SharedPreferencesMacOS();
+  }
+
+  @override
+  Future<bool> remove(String key) async {
+    return (await _kChannel.invokeMethod<bool>(
+      'remove',
+      <String, dynamic>{'key': key},
+    ))!;
+  }
+
+  @override
+  Future<bool> setValue(String valueType, String key, Object value) async {
+    return (await _kChannel.invokeMethod<bool>(
+      'set$valueType',
+      <String, dynamic>{'key': key, 'value': value},
+    ))!;
+  }
+
+  @override
+  Future<bool> clear() async {
+    return (await _kChannel.invokeMethod<bool>('clear'))!;
+  }
+
+  @override
+  Future<Map<String, Object>> getAll() async {
+    final Map<String, Object>? preferences =
+        await _kChannel.invokeMapMethod<String, Object>('getAll');
+
+    if (preferences == null) {
+      return <String, Object>{};
+    }
+    return preferences;
+  }
+}

--- a/packages/shared_preferences/shared_preferences_macos/lib/shared_preferences_macos.dart
+++ b/packages/shared_preferences/shared_preferences_macos/lib/shared_preferences_macos.dart
@@ -10,7 +10,9 @@ import 'package:shared_preferences_platform_interface/shared_preferences_platfor
 const MethodChannel _kChannel =
     MethodChannel('plugins.flutter.io/shared_preferences_macos');
 
-/// An implementation of [SharedPreferencesStorePlatform] that uses method channels.
+/// The macOS implementation of [SharedPreferencesStorePlatform].
+///
+/// This class implements the `package:shared_preferences` functionality for macOS.
 class SharedPreferencesMacOS extends SharedPreferencesStorePlatform {
   /// Registers this class as the default instance of [SharedPreferencesStorePlatform].
   static void registerWith() {

--- a/packages/shared_preferences/shared_preferences_macos/macos/Classes/SharedPreferencesPlugin.swift
+++ b/packages/shared_preferences/shared_preferences_macos/macos/Classes/SharedPreferencesPlugin.swift
@@ -8,7 +8,7 @@ import Foundation
 public class SharedPreferencesPlugin: NSObject, FlutterPlugin {
   public static func register(with registrar: FlutterPluginRegistrar) {
     let channel = FlutterMethodChannel(
-      name: "plugins.flutter.io/shared_preferences",
+      name: "plugins.flutter.io/shared_preferences_macos",
       binaryMessenger: registrar.messenger)
     let instance = SharedPreferencesPlugin()
     registrar.addMethodCallDelegate(instance, channel: channel)

--- a/packages/shared_preferences/shared_preferences_macos/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_macos/pubspec.yaml
@@ -24,4 +24,3 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.10.0

--- a/packages/shared_preferences/shared_preferences_macos/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_macos/pubspec.yaml
@@ -2,11 +2,11 @@ name: shared_preferences_macos
 description: macOS implementation of the shared_preferences plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/shared_preferences/shared_preferences_macos
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.0.2
+version: 2.0.3
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"
+  flutter: ">=2.5.0"
 
 flutter:
   plugin:
@@ -14,6 +14,7 @@ flutter:
     platforms:
       macos:
         pluginClass: SharedPreferencesPlugin
+        dartPluginClass: SharedPreferencesMacOS
 
 dependencies:
   flutter:
@@ -21,4 +22,6 @@ dependencies:
   shared_preferences_platform_interface: ^2.0.0
 
 dev_dependencies:
+  flutter_test:
+    sdk: flutter
   pedantic: ^1.10.0

--- a/packages/shared_preferences/shared_preferences_macos/test/shared_preferences_macos_test.dart
+++ b/packages/shared_preferences/shared_preferences_macos/test/shared_preferences_macos_test.dart
@@ -62,6 +62,12 @@ void main() {
       await testData.clear();
     });
 
+    test('registers instance', () {
+      SharedPreferencesMacOS.registerWith();
+      expect(SharedPreferencesStorePlatform.instance,
+          isA<SharedPreferencesMacOS>());
+    });
+
     test('getAll', () async {
       testData = InMemorySharedPreferencesStore.withData(kTestValues);
       expect(await store.getAll(), kTestValues);

--- a/packages/shared_preferences/shared_preferences_macos/test/shared_preferences_macos_test.dart
+++ b/packages/shared_preferences/shared_preferences_macos/test/shared_preferences_macos_test.dart
@@ -1,0 +1,111 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences_macos/shared_preferences_macos.dart';
+import 'package:shared_preferences_platform_interface/method_channel_shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group(MethodChannelSharedPreferencesStore, () {
+    const MethodChannel channel = MethodChannel(
+      'plugins.flutter.io/shared_preferences_macos',
+    );
+
+    const Map<String, Object> kTestValues = <String, Object>{
+      'flutter.String': 'hello world',
+      'flutter.Bool': true,
+      'flutter.Int': 42,
+      'flutter.Double': 3.14159,
+      'flutter.StringList': <String>['foo', 'bar'],
+    };
+
+    late InMemorySharedPreferencesStore testData;
+
+    final List<MethodCall> log = <MethodCall>[];
+    late SharedPreferencesStorePlatform store;
+
+    setUp(() async {
+      testData = InMemorySharedPreferencesStore.empty();
+
+      channel.setMockMethodCallHandler((MethodCall methodCall) async {
+        log.add(methodCall);
+        if (methodCall.method == 'getAll') {
+          return await testData.getAll();
+        }
+        if (methodCall.method == 'remove') {
+          final String key = (methodCall.arguments['key'] as String?)!;
+          return await testData.remove(key);
+        }
+        if (methodCall.method == 'clear') {
+          return await testData.clear();
+        }
+        final RegExp setterRegExp = RegExp(r'set(.*)');
+        final Match? match = setterRegExp.matchAsPrefix(methodCall.method);
+        if (match?.groupCount == 1) {
+          final String valueType = match!.group(1)!;
+          final String key = (methodCall.arguments['key'] as String?)!;
+          final Object value = (methodCall.arguments['value'] as Object?)!;
+          return await testData.setValue(valueType, key, value);
+        }
+        fail('Unexpected method call: ${methodCall.method}');
+      });
+      store = SharedPreferencesMacOS();
+      log.clear();
+    });
+
+    tearDown(() async {
+      await testData.clear();
+    });
+
+    test('getAll', () async {
+      testData = InMemorySharedPreferencesStore.withData(kTestValues);
+      expect(await store.getAll(), kTestValues);
+      expect(log.single.method, 'getAll');
+    });
+
+    test('remove', () async {
+      testData = InMemorySharedPreferencesStore.withData(kTestValues);
+      expect(await store.remove('flutter.String'), true);
+      expect(await store.remove('flutter.Bool'), true);
+      expect(await store.remove('flutter.Int'), true);
+      expect(await store.remove('flutter.Double'), true);
+      expect(await testData.getAll(), <String, dynamic>{
+        'flutter.StringList': <String>['foo', 'bar'],
+      });
+
+      expect(log, hasLength(4));
+      for (final MethodCall call in log) {
+        expect(call.method, 'remove');
+      }
+    });
+
+    test('setValue', () async {
+      expect(await testData.getAll(), isEmpty);
+      for (final String key in kTestValues.keys) {
+        final Object value = kTestValues[key]!;
+        expect(await store.setValue(key.split('.').last, key, value), true);
+      }
+      expect(await testData.getAll(), kTestValues);
+
+      expect(log, hasLength(5));
+      expect(log[0].method, 'setString');
+      expect(log[1].method, 'setBool');
+      expect(log[2].method, 'setInt');
+      expect(log[3].method, 'setDouble');
+      expect(log[4].method, 'setStringList');
+    });
+
+    test('clear', () async {
+      testData = InMemorySharedPreferencesStore.withData(kTestValues);
+      expect(await testData.getAll(), isNotEmpty);
+      expect(await store.clear(), true);
+      expect(await testData.getAll(), isEmpty);
+      expect(log.single.method, 'clear');
+    });
+  });
+}

--- a/packages/shared_preferences/shared_preferences_macos/test/shared_preferences_macos_test.dart
+++ b/packages/shared_preferences/shared_preferences_macos/test/shared_preferences_macos_test.dart
@@ -23,7 +23,8 @@ void main() {
       'flutter.Double': 3.14159,
       'flutter.StringList': <String>['foo', 'bar'],
     };
-
+    // Create a dummy in-memory implementation to back the mocked method channel
+    // API to simplify validation of the expected calls.
     late InMemorySharedPreferencesStore testData;
 
     final List<MethodCall> log = <MethodCall>[];
@@ -54,12 +55,7 @@ void main() {
         }
         fail('Unexpected method call: ${methodCall.method}');
       });
-      store = SharedPreferencesMacOS();
       log.clear();
-    });
-
-    tearDown(() async {
-      await testData.clear();
     });
 
     test('registers instance', () {
@@ -69,12 +65,14 @@ void main() {
     });
 
     test('getAll', () async {
+      store = SharedPreferencesMacOS();
       testData = InMemorySharedPreferencesStore.withData(kTestValues);
       expect(await store.getAll(), kTestValues);
       expect(log.single.method, 'getAll');
     });
 
     test('remove', () async {
+      store = SharedPreferencesMacOS();
       testData = InMemorySharedPreferencesStore.withData(kTestValues);
       expect(await store.remove('flutter.String'), true);
       expect(await store.remove('flutter.Bool'), true);
@@ -91,6 +89,7 @@ void main() {
     });
 
     test('setValue', () async {
+      store = SharedPreferencesMacOS();
       expect(await testData.getAll(), isEmpty);
       for (final String key in kTestValues.keys) {
         final Object value = kTestValues[key]!;
@@ -107,6 +106,7 @@ void main() {
     });
 
     test('clear', () async {
+      store = SharedPreferencesMacOS();
       testData = InMemorySharedPreferencesStore.withData(kTestValues);
       expect(await testData.getAll(), isNotEmpty);
       expect(await store.clear(), true);

--- a/packages/shared_preferences/shared_preferences_windows/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.5
+
+* Updated to make use of `dartPluginClass` only.
+
 ## 2.0.4
 
 * Removes dependency on `meta`.

--- a/packages/shared_preferences/shared_preferences_windows/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_windows/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 2.0.5
+## 2.1.0
 
 * Updated to make use of `dartPluginClass` only.
+* Deprecated `SharedPreferencesWindows.instance` in favor of `SharedPreferencesStorePlatform.instance`.
 
 ## 2.0.4
 

--- a/packages/shared_preferences/shared_preferences_windows/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_windows/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## 2.1.0
 
-* Updated to make use of `dartPluginClass` only.
 * Deprecated `SharedPreferencesWindows.instance` in favor of `SharedPreferencesStorePlatform.instance`.
 
 ## 2.0.4

--- a/packages/shared_preferences/shared_preferences_windows/example/integration_test/shared_preferences_test.dart
+++ b/packages/shared_preferences/shared_preferences_windows/example/integration_test/shared_preferences_test.dart
@@ -31,7 +31,7 @@ void main() {
     late SharedPreferencesWindows preferences;
 
     setUp(() async {
-      preferences = SharedPreferencesWindows.instance;
+      preferences = SharedPreferencesWindows();
     });
 
     tearDown(() {

--- a/packages/shared_preferences/shared_preferences_windows/example/integration_test/shared_preferences_test.dart
+++ b/packages/shared_preferences/shared_preferences_windows/example/integration_test/shared_preferences_test.dart
@@ -30,11 +30,8 @@ void main() {
 
     late SharedPreferencesWindows preferences;
 
-    setUpAll(() async {
+    setUp(() async {
       preferences = SharedPreferencesWindows();
-    });
-
-    tearDown(() {
       preferences.clear();
     });
 
@@ -48,16 +45,14 @@ void main() {
     });
 
     testWidgets('writing', (WidgetTester _) async {
-      await Future.wait(<Future<bool>>[
-        preferences.setValue(
-            'String', 'String', kTestValues2['flutter.String']!),
-        preferences.setValue('Bool', 'bool', kTestValues2['flutter.bool']!),
-        preferences.setValue('Int', 'int', kTestValues2['flutter.int']!),
-        preferences.setValue(
-            'Double', 'double', kTestValues2['flutter.double']!),
-        preferences.setValue(
-            'StringList', 'List', kTestValues2['flutter.List']!)
-      ]);
+      await preferences.setValue(
+          'String', 'String', kTestValues2['flutter.String']!);
+      await preferences.setValue('Bool', 'bool', kTestValues2['flutter.bool']!);
+      await preferences.setValue('Int', 'int', kTestValues2['flutter.int']!);
+      await preferences.setValue(
+          'Double', 'double', kTestValues2['flutter.double']!);
+      await preferences.setValue(
+          'StringList', 'List', kTestValues2['flutter.List']!);
       final Map<String, Object> values = await preferences.getAll();
       expect(values['String'], kTestValues2['flutter.String']);
       expect(values['bool'], kTestValues2['flutter.bool']);

--- a/packages/shared_preferences/shared_preferences_windows/example/integration_test/shared_preferences_test.dart
+++ b/packages/shared_preferences/shared_preferences_windows/example/integration_test/shared_preferences_test.dart
@@ -28,14 +28,9 @@ void main() {
       'flutter.List': <String>['baz', 'quox'],
     };
 
-    late SharedPreferencesWindows preferences;
-
-    setUp(() async {
-      preferences = SharedPreferencesWindows();
-      preferences.clear();
-    });
-
     testWidgets('reading', (WidgetTester _) async {
+      final SharedPreferencesWindows preferences = SharedPreferencesWindows();
+      preferences.clear();
       final Map<String, Object> values = await preferences.getAll();
       expect(values['String'], isNull);
       expect(values['bool'], isNull);
@@ -45,6 +40,8 @@ void main() {
     });
 
     testWidgets('writing', (WidgetTester _) async {
+      final SharedPreferencesWindows preferences = SharedPreferencesWindows();
+      preferences.clear();
       await preferences.setValue(
           'String', 'String', kTestValues2['flutter.String']!);
       await preferences.setValue('Bool', 'bool', kTestValues2['flutter.bool']!);
@@ -62,6 +59,8 @@ void main() {
     });
 
     testWidgets('removing', (WidgetTester _) async {
+      final SharedPreferencesWindows preferences = SharedPreferencesWindows();
+      preferences.clear();
       const String key = 'testKey';
       await preferences.setValue('String', key, kTestValues['flutter.String']!);
       await preferences.setValue('Bool', key, kTestValues['flutter.bool']!);
@@ -75,6 +74,8 @@ void main() {
     });
 
     testWidgets('clearing', (WidgetTester _) async {
+      final SharedPreferencesWindows preferences = SharedPreferencesWindows();
+      preferences.clear();
       await preferences.setValue(
           'String', 'String', kTestValues['flutter.String']!);
       await preferences.setValue('Bool', 'bool', kTestValues['flutter.bool']!);

--- a/packages/shared_preferences/shared_preferences_windows/example/integration_test/shared_preferences_test.dart
+++ b/packages/shared_preferences/shared_preferences_windows/example/integration_test/shared_preferences_test.dart
@@ -30,7 +30,7 @@ void main() {
 
     late SharedPreferencesWindows preferences;
 
-    setUp(() async {
+    setUpAll(() async {
       preferences = SharedPreferencesWindows();
     });
 

--- a/packages/shared_preferences/shared_preferences_windows/example/integration_test/shared_preferences_test.dart
+++ b/packages/shared_preferences/shared_preferences_windows/example/integration_test/shared_preferences_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:shared_preferences_windows/shared_preferences_windows.dart';

--- a/packages/shared_preferences/shared_preferences_windows/example/lib/main.dart
+++ b/packages/shared_preferences/shared_preferences_windows/example/lib/main.dart
@@ -31,7 +31,7 @@ class SharedPreferencesDemo extends StatefulWidget {
 }
 
 class SharedPreferencesDemoState extends State<SharedPreferencesDemo> {
-  final SharedPreferencesWindows prefs = SharedPreferencesWindows.instance;
+  final SharedPreferencesWindows prefs = SharedPreferencesWindows();
   late Future<int> _counter;
 
   Future<void> _incrementCounter() async {

--- a/packages/shared_preferences/shared_preferences_windows/lib/shared_preferences_windows.dart
+++ b/packages/shared_preferences/shared_preferences_windows/lib/shared_preferences_windows.dart
@@ -16,6 +16,11 @@ import 'package:shared_preferences_platform_interface/shared_preferences_platfor
 ///
 /// This class implements the `package:shared_preferences` functionality for Windows.
 class SharedPreferencesWindows extends SharedPreferencesStorePlatform {
+  /// Deprecated instance of [SharedPreferencesWindows].
+  /// Use [SharedPreferencesStorePlatform.instance] instead.
+  @Deprecated('Use `SharedPreferencesStorePlatform.instance` instead.')
+  static SharedPreferencesWindows instance = SharedPreferencesWindows();
+
   /// Registers the Windows implementation.
   static void registerWith() {
     SharedPreferencesStorePlatform.instance = SharedPreferencesWindows();

--- a/packages/shared_preferences/shared_preferences_windows/lib/shared_preferences_windows.dart
+++ b/packages/shared_preferences/shared_preferences_windows/lib/shared_preferences_windows.dart
@@ -16,14 +16,9 @@ import 'package:shared_preferences_platform_interface/shared_preferences_platfor
 ///
 /// This class implements the `package:shared_preferences` functionality for Windows.
 class SharedPreferencesWindows extends SharedPreferencesStorePlatform {
-  /// The default instance of [SharedPreferencesWindows] to use.
-  // TODO(egarciad): Remove when the Dart plugin registrant lands on Flutter stable.
-  // https://github.com/flutter/flutter/issues/81421
-  static SharedPreferencesWindows instance = SharedPreferencesWindows();
-
   /// Registers the Windows implementation.
   static void registerWith() {
-    SharedPreferencesStorePlatform.instance = instance;
+    SharedPreferencesStorePlatform.instance = SharedPreferencesWindows();
   }
 
   /// File system used to store to disk. Exposed for testing only.

--- a/packages/shared_preferences/shared_preferences_windows/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_windows/pubspec.yaml
@@ -27,4 +27,3 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.10.0

--- a/packages/shared_preferences/shared_preferences_windows/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_windows/pubspec.yaml
@@ -2,11 +2,11 @@ name: shared_preferences_windows
 description: Windows implementation of shared_preferences
 repository: https://github.com/flutter/plugins/tree/main/packages/shared_preferences/shared_preferences_windows
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.0.4
+version: 2.0.5
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
-  flutter: ">=2.0.0"
+  flutter: ">=2.5.0"
 
 flutter:
   plugin:

--- a/packages/shared_preferences/shared_preferences_windows/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_windows/pubspec.yaml
@@ -2,7 +2,7 @@ name: shared_preferences_windows
 description: Windows implementation of shared_preferences
 repository: https://github.com/flutter/plugins/tree/main/packages/shared_preferences/shared_preferences_windows
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.0.5
+version: 2.1.0
 
 environment:
   sdk: '>=2.12.0 <3.0.0'


### PR DESCRIPTION
This PR eliminates the use of the shared method channel implementation in each of the native packages for the shared_preferences plugin.

This PR's contents are based on the steps outlined in the following issue: 
- flutter/flutter#94224

No CHANGELOG change: The main package only has one of its tests changed.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.