### PR TITLE
[google_sign_in_web] Add `plugin_name` to `init` call.

### DIFF
--- a/packages/google_sign_in/google_sign_in_web/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_web/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## 0.10.1
 
 * Updates minimum Flutter version to 2.8.
-* Pass `plugin_name` to Google Sign In's `init` method so new applications can
-  continue using this plugin after April 30th 2022. [Issue](https://github.com/flutter/flutter/issues/88084).
+* Passes `plugin_name` to Google Sign-In's `init` method so new applications can
+  continue using this plugin after April 30th 2022. Issue [#88084](https://github.com/flutter/flutter/issues/88084).
 
 ## 0.10.0+5
 

--- a/packages/google_sign_in/google_sign_in_web/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_web/CHANGELOG.md
@@ -1,6 +1,8 @@
-## NEXT
+## 0.10.1
 
 * Updates minimum Flutter version to 2.8.
+* Pass `plugin_name` to Google Sign In's `init` method so new applications can
+  continue using this plugin after April 30th 2022. [Issue](https://github.com/flutter/flutter/issues/88084).
 
 ## 0.10.0+5
 

--- a/packages/google_sign_in/google_sign_in_web/example/integration_test/auth2_test.dart
+++ b/packages/google_sign_in/google_sign_in_web/example/integration_test/auth2_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:html' as html;
+
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_sign_in_platform_interface/google_sign_in_platform_interface.dart';
@@ -124,6 +126,25 @@ void main() {
             scopes: <String>['scope with spaces'],
           ),
           throwsAssertionError);
+    });
+
+    // See: https://github.com/flutter/flutter/issues/88084
+    testWidgets('Init passes plugin_name parameter with the expected value',
+        (WidgetTester tester) async {
+      await plugin.init(
+        hostedDomain: 'foo',
+        scopes: <String>['some', 'scope'],
+        clientId: '1234',
+      );
+
+      final Object? initParameters =
+          js_util.getProperty(html.window, 'gapi2.init.parameters');
+      expect(initParameters, isNotNull);
+
+      final Object? pluginNameParameter =
+          js_util.getProperty(initParameters!, 'plugin_name');
+      expect(pluginNameParameter, isA<String>());
+      expect(pluginNameParameter, 'dart-google_sign_in_web');
     });
 
     group('Successful .init, then', () {

--- a/packages/google_sign_in/google_sign_in_web/example/integration_test/gapi_mocks/src/auth2_init.dart
+++ b/packages/google_sign_in/google_sign_in_web/example/integration_test/gapi_mocks/src/auth2_init.dart
@@ -12,6 +12,8 @@ var mockUser = ${googleUser(userData)};
 
 function GapiAuth2() {}
 GapiAuth2.prototype.init = function (initOptions) {
+  /*Leak the initOptions so we can look at them later.*/
+  window['gapi2.init.parameters'] = initOptions;
   return {
     then: (onSuccess, onError) => {
       window.setTimeout(() => {

--- a/packages/google_sign_in/google_sign_in_web/lib/google_sign_in_web.dart
+++ b/packages/google_sign_in/google_sign_in_web/lib/google_sign_in_web.dart
@@ -92,7 +92,7 @@ class GoogleSignInPlugin extends GoogleSignInPlatform {
       // The js lib wants a space-separated list of values
       scope: scopes.join(' '),
       client_id: appClientId!,
-      plugin_name: 'dev_flutter_plugins_google_sign_in_web',
+      plugin_name: 'dart-google_sign_in_web',
     ));
 
     final Completer<void> isAuthInitialized = Completer<void>();

--- a/packages/google_sign_in/google_sign_in_web/lib/google_sign_in_web.dart
+++ b/packages/google_sign_in/google_sign_in_web/lib/google_sign_in_web.dart
@@ -92,6 +92,7 @@ class GoogleSignInPlugin extends GoogleSignInPlatform {
       // The js lib wants a space-separated list of values
       scope: scopes.join(' '),
       client_id: appClientId!,
+      plugin_name: 'dev_flutter_plugins_google_sign_in_web',
     ));
 
     final Completer<void> isAuthInitialized = Completer<void>();

--- a/packages/google_sign_in/google_sign_in_web/lib/src/generated/gapiauth2.dart
+++ b/packages/google_sign_in/google_sign_in_web/lib/src/generated/gapiauth2.dart
@@ -233,15 +233,23 @@ abstract class ClientConfig {
   /// The default redirect_uri is the current URL stripped of query parameters and hash fragment.
   external String? get redirect_uri;
   external set redirect_uri(String? v);
-  external factory ClientConfig(
-      {String client_id,
-      String cookie_policy,
-      String scope,
-      bool fetch_basic_profile,
-      String? hosted_domain,
-      String openid_realm,
-      String /*'popup'|'redirect'*/ ux_mode,
-      String redirect_uri});
+
+  /// Allows newly created Client IDs to use the Google Platform Library from now until the March 30th, 2023 deprecation date.
+  /// See: https://github.com/flutter/flutter/issues/88084
+  external String? get plugin_name;
+  external set plugin_name(String? v);
+
+  external factory ClientConfig({
+    String client_id,
+    String cookie_policy,
+    String scope,
+    bool fetch_basic_profile,
+    String? hosted_domain,
+    String openid_realm,
+    String /*'popup'|'redirect'*/ ux_mode,
+    String redirect_uri,
+    String plugin_name,
+  });
 }
 
 @JS('gapi.auth2.SigninOptionsBuilder')

--- a/packages/google_sign_in/google_sign_in_web/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_web/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android, iOS and Web.
 repository: https://github.com/flutter/plugins/tree/main/packages/google_sign_in/google_sign_in_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
-version: 0.10.0+5
+version: 0.10.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
This change ensures that a `plugin_name` attribute with a known value is passed to the `init` call of the current Web implementation of Google Sign In JS SDK.

This allows "new applications to continue using the plugin after April 30th, 2022".

Mitigates: https://github.com/flutter/flutter/issues/88084
See also: https://github.com/flutter/flutter/issues/101004

//FYI @brdaugherty @kevmoo

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
