### PR TITLE
[url_launcher] Workaround for url_launcher_web 2.0.7 dependency on Flutter < 2.10.0

### DIFF
--- a/packages/url_launcher/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   url_launcher_linux: ^2.0.0
   url_launcher_macos: ^2.0.0
   url_launcher_platform_interface: ^2.0.3
-  url_launcher_web: ^2.0.0
+  url_launcher_web: '>=2.0.0 <2.0.7'  # 2.0.7 requires Flutter 2.10.0+ but it is not specified
   url_launcher_windows: ^2.0.0
 
 dev_dependencies:


### PR DESCRIPTION
This PR fixes the use of url_launcher in a web deployment using Flutter <2.10.0
With Flutter 2.5.3 (for example) the maximum compatible version reported is url_launcher_web 2.0.7, which still doesn't require Flutter 2.10.0+, but this is a broken requirement chain, since the correct dependency is inserted with url_launcher_web 2.0.8

IMHO, url_launcher_web 2.0.7 should be retired\yanked in the future, allowing to restore the ^2.0.0 version specifier

There is no current issue for this, since this is a breaking change introduced less than 5 days ago (and I am not able to create a new one)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.