### PR TITLE
[image_picker] Add known issue 65995 to readme

### DIFF
--- a/packages/image_picker/image_picker/CHANGELOG.md
+++ b/packages/image_picker/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.5+1
+
+* Added [#65995](https://github.com/flutter/flutter/issues/65995) to iOS known issues
+
 ## 0.8.5
 
 * Moves Android and iOS implementations to federated packages.

--- a/packages/image_picker/image_picker/README.md
+++ b/packages/image_picker/image_picker/README.md
@@ -78,7 +78,7 @@ application. Since the data is never returned to the original call use the
 ```dart
 Future<void> getLostData() async {
   final LostDataResponse response =
-  await picker.retrieveLostData();
+    await picker.retrieveLostData();
   if (response.isEmpty) {
     return;
   }

--- a/packages/image_picker/image_picker/README.md
+++ b/packages/image_picker/image_picker/README.md
@@ -26,6 +26,9 @@ Add the following keys to your _Info.plist_ file, located in `<project root>/ios
 * `NSCameraUsageDescription` - describe why your app needs access to the camera. This is called _Privacy - Camera Usage Description_ in the visual editor.
 * `NSMicrophoneUsageDescription` - describe why your app needs access to the microphone, if you intend to record videos. This is called _Privacy - Microphone Usage Description_ in the visual editor.
 
+**Known issue:** ([#65995](https://github.com/flutter/flutter/issues/65995)) 
+When accessing the gallery for the first time, a Permission dialog will be presented to the user asking if they grant access. The user will be presented with three choices: (1) *"Select Photos..."*, (2) *"Allow Access to All Photos"* (3) *"Don't Allow"*. By selecting (1), and choosing which photos to be accessed from your app, not only the user will be later presented with all the pictures, even with the non-chosen ones, but, by going to pick images for the second time, the app will crash. As a **temporary workaround**, you may handle this specific case with third party plugins such as [permission_handler](https://pub.dev/packages/permission_handler). For instance, you could recognize when the user choose (1) *"Select Photos..."* as gallery access permission, and then present them with a specific message that let them knows that this permission mode, at the moment, is not supported. You might also want to invite them to go into the privacy settings and grant full access to the gallery as to prevent any future app crash.
+
 ### Android
 
 Starting with version **0.8.1** the Android implementation support to pick (multiple) images on Android 4.3 or higher.
@@ -75,7 +78,7 @@ application. Since the data is never returned to the original call use the
 ```dart
 Future<void> getLostData() async {
   final LostDataResponse response =
-      await picker.retrieveLostData();
+  await picker.retrieveLostData();
   if (response.isEmpty) {
     return;
   }

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for selecting images from the Android and iOS image
   library, and taking new pictures with the camera.
 repository: https://github.com/flutter/plugins/tree/main/packages/image_picker/image_picker
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 0.8.5
+version: 0.8.5+1
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
With this PR, issue [#65995](https://github.com/flutter/flutter/issues/65995) is added to the readme as a known issue for iOS.

Considering that:

- Issue [#65995](https://github.com/flutter/flutter/issues/65995) has been opened since the 17th of September 2020 with priority P3 (which is absolutely fine as there are many tasks on which the team needs to focus)
- The issue is particularly severe, i.e. after choosing "Select Photos..." the app is exposed to unpredictable crashes
- The issue is not easily caught with unit tests, rather needs more sophisticated integration tests
- Since the issue has been opened, **46 !!!!!!** new versions of the plugin have been released without any of these addressing #65995 (the issue was opened with version 0.6.7+11 !!!!)

**The issue, at this point, needs to go on the readme as a known issue for iOS.**

In this way users of the plugin will be aware of the issue and will be in the position to make informed decisions regarding the issue and the risk of severe crashes in production is reduced. I also want to mention that in the readme of image_picker there is already mentioned a known issue regarding the iOS simulator which is completely responsibility of Apple, but my point here is that the issue of the HEIC files on the simulator is absolutely insignificant or minor compared to issue #65995, so, if we have that on the readme, I think there should be no doubt whatsoever on having #65995 on the readme as a known issue.

Happy to edit the wording of the readme of this PR in case any feedback should come.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
