### PR TITLE
[camera]skip app delegate during unit test

### DIFF
--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Skips unnecessary AppDelegate setup for unit tests on iOS.
+  
 ## 0.9.4+11
 
 * Manages iOS camera's orientation-related states on a background queue to prevent potential race conditions. 

--- a/packages/camera/camera/example/ios/Runner/main.m
+++ b/packages/camera/camera/example/ios/Runner/main.m
@@ -8,6 +8,8 @@
 
 int main(int argc, char *argv[]) {
   @autoreleasepool {
-    return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
+    BOOL isTesting = NSClassFromString(@"XCTestCase") != nil;
+    return UIApplicationMain(argc, argv, nil,
+                             isTesting ? nil : NSStringFromClass([AppDelegate class]));
   }
 }

--- a/packages/camera/camera/example/ios/Runner/main.m
+++ b/packages/camera/camera/example/ios/Runner/main.m
@@ -8,6 +8,10 @@
 
 int main(int argc, char *argv[]) {
   @autoreleasepool {
+    // The setup logic in `AppDelegate::didFinishLaunchingWithOptions:` eventually sends camera
+    // operations on the background queue, which would run concurrently with the test cases during
+    // unit tests, making the debugging process confusing. This setup is actually not necessary for
+    // the unit tests, so here we want to skip the AppDelegate when running unit tests.
     BOOL isTesting = NSClassFromString(@"XCTestCase") != nil;
     return UIApplicationMain(argc, argv, nil,
                              isTesting ? nil : NSStringFromClass([AppDelegate class]));


### PR DESCRIPTION
I noticed that during unit tests there are some code in app delegate that eventually setup the FLTCam in background thread, which runs concurrently with normal unit tests in main thread, making breakpoint a bit confusing when debugging. 

This PR skips unnecessary `didFinishLaunching` setups for unit tests. 

No version change: only affect Runner app's unit tests. 

No unit tests: I don't think OCMock supports stubbing global functions. Just manually tested. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
