### PR TITLE
[url_launcher] Major version bump for desktop Dart-based url_launcher implementations

### DIFF
--- a/packages/url_launcher/url_launcher_linux/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_linux/CHANGELOG.md
@@ -1,6 +1,13 @@
+## 3.0.0
+
+* Changes the major version since, due to a typo in `default_package` in
+  existing versions of `url_launcher`, requiring Dart registration in this
+  package is in practice a breaking change.
+  * Does not include any API changes; clients can allow both 2.x or 3.x.
+
 ## 2.0.4
 
-* Switches to an in-package method channel implementation.
+* **\[Retracted\]** Switches to an in-package method channel implementation.
 
 ## 2.0.3
 

--- a/packages/url_launcher/url_launcher_linux/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_linux/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher_linux
 description: Linux implementation of the url_launcher plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/url_launcher/url_launcher_linux
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 2.0.4
+version: 3.0.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/url_launcher/url_launcher_macos/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_macos/CHANGELOG.md
@@ -1,6 +1,13 @@
+## 3.0.0
+
+* Changes the major version since, due to a typo in `default_package` in
+  existing versions of `url_launcher`, requiring Dart registration in this
+  package is in practice a breaking change.
+  * Does not include any API changes; clients can allow both 2.x or 3.x.
+
 ## 2.0.4
 
-* Switches to an in-package method channel implementation.
+* **\[Retracted\]** Switches to an in-package method channel implementation.
 
 ## 2.0.3
 

--- a/packages/url_launcher/url_launcher_macos/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_macos/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher_macos
 description: macOS implementation of the url_launcher plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/url_launcher/url_launcher_macos
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 2.0.4
+version: 3.0.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/url_launcher/url_launcher_windows/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_windows/CHANGELOG.md
@@ -1,4 +1,13 @@
+## 3.0.0
+
+* Changes the major version since, due to a typo in `default_package` in
+  existing versions of `url_launcher`, requiring Dart registration in this
+  package is in practice a breaking change.
+  * Does not include any API changes; clients can allow both 2.x or 3.x.
+
 ## 2.0.3
+
+**\[Retracted\]**
 
 * Switches to an in-package method channel implementation.
 * Adds unit tests.

--- a/packages/url_launcher/url_launcher_windows/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_windows/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher_windows
 description: Windows implementation of the url_launcher plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/url_launcher/url_launcher_windows
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 2.0.3
+version: 3.0.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
https://github.com/flutter/plugins/pull/4719 converted the url_launcher implementations to Dart-based versions. This should have been completely transparent to clients, but there is a latent bug in `url_launcher` where the `default_package` entries for Linux, macOS, and Windows are incorrect. This went unnoticed until now because currently the only client-facing effect of `default_package` is in resolving which implementation to run Dart registration for. Because of the typos in the `default_package` entries, the resolution in the `flutter` tool doesn't recognize the registration for these packages as needing to run, causing them to be broken at runtime.

The affected versions have been retracted to fix the breakage in the short term. This is PR is the first half of the long-term fix; it re-releases them as a major version bump so that existing versions of `url_launcher` will not pick them up. Once they are published, a follow-up PR will update `url_launcher` to fix the typos and relax the version constraints for the dependencies on these implementation packages to allow 2.x or 3.x. (In theory this could be one PR, but doing it as two ensures that we get real testing on the `url_launcher` change, so is safer.)

Part of a long-term fix for https://github.com/flutter/flutter/issues/98097

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
