### PR TITLE
[camera] Fix the recorded video orientation for landscape left / landscape right

### DIFF
--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Fixes an issue with the orientation of video's recorded in landscape on Android.
+
 ## 0.9.4+14
 
 * Restores compatibility with Flutter 2.5 and 2.8.

--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/features/sensororientation/DeviceOrientationManager.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/features/sensororientation/DeviceOrientationManager.java
@@ -179,10 +179,10 @@ public class DeviceOrientationManager {
         angle = 180;
         break;
       case LANDSCAPE_LEFT:
-        angle = 90;
+        angle = 270;
         break;
       case LANDSCAPE_RIGHT:
-        angle = 270;
+        angle = 90;
         break;
     }
 

--- a/packages/camera/camera/android/src/test/java/io/flutter/plugins/camera/features/sensororientation/DeviceOrientationManagerTest.java
+++ b/packages/camera/camera/android/src/test/java/io/flutter/plugins/camera/features/sensororientation/DeviceOrientationManagerTest.java
@@ -62,9 +62,9 @@ public class DeviceOrientationManagerTest {
         deviceOrientationManager.getVideoOrientation(DeviceOrientation.LANDSCAPE_RIGHT);
 
     assertEquals(0, degreesPortraitUp);
-    assertEquals(90, degreesLandscapeLeft);
+    assertEquals(270, degreesLandscapeLeft);
     assertEquals(180, degreesPortraitDown);
-    assertEquals(270, degreesLandscapeRight);
+    assertEquals(90, degreesLandscapeRight);
   }
 
   @Test
@@ -81,18 +81,27 @@ public class DeviceOrientationManagerTest {
         orientationManager.getVideoOrientation(DeviceOrientation.LANDSCAPE_RIGHT);
 
     assertEquals(90, degreesPortraitUp);
-    assertEquals(180, degreesLandscapeLeft);
+    assertEquals(0, degreesLandscapeLeft);
     assertEquals(270, degreesPortraitDown);
-    assertEquals(0, degreesLandscapeRight);
+    assertEquals(180, degreesLandscapeRight);
   }
 
   @Test
-  public void getVideoOrientation_shouldFallbackToSensorOrientationWhenOrientationIsNull() {
+  public void getVideoOrientation_givenPortraitSensorOrientationShouldFallbackToSensorOrientationWhenOrientationIsNull() {
+    setUpUIOrientationMocks(Configuration.ORIENTATION_PORTRAIT, Surface.ROTATION_0);
+
+    int degrees = deviceOrientationManager.getVideoOrientation(null);
+
+    assertEquals(0, degrees);
+  }
+
+  @Test
+  public void getVideoOrientation_givenLandscapeSensorOrientationShouldFallbackToSensorOrientationWhenOrientationIsNull() {
     setUpUIOrientationMocks(Configuration.ORIENTATION_LANDSCAPE, Surface.ROTATION_0);
 
     int degrees = deviceOrientationManager.getVideoOrientation(null);
 
-    assertEquals(90, degrees);
+    assertEquals(270, degrees);
   }
 
   @Test

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -4,7 +4,7 @@ description: A Flutter plugin for controlling the camera. Supports previewing
   Dart.
 repository: https://github.com/flutter/plugins/tree/main/packages/camera/camera
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.9.4+14
+version: 0.9.4+15
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR fixes a bug with the orientation of the recorded video on Android. In Landscape Left and Landscape Right the video was flipped 180 degrees in the wrong direction. I also added a new test for the fallback-to-sensor-orientation case for portrait. Only testing that case against landscape felt a little odd to me.

Fixes https://github.com/flutter/flutter/issues/27201, https://github.com/flutter/flutter/issues/98486

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [ ] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<details>
  <summary>Before / After samples</summary>
  
 ### Landscape Left Recording (rotated the device 90CCW, then started recording)

 #### Before

https://user-images.githubusercontent.com/23480364/155849185-abb6080e-eb14-4145-a2d6-3cab3a6a8310.mp4

 #### After 

https://user-images.githubusercontent.com/23480364/155849236-d8218434-4354-4e23-ad3a-5ff842c86642.mp4

 ### LandscapeRight Recording (rotated the device 90CW, then started recording)

 #### Before

https://user-images.githubusercontent.com/23480364/155849199-29d65b4b-fcc2-4457-aa25-050a6e54789b.mp4

 #### After 

https://user-images.githubusercontent.com/23480364/155849268-54c5d7f8-ee70-4995-be62-ad2d092ae002.mp4

</details>
