### PR TITLE
[local_auth_platform_interface] Export externally used types from local_auth_platform_interface.dart directly.

### DIFF
--- a/packages/local_auth/local_auth_platform_interface/CHANGELOG.md
+++ b/packages/local_auth/local_auth_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+* Export externally used types from local_auth_platform_interface.dart directly.
+
 ## 1.0.0
 
 * Initial release.

--- a/packages/local_auth/local_auth_platform_interface/lib/local_auth_platform_interface.dart
+++ b/packages/local_auth/local_auth_platform_interface/lib/local_auth_platform_interface.dart
@@ -3,10 +3,10 @@
 // found in the LICENSE file.
 
 import 'package:local_auth_platform_interface/default_method_channel_platform.dart';
-import 'package:local_auth_platform_interface/types/auth_messages.dart';
-import 'package:local_auth_platform_interface/types/auth_options.dart';
-import 'package:local_auth_platform_interface/types/biometric_type.dart';
+import 'package:local_auth_platform_interface/types/types.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+export 'package:local_auth_platform_interface/types/types.dart';
 
 /// The interface that implementations of local_auth must implement.
 ///

--- a/packages/local_auth/local_auth_platform_interface/lib/types/types.dart
+++ b/packages/local_auth/local_auth_platform_interface/lib/types/types.dart
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 export 'auth_messages.dart';
 export 'auth_options.dart';
 export 'biometric_type.dart';

--- a/packages/local_auth/local_auth_platform_interface/lib/types/types.dart
+++ b/packages/local_auth/local_auth_platform_interface/lib/types/types.dart
@@ -1,0 +1,3 @@
+export 'auth_messages.dart';
+export 'auth_options.dart';
+export 'biometric_type.dart';

--- a/packages/local_auth/local_auth_platform_interface/pubspec.yaml
+++ b/packages/local_auth/local_auth_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/master/packages/local_auth/l
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+local_auth%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.0.0
+version: 1.0.1
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR exports the externally required types in local_auth's platform interface package directly from the interface file. 

This PR is a precursor to #5195.

Relevant issues:
 - flutter/flutter#68498
 - flutter/flutter#94224

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
