### PR TITLE
[webview_flutter] Send history events

### DIFF
--- a/packages/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.3
+
+* Add support for Navigation History observation.
+
 ## 1.0.2
 
 * Android Code Inspection and Clean up.

--- a/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewClient.java
+++ b/packages/webview_flutter/android/src/main/java/io/flutter/plugins/webviewflutter/FlutterWebViewClient.java
@@ -148,6 +148,12 @@ class FlutterWebViewClient {
     }
   }
 
+  private void onUpdateVisitedHistory(String url) {
+    HashMap<String, Object> args = new HashMap<>();
+    args.put("url", url);
+    methodChannel.invokeMethod("onUpdateVisitedHistory", args);
+  }
+
   // This method attempts to avoid using WebViewClientCompat due to bug
   // https://bugs.chromium.org/p/chromium/issues/detail?id=925887. Also, see
   // https://github.com/flutter/flutter/issues/29446.
@@ -163,6 +169,12 @@ class FlutterWebViewClient {
 
   private WebViewClient internalCreateWebViewClient() {
     return new WebViewClient() {
+      @Override
+      public void doUpdateVisitedHistory(WebView view, String url, boolean isReload) {
+        FlutterWebViewClient.this.onUpdateVisitedHistory(url);
+        super.doUpdateVisitedHistory(view, url, isReload);
+      }
+
       @TargetApi(Build.VERSION_CODES.N)
       @Override
       public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
@@ -204,6 +216,12 @@ class FlutterWebViewClient {
 
   private WebViewClientCompat internalCreateWebViewClientCompat() {
     return new WebViewClientCompat() {
+      @Override
+      public void doUpdateVisitedHistory(WebView view, String url, boolean isReload) {
+        FlutterWebViewClient.this.onUpdateVisitedHistory(url);
+        super.doUpdateVisitedHistory(view, url, isReload);
+      }
+
       @Override
       public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
         return FlutterWebViewClient.this.shouldOverrideUrlLoading(view, request);

--- a/packages/webview_flutter/example/lib/main.dart
+++ b/packages/webview_flutter/example/lib/main.dart
@@ -82,6 +82,9 @@ class _WebViewExampleState extends State<WebViewExample> {
             print('Page finished loading: $url');
           },
           gestureNavigationEnabled: true,
+          onUpdateVisitedHistory: (String url) {
+            print('Update visited history: $url');
+          },
         );
       }),
       floatingActionButton: favoriteButton(),

--- a/packages/webview_flutter/ios/Classes/FLTWKHistoryDelegate.h
+++ b/packages/webview_flutter/ios/Classes/FLTWKHistoryDelegate.h
@@ -1,0 +1,16 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <Flutter/Flutter.h>
+#import <Foundation/Foundation.h>
+#import <WebKit/WebKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface FLTWKHistoryDelegate : NSObject
+- (instancetype)initWithWebView:(WKWebView *)webView channel:(FlutterMethodChannel *)channel;
+- (void)stopObserving:(WKWebView *)webView;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/webview_flutter/ios/Classes/FLTWKHistoryDelegate.m
+++ b/packages/webview_flutter/ios/Classes/FLTWKHistoryDelegate.m
@@ -1,0 +1,41 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "FLTWKHistoryDelegate.h"
+
+NSString *const keyPath = @"URL";
+
+@implementation FLTWKHistoryDelegate {
+  FlutterMethodChannel *_methodChannel;
+}
+
+- (instancetype)initWithWebView:(id)webView channel:(FlutterMethodChannel *)channel {
+  self = [super init];
+  if (self) {
+    _methodChannel = channel;
+    [webView addObserver:self
+              forKeyPath:keyPath
+                 options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld
+                 context:nil];
+  }
+
+  return self;
+}
+
+- (void)stopObserving:(WKWebView *)webView {
+  [webView removeObserver:self forKeyPath:keyPath];
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath
+                      ofObject:(id)object
+                        change:(NSDictionary *)change
+                       context:(void *)context {
+  if ([change[NSKeyValueChangeNewKey] isKindOfClass:[NSURL class]]) {
+    NSURL *newUrl = change[NSKeyValueChangeNewKey];
+    [_methodChannel invokeMethod:@"onUpdateVisitedHistory"
+                       arguments:@{@"url" : [newUrl absoluteString]}];
+  }
+}
+
+@end

--- a/packages/webview_flutter/ios/Classes/FlutterWebView.m
+++ b/packages/webview_flutter/ios/Classes/FlutterWebView.m
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #import "FlutterWebView.h"
+#import "FLTWKHistoryDelegate.h"
 #import "FLTWKNavigationDelegate.h"
 #import "JavaScriptChannelHandler.h"
 
@@ -64,6 +65,7 @@
   // The set of registered JavaScript channel names.
   NSMutableSet* _javaScriptChannelNames;
   FLTWKNavigationDelegate* _navigationDelegate;
+  FLTWKHistoryDelegate* _historyDelegate;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -95,6 +97,7 @@
     _navigationDelegate = [[FLTWKNavigationDelegate alloc] initWithChannel:_channel];
     _webView.UIDelegate = self;
     _webView.navigationDelegate = _navigationDelegate;
+    _historyDelegate = [[FLTWKHistoryDelegate alloc] initWithWebView:_webView channel:_channel];
     __weak __typeof__(self) weakSelf = self;
     [_channel setMethodCallHandler:^(FlutterMethodCall* call, FlutterResult result) {
       [weakSelf onMethodCall:call result:result];
@@ -117,6 +120,10 @@
     }
   }
   return self;
+}
+
+- (void)dealloc {
+  [_historyDelegate stopObserving:_webView];
 }
 
 - (UIView*)view {

--- a/packages/webview_flutter/lib/platform_interface.dart
+++ b/packages/webview_flutter/lib/platform_interface.dart
@@ -31,6 +31,9 @@ abstract class WebViewPlatformCallbacksHandler {
 
   /// Report web resource loading error to the host application.
   void onWebResourceError(WebResourceError error);
+
+  /// Invoked by [WebViewPlatformController] when the URL has changed.
+  void onUpdateVisitedHistory(String url);
 }
 
 /// Possible error type categorizations used by [WebResourceError].

--- a/packages/webview_flutter/lib/src/webview_method_channel.dart
+++ b/packages/webview_flutter/lib/src/webview_method_channel.dart
@@ -61,6 +61,9 @@ class MethodChannelWebViewPlatform implements WebViewPlatformController {
           ),
         );
         return null;
+      case 'onUpdateVisitedHistory':
+        _platformCallbacksHandler.onUpdateVisitedHistory(call.arguments['url']);
+        return null;
     }
 
     throw MissingPluginException(

--- a/packages/webview_flutter/lib/webview_flutter.dart
+++ b/packages/webview_flutter/lib/webview_flutter.dart
@@ -145,6 +145,9 @@ typedef void PageFinishedCallback(String url);
 /// Signature for when a [WebView] has failed to load a resource.
 typedef void WebResourceErrorCallback(WebResourceError error);
 
+/// Signature for when a [WebView] had a history update.
+typedef void PageUpdateVisitedHistoryCallback(String url);
+
 /// Specifies possible restrictions on automatic media playback.
 ///
 /// This is typically used in [WebView.initialMediaPlaybackPolicy].
@@ -214,6 +217,7 @@ class WebView extends StatefulWidget {
     this.onPageStarted,
     this.onPageFinished,
     this.onWebResourceError,
+    this.onUpdateVisitedHistory,
     this.debuggingEnabled = false,
     this.gestureNavigationEnabled = false,
     this.userAgent,
@@ -349,6 +353,12 @@ class WebView extends StatefulWidget {
   /// This can be called for any resource (iframe, image, etc.), not just for
   /// the main page.
   final WebResourceErrorCallback onWebResourceError;
+
+  /// Invoked when the URL in the browser changed.
+  ///
+  /// This is always triggered when the URL changes. Also when this is done via
+  /// JavaScript and no [onPageStarted] or [onPageFinished] events would be fired.
+  final PageUpdateVisitedHistoryCallback onUpdateVisitedHistory;
 
   /// Controls whether WebView debugging is enabled.
   ///
@@ -557,6 +567,13 @@ class _PlatformCallbacksHandler implements WebViewPlatformCallbacksHandler {
   void onWebResourceError(WebResourceError error) {
     if (_widget.onWebResourceError != null) {
       _widget.onWebResourceError(error);
+    }
+  }
+
+  @override
+  void onUpdateVisitedHistory(String url) {
+    if (_widget.onUpdateVisitedHistory != null) {
+      _widget.onUpdateVisitedHistory(url);
     }
   }
 

--- a/packages/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
-version: 1.0.2
+version: 1.0.3
 homepage: https://github.com/flutter/plugins/tree/master/packages/webview_flutter
 
 environment:

--- a/packages/webview_flutter/test/webview_flutter_test.dart
+++ b/packages/webview_flutter/test/webview_flutter_test.dart
@@ -889,6 +889,22 @@ void main() {
 
     expect(platformWebView.userAgent, 'UA');
   });
+  testWidgets('onUpdateVisitedHistory', (WidgetTester tester) async {
+    String visitedUrl;
+
+    await tester.pumpWidget(WebView(
+        initialUrl: 'https://youtube.com',
+        onUpdateVisitedHistory: (String url) {
+          visitedUrl = url;
+        }));
+
+    final FakePlatformWebView platformWebView =
+        fakePlatformViewsController.lastCreatedView;
+
+    platformWebView.fakeOnUpdateVisitedHistoryCallback('https://google.com');
+
+    expect(visitedUrl, 'https://google.com');
+  });
 }
 
 class FakePlatformWebView {
@@ -1046,6 +1062,24 @@ class FakePlatformWebView {
     ));
 
     ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
+      channel.name,
+      data,
+      (ByteData data) {},
+    );
+  }
+
+  void fakeOnUpdateVisitedHistoryCallback(String nextUrl) {
+    final StandardMethodCodec codec = const StandardMethodCodec();
+
+    final ByteData data = codec.encodeMethodCall(MethodCall(
+      'onUpdateVisitedHistory',
+      <dynamic, dynamic>{'url': nextUrl},
+    ));
+
+    // TODO(hterkelsen): Remove this when defaultBinaryMessages is in stable.
+    // https://github.com/flutter/flutter/issues/33446
+    // ignore: deprecated_member_use
+    BinaryMessages.handlePlatformMessage(
       channel.name,
       data,
       (ByteData data) {},


### PR DESCRIPTION
Send URL change events when the user navigates in the Browser. This also
works for JavaScript Navigation that does not actually make any request.

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
