### PR TITLE
[espresso] [video_player] Update espresso guava version

### DIFF
--- a/packages/espresso/CHANGELOG.md
+++ b/packages/espresso/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.2.0
 
 * Updates compileSdkVersion to 31.
-* **Breaking Change** Update guava version to latest stable: `com.google.guava:guava:31.0.1-android`.
+* **Breaking Change** Update guava version to latest stable: `com.google.guava:guava:31.1-android`.
 
 ## 0.1.0+4
 

--- a/packages/espresso/CHANGELOG.md
+++ b/packages/espresso/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 0.2.0
 
 * Updates compileSdkVersion to 31.
+* **Breaking Change** Update guava version to latest stable: `com.google.guava:guava:31.0.1-android`.
 
 ## 0.1.0+4
 

--- a/packages/espresso/android/build.gradle
+++ b/packages/espresso/android/build.gradle
@@ -49,7 +49,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.guava:guava:28.1-android'
+    implementation 'com.google.guava:guava:31.0.1-android'
     implementation 'com.squareup.okhttp3:okhttp:3.12.1'
     implementation 'com.google.code.gson:gson:2.8.6'
     androidTestImplementation 'org.hamcrest:hamcrest:2.2'

--- a/packages/espresso/android/build.gradle
+++ b/packages/espresso/android/build.gradle
@@ -49,7 +49,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.guava:guava:31.0.1-android'
+    implementation 'com.google.guava:guava:31.1-android'
     implementation 'com.squareup.okhttp3:okhttp:3.12.1'
     implementation 'com.google.code.gson:gson:2.8.6'
     androidTestImplementation 'org.hamcrest:hamcrest:2.2'

--- a/packages/espresso/pubspec.yaml
+++ b/packages/espresso/pubspec.yaml
@@ -3,7 +3,7 @@ description: Java classes for testing Flutter apps using Espresso.
   Allows driving Flutter widgets from a native Espresso test.
 repository: https://github.com/flutter/plugins/tree/main/packages/espresso
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+espresso%22
-version: 0.1.0+4
+version: 0.2.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/image_picker/image_picker/example/pubspec.yaml
+++ b/packages/image_picker/image_picker/example/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   video_player: ^2.1.4
 
 dev_dependencies:
+  # TODO(bparrishMines): Change version to `0.2.0` once published.
   espresso:
     path: ../../../espresso
   flutter_driver:

--- a/packages/image_picker/image_picker/example/pubspec.yaml
+++ b/packages/image_picker/image_picker/example/pubspec.yaml
@@ -20,7 +20,8 @@ dependencies:
   video_player: ^2.1.4
 
 dev_dependencies:
-  espresso: ^0.1.0+2
+  espresso:
+    path: ../../../espresso
   flutter_driver:
     sdk: flutter
   integration_test:


### PR DESCRIPTION
Updates the guava version in `espresso` to use the latest stable version: https://github.com/google/guava

In https://github.com/flutter/plugins/pull/5011, the `exoplayer` version in `video_player` was increased. This made it incompatible with the `espresso` plugin. And this broke `image_picker` which depends on `espresso` and `video_player`.

For `image_picker`:
No version change: Only updating `espresso` `dev_dependeny` for CI.
No CHANGELOG change: Only updating `espresso` `dev_dependeny` for CI.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
