### PR TITLE
[camera] Fix capture hang on Android 12 devices (Pixel 6)

### DIFF
--- a/packages/camera/camera/AUTHORS
+++ b/packages/camera/camera/AUTHORS
@@ -64,3 +64,4 @@ Aleksandr Yurkovskiy <sanekyy@gmail.com>
 Anton Borries <mail@antonborri.es>
 Alex Li <google@alexv525.com>
 Rahul Raj <64.rahulraj@gmail.com>
+Andrew Coutts <andrewjohncoutts@gmail.com>

--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,3 +1,6 @@
+* ## 0.9.4+15
+* Fix camera capture on Android 12 devices (Pixel 6) by removing unnecessary calls to abort captures after capture is finished.
+
 ## 0.9.4+14
 
 * Restores compatibility with Flutter 2.5 and 2.8.

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
@@ -583,8 +583,6 @@ class Camera
         };
 
     try {
-      captureSession.stopRepeating();
-      captureSession.abortCaptures();
       Log.i(TAG, "sending capture request");
       captureSession.capture(stillBuilder.build(), captureCallback, backgroundHandler);
     } catch (CameraAccessException e) {

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -4,7 +4,7 @@ description: A Flutter plugin for controlling the camera. Supports previewing
   Dart.
 repository: https://github.com/flutter/plugins/tree/main/packages/camera/camera
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.9.4+14
+version: 0.9.4+15
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR fixes image capture on Android 12 devices like the Pixel 6. After an image is captured, the device is stuck in `STATE_CAPTURING` because of the calls to `stopRepeating()` and `abortCaptures()` right after initiating the capture.

The best theory I can make is on devices like the Pixel 6 this causes the capture to never finish and the state machine is stuck in the capturing state forever because it aborted the capture before it finished. There must be a change in Android 12 that causes this to be an issue now.

One other note, these 2 calls were not present in the plugin prior to the big refactor last year I started that was later split into 9 different PRs. As part of the 9th PR, it seems @BeMacized added these calls in for some reason (did not see it documented unfortunately).

After removing these 2 calls, camera capture is working for the Pixel 6 and it still works for the Pixel 4 (Android 11).

Lines in question:
https://github.com/flutter/plugins/blame/main/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java#L586-L587

Commit that broke it:
[https://github.com/flutter/plugins/commit/0a86ac866b8b322a37d5fac36c7b15856a2b37e8#diff-97f0364e631a66ce678d82ff99[…]6c59511d7d848f8c33544eR556-R557](https://github.com/flutter/plugins/commit/0a86ac866b8b322a37d5fac36c7b15856a2b37e8#diff-97f0364e631a66ce678d82ff9906a3fa2f6fc75cfa6c59511d7d848f8c33544eR556-R557)

*List which issues are fixed by this PR. You must list at least one issue.*
* https://github.com/flutter/flutter/issues/92973

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
--> No new code to comment
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
--> No new behavior to test with a unit test
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
