### PR TITLE
[flutter_plugin_tools] Fix subpackage analysis

### DIFF
--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.8.1
+
+- Fixes an `analyze` regression in 0.8.0 with packages that have non-`example`
+  sub-packages.
+
 ## 0.8.0
 
 - Ensures that `firebase-test-lab` runs include an `integration_test` runner.

--- a/script/tool/lib/src/analyze_command.dart
+++ b/script/tool/lib/src/analyze_command.dart
@@ -102,16 +102,25 @@ class AnalyzeCommand extends PackageLoopingCommand {
 
   @override
   Future<PackageResult> runForPackage(RepositoryPackage package) async {
-    // For non-example packages, fetch dependencies. 'flutter packages get'
-    // automatically runs 'pub get' in examples as part of handling the parent
-    // directory, which is guaranteed to come first in the package enumeration.
-    if (package.directory.basename != 'example' ||
-        !RepositoryPackage(package.directory.parent).pubspecFile.existsSync()) {
-      final int exitCode = await processRunner.runAndStream(
-          flutterCommand, <String>['packages', 'get'],
-          workingDir: package.directory);
-      if (exitCode != 0) {
-        return PackageResult.fail(<String>['Unable to get dependencies']);
+    // Analysis runs over the package and all subpackages, so all of them need
+    // `flutter packages get` run before analyzing. `example` packages can be
+    // skipped since 'flutter packages get' automatically runs `pub get` in
+    // examples as part of handling the parent directory.
+    final List<RepositoryPackage> packagesToGet = <RepositoryPackage>[
+      package,
+      ...await getSubpackages(package).toList(),
+    ];
+    for (final RepositoryPackage packageToGet in packagesToGet) {
+      if (packageToGet.directory.basename != 'example' ||
+          !RepositoryPackage(packageToGet.directory.parent)
+              .pubspecFile
+              .existsSync()) {
+        final int exitCode = await processRunner.runAndStream(
+            flutterCommand, <String>['packages', 'get'],
+            workingDir: packageToGet.directory);
+        if (exitCode != 0) {
+          return PackageResult.fail(<String>['Unable to get dependencies']);
+        }
       }
     }
 

--- a/script/tool/lib/src/common/plugin_command.dart
+++ b/script/tool/lib/src/common/plugin_command.dart
@@ -417,14 +417,20 @@ abstract class PluginCommand extends Command<void> {
     await for (final PackageEnumerationEntry plugin
         in getTargetPackages(filterExcluded: filterExcluded)) {
       yield plugin;
-      yield* plugin.package.directory
-          .list(recursive: true, followLinks: false)
-          .where(_isDartPackage)
-          .map((FileSystemEntity directory) => PackageEnumerationEntry(
-              // _isDartPackage guarantees that this cast is valid.
-              RepositoryPackage(directory as Directory),
-              excluded: plugin.excluded));
+      yield* getSubpackages(plugin.package).map((RepositoryPackage package) =>
+          PackageEnumerationEntry(package, excluded: plugin.excluded));
     }
+  }
+
+  /// Returns all Dart package folders (e.g., examples) under the given package.
+  Stream<RepositoryPackage> getSubpackages(RepositoryPackage package,
+      {bool filterExcluded = true}) async* {
+    yield* package.directory
+        .list(recursive: true, followLinks: false)
+        .where(_isDartPackage)
+        .map((FileSystemEntity directory) =>
+            // _isDartPackage guarantees that this cast is valid.
+            RepositoryPackage(directory as Directory));
   }
 
   /// Returns the files contained, recursively, within the packages

--- a/script/tool/lib/src/make_deps_path_based_command.dart
+++ b/script/tool/lib/src/make_deps_path_based_command.dart
@@ -207,6 +207,10 @@ dependency_overrides:
           allComponents.contains('example')) {
         continue;
       }
+      if (!allComponents.contains(packagesDir.basename)) {
+        print('  Skipping $changedPath; not in packages directory.');
+        continue;
+      }
       final RepositoryPackage package =
           RepositoryPackage(packagesDir.fileSystem.file(changedPath).parent);
       // Ignored deleted packages, as they won't be published.

--- a/script/tool/pubspec.yaml
+++ b/script/tool/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_plugin_tools
 description: Productivity utils for flutter/plugins and flutter/packages
 repository: https://github.com/flutter/plugins/tree/main/script/tool
-version: 0.8.0
+version: 0.8.1
 
 dependencies:
   args: ^2.1.0

--- a/script/tool/test/analyze_command_test.dart
+++ b/script/tool/test/analyze_command_test.dart
@@ -71,6 +71,31 @@ void main() {
         ]));
   });
 
+  test('runs flutter pub get for non-example subpackages', () async {
+    final Directory mainPackageDir = createFakePackage('a', packagesDir);
+    final Directory otherPackages =
+        mainPackageDir.childDirectory('other_packages');
+    final Directory subpackage1 =
+        createFakePackage('subpackage1', otherPackages);
+    final Directory subpackage2 =
+        createFakePackage('subpackage2', otherPackages);
+
+    await runCapturingPrint(runner, <String>['analyze']);
+
+    expect(
+        processRunner.recordedCalls,
+        orderedEquals(<ProcessCall>[
+          ProcessCall('flutter', const <String>['packages', 'get'],
+              mainPackageDir.path),
+          ProcessCall(
+              'flutter', const <String>['packages', 'get'], subpackage1.path),
+          ProcessCall(
+              'flutter', const <String>['packages', 'get'], subpackage2.path),
+          ProcessCall('dart', const <String>['analyze', '--fatal-infos'],
+              mainPackageDir.path),
+        ]));
+  });
+
   test('don\'t elide a non-contained example package', () async {
     final Directory plugin1Dir = createFakePlugin('a', packagesDir);
     final Directory plugin2Dir = createFakePlugin('example', packagesDir);


### PR DESCRIPTION
Fixes a regression in `analyze` when packages have non-example
subpackages. Restructuring in 0.8.0 accidentally caused them not to have
their dependencies fetched, causing analysis failures.

Unblocks rolling flutter/packages to the latest tooling.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
