### PR TITLE
PlatformViewsService.initSurfaceAndroidView returns AndroidViewController

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.6
+
+* `PlatformViewsService.initSurfaceAndroidView` will start returning a `AndroidViewController` 
+  instead of `SurfaceAndroidViewController` after Flutter v2.11.0-0.1.pre.
+
 ## 2.1.5
 
 Removes dependency on `meta`.

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/method_channel/method_channel_google_maps_flutter.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/method_channel/method_channel_google_maps_flutter.dart
@@ -520,24 +520,21 @@ class MethodChannelGoogleMapsFlutter extends GoogleMapsFlutterPlatform {
             );
           },
           onCreatePlatformView: (PlatformViewCreationParams params) {
-            final SurfaceAndroidViewController controller =
-                PlatformViewsService.initSurfaceAndroidView(
+            return PlatformViewsService.initSurfaceAndroidView(
               id: params.id,
               viewType: 'plugins.flutter.io/google_maps',
               layoutDirection: textDirection,
               creationParams: creationParams,
               creationParamsCodec: const StandardMessageCodec(),
               onFocus: () => params.onFocusChanged(true),
-            );
-            controller.addOnPlatformViewCreatedListener(
-              params.onPlatformViewCreated,
-            );
-            controller.addOnPlatformViewCreatedListener(
-              onPlatformViewCreated,
-            );
-
-            controller.create();
-            return controller;
+            )
+              ..addOnPlatformViewCreatedListener(
+                params.onPlatformViewCreated,
+              )
+              ..addOnPlatformViewCreatedListener(
+                onPlatformViewCreated,
+              )
+              ..create();
           },
         );
       } else {

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/main/packages/google_maps_fl
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.1.5
+version: 2.1.6
 
 environment:
   sdk: '>=2.12.0 <3.0.0'


### PR DESCRIPTION
This is required after https://github.com/flutter/flutter/pull/100934.
Initially, I managed to avoid this breaking change, but `initSurfaceAndroidView` is now returning 
two different implementations depending on whether `useHybridComposition` is used.