### PR TITLE
[video_player] Increase seeking performance

### DIFF
--- a/packages/video_player/video_player_android/CHANGELOG.md
+++ b/packages/video_player/video_player_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.3
+
+* Rate limited `seekTo` calls for ExoPlayer.
+
 ## 2.3.2
 
 * Updates ExoPlayer to 2.17.0.

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
@@ -194,8 +194,8 @@ final class VideoPlayer {
               sendBufferingUpdate();
             } else if (playbackState == Player.STATE_READY) {
               readyToSeek = true; // indicate that seeking the video is now possible
-              if (futureLoation != -1) {
-                seekTo(futureLoation);
+              if (futureLocation != -1) {
+                seekTo(futureLocation);
               }
               if (!isInitialized) {
                 isInitialized = true;
@@ -261,7 +261,7 @@ final class VideoPlayer {
     exoPlayer.setPlaybackParameters(playbackParameters);
   }
 
-  int futureLoation = -1;
+  int futureLocation = -1;
 
   void seekTo(int location) {
     // Try to set the location, if the player is currently buffering because
@@ -269,10 +269,10 @@ final class VideoPlayer {
     // player will be readyToSeek
     if (readyToSeek) {
       readyToSeek = false;
-      futureLoation = -1;
+      futureLocation = -1;
       exoPlayer.seekTo(location);
     } else {
-      futureLoation = location;
+      futureLocation = location;
     }
   }
 

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
@@ -152,8 +152,9 @@ final class VideoPlayer {
         }
     }
   }
-  
+
   boolean readyToSeek = false;
+
   private void setupVideoPlayer(
       EventChannel eventChannel, TextureRegistry.SurfaceTextureEntry textureEntry) {
     eventChannel.setStreamHandler(
@@ -193,7 +194,7 @@ final class VideoPlayer {
               sendBufferingUpdate();
             } else if (playbackState == Player.STATE_READY) {
               readyToSeek = true; // indicate that seeking the video is now possible
-              if(futureLoation != -1){
+              if (futureLoation != -1) {
                 seekTo(futureLoation);
               }
               if (!isInitialized) {
@@ -261,16 +262,16 @@ final class VideoPlayer {
   }
 
   int futureLoation = -1;
+
   void seekTo(int location) {
     // Try to set the location, if the player is currently buffering because
     // of a previous seekTo, save the futureLocation to be seeked when the
     // player will be readyToSeek
-    if(readyToSeek) {
+    if (readyToSeek) {
       readyToSeek = false;
       futureLoation = -1;
       exoPlayer.seekTo(location);
-    }
-    else{
+    } else {
       futureLoation = location;
     }
   }

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
@@ -152,7 +152,8 @@ final class VideoPlayer {
         }
     }
   }
-
+  
+  boolean readyToSeek = false;
   private void setupVideoPlayer(
       EventChannel eventChannel, TextureRegistry.SurfaceTextureEntry textureEntry) {
     eventChannel.setStreamHandler(
@@ -191,6 +192,10 @@ final class VideoPlayer {
               setBuffering(true);
               sendBufferingUpdate();
             } else if (playbackState == Player.STATE_READY) {
+              readyToSeek = true; // indicate that seeking the video is now possible
+              if(futureLoation != -1){
+                seekTo(futureLoation);
+              }
               if (!isInitialized) {
                 isInitialized = true;
                 sendInitialized();
@@ -255,8 +260,19 @@ final class VideoPlayer {
     exoPlayer.setPlaybackParameters(playbackParameters);
   }
 
+  int futureLoation = -1;
   void seekTo(int location) {
-    exoPlayer.seekTo(location);
+    // Try to set the location, if the player is currently buffering because
+    // of a previous seekTo, save the futureLocation to be seeked when the
+    // player will be readyToSeek
+    if(readyToSeek) {
+      readyToSeek = false;
+      futureLoation = -1;
+      exoPlayer.seekTo(location);
+    }
+    else{
+      futureLoation = location;
+    }
   }
 
   long getPosition() {

--- a/packages/video_player/video_player_android/pubspec.yaml
+++ b/packages/video_player/video_player_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_android
 description: Android implementation of the video_player plugin.
 repository: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.3.2
+version: 2.3.3
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR prevents calling the `seekTo` functions when the player is already buffering due to a previous `seekTo` call, this should enhance the seeking experience by not blocking the preview.

Fix: https://github.com/flutter/flutter/issues/101409

### What does it do ?

To prevent the issue described in the related PR, we want to limit the number of buffer not leading to an image being displayed.
In order to do this, we just ignore `seekTo` calls when the player is not ready to play.

**What if we ask for the final location when the preview is buffering ?**

This is the reason we store the asked position when we ignore the `seekTo` call, thus,
when the play is ready, i.e. it has displayed the new frame, we check if the user have asked for a final location
and render it if needed.

This allow to keep the player responsive even if multiple locations have been asked really quickly.

### Try proposed fix

 * clone https://github.com/fluttercommunity/chewie/pull/623
 * try to go through the video quickly using the progress bar

### Result

| With optimisation | Without |
| ------ | ------ |
| ![screen-20220331-182056](https://user-images.githubusercontent.com/13080562/161261253-88fa680f-28e6-4e66-8ebb-f979a6496f74.mp4) | ![screen-20220331-181554](https://user-images.githubusercontent.com/13080562/161261281-83e4f304-6c1e-454e-9c6c-49b67f07300e.mp4) |
|![schnell](https://user-images.githubusercontent.com/13080562/161275449-3157719d-1c4b-4680-8b78-2933e88345fc.gif)|![langsam](https://user-images.githubusercontent.com/13080562/161275421-f9b1be90-9672-482e-b51b-212e788f32be.gif)|


*List which issues are fixed by this PR. You must list at least one issue.*


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
