### PR TITLE
[in_app_purchase] Make sure unsupported userInfo doesn't crash App

### DIFF
--- a/packages/in_app_purchase/in_app_purchase_storekit/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_storekit/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0+4
+
+* Ensures that `NSError` instances with an unexpected value for the `userInfo` field don't crash the app, but send an explanatory message instead.
+
 ## 0.3.0+3
 
 * Implements transaction caching for StoreKit ensuring transactions are delivered to the Flutter client.

--- a/packages/in_app_purchase/in_app_purchase_storekit/example/ios/RunnerTests/TranslatorTests.m
+++ b/packages/in_app_purchase/in_app_purchase_storekit/example/ios/RunnerTests/TranslatorTests.m
@@ -158,6 +158,52 @@
   XCTAssertEqualObjects(map, self.errorMap);
 }
 
+- (void)testErrorWithMultipleUnderlyingErrors {
+  if (@available(iOS 10.0, *)) {
+    NSError *underlyingErrorOne = [NSError errorWithDomain:SKErrorDomain code:2 userInfo:nil];
+    NSError *underlyingErrorTwo = [NSError errorWithDomain:SKErrorDomain code:1 userInfo:nil];
+    NSError *mainError = [NSError
+        errorWithDomain:SKErrorDomain
+                   code:3
+               userInfo:@{@"underlyingErrors" : @[ underlyingErrorOne, underlyingErrorTwo ]}];
+    NSDictionary *expectedMap = @{
+      @"domain" : SKErrorDomain,
+      @"code" : @3,
+      @"userInfo" : @{
+        @"underlyingErrors" : @[
+          @{@"domain" : SKErrorDomain, @"code" : @2, @"userInfo" : @{}},
+          @{@"domain" : SKErrorDomain, @"code" : @1, @"userInfo" : @{}}
+        ]
+      }
+    };
+    NSDictionary *map = [FIAObjectTranslator getMapFromNSError:mainError];
+    XCTAssertEqualObjects(expectedMap, map);
+  }
+}
+
+- (void)testErrorWithUnsupportedUserInfo {
+  if (@available(iOS 10.0, *)) {
+    NSError *error = [NSError errorWithDomain:SKErrorDomain
+                                         code:3
+                                     userInfo:@{@"user_info" : [[NSObject alloc] init]}];
+    NSDictionary *expectedMap = @{
+      @"domain" : SKErrorDomain,
+      @"code" : @3,
+      @"userInfo" : @{
+        @"user_info" : [NSString
+            stringWithFormat:
+                @"Unable to encode native userInfo object of type %@ to map. Please submit an "
+                @"issue at https://github.com/flutter/flutter/issues/new with the title "
+                @"\"[in_app_purchase_storekit] Unable to encode userInfo of type %@\" and add "
+                @"reproduction steps and the error details in the description field.",
+                [NSObject class], [NSObject class]]
+      }
+    };
+    NSDictionary *map = [FIAObjectTranslator getMapFromNSError:error];
+    XCTAssertEqualObjects(expectedMap, map);
+  }
+}
+
 - (void)testLocaleToMap {
   if (@available(iOS 10.0, *)) {
     NSLocale *system = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US"];

--- a/packages/in_app_purchase/in_app_purchase_storekit/example/ios/RunnerTests/TranslatorTests.m
+++ b/packages/in_app_purchase/in_app_purchase_storekit/example/ios/RunnerTests/TranslatorTests.m
@@ -158,50 +158,54 @@
   XCTAssertEqualObjects(map, self.errorMap);
 }
 
+- (void)testErrorWithNSNumberAsUserInfo {
+  NSError *error = [NSError errorWithDomain:SKErrorDomain code:3 userInfo:@{@"key" : @42}];
+  NSDictionary *expectedMap =
+      @{@"domain" : SKErrorDomain, @"code" : @3, @"userInfo" : @{@"key" : @42}};
+  NSDictionary *map = [FIAObjectTranslator getMapFromNSError:error];
+  XCTAssertEqualObjects(expectedMap, map);
+}
+
 - (void)testErrorWithMultipleUnderlyingErrors {
-  if (@available(iOS 10.0, *)) {
-    NSError *underlyingErrorOne = [NSError errorWithDomain:SKErrorDomain code:2 userInfo:nil];
-    NSError *underlyingErrorTwo = [NSError errorWithDomain:SKErrorDomain code:1 userInfo:nil];
-    NSError *mainError = [NSError
-        errorWithDomain:SKErrorDomain
-                   code:3
-               userInfo:@{@"underlyingErrors" : @[ underlyingErrorOne, underlyingErrorTwo ]}];
-    NSDictionary *expectedMap = @{
-      @"domain" : SKErrorDomain,
-      @"code" : @3,
-      @"userInfo" : @{
-        @"underlyingErrors" : @[
-          @{@"domain" : SKErrorDomain, @"code" : @2, @"userInfo" : @{}},
-          @{@"domain" : SKErrorDomain, @"code" : @1, @"userInfo" : @{}}
-        ]
-      }
-    };
-    NSDictionary *map = [FIAObjectTranslator getMapFromNSError:mainError];
-    XCTAssertEqualObjects(expectedMap, map);
-  }
+  NSError *underlyingErrorOne = [NSError errorWithDomain:SKErrorDomain code:2 userInfo:nil];
+  NSError *underlyingErrorTwo = [NSError errorWithDomain:SKErrorDomain code:1 userInfo:nil];
+  NSError *mainError = [NSError
+      errorWithDomain:SKErrorDomain
+                 code:3
+             userInfo:@{@"underlyingErrors" : @[ underlyingErrorOne, underlyingErrorTwo ]}];
+  NSDictionary *expectedMap = @{
+    @"domain" : SKErrorDomain,
+    @"code" : @3,
+    @"userInfo" : @{
+      @"underlyingErrors" : @[
+        @{@"domain" : SKErrorDomain, @"code" : @2, @"userInfo" : @{}},
+        @{@"domain" : SKErrorDomain, @"code" : @1, @"userInfo" : @{}}
+      ]
+    }
+  };
+  NSDictionary *map = [FIAObjectTranslator getMapFromNSError:mainError];
+  XCTAssertEqualObjects(expectedMap, map);
 }
 
 - (void)testErrorWithUnsupportedUserInfo {
-  if (@available(iOS 10.0, *)) {
-    NSError *error = [NSError errorWithDomain:SKErrorDomain
-                                         code:3
-                                     userInfo:@{@"user_info" : [[NSObject alloc] init]}];
-    NSDictionary *expectedMap = @{
-      @"domain" : SKErrorDomain,
-      @"code" : @3,
-      @"userInfo" : @{
-        @"user_info" : [NSString
-            stringWithFormat:
-                @"Unable to encode native userInfo object of type %@ to map. Please submit an "
-                @"issue at https://github.com/flutter/flutter/issues/new with the title "
-                @"\"[in_app_purchase_storekit] Unable to encode userInfo of type %@\" and add "
-                @"reproduction steps and the error details in the description field.",
-                [NSObject class], [NSObject class]]
-      }
-    };
-    NSDictionary *map = [FIAObjectTranslator getMapFromNSError:error];
-    XCTAssertEqualObjects(expectedMap, map);
-  }
+  NSError *error = [NSError errorWithDomain:SKErrorDomain
+                                       code:3
+                                   userInfo:@{@"user_info" : [[NSObject alloc] init]}];
+  NSDictionary *expectedMap = @{
+    @"domain" : SKErrorDomain,
+    @"code" : @3,
+    @"userInfo" : @{
+      @"user_info" : [NSString
+          stringWithFormat:
+              @"Unable to encode native userInfo object of type %@ to map. Please submit an "
+              @"issue at https://github.com/flutter/flutter/issues/new with the title "
+              @"\"[in_app_purchase_storekit] Unable to encode userInfo of type %@\" and add "
+              @"reproduction steps and the error details in the description field.",
+              [NSObject class], [NSObject class]]
+    }
+  };
+  NSDictionary *map = [FIAObjectTranslator getMapFromNSError:error];
+  XCTAssertEqualObjects(expectedMap, map);
 }
 
 - (void)testLocaleToMap {

--- a/packages/in_app_purchase/in_app_purchase_storekit/ios/Classes/FIAObjectTranslator.m
+++ b/packages/in_app_purchase/in_app_purchase_storekit/ios/Classes/FIAObjectTranslator.m
@@ -168,35 +168,40 @@
     return nil;
   }
 
-  NSString *unsupportedMessage =
-      @"Unable to encode native userInfo object of type %@ to map. Please submit an issue at "
-      @"https://github.com/flutter/flutter/issues/new with the title \"[in_app_purchase_storekit] "
-      @"Unable to encode userInfo of type %@\" and add reproduction steps and the error details in "
-      @"the description field.";
-
   NSMutableDictionary *userInfo = [NSMutableDictionary new];
   for (NSErrorUserInfoKey key in error.userInfo) {
     id value = error.userInfo[key];
-    if ([value isKindOfClass:[NSError class]]) {
-      userInfo[key] = [FIAObjectTranslator getMapFromNSError:value];
-    } else if ([value isKindOfClass:[NSURL class]]) {
-      userInfo[key] = [value absoluteString];
-    } else if ([value isKindOfClass:[NSArray class]]) {
-      NSMutableArray *errors = [[NSMutableArray alloc] init];
-      for (id error in value) {
-        if ([error isKindOfClass:[NSError class]]) {
-          [errors addObject:[FIAObjectTranslator getMapFromNSError:error]];
-        } else {
-          [errors addObject:[NSString
-                                stringWithFormat:unsupportedMessage, [value class], [value class]]];
-        }
-      }
-      userInfo[key] = errors;
-    } else {
-      userInfo[key] = [NSString stringWithFormat:unsupportedMessage, [value class], [value class]];
-    }
+    userInfo[key] = [FIAObjectTranslator encodeNSErrorUserInfo:value];
   }
   return @{@"code" : @(error.code), @"domain" : error.domain ?: @"", @"userInfo" : userInfo};
+}
+
++ (id)encodeNSErrorUserInfo:(id)value {
+  if ([value isKindOfClass:[NSError class]]) {
+    return [FIAObjectTranslator getMapFromNSError:value];
+  } else if ([value isKindOfClass:[NSURL class]]) {
+    return [value absoluteString];
+  } else if ([value isKindOfClass:[NSNumber class]]) {
+    return value;
+  } else if ([value isKindOfClass:[NSString class]]) {
+    return value;
+  } else if ([value isKindOfClass:[NSArray class]]) {
+    NSMutableArray *errors = [[NSMutableArray alloc] init];
+    for (id error in value) {
+      [errors addObject:[FIAObjectTranslator encodeNSErrorUserInfo:error]];
+    }
+    return errors;
+  } else {
+    return [NSString
+        stringWithFormat:
+            @"Unable to encode native userInfo object of type %@ to map. Please submit an issue at "
+            @"https://github.com/flutter/flutter/issues/new with the title "
+            @"\"[in_app_purchase_storekit] "
+            @"Unable to encode userInfo of type %@\" and add reproduction steps and the error "
+            @"details in "
+            @"the description field.",
+            [value class], [value class]];
+  }
 }
 
 + (NSDictionary *)getMapFromSKStorefront:(SKStorefront *)storefront {

--- a/packages/in_app_purchase/in_app_purchase_storekit/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_storekit/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase_storekit
 description: An implementation for the iOS platform of the Flutter `in_app_purchase` plugin. This uses the StoreKit Framework.
 repository: https://github.com/flutter/plugins/tree/main/packages/in_app_purchase/in_app_purchase_storekit
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 0.3.0+3
+version: 0.3.0+4
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
Starting from iOS 15.4 the Store Kit framework sends back underlying errors as part of the `[NSError userInfo]` field. This results in a crash because the `[FIAObjectTranslator getMapFromNSError]` method doesn't know how to handle this. 

This PR updates the `[FIAObjectTranslator getMapFromNSError]` method to add support for underlying errors and also catches future unsupported type in a way that doesn't immediately crash the consuming app and instead returns an error string that can be handled on the client side.

Resolves flutter/flutter#100458

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
