### PR TITLE
[ci] Update Chrome install script and version.

### DIFF
--- a/script/install_chromium.sh
+++ b/script/install_chromium.sh
@@ -10,24 +10,35 @@ readonly TARGET_DIR=$1
 # The build of Chromium used to test web functionality.
 #
 # Chromium builds can be located here: https://commondatastorage.googleapis.com/chromium-browser-snapshots/index.html?prefix=Linux_x64/
-readonly CHROMIUM_BUILD=768968
-# The ChromeDriver version corresponding to the build above. See
-# https://chromedriver.chromium.org/downloads
-# for versions mappings when updating Chromium.
-readonly CHROME_DRIVER_VERSION=84.0.4147.30
+#
+# Check: https://github.com/flutter/engine/blob/master/lib/web_ui/dev/browser_lock.yaml
+readonly CHROMIUM_BUILD=929514
+
+# The correct ChromeDriver is distributed alongside the chromium build above, as
+# `chromedriver_linux64.zip`, so no need to hardcode any extra info about it.
+readonly DOWNLOAD_ROOT="https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Linux_x64%2F${CHROMIUM_BUILD}%2F"
 
 # Install Chromium.
-mkdir "$TARGET_DIR"
-wget --no-verbose "https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Linux_x64%2F${CHROMIUM_BUILD}%2Fchrome-linux.zip?alt=media" -O "$TARGET_DIR"/chromium.zip
-unzip "$TARGET_DIR"/chromium.zip -d "$TARGET_DIR"/
+mkdir $TARGET_DIR
+readonly CHROMIUM_ZIP_FILE="$TARGET_DIR/chromium.zip"
+wget --no-verbose "${DOWNLOAD_ROOT}chrome-linux.zip?alt=media" -O $CHROMIUM_ZIP_FILE
+unzip -q $CHROMIUM_ZIP_FILE -d "$TARGET_DIR/"
 
 # Install ChromeDriver.
 readonly DRIVER_ZIP_FILE="$TARGET_DIR/chromedriver.zip"
-wget --no-verbose "https://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip" -O "$DRIVER_ZIP_FILE"
-unzip "$DRIVER_ZIP_FILE" -d "$TARGET_DIR/chromedriver"
+wget --no-verbose "${DOWNLOAD_ROOT}chromedriver_linux64.zip?alt=media" -O $DRIVER_ZIP_FILE
+unzip -q $DRIVER_ZIP_FILE -d "$TARGET_DIR/"
+# Rename TARGET_DIR/chromedriver_linux64 to the expected TARGET_DIR/chromedriver
+mv -T "$TARGET_DIR/chromedriver_linux64" "$TARGET_DIR/chromedriver"
+
+export CHROME_EXECUTABLE="$TARGET_DIR/chrome-linux/chrome"
 
 # Echo info at the end for ease of debugging.
-export CHROME_EXECUTABLE="$TARGET_DIR"/chrome-linux/chrome
+set +x
+echo
+readonly CHROMEDRIVER_EXECUTABLE="$TARGET_DIR/chromedriver/chromedriver"
 echo $CHROME_EXECUTABLE
 $CHROME_EXECUTABLE --version
-echo "ChromeDriver $CHROME_DRIVER_VERSION"
+echo $CHROMEDRIVER_EXECUTABLE
+$CHROMEDRIVER_EXECUTABLE --version
+echo

--- a/script/install_chromium.sh
+++ b/script/install_chromium.sh
@@ -19,15 +19,15 @@ readonly CHROMIUM_BUILD=929514
 readonly DOWNLOAD_ROOT="https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Linux_x64%2F${CHROMIUM_BUILD}%2F"
 
 # Install Chromium.
-mkdir $TARGET_DIR
+mkdir "$TARGET_DIR"
 readonly CHROMIUM_ZIP_FILE="$TARGET_DIR/chromium.zip"
-wget --no-verbose "${DOWNLOAD_ROOT}chrome-linux.zip?alt=media" -O $CHROMIUM_ZIP_FILE
-unzip -q $CHROMIUM_ZIP_FILE -d "$TARGET_DIR/"
+wget --no-verbose "${DOWNLOAD_ROOT}chrome-linux.zip?alt=media" -O "$CHROMIUM_ZIP_FILE"
+unzip -q "$CHROMIUM_ZIP_FILE" -d "$TARGET_DIR/"
 
 # Install ChromeDriver.
 readonly DRIVER_ZIP_FILE="$TARGET_DIR/chromedriver.zip"
-wget --no-verbose "${DOWNLOAD_ROOT}chromedriver_linux64.zip?alt=media" -O $DRIVER_ZIP_FILE
-unzip -q $DRIVER_ZIP_FILE -d "$TARGET_DIR/"
+wget --no-verbose "${DOWNLOAD_ROOT}chromedriver_linux64.zip?alt=media" -O "$DRIVER_ZIP_FILE"
+unzip -q "$DRIVER_ZIP_FILE" -d "$TARGET_DIR/"
 # Rename TARGET_DIR/chromedriver_linux64 to the expected TARGET_DIR/chromedriver
 mv -T "$TARGET_DIR/chromedriver_linux64" "$TARGET_DIR/chromedriver"
 
@@ -37,8 +37,8 @@ export CHROME_EXECUTABLE="$TARGET_DIR/chrome-linux/chrome"
 set +x
 echo
 readonly CHROMEDRIVER_EXECUTABLE="$TARGET_DIR/chromedriver/chromedriver"
-echo $CHROME_EXECUTABLE
-$CHROME_EXECUTABLE --version
-echo $CHROMEDRIVER_EXECUTABLE
-$CHROMEDRIVER_EXECUTABLE --version
+echo "$CHROME_EXECUTABLE"
+"$CHROME_EXECUTABLE" --version
+echo "$CHROMEDRIVER_EXECUTABLE"
+"$CHROMEDRIVER_EXECUTABLE" --version
 echo


### PR DESCRIPTION
This brings the version of Chrome that we use for integration web tests in line with the one used by flutter/flutter and flutter/engine.

No Issue (that I could find); at first I thought this would help with a test that I'm writing for an unrelated issue, but then I thought that the improvements to the script might be interesting (we might want to rollback the chromium build_id to what was there before?)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
