### PR TITLE
[google_maps_flutter] Make objects inheriting `MapsObjectId` equal

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.6
+
+* Equality operator on `MapsObjectId` preserves inheritance instead of checking for `runtimeType`.
+
 ## 2.1.5
 
 Removes dependency on `meta`.

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/maps_object.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/maps_object.dart
@@ -21,9 +21,7 @@ class MapsObjectId<T> {
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
-    if (other.runtimeType != runtimeType) return false;
-    final MapsObjectId<T> typedOther = other as MapsObjectId<T>;
-    return value == typedOther.value;
+    return other is MapsObjectId<T> && value == other.value;
   }
 
   @override

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/main/packages/google_maps_fl
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.1.5
+version: 2.1.6
 
 environment:
   sdk: '>=2.12.0 <3.0.0'

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/maps_object_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/maps_object_test.dart
@@ -42,4 +42,11 @@ void main() {
           {'id': '3'}
         ]);
   });
+
+  test('MarkerId equality should preserve inheritance and only check value', () async {
+    const String value = 'id123';
+    const MarkerId markerId = MarkerId(value);
+    const TestMapsObjectId<Marker> customMarkerId = TestMapsObjectId<Marker>(value);
+    expect(customMarkerId, equals(markerId));
+  });
 }

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/maps_object_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/maps_object_test.dart
@@ -43,10 +43,12 @@ void main() {
         ]);
   });
 
-  test('MarkerId equality should preserve inheritance and only check value', () async {
+  test('MarkerId equality should preserve inheritance and only check value',
+      () async {
     const String value = 'id123';
     const MarkerId markerId = MarkerId(value);
-    const TestMapsObjectId<Marker> customMarkerId = TestMapsObjectId<Marker>(value);
+    const TestMapsObjectId<Marker> customMarkerId =
+        TestMapsObjectId<Marker>(value);
     expect(customMarkerId, equals(markerId));
   });
 }

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/test_maps_object.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/test_maps_object.dart
@@ -45,3 +45,7 @@ class TestMapsObjectUpdate extends MapsObjectUpdates<TestMapsObject> {
       Set<TestMapsObject> previous, Set<TestMapsObject> current)
       : super.from(previous, current, objectName: 'testObject');
 }
+
+class TestMapsObjectId<T> extends MapsObjectId<T> {
+  const TestMapsObjectId(String value) : super(value);
+}


### PR DESCRIPTION
Currently, using an object of the class extending `MarkerId` results in on-tap and on-drag gestures to fail. The reason for this is that the `MapsObjectId` class checks the `runtimeType`s of the object in the `bool operator ==` and they are not equal (one is the actual extended class, the other that comes over the method channel is always `MarkerId` (see the [comment](https://github.com/flutter/flutter/issues/101119#issuecomment-1086741339) for more details). This changes checking the `runtimeType` to `is` check.

I think that checking for an actual `runtimeType` instead of preserving inheritance is a bit of an overkill because what the `MapsObjectId` really is, is just a "string value holder". Thus, I think we should allow objects that are not actually of the same class but are related according to inheritance be equal (but I might be wrong if there is a special reason for checking `runtimeType`).

Fixing this [issue](https://github.com/flutter/flutter/issues/101119).

flutter/tests repo left intact.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.