### PR TITLE
[image_picker] Fix NSNull handling on iOS

### DIFF
--- a/packages/image_picker/image_picker/CHANGELOG.md
+++ b/packages/image_picker/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.4+6
+
+* Fixes minor type issues in iOS implementation.
+
 ## 0.8.4+5
 
 * Improves the documentation on handling MainActivity being killed by the Android OS.

--- a/packages/image_picker/image_picker/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/image_picker/image_picker/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 50;
 	objects = {
 
 /* Begin PBXBuildFile section */

--- a/packages/image_picker/image_picker/example/ios/RunnerTests/PhotoAssetUtilTests.m
+++ b/packages/image_picker/image_picker/example/ios/RunnerTests/PhotoAssetUtilTests.m
@@ -101,11 +101,10 @@
 
   size_t numberOfFrames = CGImageSourceGetCount(imageSource);
 
-  NSNumber *nilSize = (NSNumber *)[NSNull null];
   NSString *savedPathGIF = [FLTImagePickerPhotoAssetUtil saveImageWithOriginalImageData:dataGIF
                                                                                   image:imageGIF
-                                                                               maxWidth:nilSize
-                                                                              maxHeight:nilSize
+                                                                               maxWidth:nil
+                                                                              maxHeight:nil
                                                                            imageQuality:nil];
   XCTAssertNotNil(savedPathGIF);
   XCTAssertEqualObjects([savedPathGIF substringFromIndex:savedPathGIF.length - 4], @".gif");

--- a/packages/image_picker/image_picker/ios/Classes/FLTImagePickerImageUtil.h
+++ b/packages/image_picker/image_picker/ios/Classes/FLTImagePickerImageUtil.h
@@ -18,9 +18,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface FLTImagePickerImageUtil : NSObject
 
+// Resizes the given image to fit within maxWidth (if non-nil) and maxHeight (if non-nil)
 + (UIImage *)scaledImage:(UIImage *)image
-                maxWidth:(NSNumber *)maxWidth
-               maxHeight:(NSNumber *)maxHeight
+                maxWidth:(nullable NSNumber *)maxWidth
+               maxHeight:(nullable NSNumber *)maxHeight
      isMetadataAvailable:(BOOL)isMetadataAvailable;
 
 // Resize all gif animation frames.

--- a/packages/image_picker/image_picker/ios/Classes/FLTImagePickerImageUtil.m
+++ b/packages/image_picker/image_picker/ios/Classes/FLTImagePickerImageUtil.m
@@ -35,8 +35,8 @@
   double originalWidth = image.size.width;
   double originalHeight = image.size.height;
 
-  bool hasMaxWidth = maxWidth != (id)[NSNull null];
-  bool hasMaxHeight = maxHeight != (id)[NSNull null];
+  bool hasMaxWidth = maxWidth != nil;
+  bool hasMaxHeight = maxHeight != nil;
 
   double width = hasMaxWidth ? MIN([maxWidth doubleValue], originalWidth) : originalWidth;
   double height = hasMaxHeight ? MIN([maxHeight doubleValue], originalHeight) : originalHeight;

--- a/packages/image_picker/image_picker/ios/Classes/FLTImagePickerPlugin.m
+++ b/packages/image_picker/image_picker/ios/Classes/FLTImagePickerPlugin.m
@@ -16,6 +16,15 @@
 #import "FLTImagePickerPhotoAssetUtil.h"
 #import "FLTPHPickerSaveImageToPathOperation.h"
 
+/**
+ * Returns the value for the given key in 'dict', or nil if the value is
+ * NSNull.
+ */
+NSObject *GetNullableValueForKey(NSDictionary *dict, NSString *key) {
+  NSObject *value = dict[key];
+  return value == [NSNull null] ? nil : value;
+}
+
 @interface FLTImagePickerPlugin () <UINavigationControllerDelegate,
                                     UIImagePickerControllerDelegate,
                                     PHPickerViewControllerDelegate,
@@ -397,9 +406,9 @@ typedef NS_ENUM(NSInteger, ImagePickerClassType) { UIImagePickerClassType, PHPic
   dispatch_queue_t backgroundQueue =
       dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0);
   dispatch_async(backgroundQueue, ^{
-    NSNumber *maxWidth = [self->_arguments objectForKey:@"maxWidth"];
-    NSNumber *maxHeight = [self->_arguments objectForKey:@"maxHeight"];
-    NSNumber *imageQuality = [self->_arguments objectForKey:@"imageQuality"];
+    NSNumber *maxWidth = GetNullableValueForKey(self->_arguments, @"maxWidth");
+    NSNumber *maxHeight = GetNullableValueForKey(self->_arguments, @"maxHeight");
+    NSNumber *imageQuality = GetNullableValueForKey(self->_arguments, @"imageQuality");
     NSNumber *desiredImageQuality = [self getDesiredImageQuality:imageQuality];
     NSOperationQueue *operationQueue = [NSOperationQueue new];
     NSMutableArray *pathList = [self createNSMutableArrayWithSize:results.count];
@@ -480,14 +489,14 @@ typedef NS_ENUM(NSInteger, ImagePickerClassType) { UIImagePickerClassType, PHPic
     if (image == nil) {
       image = [info objectForKey:UIImagePickerControllerOriginalImage];
     }
-    NSNumber *maxWidth = [_arguments objectForKey:@"maxWidth"];
-    NSNumber *maxHeight = [_arguments objectForKey:@"maxHeight"];
-    NSNumber *imageQuality = [_arguments objectForKey:@"imageQuality"];
+    NSNumber *maxWidth = GetNullableValueForKey(_arguments, @"maxWidth");
+    NSNumber *maxHeight = GetNullableValueForKey(_arguments, @"maxHeight");
+    NSNumber *imageQuality = GetNullableValueForKey(_arguments, @"imageQuality");
     NSNumber *desiredImageQuality = [self getDesiredImageQuality:imageQuality];
 
     PHAsset *originalAsset = [FLTImagePickerPhotoAssetUtil getAssetFromImagePickerInfo:info];
 
-    if (maxWidth != (id)[NSNull null] || maxHeight != (id)[NSNull null]) {
+    if (maxWidth != nil || maxHeight != nil) {
       image = [FLTImagePickerImageUtil scaledImage:image
                                           maxWidth:maxWidth
                                          maxHeight:maxHeight

--- a/packages/image_picker/image_picker/ios/Classes/FLTImagePickerPlugin.m
+++ b/packages/image_picker/image_picker/ios/Classes/FLTImagePickerPlugin.m
@@ -20,8 +20,8 @@
  * Returns the value for the given key in 'dict', or nil if the value is
  * NSNull.
  */
-NSObject *GetNullableValueForKey(NSDictionary *dict, NSString *key) {
-  NSObject *value = dict[key];
+id GetNullableValueForKey(NSDictionary *dict, NSString *key) {
+  id value = dict[key];
   return value == [NSNull null] ? nil : value;
 }
 

--- a/packages/image_picker/image_picker/ios/Classes/FLTPHPickerSaveImageToPathOperation.m
+++ b/packages/image_picker/image_picker/ios/Classes/FLTPHPickerSaveImageToPathOperation.m
@@ -91,7 +91,7 @@ typedef void (^GetSavedPath)(NSString *);
             PHAsset *originalAsset =
                 [FLTImagePickerPhotoAssetUtil getAssetFromPHPickerResult:self.result];
 
-            if (self.maxWidth != (id)[NSNull null] || self.maxHeight != (id)[NSNull null]) {
+            if (self.maxWidth != nil || self.maxHeight != nil) {
               localImage = [FLTImagePickerImageUtil scaledImage:localImage
                                                        maxWidth:self.maxWidth
                                                       maxHeight:self.maxHeight

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for selecting images from the Android and iOS image
   library, and taking new pictures with the camera.
 repository: https://github.com/flutter/plugins/tree/main/packages/image_picker/image_picker
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 0.8.4+5
+version: 0.8.4+6
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
Instead of assigning NSNull to NSNumber ivars, which is a type violation
that requires confusing and error-prone code elsewhere, convert to nil
before assignment.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
