### PR TITLE
[tool] Fix typo in `publish-plugin` readme

### DIFF
--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+- Updates `publish-plugin` command documentation.
+
 ## 0.8.2
 
 - Adds a new `custom-test` command.

--- a/script/tool/README.md
+++ b/script/tool/README.md
@@ -109,11 +109,18 @@ dart run ./script/tool/bin/flutter_plugin_tools.dart native-test --macos --packa
 
 ### Publish a Release
 
-``sh
+**Releases are automated for `flutter/plugins` and `flutter/packages`.**
+
+The manual procedure described here is _deprecated_, and should only be used when
+the automated process fails. Please, read
+[Releasing a Plugin or Package](https://github.com/flutter/flutter/wiki/Releasing-a-Plugin-or-Package)
+on the Flutter Wiki first.
+
+```sh
 cd <path_to_plugins>
 git checkout <commit_hash_to_publish>
-dart run ./script/tool/bin/flutter_plugin_tools.dart publish-plugin --package <package>
-``
+dart run ./script/tool/bin/flutter_plugin_tools.dart publish-plugin --packages <package>
+```
 
 By default the tool tries to push tags to the `upstream` remote, but some
 additional settings can be configured. Run `dart run ./script/tool/bin/flutter_plugin_tools.dart
@@ -126,10 +133,6 @@ _everything_, including untracked or uncommitted files in version control.
 `publish-plugin` will first check the status of the local
 directory and refuse to publish if there are any mismatched files with version
 control present.
-
-Automated publishing is under development. Follow
-[flutter/flutter#27258](https://github.com/flutter/flutter/issues/27258)
-for updates.
 
 ## Updating the Tool
 


### PR DESCRIPTION
While doing a manual release of a plugin, I found the docs of the `publish-plugin` tool slightly outdated.

This is a quick fix for the relevant MD file.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
