### PR TITLE
[flutter_plugin_tool] Fix iOS/macOS naming

### DIFF
--- a/script/tool/lib/src/build_examples_command.dart
+++ b/script/tool/lib/src/build_examples_command.dart
@@ -33,7 +33,7 @@ const int _exitInvalidPluginToolsConfig = 4;
 
 // Flutter build types. These are the values passed to `flutter build <foo>`.
 const String _flutterBuildTypeAndroid = 'apk';
-const String _flutterBuildTypeIos = 'ios';
+const String _flutterBuildTypeIOS = 'ios';
 const String _flutterBuildTypeLinux = 'linux';
 const String _flutterBuildTypeMacOS = 'macos';
 const String _flutterBuildTypeWeb = 'web';
@@ -48,12 +48,12 @@ class BuildExamplesCommand extends PackageLoopingCommand {
     ProcessRunner processRunner = const ProcessRunner(),
     Platform platform = const LocalPlatform(),
   }) : super(packagesDir, processRunner: processRunner, platform: platform) {
-    argParser.addFlag(kPlatformLinux);
-    argParser.addFlag(kPlatformMacos);
-    argParser.addFlag(kPlatformWeb);
-    argParser.addFlag(kPlatformWindows);
-    argParser.addFlag(kPlatformWinUwp);
-    argParser.addFlag(kPlatformIos);
+    argParser.addFlag(platformLinux);
+    argParser.addFlag(platformMacOS);
+    argParser.addFlag(platformWeb);
+    argParser.addFlag(platformWindows);
+    argParser.addFlag(platformWinUwp);
+    argParser.addFlag(platformIOS);
     argParser.addFlag(_platformFlagApk);
     argParser.addOption(
       kEnableExperiment,
@@ -68,39 +68,39 @@ class BuildExamplesCommand extends PackageLoopingCommand {
       <String, _PlatformDetails>{
     _platformFlagApk: const _PlatformDetails(
       'Android',
-      pluginPlatform: kPlatformAndroid,
+      pluginPlatform: platformAndroid,
       flutterBuildType: _flutterBuildTypeAndroid,
     ),
-    kPlatformIos: const _PlatformDetails(
+    platformIOS: const _PlatformDetails(
       'iOS',
-      pluginPlatform: kPlatformIos,
-      flutterBuildType: _flutterBuildTypeIos,
+      pluginPlatform: platformIOS,
+      flutterBuildType: _flutterBuildTypeIOS,
       extraBuildFlags: <String>['--no-codesign'],
     ),
-    kPlatformLinux: const _PlatformDetails(
+    platformLinux: const _PlatformDetails(
       'Linux',
-      pluginPlatform: kPlatformLinux,
+      pluginPlatform: platformLinux,
       flutterBuildType: _flutterBuildTypeLinux,
     ),
-    kPlatformMacos: const _PlatformDetails(
+    platformMacOS: const _PlatformDetails(
       'macOS',
-      pluginPlatform: kPlatformMacos,
+      pluginPlatform: platformMacOS,
       flutterBuildType: _flutterBuildTypeMacOS,
     ),
-    kPlatformWeb: const _PlatformDetails(
+    platformWeb: const _PlatformDetails(
       'web',
-      pluginPlatform: kPlatformWeb,
+      pluginPlatform: platformWeb,
       flutterBuildType: _flutterBuildTypeWeb,
     ),
-    kPlatformWindows: const _PlatformDetails(
+    platformWindows: const _PlatformDetails(
       'Win32',
-      pluginPlatform: kPlatformWindows,
+      pluginPlatform: platformWindows,
       pluginPlatformVariant: platformVariantWin32,
       flutterBuildType: _flutterBuildTypeWin32,
     ),
-    kPlatformWinUwp: const _PlatformDetails(
+    platformWinUwp: const _PlatformDetails(
       'UWP',
-      pluginPlatform: kPlatformWindows,
+      pluginPlatform: platformWindows,
       pluginPlatformVariant: platformVariantWinUwp,
       flutterBuildType: _flutterBuildTypeWinUwp,
     ),
@@ -288,7 +288,7 @@ class BuildExamplesCommand extends PackageLoopingCommand {
       if (!uwpDirectory.existsSync()) {
         print('Creating temporary winuwp folder');
         final int exitCode = await processRunner.runAndStream(flutterCommand,
-            <String>['create', '--platforms=$kPlatformWinUwp', '.'],
+            <String>['create', '--platforms=$platformWinUwp', '.'],
             workingDir: example.directory);
         if (exitCode == 0) {
           temporaryPlatformDirectory = uwpDirectory;

--- a/script/tool/lib/src/common/core.dart
+++ b/script/tool/lib/src/common/core.dart
@@ -11,40 +11,40 @@ import 'package:yaml/yaml.dart';
 typedef Print = void Function(Object? object);
 
 /// Key for APK (Android) platform.
-const String kPlatformAndroid = 'android';
+const String platformAndroid = 'android';
 
 /// Key for IPA (iOS) platform.
-const String kPlatformIos = 'ios';
+const String platformIOS = 'ios';
 
 /// Key for linux platform.
-const String kPlatformLinux = 'linux';
+const String platformLinux = 'linux';
 
 /// Key for macos platform.
-const String kPlatformMacos = 'macos';
+const String platformMacOS = 'macos';
 
 /// Key for Web platform.
-const String kPlatformWeb = 'web';
+const String platformWeb = 'web';
 
 /// Key for windows platform.
 ///
 /// Note that this corresponds to the Win32 variant for flutter commands like
 /// `build` and `run`, but is a general platform containing all Windows
 /// variants for purposes of the `platform` section of a plugin pubspec).
-const String kPlatformWindows = 'windows';
+const String platformWindows = 'windows';
 
 /// Key for WinUWP platform.
 ///
 /// Note that UWP is a platform for the purposes of flutter commands like
 /// `build` and `run`, but a variant of the `windows` platform for the purposes
 /// of plugin pubspecs).
-const String kPlatformWinUwp = 'winuwp';
+const String platformWinUwp = 'winuwp';
 
 /// Key for Win32 variant of the Windows platform.
 const String platformVariantWin32 = 'win32';
 
 /// Key for UWP variant of the Windows platform.
 ///
-/// See the note on [kPlatformWinUwp].
+/// See the note on [platformWinUwp].
 const String platformVariantWinUwp = 'uwp';
 
 /// Key for enable experiment.

--- a/script/tool/lib/src/common/plugin_utils.dart
+++ b/script/tool/lib/src/common/plugin_utils.dart
@@ -39,12 +39,12 @@ bool pluginSupportsPlatform(
   PlatformSupport? requiredMode,
   String? variant,
 }) {
-  assert(platform == kPlatformIos ||
-      platform == kPlatformAndroid ||
-      platform == kPlatformWeb ||
-      platform == kPlatformMacos ||
-      platform == kPlatformWindows ||
-      platform == kPlatformLinux);
+  assert(platform == platformIOS ||
+      platform == platformAndroid ||
+      platform == platformWeb ||
+      platform == platformMacOS ||
+      platform == platformWindows ||
+      platform == platformLinux);
 
   final YamlMap? platformEntry =
       _readPlatformPubspecSectionForPlugin(platform, plugin);
@@ -73,7 +73,7 @@ bool pluginSupportsPlatform(
       // Platforms with variants have a default variant when unspecified for
       // backward compatibility. Must match the flutter tool logic.
       const Map<String, String> defaultVariants = <String, String>{
-        kPlatformWindows: platformVariantWin32,
+        platformWindows: platformVariantWin32,
       };
       if (variant != defaultVariants[platform]) {
         return false;
@@ -87,7 +87,7 @@ bool pluginSupportsPlatform(
 /// Returns true if [plugin] includes native code for [platform], as opposed to
 /// being implemented entirely in Dart.
 bool pluginHasNativeCodeForPlatform(String platform, RepositoryPackage plugin) {
-  if (platform == kPlatformWeb) {
+  if (platform == platformWeb) {
     // Web plugins are always Dart-only.
     return false;
   }

--- a/script/tool/lib/src/drive_examples_command.dart
+++ b/script/tool/lib/src/drive_examples_command.dart
@@ -25,19 +25,19 @@ class DriveExamplesCommand extends PackageLoopingCommand {
     ProcessRunner processRunner = const ProcessRunner(),
     Platform platform = const LocalPlatform(),
   }) : super(packagesDir, processRunner: processRunner, platform: platform) {
-    argParser.addFlag(kPlatformAndroid,
+    argParser.addFlag(platformAndroid,
         help: 'Runs the Android implementation of the examples');
-    argParser.addFlag(kPlatformIos,
+    argParser.addFlag(platformIOS,
         help: 'Runs the iOS implementation of the examples');
-    argParser.addFlag(kPlatformLinux,
+    argParser.addFlag(platformLinux,
         help: 'Runs the Linux implementation of the examples');
-    argParser.addFlag(kPlatformMacos,
+    argParser.addFlag(platformMacOS,
         help: 'Runs the macOS implementation of the examples');
-    argParser.addFlag(kPlatformWeb,
+    argParser.addFlag(platformWeb,
         help: 'Runs the web implementation of the examples');
-    argParser.addFlag(kPlatformWindows,
+    argParser.addFlag(platformWindows,
         help: 'Runs the Windows (Win32) implementation of the examples');
-    argParser.addFlag(kPlatformWinUwp,
+    argParser.addFlag(platformWinUwp,
         help:
             'Runs the UWP implementation of the examples [currently a no-op]');
     argParser.addOption(
@@ -64,13 +64,13 @@ class DriveExamplesCommand extends PackageLoopingCommand {
   @override
   Future<void> initializeRun() async {
     final List<String> platformSwitches = <String>[
-      kPlatformAndroid,
-      kPlatformIos,
-      kPlatformLinux,
-      kPlatformMacos,
-      kPlatformWeb,
-      kPlatformWindows,
-      kPlatformWinUwp,
+      platformAndroid,
+      platformIOS,
+      platformLinux,
+      platformMacOS,
+      platformWeb,
+      platformWindows,
+      platformWinUwp,
     ];
     final int platformCount = platformSwitches
         .where((String platform) => getBoolArg(platform))
@@ -85,12 +85,12 @@ class DriveExamplesCommand extends PackageLoopingCommand {
       throw ToolExit(_exitNoPlatformFlags);
     }
 
-    if (getBoolArg(kPlatformWinUwp)) {
+    if (getBoolArg(platformWinUwp)) {
       logWarning('Driving UWP applications is not yet supported');
     }
 
     String? androidDevice;
-    if (getBoolArg(kPlatformAndroid)) {
+    if (getBoolArg(platformAndroid)) {
       final List<String> devices = await _getDevicesForPlatform('android');
       if (devices.isEmpty) {
         printError('No Android devices available');
@@ -99,24 +99,24 @@ class DriveExamplesCommand extends PackageLoopingCommand {
       androidDevice = devices.first;
     }
 
-    String? iosDevice;
-    if (getBoolArg(kPlatformIos)) {
+    String? iOSDevice;
+    if (getBoolArg(platformIOS)) {
       final List<String> devices = await _getDevicesForPlatform('ios');
       if (devices.isEmpty) {
         printError('No iOS devices available');
         throw ToolExit(_exitNoAvailableDevice);
       }
-      iosDevice = devices.first;
+      iOSDevice = devices.first;
     }
 
     _targetDeviceFlags = <String, List<String>>{
-      if (getBoolArg(kPlatformAndroid))
-        kPlatformAndroid: <String>['-d', androidDevice!],
-      if (getBoolArg(kPlatformIos)) kPlatformIos: <String>['-d', iosDevice!],
-      if (getBoolArg(kPlatformLinux)) kPlatformLinux: <String>['-d', 'linux'],
-      if (getBoolArg(kPlatformMacos)) kPlatformMacos: <String>['-d', 'macos'],
-      if (getBoolArg(kPlatformWeb))
-        kPlatformWeb: <String>[
+      if (getBoolArg(platformAndroid))
+        platformAndroid: <String>['-d', androidDevice!],
+      if (getBoolArg(platformIOS)) platformIOS: <String>['-d', iOSDevice!],
+      if (getBoolArg(platformLinux)) platformLinux: <String>['-d', 'linux'],
+      if (getBoolArg(platformMacOS)) platformMacOS: <String>['-d', 'macos'],
+      if (getBoolArg(platformWeb))
+        platformWeb: <String>[
           '-d',
           'web-server',
           '--web-port=7357',
@@ -124,12 +124,11 @@ class DriveExamplesCommand extends PackageLoopingCommand {
           if (platform.environment.containsKey('CHROME_EXECUTABLE'))
             '--chrome-binary=${platform.environment['CHROME_EXECUTABLE']}',
         ],
-      if (getBoolArg(kPlatformWindows))
-        kPlatformWindows: <String>['-d', 'windows'],
+      if (getBoolArg(platformWindows))
+        platformWindows: <String>['-d', 'windows'],
       // TODO(stuartmorgan): Check these flags once drive supports UWP:
       // https://github.com/flutter/flutter/issues/82821
-      if (getBoolArg(kPlatformWinUwp))
-        kPlatformWinUwp: <String>['-d', 'winuwp'],
+      if (getBoolArg(platformWinUwp)) platformWinUwp: <String>['-d', 'winuwp'],
     };
   }
 
@@ -148,9 +147,9 @@ class DriveExamplesCommand extends PackageLoopingCommand {
         in _targetDeviceFlags.entries) {
       final String platform = entry.key;
       String? variant;
-      if (platform == kPlatformWindows) {
+      if (platform == platformWindows) {
         variant = platformVariantWin32;
-      } else if (platform == kPlatformWinUwp) {
+      } else if (platform == platformWinUwp) {
         variant = platformVariantWinUwp;
         // TODO(stuartmorgan): Remove this once drive supports UWP.
         // https://github.com/flutter/flutter/issues/82821

--- a/script/tool/lib/src/lint_android_command.dart
+++ b/script/tool/lib/src/lint_android_command.dart
@@ -32,7 +32,7 @@ class LintAndroidCommand extends PackageLoopingCommand {
 
   @override
   Future<PackageResult> runForPackage(RepositoryPackage package) async {
-    if (!pluginSupportsPlatform(kPlatformAndroid, package,
+    if (!pluginSupportsPlatform(platformAndroid, package,
         requiredMode: PlatformSupport.inline)) {
       return PackageResult.skip(
           'Plugin does not have an Android implemenatation.');

--- a/script/tool/lib/src/native_test_command.dart
+++ b/script/tool/lib/src/native_test_command.dart
@@ -17,9 +17,9 @@ import 'common/xcode.dart';
 const String _unitTestFlag = 'unit';
 const String _integrationTestFlag = 'integration';
 
-const String _iosDestinationFlag = 'ios-destination';
+const String _iOSDestinationFlag = 'ios-destination';
 
-const int _exitNoIosSimulators = 3;
+const int _exitNoIOSSimulators = 3;
 
 /// The command to run native tests for plugins:
 /// - iOS and macOS: XCTests (XCUnitTest and XCUITest)
@@ -34,17 +34,17 @@ class NativeTestCommand extends PackageLoopingCommand {
   })  : _xcode = Xcode(processRunner: processRunner, log: true),
         super(packagesDir, processRunner: processRunner, platform: platform) {
     argParser.addOption(
-      _iosDestinationFlag,
+      _iOSDestinationFlag,
       help: 'Specify the destination when running iOS tests.\n'
           'This is passed to the `-destination` argument in the xcodebuild command.\n'
           'See https://developer.apple.com/library/archive/technotes/tn2339/_index.html#//apple_ref/doc/uid/DTS40014588-CH1-UNIT '
           'for details on how to specify the destination.',
     );
-    argParser.addFlag(kPlatformAndroid, help: 'Runs Android tests');
-    argParser.addFlag(kPlatformIos, help: 'Runs iOS tests');
-    argParser.addFlag(kPlatformLinux, help: 'Runs Linux tests');
-    argParser.addFlag(kPlatformMacos, help: 'Runs macOS tests');
-    argParser.addFlag(kPlatformWindows, help: 'Runs Windows tests');
+    argParser.addFlag(platformAndroid, help: 'Runs Android tests');
+    argParser.addFlag(platformIOS, help: 'Runs iOS tests');
+    argParser.addFlag(platformLinux, help: 'Runs Linux tests');
+    argParser.addFlag(platformMacOS, help: 'Runs macOS tests');
+    argParser.addFlag(platformWindows, help: 'Runs Windows tests');
 
     // By default, both unit tests and integration tests are run, but provide
     // flags to disable one or the other.
@@ -55,7 +55,7 @@ class NativeTestCommand extends PackageLoopingCommand {
   }
 
   // The device destination flags for iOS tests.
-  List<String> _iosDestinationFlags = <String>[];
+  List<String> _iOSDestinationFlags = <String>[];
 
   final Xcode _xcode;
 
@@ -84,11 +84,11 @@ this command.
   @override
   Future<void> initializeRun() async {
     _platforms = <String, _PlatformDetails>{
-      kPlatformAndroid: _PlatformDetails('Android', _testAndroid),
-      kPlatformIos: _PlatformDetails('iOS', _testIos),
-      kPlatformLinux: _PlatformDetails('Linux', _testLinux),
-      kPlatformMacos: _PlatformDetails('macOS', _testMacOS),
-      kPlatformWindows: _PlatformDetails('Windows', _testWindows),
+      platformAndroid: _PlatformDetails('Android', _testAndroid),
+      platformIOS: _PlatformDetails('iOS', _testIOS),
+      platformLinux: _PlatformDetails('Linux', _testLinux),
+      platformMacOS: _PlatformDetails('macOS', _testMacOS),
+      platformWindows: _PlatformDetails('Windows', _testWindows),
     };
     _requestedPlatforms = _platforms.keys
         .where((String platform) => getBoolArg(platform))
@@ -105,29 +105,29 @@ this command.
       throw ToolExit(exitInvalidArguments);
     }
 
-    if (getBoolArg(kPlatformWindows) && getBoolArg(_integrationTestFlag)) {
+    if (getBoolArg(platformWindows) && getBoolArg(_integrationTestFlag)) {
       logWarning('This command currently only supports unit tests for Windows. '
           'See https://github.com/flutter/flutter/issues/70233.');
     }
 
-    if (getBoolArg(kPlatformLinux) && getBoolArg(_integrationTestFlag)) {
+    if (getBoolArg(platformLinux) && getBoolArg(_integrationTestFlag)) {
       logWarning('This command currently only supports unit tests for Linux. '
           'See https://github.com/flutter/flutter/issues/70235.');
     }
 
     // iOS-specific run-level state.
     if (_requestedPlatforms.contains('ios')) {
-      String destination = getStringArg(_iosDestinationFlag);
+      String destination = getStringArg(_iOSDestinationFlag);
       if (destination.isEmpty) {
         final String? simulatorId =
             await _xcode.findBestAvailableIphoneSimulator();
         if (simulatorId == null) {
           printError('Cannot find any available iOS simulators.');
-          throw ToolExit(_exitNoIosSimulators);
+          throw ToolExit(_exitNoIOSSimulators);
         }
         destination = 'id=$simulatorId';
       }
-      _iosDestinationFlags = <String>[
+      _iOSDestinationFlags = <String>[
         '-destination',
         destination,
       ];
@@ -333,9 +333,9 @@ this command.
     return _PlatformResult(RunState.succeeded);
   }
 
-  Future<_PlatformResult> _testIos(RepositoryPackage plugin, _TestMode mode) {
+  Future<_PlatformResult> _testIOS(RepositoryPackage plugin, _TestMode mode) {
     return _runXcodeTests(plugin, 'iOS', mode,
-        extraFlags: _iosDestinationFlags);
+        extraFlags: _iOSDestinationFlags);
   }
 
   Future<_PlatformResult> _testMacOS(RepositoryPackage plugin, _TestMode mode) {

--- a/script/tool/lib/src/test_command.dart
+++ b/script/tool/lib/src/test_command.dart
@@ -62,7 +62,7 @@ class TestCommand extends PackageLoopingCommand {
         '--color',
         if (experiment.isNotEmpty) '--enable-experiment=$experiment',
         // TODO(ditman): Remove this once all plugins are migrated to 'drive'.
-        if (pluginSupportsPlatform(kPlatformWeb, package)) '--platform=chrome',
+        if (pluginSupportsPlatform(platformWeb, package)) '--platform=chrome',
       ],
       workingDir: package.directory,
     );

--- a/script/tool/lib/src/xcode_analyze_command.dart
+++ b/script/tool/lib/src/xcode_analyze_command.dart
@@ -21,8 +21,8 @@ class XcodeAnalyzeCommand extends PackageLoopingCommand {
     Platform platform = const LocalPlatform(),
   })  : _xcode = Xcode(processRunner: processRunner, log: true),
         super(packagesDir, processRunner: processRunner, platform: platform) {
-    argParser.addFlag(kPlatformIos, help: 'Analyze iOS');
-    argParser.addFlag(kPlatformMacos, help: 'Analyze macOS');
+    argParser.addFlag(platformIOS, help: 'Analyze iOS');
+    argParser.addFlag(platformMacOS, help: 'Analyze macOS');
   }
 
   final Xcode _xcode;
@@ -36,7 +36,7 @@ class XcodeAnalyzeCommand extends PackageLoopingCommand {
 
   @override
   Future<void> initializeRun() async {
-    if (!(getBoolArg(kPlatformIos) || getBoolArg(kPlatformMacos))) {
+    if (!(getBoolArg(platformIOS) || getBoolArg(platformMacOS))) {
       printError('At least one platform flag must be provided.');
       throw ToolExit(exitInvalidArguments);
     }
@@ -44,28 +44,28 @@ class XcodeAnalyzeCommand extends PackageLoopingCommand {
 
   @override
   Future<PackageResult> runForPackage(RepositoryPackage package) async {
-    final bool testIos = getBoolArg(kPlatformIos) &&
-        pluginSupportsPlatform(kPlatformIos, package,
+    final bool testIOS = getBoolArg(platformIOS) &&
+        pluginSupportsPlatform(platformIOS, package,
             requiredMode: PlatformSupport.inline);
-    final bool testMacos = getBoolArg(kPlatformMacos) &&
-        pluginSupportsPlatform(kPlatformMacos, package,
+    final bool testMacOS = getBoolArg(platformMacOS) &&
+        pluginSupportsPlatform(platformMacOS, package,
             requiredMode: PlatformSupport.inline);
 
     final bool multiplePlatformsRequested =
-        getBoolArg(kPlatformIos) && getBoolArg(kPlatformMacos);
-    if (!(testIos || testMacos)) {
+        getBoolArg(platformIOS) && getBoolArg(platformMacOS);
+    if (!(testIOS || testMacOS)) {
       return PackageResult.skip('Not implemented for target platform(s).');
     }
 
     final List<String> failures = <String>[];
-    if (testIos &&
+    if (testIOS &&
         !await _analyzePlugin(package, 'iOS', extraFlags: <String>[
           '-destination',
           'generic/platform=iOS Simulator'
         ])) {
       failures.add('iOS');
     }
-    if (testMacos && !await _analyzePlugin(package, 'macOS')) {
+    if (testMacOS && !await _analyzePlugin(package, 'macOS')) {
       failures.add('macOS');
     }
 

--- a/script/tool/test/build_examples_command_test.dart
+++ b/script/tool/test/build_examples_command_test.dart
@@ -57,7 +57,7 @@ void main() {
     test('fails if building fails', () async {
       createFakePlugin('plugin', packagesDir,
           platformSupport: <String, PlatformDetails>{
-            kPlatformIos: const PlatformDetails(PlatformSupport.inline),
+            platformIOS: const PlatformDetails(PlatformSupport.inline),
           });
 
       processRunner
@@ -86,7 +86,7 @@ void main() {
       createFakePlugin('plugin', packagesDir,
           examples: <String>[],
           platformSupport: <String, PlatformDetails>{
-            kPlatformIos: const PlatformDetails(PlatformSupport.inline)
+            platformIOS: const PlatformDetails(PlatformSupport.inline)
           });
 
       processRunner
@@ -136,7 +136,7 @@ void main() {
       mockPlatform.isMacOS = true;
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           platformSupport: <String, PlatformDetails>{
-            kPlatformIos: const PlatformDetails(PlatformSupport.inline),
+            platformIOS: const PlatformDetails(PlatformSupport.inline),
           });
 
       final Directory pluginExampleDirectory =
@@ -193,7 +193,7 @@ void main() {
       mockPlatform.isLinux = true;
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           platformSupport: <String, PlatformDetails>{
-            kPlatformLinux: const PlatformDetails(PlatformSupport.inline),
+            platformLinux: const PlatformDetails(PlatformSupport.inline),
           });
 
       final Directory pluginExampleDirectory =
@@ -242,7 +242,7 @@ void main() {
       mockPlatform.isMacOS = true;
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           platformSupport: <String, PlatformDetails>{
-            kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
+            platformMacOS: const PlatformDetails(PlatformSupport.inline),
           });
 
       final Directory pluginExampleDirectory =
@@ -288,7 +288,7 @@ void main() {
     test('building for web', () async {
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           platformSupport: <String, PlatformDetails>{
-            kPlatformWeb: const PlatformDetails(PlatformSupport.inline),
+            platformWeb: const PlatformDetails(PlatformSupport.inline),
           });
 
       final Directory pluginExampleDirectory =
@@ -338,7 +338,7 @@ void main() {
       mockPlatform.isWindows = true;
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           platformSupport: <String, PlatformDetails>{
-            kPlatformWindows: const PlatformDetails(PlatformSupport.inline),
+            platformWindows: const PlatformDetails(PlatformSupport.inline),
           });
 
       final Directory pluginExampleDirectory =
@@ -389,7 +389,7 @@ void main() {
           createFakePlugin('plugin', packagesDir, extraFiles: <String>[
         'example/test',
       ], platformSupport: <String, PlatformDetails>{
-        kPlatformWindows: const PlatformDetails(PlatformSupport.federated,
+        platformWindows: const PlatformDetails(PlatformSupport.federated,
             variants: <String>[platformVariantWinUwp]),
       });
 
@@ -419,7 +419,7 @@ void main() {
           createFakePlugin('plugin', packagesDir, extraFiles: <String>[
         'example/test',
       ], platformSupport: <String, PlatformDetails>{
-        kPlatformWindows: const PlatformDetails(PlatformSupport.federated,
+        platformWindows: const PlatformDetails(PlatformSupport.federated,
             variants: <String>[platformVariantWinUwp]),
       });
 
@@ -470,7 +470,7 @@ void main() {
     test('building for Android', () async {
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           platformSupport: <String, PlatformDetails>{
-            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
+            platformAndroid: const PlatformDetails(PlatformSupport.inline),
           });
 
       final Directory pluginExampleDirectory =
@@ -499,7 +499,7 @@ void main() {
     test('enable-experiment flag for Android', () async {
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           platformSupport: <String, PlatformDetails>{
-            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
+            platformAndroid: const PlatformDetails(PlatformSupport.inline),
           });
 
       final Directory pluginExampleDirectory =
@@ -521,7 +521,7 @@ void main() {
     test('enable-experiment flag for ios', () async {
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           platformSupport: <String, PlatformDetails>{
-            kPlatformIos: const PlatformDetails(PlatformSupport.inline),
+            platformIOS: const PlatformDetails(PlatformSupport.inline),
           });
 
       final Directory pluginExampleDirectory =
@@ -547,7 +547,7 @@ void main() {
     test('logs skipped platforms', () async {
       createFakePlugin('plugin', packagesDir,
           platformSupport: <String, PlatformDetails>{
-            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
+            platformAndroid: const PlatformDetails(PlatformSupport.inline),
           });
 
       final List<String> output = await runCapturingPrint(
@@ -681,8 +681,8 @@ void main() {
       mockPlatform.isLinux = true;
       final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
           platformSupport: <String, PlatformDetails>{
-            kPlatformLinux: const PlatformDetails(PlatformSupport.inline),
-            kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
+            platformLinux: const PlatformDetails(PlatformSupport.inline),
+            platformMacOS: const PlatformDetails(PlatformSupport.inline),
           });
 
       final Directory pluginExampleDirectory =

--- a/script/tool/test/common/plugin_utils_test.dart
+++ b/script/tool/test/common/plugin_utils_test.dart
@@ -25,109 +25,109 @@ void main() {
       final RepositoryPackage plugin =
           RepositoryPackage(createFakePlugin('plugin', packagesDir));
 
-      expect(pluginSupportsPlatform(kPlatformAndroid, plugin), isFalse);
-      expect(pluginSupportsPlatform(kPlatformIos, plugin), isFalse);
-      expect(pluginSupportsPlatform(kPlatformLinux, plugin), isFalse);
-      expect(pluginSupportsPlatform(kPlatformMacos, plugin), isFalse);
-      expect(pluginSupportsPlatform(kPlatformWeb, plugin), isFalse);
-      expect(pluginSupportsPlatform(kPlatformWindows, plugin), isFalse);
+      expect(pluginSupportsPlatform(platformAndroid, plugin), isFalse);
+      expect(pluginSupportsPlatform(platformIOS, plugin), isFalse);
+      expect(pluginSupportsPlatform(platformLinux, plugin), isFalse);
+      expect(pluginSupportsPlatform(platformMacOS, plugin), isFalse);
+      expect(pluginSupportsPlatform(platformWeb, plugin), isFalse);
+      expect(pluginSupportsPlatform(platformWindows, plugin), isFalse);
     });
 
     test('all platforms', () async {
       final RepositoryPackage plugin = RepositoryPackage(createFakePlugin(
           'plugin', packagesDir,
           platformSupport: <String, PlatformDetails>{
-            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
-            kPlatformIos: const PlatformDetails(PlatformSupport.inline),
-            kPlatformLinux: const PlatformDetails(PlatformSupport.inline),
-            kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
-            kPlatformWeb: const PlatformDetails(PlatformSupport.inline),
-            kPlatformWindows: const PlatformDetails(PlatformSupport.inline),
+            platformAndroid: const PlatformDetails(PlatformSupport.inline),
+            platformIOS: const PlatformDetails(PlatformSupport.inline),
+            platformLinux: const PlatformDetails(PlatformSupport.inline),
+            platformMacOS: const PlatformDetails(PlatformSupport.inline),
+            platformWeb: const PlatformDetails(PlatformSupport.inline),
+            platformWindows: const PlatformDetails(PlatformSupport.inline),
           }));
 
-      expect(pluginSupportsPlatform(kPlatformAndroid, plugin), isTrue);
-      expect(pluginSupportsPlatform(kPlatformIos, plugin), isTrue);
-      expect(pluginSupportsPlatform(kPlatformLinux, plugin), isTrue);
-      expect(pluginSupportsPlatform(kPlatformMacos, plugin), isTrue);
-      expect(pluginSupportsPlatform(kPlatformWeb, plugin), isTrue);
-      expect(pluginSupportsPlatform(kPlatformWindows, plugin), isTrue);
+      expect(pluginSupportsPlatform(platformAndroid, plugin), isTrue);
+      expect(pluginSupportsPlatform(platformIOS, plugin), isTrue);
+      expect(pluginSupportsPlatform(platformLinux, plugin), isTrue);
+      expect(pluginSupportsPlatform(platformMacOS, plugin), isTrue);
+      expect(pluginSupportsPlatform(platformWeb, plugin), isTrue);
+      expect(pluginSupportsPlatform(platformWindows, plugin), isTrue);
     });
 
     test('some platforms', () async {
       final RepositoryPackage plugin = RepositoryPackage(createFakePlugin(
           'plugin', packagesDir,
           platformSupport: <String, PlatformDetails>{
-            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
-            kPlatformLinux: const PlatformDetails(PlatformSupport.inline),
-            kPlatformWeb: const PlatformDetails(PlatformSupport.inline),
+            platformAndroid: const PlatformDetails(PlatformSupport.inline),
+            platformLinux: const PlatformDetails(PlatformSupport.inline),
+            platformWeb: const PlatformDetails(PlatformSupport.inline),
           }));
 
-      expect(pluginSupportsPlatform(kPlatformAndroid, plugin), isTrue);
-      expect(pluginSupportsPlatform(kPlatformIos, plugin), isFalse);
-      expect(pluginSupportsPlatform(kPlatformLinux, plugin), isTrue);
-      expect(pluginSupportsPlatform(kPlatformMacos, plugin), isFalse);
-      expect(pluginSupportsPlatform(kPlatformWeb, plugin), isTrue);
-      expect(pluginSupportsPlatform(kPlatformWindows, plugin), isFalse);
+      expect(pluginSupportsPlatform(platformAndroid, plugin), isTrue);
+      expect(pluginSupportsPlatform(platformIOS, plugin), isFalse);
+      expect(pluginSupportsPlatform(platformLinux, plugin), isTrue);
+      expect(pluginSupportsPlatform(platformMacOS, plugin), isFalse);
+      expect(pluginSupportsPlatform(platformWeb, plugin), isTrue);
+      expect(pluginSupportsPlatform(platformWindows, plugin), isFalse);
     });
 
     test('inline plugins are only detected as inline', () async {
       final RepositoryPackage plugin = RepositoryPackage(createFakePlugin(
           'plugin', packagesDir,
           platformSupport: <String, PlatformDetails>{
-            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
-            kPlatformIos: const PlatformDetails(PlatformSupport.inline),
-            kPlatformLinux: const PlatformDetails(PlatformSupport.inline),
-            kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
-            kPlatformWeb: const PlatformDetails(PlatformSupport.inline),
-            kPlatformWindows: const PlatformDetails(PlatformSupport.inline),
+            platformAndroid: const PlatformDetails(PlatformSupport.inline),
+            platformIOS: const PlatformDetails(PlatformSupport.inline),
+            platformLinux: const PlatformDetails(PlatformSupport.inline),
+            platformMacOS: const PlatformDetails(PlatformSupport.inline),
+            platformWeb: const PlatformDetails(PlatformSupport.inline),
+            platformWindows: const PlatformDetails(PlatformSupport.inline),
           }));
 
       expect(
-          pluginSupportsPlatform(kPlatformAndroid, plugin,
+          pluginSupportsPlatform(platformAndroid, plugin,
               requiredMode: PlatformSupport.inline),
           isTrue);
       expect(
-          pluginSupportsPlatform(kPlatformAndroid, plugin,
+          pluginSupportsPlatform(platformAndroid, plugin,
               requiredMode: PlatformSupport.federated),
           isFalse);
       expect(
-          pluginSupportsPlatform(kPlatformIos, plugin,
+          pluginSupportsPlatform(platformIOS, plugin,
               requiredMode: PlatformSupport.inline),
           isTrue);
       expect(
-          pluginSupportsPlatform(kPlatformIos, plugin,
+          pluginSupportsPlatform(platformIOS, plugin,
               requiredMode: PlatformSupport.federated),
           isFalse);
       expect(
-          pluginSupportsPlatform(kPlatformLinux, plugin,
+          pluginSupportsPlatform(platformLinux, plugin,
               requiredMode: PlatformSupport.inline),
           isTrue);
       expect(
-          pluginSupportsPlatform(kPlatformLinux, plugin,
+          pluginSupportsPlatform(platformLinux, plugin,
               requiredMode: PlatformSupport.federated),
           isFalse);
       expect(
-          pluginSupportsPlatform(kPlatformMacos, plugin,
+          pluginSupportsPlatform(platformMacOS, plugin,
               requiredMode: PlatformSupport.inline),
           isTrue);
       expect(
-          pluginSupportsPlatform(kPlatformMacos, plugin,
+          pluginSupportsPlatform(platformMacOS, plugin,
               requiredMode: PlatformSupport.federated),
           isFalse);
       expect(
-          pluginSupportsPlatform(kPlatformWeb, plugin,
+          pluginSupportsPlatform(platformWeb, plugin,
               requiredMode: PlatformSupport.inline),
           isTrue);
       expect(
-          pluginSupportsPlatform(kPlatformWeb, plugin,
+          pluginSupportsPlatform(platformWeb, plugin,
               requiredMode: PlatformSupport.federated),
           isFalse);
       expect(
-          pluginSupportsPlatform(kPlatformWindows, plugin,
+          pluginSupportsPlatform(platformWindows, plugin,
               requiredMode: PlatformSupport.inline),
           isTrue);
       expect(
-          pluginSupportsPlatform(kPlatformWindows, plugin,
+          pluginSupportsPlatform(platformWindows, plugin,
               requiredMode: PlatformSupport.federated),
           isFalse);
     });
@@ -136,60 +136,60 @@ void main() {
       final RepositoryPackage plugin = RepositoryPackage(createFakePlugin(
           'plugin', packagesDir,
           platformSupport: <String, PlatformDetails>{
-            kPlatformAndroid: const PlatformDetails(PlatformSupport.federated),
-            kPlatformIos: const PlatformDetails(PlatformSupport.federated),
-            kPlatformLinux: const PlatformDetails(PlatformSupport.federated),
-            kPlatformMacos: const PlatformDetails(PlatformSupport.federated),
-            kPlatformWeb: const PlatformDetails(PlatformSupport.federated),
-            kPlatformWindows: const PlatformDetails(PlatformSupport.federated),
+            platformAndroid: const PlatformDetails(PlatformSupport.federated),
+            platformIOS: const PlatformDetails(PlatformSupport.federated),
+            platformLinux: const PlatformDetails(PlatformSupport.federated),
+            platformMacOS: const PlatformDetails(PlatformSupport.federated),
+            platformWeb: const PlatformDetails(PlatformSupport.federated),
+            platformWindows: const PlatformDetails(PlatformSupport.federated),
           }));
 
       expect(
-          pluginSupportsPlatform(kPlatformAndroid, plugin,
+          pluginSupportsPlatform(platformAndroid, plugin,
               requiredMode: PlatformSupport.federated),
           isTrue);
       expect(
-          pluginSupportsPlatform(kPlatformAndroid, plugin,
+          pluginSupportsPlatform(platformAndroid, plugin,
               requiredMode: PlatformSupport.inline),
           isFalse);
       expect(
-          pluginSupportsPlatform(kPlatformIos, plugin,
+          pluginSupportsPlatform(platformIOS, plugin,
               requiredMode: PlatformSupport.federated),
           isTrue);
       expect(
-          pluginSupportsPlatform(kPlatformIos, plugin,
+          pluginSupportsPlatform(platformIOS, plugin,
               requiredMode: PlatformSupport.inline),
           isFalse);
       expect(
-          pluginSupportsPlatform(kPlatformLinux, plugin,
+          pluginSupportsPlatform(platformLinux, plugin,
               requiredMode: PlatformSupport.federated),
           isTrue);
       expect(
-          pluginSupportsPlatform(kPlatformLinux, plugin,
+          pluginSupportsPlatform(platformLinux, plugin,
               requiredMode: PlatformSupport.inline),
           isFalse);
       expect(
-          pluginSupportsPlatform(kPlatformMacos, plugin,
+          pluginSupportsPlatform(platformMacOS, plugin,
               requiredMode: PlatformSupport.federated),
           isTrue);
       expect(
-          pluginSupportsPlatform(kPlatformMacos, plugin,
+          pluginSupportsPlatform(platformMacOS, plugin,
               requiredMode: PlatformSupport.inline),
           isFalse);
       expect(
-          pluginSupportsPlatform(kPlatformWeb, plugin,
+          pluginSupportsPlatform(platformWeb, plugin,
               requiredMode: PlatformSupport.federated),
           isTrue);
       expect(
-          pluginSupportsPlatform(kPlatformWeb, plugin,
+          pluginSupportsPlatform(platformWeb, plugin,
               requiredMode: PlatformSupport.inline),
           isFalse);
       expect(
-          pluginSupportsPlatform(kPlatformWindows, plugin,
+          pluginSupportsPlatform(platformWindows, plugin,
               requiredMode: PlatformSupport.federated),
           isTrue);
       expect(
-          pluginSupportsPlatform(kPlatformWindows, plugin,
+          pluginSupportsPlatform(platformWindows, plugin,
               requiredMode: PlatformSupport.inline),
           isFalse);
     });
@@ -199,16 +199,16 @@ void main() {
         'plugin',
         packagesDir,
         platformSupport: <String, PlatformDetails>{
-          kPlatformWindows: const PlatformDetails(PlatformSupport.inline),
+          platformWindows: const PlatformDetails(PlatformSupport.inline),
         },
       ));
 
       expect(
-          pluginSupportsPlatform(kPlatformWindows, plugin,
+          pluginSupportsPlatform(platformWindows, plugin,
               variant: platformVariantWin32),
           isTrue);
       expect(
-          pluginSupportsPlatform(kPlatformWindows, plugin,
+          pluginSupportsPlatform(platformWindows, plugin,
               variant: platformVariantWinUwp),
           isFalse);
     });
@@ -217,18 +217,18 @@ void main() {
       final RepositoryPackage plugin = RepositoryPackage(createFakePlugin(
           'plugin', packagesDir,
           platformSupport: <String, PlatformDetails>{
-            kPlatformWindows: const PlatformDetails(
+            platformWindows: const PlatformDetails(
               PlatformSupport.federated,
               variants: <String>[platformVariantWin32, platformVariantWinUwp],
             ),
           }));
 
       expect(
-          pluginSupportsPlatform(kPlatformWindows, plugin,
+          pluginSupportsPlatform(platformWindows, plugin,
               variant: platformVariantWin32),
           isTrue);
       expect(
-          pluginSupportsPlatform(kPlatformWindows, plugin,
+          pluginSupportsPlatform(platformWindows, plugin,
               variant: platformVariantWinUwp),
           isTrue);
     });
@@ -237,18 +237,18 @@ void main() {
       final RepositoryPackage plugin = RepositoryPackage(createFakePlugin(
           'plugin', packagesDir,
           platformSupport: <String, PlatformDetails>{
-            kPlatformWindows: const PlatformDetails(
+            platformWindows: const PlatformDetails(
               PlatformSupport.federated,
               variants: <String>[platformVariantWin32],
             ),
           }));
 
       expect(
-          pluginSupportsPlatform(kPlatformWindows, plugin,
+          pluginSupportsPlatform(platformWindows, plugin,
               variant: platformVariantWin32),
           isTrue);
       expect(
-          pluginSupportsPlatform(kPlatformWindows, plugin,
+          pluginSupportsPlatform(platformWindows, plugin,
               variant: platformVariantWinUwp),
           isFalse);
     });
@@ -258,17 +258,17 @@ void main() {
         'plugin',
         packagesDir,
         platformSupport: <String, PlatformDetails>{
-          kPlatformWindows: const PlatformDetails(PlatformSupport.federated,
+          platformWindows: const PlatformDetails(PlatformSupport.federated,
               variants: <String>[platformVariantWinUwp]),
         },
       ));
 
       expect(
-          pluginSupportsPlatform(kPlatformWindows, plugin,
+          pluginSupportsPlatform(platformWindows, plugin,
               variant: platformVariantWin32),
           isFalse);
       expect(
-          pluginSupportsPlatform(kPlatformWindows, plugin,
+          pluginSupportsPlatform(platformWindows, plugin,
               variant: platformVariantWinUwp),
           isTrue);
     });
@@ -280,11 +280,11 @@ void main() {
         'plugin',
         packagesDir,
         platformSupport: <String, PlatformDetails>{
-          kPlatformWeb: const PlatformDetails(PlatformSupport.inline),
+          platformWeb: const PlatformDetails(PlatformSupport.inline),
         },
       ));
 
-      expect(pluginHasNativeCodeForPlatform(kPlatformWeb, plugin), isFalse);
+      expect(pluginHasNativeCodeForPlatform(platformWeb, plugin), isFalse);
     });
 
     test('returns false for a native-only plugin', () async {
@@ -292,15 +292,15 @@ void main() {
         'plugin',
         packagesDir,
         platformSupport: <String, PlatformDetails>{
-          kPlatformLinux: const PlatformDetails(PlatformSupport.inline),
-          kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
-          kPlatformWindows: const PlatformDetails(PlatformSupport.inline),
+          platformLinux: const PlatformDetails(PlatformSupport.inline),
+          platformMacOS: const PlatformDetails(PlatformSupport.inline),
+          platformWindows: const PlatformDetails(PlatformSupport.inline),
         },
       ));
 
-      expect(pluginHasNativeCodeForPlatform(kPlatformLinux, plugin), isTrue);
-      expect(pluginHasNativeCodeForPlatform(kPlatformMacos, plugin), isTrue);
-      expect(pluginHasNativeCodeForPlatform(kPlatformWindows, plugin), isTrue);
+      expect(pluginHasNativeCodeForPlatform(platformLinux, plugin), isTrue);
+      expect(pluginHasNativeCodeForPlatform(platformMacOS, plugin), isTrue);
+      expect(pluginHasNativeCodeForPlatform(platformWindows, plugin), isTrue);
     });
 
     test('returns true for a native+Dart plugin', () async {
@@ -308,18 +308,18 @@ void main() {
         'plugin',
         packagesDir,
         platformSupport: <String, PlatformDetails>{
-          kPlatformLinux: const PlatformDetails(PlatformSupport.inline,
+          platformLinux: const PlatformDetails(PlatformSupport.inline,
               hasNativeCode: true, hasDartCode: true),
-          kPlatformMacos: const PlatformDetails(PlatformSupport.inline,
+          platformMacOS: const PlatformDetails(PlatformSupport.inline,
               hasNativeCode: true, hasDartCode: true),
-          kPlatformWindows: const PlatformDetails(PlatformSupport.inline,
+          platformWindows: const PlatformDetails(PlatformSupport.inline,
               hasNativeCode: true, hasDartCode: true),
         },
       ));
 
-      expect(pluginHasNativeCodeForPlatform(kPlatformLinux, plugin), isTrue);
-      expect(pluginHasNativeCodeForPlatform(kPlatformMacos, plugin), isTrue);
-      expect(pluginHasNativeCodeForPlatform(kPlatformWindows, plugin), isTrue);
+      expect(pluginHasNativeCodeForPlatform(platformLinux, plugin), isTrue);
+      expect(pluginHasNativeCodeForPlatform(platformMacOS, plugin), isTrue);
+      expect(pluginHasNativeCodeForPlatform(platformWindows, plugin), isTrue);
     });
 
     test('returns false for a Dart-only plugin', () async {
@@ -327,18 +327,18 @@ void main() {
         'plugin',
         packagesDir,
         platformSupport: <String, PlatformDetails>{
-          kPlatformLinux: const PlatformDetails(PlatformSupport.inline,
+          platformLinux: const PlatformDetails(PlatformSupport.inline,
               hasNativeCode: false, hasDartCode: true),
-          kPlatformMacos: const PlatformDetails(PlatformSupport.inline,
+          platformMacOS: const PlatformDetails(PlatformSupport.inline,
               hasNativeCode: false, hasDartCode: true),
-          kPlatformWindows: const PlatformDetails(PlatformSupport.inline,
+          platformWindows: const PlatformDetails(PlatformSupport.inline,
               hasNativeCode: false, hasDartCode: true),
         },
       ));
 
-      expect(pluginHasNativeCodeForPlatform(kPlatformLinux, plugin), isFalse);
-      expect(pluginHasNativeCodeForPlatform(kPlatformMacos, plugin), isFalse);
-      expect(pluginHasNativeCodeForPlatform(kPlatformWindows, plugin), isFalse);
+      expect(pluginHasNativeCodeForPlatform(platformLinux, plugin), isFalse);
+      expect(pluginHasNativeCodeForPlatform(platformMacOS, plugin), isFalse);
+      expect(pluginHasNativeCodeForPlatform(platformWindows, plugin), isFalse);
     });
   });
 }

--- a/script/tool/test/drive_examples_command_test.dart
+++ b/script/tool/test/drive_examples_command_test.dart
@@ -17,7 +17,7 @@ import 'package:test/test.dart';
 import 'mocks.dart';
 import 'util.dart';
 
-const String _fakeIosDevice = '67d5c3d1-8bdf-46ad-8f6b-b00e2a972dda';
+const String _fakeIOSDevice = '67d5c3d1-8bdf-46ad-8f6b-b00e2a972dda';
 const String _fakeAndroidDevice = 'emulator-1234';
 
 void main() {
@@ -42,7 +42,7 @@ void main() {
     });
 
     void setMockFlutterDevicesOutput({
-      bool hasIosDevice = true,
+      bool hasIOSDevice = true,
       bool hasAndroidDevice = true,
       bool includeBanner = false,
     }) {
@@ -54,7 +54,7 @@ void main() {
 ╚════════════════════════════════════════════════════════════════════════════╝
 ''';
       final List<String> devices = <String>[
-        if (hasIosDevice) '{"id": "$_fakeIosDevice", "targetPlatform": "ios"}',
+        if (hasIOSDevice) '{"id": "$_fakeIOSDevice", "targetPlatform": "ios"}',
         if (hasAndroidDevice)
           '{"id": "$_fakeAndroidDevice", "targetPlatform": "android-x86"}',
       ];
@@ -104,7 +104,7 @@ void main() {
     });
 
     test('fails for iOS if no iOS devices are present', () async {
-      setMockFlutterDevicesOutput(hasIosDevice: false);
+      setMockFlutterDevicesOutput(hasIOSDevice: false);
 
       Error? commandError;
       final List<String> output = await runCapturingPrint(
@@ -130,7 +130,7 @@ void main() {
           'example/integration_test/foo_test.dart',
         ],
         platformSupport: <String, PlatformDetails>{
-          kPlatformIos: const PlatformDetails(PlatformSupport.inline),
+          platformIOS: const PlatformDetails(PlatformSupport.inline),
         },
       );
 
@@ -195,8 +195,8 @@ void main() {
           'example/test_driver/plugin.dart',
         ],
         platformSupport: <String, PlatformDetails>{
-          kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
-          kPlatformIos: const PlatformDetails(PlatformSupport.inline),
+          platformAndroid: const PlatformDetails(PlatformSupport.inline),
+          platformIOS: const PlatformDetails(PlatformSupport.inline),
         },
       );
 
@@ -225,7 +225,7 @@ void main() {
                 const <String>[
                   'drive',
                   '-d',
-                  _fakeIosDevice,
+                  _fakeIOSDevice,
                   '--driver',
                   'test_driver/plugin_test.dart',
                   '--target',
@@ -245,8 +245,8 @@ void main() {
           'example/test_driver/plugin_test.dart',
         ],
         platformSupport: <String, PlatformDetails>{
-          kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
-          kPlatformIos: const PlatformDetails(PlatformSupport.inline),
+          platformAndroid: const PlatformDetails(PlatformSupport.inline),
+          platformIOS: const PlatformDetails(PlatformSupport.inline),
         },
       );
 
@@ -278,8 +278,8 @@ void main() {
           'example/lib/main.dart',
         ],
         platformSupport: <String, PlatformDetails>{
-          kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
-          kPlatformIos: const PlatformDetails(PlatformSupport.inline),
+          platformAndroid: const PlatformDetails(PlatformSupport.inline),
+          platformIOS: const PlatformDetails(PlatformSupport.inline),
         },
       );
 
@@ -314,8 +314,8 @@ void main() {
           'example/integration_test/ignore_me.dart',
         ],
         platformSupport: <String, PlatformDetails>{
-          kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
-          kPlatformIos: const PlatformDetails(PlatformSupport.inline),
+          platformAndroid: const PlatformDetails(PlatformSupport.inline),
+          platformIOS: const PlatformDetails(PlatformSupport.inline),
         },
       );
 
@@ -344,7 +344,7 @@ void main() {
                 const <String>[
                   'drive',
                   '-d',
-                  _fakeIosDevice,
+                  _fakeIOSDevice,
                   '--driver',
                   'test_driver/integration_test.dart',
                   '--target',
@@ -356,7 +356,7 @@ void main() {
                 const <String>[
                   'drive',
                   '-d',
-                  _fakeIosDevice,
+                  _fakeIOSDevice,
                   '--driver',
                   'test_driver/integration_test.dart',
                   '--target',
@@ -400,7 +400,7 @@ void main() {
           'example/test_driver/plugin.dart',
         ],
         platformSupport: <String, PlatformDetails>{
-          kPlatformLinux: const PlatformDetails(PlatformSupport.inline),
+          platformLinux: const PlatformDetails(PlatformSupport.inline),
         },
       );
 
@@ -473,7 +473,7 @@ void main() {
           'example/macos/macos.swift',
         ],
         platformSupport: <String, PlatformDetails>{
-          kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
+          platformMacOS: const PlatformDetails(PlatformSupport.inline),
         },
       );
 
@@ -544,7 +544,7 @@ void main() {
           'example/test_driver/plugin.dart',
         ],
         platformSupport: <String, PlatformDetails>{
-          kPlatformWeb: const PlatformDetails(PlatformSupport.inline),
+          platformWeb: const PlatformDetails(PlatformSupport.inline),
         },
       );
 
@@ -593,7 +593,7 @@ void main() {
           'example/test_driver/plugin.dart',
         ],
         platformSupport: <String, PlatformDetails>{
-          kPlatformWeb: const PlatformDetails(PlatformSupport.inline),
+          platformWeb: const PlatformDetails(PlatformSupport.inline),
         },
       );
 
@@ -670,7 +670,7 @@ void main() {
           'example/test_driver/plugin.dart',
         ],
         platformSupport: <String, PlatformDetails>{
-          kPlatformWindows: const PlatformDetails(PlatformSupport.inline),
+          platformWindows: const PlatformDetails(PlatformSupport.inline),
         },
       );
 
@@ -717,7 +717,7 @@ void main() {
           'example/test_driver/plugin.dart',
         ],
         platformSupport: <String, PlatformDetails>{
-          kPlatformWindows: const PlatformDetails(PlatformSupport.inline,
+          platformWindows: const PlatformDetails(PlatformSupport.inline,
               variants: <String>[platformVariantWinUwp]),
         },
       );
@@ -751,7 +751,7 @@ void main() {
           'example/test_driver/plugin.dart',
         ],
         platformSupport: <String, PlatformDetails>{
-          kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
+          platformAndroid: const PlatformDetails(PlatformSupport.inline),
         },
       );
 
@@ -801,7 +801,7 @@ void main() {
           'example/test_driver/plugin.dart',
         ],
         platformSupport: <String, PlatformDetails>{
-          kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
+          platformMacOS: const PlatformDetails(PlatformSupport.inline),
         },
       );
 
@@ -834,7 +834,7 @@ void main() {
           'example/test_driver/plugin.dart',
         ],
         platformSupport: <String, PlatformDetails>{
-          kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
+          platformMacOS: const PlatformDetails(PlatformSupport.inline),
         },
       );
 
@@ -889,8 +889,8 @@ void main() {
           'example/test_driver/plugin.dart',
         ],
         platformSupport: <String, PlatformDetails>{
-          kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
-          kPlatformIos: const PlatformDetails(PlatformSupport.inline),
+          platformAndroid: const PlatformDetails(PlatformSupport.inline),
+          platformIOS: const PlatformDetails(PlatformSupport.inline),
         },
       );
 
@@ -914,7 +914,7 @@ void main() {
                 const <String>[
                   'drive',
                   '-d',
-                  _fakeIosDevice,
+                  _fakeIOSDevice,
                   '--enable-experiment=exp1',
                   '--driver',
                   'test_driver/plugin_test.dart',
@@ -931,7 +931,7 @@ void main() {
         packagesDir,
         examples: <String>[],
         platformSupport: <String, PlatformDetails>{
-          kPlatformWeb: const PlatformDetails(PlatformSupport.inline),
+          platformWeb: const PlatformDetails(PlatformSupport.inline),
         },
       );
 
@@ -963,7 +963,7 @@ void main() {
           'example/integration_test/foo_test.dart',
         ],
         platformSupport: <String, PlatformDetails>{
-          kPlatformWeb: const PlatformDetails(PlatformSupport.inline),
+          platformWeb: const PlatformDetails(PlatformSupport.inline),
         },
       );
 
@@ -995,7 +995,7 @@ void main() {
           'example/test_driver/integration_test.dart',
         ],
         platformSupport: <String, PlatformDetails>{
-          kPlatformWeb: const PlatformDetails(PlatformSupport.inline),
+          platformWeb: const PlatformDetails(PlatformSupport.inline),
         },
       );
 
@@ -1031,7 +1031,7 @@ void main() {
           'example/integration_test/foo_test.dart',
         ],
         platformSupport: <String, PlatformDetails>{
-          kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
+          platformMacOS: const PlatformDetails(PlatformSupport.inline),
         },
       );
 

--- a/script/tool/test/lint_android_command_test.dart
+++ b/script/tool/test/lint_android_command_test.dart
@@ -44,7 +44,7 @@ void main() {
           createFakePlugin('plugin1', packagesDir, extraFiles: <String>[
         'example/android/gradlew',
       ], platformSupport: <String, PlatformDetails>{
-        kPlatformAndroid: const PlatformDetails(PlatformSupport.inline)
+        platformAndroid: const PlatformDetails(PlatformSupport.inline)
       });
 
       final Directory androidDir =
@@ -75,7 +75,7 @@ void main() {
     test('fails if gradlew is missing', () async {
       createFakePlugin('plugin1', packagesDir,
           platformSupport: <String, PlatformDetails>{
-            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline)
+            platformAndroid: const PlatformDetails(PlatformSupport.inline)
           });
 
       Error? commandError;
@@ -97,7 +97,7 @@ void main() {
     test('fails if linting finds issues', () async {
       createFakePlugin('plugin1', packagesDir,
           platformSupport: <String, PlatformDetails>{
-            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline)
+            platformAndroid: const PlatformDetails(PlatformSupport.inline)
           });
 
       processRunner.mockProcessesForExecutable['gradlew'] = <io.Process>[
@@ -139,7 +139,7 @@ void main() {
     test('skips non-inline plugins', () async {
       createFakePlugin('plugin1', packagesDir,
           platformSupport: <String, PlatformDetails>{
-            kPlatformAndroid: const PlatformDetails(PlatformSupport.federated)
+            platformAndroid: const PlatformDetails(PlatformSupport.federated)
           });
 
       final List<String> output =

--- a/script/tool/test/native_test_command_test.dart
+++ b/script/tool/test/native_test_command_test.dart
@@ -207,7 +207,7 @@ void main() {
     test('reports skips with no tests', () async {
       final Directory pluginDirectory1 = createFakePlugin('plugin', packagesDir,
           platformSupport: <String, PlatformDetails>{
-            kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
+            platformMacOS: const PlatformDetails(PlatformSupport.inline),
           });
 
       final Directory pluginExampleDirectory =
@@ -241,7 +241,7 @@ void main() {
       test('skip if iOS is not supported', () async {
         createFakePlugin('plugin', packagesDir,
             platformSupport: <String, PlatformDetails>{
-              kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
+              platformMacOS: const PlatformDetails(PlatformSupport.inline),
             });
 
         final List<String> output = await runCapturingPrint(runner,
@@ -258,7 +258,7 @@ void main() {
       test('skip if iOS is implemented in a federated package', () async {
         createFakePlugin('plugin', packagesDir,
             platformSupport: <String, PlatformDetails>{
-              kPlatformIos: const PlatformDetails(PlatformSupport.federated)
+              platformIOS: const PlatformDetails(PlatformSupport.federated)
             });
 
         final List<String> output = await runCapturingPrint(runner,
@@ -275,7 +275,7 @@ void main() {
       test('running with correct destination', () async {
         final Directory pluginDirectory = createFakePlugin(
             'plugin', packagesDir, platformSupport: <String, PlatformDetails>{
-          kPlatformIos: const PlatformDetails(PlatformSupport.inline)
+          platformIOS: const PlatformDetails(PlatformSupport.inline)
         });
 
         final Directory pluginExampleDirectory =
@@ -313,7 +313,7 @@ void main() {
           () async {
         final Directory pluginDirectory = createFakePlugin(
             'plugin', packagesDir, platformSupport: <String, PlatformDetails>{
-          kPlatformIos: const PlatformDetails(PlatformSupport.inline)
+          platformIOS: const PlatformDetails(PlatformSupport.inline)
         });
         final Directory pluginExampleDirectory =
             pluginDirectory.childDirectory('example');
@@ -366,7 +366,7 @@ void main() {
       test('skip if macOS is implemented in a federated package', () async {
         createFakePlugin('plugin', packagesDir,
             platformSupport: <String, PlatformDetails>{
-              kPlatformMacos: const PlatformDetails(PlatformSupport.federated),
+              platformMacOS: const PlatformDetails(PlatformSupport.federated),
             });
 
         final List<String> output =
@@ -385,7 +385,7 @@ void main() {
         final Directory pluginDirectory1 = createFakePlugin(
             'plugin', packagesDir,
             platformSupport: <String, PlatformDetails>{
-              kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
+              platformMacOS: const PlatformDetails(PlatformSupport.inline),
             });
 
         final Directory pluginExampleDirectory =
@@ -421,7 +421,7 @@ void main() {
           'plugin',
           packagesDir,
           platformSupport: <String, PlatformDetails>{
-            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline)
+            platformAndroid: const PlatformDetails(PlatformSupport.inline)
           },
           extraFiles: <String>[
             'example/android/gradlew',
@@ -451,7 +451,7 @@ void main() {
           'plugin',
           packagesDir,
           platformSupport: <String, PlatformDetails>{
-            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline)
+            platformAndroid: const PlatformDetails(PlatformSupport.inline)
           },
           extraFiles: <String>[
             'example/android/gradlew',
@@ -481,7 +481,7 @@ void main() {
           'plugin',
           packagesDir,
           platformSupport: <String, PlatformDetails>{
-            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline)
+            platformAndroid: const PlatformDetails(PlatformSupport.inline)
           },
           extraFiles: <String>[
             'example/android/gradlew',
@@ -517,7 +517,7 @@ void main() {
           'plugin',
           packagesDir,
           platformSupport: <String, PlatformDetails>{
-            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline)
+            platformAndroid: const PlatformDetails(PlatformSupport.inline)
           },
           extraFiles: <String>[
             'example/android/gradlew',
@@ -543,7 +543,7 @@ void main() {
           'plugin',
           packagesDir,
           platformSupport: <String, PlatformDetails>{
-            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline)
+            platformAndroid: const PlatformDetails(PlatformSupport.inline)
           },
           extraFiles: <String>[
             'android/src/test/example_test.java',
@@ -582,7 +582,7 @@ void main() {
           'plugin',
           packagesDir,
           platformSupport: <String, PlatformDetails>{
-            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline)
+            platformAndroid: const PlatformDetails(PlatformSupport.inline)
           },
           extraFiles: <String>[
             'android/src/test/example_test.java',
@@ -617,7 +617,7 @@ void main() {
           'plugin',
           packagesDir,
           platformSupport: <String, PlatformDetails>{
-            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline)
+            platformAndroid: const PlatformDetails(PlatformSupport.inline)
           },
           extraFiles: <String>[
             'android/src/test/example_test.java',
@@ -649,7 +649,7 @@ void main() {
           'plugin',
           packagesDir,
           platformSupport: <String, PlatformDetails>{
-            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline)
+            platformAndroid: const PlatformDetails(PlatformSupport.inline)
           },
           extraFiles: <String>[
             'example/android/app/src/test/example_test.java',
@@ -681,7 +681,7 @@ void main() {
           'plugin1',
           packagesDir,
           platformSupport: <String, PlatformDetails>{
-            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline)
+            platformAndroid: const PlatformDetails(PlatformSupport.inline)
           },
           extraFiles: <String>[
             'example/android/gradlew',
@@ -693,7 +693,7 @@ void main() {
           'plugin2',
           packagesDir,
           platformSupport: <String, PlatformDetails>{
-            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline)
+            platformAndroid: const PlatformDetails(PlatformSupport.inline)
           },
           extraFiles: <String>[
             'android/src/test/example_test.java',
@@ -724,7 +724,7 @@ void main() {
           'plugin',
           packagesDir,
           platformSupport: <String, PlatformDetails>{
-            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline)
+            platformAndroid: const PlatformDetails(PlatformSupport.inline)
           },
           extraFiles: <String>[
             'example/android/gradlew',
@@ -765,7 +765,7 @@ void main() {
           'plugin',
           packagesDir,
           platformSupport: <String, PlatformDetails>{
-            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline)
+            platformAndroid: const PlatformDetails(PlatformSupport.inline)
           },
           extraFiles: <String>[
             'example/android/gradlew',
@@ -808,7 +808,7 @@ void main() {
           'plugin',
           packagesDir,
           platformSupport: <String, PlatformDetails>{
-            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline)
+            platformAndroid: const PlatformDetails(PlatformSupport.inline)
           },
           extraFiles: <String>[
             'example/android/gradlew',
@@ -861,7 +861,7 @@ void main() {
           'plugin',
           packagesDir,
           platformSupport: <String, PlatformDetails>{
-            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline)
+            platformAndroid: const PlatformDetails(PlatformSupport.inline)
           },
         );
 
@@ -886,7 +886,7 @@ void main() {
             createFakePlugin('plugin', packagesDir, extraFiles: <String>[
           'example/$testBinaryRelativePath'
         ], platformSupport: <String, PlatformDetails>{
-          kPlatformLinux: const PlatformDetails(PlatformSupport.inline),
+          platformLinux: const PlatformDetails(PlatformSupport.inline),
         });
         _createFakeCMakeCache(pluginDirectory, mockPlatform);
 
@@ -925,7 +925,7 @@ void main() {
           'example/$debugTestBinaryRelativePath',
           'example/$releaseTestBinaryRelativePath'
         ], platformSupport: <String, PlatformDetails>{
-          kPlatformLinux: const PlatformDetails(PlatformSupport.inline),
+          platformLinux: const PlatformDetails(PlatformSupport.inline),
         });
         _createFakeCMakeCache(pluginDirectory, mockPlatform);
 
@@ -958,7 +958,7 @@ void main() {
       test('fails if CMake has not been configured', () async {
         createFakePlugin('plugin', packagesDir,
             platformSupport: <String, PlatformDetails>{
-              kPlatformLinux: const PlatformDetails(PlatformSupport.inline),
+              platformLinux: const PlatformDetails(PlatformSupport.inline),
             });
 
         Error? commandError;
@@ -986,7 +986,7 @@ void main() {
         final Directory pluginDirectory = createFakePlugin(
             'plugin', packagesDir,
             platformSupport: <String, PlatformDetails>{
-              kPlatformLinux: const PlatformDetails(PlatformSupport.inline),
+              platformLinux: const PlatformDetails(PlatformSupport.inline),
             });
         _createFakeCMakeCache(pluginDirectory, mockPlatform);
 
@@ -1021,7 +1021,7 @@ void main() {
             createFakePlugin('plugin', packagesDir, extraFiles: <String>[
           'example/$testBinaryRelativePath'
         ], platformSupport: <String, PlatformDetails>{
-          kPlatformLinux: const PlatformDetails(PlatformSupport.inline),
+          platformLinux: const PlatformDetails(PlatformSupport.inline),
         });
         _createFakeCMakeCache(pluginDirectory, mockPlatform);
 
@@ -1062,7 +1062,7 @@ void main() {
       test('fails if xcrun fails', () async {
         createFakePlugin('plugin', packagesDir,
             platformSupport: <String, PlatformDetails>{
-              kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
+              platformMacOS: const PlatformDetails(PlatformSupport.inline),
             });
 
         processRunner.mockProcessesForExecutable['xcrun'] = <io.Process>[
@@ -1090,7 +1090,7 @@ void main() {
         final Directory pluginDirectory1 = createFakePlugin(
             'plugin', packagesDir,
             platformSupport: <String, PlatformDetails>{
-              kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
+              platformMacOS: const PlatformDetails(PlatformSupport.inline),
             });
 
         final Directory pluginExampleDirectory =
@@ -1126,7 +1126,7 @@ void main() {
         final Directory pluginDirectory1 = createFakePlugin(
             'plugin', packagesDir,
             platformSupport: <String, PlatformDetails>{
-              kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
+              platformMacOS: const PlatformDetails(PlatformSupport.inline),
             });
 
         final Directory pluginExampleDirectory =
@@ -1162,7 +1162,7 @@ void main() {
         final Directory pluginDirectory1 = createFakePlugin(
             'plugin', packagesDir,
             platformSupport: <String, PlatformDetails>{
-              kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
+              platformMacOS: const PlatformDetails(PlatformSupport.inline),
             });
 
         final Directory pluginExampleDirectory =
@@ -1198,7 +1198,7 @@ void main() {
         final Directory pluginDirectory1 = createFakePlugin(
             'plugin', packagesDir,
             platformSupport: <String, PlatformDetails>{
-              kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
+              platformMacOS: const PlatformDetails(PlatformSupport.inline),
             });
 
         final Directory pluginExampleDirectory =
@@ -1238,7 +1238,7 @@ void main() {
         final Directory pluginDirectory1 = createFakePlugin(
             'plugin', packagesDir,
             platformSupport: <String, PlatformDetails>{
-              kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
+              platformMacOS: const PlatformDetails(PlatformSupport.inline),
             });
 
         final Directory pluginExampleDirectory =
@@ -1283,9 +1283,9 @@ void main() {
             'android/src/test/example_test.java',
           ],
           platformSupport: <String, PlatformDetails>{
-            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
-            kPlatformIos: const PlatformDetails(PlatformSupport.inline),
-            kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
+            platformAndroid: const PlatformDetails(PlatformSupport.inline),
+            platformIOS: const PlatformDetails(PlatformSupport.inline),
+            platformMacOS: const PlatformDetails(PlatformSupport.inline),
           },
         );
 
@@ -1337,7 +1337,7 @@ void main() {
         final Directory pluginDirectory1 = createFakePlugin(
             'plugin', packagesDir,
             platformSupport: <String, PlatformDetails>{
-              kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
+              platformMacOS: const PlatformDetails(PlatformSupport.inline),
             });
 
         final Directory pluginExampleDirectory =
@@ -1374,7 +1374,7 @@ void main() {
       test('runs only iOS for a iOS plugin', () async {
         final Directory pluginDirectory = createFakePlugin(
             'plugin', packagesDir, platformSupport: <String, PlatformDetails>{
-          kPlatformIos: const PlatformDetails(PlatformSupport.inline)
+          platformIOS: const PlatformDetails(PlatformSupport.inline)
         });
 
         final Directory pluginExampleDirectory =
@@ -1439,9 +1439,9 @@ void main() {
           'plugin',
           packagesDir,
           platformSupport: <String, PlatformDetails>{
-            kPlatformMacos: const PlatformDetails(PlatformSupport.inline,
+            platformMacOS: const PlatformDetails(PlatformSupport.inline,
                 hasDartCode: true, hasNativeCode: false),
-            kPlatformWindows: const PlatformDetails(PlatformSupport.inline,
+            platformWindows: const PlatformDetails(PlatformSupport.inline,
                 hasDartCode: true, hasNativeCode: false),
           },
         );
@@ -1470,8 +1470,8 @@ void main() {
           'plugin',
           packagesDir,
           platformSupport: <String, PlatformDetails>{
-            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
-            kPlatformIos: const PlatformDetails(PlatformSupport.inline),
+            platformAndroid: const PlatformDetails(PlatformSupport.inline),
+            platformIOS: const PlatformDetails(PlatformSupport.inline),
           },
           extraFiles: <String>[
             'example/android/gradlew',
@@ -1526,8 +1526,8 @@ void main() {
           'plugin',
           packagesDir,
           platformSupport: <String, PlatformDetails>{
-            kPlatformAndroid: const PlatformDetails(PlatformSupport.inline),
-            kPlatformIos: const PlatformDetails(PlatformSupport.inline),
+            platformAndroid: const PlatformDetails(PlatformSupport.inline),
+            platformIOS: const PlatformDetails(PlatformSupport.inline),
           },
           extraFiles: <String>[
             'example/android/gradlew',
@@ -1625,7 +1625,7 @@ void main() {
             createFakePlugin('plugin', packagesDir, extraFiles: <String>[
           'example/$testBinaryRelativePath'
         ], platformSupport: <String, PlatformDetails>{
-          kPlatformWindows: const PlatformDetails(PlatformSupport.inline),
+          platformWindows: const PlatformDetails(PlatformSupport.inline),
         });
         _createFakeCMakeCache(pluginDirectory, mockPlatform);
 
@@ -1664,7 +1664,7 @@ void main() {
           'example/$debugTestBinaryRelativePath',
           'example/$releaseTestBinaryRelativePath'
         ], platformSupport: <String, PlatformDetails>{
-          kPlatformWindows: const PlatformDetails(PlatformSupport.inline),
+          platformWindows: const PlatformDetails(PlatformSupport.inline),
         });
         _createFakeCMakeCache(pluginDirectory, mockPlatform);
 
@@ -1696,7 +1696,7 @@ void main() {
       test('fails if CMake has not been configured', () async {
         createFakePlugin('plugin', packagesDir,
             platformSupport: <String, PlatformDetails>{
-              kPlatformWindows: const PlatformDetails(PlatformSupport.inline),
+              platformWindows: const PlatformDetails(PlatformSupport.inline),
             });
 
         Error? commandError;
@@ -1724,7 +1724,7 @@ void main() {
         final Directory pluginDirectory = createFakePlugin(
             'plugin', packagesDir,
             platformSupport: <String, PlatformDetails>{
-              kPlatformWindows: const PlatformDetails(PlatformSupport.inline),
+              platformWindows: const PlatformDetails(PlatformSupport.inline),
             });
         _createFakeCMakeCache(pluginDirectory, mockPlatform);
 
@@ -1759,7 +1759,7 @@ void main() {
             createFakePlugin('plugin', packagesDir, extraFiles: <String>[
           'example/$testBinaryRelativePath'
         ], platformSupport: <String, PlatformDetails>{
-          kPlatformWindows: const PlatformDetails(PlatformSupport.inline),
+          platformWindows: const PlatformDetails(PlatformSupport.inline),
         });
         _createFakeCMakeCache(pluginDirectory, mockPlatform);
 

--- a/script/tool/test/test_command_test.dart
+++ b/script/tool/test/test_command_test.dart
@@ -181,7 +181,7 @@ void main() {
         packagesDir,
         extraFiles: <String>['test/empty_test.dart'],
         platformSupport: <String, PlatformDetails>{
-          kPlatformWeb: const PlatformDetails(PlatformSupport.inline),
+          platformWeb: const PlatformDetails(PlatformSupport.inline),
         },
       );
 

--- a/script/tool/test/util.dart
+++ b/script/tool/test/util.dart
@@ -229,24 +229,24 @@ String _pluginPlatformSection(
       '      $platform:',
     ];
     switch (platform) {
-      case kPlatformAndroid:
+      case platformAndroid:
         lines.add('        package: io.flutter.plugins.fake');
         continue nativeByDefault;
       nativeByDefault:
-      case kPlatformIos:
-      case kPlatformLinux:
-      case kPlatformMacos:
-      case kPlatformWindows:
+      case platformIOS:
+      case platformLinux:
+      case platformMacOS:
+      case platformWindows:
         if (support.hasNativeCode) {
           final String className =
-              platform == kPlatformIos ? 'FLTFakePlugin' : 'FakePlugin';
+              platform == platformIOS ? 'FLTFakePlugin' : 'FakePlugin';
           lines.add('        pluginClass: $className');
         }
         if (support.hasDartCode) {
           lines.add('        dartPluginClass: FakeDartPlugin');
         }
         break;
-      case kPlatformWeb:
+      case platformWeb:
         lines.addAll(<String>[
           '        pluginClass: FakePlugin',
           '        fileName: ${packageName}_web.dart',

--- a/script/tool/test/xcode_analyze_command_test.dart
+++ b/script/tool/test/xcode_analyze_command_test.dart
@@ -58,7 +58,7 @@ void main() {
       test('skip if iOS is not supported', () async {
         createFakePlugin('plugin', packagesDir,
             platformSupport: <String, PlatformDetails>{
-              kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
+              platformMacOS: const PlatformDetails(PlatformSupport.inline),
             });
 
         final List<String> output =
@@ -71,7 +71,7 @@ void main() {
       test('skip if iOS is implemented in a federated package', () async {
         createFakePlugin('plugin', packagesDir,
             platformSupport: <String, PlatformDetails>{
-              kPlatformIos: const PlatformDetails(PlatformSupport.federated)
+              platformIOS: const PlatformDetails(PlatformSupport.federated)
             });
 
         final List<String> output =
@@ -84,7 +84,7 @@ void main() {
       test('runs for iOS plugin', () async {
         final Directory pluginDirectory = createFakePlugin(
             'plugin', packagesDir, platformSupport: <String, PlatformDetails>{
-          kPlatformIos: const PlatformDetails(PlatformSupport.inline)
+          platformIOS: const PlatformDetails(PlatformSupport.inline)
         });
 
         final Directory pluginExampleDirectory =
@@ -127,7 +127,7 @@ void main() {
       test('fails if xcrun fails', () async {
         createFakePlugin('plugin', packagesDir,
             platformSupport: <String, PlatformDetails>{
-              kPlatformIos: const PlatformDetails(PlatformSupport.inline)
+              platformIOS: const PlatformDetails(PlatformSupport.inline)
             });
 
         processRunner.mockProcessesForExecutable['xcrun'] = <io.Process>[
@@ -173,7 +173,7 @@ void main() {
       test('skip if macOS is implemented in a federated package', () async {
         createFakePlugin('plugin', packagesDir,
             platformSupport: <String, PlatformDetails>{
-              kPlatformMacos: const PlatformDetails(PlatformSupport.federated),
+              platformMacOS: const PlatformDetails(PlatformSupport.federated),
             });
 
         final List<String> output = await runCapturingPrint(
@@ -187,7 +187,7 @@ void main() {
         final Directory pluginDirectory1 = createFakePlugin(
             'plugin', packagesDir,
             platformSupport: <String, PlatformDetails>{
-              kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
+              platformMacOS: const PlatformDetails(PlatformSupport.inline),
             });
 
         final Directory pluginExampleDirectory =
@@ -224,7 +224,7 @@ void main() {
       test('fails if xcrun fails', () async {
         createFakePlugin('plugin', packagesDir,
             platformSupport: <String, PlatformDetails>{
-              kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
+              platformMacOS: const PlatformDetails(PlatformSupport.inline),
             });
 
         processRunner.mockProcessesForExecutable['xcrun'] = <io.Process>[
@@ -254,8 +254,8 @@ void main() {
         final Directory pluginDirectory1 = createFakePlugin(
             'plugin', packagesDir,
             platformSupport: <String, PlatformDetails>{
-              kPlatformIos: const PlatformDetails(PlatformSupport.inline),
-              kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
+              platformIOS: const PlatformDetails(PlatformSupport.inline),
+              platformMacOS: const PlatformDetails(PlatformSupport.inline),
             });
 
         final Directory pluginExampleDirectory =
@@ -314,7 +314,7 @@ void main() {
         final Directory pluginDirectory1 = createFakePlugin(
             'plugin', packagesDir,
             platformSupport: <String, PlatformDetails>{
-              kPlatformMacos: const PlatformDetails(PlatformSupport.inline),
+              platformMacOS: const PlatformDetails(PlatformSupport.inline),
             });
 
         final Directory pluginExampleDirectory =
@@ -355,7 +355,7 @@ void main() {
       test('runs only iOS for a iOS plugin', () async {
         final Directory pluginDirectory = createFakePlugin(
             'plugin', packagesDir, platformSupport: <String, PlatformDetails>{
-          kPlatformIos: const PlatformDetails(PlatformSupport.inline)
+          platformIOS: const PlatformDetails(PlatformSupport.inline)
         });
 
         final Directory pluginExampleDirectory =


### PR DESCRIPTION
Fixes capitalization of iOS and macOS in Dart names to match the Dart
naming rules for two-letter abbreviations, bringing the tool code into
compliance with the recent updates to the Flutter style guide:
https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#capitalize-identifiers-consistent-with-their-spelling

Since this touched two of the `kPlatform...` constants already, I
opportunistically fixed the long-standing naming mistake of those using
a `k` prefix, which isn't done in Dart style.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
