### PR TITLE
[in_app_purchase] Updating  in_app_purchase_platform_interface from ^1.0.0 to ^1.3.0

### DIFF
--- a/packages/in_app_purchase/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.2
+
+* Updated `in_app_purchase_platform_interface` dependency from `^1.0.0` to `^1.3.0`. This is when `PurchaseStatus.canceled` was introduced.
+
 ## 3.0.1
 
 * Internal code cleanup for stricter analysis options.

--- a/packages/in_app_purchase/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase
 description: A Flutter plugin for in-app purchases. Exposes APIs for making in-app purchases through the App Store and Google Play.
 repository: https://github.com/flutter/plugins/tree/main/packages/in_app_purchase/in_app_purchase
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 3.0.1
+version: 3.0.1+1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/in_app_purchase/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase
 description: A Flutter plugin for in-app purchases. Exposes APIs for making in-app purchases through the App Store and Google Play.
 repository: https://github.com/flutter/plugins/tree/main/packages/in_app_purchase/in_app_purchase
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 3.0.1+1
+version: 3.0.2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/in_app_purchase/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   flutter:
     sdk: flutter
   in_app_purchase_android: ^0.2.1
-  in_app_purchase_platform_interface: ^1.0.0
+  in_app_purchase_platform_interface: ^1.3.0
   in_app_purchase_storekit: ^0.3.0+1
 
 dev_dependencies:


### PR DESCRIPTION
Ran into an issue using `in_app_purchase` where it somehow used a version of `in_app_purchase_platform_interface` previous to `1.3.0`. This is an issue because from `in_app_purchase@2.0` and beyond it implements `PurchaseStatus.canceled` (according to the docs/changelog).

This PR updates the dependency of `in_app_purchase_platform_interface` to `^1.3.0` so this should not happen.