### PR TITLE
[webview_flutter] Fix debuggingEnabled on Android

### DIFF
--- a/packages/webview_flutter/webview_flutter_android/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_android/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 2.8.3
 
+* Fixes a bug causing `debuggingEnabled` to always be set to true.
 * Fixes an integration test race condition.
 
 ## 2.8.2

--- a/packages/webview_flutter/webview_flutter_android/lib/webview_android_widget.dart
+++ b/packages/webview_flutter/webview_flutter_android/lib/webview_android_widget.dart
@@ -708,6 +708,6 @@ class WebViewProxy {
   ///
   /// See [android_webview.WebView].setWebContentsDebuggingEnabled.
   Future<void> setWebContentsDebuggingEnabled(bool enabled) {
-    return android_webview.WebView.setWebContentsDebuggingEnabled(true);
+    return android_webview.WebView.setWebContentsDebuggingEnabled(enabled);
   }
 }

--- a/packages/webview_flutter/webview_flutter_android/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter_android
 description: A Flutter plugin that provides a WebView widget on Android.
 repository: https://github.com/flutter/plugins/tree/main/packages/webview_flutter/webview_flutter_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview%22
-version: 2.8.2
+version: 2.8.3
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/webview_flutter/webview_flutter_android/test/android_webview_test.dart
+++ b/packages/webview_flutter/webview_flutter_android/test/android_webview_test.dart
@@ -32,7 +32,7 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('Android WebView', () {
-    group('$WebView', () {
+    group('WebView', () {
       late MockTestWebViewHostApi mockPlatformHostApi;
 
       late InstanceManager instanceManager;
@@ -55,9 +55,14 @@ void main() {
         verify(mockPlatformHostApi.create(webViewInstanceId, false));
       });
 
-      test('setWebContentsDebuggingEnabled', () {
+      test('setWebContentsDebuggingEnabled true', () {
         WebView.setWebContentsDebuggingEnabled(true);
         verify(mockPlatformHostApi.setWebContentsDebuggingEnabled(true));
+      });
+
+      test('setWebContentsDebuggingEnabled false', () {
+        WebView.setWebContentsDebuggingEnabled(false);
+        verify(mockPlatformHostApi.setWebContentsDebuggingEnabled(false));
       });
 
       test('loadData', () {
@@ -314,7 +319,7 @@ void main() {
       });
     });
 
-    group('$WebSettings', () {
+    group('WebSettings', () {
       late MockTestWebSettingsHostApi mockPlatformHostApi;
 
       late InstanceManager instanceManager;
@@ -440,7 +445,7 @@ void main() {
       });
     });
 
-    group('$JavaScriptChannel', () {
+    group('JavaScriptChannel', () {
       late JavaScriptChannelFlutterApiImpl flutterApi;
 
       late InstanceManager instanceManager;
@@ -468,7 +473,7 @@ void main() {
       });
     });
 
-    group('$WebViewClient', () {
+    group('WebViewClient', () {
       late WebViewClientFlutterApiImpl flutterApi;
 
       late InstanceManager instanceManager;
@@ -583,7 +588,7 @@ void main() {
       });
     });
 
-    group('$DownloadListener', () {
+    group('DownloadListener', () {
       late DownloadListenerFlutterApiImpl flutterApi;
 
       late InstanceManager instanceManager;
@@ -621,7 +626,7 @@ void main() {
       });
     });
 
-    group('$WebChromeClient', () {
+    group('WebChromeClient', () {
       late WebChromeClientFlutterApiImpl flutterApi;
 
       late InstanceManager instanceManager;

--- a/packages/webview_flutter/webview_flutter_android/test/instance_manager_test.dart
+++ b/packages/webview_flutter/webview_flutter_android/test/instance_manager_test.dart
@@ -6,7 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:webview_flutter_android/src/instance_manager.dart';
 
 void main() {
-  group('$InstanceManager', () {
+  group('InstanceManager', () {
     late InstanceManager testInstanceManager;
 
     setUp(() {


### PR DESCRIPTION
The recent Dart rewrite accidentally dropped a parameter value in the
call chain, causing disabling debugging to enabled it instead.

This fixes the issue, and adds testing of that portion of the call
chain (which was entirely missing), as well as adding testing of `false`
at various other points just for added coverage.

As opportunistic cleanup, changes the test group naming, as the pattern
of using `'$FooClass'` breaks test result display in VSCode.

Fixes https://github.com/flutter/flutter/issues/98521

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
