### PR TITLE
[flutter_plugin_tool] Remove podspec --allow-warnings

### DIFF
--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -1,4 +1,4 @@
-## NEXT
+## 0.8.0
 
 - Ensures that `firebase-test-lab` runs include an `integration_test` runner.
 - Adds a `make-deps-path-based` command to convert inter-repo package
@@ -18,6 +18,7 @@
 - Adds support for `CHROME_EXECUTABLE` in `drive-examples` to match similar
   `flutter` behavior.
 - Validates `default_package` entries in plugins.
+- Removes `allow-warnings` from the `podspecs` command.
 
 ## 0.7.3
 

--- a/script/tool/lib/src/lint_podspecs_command.dart
+++ b/script/tool/lib/src/lint_podspecs_command.dart
@@ -26,13 +26,7 @@ class LintPodspecsCommand extends PackageLoopingCommand {
     Directory packagesDir, {
     ProcessRunner processRunner = const ProcessRunner(),
     Platform platform = const LocalPlatform(),
-  }) : super(packagesDir, processRunner: processRunner, platform: platform) {
-    argParser.addMultiOption('ignore-warnings',
-        help:
-            'Do not pass --allow-warnings flag to "pod lib lint" for podspecs '
-            'with this basename (example: plugins with known warnings)',
-        valueHelp: 'podspec_file_name');
-  }
+  }) : super(packagesDir, processRunner: processRunner, platform: platform);
 
   @override
   final String name = 'podspecs';
@@ -118,8 +112,6 @@ class LintPodspecsCommand extends PackageLoopingCommand {
 
   Future<ProcessResult> _runPodLint(String podspecPath,
       {required bool libraryLint}) async {
-    final bool allowWarnings = (getStringListArg('ignore-warnings'))
-        .contains(p.basenameWithoutExtension(podspecPath));
     final List<String> arguments = <String>[
       'lib',
       'lint',
@@ -127,7 +119,6 @@ class LintPodspecsCommand extends PackageLoopingCommand {
       '--configuration=Debug', // Release targets unsupported arm64 simulators. Use Debug to only build against targeted x86_64 simulator devices.
       '--skip-tests',
       '--use-modular-headers', // Flutter sets use_modular_headers! in its templates.
-      if (allowWarnings) '--allow-warnings',
       if (libraryLint) '--use-libraries'
     ];
 

--- a/script/tool/pubspec.yaml
+++ b/script/tool/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_plugin_tools
 description: Productivity utils for flutter/plugins and flutter/packages
 repository: https://github.com/flutter/plugins/tree/main/script/tool
-version: 0.7.2
+version: 0.8.0
 
 dependencies:
   args: ^2.1.0
@@ -26,7 +26,6 @@ dev_dependencies:
   build_runner: ^2.0.3
   matcher: ^0.12.10
   mockito: ^5.0.7
-  pedantic: ^1.11.0
 
 environment:
   sdk: '>=2.12.0 <3.0.0'

--- a/script/tool/test/lint_podspecs_command_test.dart
+++ b/script/tool/test/lint_podspecs_command_test.dart
@@ -123,48 +123,6 @@ void main() {
       expect(output, contains('Bar'));
     });
 
-    test('allow warnings for podspecs with known warnings', () async {
-      final Directory plugin1Dir = createFakePlugin('plugin1', packagesDir,
-          extraFiles: <String>['plugin1.podspec']);
-
-      final List<String> output = await runCapturingPrint(
-          runner, <String>['podspecs', '--ignore-warnings=plugin1']);
-
-      expect(
-        processRunner.recordedCalls,
-        orderedEquals(<ProcessCall>[
-          ProcessCall('which', const <String>['pod'], packagesDir.path),
-          ProcessCall(
-              'pod',
-              <String>[
-                'lib',
-                'lint',
-                plugin1Dir.childFile('plugin1.podspec').path,
-                '--configuration=Debug',
-                '--skip-tests',
-                '--use-modular-headers',
-                '--allow-warnings',
-                '--use-libraries'
-              ],
-              packagesDir.path),
-          ProcessCall(
-              'pod',
-              <String>[
-                'lib',
-                'lint',
-                plugin1Dir.childFile('plugin1.podspec').path,
-                '--configuration=Debug',
-                '--skip-tests',
-                '--use-modular-headers',
-                '--allow-warnings',
-              ],
-              packagesDir.path),
-        ]),
-      );
-
-      expect(output, contains('Linting plugin1.podspec'));
-    });
-
     test('fails if pod is missing', () async {
       createFakePlugin('plugin1', packagesDir,
           extraFiles: <String>['plugin1.podspec']);


### PR DESCRIPTION
This option is unused in our CI, so we no longer need to support it.

Closes https://github.com/flutter/flutter/issues/41444

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
