### PR TITLE
added a check if the cached file is a video file

### DIFF
--- a/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
+++ b/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
@@ -23,6 +23,7 @@ import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.PluginRegistry;
 import java.io.File;
 import java.io.IOException;
+import java.net.URLConnection;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -215,6 +216,11 @@ public class ImagePickerDelegate
     }
   }
 
+  boolean isVideoFile(String path) {
+    String mimeType = URLConnection.guessContentTypeFromName(path);
+    return mimeType != null && mimeType.startsWith("video");
+  }
+
   void retrieveLostImage(MethodChannel.Result result) {
     Map<String, Object> resultMap = cache.getCacheMap();
     @SuppressWarnings("unchecked")
@@ -229,7 +235,12 @@ public class ImagePickerDelegate
                 ? 100
                 : (int) resultMap.get(cache.MAP_KEY_IMAGE_QUALITY);
 
-        newPathList.add(imageResizer.resizeImageIfNeeded(path, maxWidth, maxHeight, imageQuality));
+        if(isVideoFile(path)) {
+          newPathList.add(path);
+        }
+        else {
+          newPathList.add(imageResizer.resizeImageIfNeeded(path, maxWidth, maxHeight, imageQuality));
+        }
       }
       resultMap.put(cache.MAP_KEY_PATH_LIST, newPathList);
       resultMap.put(cache.MAP_KEY_PATH, newPathList.get(newPathList.size() - 1));


### PR DESCRIPTION
added a check if the cached file is a video file in order to not put a video file in the resizeImageIfNeeded method.

fixes a problem where resizeImageIfNeeded try to convert the video file to bitmap and return null.

as a result,  trying to retrieve a lost video file will result in an error.

## Pre-launch Checklist

- [v ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ v] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ v] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [ v] I signed the [CLA].
- [ v] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [v ] I listed at least one issue that this PR fixes in the description above.
- [v ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ v] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ v] I updated/added relevant documentation (doc comments with `///`).
- [ v] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ v] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
