### PR TITLE
[in_app_purchase] Updates the dependency on in_app_purchase_storekit.

### DIFF
--- a/packages/in_app_purchase/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.0.0
 
-* **BREAKING CHANGE** Updates the dependency on `in_app_purchase_storekit` to `0.3.0+1` which ensures the `restorePurchases` method emits an empty list of purchases. 
+* **BREAKING CHANGE** Updates `restorePurchases` to emit an empty list of purchases on StoreKit when there are no purchases to restore (same as Android).
+  * This change was listed in the CHANGELOG for 2.0.0, but the change was accidentally not included in 2.0.0.
 
 ## 2.0.1
 
@@ -10,7 +11,7 @@
 
 * **BREAKING CHANGES**:
   * Adds a new `PurchaseStatus` named `canceled`. This means developers can distinguish between an error and user cancellation.
-  * Updates `restorePurchases` to emit an empty list of purchases on StoreKit when there are no purchases to restore (same as Android).
+  * ~~Updates `restorePurchases` to emit an empty list of purchases on StoreKit when there are no purchases to restore (same as Android).~~
   * Renames `in_app_purchase_ios` to `in_app_purchase_storekit`.
   * Renames `InAppPurchaseIosPlatform` to `InAppPurchaseStoreKitPlatform`.
   * Renames `InAppPurchaseIosPlatformAddition` to

--- a/packages/in_app_purchase/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.0
+
+* **BREAKING CHANGE** Updates the dependency on `in_app_purchase_storekit` to `0.3.0+1` which ensures the `restorePurchases` method emits an empty list of purchases. 
+
 ## 2.0.1
 
 * Removes the instructions on initializing the plugin since this functionality is deprecated.

--- a/packages/in_app_purchase/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase
 description: A Flutter plugin for in-app purchases. Exposes APIs for making in-app purchases through the App Store and Google Play.
 repository: https://github.com/flutter/plugins/tree/main/packages/in_app_purchase/in_app_purchase
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 2.0.1
+version: 3.0.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -21,7 +21,7 @@ dependencies:
     sdk: flutter
   in_app_purchase_platform_interface: ^1.0.0
   in_app_purchase_android: ^0.2.1
-  in_app_purchase_storekit: ^0.2.0
+  in_app_purchase_storekit: ^0.3.0+1
 
 dev_dependencies:
   flutter_driver:


### PR DESCRIPTION
Updates the dependency on the in_app_purchase_storekit to version 0.3.0+1 to ensure the `restorePurchases` method will return an empty list of purchases on the `purchaseUpdates` stream when there are no purchases to restore.

This update was supposed to go out with version 2.0.0 of the in_app_purchase package, but we missed it which unfortunately means we have to rollout another breaking change.

Resolves flutter/flutter#98113

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
