### PR TITLE
[camera]manages ios camera's orientation states on capture session queue

### DIFF
--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.4+11
+
+* Manages iOS camera's orientation-related states on a background queue to prevent potential race conditions. 
+
 ## 0.9.4+10
 
 * iOS performance improvement by moving file writing from the main queue to a background IO queue. 

--- a/packages/camera/camera/ios/Classes/CameraPlugin.m
+++ b/packages/camera/camera/ios/Classes/CameraPlugin.m
@@ -69,7 +69,7 @@
   }
 
   dispatch_async(self.captureSessionQueue, ^{
-    // `FLTCAM::setDeviceOrientation` must be called on capture session queue.
+    // `FLTCam::setDeviceOrientation` must be called on capture session queue.
     [self.camera setDeviceOrientation:orientation];
     // `CameraPlugin::sendDeviceOrientation` can be called on any queue.
     [self sendDeviceOrientation:orientation];

--- a/packages/camera/camera/ios/Classes/CameraPlugin.m
+++ b/packages/camera/camera/ios/Classes/CameraPlugin.m
@@ -17,7 +17,6 @@
 @interface CameraPlugin ()
 @property(readonly, nonatomic) FLTThreadSafeTextureRegistry *registry;
 @property(readonly, nonatomic) NSObject<FlutterBinaryMessenger> *messenger;
-@property(readonly, nonatomic) FLTCam *camera;
 @property(readonly, nonatomic) FLTThreadSafeMethodChannel *deviceEventMethodChannel;
 @end
 
@@ -69,11 +68,12 @@
     return;
   }
 
-  if (_camera) {
-    [_camera setDeviceOrientation:orientation];
-  }
-
-  [self sendDeviceOrientation:orientation];
+  dispatch_async(self.captureSessionQueue, ^{
+    // `FLTCAM::setDeviceOrientation` must be called on capture session queue.
+    [self.camera setDeviceOrientation:orientation];
+    // `CameraPlugin::sendDeviceOrientation` can be called on any queue.
+    [self sendDeviceOrientation:orientation];
+  });
 }
 
 - (void)sendDeviceOrientation:(UIDeviceOrientation)orientation {

--- a/packages/camera/camera/ios/Classes/CameraPlugin_Test.h
+++ b/packages/camera/camera/ios/Classes/CameraPlugin_Test.h
@@ -5,13 +5,17 @@
 // This header is available in the Test module. Import via "@import camera.Test;"
 
 #import <camera/CameraPlugin.h>
+#import <camera/FLTCam.h>
 #import <camera/FLTThreadSafeFlutterResult.h>
 
 /// Methods exposed for unit testing.
 @interface CameraPlugin ()
 
-// All FLTCam's state access and capture session related operations should be on run on this queue.
+/// All FLTCam's state access and capture session related operations should be on run on this queue.
 @property(nonatomic, strong) dispatch_queue_t captureSessionQueue;
+
+/// An internal camera object that manages camera's state and performs camera operations.
+@property(nonatomic, strong) FLTCam *camera;
 
 /// Inject @p FlutterTextureRegistry and @p FlutterBinaryMessenger for unit testing.
 - (instancetype)initWithRegistry:(NSObject<FlutterTextureRegistry> *)registry

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -4,7 +4,7 @@ description: A Flutter plugin for controlling the camera. Supports previewing
   Dart.
 repository: https://github.com/flutter/plugins/tree/main/packages/camera/camera
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.9.4+10
+version: 0.9.4+11
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR moves iOS camera's orientation updates to the session queue.

As discussed in [the proposal](https://docs.google.com/document/d/1Znjp-BduXIb1Ix3JOE1YKyJi1Z0d6rB-2q6Lt7j8xSo/edit#) under "Overview" section: 

> **Session queue**: handles all camera operations, including capture session setup, sample buffer processing, camera state management (for example, isRecording, isStreamingImages)

and under the list of violation of the "Thread safety for state access" section: 
> Multiple orientation related states are mutated in both session queue and main queue

Issue here: https://github.com/flutter/flutter/issues/96429

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
