### PR TITLE
[path_provider] Support unicode encoded version info values

### DIFF
--- a/packages/path_provider/path_provider_windows/CHANGELOG.md
+++ b/packages/path_provider/path_provider_windows/CHANGELOG.md
@@ -1,5 +1,3 @@
-## NEXT
-
 ## 2.0.7
 
 * Added support for unicode encoded VERSIONINFO

--- a/packages/path_provider/path_provider_windows/CHANGELOG.md
+++ b/packages/path_provider/path_provider_windows/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## NEXT
 
+## 2.0.7
+
+* Added support for unicode encoded VERSIONINFO
 * Minor fixes for new analysis options.
 
 ## 2.0.6

--- a/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_real.dart
+++ b/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_real.dart
@@ -13,21 +13,41 @@ import 'package:win32/win32.dart';
 
 import 'folders.dart';
 
+/// Constant for en-US language used in VersionInfo keys
+@visibleForTesting
+const String languageEn = '0409';
+
+/// Constant for CP1252 encoding used in VersionInfo keys
+@visibleForTesting
+const String encodingCP1252 = '04e4';
+
+/// Constant for Unicode encoding used in VersionInfo keys
+@visibleForTesting
+const String encodingUnicode = '04b0';
+
 /// Wraps the Win32 VerQueryValue API call.
 ///
 /// This class exists to allow injecting alternate metadata in tests without
 /// building multiple custom test binaries.
 @visibleForTesting
 class VersionInfoQuerier {
-  /// Returns the value for [key] in [versionInfo]s English strings section, or
-  /// null if there is no such entry, or if versionInfo is null.
-  String? getStringValue(Pointer<Uint8>? versionInfo, String key) {
+  /// Returns the value for [key] in [versionInfo]s in section with given
+  /// language and encoding, or null if there is no such entry,
+  /// or if versionInfo is null.
+  ///
+  /// See https://docs.microsoft.com/en-us/windows/win32/menurc/versioninfo-resource
+  /// for list of possible language and encoding values.
+  String? getStringValue(
+    Pointer<Uint8>? versionInfo,
+    String key, {
+    required String language,
+    required String encoding,
+  }) {
     if (versionInfo == null) {
       return null;
     }
-    const String kEnUsLanguageCode = '040904e4';
     final Pointer<Utf16> keyPath =
-        TEXT('\\StringFileInfo\\$kEnUsLanguageCode\\$key');
+        TEXT('\\StringFileInfo\\$language$encoding\\$key');
     final Pointer<Uint32> length = calloc<Uint32>();
     final Pointer<Pointer<Utf16>> valueAddress = calloc<Pointer<Utf16>>();
     try {
@@ -150,6 +170,12 @@ class PathProviderWindows extends PathProviderPlatform {
     }
   }
 
+  String? _getStringValue(Pointer<Uint8>? infoBuffer, String key) =>
+      versionInfoQuerier.getStringValue(infoBuffer, key,
+          language: languageEn, encoding: encodingCP1252) ??
+      versionInfoQuerier.getStringValue(infoBuffer, key,
+          language: languageEn, encoding: encodingUnicode);
+
   /// Returns the relative path string to append to the root directory returned
   /// by Win32 APIs for application storage (such as RoamingAppDir) to get a
   /// directory that is unique to the application.
@@ -187,10 +213,10 @@ class PathProviderWindows extends PathProviderPlatform {
           infoBuffer = null;
         }
       }
-      companyName = _sanitizedDirectoryName(
-          versionInfoQuerier.getStringValue(infoBuffer, 'CompanyName'));
-      productName = _sanitizedDirectoryName(
-          versionInfoQuerier.getStringValue(infoBuffer, 'ProductName'));
+      companyName =
+          _sanitizedDirectoryName(_getStringValue(infoBuffer, 'CompanyName'));
+      productName =
+          _sanitizedDirectoryName(_getStringValue(infoBuffer, 'ProductName'));
 
       // If there was no product name, use the executable name.
       productName ??=

--- a/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_real.dart
+++ b/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_real.dart
@@ -25,21 +25,25 @@ class VersionInfoQuerier {
     if (versionInfo == null) {
       return null;
     }
-    const String kEnUsLanguageCode = '040904e4';
-    final Pointer<Utf16> keyPath =
-        TEXT('\\StringFileInfo\\$kEnUsLanguageCode\\$key');
-    final Pointer<Uint32> length = calloc<Uint32>();
-    final Pointer<Pointer<Utf16>> valueAddress = calloc<Pointer<Utf16>>();
-    try {
-      if (VerQueryValue(versionInfo, keyPath, valueAddress, length) == 0) {
-        return null;
+    const List<String> languageCodes = <String>[
+      '040904e4', // en-US, CP1252
+      '040904b0', // en-US, Unicode
+    ];
+    for (final String code in languageCodes) {
+      final Pointer<Utf16> keyPath = TEXT('\\StringFileInfo\\$code\\$key');
+      final Pointer<Uint32> length = calloc<Uint32>();
+      final Pointer<Pointer<Utf16>> valueAddress = calloc<Pointer<Utf16>>();
+      try {
+        if (VerQueryValue(versionInfo, keyPath, valueAddress, length) != 0) {
+          return valueAddress.value.toDartString();
+        }
+      } finally {
+        calloc.free(keyPath);
+        calloc.free(length);
+        calloc.free(valueAddress);
       }
-      return valueAddress.value.toDartString();
-    } finally {
-      calloc.free(keyPath);
-      calloc.free(length);
-      calloc.free(valueAddress);
     }
+    return null;
   }
 }
 

--- a/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_real.dart
+++ b/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_real.dart
@@ -25,25 +25,21 @@ class VersionInfoQuerier {
     if (versionInfo == null) {
       return null;
     }
-    const List<String> languageCodes = <String>[
-      '040904e4', // en-US, CP1252
-      '040904b0', // en-US, Unicode
-    ];
-    for (final String code in languageCodes) {
-      final Pointer<Utf16> keyPath = TEXT('\\StringFileInfo\\$code\\$key');
-      final Pointer<Uint32> length = calloc<Uint32>();
-      final Pointer<Pointer<Utf16>> valueAddress = calloc<Pointer<Utf16>>();
-      try {
-        if (VerQueryValue(versionInfo, keyPath, valueAddress, length) != 0) {
-          return valueAddress.value.toDartString();
-        }
-      } finally {
-        calloc.free(keyPath);
-        calloc.free(length);
-        calloc.free(valueAddress);
+    const String kEnUsLanguageCode = '040904e4';
+    final Pointer<Utf16> keyPath =
+        TEXT('\\StringFileInfo\\$kEnUsLanguageCode\\$key');
+    final Pointer<Uint32> length = calloc<Uint32>();
+    final Pointer<Pointer<Utf16>> valueAddress = calloc<Pointer<Utf16>>();
+    try {
+      if (VerQueryValue(versionInfo, keyPath, valueAddress, length) == 0) {
+        return null;
       }
+      return valueAddress.value.toDartString();
+    } finally {
+      calloc.free(keyPath);
+      calloc.free(length);
+      calloc.free(valueAddress);
     }
-    return null;
   }
 }
 

--- a/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_real.dart
+++ b/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_real.dart
@@ -13,7 +13,7 @@ import 'package:win32/win32.dart';
 
 import 'folders.dart';
 
-/// Constant for en-US language used in VersionInfo keys
+/// Constant for en-US language used in VersionInfo keys.
 @visibleForTesting
 const String languageEn = '0409';
 
@@ -43,6 +43,8 @@ class VersionInfoQuerier {
     required String language,
     required String encoding,
   }) {
+    assert(language.isNotEmpty);
+    assert(encoding.isNotEmpty);
     if (versionInfo == null) {
       return null;
     }

--- a/packages/path_provider/path_provider_windows/pubspec.yaml
+++ b/packages/path_provider/path_provider_windows/pubspec.yaml
@@ -2,7 +2,7 @@ name: path_provider_windows
 description: Windows implementation of the path_provider plugin
 repository: https://github.com/flutter/plugins/tree/main/packages/path_provider/path_provider_windows
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+path_provider%22
-version: 2.0.6
+version: 2.0.7
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/path_provider/path_provider_windows/test/path_provider_windows_test.dart
+++ b/packages/path_provider/path_provider_windows/test/path_provider_windows_test.dart
@@ -7,15 +7,30 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:path_provider_windows/path_provider_windows.dart';
+import 'package:path_provider_windows/src/path_provider_windows_real.dart'
+    show languageEn, encodingCP1252, encodingUnicode;
 
 // A fake VersionInfoQuerier that just returns preset responses.
 class FakeVersionInfoQuerier implements VersionInfoQuerier {
-  FakeVersionInfoQuerier(this.responses);
+  FakeVersionInfoQuerier(this.responses,
+      [this.language = languageEn, this.encoding = encodingUnicode]);
 
+  final String language;
+  final String encoding;
   final Map<String, String> responses;
 
-  String? getStringValue(Pointer<Uint8>? versionInfo, String key) =>
-      responses[key];
+  String? getStringValue(
+    Pointer<Uint8>? versionInfo,
+    String key, {
+    required String language,
+    required String encoding,
+  }) {
+    if (language == this.language && encoding == this.encoding) {
+      return responses[key];
+    } else {
+      return null;
+    }
+  }
 }
 
 void main() {
@@ -40,18 +55,47 @@ void main() {
     expect(path, endsWith(r'flutter_tester'));
   }, skip: !Platform.isWindows);
 
-  test('getApplicationSupportPath with full version info', () async {
+  test('getApplicationSupportPath with full version info in CP1252', () async {
     final PathProviderWindows pathProvider = PathProviderWindows();
     pathProvider.versionInfoQuerier = FakeVersionInfoQuerier(<String, String>{
       'CompanyName': 'A Company',
       'ProductName': 'Amazing App',
-    });
+    }, languageEn, encodingCP1252);
     final String? path = await pathProvider.getApplicationSupportPath();
     expect(path, isNotNull);
     if (path != null) {
       expect(path, endsWith(r'AppData\Roaming\A Company\Amazing App'));
       expect(Directory(path).existsSync(), isTrue);
     }
+  }, skip: !Platform.isWindows);
+
+  test('getApplicationSupportPath with full version info in Unicode', () async {
+    final PathProviderWindows pathProvider = PathProviderWindows();
+    pathProvider.versionInfoQuerier = FakeVersionInfoQuerier(<String, String>{
+      'CompanyName': 'A Company',
+      'ProductName': 'Amazing App',
+    }, languageEn, encodingUnicode);
+    final String? path = await pathProvider.getApplicationSupportPath();
+    expect(path, isNotNull);
+    if (path != null) {
+      expect(path, endsWith(r'AppData\Roaming\A Company\Amazing App'));
+      expect(Directory(path).existsSync(), isTrue);
+    }
+  }, skip: !Platform.isWindows);
+
+  test(
+      'getApplicationSupportPath with full version info in Unsupported Encoding',
+      () async {
+    final PathProviderWindows pathProvider = PathProviderWindows();
+    pathProvider.versionInfoQuerier = FakeVersionInfoQuerier(<String, String>{
+      'CompanyName': 'A Company',
+      'ProductName': 'Amazing App',
+    }, '0000', '0000');
+    final String? path = await pathProvider.getApplicationSupportPath();
+    expect(path, contains(r'C:\'));
+    expect(path, contains(r'AppData'));
+    // The last path component should be the executable name.
+    expect(path, endsWith(r'flutter_tester'));
   }, skip: !Platform.isWindows);
 
   test('getApplicationSupportPath with missing company', () async {

--- a/packages/path_provider/path_provider_windows/test/path_provider_windows_test.dart
+++ b/packages/path_provider/path_provider_windows/test/path_provider_windows_test.dart
@@ -12,8 +12,11 @@ import 'package:path_provider_windows/src/path_provider_windows_real.dart'
 
 // A fake VersionInfoQuerier that just returns preset responses.
 class FakeVersionInfoQuerier implements VersionInfoQuerier {
-  FakeVersionInfoQuerier(this.responses,
-      [this.language = languageEn, this.encoding = encodingUnicode]);
+  FakeVersionInfoQuerier(
+    this.responses, {
+    this.language = languageEn,
+    this.encoding = encodingUnicode,
+  });
 
   final String language;
   final String encoding;
@@ -60,7 +63,7 @@ void main() {
     pathProvider.versionInfoQuerier = FakeVersionInfoQuerier(<String, String>{
       'CompanyName': 'A Company',
       'ProductName': 'Amazing App',
-    }, languageEn, encodingCP1252);
+    }, language: languageEn, encoding: encodingCP1252);
     final String? path = await pathProvider.getApplicationSupportPath();
     expect(path, isNotNull);
     if (path != null) {
@@ -74,7 +77,7 @@ void main() {
     pathProvider.versionInfoQuerier = FakeVersionInfoQuerier(<String, String>{
       'CompanyName': 'A Company',
       'ProductName': 'Amazing App',
-    }, languageEn, encodingUnicode);
+    }, language: languageEn, encoding: encodingUnicode);
     final String? path = await pathProvider.getApplicationSupportPath();
     expect(path, isNotNull);
     if (path != null) {
@@ -90,7 +93,7 @@ void main() {
     pathProvider.versionInfoQuerier = FakeVersionInfoQuerier(<String, String>{
       'CompanyName': 'A Company',
       'ProductName': 'Amazing App',
-    }, '0000', '0000');
+    }, language: '0000', encoding: '0000');
     final String? path = await pathProvider.getApplicationSupportPath();
     expect(path, contains(r'C:\'));
     expect(path, contains(r'AppData'));


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/99486

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [X] I signed the [CLA].
- [X] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [X] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
