### PR TITLE
[image_picker] Convert string to list of strings if needed

### DIFF
--- a/packages/image_picker/image_picker/CHANGELOG.md
+++ b/packages/image_picker/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.4+12
+
+* iOS: Avoid invalid type exceptions while using pickMultiImage on pre-iOS 14 devices.
+
 ## 0.8.4+11
 
 * Fixes Activity leak.

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
     sdk: flutter
   flutter_plugin_android_lifecycle: ^2.0.1
   image_picker_for_web: ^2.1.0
-  image_picker_platform_interface: ^2.3.0
+  image_picker_platform_interface: ^2.4.5
 
 dev_dependencies:
   flutter_test:

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for selecting images from the Android and iOS image
   library, and taking new pictures with the camera.
 repository: https://github.com/flutter/plugins/tree/main/packages/image_picker/image_picker
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 0.8.4+11
+version: 0.8.4+12
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/image_picker/image_picker_platform_interface/CHANGELOG.md
+++ b/packages/image_picker/image_picker_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.5
+
+* Avoid invalid type exceptions while using pickMultiImage on pre-iOS 14 devices.
+
 ## 2.4.4
 
 * Internal code cleanup for stricter analysis options.

--- a/packages/image_picker/image_picker_platform_interface/lib/src/method_channel/method_channel_image_picker.dart
+++ b/packages/image_picker/image_picker_platform_interface/lib/src/method_channel/method_channel_image_picker.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
-
 import 'package:image_picker_platform_interface/image_picker_platform_interface.dart';
 
 const MethodChannel _channel = MethodChannel('plugins.flutter.io/image_picker');
@@ -57,7 +56,7 @@ class MethodChannelImagePicker extends ImagePickerPlatform {
     double? maxWidth,
     double? maxHeight,
     int? imageQuality,
-  }) {
+  }) async {
     if (imageQuality != null && (imageQuality < 0 || imageQuality > 100)) {
       throw ArgumentError.value(
           imageQuality, 'imageQuality', 'must be between 0 and 100');
@@ -71,7 +70,7 @@ class MethodChannelImagePicker extends ImagePickerPlatform {
       throw ArgumentError.value(maxHeight, 'maxHeight', 'cannot be negative');
     }
 
-    return _channel.invokeMethod<List<dynamic>?>(
+    final dynamic paths = await _channel.invokeMethod<dynamic>(
       'pickMultiImage',
       <String, dynamic>{
         'maxWidth': maxWidth,
@@ -79,6 +78,10 @@ class MethodChannelImagePicker extends ImagePickerPlatform {
         'imageQuality': imageQuality,
       },
     );
+    if (paths is String) {
+      return <String>[paths];
+    }
+    return paths as List<String>?;
   }
 
   Future<String?> _getImagePath({

--- a/packages/image_picker/image_picker_platform_interface/lib/src/method_channel/method_channel_image_picker.dart
+++ b/packages/image_picker/image_picker_platform_interface/lib/src/method_channel/method_channel_image_picker.dart
@@ -81,7 +81,7 @@ class MethodChannelImagePicker extends ImagePickerPlatform {
     if (paths is String) {
       return <String>[paths];
     }
-    return paths as List<String>?;
+    return paths as List<dynamic>?;
   }
 
   Future<String?> _getImagePath({

--- a/packages/image_picker/image_picker_platform_interface/pubspec.yaml
+++ b/packages/image_picker/image_picker_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/main/packages/image_picker/i
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.4.4
+version: 2.4.5
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/image_picker/image_picker_platform_interface/test/new_method_channel_image_picker_test.dart
+++ b/packages/image_picker/image_picker_platform_interface/test/new_method_channel_image_picker_test.dart
@@ -340,6 +340,14 @@ void main() {
         expect(await picker.pickMultiImage(), isNull);
         expect(await picker.pickMultiImage(), isNull);
       });
+
+      test('handles a single string response gracefully', () async {
+        returnValue = '0';
+        final List<PickedFile>? files = await picker.pickMultiImage();
+        expect(files, isNotNull);
+        expect(files?.length, 1);
+        expect(files?.first.path, returnValue);
+      });
     });
 
     group('#pickVideo', () {


### PR DESCRIPTION
This change ensures that no exception will be thrown if `pickMultiImage` gets called on an iOS 12 device by checking if the returned value is a list of strings or a string.

Fixes flutter/flutter#100132

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
