### PR TITLE
[local_auth] Change stopAuthentication to return false instead of throwing on iOS.

### DIFF
--- a/packages/local_auth/local_auth_ios/CHANGELOG.md
+++ b/packages/local_auth/local_auth_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+* Changes `stopAuthentication` to always return false instead of throwing an error.
+
 ## 1.0.0
 
 * Initial release from migration to federated architecture. 

--- a/packages/local_auth/local_auth_ios/CHANGELOG.md
+++ b/packages/local_auth/local_auth_ios/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.0.1
 
-* Changes `stopAuthentication` to always return false instead of throwing an error.
+* BREAKING CHANGE: Changes `stopAuthentication` to always return false instead of throwing an error.
 
 ## 1.0.0
 

--- a/packages/local_auth/local_auth_ios/lib/local_auth_ios.dart
+++ b/packages/local_auth/local_auth_ios/lib/local_auth_ios.dart
@@ -81,8 +81,9 @@ class LocalAuthIOS extends LocalAuthPlatform {
   Future<bool> isDeviceSupported() async =>
       (await _channel.invokeMethod<bool>('isDeviceSupported')) ?? false;
 
+  /// Always returns false as this method is not supported on iOS.
   @override
   Future<bool> stopAuthentication() async {
-    throw UnimplementedError('stopAuthentication() is not supported on iOS.');
+    return false;
   }
 }

--- a/packages/local_auth/local_auth_ios/pubspec.yaml
+++ b/packages/local_auth/local_auth_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: local_auth_ios
 description: iOS implementation of the local_auth plugin.
 repository: https://github.com/flutter/plugins/tree/master/packages/local_auth/local_auth_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+local_auth%22
-version: 1.0.0
+version: 1.0.1
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/local_auth/local_auth_ios/test/local_auth_test.dart
+++ b/packages/local_auth/local_auth_ios/test/local_auth_test.dart
@@ -75,9 +75,9 @@ void main() {
       );
     });
 
-    test('stopAuthentication throws UnimplementedError', () async {
-      expect(() async => await localAuthentication.stopAuthentication(),
-          throwsUnimplementedError);
+    test('stopAuthentication returns false', () async {
+      final bool result = await localAuthentication.stopAuthentication();
+      expect(result, false);
     });
 
     group('With device auth fail over', () {


### PR DESCRIPTION
This PR changes the new iOS implementation of `local_auth` to return `false` instead of throwing an `UnimplementedError`.

It is a precursor to #4701. 

Relevant "issue":
 - https://github.com/flutter/plugins/pull/4701#discussion_r848542820

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.